### PR TITLE
Feature/test pred rpc

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 	"time"
 
-	"context"
+	"golang.org/x/net/context"
 
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc"

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -30,7 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc"
 

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -383,9 +383,8 @@ func main() {
 	}
 
 	posting.Init(clog)
-	var w *worker.Worker
 	if *instanceIdx != 0 {
-		w = worker.New(ps, nil, *instanceIdx, lenAddr)
+		worker.New(ps, nil, *instanceIdx, lenAddr)
 		uid.Init(nil)
 		go posting.CheckMemoryUsage(ps, nil)
 	} else {
@@ -393,12 +392,12 @@ func main() {
 		uidStore.Init(*uidDir)
 		defer uidStore.Close()
 		// Only server instance 0 will have uidStore
-		w = worker.New(ps, uidStore, *instanceIdx, lenAddr)
+		worker.New(ps, uidStore, *instanceIdx, lenAddr)
 		uid.Init(uidStore)
 		go posting.CheckMemoryUsage(ps, uidStore)
 	}
 
-	w.Connect(addrs, *workerPort)
+	worker.Connect(addrs, *workerPort)
 	// Grpc server runs on (port + 1)
 	go runGrpcServer(fmt.Sprintf(":%d", *port+1))
 

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -384,7 +384,7 @@ func main() {
 
 	posting.Init(clog)
 	if *instanceIdx != 0 {
-		worker.New(ps, nil, *instanceIdx, lenAddr)
+		worker.InitState(ps, nil, *instanceIdx, lenAddr)
 		uid.Init(nil)
 		go posting.CheckMemoryUsage(ps, nil)
 	} else {
@@ -392,7 +392,7 @@ func main() {
 		uidStore.Init(*uidDir)
 		defer uidStore.Close()
 		// Only server instance 0 will have uidStore
-		worker.New(ps, uidStore, *instanceIdx, lenAddr)
+		worker.InitState(ps, uidStore, *instanceIdx, lenAddr)
 		uid.Init(uidStore)
 		go posting.CheckMemoryUsage(ps, uidStore)
 	}

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/gql"

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -65,7 +65,7 @@ func prepare() (dir1, dir2 string, ps *store.Store, clog *commit.Logger, rerr er
 	clog.Init()
 
 	posting.Init(clog)
-	worker.New(ps, nil, 0, 1)
+	worker.InitState(ps, nil, 0, 1)
 	uid.Init(ps)
 	loader.Init(ps, ps)
 

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -65,7 +65,7 @@ func prepare() (dir1, dir2 string, ps *store.Store, clog *commit.Logger, rerr er
 	clog.Init()
 
 	posting.Init(clog)
-	worker.Init(ps, nil, 0, 1)
+	worker.New(ps, nil, 0, 1)
 	uid.Init(ps)
 	loader.Init(ps, ps)
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -27,9 +27,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/dgryski/go-farm"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/rdf"

--- a/posting/list.go
+++ b/posting/list.go
@@ -28,10 +28,11 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
+
 	"github.com/dgryski/go-farm"
 	"github.com/google/flatbuffers/go"
 	"github.com/zond/gotomic"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/posting/types"

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/posting/types"
@@ -145,7 +145,7 @@ func TestAddMutation(t *testing.T) {
 		t.Fail()
 	}
 	if p.Uid() != 9 {
-		t.Errorf("Expected 9. Got: %v", p.Uid)
+		t.Errorf("Expected 9. Got: %v", p.Uid())
 	}
 	if string(p.Source()) != "testing" {
 		t.Errorf("Expected testing. Got: %v", string(p.Source()))

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -26,9 +26,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/dgryski/go-farm"
 	"github.com/zond/gotomic"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/store"

--- a/query/graph/graphresponse.proto
+++ b/query/graph/graphresponse.proto
@@ -1,5 +1,5 @@
 // To compile this file run the command below from inside the graph directory
-// protoc --go_out=plugins=grpc:. *.proto
+// protoc --gofast_out=plugins=grpc:. *.proto
 
 syntax="proto3";
 package graph;

--- a/query/query.go
+++ b/query/query.go
@@ -27,8 +27,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/query/graph"

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -26,9 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/gql"

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -108,7 +108,7 @@ func TestNewGraph(t *testing.T) {
 		t.Error(err)
 	}
 
-	worker.Init(ps, nil, 0, 1)
+	worker.New(ps, nil, 0, 1)
 
 	uo := flatbuffers.GetUOffsetT(sg.Result)
 	r := new(task.Result)
@@ -139,7 +139,7 @@ func populateGraph(t *testing.T) (string, *store.Store) {
 	ps := new(store.Store)
 	ps.Init(dir)
 
-	worker.Init(ps, nil, 0, 1)
+	worker.New(ps, nil, 0, 1)
 
 	clog := commit.NewLogger(dir, "mutations", 50<<20)
 	clog.Init()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -109,7 +109,7 @@ func TestNewGraph(t *testing.T) {
 		t.Error(err)
 	}
 
-	worker.New(ps, nil, 0, 1)
+	worker.InitState(ps, nil, 0, 1)
 
 	uo := flatbuffers.GetUOffsetT(sg.Result)
 	r := new(task.Result)
@@ -140,7 +140,7 @@ func populateGraph(t *testing.T) (string, *store.Store) {
 	ps := new(store.Store)
 	ps.Init(dir)
 
-	worker.New(ps, nil, 0, 1)
+	worker.InitState(ps, nil, 0, 1)
 
 	clog := commit.NewLogger(dir, "mutations", 50<<20)
 	clog.Init()

--- a/uid/assigner.go
+++ b/uid/assigner.go
@@ -24,8 +24,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/dgryski/go-farm"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/posting/types"
@@ -46,7 +47,7 @@ type entry struct {
 	ts time.Time
 }
 
-func (e entry) isOld() bool {
+func (e *entry) isOld() bool {
 	e.Lock()
 	defer e.Unlock()
 	return time.Now().Sub(e.ts) > time.Minute
@@ -141,8 +142,6 @@ func allocateUniqueUid(xid string, instanceIdx uint64,
 		rerr = pl.AddMutation(context.Background(), t, posting.Set)
 		return uid, rerr
 	}
-	return 0, errors.New("Some unhandled route lead me here." +
-		" Wake the stupid developer up.")
 }
 
 func assignNew(pl *posting.List, xid string, instanceIdx uint64,

--- a/uid/assigner_test.go
+++ b/uid/assigner_test.go
@@ -92,13 +92,4 @@ func TestGetOrAssign(t *testing.T) {
 		}
 	}
 	return
-	{
-		xid, err := ExternalId(u2)
-		if err != nil {
-			t.Error(err)
-		}
-		if xid != "externalid1" {
-			t.Errorf("Expected externalid1. Found: [%q]", xid)
-		}
-	}
 }

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -21,8 +21,9 @@ import (
 	"log"
 	"sync"
 
+	"context"
+
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/uid"
@@ -112,7 +113,7 @@ func GetOrAssignUidsOverNetwork(ctx context.Context, xidToUid map[string]uint64)
 	// If instance number 0 called this and then it already has posting list for
 	// xid <-> uid conversion, hence call getOrAssignUids locally else call
 	// GetOrAssign using worker client.
-	if instanceIdx == 0 {
+	if wo.instanceIdx == 0 {
 		reply.Data, rerr = getOrAssignUids(ctx, xidList)
 		if rerr != nil {
 			return rerr
@@ -120,7 +121,7 @@ func GetOrAssignUidsOverNetwork(ctx context.Context, xidToUid map[string]uint64)
 
 	} else {
 		// Get pool for worker on instance 0.
-		pool := pools[0]
+		pool := wo.pools[0]
 		conn, err := pool.Get()
 		if err != nil {
 			x.Trace(ctx, "Error while retrieving connection: %v", err)

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -113,7 +113,7 @@ func GetOrAssignUidsOverNetwork(ctx context.Context, xidToUid map[string]uint64)
 	// If instance number 0 called this and then it already has posting list for
 	// xid <-> uid conversion, hence call getOrAssignUids locally else call
 	// GetOrAssign using worker client.
-	if wo.instanceIdx == 0 {
+	if ws.instanceIdx == 0 {
 		reply.Data, rerr = getOrAssignUids(ctx, xidList)
 		if rerr != nil {
 			return rerr
@@ -121,7 +121,7 @@ func GetOrAssignUidsOverNetwork(ctx context.Context, xidToUid map[string]uint64)
 
 	} else {
 		// Get pool for worker on instance 0.
-		pool := wo.pools[0]
+		pool := ws.pools[0]
 		conn, err := pool.Get()
 		if err != nil {
 			x.Trace(ctx, "Error while retrieving connection: %v", err)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"log"
 
+	"context"
+
 	"github.com/dgryski/go-farm"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/x"
@@ -62,12 +63,12 @@ func (m *Mutations) Decode(data []byte) error {
 func runMutations(ctx context.Context, edges []x.DirectedEdge, op byte, left *Mutations) error {
 	for _, edge := range edges {
 		if farm.Fingerprint64(
-			[]byte(edge.Attribute))%numInstances != instanceIdx {
+			[]byte(edge.Attribute))%wo.numInstances != wo.instanceIdx {
 			return fmt.Errorf("Predicate fingerprint doesn't match this instance")
 		}
 
 		key := posting.Key(edge.Entity, edge.Attribute)
-		plist := posting.GetOrCreate(key, dataStore)
+		plist := posting.GetOrCreate(key, wo.dataStore)
 		if err := plist.AddMutation(ctx, edge, op); err != nil {
 			if op == posting.Set {
 				left.Set = append(left.Set, edge)
@@ -99,7 +100,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 	left := new(Mutations)
 	var err error
 	// We run them locally if idx == instanceIdx
-	if idx == int(instanceIdx) {
+	if idx == int(wo.instanceIdx) {
 		if err = mutate(ctx, m, left); err != nil {
 			che <- err
 			return
@@ -116,7 +117,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 	}
 
 	// Get a connection from the pool and run mutations over the network.
-	pool := pools[idx]
+	pool := wo.pools[idx]
 	query := new(Payload)
 	query.Data, err = m.Encode()
 	if err != nil {
@@ -145,7 +146,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 // taking into account the op(operation) and the attribute.
 func addToMutationArray(mutationArray []*Mutations, edges []x.DirectedEdge, op string) {
 	for _, edge := range edges {
-		idx := farm.Fingerprint64([]byte(edge.Attribute)) % numInstances
+		idx := farm.Fingerprint64([]byte(edge.Attribute)) % wo.numInstances
 		mu := mutationArray[idx]
 		if mu == nil {
 			mu = new(Mutations)
@@ -163,13 +164,13 @@ func addToMutationArray(mutationArray []*Mutations, edges []x.DirectedEdge, op s
 // MutateOverNetwork checks which instance should be running the mutations
 // according to fingerprint of the predicate and sends it to that instance.
 func MutateOverNetwork(ctx context.Context, m Mutations) (left Mutations, rerr error) {
-	mutationArray := make([]*Mutations, numInstances)
+	mutationArray := make([]*Mutations, wo.numInstances)
 
 	addToMutationArray(mutationArray, m.Set, set)
 	addToMutationArray(mutationArray, m.Del, del)
 
-	replies := make(chan *Payload, numInstances)
-	errors := make(chan error, numInstances)
+	replies := make(chan *Payload, wo.numInstances)
+	errors := make(chan error, wo.numInstances)
 	count := 0
 	for idx, mu := range mutationArray {
 		if mu == nil || (len(mu.Set) == 0 && len(mu.Del) == 0) {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -63,12 +63,12 @@ func (m *Mutations) Decode(data []byte) error {
 func runMutations(ctx context.Context, edges []x.DirectedEdge, op byte, left *Mutations) error {
 	for _, edge := range edges {
 		if farm.Fingerprint64(
-			[]byte(edge.Attribute))%wo.numInstances != wo.instanceIdx {
+			[]byte(edge.Attribute))%ws.numInstances != ws.instanceIdx {
 			return fmt.Errorf("Predicate fingerprint doesn't match this instance")
 		}
 
 		key := posting.Key(edge.Entity, edge.Attribute)
-		plist := posting.GetOrCreate(key, wo.dataStore)
+		plist := posting.GetOrCreate(key, ws.dataStore)
 		if err := plist.AddMutation(ctx, edge, op); err != nil {
 			if op == posting.Set {
 				left.Set = append(left.Set, edge)
@@ -100,7 +100,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 	left := new(Mutations)
 	var err error
 	// We run them locally if idx == instanceIdx
-	if idx == int(wo.instanceIdx) {
+	if idx == int(ws.instanceIdx) {
 		if err = mutate(ctx, m, left); err != nil {
 			che <- err
 			return
@@ -117,7 +117,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 	}
 
 	// Get a connection from the pool and run mutations over the network.
-	pool := wo.pools[idx]
+	pool := ws.pools[idx]
 	query := new(Payload)
 	query.Data, err = m.Encode()
 	if err != nil {
@@ -146,7 +146,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 // taking into account the op(operation) and the attribute.
 func addToMutationArray(mutationArray []*Mutations, edges []x.DirectedEdge, op string) {
 	for _, edge := range edges {
-		idx := farm.Fingerprint64([]byte(edge.Attribute)) % wo.numInstances
+		idx := farm.Fingerprint64([]byte(edge.Attribute)) % ws.numInstances
 		mu := mutationArray[idx]
 		if mu == nil {
 			mu = new(Mutations)
@@ -164,13 +164,13 @@ func addToMutationArray(mutationArray []*Mutations, edges []x.DirectedEdge, op s
 // MutateOverNetwork checks which instance should be running the mutations
 // according to fingerprint of the predicate and sends it to that instance.
 func MutateOverNetwork(ctx context.Context, m Mutations) (left Mutations, rerr error) {
-	mutationArray := make([]*Mutations, wo.numInstances)
+	mutationArray := make([]*Mutations, ws.numInstances)
 
 	addToMutationArray(mutationArray, m.Set, set)
 	addToMutationArray(mutationArray, m.Del, del)
 
-	replies := make(chan *Payload, wo.numInstances)
-	errors := make(chan error, wo.numInstances)
+	replies := make(chan *Payload, ws.numInstances)
+	errors := make(chan error, ws.numInstances)
 	count := 0
 	for idx, mu := range mutationArray {
 		if mu == nil || (len(mu.Set) == 0 && len(mu.Del) == 0) {

--- a/worker/mutation_test.go
+++ b/worker/mutation_test.go
@@ -35,7 +35,7 @@ func TestAddToMutationArray(t *testing.T) {
 	defer os.RemoveAll(dir)
 	ps := new(store.Store)
 	ps.Init(dir)
-	New(ps, nil, 0, 1)
+	InitState(ps, nil, 0, 1)
 
 	mutationsArray := make([]*Mutations, 1)
 	edges := []x.DirectedEdge{}

--- a/worker/mutation_test.go
+++ b/worker/mutation_test.go
@@ -1,31 +1,43 @@
 /*
- * Copyright 2016 DGraph Labs, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * 		http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+* Copyright 2016 DGraph Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* 		http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
  */
 
 package worker
 
 import (
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/store"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestAddToMutationArray(t *testing.T) {
-	numInstances = 1
-	mutationsArray := make([]*Mutations, numInstances)
+	dir, err := ioutil.TempDir("", "storetest_")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.RemoveAll(dir)
+	ps := new(store.Store)
+	ps.Init(dir)
+	New(ps, nil, 0, 1)
+
+	mutationsArray := make([]*Mutations, 1)
 	edges := []x.DirectedEdge{}
 
 	edges = append(edges, x.DirectedEdge{

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -31,7 +31,7 @@ const (
 )
 
 // writeBatch performs a batch write of key value pairs to RocksDB.
-func (ws *State) writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
+func (ws *state) writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
 	wb := ws.dataStore.NewWriteBatch()
 	batchSize := 0
 	batchWriteNum := 1
@@ -66,7 +66,7 @@ func (ws *State) writeBatch(ctx context.Context, kv chan *task.KV, che chan erro
 
 // PopulateShard gets data for predicate pred from server with id serverId and
 // writes it to RocksDB.
-func (ws *State) PopulateShard(ctx context.Context, pred string,
+func (ws *state) PopulateShard(ctx context.Context, pred string,
 	serverId int) error {
 	var err error
 

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -31,7 +31,7 @@ const (
 )
 
 // writeBatch performs a batch write of key value pairs to RocksDB.
-func (ws *state) writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
+func (ws *State) writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
 	wb := ws.dataStore.NewWriteBatch()
 	batchSize := 0
 	batchWriteNum := 1
@@ -66,7 +66,7 @@ func (ws *state) writeBatch(ctx context.Context, kv chan *task.KV, che chan erro
 
 // PopulateShard gets data for predicate pred from server with id serverId and
 // writes it to RocksDB.
-func (ws *state) PopulateShard(ctx context.Context, pred string,
+func (ws *State) PopulateShard(ctx context.Context, pred string,
 	serverId int) error {
 	var err error
 

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -32,7 +32,7 @@ const (
 
 // writeBatch performs a batch write of key value pairs to RocksDB.
 func writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
-	wb := dataStore.NewWriteBatch()
+	wb := wo.dataStore.NewWriteBatch()
 	batchSize := 0
 	batchWriteNum := 1
 	for i := range kv {
@@ -41,7 +41,7 @@ func writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
 		// We write in batches of size 32MB.
 		if batchSize >= 32*MB {
 			x.Trace(ctx, "Doing batch write %d.", batchWriteNum)
-			if err := dataStore.WriteBatch(wb); err != nil {
+			if err := wo.dataStore.WriteBatch(wb); err != nil {
 				che <- err
 				return
 			}
@@ -58,7 +58,7 @@ func writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
 	// write batch here.
 	if batchSize > 0 {
 		x.Trace(ctx, "Doing batch write %d.", batchWriteNum)
-		che <- dataStore.WriteBatch(wb)
+		che <- wo.dataStore.WriteBatch(wb)
 		return
 	}
 	che <- nil
@@ -69,7 +69,7 @@ func writeBatch(ctx context.Context, kv chan *task.KV, che chan error) {
 func PopulateShard(ctx context.Context, pred string, serverId int) error {
 	var err error
 
-	pool := pools[serverId]
+	pool := wo.pools[serverId]
 	query := new(Payload)
 	query.Data = []byte(pred)
 	if err != nil {

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -67,7 +67,7 @@ func TestPopulateShard(t *testing.T) {
 	}
 
 	w := New(ps, nil, 0, 2)
-	go w.Connect(addrs, ":12345")
+	go Connect(addrs, ":12345")
 
 	dir1, err := ioutil.TempDir("", "store1")
 	if err != nil {
@@ -80,13 +80,13 @@ func TestPopulateShard(t *testing.T) {
 	defer ps1.Close()
 
 	w1 := New(ps1, nil, 1, 2)
-	go w1.Connect(addrs, ":12346")
+	go Connect(addrs, ":12346")
 
 	// Wait for workers to be initialized and connected.
 	time.Sleep(5 * time.Second)
 
 	// Since PredicateData reads from the global variable wo, we change it to w.
-	wo = w
+	ws = w
 	if err := w1.PopulateShard(context.Background(), "test", 0); err != nil {
 		t.Fatal(err)
 	}

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -67,7 +67,7 @@ func TestPopulateShard(t *testing.T) {
 	}
 
 	InitState(ps, nil, 0, 2)
-	w := State()
+	w := ws
 	go Connect(addrs, ":12345")
 
 	dir1, err := ioutil.TempDir("", "store1")
@@ -81,7 +81,7 @@ func TestPopulateShard(t *testing.T) {
 	defer ps1.Close()
 
 	InitState(ps1, nil, 1, 2)
-	w1 := State()
+	w1 := ws
 	go Connect(addrs, ":12346")
 
 	// Wait for workers to be initialized and connected.

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -85,7 +85,8 @@ func TestPopulateShard(t *testing.T) {
 	// Wait for workers to be initialized and connected.
 	time.Sleep(5 * time.Second)
 
-	work = w
+	// Since PredicateData reads from the global variable wo, we change it to w.
+	wo = w
 	if err := w1.PopulateShard(context.Background(), "test", 0); err != nil {
 		t.Fatal(err)
 	}

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -1,0 +1,101 @@
+/*
+* Copyright 2016 DGraph Labs, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*         http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgraph/store"
+)
+
+func checkShard(ps *store.Store) (int, []byte) {
+	it := ps.NewIterator()
+	defer it.Close()
+
+	count := 0
+	var val []byte
+	prefix := []byte("test")
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		count++
+		val = it.Value().Data()
+	}
+	return count, val
+}
+
+func TestPopulateShard(t *testing.T) {
+	var err error
+	addrs := []string{":12345", ":12346"}
+
+	dir, err := ioutil.TempDir("", "store0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ps := new(store.Store)
+	ps.Init(dir)
+	defer ps.Close()
+
+	// Batch writing dummy key value pairs which will be transferred to other
+	// instance.
+	wb := ps.NewWriteBatch()
+	for i := 0; i < 100; i++ {
+		wb.Put([]byte(fmt.Sprintf("test|%d", i)), []byte("test"))
+
+	}
+	if err := ps.WriteBatch(wb); err != nil {
+		log.Fatal(err)
+	}
+
+	w := New(ps, nil, 0, 2)
+	go w.Connect(addrs, ":12345")
+
+	dir1, err := ioutil.TempDir("", "store1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir1)
+
+	ps1 := new(store.Store)
+	ps1.Init(dir1)
+	defer ps1.Close()
+
+	w1 := New(ps1, nil, 1, 2)
+	go w1.Connect(addrs, ":12346")
+
+	// Wait for workers to be initialized and connected.
+	time.Sleep(5 * time.Second)
+
+	work = w
+	if err := w1.PopulateShard(context.Background(), "test", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Getting count on number of keys written to posting list store on instance 1.
+	count, val := checkShard(ps1)
+	if count != 100 {
+		t.Fatalf("Expected %d key value pairs. Got : %d", 100, count)
+	}
+	if string(val) != "test" {
+		t.Fatalf("Expected last value %s. Got : %s", "test", string(val))
+	}
+}

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -66,7 +66,8 @@ func TestPopulateShard(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	w := New(ps, nil, 0, 2)
+	InitState(ps, nil, 0, 2)
+	w := State()
 	go Connect(addrs, ":12345")
 
 	dir1, err := ioutil.TempDir("", "store1")
@@ -79,7 +80,8 @@ func TestPopulateShard(t *testing.T) {
 	ps1.Init(dir1)
 	defer ps1.Close()
 
-	w1 := New(ps1, nil, 1, 2)
+	InitState(ps1, nil, 1, 2)
+	w1 := State()
 	go Connect(addrs, ":12346")
 
 	// Wait for workers to be initialized and connected.

--- a/worker/task.go
+++ b/worker/task.go
@@ -41,18 +41,18 @@ func ProcessTaskOverNetwork(ctx context.Context, qu []byte) (result []byte, rerr
 	q.Init(qu, uo)
 
 	attr := string(q.Attr())
-	idx := farm.Fingerprint64([]byte(attr)) % wo.numInstances
+	idx := farm.Fingerprint64([]byte(attr)) % ws.numInstances
 
 	var runHere bool
 	// Posting list with xid -> uid and uid -> xid mapping is stored on instance 0.
 	if attr == _xid_ || attr == _uid_ {
 		idx = 0
-		runHere = (wo.instanceIdx == 0)
+		runHere = (ws.instanceIdx == 0)
 	} else {
-		runHere = (wo.instanceIdx == idx)
+		runHere = (ws.instanceIdx == idx)
 	}
 	x.Trace(ctx, "runHere: %v attr: %v instanceIdx: %v numInstances: %v",
-		runHere, attr, wo.instanceIdx, wo.numInstances)
+		runHere, attr, ws.instanceIdx, ws.numInstances)
 
 	if runHere {
 		// No need for a network call, as this should be run from within
@@ -61,7 +61,7 @@ func ProcessTaskOverNetwork(ctx context.Context, qu []byte) (result []byte, rerr
 	}
 
 	// Using a worker client for the instance idx, we get the result of the query.
-	pool := wo.pools[idx]
+	pool := ws.pools[idx]
 	addr := pool.Addr
 	query := new(Payload)
 	query.Data = qu
@@ -90,9 +90,9 @@ func processTask(query []byte) (result []byte, rerr error) {
 	q.Init(query, uo)
 
 	attr := string(q.Attr())
-	store := wo.dataStore
+	store := ws.dataStore
 	if attr == _xid_ {
-		store = wo.uidStore
+		store = ws.uidStore
 	}
 
 	b := flatbuffers.NewBuilder(0)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -44,7 +44,6 @@ type Worker struct {
 	pools []*Pool
 }
 
-// wo is a pointer to the Worker object.
 var wo *Worker
 
 // New initializes a worker on an instance with a data and a uid store.
@@ -76,11 +75,9 @@ func NewQuery(attr string, uids []uint64) []byte {
 	return b.Bytes[b.Head():]
 }
 
-type worker struct{}
-
 // Hello rpc call is used to check connection with other workers after worker
 // tcp server for this instance starts.
-func (w *worker) Hello(ctx context.Context, in *Payload) (*Payload, error) {
+func (w *Worker) Hello(ctx context.Context, in *Payload) (*Payload, error) {
 	out := new(Payload)
 	if string(in.Data) == "hello" {
 		out.Data = []byte("Oh hello there!")
@@ -92,13 +89,13 @@ func (w *worker) Hello(ctx context.Context, in *Payload) (*Payload, error) {
 }
 
 // GetOrAssign is used to get uids for a set of xids by communicating with other workers.
-func (w *worker) GetOrAssign(ctx context.Context, query *Payload) (*Payload, error) {
+func (w *Worker) GetOrAssign(ctx context.Context, query *Payload) (*Payload, error) {
 	uo := flatbuffers.GetUOffsetT(query.Data)
 	xids := new(task.XidList)
 	xids.Init(query.Data, uo)
 
-	if wo.instanceIdx != 0 {
-		log.Fatalf("instanceIdx: %v. GetOrAssign. We shouldn't be getting this req", wo.instanceIdx)
+	if w.instanceIdx != 0 {
+		log.Fatalf("instanceIdx: %v. GetOrAssign. We shouldn't be getting this req", w.instanceIdx)
 	}
 
 	reply := new(Payload)
@@ -108,7 +105,7 @@ func (w *worker) GetOrAssign(ctx context.Context, query *Payload) (*Payload, err
 }
 
 // Mutate is used to apply mutations over the network on other instances.
-func (w *worker) Mutate(ctx context.Context, query *Payload) (*Payload, error) {
+func (w *Worker) Mutate(ctx context.Context, query *Payload) (*Payload, error) {
 	m := new(Mutations)
 	if err := m.Decode(query.Data); err != nil {
 		return nil, err
@@ -126,38 +123,38 @@ func (w *worker) Mutate(ctx context.Context, query *Payload) (*Payload, error) {
 }
 
 // ServeTask is used to respond to a query.
-func (w *worker) ServeTask(ctx context.Context, query *Payload) (*Payload, error) {
+func (w *Worker) ServeTask(ctx context.Context, query *Payload) (*Payload, error) {
 	uo := flatbuffers.GetUOffsetT(query.Data)
 	q := new(task.Query)
 	q.Init(query.Data, uo)
 	attr := string(q.Attr())
 	x.Trace(ctx, "Attribute: %v NumUids: %v InstanceIdx: %v ServeTask",
-		attr, q.UidsLength(), wo.instanceIdx)
+		attr, q.UidsLength(), w.instanceIdx)
 
 	reply := new(Payload)
 	var rerr error
 	// Request for xid <-> uid conversion should be handled by instance 0 and all
 	// other requests should be handled according to modulo sharding of the predicate.
-	if (wo.instanceIdx == 0 && attr == _xid_) ||
-		farm.Fingerprint64([]byte(attr))%wo.numInstances == wo.instanceIdx {
+	if (w.instanceIdx == 0 && attr == _xid_) ||
+		farm.Fingerprint64([]byte(attr))%w.numInstances == w.instanceIdx {
 
 		reply.Data, rerr = processTask(query.Data)
 
 	} else {
-		log.Fatalf("attr: %v instanceIdx: %v Request sent to wrong server.", attr, wo.instanceIdx)
+		log.Fatalf("attr: %v instanceIdx: %v Request sent to wrong server.", attr, w.instanceIdx)
 	}
 	return reply, rerr
 }
 
 // PredicateData can be used to return data corresponding to a predicate over
 // a stream.
-func (w *worker) PredicateData(query *Payload, stream Worker_PredicateDataServer) error {
+func (w *Worker) PredicateData(query *Payload, stream Worker_PredicateDataServer) error {
 	qp := query.Data
 	prefix := append(qp, '|')
 	// TODO(pawan) - Shift to CheckPoints once we figure out how to add them to the
 	// RocksDB library we are using.
 	// http://rocksdb.org/blog/2609/use-checkpoints-for-efficient-snapshots/
-	it := wo.dataStore.NewIterator()
+	it := w.dataStore.NewIterator()
 	defer it.Close()
 
 	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
@@ -196,7 +193,7 @@ func runServer(port string) {
 	log.Printf("Worker listening at address: %v", ln.Addr())
 
 	s := grpc.NewServer(grpc.CustomCodec(&PayloadCodec{}))
-	RegisterWorkerServer(s, &worker{})
+	RegisterWorkerServer(s, wo)
 	s.Serve(ln)
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -33,8 +33,8 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-// State stores the worker state.
-type State struct {
+// state stores the worker state.
+type state struct {
 	dataStore    *store.Store
 	uidStore     *store.Store
 	instanceIdx  uint64
@@ -45,16 +45,20 @@ type State struct {
 }
 
 // Stores the worker state.
-var ws *State
+var ws *state
 
-// New initializes a worker on an instance with a data and a uid store.
-func New(ps, uStore *store.Store, idx, numInst uint64) *State {
-	ws = &State{
+// InitState initializes the state on an instance with data,uid store and other meta.
+func InitState(ps, uStore *store.Store, idx, numInst uint64) {
+	ws = &state{
 		dataStore:    ps,
 		uidStore:     uStore,
 		instanceIdx:  idx,
 		numInstances: numInst,
 	}
+}
+
+// State returns the worker state.
+func State() *state {
 	return ws
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -33,8 +33,8 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-// state stores the worker state.
-type state struct {
+// State stores the worker state.
+type State struct {
 	dataStore    *store.Store
 	uidStore     *store.Store
 	instanceIdx  uint64
@@ -45,21 +45,16 @@ type state struct {
 }
 
 // Stores the worker state.
-var ws *state
+var ws *State
 
 // InitState initializes the state on an instance with data,uid store and other meta.
 func InitState(ps, uStore *store.Store, idx, numInst uint64) {
-	ws = &state{
+	ws = &State{
 		dataStore:    ps,
 		uidStore:     uStore,
 		instanceIdx:  idx,
 		numInstances: numInst,
 	}
-}
-
-// State returns the worker state.
-func State() *state {
-	return ws
 }
 
 // NewQuery creates a Query flatbuffer table, serializes and returns it.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -34,7 +34,7 @@ import (
 )
 
 // state stores the worker state.
-type state struct {
+type State struct {
 	dataStore    *store.Store
 	uidStore     *store.Store
 	instanceIdx  uint64
@@ -45,11 +45,11 @@ type state struct {
 }
 
 // Stores the worker state.
-var ws *state
+var ws *State
 
 // New initializes a worker on an instance with a data and a uid store.
-func New(ps, uStore *store.Store, idx, numInst uint64) *state {
-	ws = &state{
+func New(ps, uStore *store.Store, idx, numInst uint64) *State {
+	ws = &State{
 		dataStore:    ps,
 		uidStore:     uStore,
 		instanceIdx:  idx,

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -33,7 +33,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-// state stores the worker state.
+// State stores the worker state.
 type State struct {
 	dataStore    *store.Store
 	uidStore     *store.Store

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"net"
 
-	"context"
+	"golang.org/x/net/context"
 
 	"github.com/dgryski/go-farm"
 	"github.com/google/flatbuffers/go"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -22,9 +22,10 @@ import (
 	"log"
 	"net"
 
+	"context"
+
 	"github.com/dgryski/go-farm"
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/dgraph/store"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -76,7 +76,7 @@ func TestProcessTask(t *testing.T) {
 	defer clog.Close()
 
 	posting.Init(clog)
-	New(ps, nil, 0, 1)
+	InitState(ps, nil, 0, 1)
 
 	edge := x.DirectedEdge{
 		ValueId:   23,

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -24,8 +24,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/posting"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -60,8 +60,6 @@ func check(r *task.Result, idx int, expected []uint64) error {
 }
 
 func TestProcessTask(t *testing.T) {
-	// logrus.SetLevel(logrus.DebugLevel)
-
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
 		t.Error(err)
@@ -77,7 +75,7 @@ func TestProcessTask(t *testing.T) {
 	defer clog.Close()
 
 	posting.Init(clog)
-	Init(ps, nil, 0, 1)
+	New(ps, nil, 0, 1)
 
 	edge := x.DirectedEdge{
 		ValueId:   23,

--- a/x/x.go
+++ b/x/x.go
@@ -23,9 +23,10 @@ import (
 	"net/http"
 	"time"
 
+	"context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/google/flatbuffers/go"
-	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
 	"github.com/dgraph-io/dgraph/task"


### PR DESCRIPTION
I have written tests for PopulateShard method. To do so I had to encapsulate some of the globals in the worker package. If it seems an overkill we can drop this though this seemed the only way to write tests for this feature.

Have also replaced `golang.org/x/net/context` with `context` except in `dgraph/main.go` and `worker\worker.go`. We can move to `context` package in these files after gogoprotobuf generates `.pb.go` files which import `context` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/180)
<!-- Reviewable:end -->
