### PR TITLE
assert.Equals takes actual then expected. Tests have this swapped.

### DIFF
--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -327,7 +327,7 @@ func TestLex(t *testing.T) {
 				test.input, rnq)
 		} else {
 			assert.NoError(t, err, "Got error for input: %q", test.input)
-			assert.Equal(t, rnq, test.nq, "Mismatch for input: %q", test.input)
+			assert.Equal(t, test.nq, rnq, "Mismatch for input: %q", test.input)
 		}
 	}
 }


### PR DESCRIPTION
This pr is quite small. Simply in your unit tests for the rdf parser the expected and actual values are flipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/340)
<!-- Reviewable:end -->
