### PR TITLE
Enable vendoring using GOVENDOR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN cd /installs/rocksdb && make shared_lib && make install
 ENV LD_LIBRARY_PATH "/usr/local/lib"
 
 # Install DGraph and update dependencies to right versions.
-RUN go get -v github.com/robfig/glock && \
+RUN go get -v github.com/kardianos/govendor && \
        go get -v github.com/dgraph-io/dgraph/... && \
-       glock sync github.com/dgraph-io/dgraph && \
+       cd $GOPATH/src/github.com/dgraph-io/dgraph && \
+       govendor sync && \
        go test github.com/dgraph-io/dgraph/... && echo "v0.2.3"
 
 # Create the dgraph and data directory. These directories should be mapped

--- a/GLOCKFILE
+++ b/GLOCKFILE
@@ -1,6 +1,0 @@
-github.com/Sirupsen/logrus 23521f1364a267387df2b99234134003e0a4486d
-github.com/dgryski/go-farm d1e51a4af19092715f4ce7d8257fe5bc8f8be727
-github.com/google/flatbuffers b4db88808f5c1f8f36d2f67952c8b7b3022e28ea
-github.com/willf/bitset 28a4168144bb8ac95454e1f51c84da1933681ad4
-github.com/willf/bloom 73320a6e73f3e139842058d7e4886e09ca83ac9b
-github.com/zond/gotomic 5b217c5578228ff3979c9f9459959176fb54c388

--- a/README.md
+++ b/README.md
@@ -135,15 +135,18 @@ export LD_LIBRARY_PATH="/usr/local/lib"
 ```
 
 ### Install DGraph
-Now get [DGraph](https://github.com/dgraph-io/dgraph) code. DGraph uses `glock` to fix dependency versions.
+Now get [DGraph](https://github.com/dgraph-io/dgraph) code. DGraph uses `govendor` to fix dependency versions. Version information for these dependencies is included in the `github.com/dgraph-io/dgraph/vendor` directory under the `vendor.json` file.  
+
 ```
-go get -v github.com/robfig/glock
-go get -v github.com/dgraph-io/dgraph/...
-glock sync github.com/dgraph-io/dgraph
+go get -u github.com/kardianos/govendor
+# cd to dgraph codebase root directory e.g. $GOPATH/src/github.com/dgraph-io/dgraph
+govendor sync
 
 # Optional
 go test github.com/dgraph-io/dgraph/...
+
 ```
+See [govendor](https://github.com/kardianos/govendor) for more information.
 
 ## Usage
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,0 +1,132 @@
+{
+	"comment": "",
+	"ignore": "test",
+	"package": [
+		{
+			"checksumSHA1": "2d0APy09NIaNsHXstcbkgFUYhHQ=",
+			"path": "github.com/Sirupsen/logrus",
+			"revision": "23521f1364a267387df2b99234134003e0a4486d",
+			"revisionTime": "2015-10-07T14:14:16Z"
+		},
+		{
+			"checksumSHA1": "a29TtOU87eZA0S6wL+rAkpqUEzc=",
+			"path": "github.com/dgryski/go-farm",
+			"revision": "d1e51a4af19092715f4ce7d8257fe5bc8f8be727",
+			"revisionTime": "2015-09-09T17:09:13Z"
+		},
+		{
+			"checksumSHA1": "FczzogSoZcKU3h21tCUyHzMsnBY=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "7cc19b78d562895b13596ddce7aafb59dd789318",
+			"revisionTime": "2016-04-25T21:53:00Z"
+		},
+		{
+			"checksumSHA1": "bAXE13JoHB8GZ5svBJpzCWiuZBQ=",
+			"path": "github.com/google/flatbuffers/go",
+			"revision": "b4db88808f5c1f8f36d2f67952c8b7b3022e28ea",
+			"revisionTime": "2015-10-08T07:23:26Z"
+		},
+		{
+			"checksumSHA1": "7LaLud3qlAQZ+xftxLTbYg3cGpo=",
+			"path": "github.com/willf/bitset",
+			"revision": "28a4168144bb8ac95454e1f51c84da1933681ad4",
+			"revisionTime": "2015-08-12T13:10:42Z"
+		},
+		{
+			"checksumSHA1": "AfNEZNbH3Dcpiz5PuNQKoCDuS7g=",
+			"path": "github.com/willf/bloom",
+			"revision": "73320a6e73f3e139842058d7e4886e09ca83ac9b",
+			"revisionTime": "2015-11-24T22:32:07Z"
+		},
+		{
+			"checksumSHA1": "+o8IunxLKImqyhMUgJ4FCkRIAhA=",
+			"path": "github.com/zond/gotomic",
+			"revision": "5b217c5578228ff3979c9f9459959176fb54c388",
+			"revisionTime": "2013-07-06T14:15:31Z"
+		},
+		{
+			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",
+			"path": "golang.org/x/net/context",
+			"revision": "ef00b378c73f107bf44d5c9b69875255ce89b79a",
+			"revisionTime": "2016-05-15T03:16:23Z"
+		},
+		{
+			"checksumSHA1": "nnTwJD196DUJlp748YVbht2uWeU=",
+			"path": "golang.org/x/net/http2",
+			"revision": "ef00b378c73f107bf44d5c9b69875255ce89b79a",
+			"revisionTime": "2016-05-15T03:16:23Z"
+		},
+		{
+			"checksumSHA1": "EYNaHp7XdLWRydUCE0amEkKAtgk=",
+			"path": "golang.org/x/net/http2/hpack",
+			"revision": "ef00b378c73f107bf44d5c9b69875255ce89b79a",
+			"revisionTime": "2016-05-15T03:16:23Z"
+		},
+		{
+			"checksumSHA1": "/k7k6eJDkxXx6K9Zpo/OwNm58XM=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "ef00b378c73f107bf44d5c9b69875255ce89b79a",
+			"revisionTime": "2016-05-15T03:16:23Z"
+		},
+		{
+			"checksumSHA1": "WpST9lFOHvWrjDVy0GJNqHe+R3E=",
+			"path": "golang.org/x/net/trace",
+			"revision": "ef00b378c73f107bf44d5c9b69875255ce89b79a",
+			"revisionTime": "2016-05-15T03:16:23Z"
+		},
+		{
+			"checksumSHA1": "6IoiLJkjSoT5hPNiHM7SVgEpW3c=",
+			"path": "google.golang.org/grpc",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "08icuA15HRkdYCt6H+Cs90RPQsY=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "a+C+FoyX7Tc4iNFhBndt/y/iPEg=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "3Lt5hNAG8qJAYSsNghR5uA1zQns=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "T3Q0p8kzvXFnRkMaK/G8mCv6mc0=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "IlzBp7dylW8F4D7eINj8xHt/jMk=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "fGJlPKvpYAZ6+HRX3qScFnZ9dd4=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "3RRoLeH6X2//7tVClOVzxW2bY+E=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		},
+		{
+			"checksumSHA1": "MILjAJUdWMpHJ6HENYA0Saemh5c=",
+			"path": "google.golang.org/grpc/transport",
+			"revision": "4c4ed377c72e199edd16a87011f13a56fd519119",
+			"revisionTime": "2016-05-13T02:30:22Z"
+		}
+	]
+}


### PR DESCRIPTION
Resolves - https://discuss.dgraph.io/t/vendoring-dependencies-for-dgraph/177

Pertaining to the discussion referenced above: GLOCKFILE has been removed,
README has been updated, and vendor/vendor.json has been added. At this
point of time we are only adding dependency information file(vendor.json) and
not the actual dependencies. This commit also helps in avoiding
installation of dependencies in $GOPATH if vendor directory is synced
using govendor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/84)
<!-- Reviewable:end -->
