### PR TITLE
Drop DISABLE_RENAMING flag

### DIFF
--- a/tok/dynflag.go
+++ b/tok/dynflag.go
@@ -4,7 +4,6 @@ package tok
 
 // We assume ICU4C is installed to /usr/local/include and /usr/local/lib.
 
-// #cgo CPPFLAGS: -DU_DISABLE_RENAMING=1
 // #cgo !darwin LDFLAGS: -licuuc -licudata
 // #cgo darwin LDFLAGS: -licuuc -licucore -licudata
 import "C"

--- a/tok/embedflag.go
+++ b/tok/embedflag.go
@@ -5,7 +5,7 @@ package tok
 // govendor get  github.com/dgraph-io/goicu/icuembed
 // govendor get  github.com/dgraph-io/goicu/icuembed/unicode
 
-// #cgo CPPFLAGS: -I../vendor/github.com/dgraph-io/goicu/icuembed -DU_DISABLE_RENAMING=1
+// #cgo CPPFLAGS: -I../vendor/github.com/dgraph-io/goicu/icuembed
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all -lrt
 import "C"


### PR DESCRIPTION
We actually want to NOT disable renaming as it allows us to work with different versions of ICU. Symbols such as ..._57 can get renamed by some magic during linking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/288)
<!-- Reviewable:end -->
