### PR TITLE
Feature/loader

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -112,6 +112,7 @@ func main() {
 			glog.WithError(err).Fatal("Unable to create gzip reader.")
 		}
 
+		// Load NQuads and write them to internal storage.
 		count, err := loader.LoadEdges(r, *instanceIdx, *numInstances)
 		if err != nil {
 			glog.WithError(err).Fatal("While handling rdf reader.")

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -105,7 +105,7 @@ func (s *state) printCounters(ticker *time.Ticker) {
 	}
 }
 
-// readLines reads the file and pushes them onto a channel.
+// readLines reads the file and pushes the nquads onto a channel.
 // Run this in a single goroutine. This function closes s.input channel.
 func (s *state) readLines(r io.Reader) {
 	var buf []string

--- a/posting/list.go
+++ b/posting/list.go
@@ -639,9 +639,8 @@ func (l *List) MergeIfDirty(ctx context.Context) (merged bool, err error) {
 	if atomic.LoadInt64(&l.dirtyTs) == 0 {
 		x.Trace(ctx, "Not committing")
 		return false, nil
-	} else {
-		x.Trace(ctx, "Committing")
 	}
+	x.Trace(ctx, "Committing")
 	return l.merge()
 }
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -108,7 +108,7 @@ func samePosting(a *types.Posting, b *types.Posting) bool {
 	return true
 }
 
-// key = (entity uid, attribute)
+// key = attribute|uid
 func Key(uid uint64, attr string) []byte {
 	buf := bytes.NewBufferString(attr)
 	if _, err := buf.WriteRune('|'); err != nil {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -113,8 +113,6 @@ func aggressivelyEvict() {
 	log.Println("Calling merge on all lists.")
 	MergeLists(100 * runtime.GOMAXPROCS(-1))
 
-	log.Println("Merged lists. Calling GC.")
-	runtime.GC() // Call GC to do some cleanup.
 	log.Println("Trying to free OS memory")
 	debug.FreeOSMemory()
 

--- a/uid/assigner.go
+++ b/uid/assigner.go
@@ -250,28 +250,3 @@ func GetOrAssign(xid string, instanceIdx uint64,
 	return 0, errors.New("Some unhandled route lead me here." +
 		" Wake the stupid developer up.")
 }
-
-// ExternalId returns the xid of a given uid by reading from the uidstore.
-// It returns an error if there is no corresponding xid.
-func ExternalId(uid uint64) (xid string, rerr error) {
-	key := posting.Key(uid, "_xid_") // uid -> "_xid_" -> xid
-	pl := posting.GetOrCreate(key, uidStore)
-	if pl.Length() == 0 {
-		return "", errors.New("NO external id")
-	}
-
-	if pl.Length() > 1 {
-		log.Fatalf("This shouldn't be happening. Uid: %v", uid)
-		return "", errors.New("Multiple external ids for this uid.")
-	}
-
-	var p types.Posting
-	if ok := pl.Get(&p, 0); !ok {
-		return "", errors.New("While retrieving posting")
-	}
-
-	if p.Uid() != math.MaxUint64 {
-		log.Fatalf("Value uid must be MaxUint64. Uid: %v", p.Uid())
-	}
-	return string(p.ValueBytes()), rerr
-}


### PR DESCRIPTION
Minor improvements in loader. On 2 runs of names.gz the time reduced from 8:30 mins to 8 mins.

1. We avoid temporary memory allocations in `gentlyMerge`.
2. We avoid calling `runtime.GC()` as `debug.FreeOSMemory` already calls GC.