### PR TITLE
Fix schema error

### DIFF
--- a/schema/parse.go
+++ b/schema/parse.go
@@ -128,7 +128,7 @@ func parseIndexDirective(it *lex.ItemIterator, predicate string,
 	var seen = make(map[string]bool)
 	var seenSortableTok bool
 
-	if typ == types.UidID || typ == types.DefaultID {
+	if typ == types.UidID || typ == types.DefaultID || typ == types.PasswordID {
 		return tokenizers, x.Errorf("Indexing not allowed on predicate %s of type %s",
 			predicate, typ.Name())
 	}

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -128,9 +128,9 @@ func parseIndexDirective(it *lex.ItemIterator, predicate string,
 	var seen = make(map[string]bool)
 	var seenSortableTok bool
 
-	if typ == types.UidID {
-		return tokenizers, x.Errorf("Indexing not allowed on predicate %s of type uid",
-			predicate)
+	if typ == types.UidID || typ == types.DefaultID {
+		return tokenizers, x.Errorf("Indexing not allowed on predicate %s of type %s",
+			predicate, typ.Name())
 	}
 	if !it.Next() {
 		// Nothing to read.

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -129,10 +129,15 @@ var schemaIndexVal3Default = `
 value:default @index .
 `
 
+var schemaIndexVal3Password = `
+pass:password @index .
+`
+
 // Object types cant be indexed.
 func TestSchemaIndex_Error2(t *testing.T) {
 	require.Error(t, ParseBytes([]byte(schemaIndexVal3Uid), 1))
 	require.Error(t, ParseBytes([]byte(schemaIndexVal3Default), 1))
+	require.Error(t, ParseBytes([]byte(schemaIndexVal3Password), 1))
 }
 
 var schemaIndexVal4 = `
@@ -220,6 +225,13 @@ func TestParse4_NoError(t *testing.T) {
 func TestParse5_Error(t *testing.T) {
 	reset()
 	schemas, err := Parse("value:default @index .")
+	require.Error(t, err)
+	require.Nil(t, schemas)
+}
+
+func TestParse6_Error(t *testing.T) {
+	reset()
+	schemas, err := Parse("pass:password @index .")
 	require.Error(t, err)
 	require.Nil(t, schemas)
 }

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -111,8 +111,6 @@ func TestSchemaIndex(t *testing.T) {
 }
 
 var schemaIndexVal2 = `
-age:uid @index(int) .
-
 name: string @index(exact, exact) .
 address: string @index(term) .
 id: id @index(exact, term, exact) .
@@ -123,13 +121,18 @@ func TestSchemaIndex_Error1(t *testing.T) {
 	require.Error(t, ParseBytes([]byte(schemaIndexVal2), 1))
 }
 
-var schemaIndexVal3 = `
+var schemaIndexVal3Uid = `
 person:uid @index .
+`
+
+var schemaIndexVal3Default = `
+value:default @index .
 `
 
 // Object types cant be indexed.
 func TestSchemaIndex_Error2(t *testing.T) {
-	require.Error(t, ParseBytes([]byte(schemaIndexVal3), 1))
+	require.Error(t, ParseBytes([]byte(schemaIndexVal3Uid), 1))
+	require.Error(t, ParseBytes([]byte(schemaIndexVal3Default), 1))
 }
 
 var schemaIndexVal4 = `
@@ -212,6 +215,13 @@ func TestParse4_NoError(t *testing.T) {
 	schemas, err := Parse("name:string @index(fulltext) .")
 	require.NotNil(t, schemas)
 	require.Nil(t, err)
+}
+
+func TestParse5_Error(t *testing.T) {
+	reset()
+	schemas, err := Parse("value:default @index .")
+	require.Error(t, err)
+	require.Nil(t, schemas)
 }
 
 var ps *store.Store


### PR DESCRIPTION
Dgraph crashes when the schema loads a value of `default` or `password` type with an index, an example is:

```
mutation {
  schema{
    attr:default @index .
    pass:password @index .
  }
}
```

This PR fix that error sending an error to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/892)
<!-- Reviewable:end -->
