### PR TITLE
Catch quit and kill commands

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -837,7 +837,8 @@ func main() {
 	// setup shutdown os signal handler
 	sdCh := make(chan os.Signal, 1)
 	defer close(sdCh)
-	signal.Notify(sdCh, os.Interrupt, syscall.SIGTERM)
+	// sigint : Ctrl-C, sigquit : Ctrl-\ (backslash), sigterm : kill command.
+	signal.Notify(sdCh, os.Interrupt, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
 	go func() {
 		_, ok := <-sdCh
 		if ok {


### PR DESCRIPTION
`kill -9` and `out of memory` can not be caught and will kill the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/757)
<!-- Reviewable:end -->
