### PR TITLE
Root url for doc

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -21,9 +21,36 @@ We use `./scripts/local.sh` script to set env variables that our documentation t
 
 Now you can make changes to the docs and see them being updated instantly thanks to Hugo.
 
+* While running locally, the version selector does not work because you need to build the documentation and serve it behind a reverse proxy to have multiple versions.
+
 ### Branch
 
-Documentation **will only run and build on `master` or `release/vx.x.x` branches.** It is because the some examples need to be adjusted depending on Dgraph version, and the documentation generator needs to know the version before.
+Depending on what branch you are on, some code examples will dynamically change. For instance, go-grpc code examples will have different import path depending on branch name.
+
+### Adding and modifying top-level menu
+
+* Add/modify top-level menu items in [config.toml](https://github.com/dgraph-io/dgraph/blob/master/wiki/config.toml)
+
+They are in a format of:
+
+```
+[[menu.main]]
+  name = "Design Concepts"
+  url = "/design-concepts/"
+  identifier = "design-concepts"
+  weight = 8
+```
+
+For the `identifier` of the menu entry, make sure that there is a matching map in `params.menudesc`. It is used to show one liner summary of the menu in the home page.
+
+```
+[params]
+  [params.menudesc]
+    ...
+    design-concepts = "A look at how Dgraph is designed to be so fast"
+    ...
+```
+
 
 ## Runnable
 

--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -1,10 +1,15 @@
-baseurl = "http://localhost:1313/latest"
+baseurl = "http://localhost:1313/"
 languageCode = "en-us"
 theme = "hugo-docs"
 
 # set by build script: title, baseurl
 title = "Dgraph Documentation"
 
+[[menu.main]]
+  name = "Home"
+  url = "/"
+  identifier = "home"
+  weight = -1
 [[menu.main]]
   name = "Get Started"
   url = "/get-started/"
@@ -46,7 +51,20 @@ title = "Dgraph Documentation"
   identifier = "design-concepts"
   weight = 8
 [[menu.main]]
-  name = "Dgraph compared to other databases"
-  url = "/dgraph-compared-to-other databases/"
-  identifier = "dgraph-compared-to-other databases"
+  name = "Dgraph Compared to Other Databases"
+  url = "/dgraph-compared-to-other-databases/"
+  identifier = "dgraph-compared-to-other-databases"
   weight = 9
+
+  [params]
+    [params.menudesc]
+      home = "Main page for official Dgraph documentation"
+      get-started = "Install Dgraph and run a query in 2 minutes."
+      guides = "A short introduction to graph database and Dgraph"
+      query-language = "An extensive guide for querying data in Dgraph"
+      clients = "Dgraph clients in various programming languages"
+      deploy = "Deploying Dgraph to production"
+      faq = "Frequently asked questions"
+      performance = "How Dgraph performs in real life"
+      design-concepts = "A look at how Dgraph is designed to be so fast"
+      dgraph-compared-to-other-databases = "Compare Dgraph to similar databases."

--- a/wiki/content/_index.md
+++ b/wiki/content/_index.md
@@ -1,0 +1,29 @@
++++
+date = "2017-03-20T19:35:35+11:00"
+title = "Dgraph Documentation"
++++
+
+![logo](https://img.shields.io/badge/status-alpha-red.svg)
+[![Wiki](https://img.shields.io/badge/res-wiki-blue.svg)](https://docs.dgraph.io)
+[![Build Status](https://travis-ci.org/dgraph-io/dgraph.svg?branch=master)](https://travis-ci.org/dgraph-io/dgraph)
+[![Coverage Status](https://coveralls.io/repos/github/dgraph-io/dgraph/badge.svg?branch=master)](https://coveralls.io/github/dgraph-io/dgraph?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/dgraph)](https://goreportcard.com/report/github.com/dgraph-io/dgraph)
+[![Slack Status](http://slack.dgraph.io/badge.svg)](http://slack.dgraph.io)
+
+**Welcome to the official Dgraph documentation. Here you will find useful documentation for Dgraph and more.**
+
+Dgraph is an open source, scalable, distributed, highly available and fast graph database, designed from ground up to be run in production.
+
+## Using Dgraph
+
+{{< toc >}}
+
+## Our Community
+
+**Dgraph is made better everyday by the growing community and the contributors all over the world.**
+
+{{< community-toc >}}
+
+## Resources
+
+{{< resources-toc >}}

--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -16,7 +16,8 @@ HOST=https://docs.dgraph.io
 # those which have docs.
 
 # Place the latest version at the beginning so that version selector can
-# append '(latest)' to the version string
+# append '(latest)' to the version string, and build script can place the
+# artifact in an appropriate location
 VERSIONS=(
 'v0.7.7'
 'master'
@@ -32,7 +33,13 @@ joinVersions() {
 
 rebuild() {
 	echo -e "$(date) $GREEN Updating docs for branch: $1.$RESET"
-	# Generate new docs after merging.
+
+	# The latest documentation is generated in the root of /public dir
+	# Older documentations are generated in their respective `/public/vx.x.x` dirs
+	dir=''
+	if [[ $2 != "${VERSIONS[0]}" ]]; then
+		dir=$2
+	fi
 
 	# In Unix environments, env variables should also be exported to be seen by Hugo
 	export CURRENT_BRANCH=${1}
@@ -41,8 +48,8 @@ rebuild() {
 	HUGO_TITLE="Dgraph Doc ${2}"\
 		VERSIONS=${VERSION_STRING} \
 		CURRENT_BRANCH=${1} hugo\
-		--destination=public/"$2"\
-		--baseURL="$HOST"/"$2" 1> /dev/null
+		--destination=public/"$dir"\
+		--baseURL="$HOST"/"$dir" 1> /dev/null
 }
 
 branchUpdated()

--- a/wiki/scripts/local.sh
+++ b/wiki/scripts/local.sh
@@ -2,6 +2,7 @@
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 VERSIONS=(
+  'v0.7.7'
   'v0.7.6'
   'master'
   'v0.7.5'
@@ -15,15 +16,6 @@ joinVersions() {
 
 VERSION_STRING=$(joinVersions)
 
-# ensure_doc_branch exits the script if doc is run on a branch not supported
-ensure_doc_branch() {
-  if [ $CURRENT_BRANCH != "master" ] && ! [[ $CURRENT_BRANCH =~ ^release\/v[0-9]\.[0-9]\.[0-9]$ ]]; then
-    echo "You can only run documentation on 'master' or 'release/vx.x.x' branches."
-    echo "See: https://github.com/dgraph-io/dgraph/tree/doc/wiki#branch"
-    exit 1
-  fi
-}
-
 run() {
   export CURRENT_BRANCH=${CURRENT_BRANCH}
   export VERSIONS=${VERSION_STRING}
@@ -33,5 +25,4 @@ run() {
   CURRENT_BRANCH=${CURRENT_BRANCH} hugo server -w
 }
 
-ensure_doc_branch
 run


### PR DESCRIPTION
* Adds the root page for documentation at `https://docs.dgraph.io/`
  * Currently we do HTML meta redirect from the root page to versioned page which is bad for SEO
* Latest version of the doc is accessible directly from the root, and archived docs are accessible using version prefix in the URL

e.g. `https://docs.dgraph.io/query-language`, `https://docs.dgraph.io/v7.7.4/query-language`

![dgraph_documentation](https://user-images.githubusercontent.com/8265228/27016416-f4a66604-4f62-11e7-82a3-912d064b2606.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1037)
<!-- Reviewable:end -->

