### PR TITLE
Another data race removed.

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -214,13 +214,13 @@ func IntersectSorted(lists []*protos.List) *protos.List {
 	return out
 }
 
-func Difference(u, v *protos.List) {
+func Difference(u, v *protos.List) *protos.List {
 	if u == nil || v == nil {
-		return
+		return &protos.List{Uids: make([]uint64, 0)}
 	}
 	n := len(u.Uids)
 	m := len(v.Uids)
-	out := make([]uint64, 0, n)
+	out := make([]uint64, 0, n/2)
 	i, k := 0, 0
 	for i < n && k < m {
 		uid := u.Uids[i]
@@ -242,7 +242,7 @@ func Difference(u, v *protos.List) {
 		out = append(out, u.Uids[i])
 		i++
 	}
-	u.Uids = out
+	return &protos.List{Uids: out}
 }
 
 // MergeSorted merges sorted lists.

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -218,9 +218,9 @@ func Difference(u, v *protos.List) {
 	if u == nil || v == nil {
 		return
 	}
-	out := u.Uids[:0]
 	n := len(u.Uids)
 	m := len(v.Uids)
+	out := make([]uint64, 0, n)
 	i, k := 0, 0
 	for i < n && k < m {
 		uid := u.Uids[i]

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -161,8 +161,8 @@ func TestDiffSorted1(t *testing.T) {
 		newList([]uint64{1, 2, 3}),
 		newList([]uint64{1}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{2, 3}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{2, 3}, output.Uids)
 }
 
 func TestDiffSorted2(t *testing.T) {
@@ -170,8 +170,8 @@ func TestDiffSorted2(t *testing.T) {
 		newList([]uint64{1, 2, 3}),
 		newList([]uint64{2}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{1, 3}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{1, 3}, output.Uids)
 }
 
 func TestDiffSorted3(t *testing.T) {
@@ -179,8 +179,8 @@ func TestDiffSorted3(t *testing.T) {
 		newList([]uint64{1, 2, 3}),
 		newList([]uint64{3}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{1, 2}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{1, 2}, output.Uids)
 }
 
 func TestDiffSorted4(t *testing.T) {
@@ -188,8 +188,8 @@ func TestDiffSorted4(t *testing.T) {
 		newList([]uint64{1, 2, 3}),
 		newList([]uint64{}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{1, 2, 3}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{1, 2, 3}, output.Uids)
 }
 
 func TestDiffSorted5(t *testing.T) {
@@ -197,8 +197,8 @@ func TestDiffSorted5(t *testing.T) {
 		newList([]uint64{}),
 		newList([]uint64{1, 2}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{}, output.Uids)
 }
 
 func TestSubSorted1(t *testing.T) {
@@ -206,8 +206,8 @@ func TestSubSorted1(t *testing.T) {
 		newList([]uint64{1, 2, 3}),
 		newList([]uint64{2, 3, 4, 5}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{1}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{1}, output.Uids)
 }
 
 func TestSubSorted6(t *testing.T) {
@@ -215,8 +215,8 @@ func TestSubSorted6(t *testing.T) {
 		newList([]uint64{10, 12, 13}),
 		newList([]uint64{2, 3, 4, 13}),
 	}
-	Difference(input[0], input[1])
-	require.Equal(t, []uint64{10, 12}, input[0].Uids)
+	output := Difference(input[0], input[1])
+	require.Equal(t, []uint64{10, 12}, output.Uids)
 }
 
 func TestUIDListIntersect1(t *testing.T) {

--- a/query/query.go
+++ b/query/query.go
@@ -1754,7 +1754,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			sg.DestUIDs = algo.MergeSorted(lists)
 		} else if sg.FilterOp == "not" {
 			x.AssertTrue(len(sg.Filters) == 1)
-			algo.Difference(sg.DestUIDs, sg.Filters[0].DestUIDs)
+			sg.DestUIDs = algo.Difference(sg.DestUIDs, sg.Filters[0].DestUIDs)
 		} else {
 			sg.DestUIDs = algo.IntersectSorted(lists)
 		}

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -3940,6 +3940,36 @@ func TestToFastJSONFilterNot4(t *testing.T) {
 		`{"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Daryl Dixon"}]}]}`, js)
 }
 
+// TestToFastJSONFilterNot4 was unstable (fails observed locally and on travis).
+// Following method repeats the query to make sure that it never fails.
+// It's commented out, because it's too slow for everyday testing.
+/*
+func TestToFastJSONFilterNot4x1000000(t *testing.T) {
+	populateGraph(t)
+	for i := 0; i < 1000000; i++ {
+		query := `
+		{
+			me(id:0x01) {
+				name
+				gender
+				friend (first:2) @filter(not anyofterms(name, "Andrea")
+				and not anyofterms(name, "glenn")
+				and not anyofterms(name, "rick")
+			) {
+				name
+			}
+		}
+	}
+	`
+
+		js := processToFastJSON(t, query)
+		require.JSONEq(t,
+			`{"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Daryl Dixon"}]}]}`, js,
+			"tzdybal: %d", i)
+	}
+}
+*/
+
 func TestToFastJSONFilterAnd(t *testing.T) {
 	populateGraph(t)
 	query := `


### PR DESCRIPTION
In #1020 there was data race that resulted in the crash (where `and`
and `not` filters was executed simultaneously).
This commit removes data race between two `not` filters running in
parallel. It makes sure that results of each `algo.Difference`
execution are stored in separate (newly allocated) slice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1036)
<!-- Reviewable:end -->
