### PR TITLE
Rearrange contents in the main page

### DIFF
--- a/wiki/README.md
+++ b/wiki/README.md
@@ -27,30 +27,6 @@ Now you can make changes to the docs and see them being updated instantly thanks
 
 Depending on what branch you are on, some code examples will dynamically change. For instance, go-grpc code examples will have different import path depending on branch name.
 
-### Adding and modifying top-level menu
-
-* Add/modify top-level menu items in [config.toml](https://github.com/dgraph-io/dgraph/blob/master/wiki/config.toml)
-
-They are in a format of:
-
-```
-[[menu.main]]
-  name = "Design Concepts"
-  url = "/design-concepts/"
-  identifier = "design-concepts"
-  weight = 8
-```
-
-For the `identifier` of the menu entry, make sure that there is a matching map in `params.menudesc`. It is used to show one liner summary of the menu in the home page.
-
-```
-[params]
-  [params.menudesc]
-    ...
-    design-concepts = "A look at how Dgraph is designed to be so fast"
-    ...
-```
-
 
 ## Runnable
 

--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -55,16 +55,3 @@ title = "Dgraph Documentation"
   url = "/dgraph-compared-to-other-databases/"
   identifier = "dgraph-compared-to-other-databases"
   weight = 9
-
-  [params]
-    [params.menudesc]
-      home = "Main page for official Dgraph documentation"
-      get-started = "Install Dgraph and run a query in 2 minutes."
-      guides = "A short introduction to graph database and Dgraph"
-      query-language = "An extensive guide for querying data in Dgraph"
-      clients = "Dgraph clients in various programming languages"
-      deploy = "Deploying Dgraph to production"
-      faq = "Frequently asked questions"
-      performance = "How Dgraph performs in real life"
-      design-concepts = "A look at how Dgraph is designed to be so fast"
-      dgraph-compared-to-other-databases = "Compare Dgraph to similar databases."

--- a/wiki/content/_index.md
+++ b/wiki/content/_index.md
@@ -10,20 +10,152 @@ title = "Dgraph Documentation"
 [![Go Report Card](https://goreportcard.com/badge/github.com/dgraph-io/dgraph)](https://goreportcard.com/report/github.com/dgraph-io/dgraph)
 [![Slack Status](http://slack.dgraph.io/badge.svg)](http://slack.dgraph.io)
 
-**Welcome to the official Dgraph documentation. Here you will find useful documentation for Dgraph and more.**
+**Welcome to the official Dgraph documentation.**
 
 Dgraph is an open source, scalable, distributed, highly available and fast graph database, designed from ground up to be run in production.
 
 ## Using Dgraph
 
-{{< toc >}}
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://tour.dgraph.io" target="_blank">
+              Tour of Dgraph <i class="fa fa-external-link external-link-icon"></i>
+            </a>
+          </div>
+          <p class="section-desc">
+            Take an interactive tour of Dgraph to learn the concepts.
+          </p>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "get-started/index.md">}}">
+              Get Started
+            </a>
+          </div>
+          <p class="section-desc">
+            Install Dgraph and run a query in 2 minutes.
+          </p>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "query-language/index.md">}}">
+              Query Language
+            </a>
+          </div>
+          <p class="section-desc">
+            A reference guide for Dgraph query language
+          </p>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "clients/index.md">}}">
+              Clients
+            </a>
+          </div>
+          <p class="section-desc">
+            Dgraph clients in various programming languages
+          </p>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "deploy/index.md">}}">
+              Deploy
+            </a>
+          </div>
+          <p class="section-desc">
+            Deploying Dgraph to production
+          </p>
+        </div>
+      </div>
+
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "faq/index.md">}}">
+              FAQ
+            </a>
+          </div>
+          <p class="section-desc">
+            Frequently asked questions
+          </p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</section>
+
 
 ## Our Community
 
 **Dgraph is made better everyday by the growing community and the contributors all over the world.**
 
-{{< community-toc >}}
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://slack.dgraph.io">
+              Slack <i class="fa fa-external-link external-link-icon"></i>
+            </a>
+          </div>
+          <p class="section-desc">
+            Chat instantly to the Dgrpah community and engineers.
+          </p>
+        </div>
+      </div>
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://discuss.dgraph.io">
+              Forum <i class="fa fa-external-link external-link-icon"></i>
+            </a>
+          </div>
+          <p class="section-desc">
+            Discuss Dgraph on the official forum.
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 
-## Resources
 
-{{< resources-toc >}}
+## Demo
+
+<section class="toc">
+  <div class="container">
+    <div class="row row-no-padding">
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="https://discuss.dgraph.io">
+              Dgraph Playground <i class="fa fa-external-link external-link-icon"></i>
+            </a>
+          </div>
+          <p class="section-desc">
+            Play with Freebase movie dataset with 21 million edges
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/wiki/content/design-concepts/index.md
+++ b/wiki/content/design-concepts/index.md
@@ -3,6 +3,8 @@ date = "2017-03-20T22:25:17+11:00"
 title = "Design Concepts"
 +++
 
+{{% notice "outdated" %}}This section is outdated. You will find [Tour of Dgraph](https://tour.dgraph.io) a much helpful resource.{{% /notice %}}
+
 ## Concepts
 
 ### XID <-> UID

--- a/wiki/content/performance/index.md
+++ b/wiki/content/performance/index.md
@@ -2,7 +2,10 @@
 title = "Performance"
 +++
 
+{{% notice "incomplete" %}}This section is still work in progress.{{% /notice %}}
+
 ## General
+
 ### Dgraphloader
 [Dgraphloader]({{< relref "deploy/index.md#bulk-data-loading" >}}) can be used to load the RDF data into Dgraph. As a reference point, it took on an average '''5 minutes to load 22M RDFs''' (from [benchmarks repository](https://github.com/dgraph-io/benchmarks/blob/master/data/21million.rdf.gz)) on an i7-6820HQ quad core Thinkpad T460 laptop with 16 GB RAM and SSD storage. The total output including the RAFT logs was 1.4 GB. Loading the same data on a ec2 [m4.large](https://aws.amazon.com/ec2/instance-types) machine took around 18 minutes.
 


### PR DESCRIPTION
* Keep the main content in the documentation as markdown rather than as a shortcode in the theme for future maintenance.
* Add notices for outdated or incomplete sections.

![dgraph_documentation](https://user-images.githubusercontent.com/8265228/27067010-b1ec3714-504b-11e7-8265-b8b15b4e29f5.png)

![performance_ _dgraph_doc_-_local](https://user-images.githubusercontent.com/8265228/27067467-63823f30-504e-11e7-8e33-dd60267fceea.png)
![design_concepts_ _dgraph_doc_-_local](https://user-images.githubusercontent.com/8265228/27067474-699a21ee-504e-11e7-81f9-88bb8607ad1f.png)


IMO, sidebar's purpose is to help user navigate documentation contents not external sites. So 'Tour' does not belong in the sidebar, and we should keep 'Home' in the sidebar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1049)
<!-- Reviewable:end -->
