### PR TITLE
Use sync.Pool for reclaiming unused posting.List

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -193,9 +193,9 @@ func (s *state) handleNQuads(wg *sync.WaitGroup) {
 
 		key := posting.Key(edge.Entity, edge.Attribute)
 
-		plist := posting.GetOrCreate(key, dataStore)
+		plist, decr := posting.GetOrCreate(key, dataStore)
 		plist.AddMutationWithIndex(ctx, edge, posting.Set)
-		plist.Decr() // Don't defer, just call because we're in a channel loop.
+		decr() // Don't defer, just call because we're in a channel loop.
 
 		atomic.AddUint64(&s.ctr.processed, 1)
 	}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -192,8 +192,11 @@ func (s *state) handleNQuads(wg *sync.WaitGroup) {
 		}
 
 		key := posting.Key(edge.Entity, edge.Attribute)
+
 		plist := posting.GetOrCreate(key, dataStore)
 		plist.AddMutationWithIndex(ctx, edge, posting.Set)
+		plist.Decr() // Don't defer, just call because we're in a channel loop.
+
 		atomic.AddUint64(&s.ctr.processed, 1)
 	}
 }

--- a/posting/index.go
+++ b/posting/index.go
@@ -112,8 +112,8 @@ func processIndexTerm(attr string, uid uint64, term []byte, del bool) {
 		Attribute: attr,
 	}
 	key := IndexKey(edge.Attribute, term)
-	plist := GetOrCreate(key, indexStore)
-	defer plist.Decr()
+	plist, decr := GetOrCreate(key, indexStore)
+	defer decr()
 	x.Assertf(plist != nil, "plist is nil [%s] %d %s", key, edge.ValueId, edge.Attribute)
 
 	ctx := context.Background()

--- a/posting/index.go
+++ b/posting/index.go
@@ -113,6 +113,7 @@ func processIndexTerm(attr string, uid uint64, term []byte, del bool) {
 	}
 	key := IndexKey(edge.Attribute, term)
 	plist := GetOrCreate(key, indexStore)
+	defer plist.Decr()
 	x.Assertf(plist != nil, "plist is nil [%s] %d %s", key, edge.ValueId, edge.Attribute)
 
 	ctx := context.Background()

--- a/posting/index.go
+++ b/posting/index.go
@@ -59,7 +59,7 @@ func init() {
 	indexLog = trace.NewEventLog("index", "Logger")
 	x.AddInit(func() {
 		if indexConfigFile == nil || len(*indexConfigFile) == 0 {
-			indexLog.Printf("No valid config file", *indexConfigFile)
+			indexLog.Printf("No valid config file: %v", *indexConfigFile)
 			return
 		}
 		f, err := ioutil.ReadFile(*indexConfigFile)

--- a/posting/list.go
+++ b/posting/list.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/dgryski/go-farm"
 	"github.com/google/flatbuffers/go"
-	"github.com/pkg/errors"
 	"github.com/zond/gotomic"
 
 	"github.com/dgraph-io/dgraph/posting/types"
@@ -75,22 +74,14 @@ type List struct {
 	dirtyTs int64 // Use atomics for this.
 }
 
-func (l *List) refCount() int32 {
-	return atomic.LoadInt32(&l.refcount)
-}
-
-func (l *List) incr() int32 {
-	return atomic.AddInt32(&l.refcount, 1)
-}
+func (l *List) refCount() int32 { return atomic.LoadInt32(&l.refcount) }
+func (l *List) incr() int32     { return atomic.AddInt32(&l.refcount, 1) }
 func (l *List) decr() {
 	val := atomic.AddInt32(&l.refcount, -1)
 	if val > 0 {
 		return
 	}
-	if val < 0 {
-		err := errors.Errorf("List reference should never be less than zero: %v", val)
-		log.Fatalf("%+v", err)
-	}
+	x.Assertf(val < 0, "List reference should never be less than zero:")
 	listPool.Put(l)
 }
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -78,10 +78,10 @@ func (l *List) refCount() int32 { return atomic.LoadInt32(&l.refcount) }
 func (l *List) incr() int32     { return atomic.AddInt32(&l.refcount, 1) }
 func (l *List) decr() {
 	val := atomic.AddInt32(&l.refcount, -1)
+	x.Assertf(val >= 0, "List reference should never be less than zero: %v", val)
 	if val > 0 {
 		return
 	}
-	x.Assertf(val < 0, "List reference should never be less than zero:")
 	listPool.Put(l)
 }
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -107,7 +107,7 @@ func checkUids(t *testing.T, l *List, uids ...uint64) error {
 }
 
 func TestAddMutation(t *testing.T) {
-	l := NewList()
+	l := getNew()
 	key := Key(1, "name")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -211,7 +211,7 @@ func TestAddMutation(t *testing.T) {
 	l.MergeIfDirty(ctx)
 
 	// Try reading the same data in another PostingList.
-	dl := NewList()
+	dl := getNew()
 	dl.init(key, ps)
 	if err := checkUids(t, dl, uids...); err != nil {
 		t.Error(err)
@@ -242,7 +242,7 @@ func checkValue(ol *List, val string) error {
 }
 
 func TestAddMutation_Value(t *testing.T) {
-	ol := NewList()
+	ol := getNew()
 	key := Key(10, "value")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -309,7 +309,7 @@ func TestAddMutation_Value(t *testing.T) {
 }
 
 func TestAddMutation_jchiu1(t *testing.T) {
-	ol := NewList()
+	ol := getNew()
 	key := Key(10, "value")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -386,7 +386,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 }
 
 func TestAddMutation_jchiu2(t *testing.T) {
-	ol := NewList()
+	ol := getNew()
 	key := Key(10, "value")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -442,7 +442,7 @@ func TestAddMutation_jchiu2(t *testing.T) {
 }
 
 func TestAddMutation_jchiu3(t *testing.T) {
-	ol := NewList()
+	ol := getNew()
 	key := Key(10, "value")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -543,7 +543,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 }
 
 func TestAddMutation_mrjn1(t *testing.T) {
-	ol := NewList()
+	ol := getNew()
 	key := Key(10, "value")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {
@@ -646,7 +646,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 
 func benchmarkAddMutations(n int, b *testing.B) {
 	// logrus.SetLevel(logrus.DebugLevel)
-	l := NewList()
+	l := getNew()
 	key := Key(1, "name")
 	dir, err := ioutil.TempDir("", "storetest_")
 	if err != nil {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -296,7 +296,6 @@ func GetOrCreate(key []byte, pstore *store.Store) (rlist *List, decr func()) {
 			l.incr() // Increment reference counter for the caller.
 			l.init(key, pstore)
 			return l, l.decr
-
 		}
 		// If we're unable to insert this, decrement the reference count.
 		// This would undo the increment in the newList() call, and allow this list to be reused.

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -297,17 +297,15 @@ func GetOrCreate(key []byte, pstore *store.Store) (rlist *List, decr func()) {
 			l.init(key, pstore)
 			return l, l.decr
 
-		} else {
-			// If we're unable to insert this, decrement the reference count.
-			l.decr()
 		}
+		// If we're unable to insert this, decrement the reference count.
+		l.decr()
 	}
 	if lp := getFromMap(gotomicKey); lp != nil {
 		return lp, lp.decr
-	} else {
-		err := errors.Errorf("Key should be present.")
-		log.Fatalf("%+v", err)
 	}
+	err := errors.Errorf("Key should be present.")
+	log.Fatalf("%+v", err)
 	return nil, nil
 }
 

--- a/posting/lmap_test.go
+++ b/posting/lmap_test.go
@@ -27,7 +27,7 @@ func BenchmarkGet(b *testing.B) {
 		for pb.Next() {
 			// i := uint64(rand.Int63())
 			_ = uint64(rand.Int63())
-			NewList()
+			getNew()
 			// lmap.Get(i)
 		}
 	})
@@ -38,7 +38,7 @@ func BenchmarkGetLinear(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		k := uint64(i)
 		if l, ok := m[k]; !ok {
-			l = NewList()
+			l = getNew()
 			m[k] = l
 		}
 	}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -126,6 +126,11 @@ func TestNewGraph(t *testing.T) {
 	}
 }
 
+func getOrCreate(key []byte, ps *store.Store) *posting.List {
+	l, _ := posting.GetOrCreate(key, ps)
+	return l
+}
+
 func populateGraph(t *testing.T) (string, *store.Store) {
 	// logrus.SetLevel(logrus.DebugLevel)
 	dir, err := ioutil.TempDir("", "storetest_")
@@ -154,54 +159,54 @@ func populateGraph(t *testing.T) (string, *store.Store) {
 		Source:    "testing",
 		Timestamp: time.Now(),
 	}
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "friend"), ps))
 
 	edge.ValueId = 24
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "friend"), ps))
 
 	edge.ValueId = 25
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "friend"), ps))
 
 	edge.ValueId = 31
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "friend"), ps))
 
 	edge.ValueId = 101
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "friend"), ps))
 
 	// Now let's add a few properties for the main user.
 	edge.Value = []byte("Michonne")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "name"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "name"), ps))
 
 	edge.Value = []byte("female")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "gender"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "gender"), ps))
 
 	edge.Value = []byte("alive")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "status"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "status"), ps))
 
 	edge.Value = []byte("38")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "age"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "age"), ps))
 
 	edge.Value = []byte("98.99")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "survival_rate"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "survival_rate"), ps))
 
 	edge.Value = []byte("true")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "sword_present"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "sword_present"), ps))
 
 	// Now let's add a name for each of the friends, except 101.
 	edge.Value = []byte("Rick Grimes")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(23, "name"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(23, "name"), ps))
 
 	edge.Value = []byte("Glenn Rhee")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(24, "name"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(24, "name"), ps))
 
 	edge.Value = []byte("Daryl Dixon")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(25, "name"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(25, "name"), ps))
 
 	edge.Value = []byte("Andrea")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(31, "name"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(31, "name"), ps))
 
 	edge.Value = []byte("mich")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(1, "_xid_"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(1, "_xid_"), ps))
 
 	return dir, ps
 }

--- a/uid/assigner.go
+++ b/uid/assigner.go
@@ -144,8 +144,8 @@ func allocateUniqueUid(xid string, instanceIdx uint64,
 
 		// Check if this uid has already been allocated.
 		key := posting.Key(uid, "_xid_") // uid -> "_xid_" -> xid
-		pl := posting.GetOrCreate(key, uidStore)
-		defer pl.Decr()
+		pl, decr := posting.GetOrCreate(key, uidStore)
+		defer decr()
 
 		if pl.Length() > 0 {
 			// Something already present here.
@@ -208,8 +208,8 @@ func StringKey(xid string) []byte {
 // Get returns the uid of the corresponding xid.
 func Get(xid string) (uid uint64, rerr error) {
 	key := StringKey(xid)
-	pl := posting.GetOrCreate(key, uidStore)
-	defer pl.Decr()
+	pl, decr := posting.GetOrCreate(key, uidStore)
+	defer decr()
 
 	if pl.Length() == 0 {
 		return 0, fmt.Errorf("xid: %v doesn't have any uid assigned.", xid)
@@ -235,8 +235,8 @@ func GetOrAssign(xid string, instanceIdx uint64,
 	}
 
 	key := StringKey(xid)
-	pl := posting.GetOrCreate(key, uidStore)
-	defer pl.Decr()
+	pl, decr := posting.GetOrCreate(key, uidStore)
+	defer decr()
 
 	if pl.Length() == 0 {
 		return assignNew(pl, xid, instanceIdx, numInstances)

--- a/uid/assigner.go
+++ b/uid/assigner.go
@@ -145,6 +145,7 @@ func allocateUniqueUid(xid string, instanceIdx uint64,
 		// Check if this uid has already been allocated.
 		key := posting.Key(uid, "_xid_") // uid -> "_xid_" -> xid
 		pl := posting.GetOrCreate(key, uidStore)
+		defer pl.Decr()
 
 		if pl.Length() > 0 {
 			// Something already present here.
@@ -208,6 +209,8 @@ func StringKey(xid string) []byte {
 func Get(xid string) (uid uint64, rerr error) {
 	key := StringKey(xid)
 	pl := posting.GetOrCreate(key, uidStore)
+	defer pl.Decr()
+
 	if pl.Length() == 0 {
 		return 0, fmt.Errorf("xid: %v doesn't have any uid assigned.", xid)
 	}
@@ -233,6 +236,8 @@ func GetOrAssign(xid string, instanceIdx uint64,
 
 	key := StringKey(xid)
 	pl := posting.GetOrCreate(key, uidStore)
+	defer pl.Decr()
+
 	if pl.Length() == 0 {
 		return assignNew(pl, xid, instanceIdx, numInstances)
 	}

--- a/uid/assigner_test.go
+++ b/uid/assigner_test.go
@@ -31,11 +31,16 @@ import (
 	"github.com/dgraph-io/dgraph/store"
 )
 
+func getOrCreate(key []byte, ps *store.Store) *posting.List {
+	l, _ := posting.GetOrCreate(key, ps)
+	return l
+}
+
 // externalId returns the xid of a given uid by reading from the uidstore.
 // It returns an error if there is no corresponding xid.
 func externalId(uid uint64) (xid string, rerr error) {
 	key := posting.Key(uid, "_xid_") // uid -> "_xid_" -> xid
-	pl := posting.GetOrCreate(key, uidStore)
+	pl := getOrCreate(key, uidStore)
 	if pl.Length() == 0 {
 		return "", errors.New("NO external id")
 	}

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -68,8 +68,8 @@ func runMutations(ctx context.Context, edges []x.DirectedEdge, op byte, left *Mu
 		}
 
 		key := posting.Key(edge.Entity, edge.Attribute)
-		plist := posting.GetOrCreate(key, ws.dataStore)
-		defer plist.Decr()
+		plist, decr := posting.GetOrCreate(key, ws.dataStore)
+		defer decr()
 
 		if err := plist.AddMutationWithIndex(ctx, edge, op); err != nil {
 			if op == posting.Set {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -69,6 +69,8 @@ func runMutations(ctx context.Context, edges []x.DirectedEdge, op byte, left *Mu
 
 		key := posting.Key(edge.Entity, edge.Attribute)
 		plist := posting.GetOrCreate(key, ws.dataStore)
+		defer plist.Decr()
+
 		if err := plist.AddMutationWithIndex(ctx, edge, op); err != nil {
 			if op == posting.Set {
 				left.Set = append(left.Set, edge)

--- a/worker/task.go
+++ b/worker/task.go
@@ -113,8 +113,8 @@ func processTask(query []byte) ([]byte, error) {
 			key = posting.Key(q.Uids(i), attr)
 		}
 		// Get or create the posting list for an entity, attribute combination.
-		pl := posting.GetOrCreate(key, store)
-		defer pl.Decr()
+		pl, decr := posting.GetOrCreate(key, store)
+		defer decr()
 
 		var valoffset flatbuffers.UOffsetT
 		// If a posting list contains a value, we store that or else we store a nil

--- a/worker/task.go
+++ b/worker/task.go
@@ -114,6 +114,7 @@ func processTask(query []byte) ([]byte, error) {
 		}
 		// Get or create the posting list for an entity, attribute combination.
 		pl := posting.GetOrCreate(key, store)
+		defer pl.Decr()
 
 		var valoffset flatbuffers.UOffsetT
 		// If a posting list contains a value, we store that or else we store a nil

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -63,6 +63,11 @@ func check(r *task.Result, idx int, expected []uint64) error {
 	return nil
 }
 
+func getOrCreate(key []byte, ps *store.Store) *posting.List {
+	l, _ := posting.GetOrCreate(key, ps)
+	return l
+}
+
 func populateGraph(t *testing.T, ps *store.Store) {
 	edge := x.DirectedEdge{
 		ValueId:   23,
@@ -71,33 +76,33 @@ func populateGraph(t *testing.T, ps *store.Store) {
 		Attribute: "friend",
 	}
 	edge.Entity = 10
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
 
 	edge.Entity = 11
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(11, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(11, "friend"), ps))
 
 	edge.Entity = 12
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 
 	edge.ValueId = 25
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 
 	edge.ValueId = 26
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 
 	edge.Entity = 10
 	edge.ValueId = 31
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
 
 	edge.Entity = 12
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 
 	edge.Entity = 12
 	edge.Value = []byte("photon")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 
 	edge.Entity = 10
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
 }
 
 func TestProcessTask(t *testing.T) {
@@ -228,9 +233,9 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 		Attribute: "friend",
 		Entity:    12,
 	}
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	edge.Value = []byte("notphoton")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 
 	// Issue a similar query.
@@ -266,15 +271,15 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 		Entity:    10,
 	}
 	// Redundant deletes.
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
 
 	// Delete followed by set.
 	edge.Entity = 12
 	edge.Value = []byte("notphoton")
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	edge.Value = []byte("ignored")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 
 	// Issue a similar query.
@@ -377,9 +382,9 @@ func TestProcessTaskIndex(t *testing.T) {
 		Attribute: "friend",
 		Entity:    12,
 	}
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	edge.Value = []byte("notphoton")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 
 	// Issue a similar query.
@@ -418,15 +423,15 @@ func TestProcessTaskIndex(t *testing.T) {
 		Entity:    10,
 	}
 	// Redundant deletes.
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(10, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(10, "friend"), ps))
 
 	// Delete followed by set.
 	edge.Entity = 12
 	edge.Value = []byte("notphoton")
-	delEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	delEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	edge.Value = []byte("ignored")
-	addEdge(t, edge, posting.GetOrCreate(posting.Key(12, "friend"), ps))
+	addEdge(t, edge, getOrCreate(posting.Key(12, "friend"), ps))
 	time.Sleep(200 * time.Millisecond) // Let the index process jobs from channel.
 
 	// Issue a similar query.

--- a/x/error.go
+++ b/x/error.go
@@ -49,7 +49,7 @@ func Checkf(err error, format string, args ...interface{}) {
 	}
 }
 
-// Assert logs fatal if b is false.
+// Assert asserts that b is true. Otherwise, it would log fatal.
 func Assert(b bool) {
 	if !b {
 		log.Fatalf("%+v", Errorf("Assert failed"))


### PR DESCRIPTION
We have to do this via reference counting because multiple goroutines might be holding the same pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/223)
<!-- Reviewable:end -->
