### PR TITLE
Expose ICU data and make goldendata.schema part of the docker image

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -22,14 +22,12 @@ RUN curl https://get.dgraph.io | bash
 # to host machine for persistence.
 RUN mkdir /dgraph && mkdir /data
 
-# Sequence of commands to bulkload some sample data:
-#   cd /data
-#   wget https://github.com/dgraph-io/benchmarks/raw/master/data/rdf-films.gz
-#   wget https://github.com/dgraph-io/benchmarks/raw/master/data/names.gz
-#   cd /dgraph
-#   time dgraphassigner -rdfgzips /data/rdf-films.gz -instanceIdx 0 -numInstances 1 -uids u
-#   time dgraphloader   -rdfgzips /data/rdf-films.gz -instanceIdx 0 -numInstances 1 -uids u -postings p
+# Export the ICU DATA variable.
+ENV ICU_DATA /usr/local/share/icudt58l.dat
 
 EXPOSE 8080
 WORKDIR /dgraph
+# Get the golden data schema.
+RUN wget "https://github.com/dgraph-io/benchmarks/blob/master/data/goldendata.schema?raw=true" -O goldendata.schema -q
+
 CMD ["dgraph"]


### PR DESCRIPTION
So that people can run the docker image with the schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/507)
<!-- Reviewable:end -->
