### PR TITLE
fix/brac for @filter

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -649,6 +649,8 @@ func (t *FilterTree) stringHelper(buf *bytes.Buffer) {
 		_, err = buf.WriteString("AND")
 	case "|":
 		_, err = buf.WriteString("OR")
+	case "(":
+		_, err = buf.WriteString("(")
 	default:
 		err = x.Errorf("Unknown operator: %q", t.Op)
 	}
@@ -793,6 +795,8 @@ func parseFilter(l *lex.Lexer) (*FilterTree, error) {
 				evalStack(opStack, valueStack)
 			}
 			opStack.push(&FilterTree{Op: op}) // Push current operator.
+		} else {
+			return nil, x.Errorf("Unexpected item while parsing @filter: %v", item)
 		}
 	}
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -688,6 +688,26 @@ func TestToJSONFilter(t *testing.T) {
 		js)
 }
 
+func TestToJSONFilterMissBrac(t *testing.T) {
+	dir, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+	query := `
+		{
+			me(_uid_:0x01) {
+				name
+				gender
+				friend @filter(anyof("name", "Andrea SomethingElse") {
+					name
+				}
+			}
+		}
+	`
+	_, _, err := gql.Parse(query)
+	require.Error(t, err)
+}
+
 func TestToJSONFilterAllOf(t *testing.T) {
 	dir, dir2, ps := populateGraph(t)
 	defer ps.Close()


### PR DESCRIPTION
https://github.com/dgraph-io/dgraph/issues/407

Found that the reason was that while parsing @filter, we did not check for unexpected items. So we read the whole query and end up with nonempty operator stack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/411)
<!-- Reviewable:end -->
