### PR TITLE
Add support for uploading and retrieving raw bytes from client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@
 package client
 
 import (
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -315,7 +316,9 @@ func (e *Edge) SetValueBytes(val []byte) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
 	}
-	v, err := types.ObjectValue(types.BinaryID, val)
+	dst := make([]byte, base64.StdEncoding.EncodedLen(len(val)))
+	base64.StdEncoding.Encode(dst, val)
+	v, err := types.ObjectValue(types.BinaryID, []byte(dst))
 	if err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -311,6 +311,19 @@ func (e *Edge) SetValueDefault(val string) error {
 	return nil
 }
 
+func (e *Edge) SetValueBytes(val []byte) error {
+	if len(e.nq.ObjectId) > 0 {
+		return ErrConnected
+	}
+	v, err := types.ObjectValue(types.BinaryID, val)
+	if err != nil {
+		return err
+	}
+	e.nq.ObjectValue = v
+	e.nq.ObjectType = int32(types.BinaryID)
+	return nil
+}
+
 func (e *Edge) AddFacet(key, val string) {
 	e.nq.Facets = append(e.nq.Facets, &protos.Facet{
 		Key: key,

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -43,7 +43,7 @@ var (
 )
 
 var DefaultOptions = BatchMutationOptions{
-	Size:          1000,
+	Size:          100,
 	Pending:       100,
 	PrintCounters: false,
 }

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -42,6 +42,12 @@ var (
 	emptyEdge      Edge
 )
 
+var DefaultOptions = BatchMutationOptions{
+	Size:          1000,
+	Pending:       100,
+	PrintCounters: false,
+}
+
 type BatchMutationOptions struct {
 	Size          int
 	Pending       int
@@ -140,9 +146,6 @@ type Dgraph struct {
 	start time.Time
 }
 
-// NewBatchMutation is used to create a new batch.
-// size is the number of RDF's that are sent as part of one request to Dgraph.
-// pending is the number of concurrent requests to make to Dgraph server.
 func NewDgraphClient(conn *grpc.ClientConn, opts BatchMutationOptions) *Dgraph {
 	client := protos.NewDgraphClient(conn)
 

--- a/client/unmarshal.go
+++ b/client/unmarshal.go
@@ -135,6 +135,9 @@ func setField(val reflect.Value, value *protos.Value, field reflect.StructField)
 	case reflect.Slice:
 		switch field.Type {
 		case reflect.TypeOf([]byte{}):
+			if value == nil {
+				return nil
+			}
 			switch value.Val.(type) {
 			case *protos.Value_GeoVal:
 				v := value.GetGeoVal()

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -526,7 +526,7 @@ func (s *grpcServer) Run(ctx context.Context,
 		return resp, x.Errorf("Multiple schema blocks found")
 	}
 	// Schema Block and Mutation can be part of query string or request
-	if res.Mutation == nil {
+	if res.Mutation == nil && req.Mutation != nil {
 		res.Mutation = &gql.Mutation{Set: req.Mutation.Set, Del: req.Mutation.Del}
 	}
 	if res.Schema == nil {
@@ -534,10 +534,13 @@ func (s *grpcServer) Run(ctx context.Context,
 	}
 
 	var queryRequest = query.QueryRequest{
-		Latency:      &l,
-		GqlQuery:     &res,
-		SchemaUpdate: req.Mutation.Schema,
+		Latency:  &l,
+		GqlQuery: &res,
 	}
+	if req.Mutation != nil && len(req.Mutation.Schema) > 0 {
+		queryRequest.SchemaUpdate = req.Mutation.Schema
+	}
+
 	var er query.ExecuteResult
 	if er, err = queryRequest.ProcessWithMutation(ctx); err != nil {
 		if tr, ok := trace.FromContext(ctx); ok {

--- a/contrib/hooks/pre-push
+++ b/contrib/hooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# /bin/bash $GOPATH/src/github.com/dgraph-io/dgraph/test
+/bin/bash $GOPATH/src/github.com/dgraph-io/dgraph/test
 

--- a/contrib/hooks/pre-push
+++ b/contrib/hooks/pre-push
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-/bin/bash $GOPATH/src/github.com/dgraph-io/dgraph/test
+# /bin/bash $GOPATH/src/github.com/dgraph-io/dgraph/test
 

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -364,7 +364,9 @@ func (fj *fastJsonNode) IsEmpty() bool {
 func valToBytes(v types.Val) ([]byte, error) {
 	switch v.Tid {
 	case types.BinaryID:
-		return v.Value.([]byte), nil
+		// Encode to base64 and add "" around the value.
+		b := fmt.Sprintf(`"%s"`, v.Value.([]byte))
+		return []byte(b), nil
 	case types.IntID:
 		return []byte(fmt.Sprintf("%d", v.Value)), nil
 	case types.FloatID:

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -365,7 +365,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 	switch v.Tid {
 	case types.BinaryID:
 		// Encode to base64 and add "" around the value.
-		b := fmt.Sprintf(`"%s"`, v.Value.([]byte))
+		b := fmt.Sprintf("%q", v.Value.([]byte))
 		return []byte(b), nil
 	case types.IntID:
 		return []byte(fmt.Sprintf("%d", v.Value)), nil

--- a/query/proto.go
+++ b/query/proto.go
@@ -18,6 +18,7 @@
 package query
 
 import (
+	"encoding/base64"
 	"time"
 
 	"github.com/dgraph-io/dgraph/protos"
@@ -46,6 +47,15 @@ func toProtoValue(v types.Val) *protos.Value {
 	case types.DateTimeID:
 		val := v.Value.(time.Time)
 		return &protos.Value{&protos.Value_StrVal{val.Format(time.RFC3339)}}
+
+	case types.BinaryID:
+		val := v.Value.([]byte)
+		dst := make([]byte, base64.StdEncoding.DecodedLen(len(val)))
+		n, _ := base64.StdEncoding.Decode(dst, val)
+		if n < len(dst) {
+			dst = dst[:n]
+		}
+		return &protos.Value{&protos.Value_BytesVal{dst}}
 
 	case types.GeoID:
 		b := types.ValueForType(types.BinaryID)

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -328,6 +328,7 @@ var typeMap = map[string]types.TypeID{
 	"xs:boolean":                                  types.BoolID,
 	"xs:double":                                   types.FloatID,
 	"xs:float":                                    types.FloatID,
+	"xs:base64Binary":                             types.BinaryID,
 	"geo:geojson":                                 types.GeoID,
 	"pwd:password":                                types.PasswordID,
 	"http://www.w3.org/2001/XMLSchema#string":     types.StringID,

--- a/types/scalar_types.go
+++ b/types/scalar_types.go
@@ -79,6 +79,8 @@ func (t TypeID) Name() string {
 		return "password"
 	case DefaultID:
 		return "default"
+	case BinaryID:
+		return "binary"
 	}
 	return ""
 }

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -67,6 +67,7 @@ type Person struct {
 	Salary       float64        `dgraph:"salary"`
 	Age          int            `dgraph:"age"`
 	Married      bool           `dgraph:"married"`
+	ByteDob      []byte         `dgraph:"bytedob"`
 	Friends      []Person       `dgraph:"friend"`
 	FriendFacets []friendFacets `dgraph:"@facets"`
 }
@@ -125,6 +126,12 @@ func main() {
 	err = req.Set(e)
 	x.Check(err)
 
+	e = person1.Edge("bytedob")
+	err = e.SetValueBytes([]byte("01-02-1991"))
+	x.Check(err)
+	err = req.Set(e)
+	x.Check(err)
+
 	person2, err := dgraphClient.NodeBlank("person2")
 	x.Check(err)
 
@@ -144,6 +151,7 @@ func main() {
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	x.Check(err)
 
+	req = client.Req{}
 	req.SetQuery(fmt.Sprintf(`{
 		me(func: uid(%v)) {
 			_uid_
@@ -154,6 +162,7 @@ func main() {
 			salary
 			age
 			married
+			bytedob
 			friend @facets {
 				_uid_
 				name

--- a/worker/export.go
+++ b/worker/export.go
@@ -66,6 +66,7 @@ var rdfTypeMap = map[types.TypeID]string{
 	types.BoolID:     "xs:boolean",
 	types.GeoID:      "geo:geojson",
 	types.PasswordID: "pwd:password",
+	types.BinaryID:   "xs:base64Binary",
 }
 
 func toRDF(buf *bytes.Buffer, item kv) {
@@ -89,8 +90,7 @@ func toRDF(buf *bytes.Buffer, item kv) {
 			if p.PostingType == protos.Posting_VALUE_LANG {
 				buf.WriteByte('@')
 				buf.WriteString(string(p.Metadata))
-			} else if vID != types.BinaryID &&
-				vID != types.DefaultID {
+			} else if vID != types.DefaultID {
 				rdfType, ok := rdfTypeMap[vID]
 				x.AssertTruef(ok, "Didn't find RDF type for dgraph type: %+v", vID.Name())
 				buf.WriteString("^^<")


### PR DESCRIPTION
Support adding and retrieving `[]byte` from client.

1. Internally they are base64 encoded and stored so that they can be written and read from backup.
2. Http client can also add base64 encoded values with `xs:base64Binary data type`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1140)
<!-- Reviewable:end -->
