### PR TITLE
snapshot based on number of entries in wal and snapshot on shutdown

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -641,32 +641,38 @@ func (n *node) snapshotPeriodically() {
 			x.Checkf(err, "Unable to get existing snapshot")
 
 			si := existing.Metadata.Index
-			if le <= si {
-				msg := fmt.Sprintf("Current watermark %d <= previous snapshot %d. Skipping.", le, si)
+			if le <= si+*maxPendingCount {
+				msg := fmt.Sprintf("Current watermark %d <= previous snapshot %d + %d. Skipping.",
+					le, si, *maxPendingCount)
 				if msg != prev {
 					prev = msg
 					fmt.Println(msg)
 				}
 				continue
 			}
-			msg := fmt.Sprintf("Taking snapshot for group: %d at watermark: %d\n", n.gid, le)
+			snapshotIdx := le - *maxPendingCount
+			msg := fmt.Sprintf("Taking snapshot for group: %d at watermark: %d\n", n.gid, snapshotIdx)
 			if msg != prev {
 				prev = msg
 				fmt.Println(msg)
 			}
 
-			rc, err := n.raftContext.Marshal()
-			x.Check(err)
-
-			s, err := n.store.CreateSnapshot(le, n.ConfState(), rc)
-			x.Checkf(err, "While creating snapshot")
-			x.Checkf(n.store.Compact(le), "While compacting snapshot")
-			x.Check(n.wal.StoreSnapshot(n.gid, s))
+			n.snapshot(le)
 
 		case <-n.done:
 			return
 		}
 	}
+}
+
+func (n *node) snapshot(idx uint64) {
+	rc, err := n.raftContext.Marshal()
+	x.Check(err)
+
+	s, err := n.store.CreateSnapshot(idx, n.ConfState(), rc)
+	x.Checkf(err, "While creating snapshot")
+	x.Checkf(n.store.Compact(idx), "While compacting snapshot")
+	x.Check(n.wal.StoreSnapshot(n.gid, s))
 }
 
 func (n *node) joinPeers() {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -550,7 +550,7 @@ func syncAllMarks(ctx context.Context) error {
 }
 
 // snapshotAll takes snapshot of all nodes of the worker group
-func snapshotAll(ctx context.Context) {
+func snapshotAll() {
 	var wg sync.WaitGroup
 	for _, n := range groups().nodes() {
 		wg.Add(1)

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -12,6 +12,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/taskp"
 	"github.com/dgraph-io/dgraph/protos/workerp"
 	"github.com/dgraph-io/dgraph/raftwal"
@@ -24,9 +25,14 @@ var (
 	groupIds = flag.String("groups", "0,1", "RAFT groups handled by this server.")
 	myAddr   = flag.String("my", "",
 		"addr:port of this server, so other Dgraph servers can talk to this.")
-	peerAddr   = flag.String("peer", "", "IP_ADDRESS:PORT of any healthy peer.")
-	raftId     = flag.Uint64("idx", 1, "RAFT ID that this server will use to join RAFT groups.")
-	schemaFile = flag.String("schema", "", "Path to schema file")
+	peerAddr = flag.String("peer", "", "IP_ADDRESS:PORT of any healthy peer.")
+	raftId   = flag.Uint64("idx", 1000, "RAFT ID that this server will use to join RAFT groups.")
+	// In case of flaky network connectivity we would try to keep upto maxPendingEntries in wal
+	// so that the nodes which have lagged behind leader can just replay entries instead of
+	// fetching snapshot if network disconnectivity is greater than the interval at which snapshots
+	// are taken
+	maxPendingCount = flag.Uint64("sc", 0, "Max number of pending entries in wal after which snapshot is taken")
+	schemaFile      = flag.String("schema", "", "Path to schema file")
 
 	emptyMembershipUpdate taskp.MembershipUpdate
 )
@@ -542,6 +548,21 @@ func syncAllMarks(ctx context.Context) error {
 	}
 	wg.Wait()
 	return err
+}
+
+// snapshotAll takes snapshot of all nodes of the worker group
+func snapshotAll(ctx context.Context) {
+	var wg sync.WaitGroup
+	for _, n := range groups().nodes() {
+		wg.Add(1)
+		go func(n *node) {
+			defer wg.Done()
+			water := posting.SyncMarkFor(n.gid)
+			idx := water.DoneUntil()
+			n.snapshot(idx)
+		}(n)
+	}
+	wg.Wait()
 }
 
 // StopAllNodes stops all the nodes of the worker group.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -108,4 +108,5 @@ func BlockingStop() {
 	if err := syncAllMarks(ctx); err != nil {
 		x.Printf("Error in sync watermarks : %s", err.Error())
 	}
+	snapshotAll(ctx)
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -108,5 +108,5 @@ func BlockingStop() {
 	if err := syncAllMarks(ctx); err != nil {
 		x.Printf("Error in sync watermarks : %s", err.Error())
 	}
-	snapshotAll(ctx)
+	snapshotAll()
 }


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/735)
<!-- Reviewable:end -->

In case of flaky network connectivity we would try to keep upto maxPendingEntries in wal
 so that the nodes which have lagged behind leader can just replay entries instead of
fetching snapshot if network disconnectivity is greater than the interval at which snapshots
 are taken