### PR TITLE
fix/icu

### DIFF
--- a/tok/embedflag.go
+++ b/tok/embedflag.go
@@ -30,6 +30,8 @@ func init() {
 		if disableICU {
 			x.Printf("Disabling ICU because tokenizer fails simple test case: %v",
 				tokens)
+			return
 		}
+		x.Printf("ICU is working fine!")
 	})
 }

--- a/tok/embedflag.go
+++ b/tok/embedflag.go
@@ -2,40 +2,34 @@
 
 package tok
 
-// govendor get  github.com/dgraph-io/goicu/icuembed
-// govendor get  github.com/dgraph-io/goicu/icuembed/unicode
-
 // #cgo CPPFLAGS: -I../vendor/github.com/dgraph-io/goicu/icuembed
 // #cgo darwin LDFLAGS: -Wl,-undefined -Wl,dynamic_lookup
 // #cgo !darwin LDFLAGS: -Wl,-unresolved-symbols=ignore-all -lrt
 import "C"
 
 import (
-	"flag"
-
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/goicu/icuembed"
-)
-
-var (
-	icuDataFile = flag.String("icu", "",
-		"Location of ICU data file such as icudt57l.dat.")
-	icuData []byte // Hold a reference.
+	_ "github.com/dgraph-io/goicu/icuembed"
 )
 
 func init() {
 	x.AddInit(func() {
-		disableICU = true
-		if len(*icuDataFile) == 0 {
-			x.Printf("WARNING: ICU data file empty")
+		t, err := NewTokenizer([]byte("hello world"))
+		if err != nil {
+			disableICU = true
+			x.Printf("Disabling ICU because we fail to create tokenizer: %v", err)
 			return
 		}
-		if err := icuembed.Load(*icuDataFile); err != nil {
-			x.Printf("WARNING: Error loading ICU datafile: %s %v",
-				*icuDataFile, err)
+		if t == nil || t.c == nil {
+			disableICU = true
+			x.Printf("Disabling ICU because tokenizer is nil")
 			return
 		}
-		// Everything well. Re-enable ICU.
-		disableICU = false
+		tokens := t.Tokens()
+		disableICU = len(tokens) != 2 || tokens[0] != "hello" || tokens[1] != "world"
+		if disableICU {
+			x.Printf("Disabling ICU because tokenizer fails simple test case: %v",
+				tokens)
+		}
 	})
 }

--- a/types/index.go
+++ b/types/index.go
@@ -31,7 +31,7 @@ func IndexTokens(sv Val) ([]string, error) {
 	case DateTimeID:
 		return TimeIndex(sv.Value.(time.Time))
 	case StringID:
-		return DefaultIndexKeys(sv.Value.(string)), nil
+		return DefaultIndexKeys(sv.Value.(string))
 	default:
 		return nil, x.Errorf("Invalid type. Cannot be indexed")
 	}
@@ -39,7 +39,7 @@ func IndexTokens(sv Val) ([]string, error) {
 }
 
 // DefaultIndexKeys tokenizes data as a string and return keys for indexing.
-func DefaultIndexKeys(val string) []string {
+func DefaultIndexKeys(val string) ([]string, error) {
 	words := strings.Fields(val)
 	tokens := make([]string, 0, 5)
 	for _, it := range words {
@@ -51,7 +51,7 @@ func DefaultIndexKeys(val string) []string {
 		x.AssertTruef(!tok.ICUDisabled(), "Indexing requires ICU to be enabled.")
 		tokenizer, err := tok.NewTokenizer([]byte(it))
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		for {
 			s := tokenizer.Next()
@@ -62,7 +62,7 @@ func DefaultIndexKeys(val string) []string {
 		}
 		tokenizer.Destroy()
 	}
-	return tokens
+	return tokens, nil
 }
 
 func encodeInt(val int32) ([]string, error) {

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -12,7 +12,7 @@ func getTokens(funcArgs []string) ([]string, error) {
 		return nil, x.Errorf("Function requires 2 arguments, but got %d",
 			len(funcArgs))
 	}
-	return types.DefaultIndexKeys(funcArgs[1]), nil
+	return types.DefaultIndexKeys(funcArgs[1])
 }
 
 // getInequalityTokens gets tokens geq / leq compared to given token.


### PR DESCRIPTION
For embedded mode, -icu datafile doesn't seem to work.

We're switching to exporting the var ICU_DATA.

The init in tok package no longer tries to load the data file. Instead it will try to tokenize something simple. If it fails, it will set disableICU=true. This will check fail only when we try to use the tokenizer, say for indexing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/438)
<!-- Reviewable:end -->
