### PR TITLE
Fix unused format argument in expand err

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2212,7 +2212,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				}
 				it.Next() // Consume the '('
 				if it.Item().Typ != itemLeftRound {
-					return x.Errorf("Invalid use of expand()", val)
+					return x.Errorf("Invalid use of expand()")
 				}
 				it.Next()
 				item := it.Item()


### PR DESCRIPTION
When invalid expand is reached, the error message shown is:

    Invalid use of expand()%!(EXTRA string=expand)

Couldn't resist nitpicking especially since the surrounding code is so clean :+1: :100:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1145)
<!-- Reviewable:end -->
