### PR TITLE
Fix/worker race

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -547,8 +547,10 @@ func main() {
 	}
 
 	posting.Init()
+	var ws *worker.State
 	if *instanceIdx != 0 {
-		worker.InitState(ps, nil, *instanceIdx, lenAddr)
+		ws = worker.NewState(ps, nil, *instanceIdx, lenAddr)
+		worker.SetWorkerState(ws)
 		uid.Init(nil)
 	} else {
 		uidStore, err := store.NewStore(*uidDir)
@@ -557,7 +559,8 @@ func main() {
 		}
 		defer uidStore.Close()
 		// Only server instance 0 will have uidStore
-		worker.InitState(ps, uidStore, *instanceIdx, lenAddr)
+		ws = worker.NewState(ps, uidStore, *instanceIdx, lenAddr)
+		worker.SetWorkerState(ws)
 		uid.Init(uidStore)
 	}
 
@@ -568,7 +571,7 @@ func main() {
 		}
 	}
 	// Initiate internal worker communication.
-	worker.Connect(addrs, *workerPort)
+	ws.Connect(addrs, *workerPort)
 
 	// Setup external communication.
 	setupServer()

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -64,7 +64,7 @@ func prepare() (dir1, dir2 string, ps *store.Store, rerr error) {
 	}
 
 	posting.Init()
-	worker.InitState(ps, nil, 0, 1)
+	worker.SetWorkerState(worker.NewState(ps, nil, 0, 1))
 	uid.Init(ps)
 	loader.Init(ps, ps)
 	posting.InitIndex(ps)

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -108,7 +108,7 @@ func TestNewGraph(t *testing.T) {
 		t.Error(err)
 	}
 
-	worker.InitState(ps, nil, 0, 1)
+	worker.SetWorkerState(worker.NewState(ps, nil, 0, 1))
 
 	r := x.NewTaskResult(sg.Result)
 	if r.UidmatrixLength() != 1 {
@@ -140,7 +140,7 @@ func populateGraph(t *testing.T) (string, *store.Store) {
 		return "", nil
 	}
 
-	worker.InitState(ps, nil, 0, 1)
+	worker.SetWorkerState(worker.NewState(ps, nil, 0, 1))
 
 	clog := commit.NewLogger(dir, "mutations", 50<<20)
 	clog.Init()

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -17,11 +17,10 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
-
-	"context"
 
 	"github.com/google/flatbuffers/go"
 

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -121,7 +121,7 @@ func GetOrAssignUidsOverNetwork(ctx context.Context, xidToUid map[string]uint64)
 
 	} else {
 		// Get pool for worker on instance 0.
-		pool := ws.pools[0]
+		pool := ws.GetPool(0)
 		conn, err := pool.Get()
 		if err != nil {
 			x.Trace(ctx, "Error while retrieving connection: %v", err)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -117,7 +117,7 @@ func runMutate(ctx context.Context, idx int, m *Mutations,
 	}
 
 	// Get a connection from the pool and run mutations over the network.
-	pool := ws.pools[idx]
+	pool := ws.GetPool(idx)
 	query := new(Payload)
 	query.Data, err = m.Encode()
 	if err != nil {

--- a/worker/mutation_test.go
+++ b/worker/mutation_test.go
@@ -38,7 +38,7 @@ func TestAddToMutationArray(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	InitState(ps, nil, 0, 1)
+	SetWorkerState(NewState(ps, nil, 0, 1))
 
 	mutationsArray := make([]*Mutations, 1)
 	edges := []x.DirectedEdge{}

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -70,7 +70,7 @@ func (ws *State) PopulateShard(ctx context.Context, pred string,
 	serverId int) error {
 	var err error
 
-	pool := ws.pools[serverId]
+	pool := ws.GetPool(serverId)
 	query := new(Payload)
 	query.Data = []byte(pred)
 	if err != nil {

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -68,9 +68,9 @@ func TestPopulateShard(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	InitState(ps, nil, 0, 2)
-	w := ws
-	go Connect(addrs, ":12345")
+	w := NewState(ps, nil, 0, 2)
+	SetWorkerState(w)
+	go w.Connect(addrs, ":12345")
 
 	dir1, err := ioutil.TempDir("", "store1")
 	if err != nil {
@@ -84,15 +84,15 @@ func TestPopulateShard(t *testing.T) {
 	}
 	defer ps1.Close()
 
-	InitState(ps1, nil, 1, 2)
-	w1 := ws
-	go Connect(addrs, ":12346")
+	w1 := NewState(ps1, nil, 1, 2)
+	SetWorkerState(w1)
+	go w1.Connect(addrs, ":12346")
 
 	// Wait for workers to be initialized and connected.
 	time.Sleep(5 * time.Second)
 
 	// Since PredicateData reads from the global variable wo, we change it to w.
-	ws = w
+	SetWorkerState(w)
 	if err := w1.PopulateShard(context.Background(), "test", 0); err != nil {
 		t.Fatal(err)
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -57,7 +57,7 @@ func ProcessTaskOverNetwork(ctx context.Context, qu []byte) (result []byte, rerr
 	}
 
 	// Using a worker client for the instance idx, we get the result of the query.
-	pool := ws.pools[idx]
+	pool := ws.GetPool(int(idx))
 	addr := pool.Addr
 	query := new(Payload)
 	query.Data = qu

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -21,6 +21,7 @@ package worker
 import (
 	"log"
 	"net"
+	"sync"
 
 	"golang.org/x/net/context"
 
@@ -41,7 +42,8 @@ type State struct {
 	numInstances uint64
 	// pools stores the pool for all the instances which is then used to send queries
 	// and mutations to the appropriate instance.
-	pools []*Pool
+	pools      []*Pool
+	poolsMutex sync.RWMutex
 }
 
 // Stores the worker state.

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -259,7 +259,7 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 
 	// Try deleting.
 	edge = x.DirectedEdge{
-		Value:     []byte("ignored"),
+		Value:     []byte("photon"),
 		Source:    "author0",
 		Timestamp: time.Now(),
 		Attribute: "friend",
@@ -269,9 +269,11 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
 
-	// Set followed by delete.
+	// Delete followed by set.
 	edge.Entity = 12
+	edge.Value = []byte("notphoton")
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	edge.Value = []byte("ignored")
 	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 
@@ -409,7 +411,7 @@ func TestProcessTaskIndex(t *testing.T) {
 
 	// Try deleting.
 	edge = x.DirectedEdge{
-		Value:     []byte("ignored"),
+		Value:     []byte("photon"),
 		Source:    "author0",
 		Timestamp: time.Now(),
 		Attribute: "friend",
@@ -419,9 +421,11 @@ func TestProcessTaskIndex(t *testing.T) {
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
 
-	// Set followed by delete.
+	// Delete followed by set.
 	edge.Entity = 12
+	edge.Value = []byte("notphoton")
 	delEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	edge.Value = []byte("ignored")
 	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -117,7 +117,7 @@ func TestProcessTask(t *testing.T) {
 	}
 	defer ps.Close()
 
-	InitState(ps, nil, 0, 1)
+	SetWorkerState(NewState(ps, nil, 0, 1))
 
 	posting.Init()
 	posting.InitIndex(ps)
@@ -195,7 +195,7 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 	defer clog.Close()
 
 	posting.Init()
-	InitState(ps, nil, 0, 1)
+	SetWorkerState(NewState(ps, nil, 0, 1))
 
 	posting.InitIndex(ps)
 
@@ -343,7 +343,7 @@ func TestProcessTaskIndex(t *testing.T) {
 	posting.InitIndex(ps)
 
 	posting.Init()
-	InitState(ps, nil, 0, 1)
+	SetWorkerState(NewState(ps, nil, 0, 1))
 
 	populateGraph(t, ps)
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.


### PR DESCRIPTION
1) Previously, there are race conditions around the array "pools" in worker.State. I added a "harmless looking" lock around it.
2) Not good to build too much logic around globals, in this case "ws". We let "Connect" become a class method for easier testing.
3) Not good to use ws as a global and also as a "self" variable. We don't want any variable shadowing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/207)
<!-- Reviewable:end -->
