### PR TITLE
retry on temporary error during rebuild index/reverse edges

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -317,12 +317,11 @@ func RebuildReverseEdges(ctx context.Context, attr string) error {
 	}
 	close(ch)
 	for i := 0; i < 1000; i++ {
-		select {
-		case err := <-che:
-			if err != nil {
-				return err
-			}
+		err := <-che
+		if err != nil {
+			return err
 		}
+
 	}
 	return nil
 }
@@ -431,11 +430,9 @@ func RebuildIndex(ctx context.Context, attr string) error {
 	}
 	close(ch)
 	for i := 0; i < 1000; i++ {
-		select {
-		case err := <-che:
-			if err != nil {
-				return err
-			}
+		err := <-che
+		if err != nil {
+			return err
 		}
 	}
 	return nil

--- a/posting/index.go
+++ b/posting/index.go
@@ -317,8 +317,7 @@ func RebuildReverseEdges(ctx context.Context, attr string) error {
 	}
 	close(ch)
 	for i := 0; i < 1000; i++ {
-		err := <-che
-		if err != nil {
+		if err := <-che; err != nil {
 			return err
 		}
 
@@ -430,8 +429,7 @@ func RebuildIndex(ctx context.Context, attr string) error {
 	}
 	close(ch)
 	for i := 0; i < 1000; i++ {
-		err := <-che
-		if err != nil {
+		if err := <-che; err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Return error to the user in case index or reverse mutation fails.

Retry index mutation during rebuild index on temporary error after stop the world eviction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/776)
<!-- Reviewable:end -->
