### PR TITLE
Make ICU optional for embedded version

### DIFF
--- a/tok/embedflag.go
+++ b/tok/embedflag.go
@@ -25,7 +25,17 @@ var (
 
 func init() {
 	x.AddInit(func() {
-		x.Assertf(len(*icuDataFile) > 0, "ICU data file empty")
-		x.Check(icuembed.Load(*icuDataFile))
+		disableICU = true
+		if len(*icuDataFile) == 0 {
+			x.Printf("WARNING: ICU data file empty")
+			return
+		}
+		if err := icuembed.Load(*icuDataFile); err != nil {
+			x.Printf("WARNING: Error loading ICU datafile: %s %v",
+				*icuDataFile, err)
+			return
+		}
+		// Everything well. Re-enable ICU.
+		disableICU = false
 	})
 }

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -59,17 +59,12 @@ func TestTokenizeBasic(t *testing.T) {
 			defer tokenizer.Destroy()
 			require.NotNil(t, tokenizer)
 			require.NoError(t, err)
-
+			tokensBytes := tokenizer.Tokens()
 			var tokens []string
-			for {
-				s := tokenizer.Next()
-				if s == nil {
-					break
-				}
-				tokens = append(tokens, string(s))
+			for _, token := range tokensBytes {
+				tokens = append(tokens, string(token))
 			}
-
-			require.EqualValues(t, tokens, expected)
+			require.EqualValues(t, expected, tokens)
 		}(d.in, d.expected)
 	}
 }

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -80,6 +82,16 @@ func TestTokenizeBasic(t *testing.T) {
 			}
 		}(d.in, d.expected)
 	}
+}
+
+func TestNoICU(t *testing.T) {
+	disableICU = true
+	tokenizer, err := NewTokenizer([]byte("hello world"))
+	defer tokenizer.Destroy()
+	require.NotNil(t, tokenizer)
+	require.NoError(t, err)
+	tokens := tokenizer.Tokens()
+	require.Empty(t, tokens)
 }
 
 func TestMain(m *testing.M) {

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -57,10 +57,9 @@ func TestTokenizeBasic(t *testing.T) {
 		func(in string, expected []string) {
 			tokenizer, err := NewTokenizer([]byte(d.in))
 			defer tokenizer.Destroy()
-			if err != nil {
-				t.Error(err)
-				return
-			}
+			require.NotNil(t, tokenizer)
+			require.NoError(t, err)
+
 			var tokens []string
 			for {
 				s := tokenizer.Next()
@@ -70,16 +69,7 @@ func TestTokenizeBasic(t *testing.T) {
 				tokens = append(tokens, string(s))
 			}
 
-			if len(tokens) != len(expected) {
-				t.Errorf("Wrong number of tokens: %d vs %d", len(tokens), len(expected))
-				return
-			}
-			for i := 0; i < len(tokens); i++ {
-				if tokens[i] != expected[i] {
-					t.Errorf("Expected token [%s] but got [%s]", expected[i], tokens[i])
-					return
-				}
-			}
+			require.EqualValues(t, tokens, expected)
 		}(d.in, d.expected)
 	}
 }


### PR DESCRIPTION
Users do not always need the index. For the embedded version, we used to require a valid ICU data file. In this PR, we make this optional. When this data file is missing, the tokenizer would not return any tokens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/301)
<!-- Reviewable:end -->
