### PR TITLE
Sync gotomic to the latest

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -85,10 +85,10 @@
 			"revisionTime": "2015-11-24T22:32:07Z"
 		},
 		{
-			"checksumSHA1": "0JL5ZeTzdHwXRYojBJHC06AnnBs=",
+			"checksumSHA1": "AbkwwrwLoURg4xUx9/iPtadihK8=",
 			"path": "github.com/zond/gotomic",
-			"revision": "25c7c0a9f89b58b13a08c2bb531363fa117159c2",
-			"revisionTime": "2016-06-26T07:37:22Z"
+			"revision": "0c6a291dd38de4e9543d10733ff4b1ad7bdecadd",
+			"revisionTime": "2016-08-30T06:32:58Z"
 		},
 		{
 			"checksumSHA1": "9jjO5GjLa0XF/nfWihF02RoH4qc=",


### PR DESCRIPTION
Get rid of race detector errors in package query and cmd/dgraph and cmd/dgraphloader.

However, there are still race detector errors in package commit and worker. The latter is new I believe and due to a recent change around this line:
InitState(ps1, nil, 1, 2)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/192)
<!-- Reviewable:end -->
