### PR TITLE
bugfix: empty value should be ignored , instead of 'Leaf predicate mu…

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -313,6 +313,12 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 				}
 			}
 		} else {
+			// algo.ListLen(ul) == 0 and attribute is non-scalar, just let it go
+			if typ, terr := schema.State().TypeOf(pc.Attr); terr == nil {
+				if !typ.IsScalar() {
+					continue
+				}
+			}
 			tv := pc.values[idx]
 			v, err := getValue(tv)
 			if err != nil {

--- a/query/query.go
+++ b/query/query.go
@@ -313,11 +313,9 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 				}
 			}
 		} else {
-			// algo.ListLen(ul) == 0 and attribute is non-scalar, just let it go
-			if typ, terr := schema.State().TypeOf(pc.Attr); terr == nil {
-				if !typ.IsScalar() {
-					continue
-				}
+			// attribute is non-scalar, just let it go
+			if typ, terr := schema.State().TypeOf(pc.Attr); terr == nil && !typ.IsScalar() {
+				continue
 			}
 			tv := pc.values[idx]
 			v, err := getValue(tv)

--- a/query/query.go
+++ b/query/query.go
@@ -378,9 +378,12 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 // convert from task.Val to types.Value which is determined by attr
 // if convert failed, try convert to types.StringID
 func convertWithBestEffort(tv *task.Value, attr string) (types.Val, error) {
+	sv := types.ValueForType(types.StringID)
+	if len(tv.Val) == 0 {
+		return sv, ErrEmptyVal
+	}
 	v, _ := getValue(tv)
 	typ, err := schema.State().TypeOf(attr)
-	sv := types.ValueForType(types.StringID)
 	if err == nil {
 		// Try to coerce types if this is an optional scalar outside an
 		// object definition.

--- a/query/query.go
+++ b/query/query.go
@@ -384,12 +384,9 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 // convert from task.Val to types.Value which is determined by attr
 // if convert failed, try convert to types.StringID
 func convertWithBestEffort(tv *task.Value, attr string) (types.Val, error) {
-	sv := types.ValueForType(types.StringID)
-	if len(tv.Val) == 0 {
-		return sv, ErrEmptyVal
-	}
 	v, _ := getValue(tv)
 	typ, err := schema.State().TypeOf(attr)
+	sv := types.ValueForType(types.StringID)
 	if err == nil {
 		// Try to coerce types if this is an optional scalar outside an
 		// object definition.

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -3490,11 +3490,31 @@ func TestIntersectsPolygon2(t *testing.T) {
 	require.JSONEq(t, expected, mp)
 }
 
+func TestNotExistObject(t *testing.T) {
+	populateGraph(t)
+	// we haven't set genre(type:uid) for 0x01, should just be ignored
+	query := `
+                {
+                        me(id:0x01) {
+                                name
+                                gender
+                                alive
+                                genre
+                        }
+                }
+        `
+	js := processToFastJSON(t, query)
+	require.EqualValues(t,
+		`{"me":[{"alive":true,"gender":"female","name":"Michonne"}]}`,
+		js)
+}
+
 const schemaStr = `
 scalar name:string @index
 scalar dob:date @index
 scalar film.film.initial_release_date:date @index
 scalar loc:geo @index
+scalar genre:uid @reverse
 scalar (
 	survival_rate : float
 	alive         : bool


### PR DESCRIPTION
given
```
scalar ( genre: uid @reverse )
```
In the generation of response,

1. if **genre** is not empty: 
    it will fall into some branch which checks for its uuid

2. else it will fall into another branch:
    which will take its value, meanwhile type.IsScalar() will be called

One quick fix: add one intercept in the 2nd case branch before the IsScalar() checked, and
return EmptyVal instead.

Still, another point is, even user specified as scalar-uid, why the schema system 
tell it's non-scalar?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/626)
<!-- Reviewable:end -->
