### PR TITLE
Add support for aggregator(min) - rough version

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -108,6 +108,13 @@ func init() {
 	}
 }
 
+func (f *Function) IsAgrtr() bool {
+	return f.Name == "count" ||
+		f.Name == "min" ||
+		f.Name == "max" ||
+		f.Name == "sum"
+}
+
 // DebugPrint is useful for debugging.
 func (gq *GraphQuery) DebugPrint(prefix string) {
 	x.Printf("%s[%x %q %q->%q]\n", prefix, gq.UID, gq.Attr, gq.Alias)
@@ -1173,7 +1180,8 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				continue
 			}
 
-			if item.Val == "count" || item.Val == "min" {
+			if item.Val == "count" || item.Val == "min" || 
+				item.Val == "max" || item.Val == "sum" {
 				if isAgrtr != 0 {
 					return x.Errorf("Invalid mention of aggregator.")
 				}
@@ -1195,7 +1203,8 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				//IsCount: isAgrtr == 1,
 			}
 			if isAgrtr == 1 {
-				child.Agrtr = &Function{Name:agrtr, Attr: item.Val}
+				child.Func = &Function{Name:agrtr, Attr: item.Val}
+				//child.Agrtr = &Function{Name:agrtr, Attr: item.Val}
 			}
 			gq.Children = append(gq.Children, child)
 			curp = child

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1200,11 +1200,9 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 			child := &GraphQuery{
 				Args:    make(map[string]string),
 				Attr:    item.Val,
-				//IsCount: isAgrtr == 1,
 			}
 			if isAgrtr == 1 {
 				child.Func = &Function{Name:agrtr, Attr: item.Val}
-				//child.Agrtr = &Function{Name:agrtr, Attr: item.Val}
 			}
 			gq.Children = append(gq.Children, child)
 			curp = child

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1185,6 +1185,20 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				continue
 			}
 
+			if isAggregator(item.Val) {
+				child := &GraphQuery{
+					Args:    make(map[string]string),
+				}
+				it.Prev()
+				if child.Func, err = parseFunction(it); err != nil {
+					return err
+				}
+				child.Attr = child.Func.Attr
+				gq.Children = append(gq.Children, child)
+				curp = child
+				continue
+			}
+
 			if item.Val == "count" {
 				if isCount != 0 {
 					return x.Errorf("Invalid mention of function count")
@@ -1204,14 +1218,6 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				Args:    make(map[string]string),
 				Attr:    item.Val,
 				IsCount: isCount == 1,
-			}
-			if isAggregator(item.Val) {
-				it.Prev()
-				child.Func, err = parseFunction(it)
-				if err != nil {
-					return err
-				}
-				child.Attr = child.Func.Attr
 			}
 			gq.Children = append(gq.Children, child)
 			curp = child
@@ -1272,7 +1278,8 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 }
 
 func isAggregator(f string) bool {
-	return f == "min" || f == "max" || f == "sum"
+	fname := strings.ToLower(f)
+	return fname == "min" || fname == "max" || fname == "sum"
 }
 
 

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -44,7 +44,6 @@ type GraphQuery struct {
 	Args     map[string]string
 	Children []*GraphQuery
 	Filter   *FilterTree
-	Agrtr    *Function
 
 	// Internal fields below.
 	// If gq.fragment is nonempty, then it is a fragment reference / spread.

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1217,11 +1217,11 @@ func TestParseCountAsFuncMultiple(t *testing.T) {
 	gq, err := Parse(query)
 	require.NoError(t, err)
 	require.Equal(t, 6, len(gq.Query[0].Children))
-	require.Equal(t, "count", gq.Query[0].Children[0].Agrtr.Name)
+	require.Equal(t, "count", gq.Query[0].Children[0].Func.Name)
 	require.Equal(t, "friends", gq.Query[0].Children[0].Attr)
-	require.Equal(t, "count", gq.Query[0].Children[1].Agrtr.Name)
+	require.Equal(t, "count", gq.Query[0].Children[1].Func.Name)
 	require.Equal(t, "relatives", gq.Query[0].Children[1].Attr)
-	require.Equal(t, "count", gq.Query[0].Children[2].Agrtr.Name)
+	require.Equal(t, "count", gq.Query[0].Children[2].Func.Name)
 	require.Equal(t, "classmates", gq.Query[0].Children[2].Attr)
 
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1252,7 +1252,7 @@ func TestParseCountAsFunc(t *testing.T) {
 `
 	gq, err := Parse(query)
 	require.NoError(t, err)
-	//require.Equal(t, true, gq.Query[0].Children[0].IsCount)
+	require.Equal(t, true, gq.Query[0].Children[0].IsCount)
 	require.Equal(t, 4, len(gq.Query[0].Children))
 
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1217,13 +1217,12 @@ func TestParseCountAsFuncMultiple(t *testing.T) {
 	gq, err := Parse(query)
 	require.NoError(t, err)
 	require.Equal(t, 6, len(gq.Query[0].Children))
-	require.Equal(t, "count", gq.Query[0].Children[0].Func.Name)
+	require.Equal(t, true, gq.Query[0].Children[0].IsCount)
 	require.Equal(t, "friends", gq.Query[0].Children[0].Attr)
-	require.Equal(t, "count", gq.Query[0].Children[1].Func.Name)
+	require.Equal(t, true, gq.Query[0].Children[1].IsCount)
 	require.Equal(t, "relatives", gq.Query[0].Children[1].Attr)
-	require.Equal(t, "count", gq.Query[0].Children[2].Func.Name)
+	require.Equal(t, true, gq.Query[0].Children[2].IsCount)
 	require.Equal(t, "classmates", gq.Query[0].Children[2].Attr)
-
 }
 
 func TestParseCountAsFuncMultipleError(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1217,11 +1217,11 @@ func TestParseCountAsFuncMultiple(t *testing.T) {
 	gq, err := Parse(query)
 	require.NoError(t, err)
 	require.Equal(t, 6, len(gq.Query[0].Children))
-	require.Equal(t, true, gq.Query[0].Children[0].IsCount)
+	require.Equal(t, "count", gq.Query[0].Children[0].Agrtr.Name)
 	require.Equal(t, "friends", gq.Query[0].Children[0].Attr)
-	require.Equal(t, true, gq.Query[0].Children[1].IsCount)
+	require.Equal(t, "count", gq.Query[0].Children[1].Agrtr.Name)
 	require.Equal(t, "relatives", gq.Query[0].Children[1].Attr)
-	require.Equal(t, true, gq.Query[0].Children[2].IsCount)
+	require.Equal(t, "count", gq.Query[0].Children[2].Agrtr.Name)
 	require.Equal(t, "classmates", gq.Query[0].Children[2].Attr)
 
 }
@@ -1253,7 +1253,7 @@ func TestParseCountAsFunc(t *testing.T) {
 `
 	gq, err := Parse(query)
 	require.NoError(t, err)
-	require.Equal(t, true, gq.Query[0].Children[0].IsCount)
+	//require.Equal(t, true, gq.Query[0].Children[0].IsCount)
 	require.Equal(t, 4, len(gq.Query[0].Children))
 
 }

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -137,7 +137,7 @@ func (sg *SubGraph) ToProtocolBuffer(l *Latency) (*graph.Node, error) {
 			n1.SetUID(uid)
 		}
 
-		if rerr := sg.preTraverse(uid, n1); rerr != nil {
+		if rerr := sg.preTraverse(uid, n1, n1); rerr != nil {
 			if rerr.Error() == "_INV_" {
 				continue
 			}
@@ -208,7 +208,7 @@ func (sg *SubGraph) ToJSON(l *Latency) ([]byte, error) {
 			n1.SetUID(uid)
 		}
 
-		if err := sg.preTraverse(uid, n1); err != nil {
+		if err := sg.preTraverse(uid, n1, n1); err != nil {
 			if err.Error() == "_INV_" {
 				continue
 			}
@@ -360,7 +360,7 @@ func processNodeUids(n *fastJsonNode, sg *SubGraph) error {
 		if sg.Params.GetUID || sg.Params.isDebug {
 			n1.SetUID(uid)
 		}
-		if err := sg.preTraverse(uid, n1); err != nil {
+		if err := sg.preTraverse(uid, n1, n1); err != nil {
 			if err.Error() == "_INV_" {
 				continue
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -295,29 +295,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 				uidAlreadySet = true
 				dst.SetUID(uid)
 			} else {
-				// globalType is the best effort type to which we try converting
-				// and if not possible, we ignore it in the result.
-				/*globalType, hasType := schema.TypeOf(pc.Attr)
-				sv := types.ValueForType(types.StringID)
-				if hasType == nil {
-					// Try to coerce types if this is an optional scalar outside an
-					// object definition.
-					if !globalType.IsScalar() {
-						return x.Errorf("Leaf predicate:'%v' must be a scalar.", pc.Attr)
-					}
-					gtID := globalType
-					// Convert to schema type.
-					sv, err = types.Convert(v, gtID)
-					if bytes.Equal(tv.Val, nil) || err != nil {
-						continue
-					}
-				} else {
-					sv, err = types.Convert(v, types.StringID)
-					x.Check(err)
-				}
-				if bytes.Equal(tv.Val, nil) {
-					continue
-				}*/
+				// if conversion not possible, we ignore it in the result.
 				sv, convErr := convertWithBestEffort(tv, pc.Attr)
 				if convErr == ErrEmptyVal {
 					continue

--- a/query/query.go
+++ b/query/query.go
@@ -144,7 +144,6 @@ type SubGraph struct {
 
 	FilterOp string
 	Filters  []*SubGraph
-	//Agrtr    string
 	Children []*SubGraph
 
 	// destUIDs is a list of destination UIDs, after applying filters, pagination.
@@ -247,7 +246,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 			{
 				uc := outc.New(pc.Attr)
 				// convert to attr's type
-				sv, err := tryBestEffortConvert(pc.values[0], pc.Attr)
+				sv, err := convertWithBestEffort(pc.values[0], pc.Attr)
 				if err != nil && err != ErrEmptyVal {
 					return err
 				}
@@ -322,11 +321,11 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 				if bytes.Equal(tv.Val, nil) {
 					continue
 				}*/
-				sv, conv_err := tryBestEffortConvert(tv, pc.Attr)
-				if conv_err == ErrEmptyVal {
+				sv, convErr := convertWithBestEffort(tv, pc.Attr)
+				if convErr == ErrEmptyVal {
 					continue
-				} else if conv_err != nil {
-					return conv_err
+				} else if convErr != nil {
+					return convErr
 				}
 				// Only strings can have empty values.
 				if sv.Tid == types.StringID && sv.Value.(string) == "_nil_" {
@@ -342,7 +341,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 
 // convert from task.Val to types.Value which is determined by attr
 // if convert failed, try convert to types.StringID 
-func tryBestEffortConvert(tv *task.Value, attr string) (types.Val, error) {
+func convertWithBestEffort(tv *task.Value, attr string) (types.Val, error) {
 	v, _ := getValue(tv)
 	typ, err := schema.TypeOf(attr)
 	sv := types.ValueForType(types.StringID)

--- a/query/query.go
+++ b/query/query.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 	"fmt"
+	"encoding/binary"
 
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/gql"
@@ -229,8 +230,8 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 		}
 		if pc.Agrtr == "count" {
 			uc := dst.New(pc.Attr)
-			c := types.ValueForType(types.StringID)
-			c.Value = string(pc.values[idx].Val)
+			c := types.ValueForType(types.Int32ID)
+			c.Value = int32(binary.LittleEndian.Uint32(pc.values[idx].Val))
 			uc.AddValue("count", c)
 			dst.AddChild(pc.Attr, uc)
 		} else if len(pc.Children) > 0 &&
@@ -338,6 +339,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 }
 
 func createProperty(prop string, v types.Val) *graph.Property {
+	fmt.Printf("[createProperty] will %v to %#v\n", prop, v)
 	pval := toProtoValue(v)
 	return &graph.Property{Prop: prop, Value: pval}
 }
@@ -569,7 +571,7 @@ func ProcessQuery(ctx context.Context, res gql.Result, l *Latency) ([]*SubGraph,
 		}
 		x.Trace(ctx, "Query parsed")
 		sgl = append(sgl, sg)
-		sg.DebugPrint("---")
+		//sg.DebugPrint("---")
 	}
 	l.Parsing += time.Since(loopStart)
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -711,7 +711,7 @@ func TestMin(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.EqualValues(t,
-		`{"me":[{"alive":true,"friend":[{"dob":[{"min":"1901-01-15"}]}],"gender":"female","name":"Michonne"}]}`,
+		`{"me":[{"alive":true,"friend":[{"min(dob)":"1901-01-15"}],"gender":"female","name":"Michonne"}]}`,
 		js)
 }
 
@@ -726,6 +726,30 @@ func TestMinError1(t *testing.T) {
 				gender
 				alive
 				min(friend)
+			}
+		}
+	`
+	res, err := gql.Parse(query)
+	require.NoError(t, err)
+
+	var l Latency
+	_, queryErr := ProcessQuery(context.Background(), res, &l)
+	require.NotNil(t, queryErr)
+}
+
+func TestMinError2(t *testing.T) {
+	populateGraph(t)
+
+	// error: min should not have children
+	query := `
+		{
+			me(id:0x01) {
+				name
+				gender
+				alive
+				min(friend) {
+                                    name     
+                                }
 			}
 		}
 	`
@@ -756,7 +780,7 @@ func TestMax(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.EqualValues(t,
-		`{"me":[{"alive":true,"friend":[{"dob":[{"max":"1910-01-02"}]}],"gender":"female","name":"Michonne"}]}`,
+		`{"me":[{"alive":true,"friend":[{"max(dob)":"1910-01-02"}],"gender":"female","name":"Michonne"}]}`,
 		js)
 }
 
@@ -777,12 +801,8 @@ func TestMaxError1(t *testing.T) {
 			}
 		}
 	`
-	res, err := gql.Parse(query)
-	require.NoError(t, err)
-
-	var l Latency
-	_, queryErr := ProcessQuery(context.Background(), res, &l)
-	require.NotNil(t, queryErr)
+	_, err := gql.Parse(query)
+	require.NotNil(t, err)
 }
 
 
@@ -805,7 +825,7 @@ func TestSum(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.EqualValues(t,
-		`{"me":[{"alive":true,"friend":[{"shadow_deep":[{"sum":18}]}],"gender":"female","name":"Michonne"}]}`,
+		`{"me":[{"alive":true,"friend":[{"sum(shadow_deep)":18}],"gender":"female","name":"Michonne"}]}`,
 		js)
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -748,7 +748,7 @@ func TestMinError2(t *testing.T) {
 				gender
 				alive
 				min(friend) {
-                                    name     
+                                    name
                                 }
 			}
 		}

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -14,16 +14,11 @@ func CouldApplyAgrtrOn(agrtr, attr string) bool {
 		return true
 	}
 	typ, err := schema.TypeOf(attr)
-	if err != nil {
-		return false
-	}
-	if !typ.IsScalar() {
+	if err != nil || !typ.IsScalar() {
 		return false
 	}
 	switch agrtr {
-	case "min":
-		fallthrough
-	case "max":
+	case "min", "max":
 		return (typ == types.Int32ID || 
 			typ == types.FloatID ||
 			typ == types.DateTimeID ||

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -9,7 +9,7 @@ import (
 )
 
 
-func CouldApplyOpOn(agrtr, attr string) bool {
+func CouldApplyAgrtrOn(agrtr, attr string) bool {
 	if agrtr == "count" {
 		return true
 	}

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -9,9 +9,6 @@ import (
 
 
 func CouldApplyAgrtrOn(agrtr string, typ types.TypeID) bool {
-	if agrtr == "count" {
-		return true
-	}
 	if !typ.IsScalar() {
 		return false
 	}

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -8,7 +8,7 @@ import (
 )
 
 
-func CouldApplyAgrtrOn(agrtr string, typ types.TypeID) bool {
+func CouldApplyAggregatorOn(agrtr string, typ types.TypeID) bool {
 	if !typ.IsScalar() {
 		return false
 	}
@@ -46,7 +46,7 @@ func convertTo(from *task.Value, typ types.TypeID) (types.Val, error) {
 }
 
 func Aggregate(agrtr string, values []*task.Value, typ types.TypeID) (*task.Value, error) {
-	if !CouldApplyAgrtrOn(agrtr, typ) {
+	if !CouldApplyAggregatorOn(agrtr, typ) {
 		return nil, x.Errorf("Cant apply aggregator %v on type %d\n", agrtr, typ)
 	}
 	
@@ -83,14 +83,13 @@ func Aggregate(agrtr string, values []*task.Value, typ types.TypeID) (*task.Valu
 		if len(iter.Val) == 0 {
 			continue
 		} else if len(result.Val) == 0 {
-			result = iter
-			if lva, err = convertTo(iter, typ); err != nil {
-				return result, err
+			if lva, err = convertTo(iter, typ); err == nil {
+				result = iter
 			}
 			continue
 		}
 		if rva, err = convertTo(iter, typ); err != nil {
-			return result, err
+			continue
 		}
 		va := accumulate(lva, rva)
 		if lva != va {

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -2,25 +2,16 @@
 package worker
 
 import (
-	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 )
 
 
-func CouldApplyAgrtrOn(agrtr, attr string) bool {
+func CouldApplyAgrtrOn(agrtr string, typ types.TypeID) bool {
 	if agrtr == "count" {
 		return true
 	}
-	typ, err := schema.TypeOf(attr)
-	if err != nil {
-		return false
-	}
-	return couldApplyAgrtrOn(agrtr, typ)
-}
-
-func couldApplyAgrtrOn(agrtr string, typ types.TypeID) bool {
 	if !typ.IsScalar() {
 		return false
 	}
@@ -58,7 +49,7 @@ func convertTo(from *task.Value, typ types.TypeID) (types.Val, error) {
 }
 
 func Aggregate(agrtr string, values []*task.Value, typ types.TypeID) (*task.Value, error) {
-	if !couldApplyAgrtrOn(agrtr, typ) {
+	if !CouldApplyAgrtrOn(agrtr, typ) {
 		return nil, x.Errorf("Cant apply aggregator %v on type %d\n", agrtr, typ)
 	}
 	

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -49,6 +49,11 @@ func getValue(tv *task.Value) (types.Val, error) {
 }
 
 func Aggregate(agrtr string, lh, rh *task.Value, typ types.TypeID) (*task.Value, error) {
+	if len(lh.Val) == 0 {
+		return rh, nil
+	} else if len(rh.Val) == 0 {
+		return lh, nil
+	}
 	if !couldApplyAgrtrOn(agrtr, typ) {
 		return lh, x.Errorf("Cant apply aggregator %v on type %d\n", agrtr, typ)
 	}

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -1,0 +1,77 @@
+
+package worker
+
+import (
+	"github.com/dgraph-io/dgraph/schema"
+	"github.com/dgraph-io/dgraph/task"
+	"github.com/dgraph-io/dgraph/types"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+
+func CouldApplyOpOn(agrtr, attr string) bool {
+	if agrtr == "count" {
+		return true
+	}
+	typ, err := schema.TypeOf(attr)
+	if err != nil {
+		return false
+	}
+	if !typ.IsScalar() {
+		return false
+	}
+	switch agrtr {
+	case "min":
+		fallthrough
+	case "max":
+		return (typ == types.Int32ID || 
+			typ == types.FloatID ||
+			typ == types.DateTimeID ||
+			typ == types.StringID ||
+			typ == types.DateID)
+	case "sum":
+		return (typ == types.Int32ID ||
+			typ == types.FloatID)
+	default:
+		return false
+	}
+	return false
+}
+
+// getValue gets the value from the task.
+func getValue(tv *task.Value) (types.Val, error) {
+	vID := types.TypeID(tv.ValType)
+	val := types.ValueForType(vID)
+	val.Value = tv.Val
+	return val, nil
+}
+
+func Aggregate(agrtr string, lh, rh *task.Value, typ types.TypeID) (*task.Value, error) {
+	lvh, _ := getValue(lh)
+	va, erra := types.Convert(lvh, typ)
+	if erra != nil {
+		return lh, x.Errorf("Fail to convert from task.Value to types.Val")
+	}
+	rvh, _ := getValue(rh)
+	vb, errb := types.Convert(rvh, typ)
+	if errb != nil {
+		return lh, x.Errorf("Fail to convert from task.Value to types.Val")
+	}
+	switch agrtr {
+	case "min":
+		if types.Less(va, vb) {
+			return lh, nil
+		} else {
+			return rh, nil
+		}
+	case "max":
+		if types.Less(va, vb) {
+			return rh, nil
+		} else {
+			return lh, nil
+		}
+	default:
+		return lh, x.Errorf("Invalid Aggregator provided")
+	}
+
+}

--- a/worker/task.go
+++ b/worker/task.go
@@ -110,7 +110,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 		case isAgrtr:
 			// confirm agrregator could apply on the attributes
 			typ, err := schema.TypeOf(attr)
-			if err != nil {
+			if err != nil && f != "count" {
 				return nil, x.Errorf("Attribute %q is not scalar-type", attr)
 			}
 			if !CouldApplyAgrtrOn(f, typ) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -109,7 +109,11 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 		switch {
 		case isAgrtr:
 			// confirm agrregator could apply on the attributes
-			if !CouldApplyAgrtrOn(f, attr) {
+			typ, err := schema.TypeOf(attr)
+			if err != nil {
+				return nil, x.Errorf("Attribute %q is not scalar-type", attr)
+			}
+			if !CouldApplyAgrtrOn(f, typ) {
 				return nil, x.Errorf("Aggregator %q could not apply on %v",
 					f, attr)
 			}

--- a/worker/task.go
+++ b/worker/task.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	//"strconv"
 	"encoding/binary"
-	"fmt"
+	//"fmt"
 
 	"golang.org/x/net/context"
 
@@ -93,7 +93,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 	attr := q.Attr
 
 	useFunc := len(q.SrcFunc) != 0
-	fmt.Printf("[processTask] task.Query: %#v\n", q)
+	//fmt.Printf("[processTask] task.Query: %#v\n", q)
 	var n int
 	var tokens []string
 	var geoQuery *types.GeoQueryData
@@ -106,7 +106,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 	if useFunc {
 		f := q.SrcFunc[0]
 		isIneq = f == "leq" || f == "geq" || f == "lt" || f == "gt" || f == "eq"
-		isAgrtr = f == "count" || f == "min"
+		isAgrtr = f == "count" || f == "min" || f == "max" || f == "sum"
 		switch {
 		case isAgrtr:
 			// confirm agrregator could apply on the attributes
@@ -211,10 +211,10 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 				// do nothing
 			} else if len(out.Values) == 0 {
 				out.Values = append(out.Values, newValue)
-				out.UidMatrix = append(out.UidMatrix, &emptyUIDList)
 			} else {
 				out.Values[0], _ = Aggregate(q.SrcFunc[0], out.Values[0], newValue, typ)
 			}
+			out.UidMatrix = append(out.UidMatrix, &emptyUIDList)
 			continue
 		}
 		// The more usual case: Getting the UIDs.

--- a/worker/task.go
+++ b/worker/task.go
@@ -93,7 +93,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 	attr := q.Attr
 
 	useFunc := len(q.SrcFunc) != 0
-	//fmt.Printf("[processTask] task.Query: %#v\n", q)
+	fmt.Printf("[processTask] task.Query: %#v\n", q)
 	var n int
 	var tokens []string
 	var geoQuery *types.GeoQueryData
@@ -174,12 +174,12 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 	typ, _ := schema.TypeOf(attr)
 	for i := 0; i < n; i++ {
 		var key []byte
-		if isAgrtr {
+		if q.Reverse {
+			key = x.ReverseKey(attr, q.Uids[i])
+		} else if isAgrtr {
 			key = x.DataKey(attr, q.Uids[i])
 		} else if useFunc {
 			key = x.IndexKey(attr, tokens[i])
-		} else if q.Reverse {
-			key = x.ReverseKey(attr, q.Uids[i])
 		} else {
 			key = x.DataKey(attr, q.Uids[i])
 		}

--- a/worker/task.go
+++ b/worker/task.go
@@ -18,9 +18,7 @@ package worker
 
 import (
 	"strings"
-	//"strconv"
 	"encoding/binary"
-	//"fmt"
 
 	"golang.org/x/net/context"
 
@@ -111,7 +109,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 		case isAgrtr:
 			// confirm agrregator could apply on the attributes
 			if !CouldApplyAgrtrOn(f, attr) {
-				return nil, x.Errorf("Aggregator %v could not apply on %v",
+				return nil, x.Errorf("Aggregator %q could not apply on %v",
 					f, attr)
 			}
 
@@ -207,9 +205,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 			out.UidMatrix = append(out.UidMatrix, &emptyUIDList)
 			continue
 		} else {
-			if len(newValue.Val) == 0 {
-				// do nothing
-			} else if len(out.Values) == 0 {
+			if len(out.Values) == 0 {
 				out.Values = append(out.Values, newValue)
 			} else {
 				out.Values[0], _ = Aggregate(q.SrcFunc[0], out.Values[0], newValue, typ)

--- a/worker/task.go
+++ b/worker/task.go
@@ -18,7 +18,6 @@ package worker
 
 import (
 	"strings"
-	//"fmt"
 	"golang.org/x/net/context"
 
 	"github.com/dgraph-io/dgraph/algo"
@@ -90,7 +89,6 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 	attr := q.Attr
 
 	useFunc := len(q.SrcFunc) != 0
-	//fmt.Printf("[processTask] task.Query: %#v\n", q)
 	var n int
 	var tokens []string
 	var geoQuery *types.GeoQueryData
@@ -112,7 +110,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 			if err != nil {
 				return nil, x.Errorf("Attribute %q is not scalar-type", attr)
 			}
-			if !CouldApplyAgrtrOn(f, typ) {
+			if !CouldApplyAggregatorOn(f, typ) {
 				return nil, x.Errorf("Aggregator %q could not apply on %v",
 					f, attr)
 			}
@@ -225,6 +223,7 @@ func processTask(q *task.Query, gid uint32) (*task.Result, error) {
 		if err != nil {
 			return nil, err
 		}
+		out.Values = out.Values[0:1] // trim length to 1
 	}
 
 	if isIneq && len(tokens) > 0 && ineqValueToken == tokens[0] {


### PR DESCRIPTION
Though both 'count' and 'min' belong to Aggregator,  the layer of object on which they applied is different.  'count' performs on Parent layer, while 'min' performs on Leaf Node, for example
```
  director(id: m.06pj8) {
    count(film.director.film)
  }

  director(id: m.06pj8) {
    film.director.film {
    	min(film.film.initial_release_date)
    }
  }
```
Since there is the constraint on 'min' that it must performs on scalar-types.

And the Filter-on-min, keep the filter at the Parent layer instead of at the Leaf layer, for example
```
  director(id: m.06pj8) {
    count(film.director.film @filter(gt(init_release_date, "1990")))
  }

  director(id: m.06pj8) {
    film.director.film @filter(gt(init_release_date, "1990")) {
    	min(film.film.initial_release_date)
    }
  }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/560)
<!-- Reviewable:end -->
