### PR TITLE
gql/iriref : Parsing of IRI chars in gql.

### DIFF
--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1327,6 +1327,16 @@ func TestParseIRIRefSpace(t *testing.T) {
 	require.Error(t, err) // because of space.
 }
 
+func TestParseIRIRefInvalidChar(t *testing.T) {
+	query := `{
+		me(id:<http://helloworld.com/how/are/^you>) {
+                }
+              }`
+
+	_, err := Parse(query)
+	require.Error(t, err) // because of ^
+}
+
 func TestParseGeoJson(t *testing.T) {
 	query := `
 	mutation {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1188,7 +1188,7 @@ func TestParseCountAsFuncMultiple(t *testing.T) {
 }
 
 func TestParseCountAsFuncMultipleError(t *testing.T) {
-	schema.ParseBytes([]byte("scalar name:string @index"))
+	require.NoError(t, schema.ParseBytes([]byte("scalar name:string @index")))
 	query := `{
 		me(id:1) {
 			count(friends, relatives
@@ -1319,6 +1319,7 @@ func TestParseIRIRef(t *testing.T) {
 }
 
 func TestParseIRIRef2(t *testing.T) {
+	require.NoError(t, schema.ParseBytes([]byte("scalar <http://helloworld.com/how/are/you>:string @index")))
 	query := `{
 		me(anyof(<http://helloworld.com/how/are/you>, "good better bad")) {
 			<http://verygood.com/what/about/you>
@@ -1330,10 +1331,11 @@ func TestParseIRIRef2(t *testing.T) {
 
 	gq, err := Parse(query)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(gq.Query[0].Children))
+	require.Equal(t, 2, len(gq.Query[0].Children))
 	require.Equal(t, "http://verygood.com/what/about/you", gq.Query[0].Children[0].Attr)
 	require.Equal(t, `(allof "http://verygood.com/what/about/you" "good better bad")`,
 		gq.Query[0].Children[1].Filter.debugString())
+	require.Equal(t, "http://helloworld.com/how/are/you", gq.Query[0].Func.Attr)
 }
 
 func TestParseIRIRefSpace(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1298,6 +1298,35 @@ func TestParseGenerator(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestParseIRIRef(t *testing.T) {
+	query := `{
+		me(id:<http://helloworld.com/how/are/you>) {
+                        <http://verygood.com/what/about/you>
+			friends @filter(allof(<http://verygood.com/what/about/you>, "good better bad")){
+				name
+			}
+			gender,age
+			hometown
+		}
+	}`
+
+	gq, err := Parse(query)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(gq.Query[0].Children))
+	require.Equal(t, "http://verygood.com/what/about/you", gq.Query[0].Children[0].Attr)
+	require.Equal(t, `(allof "http://verygood.com/what/about/you" "good better bad")`, gq.Query[0].Children[1].Filter.debugString())
+}
+
+func TestParseIRIRefSpace(t *testing.T) {
+	query := `{
+		me(id:<http://helloworld.com/how/are/ you>) {
+                }
+              }`
+
+	_, err := Parse(query)
+	require.Error(t, err) // because of space.
+}
+
 func TestParseGeoJson(t *testing.T) {
 	query := `
 	mutation {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1300,8 +1300,8 @@ func TestParseGenerator(t *testing.T) {
 
 func TestParseIRIRef(t *testing.T) {
 	query := `{
-		me(id:<http://helloworld.com/how/are/you>) {
-                        <http://verygood.com/what/about/you>
+		me(id: <http://helloworld.com/how/are/you>) {
+			<http://verygood.com/what/about/you>
 			friends @filter(allof(<http://verygood.com/what/about/you>, "good better bad")){
 				name
 			}
@@ -1314,14 +1314,33 @@ func TestParseIRIRef(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 5, len(gq.Query[0].Children))
 	require.Equal(t, "http://verygood.com/what/about/you", gq.Query[0].Children[0].Attr)
-	require.Equal(t, `(allof "http://verygood.com/what/about/you" "good better bad")`, gq.Query[0].Children[1].Filter.debugString())
+	require.Equal(t, `(allof "http://verygood.com/what/about/you" "good better bad")`,
+		gq.Query[0].Children[1].Filter.debugString())
+}
+
+func TestParseIRIRef2(t *testing.T) {
+	query := `{
+		me(anyof(<http://helloworld.com/how/are/you>, "good better bad")) {
+			<http://verygood.com/what/about/you>
+			friends @filter(allof(<http://verygood.com/what/about/you>, "good better bad")){
+				name
+			}
+		}
+	}`
+
+	gq, err := Parse(query)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(gq.Query[0].Children))
+	require.Equal(t, "http://verygood.com/what/about/you", gq.Query[0].Children[0].Attr)
+	require.Equal(t, `(allof "http://verygood.com/what/about/you" "good better bad")`,
+		gq.Query[0].Children[1].Filter.debugString())
 }
 
 func TestParseIRIRefSpace(t *testing.T) {
 	query := `{
-		me(id:<http://helloworld.com/how/are/ you>) {
-                }
-              }`
+		me(id: <http://helloworld.com/how/are/ you>) {
+		}
+	      }`
 
 	_, err := Parse(query)
 	require.Error(t, err) // because of space.
@@ -1329,9 +1348,9 @@ func TestParseIRIRefSpace(t *testing.T) {
 
 func TestParseIRIRefInvalidChar(t *testing.T) {
 	query := `{
-		me(id:<http://helloworld.com/how/are/^you>) {
-                }
-              }`
+		me(id: <http://helloworld.com/how/are/^you>) {
+		}
+	      }`
 
 	_, err := Parse(query)
 	require.Error(t, err) // because of ^

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1302,7 +1302,8 @@ func TestParseIRIRef(t *testing.T) {
 	query := `{
 		me(id: <http://helloworld.com/how/are/you>) {
 			<http://verygood.com/what/about/you>
-			friends @filter(allof(<http://verygood.com/what/about/you>, "good better bad")){
+			friends @filter(allof(<http://verygood.com/what/about/you>,
+				"good better bad")){
 				name
 			}
 			gender,age
@@ -1319,11 +1320,13 @@ func TestParseIRIRef(t *testing.T) {
 }
 
 func TestParseIRIRef2(t *testing.T) {
-	require.NoError(t, schema.ParseBytes([]byte("scalar <http://helloworld.com/how/are/you>:string @index")))
+	require.NoError(t, schema.ParseBytes(
+		[]byte("scalar <http://helloworld.com/how/are/you>:string @index")))
 	query := `{
 		me(anyof(<http://helloworld.com/how/are/you>, "good better bad")) {
 			<http://verygood.com/what/about/you>
-			friends @filter(allof(<http://verygood.com/what/about/you>, "good better bad")){
+			friends @filter(allof(<http://verygood.com/what/about/you>,
+				"good better bad")){
 				name
 			}
 		}

--- a/gql/state.go
+++ b/gql/state.go
@@ -290,15 +290,12 @@ func lexText(l *lex.Lexer) lex.StateFn {
 
 func lexIRIRef(l *lex.Lexer) lex.StateFn {
 	l.Ignore() // ignore '<'
-	lastr, validr := l.AcceptRun(func(r rune) bool {
-		return r != grThan && !isSpace(r)
-	})
-	if validr && isSpace(lastr) {
-		return l.Errorf("Spaces are not allowed in IRI")
+	l.AcceptRunRec(isIRIChar)
+	l.Emit(itemName) // will emit without '<' and '>'
+	r := l.Next()
+	if r != '>' {
+		return l.Errorf("IRI should end with '>'. Got %v", r)
 	}
-
-	l.Emit(itemName)
-	l.Next()
 	l.Ignore() // ignore '>'
 	return lexText
 }
@@ -546,4 +543,56 @@ func isNameSuffix(r rune) bool {
 		return true
 	}
 	return false
+}
+
+// IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+func isIRIChar(r rune, l *lex.Lexer) bool {
+	if r <= 32 { // no chars b/w 0x00 to 0x20 inclusive
+		return false
+	}
+	switch r {
+	case '<':
+	case '>':
+	case '"':
+	case '{':
+	case '}':
+	case '|':
+	case '^':
+	case '`':
+	case '\\':
+		r2 := l.Next()
+		if r2 != 'u' && r2 != 'U' {
+			l.Backup()
+			return false
+		} else {
+			return hasUChars(r2, l)
+		}
+	default:
+		return true
+	}
+	return false
+}
+
+// UCHAR ::= '\u' HEX HEX HEX HEX | '\U' HEX HEX HEX HEX HEX HEX HEX HEX
+func hasUChars(r rune, l *lex.Lexer) bool {
+	if r != 'u' && r != 'U' {
+		return false
+	}
+	times := 4
+	if r == 'U' {
+		times = 8
+	}
+	return times == l.AcceptRunTimes(isHex, times)
+}
+
+// HEX ::= [0-9] | [A-F] | [a-f]
+func isHex(r rune) bool {
+	switch {
+	case r >= '0' && r <= '9':
+	case r >= 'a' && r <= 'f':
+	case r >= 'A' && r <= 'F':
+	default:
+		return false
+	}
+	return true
 }

--- a/gql/state.go
+++ b/gql/state.go
@@ -564,9 +564,8 @@ func isIRIChar(r rune, l *lex.Lexer) bool {
 		if r2 != 'u' && r2 != 'U' {
 			l.Backup()
 			return false
-		} else {
-			return hasUChars(r2, l)
 		}
+		return hasUChars(r2, l)
 	default:
 		return true
 	}

--- a/gql/state_test.go
+++ b/gql/state_test.go
@@ -142,8 +142,8 @@ func TestVariablesDefault(t *testing.T) {
 func TestIRIRef(t *testing.T) {
 	input := `
 	query testQuery {
-		me(_xid_: <http://helloworld.com/how/are/you>) {
-                     <http://verygood.com/what/about/you>
+		me(id : <http://helloworld.com/how/are/you>) {
+		        <http://verygood.com/what/about/you>
 		}
 	}`
 	l := lex.NewLexer(input).Run(lexText)

--- a/gql/state_test.go
+++ b/gql/state_test.go
@@ -138,3 +138,19 @@ func TestVariablesDefault(t *testing.T) {
 		t.Log(item.String())
 	}
 }
+
+func TestIRIRef(t *testing.T) {
+	input := `
+	query testQuery {
+		me(_xid_: <http://helloworld.com/how/are/you>) {
+                     <http://verygood.com/what/about/you>
+		}
+	}`
+	l := lex.NewLexer(input).Run(lexText)
+	it := l.NewIterator()
+	for it.Next() {
+		item := it.Item()
+		require.NotEqual(t, item.Typ, lex.ItemError)
+		t.Log(item.String())
+	}
+}

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -413,9 +413,8 @@ func isIRIChar(r rune, l *lex.Lexer) bool {
 		if r2 != 'u' && r2 != 'U' {
 			l.Backup()
 			return false
-		} else {
-			return hasUChars(r2, l)
 		}
+		return hasUChars(r2, l)
 	default:
 		return true
 	}

--- a/schema/state.go
+++ b/schema/state.go
@@ -291,7 +291,8 @@ L:
 			l.Backup()
 			break L
 		default:
-			return l.Errorf("Invalid schema. Unexpected %s", l.Input[l.Start:l.Pos])
+			return l.Errorf("Invalid schema. Unexpected %s and %v",
+				l.Input[l.Start:l.Pos], r)
 		}
 	}
 

--- a/schema/state.go
+++ b/schema/state.go
@@ -16,7 +16,12 @@
 
 package schema
 
-import "github.com/dgraph-io/dgraph/lex"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dgraph-io/dgraph/lex"
+)
 
 const (
 	leftCurl   = '{'
@@ -24,6 +29,8 @@ const (
 	leftRound  = '('
 	rightRound = ')'
 	collon     = ':'
+	lsThan     = '<'
+	grThan     = '>'
 )
 
 // Constants representing type of different graphql lexed items.
@@ -96,7 +103,7 @@ func lexStart(l *lex.Lexer) lex.StateFn {
 func lexScalar(l *lex.Lexer) lex.StateFn {
 	for {
 		switch r := l.Next(); {
-		case isNameBegin(r):
+		case r == lsThan || isNameBegin(r):
 			l.Backup()
 			return lexScalarPair
 		case r == leftRound:
@@ -117,7 +124,7 @@ func lexScalarBlock(l *lex.Lexer) lex.StateFn {
 		case r == ')':
 			l.Emit(itemRightRound)
 			return lexText
-		case isNameBegin(r):
+		case r == lsThan || isNameBegin(r):
 			l.Backup()
 			return lexScalarPair1
 		case isSpace(r) || isEndOfLine(r):
@@ -135,19 +142,12 @@ func lexObject(l *lex.Lexer) lex.StateFn {
 			return lexText
 		case isSpace(r) || isEndOfLine(r):
 			l.Ignore()
-		case isNameBegin(r):
-			{
-				for {
-					r := l.Next()
-					if isNameSuffix(r) {
-						continue // absorb
-					}
-					l.Backup()
-					l.Emit(itemObject)
-					break
-				}
-				return lexObjectBlock
+		case r == lsThan || isNameBegin(r):
+			l.Backup()
+			if err := lexName(l, itemObject); err != nil {
+				return l.Errorf("Invalid schema. Error: ", err.Error())
 			}
+			return lexObjectBlock
 		default:
 			return l.Errorf("Invalid schema. Unexpected %s", l.Input[l.Start:l.Pos])
 		}
@@ -164,7 +164,8 @@ func lexObjectBlock(l *lex.Lexer) lex.StateFn {
 		case r == rightCurl:
 			l.Emit(itemRightCurl)
 			return lexText
-		case isNameBegin(r):
+		case r == '<' || isNameBegin(r):
+			l.Backup()
 			return lexObjectPair
 		default:
 			return l.Errorf("Invalid schema. Unexpected %s", l.Input[l.Start:l.Pos])
@@ -173,15 +174,8 @@ func lexObjectBlock(l *lex.Lexer) lex.StateFn {
 }
 
 func lexScalarPair(l *lex.Lexer) lex.StateFn {
-	for {
-		r := l.Next()
-		if isNameSuffix(r) {
-			continue // absorb
-		}
-		l.Backup()
-		// l.Pos would be index of the end of operation type + 1.
-		l.Emit(itemScalarName)
-		break
+	if err := lexName(l, itemScalarName); err != nil {
+		return l.Errorf("Invalid schema. Error : %s", err.Error())
 	}
 
 L:
@@ -219,7 +213,7 @@ L1:
 		switch r := l.Next(); {
 		case isSpace(r):
 			l.Ignore()
-		case isEndOfLine(r):
+		case r == lex.EOF || isEndOfLine(r):
 			break L1
 		case r == '@':
 			l.Emit(itemAt)
@@ -248,7 +242,12 @@ L1:
 	return lexText
 }
 
-func lexScalarPair1(l *lex.Lexer) lex.StateFn {
+func lexName(l *lex.Lexer, styp lex.ItemType) error {
+	r := l.Next()
+	if r == lsThan {
+		return lexIRIRef(l, styp)
+	}
+
 	for {
 		r := l.Next()
 		if isNameSuffix(r) {
@@ -256,8 +255,28 @@ func lexScalarPair1(l *lex.Lexer) lex.StateFn {
 		}
 		l.Backup()
 		// l.Pos would be index of the end of operation type + 1.
-		l.Emit(itemScalarName)
+		l.Emit(styp)
 		break
+	}
+	return nil
+}
+
+// assumes '<' is already lexed.
+func lexIRIRef(l *lex.Lexer, styp lex.ItemType) error {
+	l.Ignore() // ignore '<'
+	l.AcceptRunRec(isIRIChar)
+	l.Emit(styp) // will emit without '<' and '>'
+	r := l.Next()
+	if r != grThan {
+		return errors.New(fmt.Sprintf("Unexpected character %v. Expected '>'.", r))
+	}
+	l.Ignore() // ignore '>'
+	return nil
+}
+
+func lexScalarPair1(l *lex.Lexer) lex.StateFn {
+	if err := lexName(l, itemScalarName); err != nil {
+		return l.Errorf("Invalid schema. Error : %s", err.Error())
 	}
 
 L:
@@ -321,14 +340,8 @@ L1:
 }
 
 func lexObjectPair(l *lex.Lexer) lex.StateFn {
-	for {
-		r := l.Next()
-		if isNameSuffix(r) {
-			continue // absorb
-		}
-		l.Backup()
-		l.Emit(itemObjectName)
-		break
+	if err := lexName(l, itemObjectName); err != nil {
+		return l.Errorf("Invalid schema. Error: ", err.Error())
 	}
 
 L:
@@ -428,4 +441,55 @@ func isSpace(r rune) bool {
 // isEndOfLine returns true if the rune is a Linefeed or a Carriage return.
 func isEndOfLine(r rune) bool {
 	return r == '\u000A' || r == '\u000D'
+}
+
+// IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
+func isIRIChar(r rune, l *lex.Lexer) bool {
+	if r <= 32 { // no chars b/w 0x00 to 0x20 inclusive
+		return false
+	}
+	switch r {
+	case '<':
+	case '>':
+	case '"':
+	case '{':
+	case '}':
+	case '|':
+	case '^':
+	case '`':
+	case '\\':
+		r2 := l.Next()
+		if r2 != 'u' && r2 != 'U' {
+			l.Backup()
+			return false
+		}
+		return hasUChars(r2, l)
+	default:
+		return true
+	}
+	return false
+}
+
+// UCHAR ::= '\u' HEX HEX HEX HEX | '\U' HEX HEX HEX HEX HEX HEX HEX HEX
+func hasUChars(r rune, l *lex.Lexer) bool {
+	if r != 'u' && r != 'U' {
+		return false
+	}
+	times := 4
+	if r == 'U' {
+		times = 8
+	}
+	return times == l.AcceptRunTimes(isHex, times)
+}
+
+// HEX ::= [0-9] | [A-F] | [a-f]
+func isHex(r rune) bool {
+	switch {
+	case r >= '0' && r <= '9':
+	case r >= 'a' && r <= 'f':
+	case r >= 'A' && r <= 'F':
+	default:
+		return false
+	}
+	return true
 }

--- a/schema/testfiles/test_schema
+++ b/schema/testfiles/test_schema
@@ -1,8 +1,9 @@
- scalar age:int
+scalar age:int
 
 scalar (
   name: string
   address: string
+  <http://scalar.com/helloworld/> : string
   )
 
 type  Person {
@@ -23,4 +24,9 @@ films: Film
 type Film {
 name: string
 budget: int
+}
+
+type <http://film.com/> {
+     <http://film.com/name>: string
+     <http://film.com/budget>: int
 }


### PR DESCRIPTION
Following the grammar :

```
IRIREF ::= '<' ([^#x00-#x20<>"{}|^`\] | UCHAR)* '>'
UCHAR ::= '\u' HEX HEX HEX HEX | '\U' HEX HEX HEX HEX HEX HEX HEX HEX
HEX ::= [0-9] | [A-F] | [a-f]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/524)
<!-- Reviewable:end -->
