### PR TITLE
Remove double encoding for Password

### DIFF
--- a/types/password.go
+++ b/types/password.go
@@ -1,10 +1,6 @@
 package types
 
 import (
-	"encoding/base64"
-	"fmt"
-	"strings"
-
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/dgraph-io/dgraph/x"
@@ -15,35 +11,22 @@ const (
 )
 
 func Encrypt(plain string) (string, error) {
-	var result string
 	if len(plain) < pwdLenLimit {
-		return result, x.Errorf("Password too short, i.e. should has at least 6 chars")
+		return "", x.Errorf("Password too short, i.e. should has at least 6 chars")
 	}
-	// no need to generate salt outselves since salt is incorporated in the result as well
-	// check wiki https://en.wikipedia.org/wiki/Bcrypt
-	byt, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
-	if err != nil {
-		return result, err
-	}
-	// follow the format like linux used: $2a$cost$crypted
-	// get rid of '$', since '$' is the delimiter
-	result = base64.StdEncoding.EncodeToString(byt)
-	result = fmt.Sprintf("$2a$%d$%s", bcrypt.DefaultCost, result)
 
-	return result, nil
+	encrypted, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(encrypted), nil
 }
 
 func VerifyPassword(plain, encrypted string) error {
 	if len(plain) < pwdLenLimit || len(encrypted) == 0 {
 		return x.Errorf("invalid password/crypted string")
 	}
-	// password stored format like: $2a$10$crypted
-	arr := strings.Split(strings.Trim(encrypted, "$"), "$")
-	x.AssertTruef(len(arr) == 3, "Password is corrupted")
-	target := arr[2]
 
-	byt, err := base64.StdEncoding.DecodeString(target)
-	x.AssertTruef(err == nil, "Password is corrupted")
-
-	return bcrypt.CompareHashAndPassword(byt, []byte(plain))
+	return bcrypt.CompareHashAndPassword([]byte(encrypted), []byte(plain))
 }

--- a/types/password_test.go
+++ b/types/password_test.go
@@ -1,0 +1,133 @@
+package types
+
+import "testing"
+
+func TestEncrypt(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:    "case 1",
+			input:   "",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "case 2",
+			input:   "12345",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name:    "case 3",
+			input:   "123456",
+			want:    60,
+			wantErr: false,
+		},
+		{
+			name:    "case 4",
+			input:   "1234567890",
+			want:    60,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Encrypt(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Encrypt() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != tt.want {
+				t.Errorf("Encrypt() = %v, want %v", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyPassword(t *testing.T) {
+	type args struct {
+		plain     string
+		encrypted string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "case 1",
+			args: args{
+				plain:     "",
+				encrypted: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 2",
+			args: args{
+				plain:     "",
+				encrypted: "$2a$10$LMGgvb5dOq4/YrWXjAy6W.tBfFQC4QDNFAuOCWGRk3f/Z1TMXswaC",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 3",
+			args: args{
+				plain:     "1234567890",
+				encrypted: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 4",
+			args: args{
+				plain:     "12345",
+				encrypted: "$2a$10$LMGgvb5dOq4/YrWXjAy6W.tBfFQC4QDNFAuOCWGRk3f/Z1TMXswaC",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 5",
+			args: args{
+				plain:     "12345678",
+				encrypted: "$2a$10$LMGgvb5dOq4/YrWXjAy6W.tBfFQC4QDNFAuOCWGRk3f/Z1TMXswaC",
+			},
+			wantErr: true,
+		},
+		{
+			name: "case 6",
+			args: args{
+				plain:     "123456",
+				encrypted: "$2a$10$LMGgvb5dOq4/YrWXjAy6W.tBfFQC4QDNFAuOCWGRk3f/Z1TMXswaC",
+			},
+			wantErr: false,
+		},
+		{
+			name: "case 7",
+			args: args{
+				plain:     "123456",
+				encrypted: "$2a$10$kXtSFCVmzsu0lwVqaWxo5OXlLGUakcY2t18QcqcVpvoTHsPqclOca",
+			},
+			wantErr: false,
+		},
+		{
+			name: "case 8",
+			args: args{
+				plain:     "1234567890",
+				encrypted: "$2a$10$WdCWNpOP6c4l7ECv3hEWKeD3oSiszlRJFmT4uRT1P/W9V9zUye8pS",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := VerifyPassword(tt.args.plain, tt.args.encrypted); (err != nil) != tt.wantErr {
+				t.Errorf("VerifyPassword() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Remove formatting and encode/decode for password, due it is unnecessary because the password is already formatted as "$2x$xx$.....". **This is going to break any password validation** who is currently used, not allowing to validate the current stored password, this is provoked by the original double encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/688)
<!-- Reviewable:end -->
