### PR TITLE
Refactor queryHandler and Run and move common code to processRequest

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -396,7 +396,8 @@ type wrappedErr struct {
 	Message string
 }
 
-func processRequest(ctx context.Context, gq *gql.GraphQuery, l *query.Latency) (*query.SubGraph, wrappedErr) {
+func processRequest(ctx context.Context, gq *gql.GraphQuery,
+	l *query.Latency) (*query.SubGraph, wrappedErr) {
 	if gq == nil || (len(gq.UID) == 0 && gq.Func == nil) {
 		return &query.SubGraph{}, wrappedErr{nil, x.ErrorOk}
 	}


### PR DESCRIPTION
There was a difference in the logic between Run and queryHandler and requests which had a filter function at root were being returned empty. I have moved the common language for processing a query to a function which is used by both these functions. This also fixes the bug.

We can abstract out the parameters to another function if we think that three parameters are too many.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/486)
<!-- Reviewable:end -->
