### PR TITLE
Add max size of 256MB for gRPC communication

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -634,7 +634,9 @@ func setupListener(addr string, port int) (listener net.Listener, err error) {
 
 func serveGRPC(l net.Listener) {
 	defer func() { finishCh <- struct{}{} }()
-	s := grpc.NewServer(grpc.CustomCodec(&query.Codec{}))
+	s := grpc.NewServer(grpc.CustomCodec(&query.Codec{}),
+		grpc.MaxRecvMsgSize(x.GrpcMaxSize),
+		grpc.MaxSendMsgSize(x.GrpcMaxSize))
 	protos.RegisterDgraphServer(s, &grpcServer{})
 	err := s.Serve(l)
 	log.Printf("gRpc server stopped : %s", err.Error())

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -93,7 +93,9 @@ func RunServer(bindall bool) {
 	}
 	log.Printf("Worker listening at address: %v", ln.Addr())
 
-	workerServer = grpc.NewServer()
+	workerServer = grpc.NewServer(
+		grpc.MaxRecvMsgSize(x.GrpcMaxSize),
+		grpc.MaxSendMsgSize(x.GrpcMaxSize))
 	protos.RegisterWorkerServer(workerServer, &grpcWorker{})
 	workerServer.Serve(ln)
 }

--- a/x/x.go
+++ b/x/x.go
@@ -45,6 +45,7 @@ const (
 	ErrorInvalidMutation = "ErrorInvalidMutation"
 	ValidHostnameRegex   = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
 	Star                 = "_STAR_"
+	GrpcMaxSize          = 256 << 20
 )
 
 var (


### PR DESCRIPTION
Increase max size for the data that client facing and internal grpc server can send and receive to 256MB.
This should fix #396 and #1073.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1100)
<!-- Reviewable:end -->
