### PR TITLE
Parse Mutation block from GraphQL

### DIFF
--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -63,6 +63,7 @@ type Lexer struct {
 	Width int       // width of last rune read from input.
 	Items chan item // channel of scanned items.
 	Depth int       // nesting of {}
+	Mode  int       // mode based on information so far.
 }
 
 func NewLexer(input string) *Lexer {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -190,7 +190,7 @@ func TestProcessGraph(t *testing.T) {
 			}
 		}
 	`
-	gq, err := gql.Parse(query)
+	gq, _, err := gql.Parse(query)
 	if err != nil {
 		t.Error(err)
 	}
@@ -282,7 +282,7 @@ func TestToJson(t *testing.T) {
 		}
 	`
 
-	gq, err := gql.Parse(query)
+	gq, _, err := gql.Parse(query)
 	if err != nil {
 		t.Error(err)
 	}

--- a/server/main.go
+++ b/server/main.go
@@ -72,7 +72,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	glog.WithField("q", string(q)).Debug("Query received.")
-	gq, err := gql.Parse(string(q))
+	gq, _, err := gql.Parse(string(q))
 	if err != nil {
 		x.Err(glog, err).Error("While parsing query")
 		x.SetStatus(w, x.E_INVALID_REQUEST, err.Error())

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -88,7 +88,7 @@ func TestQuery(t *testing.T) {
 	defer closeAll(dir1, dir2, clog)
 
 	// Parse GQL into internal query representation.
-	gq, err := gql.Parse(q0)
+	gq, _, err := gql.Parse(q0)
 	if err != nil {
 		t.Error(err)
 		return
@@ -184,7 +184,7 @@ func BenchmarkQuery(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		gq, err := gql.Parse(q1)
+		gq, _, err := gql.Parse(q1)
 		if err != nil {
 			b.Error(err)
 			return


### PR DESCRIPTION
GraphQL doesn't have a self-sufficient way to provide mutations. So, I created something which should work well, using RDF as the input format. This is how a valid mutation would look like:
```
    mutation {
      set {
        <name> <is> <something> .
        <hometown> <is> <san francisco> .
      }
      delete {
        <name> <is> <something-else> .
      }
    }
    query {
      me(_xid_: tomhanks) {
        name
        hometown
      }
    }
```

Mutation supports 2 operations: `set`, and `delete`. The data inside the `set` and `delete` blocks is in RDF NQuad format; the same format that our bulk loader parses as well.

Mutations can be independent, but a `mutation` block can also be paired with a `query` block. The order in which these would run would be mutation first, then query.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/29)
<!-- Reviewable:end -->
