### PR TITLE
Feature/travis multiple

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,39 @@
 language: go
 go:
-  - 1.7
+- 1.7
 dist: trusty
 sudo: required
 notifications:
   email:
     recipients:
-      - minions@dgraph.io
+    - minions@dgraph.io
 addons:
+  artifacts:
+    paths:
+    - $HOME/gopath/src/github.com/dgraph-io/dgraph/cmd/dgraph
+    - cmd/dgraph
+    debug: true
   apt:
     sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.8
+    - ubuntu-toolchain-r-test
+    - llvm-toolchain-precise-3.8
     packages:
-      - clang-3.8
-      - libbz2-dev
-      - libsnappy-dev
-      - zlib1g-dev
-      - jq
-    artifacts:
-        paths:
-            - $HOME/gopath/src/github.com/dgraph-io/dgraph/cmd/dgraph
-        debug: true
+    - clang-3.8
+    - libbz2-dev
+    - libsnappy-dev
+    - zlib1g-dev
+    - jq
 env:
-  - CC=clang-3.8 CXX=clang++-3.8
+- CC=clang-3.8 CXX=clang++-3.8
 cache:
   apt: true
   directories:
-    - $HOME/build
+  - "$HOME/build"
 install:
-  # Passing the directory in which RocksDB is to be installed as an argument
-  # to the bash script.
-  - bash contrib/build-rocksdb.sh $HOME/build
+- bash contrib/build-rocksdb.sh $HOME/build
 before_script:
-  - go get github.com/mattn/goveralls
+- go get github.com/mattn/goveralls
 script:
-  - bash contrib/cover.sh $HOME/build coverage.out
-  - bash contrib/load-test.sh $HOME/build
-  - goveralls -service=travis-ci -coverprofile=coverage.out
+- bash contrib/cover.sh $HOME/build coverage.out
+- bash contrib/load-test.sh $HOME/build
+- goveralls -service=travis-ci -coverprofile=coverage.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ notifications:
     recipients:
     - minions@dgraph.io
 addons:
+  # Uploading Dgraph binary, CPU and memory profiles.
   artifacts:
     paths:
     - cmd/dgraph/dgraph
     - cmd/dgraph/dmem.prof
     - cmd/dgraph/dcpu.prof
-    debug: true
   apt:
     sources:
     - ubuntu-toolchain-r-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,10 @@ addons:
       - libsnappy-dev
       - zlib1g-dev
       - jq
+    artifacts:
+        paths:
+            - $HOME/gopath/src/github.com/dgraph-io/dgraph/cmd/dgraph
+        debug: true
 env:
   - CC=clang-3.8 CXX=clang++-3.8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,9 @@ notifications:
 addons:
   artifacts:
     paths:
-    - $HOME/gopath/src/github.com/dgraph-io/dgraph/cmd/dgraph
-    - cmd/dgraph
+    - cmd/dgraph/dgraph
+    - cmd/dgraph/dmem.prof
+    - cmd/dgraph/dcpu.prof
     debug: true
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ addons:
   # Uploading Dgraph binary, CPU and memory profiles.
   artifacts:
     paths:
-    - cmd/dgraph/dgraph
-    - cmd/dgraph/dmem.prof
-    - cmd/dgraph/dcpu.prof
+    - cmd/dgraph
   apt:
     sources:
     - ubuntu-toolchain-r-test

--- a/contrib/assign.sh
+++ b/contrib/assign.sh
@@ -38,5 +38,12 @@ export LD_LIBRARY_PATH="${ROCKSDBDIR}:${LD_LIBRARY_PATH}"
 
 pushd cmd/dgraphassigner &> /dev/null
 go build .
-./dgraphassigner --numInstances 1 --instanceIdx 0 --rdfgzips $benchmark/actor-director.gz --uids ~/dgraph/u --stw_ram_mb 3000
+i=0; ./dgraphassigner --numInstances 2 --instanceIdx $i --rdfgzips $benchmark/actor-director.gz --uids ~/dgraph/uids/u$i --stw_ram_mb 3000
+i=1; ./dgraphassigner --numInstances 2 --instanceIdx $i --rdfgzips $benchmark/actor-director.gz --uids ~/dgraph/uids/u$i --stw_ram_mb 3000
 popd &> /dev/null
+
+pushd cmd/dgraphmerge &> /dev/null
+go build .
+./dgraphmerge --stores ~/dgraph/uids --dest ~/dgraph/u
+popd &> /dev/null
+

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -7,9 +7,9 @@ bash contrib/simple-e2e.sh $1
 
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
-if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
-  bash contrib/assign.sh $1
-  bash contrib/loader.sh $1
+#if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
+#  bash contrib/assign.sh $1
+#  bash contrib/loader.sh $1
   bash contrib/queries.sh $1
-fi
+#fi
 

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -8,8 +8,8 @@ bash contrib/simple-e2e.sh $1
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
 # if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
-#  bash contrib/assign.sh $1
-# bash contrib/loader.sh $1
+  bash contrib/assign.sh $1
+  bash contrib/loader.sh $1
   bash contrib/queries.sh $1
 # fi
 

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -7,9 +7,9 @@ bash contrib/simple-e2e.sh $1
 
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
-if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
+# if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
   bash contrib/assign.sh $1
   bash contrib/loader.sh $1
   bash contrib/queries.sh $1
-fi
+# fi
 

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -7,9 +7,9 @@ bash contrib/simple-e2e.sh $1
 
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
-#if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
-#  bash contrib/assign.sh $1
-#  bash contrib/loader.sh $1
+if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
+  bash contrib/assign.sh $1
+  bash contrib/loader.sh $1
   bash contrib/queries.sh $1
-#fi
+fi
 

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -7,9 +7,9 @@ bash contrib/simple-e2e.sh $1
 
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
-# if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
+if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
   bash contrib/assign.sh $1
   bash contrib/loader.sh $1
   bash contrib/queries.sh $1
-# fi
+fi
 

--- a/contrib/load-test.sh
+++ b/contrib/load-test.sh
@@ -8,8 +8,8 @@ bash contrib/simple-e2e.sh $1
 # We run the assigner and the loader only when a commit is made on master/release
 # branches.
 # if [[ $TRAVIS_BRANCH =~ master|release\/ ]] && [ $TRAVIS_EVENT_TYPE = "push" ] ; then
-  bash contrib/assign.sh $1
-  bash contrib/loader.sh $1
+#  bash contrib/assign.sh $1
+# bash contrib/loader.sh $1
   bash contrib/queries.sh $1
 # fi
 

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -23,5 +23,5 @@ export LD_LIBRARY_PATH="${ROCKSDBDIR}:${LD_LIBRARY_PATH}"
 
 pushd cmd/dgraphloader &> /dev/null
 go build .
-./dgraphloader --numInstances 1 --instanceIdx 0 --rdfgzips $benchmark/actor-director.gz --uids ~/dgraph/u --postings ~/dgraph/p --stw_ram_mb 3000
+./dgraphloader --numInstances 1 --instanceIdx 0 --rdfgzips $benchmark/actor-director.gz --uids ~/dgraph/u --postings ~/dgraph/p --stw_ram_mb 3000 --numCpu 1
 popd &> /dev/null

--- a/contrib/queries.sh
+++ b/contrib/queries.sh
@@ -27,7 +27,5 @@ go build . && ./throughputtest --numsec 30 --ip "http://127.0.0.1:8080/query"  -
 popd &> /dev/null
 # shutdown Dgraph server.
 curl 127.0.0.1:8080/query -XPOST -d 'SHUTDOWN'
-# TODO - Have a way to upload cpu and memory profiles after adding the functionality
-# to stop the server from the client.
 
 popd &>/dev/null

--- a/contrib/queries.sh
+++ b/contrib/queries.sh
@@ -20,7 +20,7 @@ export LD_LIBRARY_PATH="${ROCKSDBDIR}:${LD_LIBRARY_PATH}"
 pushd cmd/dgraph &> /dev/null
 go build .
 # Start dgraph in the background.
-./dgraph --mutations ~/dgraph/m --postings ~/dgraph/p --uids ~/dgraph/u --memprof dmem.prof --cpuprof dcpu.prof --shutdown true &
+./dgraph --mutations ~/dgraph/m --postings ~/dgraph/p --uids ~/dgraph/u --memprof dmem-"$TRAVIS_COMMIT".prof --cpuprof dcpu-"$TRAVIS_COMMIT".prof --shutdown true &
 
 pushd $BUILD/benchmarks/throughputtest &> /dev/null
 go build . && ./throughputtest --numsec 30 --ip "http://127.0.0.1:8080/query"  --numuser 1000

--- a/contrib/queries.sh
+++ b/contrib/queries.sh
@@ -20,13 +20,13 @@ export LD_LIBRARY_PATH="${ROCKSDBDIR}:${LD_LIBRARY_PATH}"
 pushd cmd/dgraph &> /dev/null
 go build .
 # Start dgraph in the background.
-./dgraph --mutations ~/dgraph/m --postings ~/dgraph/p --uids ~/dgraph/u &
+./dgraph --mutations ~/dgraph/m --postings ~/dgraph/p --uids ~/dgraph/u --memprof dmem.prof --cpuprof dcpu.prof --shutdown true &
 
 pushd $BUILD/benchmarks/throughputtest &> /dev/null
 go build . && ./throughputtest --numsec 30 --ip "http://127.0.0.1:8080/query"  --numuser 1000
 popd &> /dev/null
-
-killall dgraph
+# shutdown Dgraph server.
+curl 127.0.0.1:8080/query -XPOST -d 'SHUTDOWN'
 # TODO - Have a way to upload cpu and memory profiles after adding the functionality
 # to stop the server from the client.
 


### PR DESCRIPTION
After this change

1. Travis will boot up 2 instances of `dgraphassigner` to assign uids and then run `dgraphmerge`.
2. After the throughput test, the memory and cpu profiles along with the binary would be uploaded to s3 as part of `travis-profiles` bucket.
3. dgraphloader is now run with `numCpu` = 1 to avoid the loader getting killed and the build erroring out.

We are very close to the maximum time of 50 mins though(most builds on master now take more than 45 mins). So we should perhaps investigate loading a smaller dataset.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/208)
<!-- Reviewable:end -->
