### PR TITLE
Fix filtering

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -46,7 +46,12 @@ func (u *UIDList) Get(i int) uint64 {
 
 // Size returns size of UIDList.
 func (u *UIDList) Size() int {
-	x.Assert(u != nil)
+	if u == nil {
+		// In a subgraph node, in processGraph, sometimes we might fan out to zero
+		// nodes, i.e., sg.destUIDs is empty. In this case, child subgraph might not
+		// have its srcUIDs initialized.
+		return 0
+	}
 	if u.list != nil {
 		return u.list.UidsLength()
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -164,6 +164,7 @@ func mergeInterfaces(i1 interface{}, i2 interface{}) interface{} {
 
 // postTraverse traverses the subgraph recursively and returns final result for the query.
 func postTraverse(sg *SubGraph) (map[uint64]interface{}, error) {
+	// No need to check for nil as Size() will return 0 in that case.
 	if sg.srcUIDs.Size() == 0 {
 		return nil, nil
 	}
@@ -819,7 +820,7 @@ func ProcessGraph(ctx context.Context, sg *SubGraph, taskQuery []byte, rch chan 
 	}
 
 	if sg.destUIDs.Size() == 0 {
-		// Looks like we're done here.
+		// Looks like we're done here. Be careful with nil srcUIDs!
 		x.Trace(ctx, "Zero uids. Num attr children: %v", len(sg.Children))
 		rch <- nil
 		return


### PR DESCRIPTION
In ProcessGraph, when sg.destUIDs is empty (but not nil), we will save some work and return early. As a result, sg.child.srcUIDs might remain as nil.

There are two ways to fix.

(1) Every time you access srcUIDs, you need to check if it is nil.
(2) Check for nil in algo.UIDList's Size() method. This function is used to see if there is any work to be done.

I decide to go with (2). It is more in line with the Go proverb "make zero value useful". This check for nil is only in the Size() method. In other methods, we continue to assert for non-nil algo.UIDList pointers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/273)
<!-- Reviewable:end -->
