### PR TITLE
Fixing tests in worker package.

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -57,7 +57,7 @@ var (
 	port        = flag.Int("port", 8080, "Port to run server on.")
 	numcpu      = flag.Int("cores", runtime.NumCPU(),
 		"Number of cores to be used by the process")
-	raftId     = flag.Uint64("idx", 0, "RAFT ID that this server will use to join RAFT groups.")
+	raftId     = flag.Uint64("idx", 1, "RAFT ID that this server will use to join RAFT groups.")
 	cluster    = flag.String("cluster", "", "List of peers in this format: ID1:URL1,ID2:URL2,...")
 	peer       = flag.String("peer", "", "Address of any peer.")
 	workerPort = flag.String("workerport", ":12345",

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -261,16 +261,11 @@ var (
 
 // Init initializes the posting lists package, the in memory and dirty list hash.
 func Init() {
+	lhmap = newShardedListMap(*lhmapNumShards)
 	dirtyChan = make(chan uint64, 10000)
 	// Capacity is max number of gentle merges that can happen in parallel.
 	gentleMergeChan = make(chan struct{}, 18)
 	go periodicMerging()
-}
-
-func init() {
-	// Move this to package default init. So, we can use this package without
-	// initializing periodic merging.
-	lhmap = newShardedListMap(*lhmapNumShards)
 }
 
 func getFromMap(key uint64) *List {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -152,7 +152,8 @@ func (n *node) processSnapshot(s raftpb.Snapshot) {
 	}
 	pool := n.peers[lead]
 	fmt.Printf("Getting snapshot from leader: %v", lead)
-	x.Checkf(ws.PopulateShard(context.TODO(), pool, 0), "processSnapshot")
+	_, err := ws.PopulateShard(context.TODO(), pool, 0)
+	x.Checkf(err, "processSnapshot")
 	fmt.Printf("DONE with snapshot ============================")
 }
 
@@ -239,7 +240,8 @@ func (n *node) JoinCluster(any string) {
 	pool := n.peers[pid]
 	// TODO: Ask for the leader, before running PopulateShard.
 	// Bring the instance up to speed first.
-	x.Checkf(ws.PopulateShard(context.TODO(), pool, 0), "Error while populating shard")
+	_, err := ws.PopulateShard(context.TODO(), pool, 0)
+	x.Checkf(err, "Error while populating shard")
 
 	fmt.Printf("TELLING PEER TO ADD ME: %v\n", any)
 	query := &Payload{}

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -79,6 +79,7 @@ func TestPopulateShard(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ps.Close()
+	posting.Init()
 
 	writePLs(t, 100, 2, ps)
 	w := NewState(ps, nil, 0, 1)
@@ -165,6 +166,7 @@ func TestGenerateGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ps.Close()
+	posting.Init()
 
 	writePLs(t, 100, 2, ps)
 	ws := NewState(ps, nil, 0, 1)

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/posting"
+	"github.com/dgraph-io/dgraph/posting/types"
 	"github.com/dgraph-io/dgraph/store"
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/x"
@@ -35,20 +36,38 @@ func checkShard(ps *store.Store) (int, []byte) {
 	defer it.Close()
 
 	count := 0
-	var val []byte
-	prefix := []byte("test")
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+	for it.SeekToFirst(); it.Valid(); it.Next() {
 		count++
-		val = it.Value().Data()
 	}
-	return count, val
+	return count, it.Key().Data()
 }
 
-/*
+func writePLs(t *testing.T, count int, vid uint64, ps *store.Store) {
+	for i := 0; i < count; i++ {
+		k := fmt.Sprintf("%03d", i)
+		t.Logf("key: %v", k)
+		list, _ := posting.GetOrCreate([]byte(k), ps)
+
+		de := x.DirectedEdge{
+			ValueId:   vid,
+			Source:    "test",
+			Timestamp: time.Now(),
+		}
+		list.AddMutation(context.TODO(), de, posting.Set)
+		if merged, err := list.MergeIfDirty(context.TODO()); err != nil {
+			t.Errorf("While merging: %v", err)
+		} else if !merged {
+			t.Errorf("No merge happened")
+		}
+	}
+}
+
+func initNode(id uint64, my string) {
+	thisNode = newNode(id, my)
+}
+
 func TestPopulateShard(t *testing.T) {
 	var err error
-	addrs := []string{":12345", ":12346"}
-
 	dir, err := ioutil.TempDir("", "store0")
 	if err != nil {
 		t.Fatal(err)
@@ -61,19 +80,10 @@ func TestPopulateShard(t *testing.T) {
 	}
 	defer ps.Close()
 
-	// Batch writing dummy key value pairs which will be transferred to other
-	// instance.
-	wb := ps.NewWriteBatch()
-	for i := 0; i < 100; i++ {
-		wb.Put([]byte(fmt.Sprintf("test|%d", i)), []byte("test"))
-	}
-	if err := ps.WriteBatch(wb); err != nil {
-		log.Fatal(err)
-	}
-
-	w := NewState(ps, nil, 0, 2)
+	writePLs(t, 100, 2, ps)
+	w := NewState(ps, nil, 0, 1)
 	SetWorkerState(w)
-	go w.Connect(addrs, ":12345")
+	go RunServer(":12345")
 
 	dir1, err := ioutil.TempDir("", "store1")
 	if err != nil {
@@ -88,32 +98,63 @@ func TestPopulateShard(t *testing.T) {
 	defer ps1.Close()
 
 	w1 := NewState(ps1, nil, 1, 2)
-	SetWorkerState(w1)
-	go w1.Connect(addrs, ":12346")
-
-	// Wait for workers to be initialized and connected.
-	time.Sleep(5 * time.Second)
-
-	// Since PredicateData reads from the global variable wo, we change it to w.
+	go RunServer(":12346")
 	SetWorkerState(w)
-	pool := w.GetPool(0)
-	if err := w1.PopulateShard(context.Background(), pool, 0); err != nil {
+	pool := NewPool("localhost:12345", 5)
+	_, err = w1.PopulateShard(context.Background(), pool, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Getting count on number of keys written to posting list store on instance 1.
-	count, val := checkShard(ps1)
+	count, k := checkShard(ps1)
 	if count != 100 {
 		t.Fatalf("Expected %d key value pairs. Got : %d", 100, count)
 	}
-	if string(val) != "test" {
-		t.Fatalf("Expected last value %s. Got : %s", "test", string(val))
+	if string(k) != "099" {
+		t.Fatalf("Expected key to be: %v. Got %v", "099", string(k))
+	}
+
+	l, _ := posting.GetOrCreate(k, ps)
+	if l.Length() != 1 {
+		t.Error("Unable to find added elements in posting list")
+	}
+	var p types.Posting
+	if ok := l.Get(&p, 0); !ok {
+		t.Error("Unable to retrieve posting at 1st iter")
+		t.Fail()
+	}
+	if p.Uid() != 2 {
+		t.Errorf("Expected 2. Got: %v", p.Uid())
+	}
+	if string(p.Source()) != "test" {
+		t.Errorf("Expected testing. Got: %v", string(p.Source()))
+	}
+
+	// We modify the ValueId in 50 PLs. So now PopulateShard should only return these after checking the Checksum.
+	writePLs(t, 50, 5, ps)
+	count, err = w1.PopulateShard(context.Background(), pool, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 50 {
+		t.Errorf("Expected PopulateShard to return %v k-v pairs. Got: %v", 50, count)
 	}
 }
-*/
+
+func TestJoinCluster(t *testing.T) {
+	// initNode(1, "localhost:12345")
+	// n1 := GetNode()
+	// n1.StartNode("1:localhost:12345")
+
+	// initNode(2, "localhost:12346")
+	// n2 := GetNode()
+	// n2.StartNode("")
+	// thisNode = n1
+}
 
 func TestGenerateGroup(t *testing.T) {
-	dir, err := ioutil.TempDir("", "store0")
+	dir, err := ioutil.TempDir("", "store3")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,26 +166,7 @@ func TestGenerateGroup(t *testing.T) {
 	}
 	defer ps.Close()
 
-	// Batch writing dummy key value pairs which will be transferred to other
-	// instance.
-	for i := 0; i < 100; i++ {
-		k := fmt.Sprintf("%03d", i)
-		t.Logf("key: %v", k)
-		list, _ := posting.GetOrCreate([]byte(k), ps)
-
-		de := x.DirectedEdge{
-			ValueId:   2,
-			Source:    "test",
-			Timestamp: time.Now(),
-		}
-		list.AddMutation(context.TODO(), de, posting.Set)
-		if merged, err := list.MergeIfDirty(context.TODO()); err != nil {
-			t.Errorf("While merging: %v", err)
-		} else if !merged {
-			t.Errorf("No merge happened")
-		}
-	}
-
+	writePLs(t, 100, 2, ps)
 	ws := NewState(ps, nil, 0, 1)
 	data, err := ws.generateGroup(0)
 	if err != nil {

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/commit"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/store"
 	"github.com/dgraph-io/dgraph/task"
@@ -196,10 +195,6 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 		return
 	}
 	defer ps.Close()
-
-	clog := commit.NewLogger(dir, "mutations", 50<<20)
-	clog.Init()
-	defer clog.Close()
 
 	posting.Init()
 	SetWorkerState(NewState(ps, nil, 0, 1))


### PR DESCRIPTION
As we moved `lhmap` to package level init, it was getting initialized only once. So the first test usually passed but the subsequent tests failed with nil pointer dereference error. So I have reverted that change for now. Let me know if there is a better way to handle this.

I have also fixed populateShard test and verified that only keys with updated checksum are returned by it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/247)
<!-- Reviewable:end -->
