### PR TITLE
Add stub to prevent go build error

### DIFF
--- a/contrib/freebase/stub.go
+++ b/contrib/freebase/stub.go
@@ -1,0 +1,1 @@
+package testing


### PR DESCRIPTION
This is a trivial change but currently running `go build` or `go get` returns an error exit value (which messes with packaging). This is due to the freebase contrib folder. I've added a stub which prevents the error. 

Error details:

```
$ go build github.com/dgraph-io/dgraph/...
go build github.com/dgraph-io/dgraph/contrib/freebase: no buildable
Go source files in /home/trengrj/go/src/github.com/dgraph-io/dgraph/contrib/freebase
$ echo $?
1
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/300)

<!-- Reviewable:end -->
