### PR TITLE
Allow alias for math expressions

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2036,11 +2036,8 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				curp = nil
 				continue
 			} else if isMathBlock(valLower) {
-				if varName == "" {
-					return x.Errorf("Function %v should be used with a variable", val)
-				}
-				if alias != "" {
-					return x.Errorf("math() cannot have an alias")
+				if varName == "" && alias == "" {
+					return x.Errorf("Function math should be used with a variable or have an alias")
 				}
 				mathTree, again, err := parseMathFunc(it, false)
 				if err != nil {
@@ -2051,6 +2048,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				}
 				child := &GraphQuery{
 					Attr:       val,
+					Alias:      alias,
 					Args:       make(map[string]string),
 					Var:        varName,
 					MathExp:    mathTree,

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -2751,7 +2751,7 @@ func TestParseGroupbyRoot(t *testing.T) {
 		me(id: [1, 2, 3]) @groupby(friends) {
 				a as count(_uid_)
 		}
-		
+
 		groups(id: var(a)) {
 			_uid_
 			var(a)
@@ -3410,4 +3410,15 @@ func TestHasFilterAtChild(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.NoError(t, err)
+}
+
+func TestMathWithoutVarAlias(t *testing.T) {
+	query := `{
+			f(func: anyofterms(name, "Rick Michonne Andrea")) {
+				ageVar as age
+				math(ageVar *2)
+			}
+		}`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.Error(t, err)
 }

--- a/query/query.go
+++ b/query/query.go
@@ -376,7 +376,6 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 		ul := pc.uidMatrix[idx]
 
 		fieldName := pc.fieldName()
-
 		if len(pc.counts) > 0 {
 			c := types.ValueForType(types.IntID)
 			c.Value = int64(pc.counts[idx])
@@ -566,8 +565,20 @@ func uniqueKey(gchild *gql.GraphQuery) string {
 	if gchild.Func != nil {
 		key += fmt.Sprintf("%v", gchild.Func)
 	}
-	if len(gchild.NeedsVar) > 0 {
-		key += fmt.Sprintf("%v", gchild.NeedsVar)
+	// This is the case when we ask for a variable.
+	if gchild.Attr == "var" {
+		// E.g. a as age, result is returned as var(a)
+		if gchild.Var != "" && gchild.Var != "var" {
+			key = fmt.Sprintf("var(%v)", gchild.Var)
+		} else if len(gchild.NeedsVar) > 0 {
+			// For var(s)
+			key = fmt.Sprintf("var(%v)", gchild.NeedsVar[0].Name)
+		}
+
+		// Could be min(var(x)) && max(var(x))
+		if gchild.Func != nil {
+			key += gchild.Func.Name
+		}
 	}
 	if gchild.IsCount { // ignore count subgraphs..
 		key += "count"
@@ -576,7 +587,8 @@ func uniqueKey(gchild *gql.GraphQuery) string {
 		key += fmt.Sprintf("%v", gchild.Langs)
 	}
 	if gchild.MathExp != nil {
-		key += fmt.Sprintf("%+v", gchild.MathExp)
+		// For math exp variable is mandatory.
+		key = fmt.Sprintf("var(%+v)", gchild.Var)
 	}
 	if gchild.IsGroupby {
 		key += "groupby"

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -7393,3 +7393,21 @@ func TestMathVarAlias2(t *testing.T) {
 	js := processToFastJSON(t, query)
 	require.JSONEq(t, `{"me":[{"age":38,"doubleAge":76.000000},{"age":15,"doubleAge":30.000000},{"age":19,"doubleAge":38.000000}],"me2":[{"var(a)":76.000000},{"var(a)":30.000000},{"var(a)":38.000000}]}`, string(js))
 }
+
+func TestMathVar3(t *testing.T) {
+	populateGraph(t)
+	query := `
+		{
+			f as me(func: anyofterms(name, "Rick Michonne Andrea")) {
+				ageVar as age
+				a as math(ageVar *2)
+			}
+
+			me2(id: var(f)) {
+				var(a)
+			}
+		}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"me":[{"age":38,"var(a)":76.000000},{"age":15,"var(a)":30.000000},{"age":19,"var(a)":38.000000}],"me2":[{"var(a)":76.000000},{"var(a)":30.000000},{"var(a)":38.000000}]}`, string(js))
+}


### PR DESCRIPTION
This change fixes #998 

1. We use an alias if we have one for math expressions. This is the preferred way to fetch value for a math expression.
2. If we don't have an alias but a variable is defined for a math expression, then we return the value under the variable given that the variable is used in somewhere. This behavior is same as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1000)
<!-- Reviewable:end -->
