### PR TITLE
allow clients to flush buffers and forget blank nodes

### DIFF
--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -288,6 +288,9 @@ func ExampleReq_BatchFlushing() {
 
 	req.SetQuery(queryTXT)
 
+	for ; dgraphClient.AwaitingBuffering() > 0; {
+		time.Sleep(10 * time.Millisecond)	
+	}
 	dgraphClient.BatchFlush()					// flush the XIDs before query
 	time.Sleep(10 * time.Second)				// workaround until index issue is fixed
 
@@ -335,6 +338,9 @@ func ExampleReq_BatchFlushing() {
 	req.SetQuery(queryTXT)
 
 
+	for ; dgraphClient.AwaitingBuffering() > 0; {
+		time.Sleep(10 * time.Millisecond)	
+	}
 	dgraphClient.BatchFlush()					// flush the XIDs before query
 
 

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -332,6 +332,12 @@ func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 }
 
 
+// AwaitingBuffering returns the number of set and del mutations that have been added with BatchSet() or BatchDelete() and have not yet
+// been added to a buffer for batching.  Can be called before flushing buffers to ensure all pending changes are buffered before flushing.
+func (d *Dgraph) AwaitingBuffering() int {
+	return len(d.nquads)
+}
+
 // BatchFlush flushes any currently pending requests, but keeps the channels open so the client can continue.
 // To flush bbuffers in long running clients.
 func (d *Dgraph) BatchFlush() {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -246,8 +246,9 @@ func main() {
 			processFile(file, dgraphClient)
 		}(file)
 	}
-	wg.Wait()
-	dgraphClient.BatchFlush()
+
+	wg.Wait()	
+	dgraphClient.BatchEnd()
 
 	c := dgraphClient.Counter()
 	var rate uint64


### PR DESCRIPTION
Currently clients can't add to batches (e.g. in background with XID) and then query.  Could be done by closing client, but then XID map is forgotten.  This PR allows things like

https://github.com/dgraph-io/dgraph/blob/f8a89cf29f62068ae1d94d10ff6105262ea953eb/client/examples_test.go#L231-L351

where a client can have multiple interactions.

Also allows purging the blank node map, so clients don't have to create new labels.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1134)
<!-- Reviewable:end -->
