### PR TITLE
#487: rdf comments is supported

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -69,7 +69,7 @@ func processFile(file string, batch *client.BatchMutation) {
 			break
 		}
 		nq, err := rdf.Parse(buf.String())
-		if err != nil && err.Error() == "EMPTY_LINE" { // special case: comment/empty line
+		if err == rdf.ErrEmpty { // special case: comment/empty line
 			buf.Reset()
 			continue
 		} else if err != nil {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -71,6 +71,9 @@ func processFile(file string, batch *client.BatchMutation) {
 		nq, err := rdf.Parse(buf.String())
 		if err != nil {
 			log.Fatal("While parsing RDF: ", err)
+		} else if len(nq.Subject) == 0 { // empty line
+			buf.Reset()
+			continue
 		}
 		buf.Reset()
 		if err = batch.AddMutation(nq, client.SET); err != nil {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -69,11 +69,11 @@ func processFile(file string, batch *client.BatchMutation) {
 			break
 		}
 		nq, err := rdf.Parse(buf.String())
-		if err != nil {
-			log.Fatal("While parsing RDF: ", err)
-		} else if len(nq.Subject) == 0 { // empty line
+		if err != nil && err.Error() == "EMPTY_LINE" { // special case: comment/empty line
 			buf.Reset()
 			continue
+		} else if err != nil {
+			log.Fatal("While parsing RDF: ", err)
 		}
 		buf.Reset()
 		if err = batch.AddMutation(nq, client.SET); err != nil {

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -253,7 +253,7 @@ func Parse(line string) (rnq graph.NQuad, rerr error) {
 		return rnq, x.Errorf("Invalid end of input. Input: [%s]", line)
 	}
 	if isCommentLine {
-		return rnq, nil
+		return rnq, x.Errorf("EMPTY_LINE")
 	}
 	if len(oval) > 0 {
 		rnq.ObjectValue = &graph.Value{&graph.Value_StrVal{oval}}

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -173,6 +173,7 @@ func Parse(line string) (rnq graph.NQuad, rerr error) {
 	it := l.NewIterator()
 	var oval string
 	var vend, hasBrackets bool
+	isCommentLine := false
 	// We read items from the l.Items channel to which the lexer sends items.
 	for it.Next() {
 		item := it.Item()
@@ -236,6 +237,10 @@ func Parse(line string) (rnq graph.NQuad, rerr error) {
 		case lex.ItemError:
 			return rnq, x.Errorf(item.Val)
 
+		case itemComment:
+			isCommentLine = true
+			vend = true
+
 		case itemValidEnd:
 			vend = true
 
@@ -246,6 +251,9 @@ func Parse(line string) (rnq graph.NQuad, rerr error) {
 
 	if !vend {
 		return rnq, x.Errorf("Invalid end of input. Input: [%s]", line)
+	}
+	if isCommentLine {
+		return rnq, nil
 	}
 	if len(oval) > 0 {
 		rnq.ObjectValue = &graph.Value{&graph.Value_StrVal{oval}}

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -17,6 +17,7 @@
 package rdf
 
 import (
+	"errors"
 	"log"
 	"strconv"
 	"strings"
@@ -32,6 +33,9 @@ import (
 )
 
 var emptyEdge task.DirectedEdge
+var (
+	ErrEmpty = errors.New("rdf: harmless error, e.g. comment line")
+)
 
 // Gets the uid corresponding to an xid from the posting list which stores the
 // mapping.
@@ -253,7 +257,7 @@ func Parse(line string) (rnq graph.NQuad, rerr error) {
 		return rnq, x.Errorf("Invalid end of input. Input: [%s]", line)
 	}
 	if isCommentLine {
-		return rnq, x.Errorf("EMPTY_LINE")
+		return rnq, ErrEmpty
 	}
 	if len(oval) > 0 {
 		rnq.ObjectValue = &graph.Value{&graph.Value_StrVal{oval}}

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -346,6 +346,20 @@ var testNQuads = []struct {
 		input:       `_:gabe <name> "Gabe' .`,
 		expectedErr: true,
 	},
+	{
+		input: `# nothing happened`,
+		nq: graph.NQuad{},
+		expectedErr: false,
+	},
+	{
+		input: `  `,
+		nq: graph.NQuad{},
+		expectedErr: false,
+	},
+	{
+		input: `check me as error`,
+		expectedErr: true,
+	},
 }
 
 func TestLex(t *testing.T) {

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -376,7 +376,7 @@ func TestLex(t *testing.T) {
 		t.Logf("Testing %v", test.input)
 		rnq, err := Parse(test.input)
 		if test.expectedErr && test.shouldIgnore {
-			assert.Equal(t, "EMPTY_LINE", err.Error(), "Catch an ignorable case: %v", 
+			assert.Equal(t, ErrEmpty, err, "Catch an ignorable case: %v", 
 				err.Error())
 		} else if test.expectedErr {
 			assert.Error(t, err, "Expected error for input: %q. Output: %+v",

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -24,9 +24,10 @@ import (
 )
 
 var testNQuads = []struct {
-	input       string
-	nq          graph.NQuad
-	expectedErr bool
+	input        string
+	nq           graph.NQuad
+	expectedErr  bool
+	shouldIgnore bool
 }{
 	{
 		input: `<some_subject_id> <predicate> <object_id> .`,
@@ -348,17 +349,25 @@ var testNQuads = []struct {
 	},
 	{
 		input: `# nothing happened`,
-		nq: graph.NQuad{},
-		expectedErr: false,
+		expectedErr: true,
+		shouldIgnore: true,
 	},
 	{
-		input: `  `,
-		nq: graph.NQuad{},
-		expectedErr: false,
+		input: `<some_subject_id> # <predicate> <object_id> .`,
+		expectedErr: true,
+	},
+	{
+		input: `<some_subject_id> <predicate> <object_id> # .`,
+		expectedErr: true,
 	},
 	{
 		input: `check me as error`,
 		expectedErr: true,
+	},
+	{
+		input: `   `,
+		expectedErr: true,
+		shouldIgnore: true,
 	},
 }
 
@@ -366,7 +375,10 @@ func TestLex(t *testing.T) {
 	for _, test := range testNQuads {
 		t.Logf("Testing %v", test.input)
 		rnq, err := Parse(test.input)
-		if test.expectedErr {
+		if test.expectedErr && test.shouldIgnore {
+			assert.Equal(t, "EMPTY_LINE", err.Error(), "Catch an ignorable case: %v", 
+				err.Error())
+		} else if test.expectedErr {
 			assert.Error(t, err, "Expected error for input: %q. Output: %+v",
 				test.input, rnq)
 		} else {

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -35,6 +35,7 @@ const (
 	itemLanguage                           // language, 11
 	itemObjectType                         // object type, 12
 	itemValidEnd                           // end with dot, 13
+	itemComment                            // comment, 14
 )
 
 // These constants keep a track of the depth while parsing an rdf N-Quad.
@@ -85,6 +86,12 @@ Loop:
 			l.Emit(itemText)
 			return lexObject
 
+		case r == '#':
+			if l.Depth != atSubject {
+				return l.Errorf("Invalid input: %c at lexText", r)
+			}
+			return lexComment
+
 		case r == lex.EOF:
 			break Loop
 
@@ -102,6 +109,9 @@ Loop:
 	}
 	if l.Pos > l.Start {
 		l.Emit(itemText)
+	}
+	if l.Depth == atSubject { // no valid term encountered, taken as comment-line
+		return lexComment
 	}
 	l.Emit(lex.ItemEOF)
 	return nil
@@ -315,6 +325,20 @@ func lexLabel(l *lex.Lexer) lex.StateFn {
 	return l.Errorf("Invalid char: %v at lexLabel", r)
 }
 
+// lexComment lexes a comment text.
+func lexComment(l *lex.Lexer) lex.StateFn {
+	l.Backup()
+	for {
+		r := l.Next()
+		if isEndOfLine(r) || r == lex.EOF {
+			break
+		}
+	}
+	l.Emit(itemComment)
+	l.Emit(lex.ItemEOF)
+	return nil // Stop the run loop.
+}
+
 func isClosingBracket(r rune) bool {
 	return r == '>'
 }
@@ -322,6 +346,11 @@ func isClosingBracket(r rune) bool {
 // isSpace returns true if the rune is a tab or space.
 func isSpace(r rune) bool {
 	return r == '\u0009' || r == '\u0020'
+}
+
+// isEndOfLine returns true if the rune is a Linefeed or a Carriage return.
+func isEndOfLine(r rune) bool {
+	return r == '\u000A' || r == '\u000D'
 }
 
 func isEndLiteral(r rune) bool {


### PR DESCRIPTION
Comment/blank line should not be considered as 'error', while in parse.Parse() you can't express 'empty yet harmless' feedback. 
I just keep that interface intact, with returning len(NQuad.Subject) == 0 indicate 'empty yet harmless'.
Do the comment-filter stuff in dgraphloader.main() is inappropriate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/506)
<!-- Reviewable:end -->
