### PR TITLE
Fetch and print commit SHA1, version and other details on startup

### DIFF
--- a/contrib/releases/build.sh
+++ b/contrib/releases/build.sh
@@ -29,14 +29,26 @@ fi
 
 mkdir $tmp_dir;
 
+lastCommitSHA1=$(git rev-parse --short HEAD);
+gitBranch=$(git rev-parse --abbrev-ref HEAD)
+lastCommitTime=$(git log -1 --format=%ci)
 dgraph_cmd=$GOPATH/src/github.com/dgraph-io/dgraph/cmd;
-build_flags='-v -tags=embed'
+
+release="github.com/dgraph-io/dgraph/x.dgraphVersion"
+branch="github.com/dgraph-io/dgraph/x.gitBranch"
+commitSHA1="github.com/dgraph-io/dgraph/x.lastCommitSHA"
+commitTime="github.com/dgraph-io/dgraph/x.lastCommitTime"
 
 echo -e "\033[1;33mBuilding binaries\033[0m"
 echo "dgraph"
-cd $dgraph_cmd/dgraph && go build $build_flags .;
+cd $dgraph_cmd/dgraph && \
+   go build -v -tags=embed -ldflags \
+   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .;
 echo "dgraphloader"
-cd $dgraph_cmd/dgraphloader && go build $build_flags .;
+echo $release
+cd $dgraph_cmd/dgraphloader && \
+   go build -v -tags=embed -ldflags \
+   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .;
 
 echo -e "\n\033[1;33mCopying binaries to tmp folder\033[0m"
 cd $tmp_dir;

--- a/contrib/releases/build.sh
+++ b/contrib/releases/build.sh
@@ -34,9 +34,9 @@ build_flags='-v -tags=embed'
 
 echo -e "\033[1;33mBuilding binaries\033[0m"
 echo "dgraph"
-cd $dgraph_cmd/dgraph && go build $build_flags -ldflags="-X github.com/dgraph-io/dgraph/x.dgraphVersion=$release_version" .;
+cd $dgraph_cmd/dgraph && go build $build_flags .;
 echo "dgraphloader"
-cd $dgraph_cmd/dgraphloader && go build $build_flags -ldflags="-X github.com/dgraph-io/dgraph/x.dgraphVersion=$release_version" .;
+cd $dgraph_cmd/dgraphloader && go build $build_flags .;
 
 echo -e "\n\033[1;33mCopying binaries to tmp folder\033[0m"
 cd $tmp_dir;

--- a/x/init.go
+++ b/x/init.go
@@ -101,10 +101,11 @@ func printBuildDetails() {
 		return
 	}
 
-	fmt.Printf(fmt.Sprintf(`Dgraph version   : %v
+	fmt.Printf(fmt.Sprintf(`
+Dgraph version   : %v
 Commit SHA-1     : %v
 Commit timestamp : %v
-Branch       	 : %v`,
+Branch           : %v`,
 		dgraphVersion, lastCommitSHA, lastCommitTime, gitBranch) + "\n\n")
 }
 


### PR DESCRIPTION
Dgraphloader and Dgraph have an output like this on startup.

```
Dgraph version   : v0.7.3
Commit SHA-1     : 94dafbc
Commit timestamp : 2017-03-21 12:00:54 +1100
Branch       	 : feature/build-info
```

Dgraph version outputs the following
```
➜  dgraph git:(feature/build-info) ✗ ./dgraph --version
Dgraph version   : v0.7.3
Commit SHA-1     : 93093f4
Commit timestamp : 2017-03-21 14:50:51 +1100
Branch       	 : feature/build-info

Copyright 2016 Dgraph Labs, Inc.

Licensed under the Apache License, version 2.0.
For Dgraph official documentation, visit https://wiki.dgraph.io.
For discussions about Dgraph     , visit https://discuss.dgraph.io.
To say hi to the community       , visit https://dgraph.slack.com.

```

This should fix #697

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/728)
<!-- Reviewable:end -->
