### PR TITLE
fix #826

### DIFF
--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -36,9 +36,9 @@ func populateGraphWithFacets(t *testing.T) {
 	friendFacets2 := map[string]string{
 		"since": "2005-05-02T15:04:05", "close": "true", "family": "false", "age": "33"}
 	friendFacets3 := map[string]string{
-		"since": "2004-05-02T15:04:05", "close": "true", "family": "true"}
+		"since": "2004-05-02T15:04:05", "close": "true", "family": "true", "tag": "\"Domain3\""}
 	friendFacets4 := map[string]string{
-		"since": "2007-05-02T15:04:05", "close": "false", "family": "true"}
+		"since": "2007-05-02T15:04:05", "close": "false", "family": "true", "tag": "34"}
 	addEdgeToUID(t, "friend", 1, 23, friendFacets1)
 	addEdgeToUID(t, "friend", 1, 24, friendFacets3)
 	addEdgeToUID(t, "friend", 1, 25, friendFacets4)
@@ -145,7 +145,7 @@ func TestRetrieveFacetsUidValues(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z"}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}]}]}`,
+		`{"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z", "tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}]}]}`,
 		js)
 }
 
@@ -167,7 +167,7 @@ func TestRetrieveFacetsAll(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"me":[{"@facets":{"name":{"origin":"french"}},"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"gender":"male","name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z"}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}],"gender":"female","name":"Michonne"}]}`,
+		`{"me":[{"@facets":{"name":{"origin":"french"}},"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"gender":"male","name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z","tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}],"gender":"female","name":"Michonne"}]}`,
 		js)
 }
 
@@ -295,7 +295,7 @@ func TestFacetsMutation(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z"}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"close":false,"family":false,"since":"2001-11-10T00:00:00Z"}}}],"name":"Michonne"}]}`,
+		`{"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z","tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"close":false,"family":false,"since":"2001-11-10T00:00:00Z"}}}],"name":"Michonne"}]}`,
 		js)
 }
 
@@ -400,6 +400,12 @@ children: <
               str_val: "2004-05-02T15:04:05Z"
             >
           >
+          properties: <
+            prop: "tag"
+            value: <
+              str_val: "Domain3"
+            >
+          >
         >
       >
     >
@@ -435,6 +441,12 @@ children: <
             prop: "since"
             value: <
               str_val: "2007-05-02T15:04:05Z"
+            >
+          >
+          properties: <
+            prop: "tag"
+            value: <
+              int_val: 34
             >
           >
         >
@@ -540,6 +552,50 @@ func TestFacetsFilterSimple(t *testing.T) {
 	// 0x65 does not have name.
 	require.JSONEq(t,
 		`{"me":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee"},{"_uid_":"0x65"}],"name":"Michonne"}]}`,
+		js)
+}
+
+func TestFacetsFilterSimple2(t *testing.T) {
+	populateGraphWithFacets(t)
+	defer teardownGraphWithFacets(t)
+	// find close friends of 1
+	query := `
+		{
+			me(id:0x1) {
+				name
+				friend @facets(eq(tag, "Domain3")) {
+					name
+					_uid_
+				}
+			}
+		}
+	`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee"}],"name":"Michonne"}]}`,
+		js)
+}
+
+func TestFacetsFilterSimple3(t *testing.T) {
+	populateGraphWithFacets(t)
+	defer teardownGraphWithFacets(t)
+	// find close friends of 1
+	query := `
+		{
+			me(id:0x1) {
+				name
+				friend @facets(eq(tag, "34")) {
+					name
+					_uid_
+				}
+			}
+		}
+	`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"friend":[{"_uid_":"0x19","name":"Daryl Dixon"}],"name":"Michonne"}]}`,
 		js)
 }
 
@@ -742,26 +798,6 @@ func TestFacetsFilterUnknownOrKnown(t *testing.T) {
 	require.JSONEq(t,
 		`{"me":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee"},{"_uid_":"0x19","name":"Daryl Dixon"}],"name":"Michonne"}]}`,
 		js)
-}
-
-func TestFacetsFilterFail1(t *testing.T) {
-	populateGraphWithFacets(t)
-	defer teardownGraphWithFacets(t)
-	// integer overflow error is propagated to stop the query.
-	query := `
-		{
-			me(id:0x1) {
-				name
-				friend @facets(ge(age, 111111111111111111118888888)) {
-					name
-					_uid_
-				}
-			}
-		}
-	`
-
-	_, err := processToFastJsonReq(t, query)
-	require.Error(t, err)
 }
 
 func TestFacetsFilterallofterms(t *testing.T) {

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -280,7 +280,7 @@ func TestFacetsMutation(t *testing.T) {
 	populateGraphWithFacets(t)
 	defer teardownGraphWithFacets(t)
 	delEdgeToUID(t, "friend", 1, 24) // Delete friendship between Michonne and Glenn
-	friendFacets := map[string]string{"since": "2001-11-10", "close": "false", "family": "false"}
+	friendFacets := map[string]string{"since": "2001-11-10T00:00:00Z", "close": "false", "family": "false"}
 	addEdgeToUID(t, "friend", 1, 101, friendFacets) // and 101 is not close friend now.
 	query := `
 		{

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -660,7 +660,7 @@ var testNQuads = []struct {
 	},
 	// Should parse dates
 	{
-		input: `_:alice <knows> "stuff" (key1=2002-10-02T15:00:00.05Z, key2=2006-01-02T15:04:05, key3=2006-01-02) .`,
+		input: `_:alice <knows> "stuff" (key1=2002-10-02T15:00:00.05Z, key2=2006-01-02T15:04:05, key3=2006-01-02T00:00:00Z) .`,
 		nq: graphp.NQuad{
 			Subject:     "_:alice",
 			Predicate:   "knows",

--- a/types/facets/utils.go
+++ b/types/facets/utils.go
@@ -155,13 +155,9 @@ func parseTime(val string) (time.Time, error) {
 	if err := t.UnmarshalText([]byte(val)); err == nil {
 		return t, err
 	}
-	if t, err := time.Parse(dateTimeFormat, val); err == nil {
-		return t, err
-	}
-	return time.Parse(dateFormatYMD, val)
+	return time.Parse(dateTimeFormat, val)
 }
 
-const dateFormatYMD = "2006-01-02"
 const dateTimeFormat = "2006-01-02T15:04:05"
 
 // TypeIDFor gives TypeID for facet.

--- a/types/facets/utils.go
+++ b/types/facets/utils.go
@@ -155,9 +155,13 @@ func parseTime(val string) (time.Time, error) {
 	if err := t.UnmarshalText([]byte(val)); err == nil {
 		return t, err
 	}
-	return time.Parse(dateTimeFormat, val)
+	if t, err := time.Parse(dateTimeFormat, val); err == nil {
+		return t, err
+	}
+	return time.Parse(dateFormatYMD, val)
 }
 
+const dateFormatYMD = "2006-01-02"
 const dateTimeFormat = "2006-01-02T15:04:05"
 
 // TypeIDFor gives TypeID for facet.


### PR DESCRIPTION
Facet is converted to appropriate type based on stored facet(since we don't have schema for facets and function arguments are string in gql query).

@facet(tag,"34") - used to match only int 34 earlier. Now it will match both int 34 and String 34(based on stored facet).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/875)
<!-- Reviewable:end -->
