### PR TITLE
Experiment/loader

### DIFF
--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -138,6 +138,7 @@ func TestTokensTable(t *testing.T) {
 		Entity: 157,
 	}
 	addMutationWithIndex(t, l, edge, Set)
+	time.Sleep(20 * time.Millisecond)
 
 	key = x.IndexKey("name", "david")
 	slice, err := ps.Get(key)

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -443,9 +443,8 @@ func GetOrCreate(key []byte, group uint32) (rlist *List, decr func()) {
 	// index key to the data store, with essentially an empty value. We just need
 	// the keys for filtering / sorting.
 	if l == lp && pk.IsIndex() {
-		// Lock before entering goroutine. Otherwise, some tests in query will fail.
-		l.Lock()
 		go func(key []byte) {
+			l.Lock()
 			defer l.Unlock()
 			slice, err := pstore.Get(key)
 			x.Check(err)
@@ -455,6 +454,7 @@ func GetOrCreate(key []byte, group uint32) (rlist *List, decr func()) {
 			if slice != nil {
 				slice.Free() // Remember to free.
 			}
+			fmt.Printf("done\n")
 		}(key)
 	}
 	return lp, lp.decr

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -454,7 +454,6 @@ func GetOrCreate(key []byte, group uint32) (rlist *List, decr func()) {
 			if slice != nil {
 				slice.Free() // Remember to free.
 			}
-			fmt.Printf("done\n")
 		}(key)
 	}
 	return lp, lp.decr


### PR DESCRIPTION
Prior to this change, whenever we were loading data. Before doing index mutation, the index key was being persisted to db(which takes around 6-9ms on my machine). So mutation waits on the lock and hence loading was slow.(This coupled with the fact that mutations within a request are executed sequentially was causing the data loading to be slow).

The index key would be persisted eventually now(immediately). After this change data loads 4 times faster on my machine. If write to db fails then server would crash and 
1. if synced watermark reaches the index, the index would be persisted to db so on restart there is no need to write index key
2. otherwise the raft log would be replayed and the index key would be written again.

The only downside would be that the mutation would succeed, but we would need to wait for 10-20ms for filtering or sorting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/905)
<!-- Reviewable:end -->
