### PR TITLE
Support multi-level variables and remove UIDs by cascading

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -286,11 +286,15 @@ func substituteVariables(gq *GraphQuery, vmap varMap) error {
 	return nil
 }
 
+// Vars struct contains the list of variables defined and used by a
+// query block.
 type Vars struct {
 	Defines []string
 	Needs   []string
 }
 
+// Result struct contains the Query list, its corresponding variable use list
+// and the mutation block.
 type Result struct {
 	Query     []*GraphQuery
 	QueryVars []*Vars

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -967,6 +967,17 @@ func getRoot(it *lex.ItemIterator) (gq *GraphQuery, rerr error) {
 		return nil, x.Errorf("Expected some name. Got: %v", item)
 	}
 
+	peekIt, err := it.Peek(1)
+	if err != nil {
+		return nil, x.Errorf("Invalid Query")
+	}
+	if peekIt[0].Typ == itemName && peekIt[0].Val == "AS" {
+		gq.Var = item.Val
+		it.Next() // Consume the "AS".
+		it.Next()
+		item = it.Item()
+	}
+
 	gq.Alias = item.Val
 	it.Next()
 	item = it.Item()

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -376,39 +376,39 @@ func Parse(input string) (res Result, rerr error) {
 }
 
 func checkDependency(vl []*Vars) error {
-	l1, l2 := make([]string, 0, 10), make([]string, 0, 10)
+	needs, defines := make([]string, 0, 10), make([]string, 0, 10)
 	for _, it := range vl {
 		for _, v := range it.Needs {
-			l1 = append(l1, v)
+			needs = append(needs, v)
 		}
 		for _, v := range it.Defines {
-			l2 = append(l2, v)
+			defines = append(defines, v)
 		}
 	}
 
-	sort.Strings(l1)
-	sort.Strings(l2)
+	sort.Strings(needs)
+	sort.Strings(defines)
 	i, j := 0, 0
-	if len(l2) > len(l1) {
+	if len(defines) > len(needs) {
 		return x.Errorf("Some variables are defined and not used")
 	}
 
-	for i < len(l1) && j < len(l2) {
-		if l1[i] != l2[j] {
-			return x.Errorf("Variable %s defined but not used", l2[j])
+	for i < len(needs) && j < len(defines) {
+		if needs[i] != defines[j] {
+			return x.Errorf("Variable %s defined but not used", defines[j])
 		}
 
 		i++
-		for i < len(l1) && l1[i-1] == l1[i] {
+		for i < len(needs) && needs[i-1] == needs[i] {
 			i++
 		}
 		j++
-		if j < len(l2) && l2[j] == l2[j-1] {
-			return x.Errorf("Variable %s defined multiple times", l2[j])
+		if j < len(defines) && defines[j] == defines[j-1] {
+			return x.Errorf("Variable %s defined multiple times", defines[j])
 		}
 	}
 
-	if i != len(l1) || j != len(l2) {
+	if i != len(needs) || j != len(defines) {
 		return x.Errorf("Some variables are used but not defined")
 	}
 

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -397,7 +397,6 @@ func checkDependency(vl []*Vars) error {
 		if needs[i] != defines[j] {
 			return x.Errorf("Variable %s defined but not used", defines[j])
 		}
-
 		i++
 		for i < len(needs) && needs[i-1] == needs[i] {
 			i++
@@ -407,11 +406,9 @@ func checkDependency(vl []*Vars) error {
 			return x.Errorf("Variable %s defined multiple times", defines[j])
 		}
 	}
-
 	if i != len(needs) || j != len(defines) {
 		return x.Errorf("Some variables are used but not defined")
 	}
-
 	return nil
 }
 
@@ -419,15 +416,12 @@ func (qu *GraphQuery) collectVars(v *Vars) {
 	if qu.Var != "" {
 		v.Defines = append(v.Defines, qu.Var)
 	}
-
 	if qu.NeedsVar != "" {
 		v.Needs = append(v.Needs, qu.NeedsVar)
 	}
-
 	for _, ch := range qu.Children {
 		ch.collectVars(v)
 	}
-
 	if qu.Filter != nil {
 		qu.Filter.collectVars(v)
 	}
@@ -437,7 +431,6 @@ func (f *FilterTree) collectVars(v *Vars) {
 	if f.Func != nil && f.Func.NeedsVar != "" {
 		v.Needs = append(v.Needs, f.Func.NeedsVar)
 	}
-
 	for _, fch := range f.Child {
 		fch.collectVars(v)
 	}

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -830,7 +830,7 @@ func parseFunction(it *lex.ItemIterator) (*Function, error) {
 	for it.Next() {
 		item := it.Item()
 		if item.Typ == itemName { // Value.
-			g = &Function{Name: item.Val}
+			g = &Function{Name: strings.ToLower(item.Val)}
 			it.Next()
 			itemInFunc := it.Item()
 			if itemInFunc.Typ != itemLeftRound {
@@ -880,7 +880,7 @@ func parseFilter(it *lex.ItemIterator) (*FilterTree, error) {
 		if item.Typ == itemName { // Value.
 			f := &Function{}
 			leaf := &FilterTree{Func: f}
-			f.Name = item.Val
+			f.Name = strings.ToLower(item.Val)
 			it.Next()
 			itemInFunc := it.Item()
 			if itemInFunc.Typ != itemLeftRound {

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -386,7 +386,7 @@ func collectVars(idx int, qu *GraphQuery, res *Result) {
 }
 
 func collectVarsFilter(idx int, f *FilterTree, res *Result) {
-	if f.Func.NeedsVar != "" {
+	if f.Func != nil && f.Func.NeedsVar != "" {
 		res.NeedsVarList[idx] = append(res.NeedsVarList[idx], f.Func.NeedsVar)
 	}
 

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -35,29 +35,12 @@ func childAttrs(g *GraphQuery) []string {
 func TestParseQueryWithVar(t *testing.T) {
 	query := `
 	{	
-		me(L) {
-		 name	
-		}
-
-		him(J) {
-			name
-		}
-	
-		you(K) {
-			name
-		}
-
-		var(id:0x0a) {
-			L AS friends
-		}
-		
-		var(id:0x0a) {
-			J AS friends
-		}
-		
-		var(id:0x0a) {
-			K AS friends
-		}
+		me(L) {name}
+		him(J) {name}
+		you(K) {name}
+		var(id:0x0a) {L AS friends}
+		var(id:0x0a) {J AS friends}
+		var(id:0x0a) {K AS friends}
 	}
 `
 	res, err := Parse(query)
@@ -75,25 +58,11 @@ func TestParseQueryWithVar(t *testing.T) {
 func TestParseQueryWithVarError1(t *testing.T) {
 	query := `
 	{	
-		him(J) {
-			name
-		}
-	
-		you(K) {
-			name
-		}
-
-		var(id:0x0a) {
-			L AS friends
-		}
-		
-		var(id:0x0a) {
-			J AS friends
-		}
-		
-		var(id:0x0a) {
-			K AS friends
-		}
+		him(J) {name}
+		you(K) {name}
+		var(id:0x0a) {L AS friends}
+		var(id:0x0a) {J AS friends}
+		var(id:0x0a) {K AS friends}
 	}
 `
 	_, err := Parse(query)
@@ -103,25 +72,11 @@ func TestParseQueryWithVarError1(t *testing.T) {
 func TestParseQueryWithVarError2(t *testing.T) {
 	query := `
 	{	
-		me(L) {
-		 name	
-		}
-
-		him(J) {
-			name
-		}
-	
-		you(K) {
-			name
-		}
-
-		var(id:0x0a) {
-			L AS friends
-		}
-		
-		var(id:0x0a) {
-			K AS friends
-		}
+		me(L) {name}
+		him(J) {name}	
+		you(K) {name}
+		var(id:0x0a) {L AS friends}
+		var(id:0x0a) {K AS friends}
 	}
 `
 	_, err := Parse(query)

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -72,6 +72,28 @@ func TestParseQueryWithVar(t *testing.T) {
 	require.Equal(t, "K", res.Query[5].Children[0].Var)
 }
 
+func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
+	query := `
+	{
+		K AS var(id:0x0a) {
+			L AS friends
+		}
+	
+		me(id:0xa) @filter(id(L)) {
+		 name	
+		}
+	}
+`
+	res, err := Parse(query)
+	require.NoError(t, err)
+	require.NotNil(t, res.Query)
+	require.Equal(t, 2, len(res.Query))
+	require.Equal(t, "K", res.Query[0].Var)
+	require.Equal(t, "L", res.Query[0].Children[0].Var)
+	require.Equal(t, "L", res.Query[1].Filter.Func.NeedsVar)
+	require.Equal(t, [][]string{[]string{"K", "L"}, []string(nil)}, res.VarList)
+}
+
 func TestParseQueryWithVarAtRoot(t *testing.T) {
 	query := `
 	{

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -79,7 +79,7 @@ func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
 			L AS friends
 		}
 	
-		me(id:0xa) @filter(id(L)) {
+		me(K) @filter(id(L)) {
 		 name	
 		}
 	}
@@ -101,8 +101,8 @@ func TestParseQueryWithVarAtRoot(t *testing.T) {
 			fr as friends
 		}
 	
-		me(fr) {
-		 name	
+		me(fr) @filter(id(K)) {
+		 name	@filter(id(fr))
 		}
 	}
 `
@@ -164,6 +164,7 @@ func TestParseQueryWithMultipleVar(t *testing.T) {
 	require.Equal(t, "B", res.Query[2].NeedsVar)
 	require.Equal(t, []string{"L", "B"}, res.QueryVars[0].Defines)
 	require.Equal(t, []string{"L"}, res.QueryVars[1].Needs)
+	require.Equal(t, []string{"B"}, res.QueryVars[2].Needs)
 }
 
 func TestParseMultipleQueries(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -72,6 +72,28 @@ func TestParseQueryWithVar(t *testing.T) {
 	require.Equal(t, "K", res.Query[5].Children[0].Var)
 }
 
+func TestParseQueryWithVarAtRoot(t *testing.T) {
+	query := `
+	{
+		K AS var(id:0x0a) {
+			L AS friends
+		}
+	
+		me(L) {
+		 name	
+		}
+	}
+`
+	res, err := Parse(query)
+	require.NoError(t, err)
+	require.NotNil(t, res.Query)
+	require.Equal(t, 2, len(res.Query))
+	require.Equal(t, "K", res.Query[0].Var)
+	require.Equal(t, "L", res.Query[0].Children[0].Var)
+	require.Equal(t, "L", res.Query[1].NeedsVar)
+	require.Equal(t, [][]string{[]string{"K", "L"}, []string(nil)}, res.VarList)
+}
+
 func TestParseQueryWithVar1(t *testing.T) {
 	query := `
 	{

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -72,6 +72,62 @@ func TestParseQueryWithVar(t *testing.T) {
 	require.Equal(t, "K", res.Query[5].Children[0].Var)
 }
 
+func TestParseQueryWithVarError1(t *testing.T) {
+	query := `
+	{	
+		him(J) {
+			name
+		}
+	
+		you(K) {
+			name
+		}
+
+		var(id:0x0a) {
+			L AS friends
+		}
+		
+		var(id:0x0a) {
+			J AS friends
+		}
+		
+		var(id:0x0a) {
+			K AS friends
+		}
+	}
+`
+	_, err := Parse(query)
+	require.Error(t, err)
+}
+
+func TestParseQueryWithVarError2(t *testing.T) {
+	query := `
+	{	
+		me(L) {
+		 name	
+		}
+
+		him(J) {
+			name
+		}
+	
+		you(K) {
+			name
+		}
+
+		var(id:0x0a) {
+			L AS friends
+		}
+		
+		var(id:0x0a) {
+			K AS friends
+		}
+	}
+`
+	_, err := Parse(query)
+	require.Error(t, err)
+}
+
 func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
 	query := `
 	{

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -92,6 +92,36 @@ func TestParseQueryWithVar1(t *testing.T) {
 	require.Equal(t, "L", res.Query[1].NeedsVar)
 }
 
+func TestParseQueryWithMultipleVar(t *testing.T) {
+	query := `
+	{
+		var(id:0x0a) {
+			L AS friends {
+				B AS relatives
+			}
+		}
+	
+		me(L) {
+		 name	
+		}
+
+		relatives(B) {
+			name
+		}
+	}
+`
+	res, err := Parse(query)
+	require.NoError(t, err)
+	require.NotNil(t, res.Query)
+	require.Equal(t, 3, len(res.Query))
+	require.Equal(t, "L", res.Query[0].Children[0].Var)
+	require.Equal(t, "B", res.Query[0].Children[0].Children[0].Var)
+	require.Equal(t, "L", res.Query[1].NeedsVar)
+	require.Equal(t, "B", res.Query[2].NeedsVar)
+	require.Equal(t, [][]string{[]string{"L", "B"}, []string(nil), []string(nil)}, res.VarList)
+	require.Equal(t, [][]string{[]string(nil), []string{"L"}, []string{"B"}}, res.NeedsVarList)
+}
+
 func TestParseMultipleQueries(t *testing.T) {
 	query := `
 	{

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -75,7 +75,7 @@ func TestParseQueryWithVar(t *testing.T) {
 func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
 	query := `
 	{
-		K AS var(id:0x0a) {
+		K as var(id:0x0a) {
 			L AS friends
 		}
 	
@@ -91,17 +91,17 @@ func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
 	require.Equal(t, "K", res.Query[0].Var)
 	require.Equal(t, "L", res.Query[0].Children[0].Var)
 	require.Equal(t, "L", res.Query[1].Filter.Func.NeedsVar)
-	require.Equal(t, [][]string{[]string{"K", "L"}, []string(nil)}, res.VarList)
+	require.Equal(t, []string{"K", "L"}, res.QueryVars[0].Defines)
 }
 
 func TestParseQueryWithVarAtRoot(t *testing.T) {
 	query := `
 	{
 		K AS var(id:0x0a) {
-			L AS friends
+			fr as friends
 		}
 	
-		me(L) {
+		me(fr) {
 		 name	
 		}
 	}
@@ -111,9 +111,9 @@ func TestParseQueryWithVarAtRoot(t *testing.T) {
 	require.NotNil(t, res.Query)
 	require.Equal(t, 2, len(res.Query))
 	require.Equal(t, "K", res.Query[0].Var)
-	require.Equal(t, "L", res.Query[0].Children[0].Var)
-	require.Equal(t, "L", res.Query[1].NeedsVar)
-	require.Equal(t, [][]string{[]string{"K", "L"}, []string(nil)}, res.VarList)
+	require.Equal(t, "fr", res.Query[0].Children[0].Var)
+	require.Equal(t, "fr", res.Query[1].NeedsVar)
+	require.Equal(t, []string{"K", "fr"}, res.QueryVars[0].Defines)
 }
 
 func TestParseQueryWithVar1(t *testing.T) {
@@ -162,8 +162,8 @@ func TestParseQueryWithMultipleVar(t *testing.T) {
 	require.Equal(t, "B", res.Query[0].Children[0].Children[0].Var)
 	require.Equal(t, "L", res.Query[1].NeedsVar)
 	require.Equal(t, "B", res.Query[2].NeedsVar)
-	require.Equal(t, [][]string{[]string{"L", "B"}, []string(nil), []string(nil)}, res.VarList)
-	require.Equal(t, [][]string{[]string(nil), []string{"L"}, []string{"B"}}, res.NeedsVarList)
+	require.Equal(t, []string{"L", "B"}, res.QueryVars[0].Defines)
+	require.Equal(t, []string{"L"}, res.QueryVars[1].Needs)
 }
 
 func TestParseMultipleQueries(t *testing.T) {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -31,6 +31,8 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 )
 
+// ToProtocolBuf returns the list of graph.Node which would be returned to the go
+// client.
 func ToProtocolBuf(l *Latency, sgl []*SubGraph) ([]*graph.Node, error) {
 	var resNode []*graph.Node
 	for _, sg := range sgl {
@@ -43,6 +45,7 @@ func ToProtocolBuf(l *Latency, sgl []*SubGraph) ([]*graph.Node, error) {
 	return resNode, nil
 }
 
+// ToJson converts the list of subgraph into a JSON response by calling ToFastJSON.
 func ToJson(l *Latency, sgl []*SubGraph) ([]byte, error) {
 	sgr := &SubGraph{
 		Attr: "__",

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -45,7 +45,7 @@ func ToProtocolBuf(l *Latency, sgl []*SubGraph) ([]*graph.Node, error) {
 
 func ToJson(l *Latency, sgl []*SubGraph) ([]byte, error) {
 	sgr := &SubGraph{
-		Attr: "_root_",
+		Attr: "__",
 	}
 	for _, sg := range sgl {
 		if sg.Params.Alias == "var" {
@@ -335,6 +335,9 @@ func (fj *fastJsonNode) encode(jsBuf *bytes.Buffer) {
 
 func processNodeUids(n *fastJsonNode, sg *SubGraph) error {
 	var seedNode *fastJsonNode
+	if sg.DestUIDs == nil {
+		return nil
+	}
 	for _, uid := range sg.DestUIDs.Uids {
 		n1 := seedNode.New(sg.Params.Alias)
 		if sg.Params.GetUID || sg.Params.isDebug {
@@ -358,7 +361,7 @@ func processNodeUids(n *fastJsonNode, sg *SubGraph) error {
 func (sg *SubGraph) ToFastJSON(l *Latency) ([]byte, error) {
 	var seedNode *fastJsonNode
 	n := seedNode.New("_root_")
-	if sg.Attr == "_root_" {
+	if sg.Attr == "__" {
 		for _, sg := range sg.Children {
 			err := processNodeUids(n.(*fastJsonNode), sg)
 			if err != nil {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -31,6 +31,34 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 )
 
+func ToProtocolBuf(l *Latency, sgl []*SubGraph) ([]*graph.Node, error) {
+	var resNode []*graph.Node
+	for _, sg := range sgl {
+		node, err := sg.ToProtocolBuffer(l)
+		if err != nil {
+			return nil, err
+		}
+		resNode = append(resNode, node)
+	}
+	return resNode, nil
+}
+
+func ToJson(l *Latency, sgl []*SubGraph) ([]byte, error) {
+	sgr := &SubGraph{
+		Attr: "_root_",
+	}
+	for _, sg := range sgl {
+		if sg.Params.Alias == "var" {
+			continue
+		}
+		if sg.Params.isDebug {
+			sgr.Params.isDebug = true
+		}
+		sgr.Children = append(sgr.Children, sg)
+	}
+	return sgr.ToFastJSON(l)
+}
+
 // outputNode is the generic output / writer for preTraverse.
 type outputNode interface {
 	AddValue(attr string, v types.Val)

--- a/query/query.go
+++ b/query/query.go
@@ -722,6 +722,9 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 		}
 	}
 
+	for _, l := range sg.uidMatrix {
+		algo.IntersectWith(l, sg.DestUIDs)
+	}
 	if len(sg.Params.Order) == 0 {
 		// There is no ordering. Just apply pagination and return.
 		if err = sg.applyPagination(ctx); err != nil {
@@ -810,12 +813,12 @@ func pageRange(p *params, n int) (int, int) {
 // applyWindow applies windowing to sg.sorted.
 func (sg *SubGraph) applyPagination(ctx context.Context) error {
 	params := sg.Params
+
 	if params.Count == 0 && params.Offset == 0 { // No pagination.
 		return nil
 	}
 	x.AssertTrue(len(sg.SrcUIDs.Uids) == len(sg.uidMatrix))
 	for _, l := range sg.uidMatrix {
-		algo.IntersectWith(l, sg.DestUIDs)
 		start, end := pageRange(&sg.Params, len(l.Uids))
 		l.Uids = l.Uids[start:end]
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -594,7 +594,7 @@ func populateVarMap(sg *SubGraph, doneVars map[string]*task.List) {
 	for _, child := range sg.Children {
 		populateVarMap(child, doneVars)
 		for i := 0; i < len(child.uidMatrix); i++ {
-			if len(child.uidMatrix[i].Uids) == 0 {
+			if len(child.values[i].Val) == 0 && len(child.uidMatrix[i].Uids) == 0 {
 				excluded[sg.DestUIDs.Uids[i]] = true
 			}
 		}

--- a/query/query.go
+++ b/query/query.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 DGraph Labs, Inc.
+ * Copyright 2017 DGraph Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/query/query.go
+++ b/query/query.go
@@ -589,11 +589,6 @@ func ProcessQuery(ctx context.Context, res gql.Result, l *Latency) ([]*SubGraph,
 }
 
 func populateVarMap(sg *SubGraph, doneVars map[string]*task.List) {
-	if sg.Params.Alias != "var" {
-		// This function should only execute for "var" blocks.
-		return
-	}
-
 	// Filter out UIDs that don't have atleast one UID in every child.
 	excluded := make(map[uint64]bool)
 	for _, child := range sg.Children {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2268,6 +2268,26 @@ func TestGeneratorMultiRootMultiQueryRootVar(t *testing.T) {
 	require.JSONEq(t, `{"you":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}`, js)
 }
 
+func TestGeneratorMultiRootMultiQueryRootVarFilter(t *testing.T) {
+	dir1, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir1)
+	defer os.RemoveAll(dir2)
+	query := `
+    {
+			friend AS var(anyof("name", "Michonne Rick Glenn")) {
+      	name
+			}
+
+			you(anyof(name, "Michonne Andrea Glenn")) @filter(id(friend)) {
+				name
+			}
+    }
+  `
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"you":[{"name":"Michonne"}, {"name":"Glenn Rhee"}]}`, js)
+}
+
 func TestGeneratorMultiRootMultiQuery(t *testing.T) {
 	dir1, dir2, ps := populateGraph(t)
 	defer ps.Close()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2268,6 +2268,28 @@ func TestGeneratorMultiRootMultiQueryRootVar(t *testing.T) {
 	require.JSONEq(t, `{"you":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}`, js)
 }
 
+func TestGeneratorMultiRootMultiQueryVarFilter(t *testing.T) {
+	dir1, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir1)
+	defer os.RemoveAll(dir2)
+	query := `
+    {
+			f AS var(anyof("name", "Michonne Rick Glenn")) {
+      	name
+			}
+
+			you(anyof(name, "Michonne")) {
+				friend @filter(id(f)) {
+					name
+				}
+			}
+    }
+  `
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"you":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"}]}]}`, js)
+}
+
 func TestGeneratorMultiRootMultiQueryRootVarFilter(t *testing.T) {
 	dir1, dir2, ps := populateGraph(t)
 	defer ps.Close()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -371,6 +371,61 @@ func TestUseVarsMultiCascade(t *testing.T) {
 		js)
 }
 
+func TestUseVarsMultiOrder(t *testing.T) {
+	dir, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+	query := `
+		{
+			var(id:0x01) {
+				L AS friend(first:2, order: dob)
+			}
+			
+			var(id:0x01) {
+				G AS friend(first:2, offset:2, order: dob)
+			}
+
+			friend1(L) {
+				name
+			}
+
+			friend2(G) {
+				name
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"friend1":[{"name":"Daryl Dixon"}, {"name":"Andrea"}],"friend2":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}`,
+		js)
+}
+func TestUseVarsMultiFilterId(t *testing.T) {
+	dir, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+	query := `
+		{
+			var(id:0x01) {
+				L AS friend
+			}
+
+			var(id:31) {
+				G AS friend
+			}
+
+			friend(L) @filter(id(G)) {
+				name
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"friend":[{"name":"Glenn Rhee"}]}`,
+		js)
+}
+
 func TestUseVarsCascade(t *testing.T) {
 	dir, dir2, ps := populateGraph(t)
 	defer ps.Close()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2248,6 +2248,26 @@ func TestGenerator(t *testing.T) {
 	require.JSONEq(t, `{"me":[{"gender":"female","name":"Michonne"}]}`, js)
 }
 
+func TestGeneratorMultiRootMultiQueryRootVar(t *testing.T) {
+	dir1, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir1)
+	defer os.RemoveAll(dir2)
+	query := `
+    {
+			friend AS var(anyof("name", "Michonne Rick Glenn")) {
+      	name
+			}
+
+			you(friend) {
+				name
+			}
+    }
+  `
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"you":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}`, js)
+}
+
 func TestGeneratorMultiRootMultiQuery(t *testing.T) {
 	dir1, dir2, ps := populateGraph(t)
 	defer ps.Close()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -343,6 +343,58 @@ func TestMultiEmptyBlocks(t *testing.T) {
 		js)
 }
 
+func TestUseVarsMultiCascade(t *testing.T) {
+	dir, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+	query := `
+		{
+			var(id:0x01) {
+				L AS friend {
+				 B AS friend	
+				}
+			}
+
+			me(L) {
+				name
+			}
+
+			friend(B) {
+				name
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"name":"Andrea"}], "friend":[{"name":"Glenn Rhee"}]}`,
+		js)
+}
+
+func TestUseVarsCascade(t *testing.T) {
+	dir, dir2, ps := populateGraph(t)
+	defer ps.Close()
+	defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir2)
+	query := `
+		{
+			var(id:0x01) {
+				L AS friend {
+				  friend	
+				}
+			}
+
+			me(L) {
+				name
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"name":"Andrea"}]}`,
+		js)
+}
+
 func TestUseVars(t *testing.T) {
 	dir, dir2, ps := populateGraph(t)
 	defer ps.Close()

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2298,7 +2298,6 @@ func TestGeneratorMultiRootMultiQueryRootVarFilter(t *testing.T) {
 	query := `
     {
 			friend AS var(anyof("name", "Michonne Rick Glenn")) {
-      	name
 			}
 
 			you(anyof(name, "Michonne Andrea Glenn")) @filter(id(friend)) {


### PR DESCRIPTION
Now we can do queries like: 
```
    {
      var(id:0x01) {
        L AS friend {
         B AS friend  
        }
      }

      me(L) {
        name
      }

      friend(B) {
        name
      }
    }
```
Note that variable `L` will only contain those UIDs that have atleast one friend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/498)
<!-- Reviewable:end -->
