### PR TITLE
Remove gql module's dependency on query. Make it the other way round.…

### DIFF
--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -19,11 +19,9 @@ package gql
 import (
 	"fmt"
 	"testing"
-
-	"github.com/dgraph-io/dgraph/query"
 )
 
-func checkAttr(g *query.SubGraph, attr string) error {
+func checkAttr(g *GraphQuery, attr string) error {
 	if g.Attr != attr {
 		return fmt.Errorf("Expected: %v. Got: %v", attr, g.Attr)
 	}
@@ -43,31 +41,31 @@ func TestParse(t *testing.T) {
 	}
 `
 
-	sg, err := Parse(query)
+	gq, err := Parse(query)
 	if err != nil {
 		t.Error(err)
 	}
-	if sg == nil {
+	if gq == nil {
 		t.Error("subgraph is nil")
 		return
 	}
-	if len(sg.Children) != 4 {
-		t.Errorf("Expected 4 children. Got: %v", len(sg.Children))
+	if len(gq.Children) != 4 {
+		t.Errorf("Expected 4 children. Got: %v", len(gq.Children))
 		return
 	}
-	if err := checkAttr(sg.Children[0], "friends"); err != nil {
+	if err := checkAttr(gq.Children[0], "friends"); err != nil {
 		t.Error(err)
 	}
-	if err := checkAttr(sg.Children[1], "gender"); err != nil {
+	if err := checkAttr(gq.Children[1], "gender"); err != nil {
 		t.Error(err)
 	}
-	if err := checkAttr(sg.Children[2], "age"); err != nil {
+	if err := checkAttr(gq.Children[2], "age"); err != nil {
 		t.Error(err)
 	}
-	if err := checkAttr(sg.Children[3], "hometown"); err != nil {
+	if err := checkAttr(gq.Children[3], "hometown"); err != nil {
 		t.Error(err)
 	}
-	child := sg.Children[0]
+	child := gq.Children[0]
 	if len(child.Children) != 1 {
 		t.Errorf("Expected 1 child of friends. Got: %v", len(child.Children))
 	}
@@ -84,19 +82,19 @@ func TestParseXid(t *testing.T) {
 			type.object.name
 		}
 	}`
-	sg, err := Parse(query)
+	gq, err := Parse(query)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if sg == nil {
+	if gq == nil {
 		t.Error("subgraph is nil")
 		return
 	}
-	if len(sg.Children) != 1 {
-		t.Errorf("Expected 1 children. Got: %v", len(sg.Children))
+	if len(gq.Children) != 1 {
+		t.Errorf("Expected 1 children. Got: %v", len(gq.Children))
 	}
-	if err := checkAttr(sg.Children[0], "type.object.name"); err != nil {
+	if err := checkAttr(gq.Children[0], "type.object.name"); err != nil {
 		t.Error(err)
 	}
 }
@@ -143,22 +141,22 @@ func TestParse_pass1(t *testing.T) {
 			}
 		}
 	`
-	sg, err := Parse(query)
+	gq, err := Parse(query)
 	if err != nil {
 		t.Error(err)
 	}
-	if len(sg.Children) != 2 {
-		t.Errorf("Expected 2. Got: %v", len(sg.Children))
+	if len(gq.Children) != 2 {
+		t.Errorf("Expected 2. Got: %v", len(gq.Children))
 	}
-	if err := checkAttr(sg.Children[0], "name"); err != nil {
+	if err := checkAttr(gq.Children[0], "name"); err != nil {
 		t.Error(err)
 	}
-	if err := checkAttr(sg.Children[1], "friends"); err != nil {
+	if err := checkAttr(gq.Children[1], "friends"); err != nil {
 		t.Error(err)
 	}
-	f := sg.Children[1]
+	f := gq.Children[1]
 	if len(f.Children) != 0 {
-		t.Errorf("Expected 0. Got: %v", len(sg.Children))
+		t.Errorf("Expected 0. Got: %v", len(gq.Children))
 	}
 }
 
@@ -170,14 +168,14 @@ func TestParse_block(t *testing.T) {
 			}
 		}
 	`
-	sg, err := Parse(query)
+	gq, err := Parse(query)
 	if err != nil {
 		t.Error(err)
 	}
-	if len(sg.Children) != 1 {
-		t.Errorf("Expected 1. Got: %v", len(sg.Children))
+	if len(gq.Children) != 1 {
+		t.Errorf("Expected 1. Got: %v", len(gq.Children))
 	}
-	if err := checkAttr(sg.Children[0], "type.object.name.es-419"); err != nil {
+	if err := checkAttr(gq.Children[0], "type.object.name.es-419"); err != nil {
 		t.Error(err)
 	}
 }

--- a/query/query.go
+++ b/query/query.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/uid"
@@ -251,7 +252,25 @@ func (g *SubGraph) ToJson(l *Latency) (js []byte, rerr error) {
 	return json.Marshal(r)
 }
 
-func NewGraph(euid uint64, exid string) (*SubGraph, error) {
+func treeCopy(gq *gql.GraphQuery, sg *SubGraph) {
+	for _, gchild := range gq.Children {
+		dst := new(SubGraph)
+		dst.Attr = gchild.Attr
+		sg.Children = append(sg.Children, dst)
+		treeCopy(gchild, dst)
+	}
+}
+
+func ToSubGraph(gq *gql.GraphQuery) (*SubGraph, error) {
+	sg, err := newGraph(gq.UID, gq.XID)
+	if err != nil {
+		return nil, err
+	}
+	treeCopy(gq, sg)
+	return sg, nil
+}
+
+func newGraph(euid uint64, exid string) (*SubGraph, error) {
 	// This would set the Result field in SubGraph,
 	// and populate the children for attributes.
 	if len(exid) > 0 {

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -88,11 +88,17 @@ func TestQuery(t *testing.T) {
 	defer closeAll(dir1, dir2, clog)
 
 	// Parse GQL into internal query representation.
-	g, err := gql.Parse(q0)
+	gq, err := gql.Parse(q0)
 	if err != nil {
 		t.Error(err)
 		return
 	}
+	g, err := query.ToSubGraph(gq)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	// Test internal query representation.
 	if len(g.Children) != 3 {
 		t.Errorf("Expected 3 children. Got: %v", len(g.Children))
@@ -178,11 +184,17 @@ func BenchmarkQuery(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		g, err := gql.Parse(q1)
+		gq, err := gql.Parse(q1)
 		if err != nil {
 			b.Error(err)
 			return
 		}
+		g, err := query.ToSubGraph(gq)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+
 		ch := make(chan error)
 		go query.ProcessGraph(g, ch)
 		if err := <-ch; err != nil {


### PR DESCRIPTION
… GraphQL query string, now gets converted into query.SubGraph as an additional step run via query.ToSubGraph.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/27)
<!-- Reviewable:end -->
