### PR TITLE
Accept geoJson type strings.

### DIFF
--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -701,3 +701,18 @@ func TestParseFilter_unknowndirective(t *testing.T) {
 	_, _, err := Parse(query)
 	require.Error(t, err)
 }
+
+func TestParseGeoJson(t *testing.T) {
+	query := `
+	mutation {
+		set {              
+			<_uid_:1> <loc> "{
+				\'Type\':\'Point\' , 
+				\'Coordinates\':[1.1,2.0]
+			}"^^<geo:geojson> . 
+		}
+	}
+	`
+	_, _, err := Parse(query)
+	require.NoError(t, err)
+}

--- a/gql/state.go
+++ b/gql/state.go
@@ -375,6 +375,15 @@ func lexTextMutation(l *lex.Lexer) lex.StateFn {
 		if r == lex.EOF {
 			return l.Errorf("Unclosed mutation text")
 		}
+		if r == leftCurl {
+			l.Depth++
+		}
+		if r == rightCurl {
+			if l.Depth > 2 {
+				l.Depth--
+				continue
+			}
+		}
 		if r != rightCurl {
 			// Absorb everything until we find '}'.
 			continue

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -154,7 +154,7 @@ func Parse(line string) (rnq NQuad, rerr error) {
 			rnq.ObjectId = stripBracketsAndTrim(item.Val)
 
 		case itemLiteral:
-			oval = item.Val
+			oval = strings.Replace(item.Val, "'", "\"", -1)
 
 		case itemLanguage:
 			rnq.Predicate += "." + item.Val


### PR DESCRIPTION
To allow mutations like (Which have curly braces in them): 
```
mutation {
set {              
  <_uid_:1> <loc> "{\'Type\':\'Point\' , \'Coordinates\':[1.1,2.0]}"^^<geo:geojson> . 
 }
}
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/314)
<!-- Reviewable:end -->
