### PR TITLE
Add HTTP read and write timeouts

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -656,7 +656,7 @@ func serveGRPC(l net.Listener) {
 
 func serveHTTP(l net.Listener) {
 	srv := &http.Server{
-		ReadTimeout:  60 * time.Second,
+		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 60 * time.Second,
 		// TODO(Ashwin): Add idle timeout while switching to Go 1.8.
 	}

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -651,15 +651,16 @@ func checkFlagsAndInitDirs() {
 func serveGRPC(l net.Listener) {
 	s := grpc.NewServer(grpc.CustomCodec(&query.Codec{}))
 	graph.RegisterDgraphServer(s, &grpcServer{})
-	if err := s.Serve(l); err != nil {
-		log.Fatalf("While serving gRpc request: %v", err)
-	}
+	x.Checkf(s.Serve(l), "Error while serving gRpc request")
 }
 
 func serveHTTP(l net.Listener) {
-	if err := http.Serve(l, nil); err != nil {
-		log.Fatalf("While serving http request: %v", err)
+	srv := &http.Server{
+		ReadTimeout:  60 * time.Second,
+		WriteTimeout: 60 * time.Second,
+		// TODO(Ashwin): Add idle timeout while switching to Go 1.8.
 	}
+	x.Checkf(srv.Serve(l), "Error while serving http request")
 }
 
 func setupServer(che chan error) {


### PR DESCRIPTION
A post by cloudfare talks about the too many open files error and suggests we set timeouts for HTTP server. https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/402)
<!-- Reviewable:end -->
