### PR TITLE
Fix import paths for badger

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -42,7 +42,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc"

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/group"
 	"github.com/dgraph-io/dgraph/posting"

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/group"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos"

--- a/posting/index.go
+++ b/posting/index.go
@@ -24,7 +24,7 @@ import (
 
 	"golang.org/x/net/trace"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgryski/go-farm"
 
 	"github.com/dgraph-io/dgraph/group"

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/protos"

--- a/posting/list.go
+++ b/posting/list.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/trace"
 
 	"github.com/dgryski/go-farm"

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/group"

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -35,7 +35,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgryski/go-farm"
 
 	"github.com/dgraph-io/dgraph/protos"

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -25,7 +25,7 @@ import (
 
 	"google.golang.org/grpc/metadata"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 	geom "github.com/twpayne/go-geom"
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -30,7 +30,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
 	geom "github.com/twpayne/go-geom"

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 
 	"github.com/dgraph-io/dgraph/x"
 )

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/group"

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/trace"
 
 	"github.com/dgraph-io/dgraph/group"

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -30,7 +30,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 

--- a/worker/backup_test.go
+++ b/worker/backup_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 	geom "github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/wkb"

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -28,7 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -23,7 +23,7 @@ import (
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/group"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos"

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/trace"
 
 	"github.com/dgraph-io/dgraph/group"

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"testing"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/dgraph/posting"

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 

--- a/worker/task.go
+++ b/worker/task.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -21,7 +21,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/tok"

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/group"
 	"github.com/dgraph-io/dgraph/protos"
 	"github.com/dgraph-io/dgraph/x"

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/badger"
+	"github.com/dgraph-io/badger"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/algo"


### PR DESCRIPTION
This seems necessary to compile Dgraph.  The commit 1c84ab8cd8f3528ff9a68059db2e4fc4d0b4f947 in the badger repo removed the extra badger directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1097)
<!-- Reviewable:end -->
