### PR TITLE
End to end test for JoinCluster

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -594,7 +594,7 @@ func main() {
 	worker.InitNode(*raftId, my)
 	worker.GetNode().StartNode(*cluster)
 	if len(*peer) > 0 {
-		go worker.GetNode().JoinCluster(*peer)
+		go worker.GetNode().JoinCluster(*peer, ws)
 	}
 	go worker.GetNode().SnapshotPeriodically()
 

--- a/contrib/simple-e2e.sh
+++ b/contrib/simple-e2e.sh
@@ -82,22 +82,22 @@ check_val() {
         fi
 }
 
-authname=$(echo $resp | jq '.me.author.name')
+authname=$(echo $resp | jq '.me[0].author[0].name')
 check_val '"Lewis Carroll"' "$authname";
 
-born=$(echo $resp | jq '.me.author.born')
+born=$(echo $resp | jq '.me[0].author[0].born')
 check_val \"1832\" $born;
 
-died=$(echo $resp | jq '.me.author.died')
+died=$(echo $resp | jq '.me[0].author[0].died')
 check_val \"1898\" $died;
 
-charname=$(echo $resp | jq '.me.character.name')
+charname=$(echo $resp | jq '.me[0].character[0].name')
 check_val \"Alice\" $charname;
 
-name=$(echo $resp | jq '.me.name')
+name=$(echo $resp | jq '.me[0].name')
 check_val '"Alice in Wonderland"' "$name";
 
-written=$(echo $resp | jq --raw-output '.me | . ["written-in"]')
+written=$(echo $resp | jq --raw-output '.me[0] | . ["written-in"]')
 check_val "1865" $written;
 
 GREEN='\033[0;32m'

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -230,7 +230,7 @@ func parsePeer(peer string) (uint64, string) {
 	return pid, kv[1]
 }
 
-func (n *node) JoinCluster(any string) {
+func (n *node) JoinCluster(any string, s *State) {
 	// Tell one of the peers to join.
 
 	pid, paddr := parsePeer(any)
@@ -240,7 +240,7 @@ func (n *node) JoinCluster(any string) {
 	pool := n.peers[pid]
 	// TODO: Ask for the leader, before running PopulateShard.
 	// Bring the instance up to speed first.
-	_, err := ws.PopulateShard(context.TODO(), pool, 0)
+	_, err := s.PopulateShard(context.TODO(), pool, 0)
 	x.Checkf(err, "Error while populating shard")
 
 	fmt.Printf("TELLING PEER TO ADD ME: %v\n", any)


### PR DESCRIPTION
I had to modify the API for calling JoinCluster. It now takes an additional parameter(worker state). This is necessary for testing any function in worker package so that we can use two states(for simulating two different instances). The RPC function(PredicateData) reads from the global state, and we pass in a different state to our function(JoinCluster here).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/248)
<!-- Reviewable:end -->
