### PR TITLE
Improv/build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,11 @@ set -e
 cur_dir=$(pwd);
 tmp_dir=/tmp/dgraph-build;
 release_version=$(git describe --abbrev=0);
+platform="$(uname | tr '[:upper:]' '[:lower:]')"
+checksum_file=$cur_dir/"dgraph-checksum-$platform-amd64-$release_version".md5
+if [ -f "$checksum_file" ]; then
+	rm $checksum_file
+fi
 
 # If temporary directory already exists delete it.
 if [ -d "$tmp_dir" ]; then
@@ -20,7 +25,7 @@ fi
 mkdir $tmp_dir;
 
 dgraph_cmd=$GOPATH/src/github.com/dgraph-io/dgraph/cmd;
-build_flags='-tags=embed -v'
+build_flags='-v -tags=embed'
 
 echo -e "\033[1;33mBuilding binaries\033[0m"
 echo "dgraph"
@@ -33,7 +38,6 @@ cd $tmp_dir;
 mkdir dgraph && pushd &> /dev/null dgraph;
 cp $dgraph_cmd/dgraph/dgraph $dgraph_cmd/dgraphloader/dgraphloader .;
 
-platform="$(uname | tr '[:upper:]' '[:lower:]')"
 # Stripping the binaries.
 # Stripping binaries on Mac doesn't lead to much reduction in size and
 # instead gives an error.
@@ -41,6 +45,11 @@ if [ "$platform" = "linux" ]; then
   strip dgraph dgraphloader
   echo -e "\n\033[1;34mSize of files after strip: $(du -sh)\033[0m"
 fi
+
+checksum=$(md5sum dgraph | awk '{print $1}')
+echo "$checksum /usr/local/bin/dgraph" >> $checksum_file
+checksum=$(md5sum dgraphloader | awk '{print $1}')
+echo "$checksum /usr/local/bin/dgraphloader" >> $checksum_file
 
 echo -e "\n\033[1;33mCreating tar file\033[0m"
 tar_file=dgraph-"$platform"-amd64-$release_version
@@ -52,3 +61,7 @@ echo -e "\n\033[1;34mSize of tar file: $(du -sh $tar_file.tar.gz)\033[0m"
 echo -e "\n\033[1;33mMoving tarfile to original directory\033[0m"
 mv $tar_file.tar.gz $cur_dir
 rm -rf $tmp_dir
+
+echo -e "\nCalculating and storing checksum for ICU data file."
+checksum=$(md5sum $GOPATH/src/github.com/dgraph-io/goicu/icudt58l.dat | awk '{print $1}')
+echo "$checksum /usr/local/share/icudt58l.dat" >> $checksum_file

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e
 
 cur_dir=$(pwd);
 tmp_dir=/tmp/dgraph-build;
-release_version=0.7.1;
+release_version=$(git describe --abbrev=0);
 
 # If temporary directory already exists delete it.
 if [ -d "$tmp_dir" ]; then
@@ -24,9 +24,9 @@ build_flags='-tags=embed -v'
 
 echo -e "\033[1;33mBuilding binaries\033[0m"
 echo "dgraph"
-cd $dgraph_cmd/dgraph && go build $build_flags .;
+cd $dgraph_cmd/dgraph && go build $build_flags -ldflags="-X github.com/dgraph-io/dgraph/x.dgraphVersion=$release_version" .;
 echo "dgraphloader"
-cd $dgraph_cmd/dgraphloader && go build $build_flags .;
+cd $dgraph_cmd/dgraphloader && go build $build_flags -ldflags="-X github.com/dgraph-io/dgraph/x.dgraphVersion=$release_version" .;
 
 echo -e "\n\033[1;33mCopying binaries to tmp folder\033[0m"
 cd $tmp_dir;
@@ -43,7 +43,7 @@ if [ "$platform" = "linux" ]; then
 fi
 
 echo -e "\n\033[1;33mCreating tar file\033[0m"
-tar_file=dgraph-"$platform"-amd64-v$release_version
+tar_file=dgraph-"$platform"-amd64-$release_version
 popd &> /dev/null
 # Create a tar file with the contents of the dgraph folder (i.e the binaries)
 tar -zcf $tar_file.tar.gz dgraph;

--- a/x/init.go
+++ b/x/init.go
@@ -26,7 +26,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const dgraphVersion = "0.7.1"
+var dgraphVersion string
 
 var (
 	configFile = flag.String("config", "",
@@ -81,7 +81,7 @@ func loadConfigFromYAML() {
 // printVersionOnly prints version and other helpful information if --version.
 func printVersionOnly() {
 	if *version {
-		fmt.Printf("Dgraph version %s\n", dgraphVersion)
+		fmt.Printf("Dgraph %s\n", dgraphVersion)
 		fmt.Println("\nCopyright 2016 Dgraph Labs, Inc.")
 		fmt.Println(`
 Licensed under the Apache License, version 2.0.


### PR DESCRIPTION
1. We pick version number for the build script and binary from latest git tag.
2. Checksum file is created which has checksums for dgraph, dgraphloader and icudt58.dat, one for each platform Darwin/Linux. First the checksum file is downloaded. Checksums are verified, if they aren't same then we download the files.

Corresponding PR for the getdgraph.sh script https://github.com/dgraph-io/website/pull/2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/444)
<!-- Reviewable:end -->
