### PR TITLE
Fix bugs in Posting List. Improve test coverage.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -113,7 +113,9 @@ func samePosting(a *types.Posting, b *types.Posting) bool {
 // key = (entity uid, attribute)
 func Key(uid uint64, attr string) []byte {
 	buf := bytes.NewBufferString(attr)
-	buf.WriteRune('|')
+	if _, err := buf.WriteRune('|'); err != nil {
+		log.Fatalf("Error while writing |")
+	}
 	if err := binary.Write(buf, binary.LittleEndian, uid); err != nil {
 		log.Fatalf("Error while creating key with attr: %v uid: %v\n", attr, uid)
 	}

--- a/posting/list.go
+++ b/posting/list.go
@@ -430,7 +430,19 @@ func (l *List) mergeMutation(mp *types.Posting) {
 
 		} else { // curUid not found in mindex.
 
-			if inPlist { // In plist, so insert in mindex.
+			// If present in mlayer, and matches with what we have, remove from it.
+			if tp, ok := l.mlayer[pi]; ok {
+				if !samePosting(&tp, mp) {
+					return
+				}
+				delete(l.mlayer, pi)
+
+				mlink.moveidx = 1
+				l.mdelta--
+				mlink.idx = pi + mi + 1
+				l.mindexInsertAt(mlink, mi+1)
+
+			} else if inPlist { // In plist, so insert in mindex.
 				plist := l.getPostingList()
 				var tp types.Posting
 				if ok := plist.Postings(&tp, pi); ok {

--- a/posting/list.go
+++ b/posting/list.go
@@ -330,14 +330,14 @@ func (l *List) mindexInsertAt(mlink *MutationLink, mi int) {
 	copy(l.mindex[mi+1:], l.mindex[mi:])
 	l.mindex[mi] = mlink
 	for i := mi + 1; i < len(l.mindex); i++ {
-		l.mindex[i].idx += 1
+		l.mindex[i].idx++
 	}
 }
 
 func (l *List) mindexDeleteAt(mi int) {
 	l.mindex = append(l.mindex[:mi], l.mindex[mi+1:]...)
 	for i := mi; i < len(l.mindex); i++ {
-		l.mindex[i].idx -= 1
+		l.mindex[i].idx--
 	}
 }
 
@@ -422,7 +422,7 @@ func (l *List) mergeMutation(mp *types.Posting) {
 				l.mindex[mi] = mlink
 
 			} else { // Not in plist, so delete previous instruction in mindex.
-				l.mdelta -= 1
+				l.mdelta--
 				l.mindexDeleteAt(mi)
 			}
 
@@ -439,7 +439,7 @@ func (l *List) mergeMutation(mp *types.Posting) {
 				}
 
 				mlink.moveidx = 1
-				l.mdelta -= 1
+				l.mdelta--
 				mlink.idx = pi + mi + 1
 				l.mindexInsertAt(mlink, mi+1)
 
@@ -453,7 +453,7 @@ func (l *List) mergeMutation(mp *types.Posting) {
 			if inPlist { // In plist, so delete previous instruction, set in mlayer.
 				l.mindexDeleteAt(mi)
 				l.mlayer[pi] = *mp
-				l.mdelta += 1
+				l.mdelta++
 
 			} else { // Not in plist, so replace previous set instruction in mindex.
 				// NOTE: This prev instruction couldn't have been a Del instruction.
@@ -482,7 +482,7 @@ func (l *List) mergeMutation(mp *types.Posting) {
 
 			} else { // not in plist, not in mindex, so insert in mindex.
 				mlink.moveidx = -1
-				l.mdelta += 1
+				l.mdelta++
 				mlink.idx = pi + 1 + mi + 1 // right of pi, and right of mi.
 				l.mindexInsertAt(mlink, mi+1)
 			}

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -148,7 +148,7 @@ func gentlyMerge(mr *mergeRoutines) {
 	idx := 0
 	dirtymap.Each(func(k gotomic.Hashable, v gotomic.Thing) bool {
 		if idx < start {
-			idx += 1
+			idx++
 			return false
 		}
 


### PR DESCRIPTION
Check if the `Posting` being deleted is the same as the one stored. Previously, this was being done purely based on `UID`, the value wasn't being checked.

Delete `Posting` from replace layer if present, if the same `Posting` exists in the committed version.

Have a complete test coverage for `mergeMutation` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/197)
<!-- Reviewable:end -->
