### PR TITLE
Update release Dockerfile to use ubuntu:14.04 so that Dgraph can run

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -8,15 +8,12 @@
 # To go into bash:
 #   docker run -it dgraph/dgraph bash
 
-# We need libc (not the lightweight version). Otherwise, dgraph cannot run.
-FROM frolvlad/alpine-glibc
+FROM ubuntu:14.04
 MAINTAINER Dgraph Labs <contact@dgraph.io>
 
-# We need libstdc++ as the embedded binaries are dynamically linked with libstdc++.
-# You might see warnings such as the following, but dgraph will run fine.
-# Your stdout won't be flooded with these warnings.
-#   dgraph: /usr/lib/libstdc++.so.6: no version information available (required by dgraph)
-RUN apk add --no-cache bash wget curl libstdc++
+RUN apt-get update
+
+RUN apt-get -y --force-yes install wget curl tar
 
 # Get embedded binaries from Dgraph.
 RUN curl https://get.dgraph.io | bash


### PR DESCRIPTION
We update the base image to ubuntu:14.04.

As the released Dgraph binary is dynamically linked to the system libraries, there is a version incompatibility for libstdc++ (between Alpine Linux and Ubuntu 14.04) and Dgraph server doesn't start. We get the following warning

`dgraph: /usr/lib/libstdc++.so.6: no version information available (required by dgraph)`

We got the warning earlier too (v0.4.4) but the server started after a bit, from v0.7 it doesn't start. Any ideas about this @jchiu0? The binary was compiled on Ubuntu 14.04.

I have pushed the Docker image for v0.7 and the compressed size for it is 100MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/373)
<!-- Reviewable:end -->
