### PR TITLE
Enables dashboard external (instead: localhost) URL support

### DIFF
--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -15,7 +15,8 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <script>
-      window.SERVER_PORT = __SERVER_PORT__;
+      //window.SERVER_PORT = __SERVER_PORT__;
+      window.SERVER_ADDRESS = window.location.href.substr(0,-1);
     </script>
     <title>Dgraph UI</title>
 </head>

--- a/dashboard/src/containers/Helpers.js
+++ b/dashboard/src/containers/Helpers.js
@@ -520,5 +520,5 @@ export function sortStrings(a, b) {
 }
 
 export function dgraphAddress() {
-  return "http://localhost:" + window.SERVER_PORT;
+  return window.SERVER_ADDRESS;
 }


### PR DESCRIPTION
This should enable dashboard external (instead: localhost) URL support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/749)
<!-- Reviewable:end -->
