### PR TITLE
Remove extra check

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -265,11 +265,6 @@ func (batch *BatchMutation) AddMutation(nq protos.NQuad, op Op) error {
 	if err := checkNQuad(nq); err != nil {
 		return err
 	}
-	if op == SET &&
-		((nq.ObjectType == int32(types.DefaultID) && nq.ObjectValue.GetDefaultVal() == "*") ||
-			(nq.ObjectType == int32(types.StringID) && nq.ObjectValue.GetStrVal() == "*")) {
-		return x.Errorf("Cannot set the value as '*'")
-	}
 	batch.nquads <- nquadOp{nq: nq, op: op}
 	atomic.AddUint64(&batch.rdfs, 1)
 	return nil


### PR DESCRIPTION
The check didn't allow setting `*` as an object value. I think it's not needed because

Setting object value as `*` during a delete operation won't delete everything. It would only delete the value if it was actually `*`.

To do `S P *` the user has to set ObjectValue as `x.DeleteAllObjects` from the client. @janardhan1993  we can probably provide a helper function in the new client mutation library that we are building so that its easier for the user to do this and `DeleteAllPredicate` operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1039)
<!-- Reviewable:end -->
