### PR TITLE
strict parsing of IRIRef in rdf

### DIFF
--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -175,11 +175,22 @@ func (l *Lexer) Ignore() {
 }
 
 type CheckRune func(r rune) bool
+type CheckRuneRec func(r rune, l *Lexer) bool
 
 func (l *Lexer) AcceptRun(c CheckRune) {
 	for {
 		r := l.Next()
 		if r == EOF || !c(r) {
+			break
+		}
+	}
+	l.Backup()
+}
+
+func (l *Lexer) AcceptRunRec(c CheckRuneRec) {
+	for {
+		r := l.Next()
+		if r == EOF || !c(r, l) {
 			break
 		}
 	}
@@ -194,4 +205,18 @@ func (l *Lexer) AcceptUntil(c CheckRune) {
 		}
 	}
 	l.Backup()
+}
+
+// Tries to accept checkrune given number of times.
+// returns number of times it was successful.
+func (l *Lexer) AcceptRunTimes(c CheckRune, times int) int {
+	i := 0
+	for ; i < times; i++ {
+		r := l.Next()
+		if r == EOF || !c(r) {
+			break
+		}
+	}
+	l.Backup()
+	return i
 }

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -174,9 +174,15 @@ func (l *Lexer) Ignore() {
 	l.Start = l.Pos
 }
 
+// CheckRune is predicate signature for accepting valid runes on input.
 type CheckRune func(r rune) bool
+
+// CheckRuneRec is like CheckRune with getting Lexer in input. This can
+// be used to recursively call other CheckRune(s).
 type CheckRuneRec func(r rune, l *Lexer) bool
 
+// AcceptRun accepts tokens based on CheckRune
+// untill it returns false or EOF is reached.
 func (l *Lexer) AcceptRun(c CheckRune) {
 	for {
 		r := l.Next()
@@ -187,6 +193,8 @@ func (l *Lexer) AcceptRun(c CheckRune) {
 	l.Backup()
 }
 
+// AcceptRunRec accepts tokens based on CheckRuneRec
+// untill it returns false or EOF is reached.
 func (l *Lexer) AcceptRunRec(c CheckRuneRec) {
 	for {
 		r := l.Next()
@@ -197,6 +205,8 @@ func (l *Lexer) AcceptRunRec(c CheckRuneRec) {
 	l.Backup()
 }
 
+// AcceptUntil accepts tokens based on CheckRune
+// till it returns false or EOF is reached.
 func (l *Lexer) AcceptUntil(c CheckRune) {
 	for {
 		r := l.Next()
@@ -207,7 +217,7 @@ func (l *Lexer) AcceptUntil(c CheckRune) {
 	l.Backup()
 }
 
-// Tries to accept checkrune given number of times.
+// AcceptRunTimes accepts tokens with CheckRune given number of times.
 // returns number of times it was successful.
 func (l *Lexer) AcceptRunTimes(c CheckRune, times int) int {
 	i := 0

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -354,7 +354,6 @@ var testNQuads = []struct {
 		input:       `<\u0021> <\U123abcdg> <\u0024> .`,
 		expectedErr: true, // `g` is not a Hex char
 	},
-
 	{
 		input:       `<messi with space> <friend> <ronaldo> .`,
 		expectedErr: true, // should fail because of spaces in subject

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -343,6 +343,46 @@ var testNQuads = []struct {
 		},
 	},
 	{
+		input:       `<messi with space> <friend> <ronaldo> .`,
+		expectedErr: true, // should fail because of spaces in subject
+	},
+	{
+		input:       `<with<> <with> <with> .`,
+		expectedErr: true, // should fail because of < after with in subject
+	},
+	{
+		input:       `<wi>th> <with> <with> .`,
+		expectedErr: true, // should fail
+	},
+	{
+		input:       `<"with> <with> <with> .`,
+		expectedErr: true, // should fail because of "
+	},
+	{
+		input:       `<{with> <with> <with> .`,
+		expectedErr: true, // should fail because of {
+	},
+	{
+		input:       `<wi{th> <with> <with> .`,
+		expectedErr: true, // should fail because of }
+	},
+	{
+		input:       `<with|> <with> <with> .`,
+		expectedErr: true, // should fail because of |
+	},
+	{
+		input:       `<wit^h> <with> <with> .`,
+		expectedErr: true, // should fail because of ^
+	},
+	{
+		input:       "<w`ith> <with> <with> .",
+		expectedErr: true, // should fail because of `
+	},
+	{
+		input:       `<wi\th> <with> <with> .`,
+		expectedErr: true, // should fail because of \
+	},
+	{
 		input:       `_:gabe <name> "Gabe' .`,
 		expectedErr: true,
 	},

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -343,6 +343,14 @@ var testNQuads = []struct {
 		},
 	},
 	{
+		input: `<\u0021> <\U123abcdE> <\u0024> .`,
+		nq: graph.NQuad{
+			Subject:   `\u0021`,
+			Predicate: `\U123abcdE`,
+			ObjectId:  `\u0024`,
+		},
+	},
+	{
 		input:       `<messi with space> <friend> <ronaldo> .`,
 		expectedErr: true, // should fail because of spaces in subject
 	},

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -351,6 +351,11 @@ var testNQuads = []struct {
 		},
 	},
 	{
+		input:       `<\u0021> <\U123abcdg> <\u0024> .`,
+		expectedErr: true, // `g` is not a Hex char
+	},
+
+	{
 		input:       `<messi with space> <friend> <ronaldo> .`,
 		expectedErr: true, // should fail because of spaces in subject
 	},

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -107,11 +107,14 @@ Loop:
 	return nil
 }
 
-// This function lexes text until it finds the '>' bracket.
-func lexUntilClosing(l *lex.Lexer, styp lex.ItemType,
+func lexIRIRef(l *lex.Lexer, styp lex.ItemType,
 	sfn lex.StateFn) lex.StateFn {
-	l.AcceptUntil(isClosingBracket)
 	r := l.Next()
+	if r != '<' {
+		return l.Errorf("IRIRef should start from < , instead found %v", r)
+	}
+	l.AcceptRun(isIRIChar)
+	r = l.Next()
 	if r == lex.EOF {
 		return l.Errorf("Unexpected end of subject")
 	}
@@ -171,7 +174,8 @@ func lexSubject(l *lex.Lexer) lex.StateFn {
 	// The subject is an IRI, so we lex till we encounter '>'.
 	if r == '<' {
 		l.Depth++
-		return lexUntilClosing(l, itemSubject, lexText)
+		l.Backup()
+		return lexIRIRef(l, itemSubject, lexText)
 	}
 
 	// The subject represents a blank node.
@@ -196,7 +200,8 @@ func lexPredicate(l *lex.Lexer) lex.StateFn {
 	}
 
 	l.Depth++
-	return lexUntilClosing(l, itemPredicate, lexText)
+	l.Backup()
+	return lexIRIRef(l, itemPredicate, lexText)
 }
 
 func lexLanguage(l *lex.Lexer) lex.StateFn {
@@ -265,7 +270,8 @@ func lexObjectType(l *lex.Lexer) lex.StateFn {
 		return l.Errorf("Expected < for lexObjectType")
 	}
 
-	return lexUntilClosing(l, itemObjectType, lexText)
+	l.Backup()
+	return lexIRIRef(l, itemObjectType, lexText)
 }
 
 func lexObject(l *lex.Lexer) lex.StateFn {
@@ -273,7 +279,8 @@ func lexObject(l *lex.Lexer) lex.StateFn {
 	// The object can be an IRI, blank node or a literal.
 	if r == '<' {
 		l.Depth++
-		return lexUntilClosing(l, itemObject, lexText)
+		l.Backup()
+		return lexIRIRef(l, itemObject, lexText)
 	}
 
 	if r == '_' {
@@ -299,7 +306,8 @@ func lexLabel(l *lex.Lexer) lex.StateFn {
 	// Graph label can either be an IRI or a blank node according to spec.
 	if r == '<' {
 		l.Depth++
-		return lexUntilClosing(l, itemLabel, lexText)
+		l.Backup()
+		return lexIRIRef(l, itemLabel, lexText)
 	}
 
 	if r == '_' {
@@ -353,4 +361,24 @@ func isLangTag(r rune) bool {
 	default:
 		return false
 	}
+}
+
+func isIRIChar(r rune) bool {
+	if r <= 32 { // no chars b/w 0x00 to 0x20 inclusive
+		return false
+	}
+	switch r {
+	case '<':
+	case '>':
+	case '"':
+	case '{':
+	case '}':
+	case '|':
+	case '^':
+	case '`':
+	case '\\':
+	default:
+		return true
+	}
+	return false
 }

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -398,8 +398,8 @@ func isIRIChar(r rune, l *lex.Lexer) bool {
 func isHex(r rune) bool {
 	switch {
 	case r >= '0' && r <= '9':
-	case r >= 'a' && r <= 'z':
-	case r >= 'A' && r <= 'Z':
+	case r >= 'a' && r <= 'f':
+	case r >= 'A' && r <= 'F':
 	default:
 		return false
 	}

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -109,12 +109,8 @@ Loop:
 
 func lexIRIRef(l *lex.Lexer, styp lex.ItemType,
 	sfn lex.StateFn) lex.StateFn {
-	r := l.Next()
-	if r != '<' {
-		return l.Errorf("IRIRef should start from < , instead found %v", r)
-	}
 	l.AcceptRunRec(isIRIChar)
-	r = l.Next()
+	r := l.Next()
 	if r == lex.EOF {
 		return l.Errorf("Unexpected end of subject")
 	}
@@ -174,7 +170,6 @@ func lexSubject(l *lex.Lexer) lex.StateFn {
 	// The subject is an IRI, so we lex till we encounter '>'.
 	if r == '<' {
 		l.Depth++
-		l.Backup()
 		return lexIRIRef(l, itemSubject, lexText)
 	}
 
@@ -200,7 +195,6 @@ func lexPredicate(l *lex.Lexer) lex.StateFn {
 	}
 
 	l.Depth++
-	l.Backup()
 	return lexIRIRef(l, itemPredicate, lexText)
 }
 
@@ -270,7 +264,6 @@ func lexObjectType(l *lex.Lexer) lex.StateFn {
 		return l.Errorf("Expected < for lexObjectType")
 	}
 
-	l.Backup()
 	return lexIRIRef(l, itemObjectType, lexText)
 }
 
@@ -279,7 +272,6 @@ func lexObject(l *lex.Lexer) lex.StateFn {
 	// The object can be an IRI, blank node or a literal.
 	if r == '<' {
 		l.Depth++
-		l.Backup()
 		return lexIRIRef(l, itemObject, lexText)
 	}
 
@@ -306,7 +298,6 @@ func lexLabel(l *lex.Lexer) lex.StateFn {
 	// Graph label can either be an IRI or a blank node according to spec.
 	if r == '<' {
 		l.Depth++
-		l.Backup()
 		return lexIRIRef(l, itemLabel, lexText)
 	}
 


### PR DESCRIPTION
Grammar :

IRIREF 	::= 	'<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
UCHAR 	::= 	'\u' HEX HEX HEX HEX | '\U' HEX HEX HEX HEX HEX HEX HEX HEX
HEX 	::= 	[0-9] | [A-F] | [a-f]

We were allowing any characters in IRI. Restricting them to the spec.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/508)
<!-- Reviewable:end -->
