### PR TITLE
Stop redirecting in nginx

### DIFF
--- a/wiki/nginx/docs.conf
+++ b/wiki/nginx/docs.conf
@@ -4,11 +4,7 @@ server {
     root /home/ubuntu/dgraph/wiki/public;
     add_header Cache-Control "no-cache";
 
-    location = / {
-        return 307 /v0.7.7;
-    }
-
     location / {
-        try_files $uri $uri/index.html /v0.7.7/404.html;
+      try_files $uri $uri/index.html /404.html;
     }
 }


### PR DESCRIPTION
We no longer redirect in nginx as we now have root page for docs.

https://github.com/dgraph-io/dgraph/pull/1037

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1040)
<!-- Reviewable:end -->
