### PR TITLE
Print faulty line with no and the character causing error: Fixes #635

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -63,17 +63,19 @@ func processFile(file string, batch *client.BatchMutation) {
 
 	var buf bytes.Buffer
 	bufReader := bufio.NewReader(gr)
+	var line int
 	for {
 		err = readLine(bufReader, &buf)
 		if err != nil {
 			break
 		}
+		line++
 		nq, err := rdf.Parse(buf.String())
 		if err == rdf.ErrEmpty { // special case: comment/empty line
 			buf.Reset()
 			continue
 		} else if err != nil {
-			log.Fatal("While parsing RDF: ", err)
+			log.Fatalf("Error while parsing RDF: %v, on line:%v %v", err, line, buf.String())
 		}
 		buf.Reset()
 		if err = batch.AddMutation(nq, client.SET); err != nil {

--- a/lex/iri.go
+++ b/lex/iri.go
@@ -31,7 +31,7 @@ func LexIRIRef(l *Lexer, styp ItemType) error {
 	}
 	if r != '>' {
 		return fmt.Errorf(
-			"Unexpected character %q while parsing IRI for itemtype: %v", r, styp)
+			"Unexpected character %q while parsing IRI", r)
 	}
 	l.Ignore() // ignore '>'
 	return nil

--- a/lex/iri.go
+++ b/lex/iri.go
@@ -30,8 +30,8 @@ func LexIRIRef(l *Lexer, styp ItemType) error {
 		return errors.New("Unexpected end of IRI.")
 	}
 	if r != '>' {
-		return errors.New(fmt.Sprintf(
-			"Unexpected character %v while parsing IRI for itemtype: %v", r, styp))
+		return fmt.Errorf(
+			"Unexpected character %q while parsing IRI for itemtype: %v", r, styp)
 	}
 	l.Ignore() // ignore '>'
 	return nil


### PR DESCRIPTION
How about adding some red colour to the error in the output (might include introducing an external dependency for the loader)?

The current output after the change looks like. 
`2017/02/24 11:53:24 main.go:78: Error while parsing RDF: Unexpected character ' ' while parsing IRI, on line:12 <div class="noautonum">__TOC__</div>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/636)
<!-- Reviewable:end -->
