### PR TITLE
Avoid 1701 crash

### DIFF
--- a/worker/conn.go
+++ b/worker/conn.go
@@ -97,11 +97,13 @@ func (p *poolsi) connect(addr string) {
 	resp, err := c.Echo(context.Background(), query)
 	if err != nil {
 		log.Printf("While trying to connect to %q, got error: %v\n", addr, err)
-		return
+		// Don't return -- let's still put the empty pool in the map.  Its users
+		// have to handle errors later anyway.
+	} else {
+		x.AssertTrue(bytes.Equal(resp.Data, query.Data))
+		x.Check(pool.Put(conn))
+		fmt.Printf("Connection with %q successful.\n", addr)
 	}
-	x.AssertTrue(bytes.Equal(resp.Data, query.Data))
-	x.Check(pool.Put(conn))
-	fmt.Printf("Connection with %q successful.\n", addr)
 
 	p.Lock()
 	defer p.Unlock()


### PR DESCRIPTION
This makes us stop crashing the way we do in #1071.  There are still a lot other places where we'll willfully exit the process because a network connection failed -- and shouldn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1112)
<!-- Reviewable:end -->
