### PR TITLE
Separate gRPC client port

### DIFF
--- a/client/doc.go
+++ b/client/doc.go
@@ -22,7 +22,7 @@ to upload data concurrently. It communicates with the server using gRPC.
 In this example, we first create a node, add a name (Steven Spielberg) and age
 attribute to it. We then create another node, add a name attribute (William Jones),
 we then add a friend edge between the two nodes.
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	dgraphClient := protos.NewDgraphClient(conn)
 	req := client.Req{}
 

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -48,7 +48,7 @@ func Node(val string, c *client.Dgraph) string {
 }
 
 func ExampleReq_AddMutation() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -81,7 +81,7 @@ func ExampleReq_AddMutation() {
 }
 
 func ExampleReq_BatchMutation() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -109,7 +109,7 @@ func ExampleReq_BatchMutation() {
 }
 
 func ExampleReq_AddMutation_facets() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -161,7 +161,7 @@ func ExampleReq_AddMutation_facets() {
 }
 
 func ExampleReq_AddMutation_schema() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -192,7 +192,7 @@ schema {}
 }
 
 func ExampleReq_SetQuery() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -227,7 +227,7 @@ func ExampleReq_SetQuery() {
 }
 
 func ExampleReq_SetQueryWithVariables() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 

--- a/cmd/dgraph/debug.yaml
+++ b/cmd/dgraph/debug.yaml
@@ -10,8 +10,11 @@ idx: 1
 # Groups to be served by this instance.
 groups: "0,1"
 
-# Port to run server on. (default 8080)
+# Port to run http server on. (default 8080)
 port: 8080
+
+# Port to run grpc server on. (default 9080)
+grpc_port: 9080
 
 # Port used by worker for internal communication.
 workerport: 12345

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -60,11 +60,12 @@ import (
 )
 
 var (
-	gconf      = flag.String("group_conf", "", "group configuration file")
-	postingDir = flag.String("p", "p", "Directory to store posting lists.")
-	walDir     = flag.String("w", "w", "Directory to store raft write-ahead logs.")
-	port       = flag.Int("port", 8080, "Port to run server on.")
-	bindall    = flag.Bool("bindall", false,
+	gconf        = flag.String("group_conf", "", "group configuration file")
+	postingDir   = flag.String("p", "p", "Directory to store posting lists.")
+	walDir       = flag.String("w", "w", "Directory to store raft write-ahead logs.")
+	baseHttpPort = flag.Int("port", 8080, "Port to run HTTP service on.")
+	baseGrpcPort = flag.Int("grpc_port", 9080, "Port to run gRPC service on.")
+	bindall      = flag.Bool("bindall", false,
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
 	nomutations = flag.Bool("nomutations", false, "Don't allow mutations on this server.")
 	exposeTrace = flag.Bool("expose_trace", false,
@@ -89,6 +90,14 @@ var (
 	tlsMinVersion    = flag.String("tls.min_version", "TLS11", "TLS min version.")
 	tlsMaxVersion    = flag.String("tls.max_version", "TLS12", "TLS max version.")
 )
+
+func httpPort() int {
+	return *x.PortOffset + *baseHttpPort
+}
+
+func grpcPort() int {
+	return *x.PortOffset + *baseGrpcPort
+}
 
 func stopProfiling() {
 	// Stop the CPU profiling that was initiated.
@@ -680,15 +689,19 @@ func setupServer(che chan error) {
 		laddr = "0.0.0.0"
 	}
 
-	l, err := setupListener(laddr, *port)
+	httpListener, err := setupListener(laddr, httpPort())
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	tcpm := cmux.New(l)
-	grpcl := tcpm.Match(cmux.HTTP2HeaderField("content-type", "application/grpc"))
-	httpl := tcpm.Match(cmux.HTTP1Fast())
-	http2 := tcpm.Match(cmux.HTTP2())
+	grpcListener, err := setupListener(laddr, grpcPort())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	httpMux := cmux.New(httpListener)
+	httpl := httpMux.Match(cmux.HTTP1Fast())
+	http2 := httpMux.Match(cmux.HTTP2())
 
 	http.HandleFunc("/health", healthCheck)
 	http.HandleFunc("/query", queryHandler)
@@ -705,23 +718,24 @@ func setupServer(che chan error) {
 	http.HandleFunc("/ui/keywords", keywordHandler)
 
 	// Initilize the servers.
-	go serveGRPC(grpcl)
+	go serveGRPC(grpcListener)
 	go serveHTTP(httpl)
 	go serveHTTP(http2)
 
 	go func() {
 		<-shutdownCh
 		// Stops grpc/http servers; Already accepted connections are not closed.
-		l.Close()
+		grpcListener.Close()
+		httpListener.Close()
 	}()
 
 	log.Println("grpc server started.")
 	log.Println("http server started.")
-	log.Println("Server listening on port", *port)
+	log.Println("Server listening on port", httpPort())
 
-	err = tcpm.Serve() // Start cmux serving. blocking call
-	<-shutdownCh       // wait for shutdownServer to finish
-	che <- err         // final close for main.
+	err = httpMux.Serve() // Start cmux serving. blocking call
+	<-shutdownCh          // wait for shutdownServer to finish
+	che <- err            // final close for main.
 }
 
 func main() {

--- a/cmd/dgraph/testrun/conf1.yaml
+++ b/cmd/dgraph/testrun/conf1.yaml
@@ -4,6 +4,9 @@ idx: 1
 # Port to run server on. (default 8080)
 port: 8080
 
+# Grpc port
+grpc_port: 9080
+
 # Directory to store posting lists.
 p: p1
 

--- a/cmd/dgraph/testrun/conf2.yaml
+++ b/cmd/dgraph/testrun/conf2.yaml
@@ -4,6 +4,8 @@ idx: 2
 # Port to run server on. (default 8080)
 port: 8082
 
+grpc_port: 9082
+
 # Directory to store posting lists.
 p: p2
 

--- a/cmd/dgraph/testrun/conf3.yaml
+++ b/cmd/dgraph/testrun/conf3.yaml
@@ -4,6 +4,8 @@ idx: 3
 # Port to run server on. (default 8080)
 port: 8084
 
+grpc_port: 9084
+
 # Directory to store posting lists.
 p: p3
 

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -36,7 +36,7 @@ import (
 var (
 	files      = flag.String("r", "", "Location of rdf files to load")
 	schemaFile = flag.String("s", "", "Location of schema file")
-	dgraph     = flag.String("d", "127.0.0.1:8080", "Dgraph server address")
+	dgraph     = flag.String("d", "127.0.0.1:9080", "Dgraph gRPC server address")
 	concurrent = flag.Int("c", 100, "Number of concurrent requests to make to Dgraph")
 	numRdf     = flag.Int("m", 1000, "Number of RDF N-Quads to send as part of a mutation.")
 	storeXid   = flag.Bool("x", false, "Store xids by adding corresponding _xid_ edges")

--- a/contrib/tlstest/client_12.sh
+++ b/contrib/tlstest/client_12.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:8080 -tls.on -tls.ca_certs ca.crt -tls.cert client.crt -tls.cert_key client.key -tls.server_name server1.dgraph.io -tls.min_version=TLS12 -r data.rdf.gz 
+../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:9080 -tls.on -tls.ca_certs ca.crt -tls.cert client.crt -tls.cert_key client.key -tls.server_name server1.dgraph.io -tls.min_version=TLS12 -r data.rdf.gz 

--- a/contrib/tlstest/client_nocert.sh
+++ b/contrib/tlstest/client_nocert.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:8080 -tls.on -tls.ca_certs ca.crt -tls.server_name server1.dgraph.io -r data.rdf.gz 
+../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:9080 -tls.on -tls.ca_certs ca.crt -tls.server_name server1.dgraph.io -r data.rdf.gz 

--- a/contrib/tlstest/client_nopass.sh
+++ b/contrib/tlstest/client_nopass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:8080 -tls.on -tls.ca_certs ca.crt -tls.cert client.crt -tls.cert_key client.key -tls.server_name server1.dgraph.io -r data.rdf.gz 
+../../cmd/dgraphloader/dgraphloader -d server1.dgraph.io:9080 -tls.on -tls.ca_certs ca.crt -tls.cert client.crt -tls.cert_key client.key -tls.server_name server1.dgraph.io -r data.rdf.gz 

--- a/contrib/tlstest/client_pass.sh
+++ b/contrib/tlstest/client_pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../cmd/dgraphloader/dgraphloader -d server2.dgraph.io:8080 -tls.on -tls.ca_certs ca.crt -tls.cert client_pass.crt -tls.cert_key client_pass.key -tls.cert_key_passphrase secret -tls.server_name server2.dgraph.io -r data.rdf.gz 
+../../cmd/dgraphloader/dgraphloader -d server2.dgraph.io:9080 -tls.on -tls.ca_certs ca.crt -tls.cert client_pass.crt -tls.cert_key client_pass.key -tls.cert_key_passphrase secret -tls.server_name server2.dgraph.io -r data.rdf.gz 

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -26,6 +26,7 @@ RUN curl https://get.dgraph.io | bash
 RUN mkdir /dgraph && mkdir /data
 
 EXPOSE 8080
+EXPOSE 9080
 WORKDIR /dgraph
 
 CMD ["dgraph"]

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -15,7 +15,7 @@ The proto file used by Dgraph is located at [graphresponse.proto](https://github
 
 [![GoDoc](https://godoc.org/github.com/dgraph-io/dgraph/client?status.svg)](https://godoc.org/github.com/dgraph-io/dgraph/client)
 
-After you have the followed [Get started]({{< relref "get-started/index.md">}}) and got the server running on `127.0.0.1:8080`, you can use the Go client to run queries and mutations as shown in the example below.
+After you have the followed [Get started]({{< relref "get-started/index.md">}}) and got the server running on `127.0.0.1:8080` and (for gRPC) `127.0.0.1:9080`, you can use the Go client to run queries and mutations as shown in the example below.
 
 {{% notice "note" %}}The example below would store values with the correct types only if the
 correct [schema type]({{< relref "query-language/index.md#schema" >}}) is specified in the mutation, otherwise everything would be converted to schema type and stored. Schema is derived based on first mutation received by the server. If first mutation is of default type then everything would be stored as default type.{{% /notice %}}
@@ -51,7 +51,7 @@ import (
 )
 
 var (
-	dgraph = flag.String("d", "127.0.0.1:8080", "Dgraph server address")
+	dgraph = flag.String("d", "127.0.0.1:9080", "Dgraph server address")
 )
 
 func main() {
@@ -309,7 +309,7 @@ import (
 )
 
 func ExampleBatchMutation() {
-	conn, err := grpc.Dial("127.0.0.1:8080", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
@@ -385,7 +385,7 @@ pip install -U pydgraph
 git clone https://github.com/dgraph-io/pydgraph
 cd pydgraph
 
-# Optional: If you have the dgraph server running on localhost:8080 you can run tests.
+# Optional: If you have the dgraph server running on localhost:8080 and localhost:9080 you can run tests.
 python setup.py test
 
 # Install the python package.
@@ -472,7 +472,7 @@ import io.dgraph.client.DgraphResult;
 
 public class DgraphMain {
     public static void main(final String[] args) {
-        final DgraphClient dgraphClient = GrpcDgraphClient.newInstance("localhost", 8080);
+        final DgraphClient dgraphClient = GrpcDgraphClient.newInstance("localhost", 9080);
         final DgraphResult result = dgraphClient.query("{me(_xid_: alice) { name _xid_ follows { name _xid_ follows {name _xid_ } } }}");
         System.out.println(result.toJsonObject().toString());
     }
@@ -488,7 +488,7 @@ javac -cp dgraph4j/build/libs/dgraph4j-all-0.0.1.jar DgraphMain.java
 ```
 java -cp dgraph4j/build/libs/dgraph4j-all-0.0.1.jar:. DgraphMain
 Jun 29, 2016 12:28:03 AM io.grpc.internal.ManagedChannelImpl <init>
-INFO: [ManagedChannelImpl@5d3411d] Created with target localhost:8080
+INFO: [ManagedChannelImpl@5d3411d] Created with target localhost:9080
 {"_root_":[{"_uid_":"0x8c84811dffd0a905","_xid_":"alice","name":"Alice","follows":[{"_uid_":"0xdd77c65008e3c71","_xid_":"bob","name":"Bob"},{"_uid_":"0x5991e7d8205041b3","_xid_":"greg","name":"Greg"}]}],"server_latency":{"pb":"11.487µs","parsing":"85.504µs","processing":"270.597µs"}}
 ```
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -22,7 +22,7 @@ $ sudo tar -C /usr/local/bin -xzf dgraph-darwin-amd64-VERSION.tar.gz
 
 ## Endpoints
 
-On its port, a running Dgraph instance exposes a number of service endpoints.
+On its http port, a running Dgraph instance exposes a number of service endpoints.
 
 * `/` Browser UI and query visualization.
 * `/query` receive queries and respond in JSON.
@@ -42,11 +42,12 @@ Whether running standalone or in a cluster, each Dgraph instance relies on the f
 * A `p` directory.  This is where Dgraph persists the graph data as posting lists. (option `--p`, default: directory `p` where the instance was started)
 * A `w` directory.  This is where Dgraph stores its write ahead logs. (option `--w`, default: directory `w` where the instance was started)
 * The `p` and `w` directories must be different.
-* A port exposing the instance for query, client connections and other [endpoints]({{< relref "#endpoints">}}). (option `--port`, default: `8080` on `localhost`)
+* A port for query, http client connections and other [endpoints]({{< relref "#endpoints">}}). (option `--port`, default: `8080` on `localhost`)
+* A port for gRPC client connections. (option `--grpc_port`, default: `9080` on `localhost`)
 * A port on which to run a worker node, used for Dgraph's communication between nodes. (option `--workerport`, default: `12345`)
 * An address and port at which the node advertises its worker.  (option `--my`, default: `localhost:workerport`)
 
-{{% notice "note" %}}By default `8080` or the port specified by `--port` is bound to `localhost` (the loopback address only accessible from the same machine).  The `--bindall=true` option binds to `0.0.0.0` and thus allows external connections. {{% /notice %}}
+{{% notice "note" %}}By default the server listens on `localhost` (the loopback address only accessible from the same machine).  The `--bindall=true` option binds to `0.0.0.0` and thus allows external connections. {{% /notice %}}
 
 ### Config
 The command-line flags can be stored in a YAML file and provided via the `--config` flag.  For example:
@@ -66,6 +67,9 @@ groups: "0,1-5"
 
 # Port to run server on. (default 8080)
 port: 8080
+
+# GRPC port to run server on. (default 9080)
+grpc_port: 9080
 
 # Port used by worker for internal communication.
 workerport: 12345
@@ -254,7 +258,7 @@ To run a cluster, begin by bringing up a single server that serves at least grou
 ```
 $ dgraph --group_conf groups.conf --groups "0,1" --idx 1 --my "ip-address-others-should-access-me-at" --bindall=true
 
-# This instance with ID 1 will serve groups 0 and 1, using the default 8080 port for clients and 12345 for peers.
+# This instance with ID 1 will serve groups 0 and 1, using the default 8080/9080 ports for clients and 12345 for peers.
 ```
 
 {{% notice "note" %}} The `--bindall=true` option is required when running on multiple machines, otherwise the node's port and workerport will be bound to localhost and not be accessible over a network. {{% /notice %}}
@@ -320,7 +324,7 @@ The `dgraphloader` binary is a small helper program which reads RDF NQuads from 
 ```
 $ dgraphloader --help # To see the available flags.
 
-# Read RDFs from the passed file, and send them to Dgraph on localhost:8080.
+# Read RDFs from the passed file, and send them to Dgraph on localhost:9080.
 $ dgraphloader -r <path-to-rdf-gzipped-file>
 
 # Read RDFs and a schema file and send do Dgraph running at given address

--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -48,21 +48,21 @@ dgraph
 
 The `-v` flag lets Docker mount a directory so that dgraph can persist data to disk and access files for loading data.
 
-#### Map to default port (8080 on the local interface)
+#### Map to default ports (8080 and 9080 on the local interface)
 
 ```sh
 mkdir -p ~/dgraph
-docker run -it -p 127.0.0.1:8080:8080 -v ~/dgraph:/dgraph --name dgraph dgraph/dgraph dgraph --bindall=true
+docker run -it -p 127.0.0.1:8080:8080 -p 127.0.0.1:9080:9080 -v ~/dgraph:/dgraph --name dgraph dgraph/dgraph dgraph --bindall=true
 ```
 
 #### Map to custom port
 ```sh
 mkdir -p ~/dgraph
-# Mapping port 8080 from within the container to 9090 (bound to the local interface) of the instance
-docker run -it -p 127.0.0.1:9090:8080 -v ~/dgraph:/dgraph --name dgraph dgraph/dgraph dgraph --bindall=true
+# Mapping port 8080 from within the container to 18080 (bound to the local interface) of the instance, likewise with the gRPC port 9090.
+docker run -it -p 127.0.0.1:18080:8080 -p 127.0.0.1:19090:9090 -v ~/dgraph:/dgraph --name dgraph dgraph/dgraph dgraph --bindall=true
 ```
 
-{{% notice "note" %}}The dgraph server listens on port 8080 (unless mapped to another port above) with log output to the terminal.{{% /notice %}}
+{{% notice "note" %}}The dgraph server listens on ports 8080 and 9090 (unless mapped to another port above) with log output to the terminal.{{% /notice %}}
 
 ## Step 3: Run Queries
 {{% notice "tip" %}}Once Dgraph is running, a user interface is available at [`http://localhost:8080`](http://localhost:8080).  It allows browser-based queries, mutations and visualizations.

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -92,7 +92,7 @@ func StartRaftNodes(walDir string) {
 	gr.ctx, gr.cancel = context.WithCancel(context.Background())
 
 	if len(*myAddr) == 0 {
-		*myAddr = fmt.Sprintf("localhost:%d", *workerPort)
+		*myAddr = fmt.Sprintf("localhost:%d", workerPort())
 	} else {
 		// check if address is valid or not
 		ok := x.ValidateAddress(*myAddr)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	workerPort = flag.Int("workerport", 12345,
+	baseWorkerPort = flag.Int("workerport", 12345,
 		"Port used by worker for internal communication.")
 	exportPath = flag.String("export", "export",
 		"Folder in which to store exports.")
@@ -49,6 +49,10 @@ var (
 	leaseGid         uint32
 	pendingProposals chan struct{}
 )
+
+func workerPort() int {
+	return *x.PortOffset + *baseWorkerPort
+}
 
 func Init(ps *badger.KV) {
 	pstore = ps
@@ -94,7 +98,7 @@ func RunServer(bindall bool) {
 		laddr = "0.0.0.0"
 	}
 	var err error
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", laddr, *workerPort))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", laddr, workerPort()))
 	if err != nil {
 		log.Fatalf("While running server: %v", err)
 		return

--- a/x/x.go
+++ b/x/x.go
@@ -50,6 +50,8 @@ const (
 var (
 	debugMode = flag.Bool("debugmode", false,
 		"enable debug mode for more debug information")
+	// Useful for running multiple servers on the same machine.
+	PortOffset     = flag.Int("port_offset", 0, "Value added to all listening port numbers.")
 	regExpHostName = regexp.MustCompile(ValidHostnameRegex)
 )
 


### PR DESCRIPTION
This adds a separate gRPC client port.  I chose 9080 as the value of the port.

It also adds a convenient `--port_offset` flag, which, when launching test clusters, would come in handy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1135)
<!-- Reviewable:end -->

Connects to #1131