### PR TITLE
set doneuntil in watermark from saved snapshot

### DIFF
--- a/x/watermark.go
+++ b/x/watermark.go
@@ -82,6 +82,10 @@ func (w *WaterMark) DoneUntil() uint64 {
 	return atomic.LoadUint64(&w.doneUntil)
 }
 
+func (w *WaterMark) SetDoneUntil(val uint64) {
+	atomic.StoreUint64(&w.doneUntil, val)
+}
+
 // WaitingFor returns whether we are waiting for a task to be done.
 func (w *WaterMark) WaitingFor() bool {
 	return atomic.LoadUint32(&w.waitingFor) != 0


### PR DESCRIPTION


On Restart doneuntil is reset to zero inside watermark. Setting doneuntil from snapshot on restart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/773)
<!-- Reviewable:end -->
