### PR TITLE
Maintain list count

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -373,14 +373,9 @@ func (l *List) updateMutationLayer(mpost *types.Posting) bool {
 			// Posting not found in PL. This is considered an Add operation.
 			mpost.MutateOp(Add)
 		}
-	} else {
-		if !uidFound || !psame {
-			// uidFound=false: Couldn't find the posting in immutable layer. So,
-			// no need to Del.
-			// psam=false: Found the index in the immutable layer, but contents
-			// don't match. Do not Del.
-			return false
-		}
+	} else if !psame { // mpost.Op==Del
+		// Either we fail to find UID in immutable PL or contents don't match.
+		return false
 	}
 
 	// Doesn't match what we already have in immutable layer. So, add to mutable layer.

--- a/posting/list.go
+++ b/posting/list.go
@@ -44,9 +44,9 @@ var E_TMP_ERROR = fmt.Errorf("Temporary Error. Please retry.")
 var ErrNoValue = fmt.Errorf("No value found")
 
 const (
-	Set byte = 0x01 // Contributes 0 to count.
-	Del byte = 0x02 // Contributes -1 to count.
-	Add byte = 0x03 // Contributes 1 to count.
+	Set byte = 0x01 // Contributes 0 in Length().
+	Del byte = 0x02 // Contributes -1 in Length().
+	Add byte = 0x03 // Contributes 1 in Length().
 )
 
 type buffer struct {

--- a/posting/list.go
+++ b/posting/list.go
@@ -531,7 +531,7 @@ func (l *List) iterate(afterUid uint64, f func(obj *types.Posting) bool) {
 	}
 }
 
-// Length iterates over the posting list and counts the number of elements. This is NOT CHEAP. So, use it sparingly.
+// Length iterates over the mutation layer and counts number of elements.
 func (l *List) Length(afterUid uint64) int {
 	pidx, midx := 0, 0
 	pl := l.getPostingList()

--- a/posting/list.go
+++ b/posting/list.go
@@ -515,12 +515,12 @@ func (l *List) iterate(afterUid uint64, f func(obj *types.Posting) bool) {
 			cont = f(pp)
 			pidx++
 		case pp.Uid() == 0 || (mp.Uid() > 0 && mp.Uid() < pp.Uid()):
-			if mp.Op() == Set || mp.Op() == Add {
+			if mp.Op() != Del {
 				cont = f(mp)
 			}
 			midx++
 		case pp.Uid() == mp.Uid():
-			if mp.Op() == Set || mp.Op() == Add {
+			if mp.Op() != Del {
 				cont = f(mp)
 			}
 			pidx++

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -307,6 +307,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
+	require.Equal(t, 1, getLength(ol))
 	merged, err := ol.CommitIfDirty(context.Background())
 	require.NoError(t, err)
 	require.True(t, merged)
@@ -319,7 +320,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, getLength(ol), 0)
+	require.Equal(t, 0, getLength(ol))
 
 	// Set value to newcars, but don't merge yet.
 	edge = x.DirectedEdge{
@@ -337,7 +338,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.NotEqual(t, getLength(ol), 0)
+	require.NotEqual(t, 0, getLength(ol))
 	checkValue(t, ol, "newcars")
 
 	// Del a value newcars and but don't merge.
@@ -347,7 +348,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, getLength(ol), 0)
+	require.Equal(t, 0, getLength(ol))
 }
 
 func TestAddMutation_mrjn1(t *testing.T) {
@@ -388,7 +389,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, getLength(ol), 0)
+	require.Equal(t, 0, getLength(ol))
 
 	// Do this again to cover Del, muid == curUid, inPlist test case.
 	// Delete the previously committed value cars. But don't merge.
@@ -398,7 +399,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, getLength(ol), 0)
+	require.Equal(t, 0, getLength(ol))
 
 	// Set the value again to cover Set, muid == curUid, inPlist test case.
 	// Set the previously committed value cars. But don't merge.
@@ -417,7 +418,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, getLength(ol), 0)
+	require.Equal(t, 0, getLength(ol))
 }
 
 func TestAddMutation_checksum(t *testing.T) {
@@ -666,4 +667,9 @@ func BenchmarkAddMutations(b *testing.B) {
 			b.Error(err)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	x.Init()
+	os.Exit(m.Run())
 }

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -752,6 +752,7 @@ func TestAfterUIDCountWithCommit(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, merged)
 
+	// Mutation layer starts afresh from here.
 	// Delete half of the edges.
 	for i := 100; i < 300; i += 2 {
 		edge.ValueId = uint64(i)

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -76,10 +76,6 @@ func TestKey(t *testing.T) {
 	}
 }
 
-func getLength(l *List) int {
-	return l.Length(0)
-}
-
 func TestAddMutation(t *testing.T) {
 	l := getNew()
 	key := Key(1, "name")
@@ -220,6 +216,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, merged)
 
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "cars")
 
 	// Set value to newcars, but don't merge yet.
@@ -229,6 +226,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "newcars")
 
 	// Set value to someothercars, but don't merge yet.
@@ -238,6 +236,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "someothercars")
 
 	// Set value back to the committed value cars, but don't merge yet.
@@ -247,6 +246,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "cars")
 }
 
@@ -268,6 +268,7 @@ func TestAddMutation_jchiu2(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
+	require.EqualValues(t, 0, ol.Length(0))
 
 	// Set value to newcars, but don't merge yet.
 	edge = x.DirectedEdge{
@@ -277,15 +278,17 @@ func TestAddMutation_jchiu2(t *testing.T) {
 	}
 	addMutation(t, ol, edge, Set)
 	require.NoError(t, err)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "newcars")
 
-	// Set value back to cars, but don't merge yet.
+	// Del a value cars. This operation should be ignored.
 	edge = x.DirectedEdge{
 		Value:     []byte("cars"),
 		Source:    "jchiu",
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "newcars")
 }
 
@@ -307,10 +310,11 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
-	require.Equal(t, 1, getLength(ol))
+	require.Equal(t, 1, ol.Length(0))
 	merged, err := ol.CommitIfDirty(context.Background())
 	require.NoError(t, err)
 	require.True(t, merged)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "cars")
 
 	// Del a value cars and but don't merge.
@@ -320,7 +324,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, 0, getLength(ol))
+	require.Equal(t, 0, ol.Length(0))
 
 	// Set value to newcars, but don't merge yet.
 	edge = x.DirectedEdge{
@@ -329,6 +333,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Set)
+	require.EqualValues(t, 1, ol.Length(0))
 	checkValue(t, ol, "newcars")
 
 	// Del a value othercars and but don't merge.
@@ -338,7 +343,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.NotEqual(t, 0, getLength(ol))
+	require.NotEqual(t, 0, ol.Length(0))
 	checkValue(t, ol, "newcars")
 
 	// Del a value newcars and but don't merge.
@@ -348,7 +353,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, 0, getLength(ol))
+	require.Equal(t, 0, ol.Length(0))
 }
 
 func TestAddMutation_mrjn1(t *testing.T) {
@@ -389,7 +394,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, 0, getLength(ol))
+	require.Equal(t, 0, ol.Length(0))
 
 	// Do this again to cover Del, muid == curUid, inPlist test case.
 	// Delete the previously committed value cars. But don't merge.
@@ -399,7 +404,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, 0, getLength(ol))
+	require.Equal(t, 0, ol.Length(0))
 
 	// Set the value again to cover Set, muid == curUid, inPlist test case.
 	// Set the previously committed value cars. But don't merge.
@@ -418,7 +423,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Timestamp: time.Now(),
 	}
 	addMutation(t, ol, edge, Del)
-	require.Equal(t, 0, getLength(ol))
+	require.Equal(t, 0, ol.Length(0))
 }
 
 func TestAddMutation_checksum(t *testing.T) {

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -635,6 +635,93 @@ func TestAddMutation_gru2(t *testing.T) {
 	require.Equal(t, uids, listToArray(t, 0, ol))
 }
 
+func TestAfterUIDCount(t *testing.T) {
+	ol := getNew()
+	key := Key(10, "value")
+	dir, err := ioutil.TempDir("", "storetest_")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	ps, err := store.NewStore(dir)
+	require.NoError(t, err)
+	ol.init(key, ps)
+
+	// Set value to cars and merge to RocksDB.
+	edge := x.DirectedEdge{
+		Source:    "jchiu",
+		Timestamp: time.Now(),
+	}
+
+	for i := 100; i < 300; i++ {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Set)
+	}
+	require.EqualValues(t, 200, ol.Length(0))
+	require.EqualValues(t, 100, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Delete half of the edges.
+	for i := 100; i < 300; i += 2 {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Del)
+	}
+	require.EqualValues(t, 100, ol.Length(0))
+	require.EqualValues(t, 50, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Try to delete half of the edges. Redundant deletes.
+	for i := 100; i < 300; i += 2 {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Del)
+	}
+	require.EqualValues(t, 100, ol.Length(0))
+	require.EqualValues(t, 50, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Delete everything.
+	for i := 100; i < 300; i++ {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Del)
+	}
+	require.EqualValues(t, 0, ol.Length(0))
+	require.EqualValues(t, 0, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Insert 1/4 of the edges.
+	for i := 100; i < 300; i += 4 {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Set)
+	}
+	require.EqualValues(t, 50, ol.Length(0))
+	require.EqualValues(t, 25, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Insert 1/4 of the edges.
+	edge.Timestamp = time.Now() // Force an update of the edge.
+	edge.Source = "somethingelse"
+	for i := 100; i < 300; i += 4 {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Set)
+	}
+	require.EqualValues(t, 50, ol.Length(0)) // Expect no change.
+	require.EqualValues(t, 25, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+
+	// Insert 1/4 of the edges.
+	for i := 103; i < 300; i += 4 {
+		edge.ValueId = uint64(i)
+		addMutation(t, ol, edge, Set)
+	}
+	require.EqualValues(t, 100, ol.Length(0))
+	require.EqualValues(t, 50, ol.Length(199))
+	require.EqualValues(t, 0, ol.Length(300))
+}
+
+func TestMain(m *testing.M) {
+	x.Init()
+	os.Exit(m.Run())
+}
+
 func BenchmarkAddMutations(b *testing.B) {
 	// logrus.SetLevel(logrus.DebugLevel)
 	l := getNew()
@@ -667,9 +754,4 @@ func BenchmarkAddMutations(b *testing.B) {
 			b.Error(err)
 		}
 	}
-}
-
-func TestMain(m *testing.M) {
-	x.Init()
-	os.Exit(m.Run())
 }

--- a/x/error.go
+++ b/x/error.go
@@ -93,6 +93,11 @@ func Errorf(format string, args ...interface{}) error {
 	return errors.Errorf(format, args...)
 }
 
+// Fatalf logs fatal.
+func Fatalf(format string, args ...interface{}) {
+	log.Fatalf("%+v", Errorf(format, args...))
+}
+
 const (
 	dgraphPrefix  = "github.com/dgraph-io/dgraph/"
 	runtimePrefix = "src/runtime/"

--- a/x/init.go
+++ b/x/init.go
@@ -73,7 +73,7 @@ To say hi to the community       , visit https://dgraph.slack.com.
 // Let's add Printf to "x" and include "x" almost everywhere. Caution: Do remember
 // to call x.Init. For tests, you need a TestMain that calls x.Init.
 func Printf(format string, args ...interface{}) {
-	Assert(logger != nil)
+	Assertf(logger != nil, "Logger is not defined. Have you called x.Init?")
 	// Call depth is one higher than default.
-	logger.Output(3, fmt.Sprintf(format, args...))
+	logger.Output(2, fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
Speed up list.Length by maintaining count information for mutation layer.

We did not add to posting because that is a flatbuffer and is not mutable in theory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/305)
<!-- Reviewable:end -->
