### PR TITLE
Add TLS configuration for client and server

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,8 @@ package client
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -171,7 +173,12 @@ func (batch *BatchMutation) request(req *Req) {
 RETRY:
 	_, err := batch.dc.Run(context.Background(), &req.gr)
 	if err != nil {
-		fmt.Printf("Retrying req: %d. Error: %v\n", counter, err)
+		errString := err.Error()
+		// Invalid certificate, irrecoverable
+		if strings.Contains(errString, "x509") {
+			log.Fatal(errString)
+		}
+		fmt.Printf("Retrying req: %d. Error: %v\n", counter, errString)
 		time.Sleep(5 * time.Millisecond)
 		goto RETRY
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"github.com/dgraph-io/dgraph/query/graph"
 )
@@ -174,8 +175,8 @@ RETRY:
 	_, err := batch.dc.Run(context.Background(), &req.gr)
 	if err != nil {
 		errString := err.Error()
-		// Invalid certificate, irrecoverable
-		if strings.Contains(errString, "x509") {
+		// Irrecoverable
+		if strings.Contains(errString, "x509") || grpc.Code(err) == codes.Internal {
 			log.Fatal(errString)
 		}
 		fmt.Printf("Retrying req: %d. Error: %v\n", counter, errString)

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -82,11 +82,11 @@ var (
 	tlsCert          = flag.String("tls.cert", "", "Certificate file path.")
 	tlsKey           = flag.String("tls.cert_key", "", "Certificate key file path.")
 	tlsKeyPass       = flag.String("tls.cert_key_passphrase", "", "Certificate key passphrase.")
-	tlsClientAuth    = flag.String("tls.client_auth", "", "Enable TLS client auth")
-	tlsClientCACerts = flag.String("tls.client_ca_certs", "", "Client CA Certs file path.")
-	tlsSystemCACerts = flag.Bool("tls.use_system_ca", false, "Include System CA into Clients CA Certs.")
-	tlsMinVersion    = flag.String("tls.min_version", "TLS11", "TLS min versions.")
-	tlsMaxVersion    = flag.String("tls.max_version", "TLS12", "TLS max versions.")
+	tlsClientAuth    = flag.String("tls.client_auth", "", "Enable TLS client authentication")
+	tlsClientCACerts = flag.String("tls.ca_certs", "", "CA Certs file path.")
+	tlsSystemCACerts = flag.Bool("tls.use_system_ca", false, "Include System CA into CA Certs.")
+	tlsMinVersion    = flag.String("tls.min_version", "TLS11", "TLS min version.")
+	tlsMaxVersion    = flag.String("tls.max_version", "TLS12", "TLS max version.")
 )
 
 type mutationResult struct {

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -67,7 +67,7 @@ var (
 	port       = flag.Int("port", 8080, "Port to run server on.")
 	bindall    = flag.Bool("bindall", false,
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
-	tlsEnabled     = flag.Bool("tls", true, "Use TLS connections with clients")
+	tlsEnabled     = flag.Bool("tls", false, "Use TLS connections with clients")
 	cert           = flag.String("cert", "", "Certificate file path")
 	key            = flag.String("cert_key", "", "Certificate key file key")
 	nomutations    = flag.Bool("nomutations", false, "Don't allow mutations on this server.")
@@ -711,7 +711,7 @@ func setupListener(addr string, port int) (net.Listener, error) {
 
 	certificate, err := tls.LoadX509KeyPair(*cert, *key)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading certificate {cert: '%s', key: '%s'}\n%s", *cert, *key, err)
+		return nil, fmt.Errorf("Error reading certificate {cert: '%s', cert_key: '%s'}\n%s", *cert, *key, err)
 	}
 
 	tlsCfg := &tls.Config{

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"crypto/tls"
 	"encoding/gob"
 	"encoding/json"
 	"flag"
@@ -66,6 +67,9 @@ var (
 	port       = flag.Int("port", 8080, "Port to run server on.")
 	bindall    = flag.Bool("bindall", false,
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
+	tlsEnabled     = flag.Bool("tls", true, "Use TLS connections with clients")
+	cert           = flag.String("cert", "", "Certificate file path")
+	key            = flag.String("cert_key", "", "Certificate key file key")
 	nomutations    = flag.Bool("nomutations", false, "Don't allow mutations on this server.")
 	tracing        = flag.Float64("trace", 0.0, "The ratio of queries to trace.")
 	schemaFile     = flag.String("schema", "", "Path to schema file")
@@ -699,6 +703,25 @@ func checkFlagsAndInitDirs() {
 	x.Check(os.MkdirAll(*postingDir, 0700))
 }
 
+func setupListener(addr string, port int) (net.Listener, error) {
+	laddr := fmt.Sprintf("%s:%d", addr, port)
+	if !*tlsEnabled {
+		return net.Listen("tcp", laddr)
+	}
+
+	certificate, err := tls.LoadX509KeyPair(*cert, *key)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading certificate {cert: '%s', key: '%s'}\n%s", *cert, *key, err)
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:   tls.VersionTLS11, // min secure version
+		Certificates: []tls.Certificate{certificate},
+	}
+
+	return tls.Listen("tcp", laddr, tlsCfg)
+}
+
 func serveGRPC(l net.Listener) {
 	defer func() { finishCh <- struct{}{} }()
 	s := grpc.NewServer(grpc.CustomCodec(&query.Codec{}))
@@ -729,7 +752,7 @@ func setupServer(che chan error) {
 		laddr = "0.0.0.0"
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", laddr, *port))
+	l, err := setupListener(laddr, *port)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -30,7 +30,7 @@ import (
 var (
 	files      = flag.String("r", "", "Location of rdf files to load")
 	dgraph     = flag.String("d", "127.0.0.1:8080", "Dgraph server address")
-	tlsEnabled = flag.Bool("tls", true, "Enable TLS connection")
+	tlsEnabled = flag.Bool("tls", false, "Enable TLS connection")
 	insecure   = flag.Bool("insecure", false, "Skip insecure cert validation")
 	concurrent = flag.Int("c", 100, "Number of concurrent requests to make to Dgraph")
 	numRdf     = flag.Int("m", 1000, "Number of RDF N-Quads to send as part of a mutation.")

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -33,15 +33,15 @@ var (
 	numRdf     = flag.Int("m", 1000, "Number of RDF N-Quads to send as part of a mutation.")
 	// TLS configuration
 	tlsEnabled       = flag.Bool("tls.on", false, "Use TLS connections.")
-	tlsInsecure      = flag.Bool("tls.insecure", false, "Skip insecure cert validation")
+	tlsInsecure      = flag.Bool("tls.insecure", false, "Skip certificate validation (insecure)")
 	tlsServerName    = flag.String("tls.server_name", "", "Server name.")
 	tlsCert          = flag.String("tls.cert", "", "Certificate file path.")
 	tlsKey           = flag.String("tls.cert_key", "", "Certificate key file path.")
 	tlsKeyPass       = flag.String("tls.cert_key_passphrase", "", "Certificate key passphrase.")
-	tlsRootCACerts   = flag.String("tls.root_ca_certs", "", "Include Client CA Certs file path.")
-	tlsSystemCACerts = flag.Bool("tls.use_system_ca", false, "Include System CA into Root CA Certs.")
-	tlsMinVersion    = flag.String("tls.min_version", "TLS11", "TLS min versions.")
-	tlsMaxVersion    = flag.String("tls.max_version", "TLS12", "TLS max versions.")
+	tlsRootCACerts   = flag.String("tls.ca_certs", "", "CA Certs file path.")
+	tlsSystemCACerts = flag.Bool("tls.use_system_ca", false, "Include System CA into CA Certs.")
+	tlsMinVersion    = flag.String("tls.min_version", "TLS11", "TLS min version.")
+	tlsMaxVersion    = flag.String("tls.max_version", "TLS12", "TLS max version.")
 )
 
 // Reads a single line from a buffered reader. The line is read into the

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -1,0 +1,194 @@
+package x
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// TLSHelperConfig define params used to create a tls.Config
+type TLSHelperConfig struct {
+	CertRequired           bool
+	Cert                   string
+	Key                    string
+	KeyPassphrase          string
+	ServerName             string
+	Insecure               bool
+	RootCACerts            string
+	UseSystemRootCACerts   bool
+	ClientAuth             string
+	ClientCACerts          string
+	UseSystemClientCACerts bool
+	MinVersion             string
+	MaxVersion             string
+}
+
+func setupCACert(caPool **x509.CertPool, certPath string, useSystemCA bool) error {
+	if useSystemCA {
+		var err error
+		if *caPool, err = x509.SystemCertPool(); err != nil {
+			return err
+		}
+	} else {
+		*caPool = x509.NewCertPool()
+	}
+
+	if len(certPath) > 0 {
+		caFile, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return err
+		}
+
+		if !(*caPool).AppendCertsFromPEM(caFile) {
+			return fmt.Errorf("Error reading CA file '%s'.\n%s", certPath, err)
+		}
+	}
+
+	return nil
+}
+
+func setupCertificate(cfg *tls.Config, required bool, certPath string, certKeyPath string, certKeyPass string) error {
+	if len(certKeyPath) > 0 || len(certPath) > 0 || required {
+		// Load key
+		keyFile, err := ioutil.ReadFile(certKeyPath)
+		if err != nil {
+			return err
+		}
+
+		var certKey []byte
+		if block, _ := pem.Decode(keyFile); block != nil {
+			if x509.IsEncryptedPEMBlock(block) {
+				decryptKey, err := x509.DecryptPEMBlock(block, []byte(certKeyPass))
+				if err != nil {
+					return err
+				}
+
+				privKey, err := x509.ParsePKCS1PrivateKey(decryptKey)
+				if err != nil {
+					return err
+				}
+
+				certKey = pem.EncodeToMemory(&pem.Block{
+					Type:  "RSA PRIVATE KEY",
+					Bytes: x509.MarshalPKCS1PrivateKey(privKey),
+				})
+			} else {
+				certKey = pem.EncodeToMemory(block)
+			}
+		} else {
+			return err
+		}
+
+		// Load cert
+		certFile, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return err
+		}
+
+		// Load certificate, pair cert/key
+		certificate, err := tls.X509KeyPair(certFile, certKey)
+		if err != nil {
+			return fmt.Errorf("Error reading certificate {cert: '%s', key: '%s'}\n%s", certPath, certKeyPath, err)
+		}
+
+		cfg.Certificates = []tls.Certificate{certificate}
+	}
+	return nil
+}
+
+func setupVersion(cfg *tls.Config, minVersion string, maxVersion string) error {
+	// Configure TLS version
+	tlsVersion := map[string]uint16{
+		"TLS11": tls.VersionTLS11,
+		"TLS12": tls.VersionTLS12,
+	}
+
+	if len(minVersion) > 0 {
+		if val, has := tlsVersion[strings.ToUpper(minVersion)]; has {
+			cfg.MinVersion = val
+		} else {
+			return fmt.Errorf("Invalid min_version '%s'. Valid values [TLS11, TLS12]", minVersion)
+		}
+	} else {
+		cfg.MinVersion = tls.VersionTLS11
+	}
+
+	if len(maxVersion) > 0 {
+		if val, has := tlsVersion[strings.ToUpper(maxVersion)]; has && val >= cfg.MinVersion {
+			cfg.MaxVersion = val
+		} else {
+			if has {
+				return fmt.Errorf("Cannot use '%s' as max_version, it's lower than '%s'", maxVersion, minVersion)
+			}
+			return fmt.Errorf("Invalid max_version '%s'. Valid values [TLS11, TLS12]", maxVersion)
+		}
+	} else {
+		cfg.MaxVersion = tls.VersionTLS12
+	}
+	return nil
+}
+
+func setupClientAuth(cfg *tls.Config, authType string) error {
+	auth := map[string]tls.ClientAuthType{
+		"REQUEST":          tls.RequestClientCert,
+		"REQUIREANY":       tls.RequireAnyClientCert,
+		"VERIFYIFGIVEN":    tls.VerifyClientCertIfGiven,
+		"REQUIREANDVERIFY": tls.RequireAndVerifyClientCert,
+	}
+
+	if len(authType) > 0 {
+		if v, has := auth[strings.ToUpper(authType)]; has {
+			cfg.ClientAuth = v
+		} else {
+			return fmt.Errorf("Invalid client auth. Valid values [REQUEST, REQUIREANY, VERIFYIFGIVEN, REQUIREANDVERIFY]")
+		}
+	}
+
+	return nil
+}
+
+// GenerateTLSConfig creates and returns a new *tls.Config with the configuration provided, otherwise returns an error
+func GenerateTLSConfig(config TLSHelperConfig) (*tls.Config, error) {
+	var err error
+	tlsCfg := &tls.Config{}
+
+	err = setupCertificate(tlsCfg, config.CertRequired, config.Cert, config.Key, config.KeyPassphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure Root CAs
+	if len(config.RootCACerts) > 0 || config.UseSystemRootCACerts {
+		err = setupCACert(&tlsCfg.RootCAs, config.RootCACerts, config.UseSystemRootCACerts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Configure Client CAs
+	if len(config.ClientCACerts) > 0 || config.UseSystemClientCACerts {
+		err = setupCACert(&tlsCfg.ClientCAs, config.ClientCACerts, config.UseSystemClientCACerts)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = setupVersion(tlsCfg, config.MinVersion, config.MaxVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	err = setupClientAuth(tlsCfg, config.ClientAuth)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsCfg.InsecureSkipVerify = config.Insecure
+	tlsCfg.ServerName = config.ServerName
+	tlsCfg.BuildNameToCertificate()
+
+	return tlsCfg, nil
+}

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -79,7 +79,7 @@ func setupCertificate(cfg *tls.Config, required bool, certPath string, certKeyPa
 				certKey = pem.EncodeToMemory(block)
 			}
 		} else {
-			return err
+			return fmt.Errorf("Invalid Cert Key")
 		}
 
 		// Load cert


### PR DESCRIPTION
Add additional flags to configure the server to use TLS
- tls: boolean, use a tls listener on server, default false
- cert: string, certificate path, default blank
- cert_key: certificate key path, default blank

For client (dgraphloader)
- tls: boolean, use tls to connect with the server, default false
- insecure: boolean, skip certificate validation (useful for self-signed certificates), default false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/593)
<!-- Reviewable:end -->
