### PR TITLE
Lexer cleanup

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -470,7 +470,7 @@ func Parse(r Request) (res Result, rerr error) {
 		return res, err
 	}
 
-	l := lex.NewLexer(query).Run(lexText)
+	l := lex.NewLexer(query).Run(lexTopLevel)
 
 	var qu *GraphQuery
 	it := l.NewIterator()
@@ -682,14 +682,11 @@ L2:
 		switch item.Typ {
 		case lex.ItemError:
 			return nil, x.Errorf(item.Val)
-		case itemText:
-			v := strings.TrimSpace(item.Val)
-			if len(v) > 0 {
-				if name != "" {
-					return nil, x.Errorf("Multiple word query name not allowed.")
-				}
-				name = item.Val
+		case itemName:
+			if name != "" {
+				return nil, x.Errorf("Multiple word query name not allowed.")
 			}
+			name = item.Val
 		case itemLeftRound:
 			if name == "" {
 				return nil, x.Errorf("Variables can be defined only in named queries.")

--- a/gql/state_test.go
+++ b/gql/state_test.go
@@ -37,7 +37,7 @@ func TestNewLexer(t *testing.T) {
 			}
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexQuery)
 
 	it := l.NewIterator()
 	for it.Next() {
@@ -64,11 +64,11 @@ func TestNewLexerMutation(t *testing.T) {
 			_city
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
-		require.NotEqual(t, item.Typ, lex.ItemError)
+		require.NotEqual(t, item.Typ, lex.ItemError, "Error: %v", item.String())
 		t.Log(item.String())
 	}
 }
@@ -91,7 +91,7 @@ func TestNewSchemaQuery(t *testing.T) {
 		pred
 		type
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -105,7 +105,7 @@ func TestAbruptSchemaQuery(t *testing.T) {
 	schema {
 		pred
 	`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	var typ lex.ItemType
 	it := l.NewIterator()
 	for it.Next() {
@@ -124,7 +124,7 @@ func TestAbruptMutation(t *testing.T) {
 			Why is this #!!?
 			How is this?
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	var typ lex.ItemType
 	it := l.NewIterator()
 	for it.Next() {
@@ -142,7 +142,7 @@ func TestVariables1(t *testing.T) {
 			_city
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -158,7 +158,7 @@ func TestVariables2(t *testing.T) {
 			_city
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -174,7 +174,7 @@ func TestVariablesDefault(t *testing.T) {
 			_city
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -190,7 +190,7 @@ func TestIRIRef(t *testing.T) {
 		        <http://verygood.com/what/about/you>
 		}
 	}`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -207,7 +207,7 @@ func TestLangSupport(t *testing.T) {
 		}
 	}
 	`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -224,7 +224,7 @@ func TestMultiLangSupport(t *testing.T) {
 		}
 	}
 	`
-	l := lex.NewLexer(input).Run(lexText)
+	l := lex.NewLexer(input).Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -100,15 +100,14 @@ type Lexer struct {
 	// NOTE: Using a text scanner wouldn't work because it's designed for parsing
 	// Golang. It won't keep track of Start Position, or allow us to retrieve
 	// slice from [Start:Pos]. Better to just use normal string.
-	Input           string // string being scanned.
-	Start           int    // Start Position of this item.
-	Pos             int    // current Position of this item.
-	Width           int    // Width of last rune read from input.
-	items           []item // channel of scanned items.
-	Depth           int    // nesting of {}
-	ArgDepth        int    // nesting of ()
-	Mode            int    // mode based on information so far.
-	InsideDirective bool   // To indicate we are inside directive.
+	Input    string  // string being scanned.
+	Start    int     // Start Position of this item.
+	Pos      int     // current Position of this item.
+	Width    int     // Width of last rune read from input.
+	items    []item  // channel of scanned items.
+	Depth    int     // nesting of {}
+	ArgDepth int     // nesting of ()
+	Mode     StateFn // Default state to go back to after reading a token.
 }
 
 func NewLexer(input string) *Lexer {


### PR DESCRIPTION
I made some lexer cleanup. Defined what exactly Mode is: StateFn - default state we go back to, avoided jumping to lexText and than using mode to actual state, deleted Lexer.InsideDirective which was not used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/934)
<!-- Reviewable:end -->
