### PR TITLE
Default to ~/go if GOPATH unset (for uiDir)

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -618,7 +618,7 @@ func init() {
 	flag.StringVar(&uiDir, "ui", uiDir, "Directory which contains assets for the user interface")
 	if uiDir == "" {
 		gopath, _ := bestEffortGopath()
-		uiDir = gopath + "/src/github.com/dgraph-io/dgraph/dashboard/build"
+		uiDir = path.Join(gopath, "src/github.com/dgraph-io/dgraph/dashboard/build")
 	}
 }
 


### PR DESCRIPTION
With Golang 1.8 there is a default GOPATH if not otherwise set, ~/go.

Connected to #1141.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1142)
<!-- Reviewable:end -->
