### PR TITLE
Add support for reload server TLS Certs and CAs

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -153,8 +153,8 @@ func setupConnection() (*grpc.ClientConn, error) {
 		return grpc.Dial(*dgraph, grpc.WithInsecure())
 	}
 
-	tlsCfg, err := x.GenerateTLSConfig(x.TLSHelperConfig{
-		ConfigType:           x.TLSServerConfig,
+	tlsCfg, _, err := x.GenerateTLSConfig(x.TLSHelperConfig{
+		ConfigType:           x.TLSClientConfig,
 		Insecure:             *tlsInsecure,
 		ServerName:           *tlsServerName,
 		Cert:                 *tlsCert,

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -154,6 +154,7 @@ func setupConnection() (*grpc.ClientConn, error) {
 	}
 
 	tlsCfg, err := x.GenerateTLSConfig(x.TLSHelperConfig{
+		ConfigType:           x.TLSServerConfig,
 		Insecure:             *tlsInsecure,
 		ServerName:           *tlsServerName,
 		Cert:                 *tlsCert,

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -210,7 +210,11 @@ func GenerateTLSConfig(config TLSHelperConfig) (tlsCfg *tls.Config, reloadConfig
 	}
 
 	if auth >= tls.VerifyClientCertIfGiven {
-		tlsCfg.ClientAuth = tls.RequireAnyClientCert
+		if auth == tls.VerifyClientCertIfGiven {
+			tlsCfg.ClientAuth = tls.RequestClientCert
+		} else {
+			tlsCfg.ClientAuth = tls.RequireAnyClientCert
+		}
 		wrapper.clientAuth = auth
 	} else {
 		tlsCfg.ClientAuth = auth
@@ -286,7 +290,9 @@ func (c *wrapperTLSConfig) getClientCertificate(_ *tls.CertificateRequestInfo) (
 }
 
 func (c *wrapperTLSConfig) verifyPeerCertificate(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-	if c.clientAuth >= tls.VerifyClientCertIfGiven {
+	if c.clientAuth == tls.VerifyClientCertIfGiven && len(rawCerts) == 0 {
+		return nil
+	} else if c.clientAuth >= tls.VerifyClientCertIfGiven {
 		if len(rawCerts) > 0 {
 			pool := x509.NewCertPool()
 			for _, raw := range rawCerts[1:] {


### PR DESCRIPTION
Simple support for reload server Cert and CAs used when the TLS is enabled. The reload procedure is triggered when a signal SIGHUP is sent to dgraph process like `kill -SIGHUP PID` or `pkill --signal SIGHUP dgraph`.

If the cert and/or ca file is corrupt (malformed or cannot be loaded), the server will continue using the previous correct configuration for that param.

This is only used to reconfigure the TLS in the server, so it doesn't add support to use TLS between nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/789)
<!-- Reviewable:end -->
