### PR TITLE
Have a cascade directive

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -48,6 +48,7 @@ type GraphQuery struct {
 	Children     []*GraphQuery
 	Filter       *FilterTree
 	Normalize    bool
+	Cascade      bool
 	Facets       *Facets
 	FacetsFilter *FilterTree
 
@@ -586,6 +587,8 @@ L:
 
 			case "normalize":
 				gq.Normalize = true
+			case "cascade":
+				gq.Cascade = true
 			default:
 				return nil, x.Errorf("Unknown directive [%s]", item.Val)
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -1047,6 +1047,9 @@ func shouldCascade(res gql.Result, idx int) bool {
 		return false
 	}
 
+	if len(res.QueryVars[idx].Defines) == 0 {
+		return false
+	}
 	for _, def := range res.QueryVars[idx].Defines {
 		for _, need := range res.QueryVars[idx].Needs {
 			if def == need {

--- a/query/query.go
+++ b/query/query.go
@@ -135,6 +135,7 @@ type params struct {
 	uidToVal     map[uint64]types.Val
 	Langs        []string
 	Normalize    bool
+	Cascade      bool
 	From         uint64
 	To           uint64
 	Facet        *facetsp.Param
@@ -660,6 +661,7 @@ func newGraph(ctx context.Context, gq *gql.GraphQuery) (*SubGraph, error) {
 		Var:        gq.Var,
 		ParentVars: make(map[string]*taskp.List),
 		Normalize:  gq.Normalize,
+		Cascade:    gq.Cascade,
 	}
 	if gq.Facets != nil {
 		args.Facet = &facetsp.Param{gq.Facets.AllKeys, gq.Facets.Keys}
@@ -1014,11 +1016,7 @@ func ProcessQuery(ctx context.Context, res gql.Result, l *Latency) ([]*SubGraph,
 			if err != nil {
 				return nil, err
 			}
-			if len(res.QueryVars[idx].Defines) == 0 {
-				continue
-			}
-
-			isCascade := shouldCascade(res, idx)
+			isCascade := sg.Params.Cascade || shouldCascade(res, idx)
 			populateVarMap(sg, doneVars, isCascade)
 			err = sg.populatePostAggregation(doneVars)
 			if err != nil {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -335,6 +335,30 @@ func TestGetUIDNotInChild(t *testing.T) {
 		js)
 }
 
+func TestCascadeDirective(t *testing.T) {
+	populateGraph(t)
+	query := `
+		{
+			me(id:0x01) @cascade {
+				name
+				gender
+				friend {
+					name
+					friend{
+						name
+						dob
+						age
+					}
+				}
+			}
+		}
+	`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"me":[{"friend":[{"friend":[{"age":38,"dob":"1910-01-01","name":"Michonne"}],"name":"Rick Grimes"},{"friend":[{"age":15,"dob":"1909-05-05","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}`,
+		js)
+}
+
 func TestQueryVarValAggMinMaxSelf(t *testing.T) {
 	populateGraph(t)
 	query := `
@@ -4157,30 +4181,6 @@ children: <
 	require.EqualValues(t,
 		expectedPb,
 		proto.MarshalTextString(pb))
-}
-
-func TestCascadeDirective(t *testing.T) {
-	populateGraph(t)
-	query := `
-		{
-			me(id:0x01) @cascade {
-				name
-				gender
-				friend {
-					name
-					friend{
-						name
-						dob
-						age
-					}
-				}
-			}
-		}
-	`
-
-	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"me":[{"friend":[{"friend":[{"age":38,"dob":"1910-01-01","name":"Michonne"}],"name":"Rick Grimes"},{"friend":[{"age":15,"dob":"1909-05-05","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}`,
-		js)
 }
 
 func TestNormalizeDirective(t *testing.T) {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -4159,6 +4159,30 @@ children: <
 		proto.MarshalTextString(pb))
 }
 
+func TestCascadeDirective(t *testing.T) {
+	populateGraph(t)
+	query := `
+		{
+			me(id:0x01) @cascade {
+				name
+				gender
+				friend {
+					name
+					friend{
+						name
+						dob
+						age
+					}
+				}
+			}
+		}
+	`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"me":[{"friend":[{"friend":[{"age":38,"dob":"1910-01-01","name":"Michonne"}],"name":"Rick Grimes"},{"friend":[{"age":15,"dob":"1909-05-05","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}`,
+		js)
+}
+
 func TestNormalizeDirective(t *testing.T) {
 	populateGraph(t)
 	query := `

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1038,7 +1038,7 @@ curl localhost:8080/query -XPOST -d $'{
     }
   }
 }
-' | jq
+' 
 ```
 Output:
 ```
@@ -3038,6 +3038,194 @@ Output:
   ]
 }
 ```
+## Cascade Directive 
+
+`@cascade` directive forces a removal of those entites that don't have all the fields specified in the query. This can be useful, if a filter was applied because without cascade. For example
+
+```
+curl localhost:8080/query -XPOST -d $'{
+  HP(func: allofterms(name, "Harry Potter")) @cascade {
+    name@en
+    starring{
+        performance.character {
+          name@en
+        }
+        performance.actor @filter(allofterms(name, "Warwick")){
+            name@en
+         }
+    }
+  }
+}'
+```
+Output:
+```
+{
+  "HP": [
+    {
+      "name@en": "Harry Potter and the Order of the Phoenix",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Philosopher's Stone",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        },
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Goblin Bank Teller"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Prisoner of Azkaban",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Half-Blood Prince",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Chamber of Secrets",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Deathly Hallows – Part 2",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        },
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Griphook"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Deathly Hallows - Part I",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Griphook"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name@en": "Harry Potter and the Goblet of Fire",
+      "starring": [
+        {
+          "performance.actor": [
+            {
+              "name@en": "Warwick Davis"
+            }
+          ],
+          "performance.character": [
+            {
+              "name@en": "Professor Filius Flitwick"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Here we also remove all the nodes that don't have a corresponding valid sibling node for `Warwick Davis`.
 
 ## Normalize directive
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -3040,7 +3040,7 @@ Output:
 ```
 ## Cascade Directive 
 
-`@cascade` directive forces a removal of those entites that don't have all the fields specified in the query. This can be useful, if a filter was applied because without cascade. For example
+`@cascade` directive forces a removal of those entites that don't have all the fields specified in the query. This can be useful in cases where some filter was applied. For example, consider this query:
 
 ```
 curl localhost:8080/query -XPOST -d $'{


### PR DESCRIPTION
This query
```
{
  HP(func: allofterms(name, "Harry Potter")) @cascade {
    name
    starring{
        performance.character {
          name@ta
        }
        performance.actor @filter(allofterms(name, "Warwick")){
            name@ta
         }
    }
  }
}
```
Without the cascade directive, would return all the performance character. But if we want to see only the filtered (on sibling) nodes, the only way is to use a variable which would force a cascade and use it in another block. So it's better to provide a `@cascade` directive at root which can help achieve this.

So, if any of the specified field is missing, that enitity would be discarded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/782)
<!-- Reviewable:end -->
