### PR TITLE
Fix count with sort order

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -590,10 +590,13 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			return
 		}
 	} else {
-		// We need to sort first before pagination.
-		if err = sg.applyOrderAndPagination(ctx); err != nil {
-			rch <- err
-			return
+		// If we are asked for count, we don't need to change the order of results.
+		if !sg.Params.DoCount {
+			// We need to sort first before pagination.
+			if err = sg.applyOrderAndPagination(ctx); err != nil {
+				rch <- err
+				return
+			}
 		}
 	}
 
@@ -608,6 +611,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 		for i, ul := range sg.uidMatrix {
 			// A possible optimization is to return the size of the intersection
 			// without forming the intersection.
+
 			algo.IntersectWith(ul, sg.DestUIDs)
 			sg.counts[i] = uint32(len(ul.Uids))
 		}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -527,7 +527,7 @@ func TestToJSON(t *testing.T) {
 			me(_uid_:0x01) {
 				name
 				gender
-			  alive
+				alive
 				friend {
 					name
 				}
@@ -1514,7 +1514,6 @@ func TestToJSONOrder(t *testing.T) {
 		js)
 }
 
-/*
 // Test sorting / ordering by dob.
 func TestToJSONOrderDesc(t *testing.T) {
 	dir, dir2, _ := populateGraph(t)
@@ -1536,10 +1535,34 @@ func TestToJSONOrderDesc(t *testing.T) {
 
 	js := processToJSON(t, query)
 	require.JSONEq(t,
-		`{"me":[{"friend":[{"dob":"1901-01-15","name":"Andrea"},{"dob":"1909-01-10","name":"Daryl Dixon"},{"dob":"1909-05-05","name":"Glenn Rhee"},{"dob":"1910-01-02","name":"Rick Grimes"}],"gender":"female","name":"Michonne"}]}`,
+		`{"me":[{"friend":[{"dob":"1910-01-02","name":"Rick Grimes"},{"dob":"1909-05-05","name":"Glenn Rhee"},{"dob":"1909-01-10","name":"Daryl Dixon"},{"dob":"1901-01-15","name":"Andrea"}],"gender":"female","name":"Michonne"}]}`,
 		string(js))
 }
-*/
+
+// Test sorting / ordering by dob and count.
+func TestToJSONOrderDescCount(t *testing.T) {
+	dir, dir2, _ := populateGraph(t)
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+
+	query := `
+		{
+			me(_uid_:0x01) {
+				name
+				gender
+				friend @filter(anyof("name", "Rick")) (order: dob) {
+					_count_
+				}
+			}
+		}
+	`
+
+	js := processToJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"friend":[{"_count_":1}],"gender":"female","name":"Michonne"}]}`,
+		string(js))
+}
+
 // Test sorting / ordering by dob.
 func TestToJSONOrderOffset(t *testing.T) {
 	dir, dir2, ps := populateGraph(t)


### PR DESCRIPTION
IntersectsWith was getting unsorted lists when sort order was applied (hence the wrong result). Now we don't change sort order if count is asked for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/426)
<!-- Reviewable:end -->
