### PR TITLE
Get nodes from sync.Pool

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -318,7 +318,7 @@ func runGrpcServer(address string) {
 	}
 	log.Printf("Client worker listening: %v", ln.Addr())
 
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.CustomCodec(&query.Codec{}))
 	graph.RegisterDgraphServer(s, &server{})
 	if err = s.Serve(ln); err != nil {
 		log.Fatalf("While serving gRpc requests: %v", err)
@@ -386,6 +386,7 @@ func main() {
 	worker.Connect(addrs)
 	// Grpc server runs on (port + 1)
 	go runGrpcServer(fmt.Sprintf(":%d", *port+1))
+	go query.InitRelease()
 
 	http.HandleFunc("/query", queryHandler)
 	log.Printf("Listening for requests at port: %v", *port)

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -386,7 +386,6 @@ func main() {
 	worker.Connect(addrs)
 	// Grpc server runs on (port + 1)
 	go runGrpcServer(fmt.Sprintf(":%d", *port+1))
-	go query.InitRelease()
 
 	http.HandleFunc("/query", queryHandler)
 	log.Printf("Listening for requests at port: %v", *port)

--- a/query/benchmark/README.txt
+++ b/query/benchmark/README.txt
@@ -69,8 +69,8 @@ BenchmarkToPB_1000_Director-4       2000      908611 ns/op    150163 B/op     30
 5 August 2016
 -------------
 These are the benchmarking results after including the protocol buffer Marshalling
-step which was missing in the previous benchmarks. So, this would be the true 
-comparison of Json vs Protocol buffers. Also, the proto library was changed to 
+step which was missing in the previous benchmarks. So, this would be the true
+comparison of Json vs Protocol buffers. Also, the proto library was changed to
 gogo protobuf from go protobuf.
 
 BenchmarkToJSON_10_Actor-2                 50000             29130 ns/op            6833 B/op        105 allocs/op
@@ -86,3 +86,14 @@ BenchmarkToPB_100_Director-2               20000             70183 ns/op        
 BenchmarkToPB_1000_Actor-2                  5000            389853 ns/op           72856 B/op        959 allocs/op
 BenchmarkToPB_1000_Director-2               2000           1036647 ns/op          207506 B/op       3081 allocs/op
 
+9 August 2016
+-------------
+
+On using sync.Pool to manage the graph.Node in ToProtocolBuffer, we can see improvements
+in the amount of memory used. On generating a memory profile from PB benchmarks like
+
+go test -run=xx -bench=BenchmarkToPB_ -memprofile=syncpool.mem
+go tool pprof --alloc_space query.test syncpool.mem
+
+We observe that 1.28GB memory is allocated in total compared to 1.76GB before the change.
+Most of the reduction comes from the preTraverse function.

--- a/query/codec.go
+++ b/query/codec.go
@@ -1,0 +1,43 @@
+package query
+
+import (
+	"log"
+
+	"github.com/dgraph-io/dgraph/query/graph"
+	"github.com/gogo/protobuf/proto"
+)
+
+type Codec struct{}
+
+func (c *Codec) Marshal(v interface{}) ([]byte, error) {
+	r, ok := v.(*graph.Response)
+	if !ok {
+		log.Fatalf("Invalid type of value: %+v", v)
+	}
+
+	b, err := proto.Marshal(r)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	select {
+	// Passing onto to channel which would put it into the sync pool.
+	case nodeCh <- r.N:
+	default:
+	}
+
+	return b, nil
+}
+
+func (c *Codec) Unmarshal(data []byte, v interface{}) error {
+	n, ok := v.(*graph.Request)
+	if !ok {
+		log.Fatalf("Invalid type of value: %+v", v)
+	}
+
+	return proto.Unmarshal(data, n)
+}
+
+func (c *Codec) String() string {
+	return "query.Codec"
+}

--- a/query/codec.go
+++ b/query/codec.go
@@ -7,8 +7,10 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
+// Codec implements the custom codec interface.
 type Codec struct{}
 
+// Marshal release the graph.Node pointers after marshalling the response.
 func (c *Codec) Marshal(v interface{}) ([]byte, error) {
 	r, ok := v.(*graph.Response)
 	if !ok {
@@ -29,6 +31,7 @@ func (c *Codec) Marshal(v interface{}) ([]byte, error) {
 	return b, nil
 }
 
+// Unmarshal constructs graph.Request from the byte slice.
 func (c *Codec) Unmarshal(data []byte, v interface{}) error {
 	n, ok := v.(*graph.Request)
 	if !ok {

--- a/query/query.go
+++ b/query/query.go
@@ -303,10 +303,9 @@ func release() {
 	}
 }
 
-// InitRelease intialises the channel and calls release function.
-func InitRelease() {
+func init() {
 	nodeCh = make(chan *graph.Node, 1000)
-	release()
+	go release()
 }
 
 // This method gets the values and children for a subgraph.

--- a/query/query.go
+++ b/query/query.go
@@ -303,6 +303,7 @@ func release() {
 	}
 }
 
+// InitRelease intialises the channel and calls release function.
 func InitRelease() {
 	nodeCh = make(chan *graph.Node, 1000)
 	release()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -474,6 +474,7 @@ func BenchmarkToJSON_1000_Director(b *testing.B) { benchmarkToJson("benchmark/di
 
 func benchmarkToPB(file string, b *testing.B) {
 	b.ReportAllocs()
+	go InitRelease()
 	var sg SubGraph
 	var l Latency
 
@@ -495,7 +496,10 @@ func benchmarkToPB(file string, b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		if _, err = proto.Marshal(pb); err != nil {
+		r := new(graph.Response)
+		r.N = pb
+		var c Codec
+		if _, err = c.Marshal(r); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -474,7 +474,6 @@ func BenchmarkToJSON_1000_Director(b *testing.B) { benchmarkToJson("benchmark/di
 
 func benchmarkToPB(file string, b *testing.B) {
 	b.ReportAllocs()
-	go InitRelease()
 	var sg SubGraph
 	var l Latency
 

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -48,8 +48,7 @@ func NewPool(addr string, maxCap int) *Pool {
 }
 
 func (p *Pool) dialNew() (*grpc.ClientConn, error) {
-	return grpc.Dial(p.Addr, grpc.WithInsecure(), grpc.WithInsecure(),
-		grpc.WithCodec(&PayloadCodec{}))
+	return grpc.Dial(p.Addr, grpc.WithInsecure(), grpc.WithCodec(&PayloadCodec{}))
 }
 
 func (p *Pool) Get() (*grpc.ClientConn, error) {


### PR DESCRIPTION
Unfortunately, the change doesn't work as expected because when releasing nodes their content is emptied. Since Node children are also pointers, their content is emptied too. Tests also fail because of this. I wanted to get an idea of whether there something wrong that I am doing here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/150)
<!-- Reviewable:end -->
