### PR TITLE
Modify Docker host port mappings to bind on local interface

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -54,18 +54,18 @@ dgraph
 If you want to persist the data while you play with Dgraph, you should mount the `dgraph` volume, using the `-v` flag.
 {{% /notice %}}
 
-#### Map to default port (8080)
+#### Map to default port (8080 on the local interface)
 
 ```sh
 mkdir -p ~/dgraph
-docker run -it -p 8080:8080 -v ~/dgraph:/dgraph dgraph/dgraph dgraph --bindall=true
+docker run -it -p 127.0.0.1:8080:8080 -v ~/dgraph:/dgraph dgraph/dgraph dgraph --bindall=true
 ```
 
 #### Map to custom port
 ```sh
 mkdir -p ~/dgraph
-# Mapping port 8080 from within the container to 9090  of the instance
-docker run -it -p 9090:8080 -v ~/dgraph:/dgraph dgraph/dgraph dgraph --bindall=true
+# Mapping port 8080 from within the container to 9090 (bound to the local interface) of the instance
+docker run -it -p 127.0.0.1:9090:8080 -v ~/dgraph:/dgraph dgraph/dgraph dgraph --bindall=true
 ```
 
 {{% notice "note" %}}The dgraph server listens on port 8080 (unless you have mapped to another port above) with log output to the terminal.{{% /notice %}}


### PR DESCRIPTION
When binding ports with Docker to the host machine, they bind to 0.0.0.0 by default. This means the port is open to remote machines. Unless this access is necessary, it is best to bind only on the local interface. This change binds the container ports only to the local interface so that they are only locally accessible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/965)
<!-- Reviewable:end -->
