### PR TITLE
Try to serve Go client and http clients on the same port

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -316,7 +316,7 @@ func runGrpcServer(ln net.Listener) {
 	s := grpc.NewServer()
 	graph.RegisterDgraphServer(s, &server{})
 	if err := s.Serve(ln); err != nil {
-		log.Fatalf("While serving gRpc requests", err)
+		log.Fatal("While serving gRpc requests: %v", err)
 	}
 	return
 }


### PR DESCRIPTION
Doesn't work, but wanted to get a second view on how I am doing things here. Using the same listener, either the serve method for HTTP takes up all calls or that for Grpc. So only one of them works.

Also wanted to check houndci.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/146)
<!-- Reviewable:end -->
