### PR TITLE
String/bugs

### DIFF
--- a/client/value.go
+++ b/client/value.go
@@ -70,8 +70,21 @@ func Datetime(dateTime time.Time, nq *graphp.NQuad) error {
 	return nil
 }
 
+func validateStr(val string) error {
+	for idx, c := range val {
+		if c == '"' && (idx == 0 || val[idx-1] != '\\') {
+			return fmt.Errorf(`" must be preceded by a \ in object value`)
+		}
+	}
+	return nil
+}
+
 // Str is a helper function to add a string to an NQuad.ObjectValue.
 func Str(val string, nq *graphp.NQuad) error {
+	if err := validateStr(val); err != nil {
+		return err
+	}
+
 	v, err := types.ObjectValue(types.StringID, val)
 	if err != nil {
 		return err

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -341,7 +341,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 		}
 		return []byte("false"), nil
 	case types.StringID, types.DefaultID:
-		return []byte(fmt.Sprintf("%q", v.Value.(string))), nil
+		return []byte(fmt.Sprintf(`"%s"`, v.Value.(string))), nil
 	case types.DateID:
 		s := v.Value.(time.Time).Format("2006-01-02")
 		return json.Marshal(s)

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -283,6 +283,8 @@ func populateGraph(t *testing.T) {
 	addEdgeToUID(t, "son", 1, 2300, nil)
 	addEdgeToValue(t, "name", 2300, "Andre", nil)
 
+	addEdgeToValue(t, "name", 2301, `Alice\"`, nil)
+
 	time.Sleep(5 * time.Millisecond)
 }
 
@@ -5924,4 +5926,19 @@ children: <
   >
 >
 `, proto.MarshalTextString(pb[0]))
+}
+
+func TestStringEscape(t *testing.T) {
+	populateGraph(t)
+	query := `
+		{
+			me(id: 2301) {
+				name
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"name":"Alice\""}]}`,
+		js)
 }


### PR DESCRIPTION
Fixes #862 

1. We have a validateStr function in Go client which makes sure we don't input values like `Alice"`, `"` should be properly escaped. Hence
`err = client.Str(`Alice\"`, &nq)`
`err = client.Str("Alice\\\"", &nq)`

would work well but
`err = client.Str("Alice\"", &nq)`
would fail validation.

2. We don't quote the response for JSON anymore, because we are already storing the the raw string internally. So we just need to return that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/886)
<!-- Reviewable:end -->
