### PR TITLE
RAFT Group Membership: Use group one as default for data

### DIFF
--- a/cmd/dgraph/groups.conf
+++ b/cmd/dgraph/groups.conf
@@ -1,2 +1,2 @@
 // Default formula for getting group where fp is the fingerprint of a predicate.
-default: fp % 1 
+default: fp % 1 + 1

--- a/group/conf.go
+++ b/group/conf.go
@@ -69,7 +69,7 @@ func parseDefaultConfig(l string) (uint32, error) {
 		if conf[3] != "+" {
 			return 0, fmt.Errorf("Default config format should be like: %v", "default: fp % n + k")
 		}
-		n, err = strconv.ParseUint(conf[4], 10, 64)
+		n, err = strconv.ParseUint(conf[4], 10, 32)
 		groupConfig.k = uint32(n)
 		x.Check(err)
 	}
@@ -116,7 +116,7 @@ func ParseConfig(r io.Reader) error {
 				return fmt.Errorf("Default config should be specified as the last line. Found %v",
 					l)
 			}
-			groupId, err := strconv.ParseUint(c[0], 10, 64)
+			groupId, err := strconv.ParseUint(c[0], 10, 32)
 			x.Check(err)
 			if curGroupId != uint32(groupId) {
 				return fmt.Errorf("Group ids should be sequential and should start from 0. "+

--- a/group/conf.go
+++ b/group/conf.go
@@ -19,8 +19,8 @@ type predMeta struct {
 }
 
 type config struct {
-	n    uint64
-	k    uint64
+	n    uint32
+	k    uint32
 	pred []predMeta
 }
 
@@ -46,7 +46,7 @@ func parsePredicates(groupId uint32, p string) error {
 	return nil
 }
 
-func parseDefaultConfig(l string) (uint64, error) {
+func parseDefaultConfig(l string) (uint32, error) {
 	// If we have already seen a default config line, and n has a value then we
 	// log.Fatal.
 	if groupConfig.n != 0 {
@@ -60,14 +60,17 @@ func parseDefaultConfig(l string) (uint64, error) {
 	}
 
 	var err error
-	groupConfig.n, err = strconv.ParseUint(conf[2], 10, 64)
+	var n uint64
+	n, err = strconv.ParseUint(conf[2], 10, 32)
 	x.Check(err)
+	groupConfig.n = uint32(n)
 	x.AssertTrue(groupConfig.n != 0)
 	if len(conf) == 5 {
 		if conf[3] != "+" {
 			return 0, fmt.Errorf("Default config format should be like: %v", "default: fp % n + k")
 		}
-		groupConfig.k, err = strconv.ParseUint(conf[4], 10, 64)
+		n, err = strconv.ParseUint(conf[4], 10, 64)
+		groupConfig.k = uint32(n)
 		x.Check(err)
 	}
 	return groupConfig.k, nil
@@ -79,7 +82,7 @@ func ParseConfig(r io.Reader) error {
 	scanner := bufio.NewScanner(r)
 	// To keep track of last groupId seen across lines. If we the groups ids are
 	// not sequential, we log.Fatal.
-	var curGroupId uint64
+	var curGroupId uint32
 	// If after seeing line with default config, we see other lines, we log.Fatal.
 	// Default config should be specified as the last line, so that we can check
 	// accurately that k in (fp % N + k) generates consecutive groups.
@@ -115,7 +118,7 @@ func ParseConfig(r io.Reader) error {
 			}
 			groupId, err := strconv.ParseUint(c[0], 10, 64)
 			x.Check(err)
-			if curGroupId != groupId {
+			if curGroupId != uint32(groupId) {
 				return fmt.Errorf("Group ids should be sequential and should start from 0. "+
 					"Found %v, should have been %v", groupId, curGroupId)
 			}
@@ -135,6 +138,7 @@ func ParseGroupConfig(file string) error {
 	cf, err := os.Open(file)
 	if os.IsNotExist(err) {
 		groupConfig.n = 1
+		groupConfig.k = 1
 		return nil
 	}
 	x.Check(err)
@@ -148,7 +152,11 @@ func ParseGroupConfig(file string) error {
 }
 
 func fpGroup(pred string) uint32 {
-	return farm.Fingerprint32([]byte(pred))%uint32(groupConfig.n) + uint32(groupConfig.k)
+	if groupConfig.n == 1 {
+		return groupConfig.k
+	}
+
+	return farm.Fingerprint32([]byte(pred))%groupConfig.n + groupConfig.k
 }
 
 func BelongsTo(pred string) uint32 {

--- a/group/conf_test.go
+++ b/group/conf_test.go
@@ -8,8 +8,8 @@ func TestGroups(t *testing.T) {
 		t.Errorf("Expected nil error. Got: %v", err)
 	}
 	gid := BelongsTo("type.object.name.en")
-	if gid != 0 {
-		t.Errorf("Expected groupId to be: %v. Got: %v", 0, gid)
+	if gid != 1 {
+		t.Errorf("Expected groupId to be: %v. Got: %v", 1, gid)
 	}
 
 	groupConfig = config{}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -19,12 +19,11 @@ import (
 )
 
 var (
-	groupIds = flag.String("groups", "0", "RAFT groups handled by this server.")
+	groupIds = flag.String("groups", "0,1", "RAFT groups handled by this server.")
 	myAddr   = flag.String("my", "",
 		"addr:port of this server, so other Dgraph servers can talk to this.")
-	peer           = flag.String("peer", "", "Address of any peer.")
-	raftId         = flag.Uint64("idx", 1, "RAFT ID that this server will use to join RAFT groups.")
-	redirectPrefix = []byte("REDIRECT:")
+	peer   = flag.String("peer", "", "Address of any peer.")
+	raftId = flag.Uint64("idx", 1, "RAFT ID that this server will use to join RAFT groups.")
 
 	emptyMembershipUpdate task.MembershipUpdate
 )

--- a/worker/mutation_test.go
+++ b/worker/mutation_test.go
@@ -42,12 +42,12 @@ func TestAddToMutationArray(t *testing.T) {
 	})
 
 	addToMutationMap(mutationsMap, edges, set)
-	mu := mutationsMap[0]
+	mu := mutationsMap[1]
 	require.NotNil(t, mu)
 	require.NotNil(t, mu.Set)
 
 	addToMutationMap(mutationsMap, edges, del)
-	mu = mutationsMap[0]
+	mu = mutationsMap[1]
 	require.NotNil(t, mu)
 	require.NotNil(t, mu.Del)
 }


### PR DESCRIPTION
Move all predicate data by default to group one, leaving group zero only for membership information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/379)
<!-- Reviewable:end -->
