### PR TITLE
Optimize sorting by skipping index search if the number of entities are less

### DIFF
--- a/query/query_test.go
+++ b/query/query_test.go
@@ -912,7 +912,7 @@ func TestShortestPath_filter2(t *testing.T) {
 				follow @filter(not anyofterms(name, "bob"))
 			}
 
-			me(id: var( A)) {
+			me(id: var(A)) {
 				name
 			}
 		}`

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -135,12 +135,14 @@ func processSort(ctx context.Context, ts *taskp.Sort) (*taskp.SortResult, error)
 	}
 
 	if uidsLen < 10000 {
-		// Sort and paginate directly.
+		// Sort and paginate directly as it'd be expensive to iterate over the index which
+		// might have millions of keys just for retrieving some values.
 		sType, err := schema.State().TypeOf(ts.Attr)
 		if err != nil || !sType.IsScalar() {
 			return nil, x.Errorf("Cannot sort attribute %s of type object.", ts.Attr)
 		}
 		for i := 0; i < n; i++ {
+			// Copy, otherwise it'd affect the destUids and hence the srcUids of Next level.
 			ts.UidMatrix[i] = &taskp.List{ts.UidMatrix[i].Uids}
 			err := sortByValue(ts.Attr, ts.Langs, ts.UidMatrix[i], sType, ts.Desc)
 			if err != nil {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -302,33 +302,8 @@ func intersectBucket(ts *taskp.Sort, attr, token string, out []intersectedList) 
 	return errDone
 }
 
-func pageRange(count, offset, n int) (int, int) {
-	if count == 0 && offset == 0 {
-		return 0, n
-	}
-	if count < 0 {
-		// Items from the back of the array, like Python arrays. Do a positive mod n.
-		return (((n + count) % n) + n) % n, n
-	}
-	start := offset
-	if start < 0 {
-		start = 0
-	}
-	if start > n {
-		return n, n
-	}
-	if count == 0 { // No count specified. Just take the offset parameter.
-		return start, n
-	}
-	end := start + count
-	if end > n {
-		end = n
-	}
-	return start, end
-}
-
 func paginate(offset, count int, dest *taskp.List) {
-	start, end := pageRange(count, offset, len(dest.Uids))
+	start, end := x.PageRange(count, offset, len(dest.Uids))
 	dest.Uids = dest.Uids[start:end]
 }
 

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -125,16 +125,16 @@ func sortWithoutIndex(cancelCtx context.Context, ts *taskp.Sort, resCh chan resu
 			return
 		default:
 			// Copy, otherwise it'd affect the destUids and hence the srcUids of Next level.
-			ts.UidMatrix[i] = &taskp.List{ts.UidMatrix[i].Uids}
-			err := sortByValue(ts.Attr, ts.Langs, ts.UidMatrix[i], sType, ts.Desc)
+			tempList := &taskp.List{ts.UidMatrix[i].Uids}
+			err := sortByValue(ts.Attr, ts.Langs, tempList, sType, ts.Desc)
 			if err != nil {
 				resCh <- result{
 					res: r,
 					err: err,
 				}
 			}
-			paginate(int(ts.Offset), int(ts.Count), ts.UidMatrix[i])
-			r.UidMatrix = append(r.UidMatrix, ts.UidMatrix[i])
+			paginate(int(ts.Offset), int(ts.Count), tempList)
+			r.UidMatrix = append(r.UidMatrix, tempList)
 		}
 	}
 	resCh <- result{

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -310,8 +310,7 @@ func intersectBucket(ts *taskp.Sort, attr, token string, out []intersectedList) 
 
 		// We are within the page. We need to apply sorting.
 		// Sort results by value before applying offset.
-		err := sortByValue(attr, ts.Langs, result, scalar, ts.Desc)
-		if err != nil {
+		if err := sortByValue(attr, ts.Langs, result, scalar, ts.Desc); err != nil {
 			return err
 		}
 

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -259,11 +259,10 @@ type result struct {
 // enough for our pagination params. When all the UID lists are done, we stop
 // iterating over the index.
 func processSort(ctx context.Context, ts *taskp.Sort) (*taskp.SortResult, error) {
-	x.AssertTruef(ts.Count > 0,
-		("We do not yet support negative or infinite count with sorting: %s %d. " +
-			"Try flipping order and return first few elements instead."),
-		ts.Attr, ts.Count)
-
+	if ts.Count < 0 {
+		return nil, x.Errorf("We do not yet support negative or infinite count with sorting: %s %d. "+
+			"Try flipping order and return first few elements instead.", ts.Attr, ts.Count)
+	}
 	cancelCtx, cancel := context.WithCancel(ctx)
 	resCh := make(chan result, 2)
 	go sortWithoutIndex(cancelCtx, ts, resCh)

--- a/x/x.go
+++ b/x/x.go
@@ -154,7 +154,7 @@ func Round(d time.Duration) time.Duration {
 	return d
 }
 
-// pageRange returns start and end indices given pagination params. Note that n
+// PageRange returns start and end indices given pagination params. Note that n
 // is the size of the input list.
 func PageRange(count, offset, n int) (int, int) {
 	if n == 0 {

--- a/x/x.go
+++ b/x/x.go
@@ -154,6 +154,8 @@ func Round(d time.Duration) time.Duration {
 	return d
 }
 
+// pageRange returns start and end indices given pagination params. Note that n
+// is the size of the input list.
 func PageRange(count, offset, n int) (int, int) {
 	if n == 0 {
 		return 0, 0

--- a/x/x.go
+++ b/x/x.go
@@ -153,3 +153,34 @@ func Round(d time.Duration) time.Duration {
 	}
 	return d
 }
+
+func PageRange(count, offset, n int) (int, int) {
+	if n == 0 {
+		return 0, 0
+	}
+	if count == 0 && offset == 0 {
+		return 0, n
+	}
+	if count < 0 {
+		// Items from the back of the array, like Python arrays. Do a positive mod n.
+		if count*-1 > n {
+			count = -n
+		}
+		return (((n + count) % n) + n) % n, n
+	}
+	start := offset
+	if start < 0 {
+		start = 0
+	}
+	if start > n {
+		return n, n
+	}
+	if count == 0 { // No count specified. Just take the offset parameter.
+		return start, n
+	}
+	end := start + count
+	if end > n {
+		end = n
+	}
+	return start, end
+}


### PR DESCRIPTION
```
{
        fan(func:alloftext(name, "steven spielberg"), orderasc:name) {
                name
  	}
}
```
Reduces the query time of such queries from around a minute to a few milliseconds as the index for names is too huge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/762)
<!-- Reviewable:end -->
