### PR TITLE
Adding sync pool for sharing the bytebuffers.

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -524,6 +524,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	err = query.ToJson(&l, sgl, w)
 	if err != nil {
 		x.TraceError(ctx, x.Wrapf(err, "Error while converting to Json"))
@@ -532,8 +533,6 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	x.Trace(ctx, "Latencies: Total: %v Parsing: %v Process: %v Json: %v",
 		time.Since(l.Start), l.Parsing, l.Processing, l.Json)
-
-	w.Header().Set("Content-Type", "application/json")
 }
 
 // storeStatsHandler outputs some basic stats for data store.

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -524,7 +524,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	js, err := query.ToJson(&l, sgl)
+	err = query.ToJson(&l, sgl, w)
 	if err != nil {
 		x.TraceError(ctx, x.Wrapf(err, "Error while converting to Json"))
 		x.SetStatus(w, x.Error, err.Error())
@@ -534,7 +534,6 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		time.Since(l.Start), l.Parsing, l.Processing, l.Json)
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Write(js)
 }
 
 // storeStatsHandler outputs some basic stats for data store.

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -527,6 +527,8 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	err = query.ToJson(&l, sgl, w)
 	if err != nil {
+		// since we performed w.Write in ToJson above,
+		// calling WriteHeader with 500 code will be ignored.
 		x.TraceError(ctx, x.Wrapf(err, "Error while converting to Json"))
 		x.SetStatus(w, x.Error, err.Error())
 		return

--- a/query/geo_test.go
+++ b/query/geo_test.go
@@ -17,6 +17,7 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -105,9 +106,10 @@ func runQuery(t *testing.T, gq *gql.GraphQuery) string {
 	require.NoError(t, err)
 
 	var l Latency
-	js, err := sg.ToFastJSON(&l)
+	var buf bytes.Buffer
+	err = sg.ToFastJSON(&l, &buf)
 	require.NoError(t, err)
-	return string(js)
+	return string(buf.Bytes())
 }
 
 func TestWithinPoint(t *testing.T) {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	geom "github.com/twpayne/go-geom"
@@ -373,12 +372,4 @@ func (sg *SubGraph) ToFastJSON(l *Latency, w io.Writer) error {
 	n.(*fastJsonNode).encode(bufW)
 	bufW.Flush()
 	return nil
-}
-
-var bufferPool = sync.Pool{
-	New: func() interface{} {
-		var buf bytes.Buffer
-		buf.Grow(4096)
-		return buf
-	},
 }

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -362,14 +362,15 @@ func (sg *SubGraph) ToFastJSON(l *Latency, w io.Writer) error {
 		}
 
 		var slBuf bytes.Buffer
-		bufW := bufio.NewWriter(&slBuf)
-		sl.encode(bufW)
-		bufW.Flush()
-		n.(*fastJsonNode).attrs["server_latency"] = slBuf.Bytes()
+		slW := bufio.NewWriter(&slBuf)
+		sl.encode(slW)
+		if slW.Flush() != nil {
+			return slW.Flush()
+		}
+		n.(*fastJsonNode).attrs["server_latency"] = slB.Bytes()
 	}
 
 	bufW := bufio.NewWriter(w)
 	n.(*fastJsonNode).encode(bufW)
-	bufW.Flush()
-	return nil
+	return bufW.Flush()
 }

--- a/query/query.go
+++ b/query/query.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"log"
 	"strconv"
 	"strings"
@@ -845,7 +846,7 @@ func ToProtocolBuf(l *Latency, sgl []*SubGraph) ([]*graph.Node, error) {
 	return resNode, nil
 }
 
-func ToJson(l *Latency, sgl []*SubGraph) ([]byte, error) {
+func ToJson(l *Latency, sgl []*SubGraph, w io.Writer) error {
 	sgr := &SubGraph{
 		Attr: "_root_",
 	}
@@ -858,5 +859,5 @@ func ToJson(l *Latency, sgl []*SubGraph) ([]byte, error) {
 		}
 		sgr.Children = append(sgr.Children, sg)
 	}
-	return sgr.ToFastJSON(l)
+	return sgr.ToFastJSON(l, w)
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -17,6 +17,7 @@
 package query
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
@@ -269,9 +270,10 @@ func processToFastJSON(t *testing.T, query string) string {
 	sgl, err := ProcessQuery(ctx, res, &l)
 	require.NoError(t, err)
 
-	js, err := ToJson(&l, sgl)
+	var buf bytes.Buffer
+	err = ToJson(&l, sgl, &buf)
 	require.NoError(t, err)
-	return string(js)
+	return string(buf.Bytes())
 }
 
 func TestGetUID(t *testing.T) {
@@ -1839,7 +1841,9 @@ func mockSubGraph() *SubGraph {
 func TestMockSubGraphFastJson(t *testing.T) {
 	sg := mockSubGraph()
 	var l Latency
-	js, _ := sg.ToFastJSON(&l)
+	var buf bytes.Buffer
+	require.NoError(t, ToJson(&l, []*SubGraph{sg}, &buf))
+	js := buf.Bytes()
 	// check validity of json
 	var unmarshalJs map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(js), &unmarshalJs))

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -271,8 +271,7 @@ func processToFastJSON(t *testing.T, query string) string {
 	require.NoError(t, err)
 
 	var buf bytes.Buffer
-	err = ToJson(&l, sgl, &buf)
-	require.NoError(t, err)
+	require.NoError(t, ToJson(&l, sgl, &buf))
 	return string(buf.Bytes())
 }
 


### PR DESCRIPTION
~~Using buffer pool in `toFastJson` for sharing buffers between requests..~~
1. We have to make copy of buffer bytes before returning to the pool, as buffer.Bytes() are valid till next read/write on buffer.
On thinking, this seems to be fine with me; as this does not matter when we have less queries; on load, we are returning buffer faster so now new buffers will be created. So, it seems to be the same memory footprint.

Now writing directly to HttpResponseWriter.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/502)
<!-- Reviewable:end -->
