### PR TITLE
Case insensitive regexp + new syntax

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -364,7 +364,7 @@ func checkValueType(vm varMap) error {
 }
 
 func substituteVar(f string, res *string, vmap varMap) error {
-	if f[0] == '$' {
+	if len(f) > 0 && f[0] == '$' {
 		va, ok := vmap[f]
 		if !ok {
 			return x.Errorf("Variable not defined %v", f)
@@ -1307,6 +1307,18 @@ L:
 						return nil, x.Errorf("Invalid use of $ in func args")
 					}
 					isDollar = true
+					continue
+				} else if itemInFunc.Typ == itemRegex {
+					end := strings.LastIndex(itemInFunc.Val, "/")
+					x.AssertTrue(end >= 0)
+					expr := strings.Replace(itemInFunc.Val[1:end], "\\/", "/", -1)
+					flags := ""
+					if end+1 < len(itemInFunc.Val) {
+						flags = itemInFunc.Val[end+1:]
+					}
+
+					g.Args = append(g.Args, expr, flags)
+					expectArg = false
 					continue
 				} else if itemInFunc.Typ != itemName {
 					return nil, x.Errorf("Expected arg after func [%s], but got item %v",

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2519,18 +2519,19 @@ func TestValidFulltextIndex(t *testing.T) {
 		`{"me":[{"name":"Michonne", "friend":[{"alias":"Bob Joe"}]}]}`, js)
 }
 
+// dob (date of birth) is not a string
 func TestFilterRegexError(t *testing.T) {
 	populateGraph(t)
 	query := `
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(dob, "^[a-z A-Z]+$")) {
+        friend @filter(regexp(dob, /^[a-z A-Z]+$/)) {
           name
         }
       }
     }
-  `
+`
 
 	res, err := gql.Parse(gql.Request{Str: query})
 	require.NoError(t, err)
@@ -2553,12 +2554,12 @@ func TestFilterRegex1(t *testing.T) {
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(name, "^[a-z A-Z]+$")) {
+        friend @filter(regexp(name, /^[a-z A-Z]+$/)) {
           name
         }
       }
     }
-  `
+`
 
 	_, err := processToFastJsonReq(t, query)
 	require.Error(t, err)
@@ -2571,12 +2572,12 @@ func TestFilterRegex2(t *testing.T) {
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(name, "^[^ao]+$")) {
+        friend @filter(regexp(name, /^[^ao]+$/)) {
           name
         }
       }
     }
-  `
+`
 
 	_, err := processToFastJsonReq(t, query)
 	require.Error(t, err)
@@ -2589,12 +2590,12 @@ func TestFilterRegex3(t *testing.T) {
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(name, "^Rick")) {
+        friend @filter(regexp(name, /^Rick/)) {
           name
         }
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2608,12 +2609,12 @@ func TestFilterRegex4(t *testing.T) {
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(name, "((en)|(xo))n")) {
+        friend @filter(regexp(name, /((en)|(xo))n/)) {
           name
         }
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2627,12 +2628,12 @@ func TestFilterRegex5(t *testing.T) {
     {
       me(id:0x01) {
         name
-        friend @filter(regexp(name, "^[a-zA-z]*[^Kk ]?[Nn]ight")) {
+        friend @filter(regexp(name, /^[a-zA-z]*[^Kk ]?[Nn]ight/)) {
           name
         }
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2642,16 +2643,16 @@ func TestFilterRegex5(t *testing.T) {
 func TestFilterRegex6(t *testing.T) {
 	populateGraph(t)
 	posting.CommitLists(10, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	query := `
     {
 	  me(id:0x1234) {
-		pattern @filter(regexp(value, "miss((issippi)|(ouri))")) {
+		pattern @filter(regexp(value, /miss((issippi)|(ouri))/)) {
 			value
 		}
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2661,16 +2662,16 @@ func TestFilterRegex6(t *testing.T) {
 func TestFilterRegex7(t *testing.T) {
 	populateGraph(t)
 	posting.CommitLists(10, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	query := `
     {
 	  me(id:0x1234) {
-		pattern @filter(regexp(value, "[aeiou]mission")) {
+		pattern @filter(regexp(value, /[aeiou]mission/)) {
 			value
 		}
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2680,16 +2681,16 @@ func TestFilterRegex7(t *testing.T) {
 func TestFilterRegex8(t *testing.T) {
 	populateGraph(t)
 	posting.CommitLists(10, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	query := `
     {
 	  me(id:0x1234) {
-		pattern @filter(regexp(value, "^(trans)?mission")) {
+		pattern @filter(regexp(value, /^(trans)?mission/)) {
 			value
 		}
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2699,16 +2700,16 @@ func TestFilterRegex8(t *testing.T) {
 func TestFilterRegex9(t *testing.T) {
 	populateGraph(t)
 	posting.CommitLists(10, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	query := `
     {
 	  me(id:0x1234) {
-		pattern @filter(regexp(value, "s.{2,5}mission")) {
+		pattern @filter(regexp(value, /s.{2,5}mission/)) {
 			value
 		}
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
@@ -2718,20 +2719,82 @@ func TestFilterRegex9(t *testing.T) {
 func TestFilterRegex10(t *testing.T) {
 	populateGraph(t)
 	posting.CommitLists(10, 1)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	query := `
     {
 	  me(id:0x1234) {
-		pattern @filter(regexp(value, "[^m]iss")) {
+		pattern @filter(regexp(value, /[^m]iss/)) {
 			value
 		}
       }
     }
-  `
+`
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
 		`{"me":[{"pattern":[{"value":"mississippi"}, {"value":"whissle"}]}]}`, js)
+}
+
+func TestFilterRegex11(t *testing.T) {
+	populateGraph(t)
+	posting.CommitLists(10, 1)
+	time.Sleep(50 * time.Millisecond)
+	query := `
+    {
+	  me(id:0x1234) {
+		pattern @filter(regexp(value, /SUB[cm]/i)) {
+			value
+		}
+      }
+    }
+`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"pattern":[{"value":"submission"}, {"value":"subcommission"}]}]}`, js)
+}
+
+// case insensitive mode may be turned on with modifier:
+// http://www.regular-expressions.info/modifiers.html - this is completely legal
+func TestFilterRegex12(t *testing.T) {
+	populateGraph(t)
+	posting.CommitLists(10, 1)
+	time.Sleep(50 * time.Millisecond)
+	query := `
+    {
+	  me(id:0x1234) {
+		pattern @filter(regexp(value, /(?i)SUB[cm]/)) {
+			value
+		}
+      }
+    }
+`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"pattern":[{"value":"submission"}, {"value":"subcommission"}]}]}`, js)
+}
+
+// case insensitive mode may be turned on and off with modifier:
+// http://www.regular-expressions.info/modifiers.html - this is completely legal
+func TestFilterRegex13(t *testing.T) {
+	populateGraph(t)
+	posting.CommitLists(10, 1)
+	time.Sleep(50 * time.Millisecond)
+	query := `
+    {
+	  me(id:0x1234) {
+		pattern @filter(regexp(value, /(?i)SUB[cm](?-i)ISSION/)) {
+			value
+		}
+      }
+    }
+`
+
+	// no results are returned, becaues case insensive mode is turned off before 'ISSION'
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{}`, js)
 }
 
 func TestToFastJSONFilterUID(t *testing.T) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -635,11 +635,16 @@ func parseSrcFn(q *taskp.Query) (*functionContext, error) {
 		fc.intersectDest = strings.HasPrefix(fnName, "allof") // allofterms and alloftext
 		fc.n = len(fc.tokens)
 	case RegexFn:
-		err = ensureArgsCount(q.SrcFunc, 1)
+		err = ensureArgsCount(q.SrcFunc, 2)
 		if err != nil {
 			return nil, err
 		}
-		fc.regex, err = cregexp.Compile("(?m)" + q.SrcFunc[2])
+		ignoreCase := q.SrcFunc[3] == "i"
+		matchType := "(?m)" // this is cregexp library specific
+		if ignoreCase {
+			matchType = "(?i)" + matchType
+		}
+		fc.regex, err = cregexp.Compile(matchType + q.SrcFunc[2])
 		if err != nil {
 			return nil, err
 		}

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -59,8 +59,10 @@ func uidsForRegex(attr string, gid uint32,
 				algo.IntersectWith(results, trigramUids, results)
 			}
 
-			if results.Size() == 0 || results.Size() > maxUidsForTrigram {
-				return results, regexTooWideErr
+			if results.Size() == 0 {
+				return results, nil
+			} else if results.Size() > maxUidsForTrigram {
+				return nil, regexTooWideErr
 			}
 		}
 		for _, sub := range query.Sub {
@@ -68,11 +70,14 @@ func uidsForRegex(attr string, gid uint32,
 				results = intersect
 			}
 			// current list of result is passed for intersection
-			results, err := uidsForRegex(attr, gid, sub, results)
+			var err error
+			results, err = uidsForRegex(attr, gid, sub, results)
 			if err != nil {
 				return nil, err
 			}
-			if results.Size() == 0 || results.Size() > maxUidsForTrigram {
+			if results.Size() == 0 {
+				return results, nil
+			} else if results.Size() > maxUidsForTrigram {
 				return nil, regexTooWideErr
 			}
 		}


### PR DESCRIPTION
This PR contains following changes:

1. Introduction of new syntax for regular expressions - `regexp(attr, /expression/flags)`.
1. Support of ignore case flag - `i`.
1. Bug fixes in trigram query processing. 

The case insensitivity should work without those changes, because regex library supports [modifiers](http://www.regular-expressions.info/modifiers.html) (`i` flag itself is implemented with `(?i)` modifier). New syntax was introduced for convenience.

Tokenization is not affected by the changes. Adding lower-cased trigrams to the index would make it impossible to search for lower-cased expressions in case-sensitive manner (as there is no way to distinguish lower-cased and normal tokens).

The `(?i)` modifier, forces generation of trigrams in all possible case combinations. This greatly improves the number of generated trigrams and may affect performance. Every trigram produces at least 8 trigrams, like `/abc/i/` results in following trigrams: `abc`, `abC`, `aBc`, `Abc`, `aBC`, `AbC`, `ABc`, `ABC` (uppercase <-> lowercase mapping [is not always 1 to 1](http://unicode.org/faq/casemap_charprop.html#7a), even more trigrams may be generated from single source trigram).