### PR TITLE
Fix schema backup restore

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -75,7 +75,7 @@ func processSchemaFile(file string, batch *client.BatchMutation) {
 	defer f.Close()
 
 	var reader io.Reader
-	if size := len(file); size > 3 && strings.ToLower(file[size-3:size]) == ".gz" {
+	if strings.HasSuffix(strings.ToLower(file), ".gz") {
 		reader, err = gzip.NewReader(f)
 		x.Check(err)
 	} else {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -75,17 +75,11 @@ func processSchemaFile(file string, batch *client.BatchMutation) {
 	defer f.Close()
 
 	var reader io.Reader
-	reader, err = gzip.NewReader(f)
-	if err != nil {
-		if err == gzip.ErrHeader {
-			log.Println("Schema file is not a valid gzip file, reading as plain text instead.")
-			if _, err = f.Seek(0, 0); err != nil {
-				log.Fatal(err)
-			}
-			reader = f
-		} else {
-			log.Fatal(err)
-		}
+	if size := len(file); size > 3 && strings.ToLower(file[size-3:size]) == ".gz" {
+		reader, err = gzip.NewReader(f)
+		x.Check(err)
+	} else {
+		reader = f
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
Currently dgraphloader is reading the schema file as plain text, this is provoking an error when is trying to reload a backup (#843 is related) because the backup files are gzip.
With this changes, the schema file is reading as gzip first, if it's not a valid gzip file, the file is read as plain text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/866)
<!-- Reviewable:end -->
