### PR TITLE
Connection pool: one connection (each way), close dead connections

### DIFF
--- a/worker/assign.go
+++ b/worker/assign.go
@@ -78,7 +78,7 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 		}
 		return &emptyAssignedIds, err
 	}
-	defer pools().put(p)
+	defer pools().release(p)
 	conn := p.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Calling AssignUids for group: %d, addr: %s", leaseGid, addr)

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -78,7 +78,7 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 		}
 		return &emptyAssignedIds, err
 	}
-	defer pools().release(p)
+	defer pools().decrRef(p)
 	conn := p.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Calling AssignUids for group: %d, addr: %s", leaseGid, addr)

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -78,6 +78,7 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 		}
 		return &emptyAssignedIds, err
 	}
+	defer pools().put(p)
 	conn := p.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Calling AssignUids for group: %d, addr: %s", leaseGid, addr)

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -71,7 +71,13 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Not leader of group: %d. Sending to: %d", leaseGid, lid)
 	}
-	p := pools().get(addr)
+	p, err := pools().get(addr)
+	if err != nil {
+		if tr, ok := trace.FromContext(ctx); ok {
+			tr.LazyPrintf("Error while retrieving connection: %+v", err)
+		}
+		return &emptyAssignedIds, err
+	}
 	conn, err := p.Get()
 	if err != nil {
 		if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -79,7 +79,6 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 		return &emptyAssignedIds, err
 	}
 	conn := p.Get()
-	defer p.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Calling AssignUids for group: %d, addr: %s", leaseGid, addr)
 	}

--- a/worker/assign.go
+++ b/worker/assign.go
@@ -78,13 +78,7 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 		}
 		return &emptyAssignedIds, err
 	}
-	conn, err := p.Get()
-	if err != nil {
-		if tr, ok := trace.FromContext(ctx); ok {
-			tr.LazyPrintf("Error while retrieving connection: %+v", err)
-		}
-		return &emptyAssignedIds, err
-	}
+	conn := p.Get()
 	defer p.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Calling AssignUids for group: %d, addr: %s", leaseGid, addr)

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -86,7 +86,7 @@ func (p *poolsi) get(addr string) (*pool, error) {
 }
 
 // One of these must be called for each call to get(...).
-func (p *poolsi) put(pl *pool) {
+func (p *poolsi) release(pl *pool) {
 	// We close the conn after unlocking p.
 	newRefcount := atomic.AddInt64(&pl.refcount, -1)
 	if newRefcount == 0 {
@@ -140,7 +140,7 @@ func (p *poolsi) connect(addr string) (*pool, bool) {
 	// No need to block this thread just to print some messages.
 	pool.AddOwner() // matches p.put() in goroutine
 	go func() {
-		defer p.put(pool)
+		defer p.release(pool)
 		err = TestConnection(pool)
 		if err != nil {
 			log.Printf("Connection to %q fails, got error: %v\n", addr, err)

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -70,11 +70,14 @@ func (p *poolsi) any() *pool {
 	return nil
 }
 
-func (p *poolsi) get(addr string) *pool {
+func (p *poolsi) get(addr string) (*pool, error) {
 	p.RLock()
 	defer p.RUnlock()
-	pool, _ := p.all[addr]
-	return pool
+	pool, ok := p.all[addr]
+	if !ok {
+		return nil, errNoConnection
+	}
+	return pool, nil
 }
 
 func (p *poolsi) connect(addr string) {

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -90,6 +90,16 @@ func (p *poolsi) connect(addr string) {
 
 	pool, err := newPool(addr, 5)
 	x.Checkf(err, "Unable to connect to host %s", addr)
+
+	p.Lock()
+	_, has = p.all[addr]
+	if has {
+		p.Unlock()
+		return
+	}
+	p.all[addr] = pool
+	p.Unlock()
+
 	query := new(protos.Payload)
 	query.Data = make([]byte, 10)
 	x.Check2(rand.Read(query.Data))
@@ -108,14 +118,6 @@ func (p *poolsi) connect(addr string) {
 		x.Check(pool.Put(conn))
 		fmt.Printf("Connection with %q successful.\n", addr)
 	}
-
-	p.Lock()
-	defer p.Unlock()
-	_, has = p.all[addr]
-	if has {
-		return
-	}
-	p.all[addr] = pool
 }
 
 // NewPool creates a new "pool" with one or more gRPC connections.

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -121,7 +121,7 @@ func (p *poolsi) connect(addr string) (*pool, bool) {
 	}
 	p.RUnlock()
 
-	pool, err := newPool(addr, 5)
+	pool, err := newPool(addr)
 	// TODO: This can get triggered with totally bogus config.
 	x.Checkf(err, "Unable to connect to host %s", addr)
 
@@ -174,7 +174,7 @@ func TestConnection(p *pool) error {
 }
 
 // NewPool creates a new "pool" with one gRPC connection, refcount 0.
-func newPool(addr string, maxCap int) (*pool, error) {
+func newPool(addr string) (*pool, error) {
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {
 		return nil, err

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -132,7 +132,6 @@ func (p *poolsi) connect(addr string) (*pool, bool) {
 		return existingPool, true
 	}
 	p.all[addr] = pool
-	// TODO: Callers should decrement this refcount.
 	pool.refcount++
 	// This refcount gets decremented by the goroutine here
 	pool.refcount++

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -80,6 +80,12 @@ func (p *poolsi) get(addr string) (*pool, error) {
 	return pool, nil
 }
 
+// One of these must be called for each call to get(...).
+// TODO: Make put include information about pool health.
+func (p *poolsi) put(_ *pool) {
+	// nothing to do.
+}
+
 func (p *poolsi) connect(addr string) *pool {
 	if addr == *myAddr {
 		return nil

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -117,7 +117,6 @@ func (p *poolsi) connect(addr string) {
 		// have to handle errors later anyway.
 	} else {
 		x.AssertTrue(bytes.Equal(resp.Data, query.Data))
-		x.Check(pool.Put(conn))
 		fmt.Printf("Connection with %q successful.\n", addr)
 	}
 }
@@ -131,14 +130,7 @@ func newPool(addr string, maxCap int) (*pool, error) {
 	return &pool{conn: conn, Addr: addr}, nil
 }
 
-// Get returns a connection to use from the pool of connections.
+// Get returns the connection to use from the pool of connections.
 func (p *pool) Get() *grpc.ClientConn {
 	return p.conn
-}
-
-// Put returns a connection to the pool.
-func (p *pool) Put(conn *grpc.ClientConn) error {
-	// TODO: Get rid of this Put() or not.
-	x.AssertTrue(conn == p.conn)
-	return nil
 }

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -120,7 +120,7 @@ func (p *poolsi) connect(addr string) {
 	}
 }
 
-// NewPool creates a new "pool" with one or more gRPC connections.
+// NewPool creates a new "pool" with one gRPC connection.
 func newPool(addr string, maxCap int) (*pool, error) {
 	conn, err := grpc.Dial(addr, grpc.WithInsecure())
 	if err != nil {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -448,8 +448,7 @@ func (n *node) doSendMessage(to uint64, data []byte) {
 	pool, err := pools().get(addr)
 	// TODO: No, don't fail like this?
 	x.Check(err)
-	conn, err := pool.Get()
-	x.Check(err)
+	conn := pool.Get()
 	defer pool.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
@@ -847,8 +846,7 @@ func (n *node) joinPeers() {
 	// _, err := populateShard(n.ctx, pool, n.gid)
 	// x.Checkf(err, "Error while populating shard")
 
-	conn, err := pool.Get()
-	x.Check(err)
+	conn := pool.Get()
 	defer pool.Put(conn)
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -667,7 +667,6 @@ func (n *node) saveToStorage(s raftpb.Snapshot, h raftpb.HardState,
 func (n *node) retrieveSnapshot(rc protos.RaftContext) {
 	addr, ok := n.GetPeer(rc.Id)
 	x.AssertTruef(ok, "Should have the address for %d", rc.Id)
-	x.AssertTruef(addr != "", "Should have non-empty address for %d", rc.Id)
 	pool, err := pools().get(addr)
 	if err != nil {
 		log.Fatalf("Pool shouldn't be nil for address: %v for id: %v, error: %v\n", addr, rc.Id, err)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -456,6 +456,7 @@ func (n *node) doSendMessage(to uint64, data []byte) {
 	pool, err := pools().get(addr)
 	// TODO: No, don't fail like this?
 	x.Check(err)
+	defer pools().put(pool)
 	conn := pool.Get()
 
 	c := protos.NewWorkerClient(conn)
@@ -648,6 +649,7 @@ func (n *node) retrieveSnapshot(rc protos.RaftContext) {
 	if err != nil {
 		log.Fatalf("Pool shouldn't be nil for address: %v for id: %v, error: %v\n", addr, rc.Id, err)
 	}
+	defer pools().put(pool)
 
 	x.AssertTrue(rc.Group == n.gid)
 	// Get index of last committed.
@@ -846,6 +848,7 @@ func (n *node) joinPeers() {
 	if err != nil {
 		log.Fatalf("Unable to get pool for addr: %q for peer: %d, error: %v\n", paddr, pid, err)
 	}
+	defer pools().put(pool)
 
 	// Bring the instance up to speed first.
 	// Raft would decide whether snapshot needs to fetched or not

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -941,7 +941,7 @@ func (n *node) AmLeader() bool {
 	return r.Status().Lead == r.Status().ID
 }
 
-func (w *grpcWorker) applyMessage(ctx context.Context, msg raftpb.Message) error {
+func applyMessage(ctx context.Context, msg raftpb.Message) error {
 	var rc protos.RaftContext
 	x.Check(rc.Unmarshal(msg.Context))
 	node := groups().Node(rc.Group)
@@ -982,7 +982,7 @@ func (w *grpcWorker) RaftMessage(ctx context.Context, query *protos.Payload) (*p
 		if msg.Type != raftpb.MsgHeartbeat && msg.Type != raftpb.MsgHeartbeatResp {
 			fmt.Printf("RECEIVED: %v %v-->%v\n", msg.Type, msg.From, msg.To)
 		}
-		if err := w.applyMessage(ctx, msg); err != nil {
+		if err := applyMessage(ctx, msg); err != nil {
 			return &protos.Payload{}, err
 		}
 		idx += sz

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -71,7 +71,7 @@ func (p *peerPool) set(id uint64, addr string, pl *pool) {
 	defer p.Unlock()
 	if old, ok := p.peers[id]; ok {
 		if old.poolOrNil != nil {
-			pools().release(old.poolOrNil)
+			pools().decrRef(old.poolOrNil)
 		}
 	}
 	p.peers[id] = peerPoolEntry{addr, pl}
@@ -478,7 +478,7 @@ func (n *node) doSendMessage(to uint64, data []byte) {
 	pool, err := pools().get(addr)
 	// TODO: No, don't fail like this?
 	x.Check(err)
-	defer pools().release(pool)
+	defer pools().decrRef(pool)
 	conn := pool.Get()
 
 	c := protos.NewWorkerClient(conn)
@@ -672,7 +672,7 @@ func (n *node) retrieveSnapshot(rc protos.RaftContext) {
 	if err != nil {
 		log.Fatalf("Pool shouldn't be nil for address: %v for id: %v, error: %v\n", addr, rc.Id, err)
 	}
-	defer pools().release(pool)
+	defer pools().decrRef(pool)
 
 	x.AssertTrue(rc.Group == n.gid)
 	// Get index of last committed.
@@ -871,7 +871,7 @@ func (n *node) joinPeers() {
 	if err != nil {
 		log.Fatalf("Unable to get pool for addr: %q for peer: %d, error: %v\n", paddr, pid, err)
 	}
-	defer pools().release(pool)
+	defer pools().decrRef(pool)
 
 	// Bring the instance up to speed first.
 	// Raft would decide whether snapshot needs to fetched or not

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -43,7 +43,7 @@ const (
 	proposalMutation   = 0
 	proposalReindex    = 1
 	proposalMembership = 2
-	ErrorNodeIDExists  = "Error Node ID already exists in the cluster"
+	errorNodeIDExists  = "Error Node ID already exists in the cluster"
 )
 
 // peerPool stores the peers per node and the addresses corresponding to them.
@@ -1004,7 +1004,7 @@ func (w *grpcWorker) JoinCluster(ctx context.Context, rc *protos.RaftContext) (*
 
 	// Best effor reject
 	if _, found := groups().Server(rc.Id, rc.Group); found || rc.Id == *raftId {
-		return &protos.Payload{}, x.Errorf(ErrorNodeIDExists)
+		return &protos.Payload{}, x.Errorf(errorNodeIDExists)
 	}
 
 	node := groups().Node(rc.Group)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -223,10 +223,6 @@ func newNode(gid uint32, id uint64, myAddr string) *node {
 }
 
 func (n *node) Connect(pid uint64, addr string) {
-	for n == nil {
-		// Sometimes this function causes a panic. My guess is that n is sometimes still uninitialized.
-		time.Sleep(time.Second)
-	}
 	if pid == n.id {
 		return
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -449,7 +449,6 @@ func (n *node) doSendMessage(to uint64, data []byte) {
 	// TODO: No, don't fail like this?
 	x.Check(err)
 	conn := pool.Get()
-	defer pool.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
 	p := &protos.Payload{Data: data}
@@ -847,7 +846,6 @@ func (n *node) joinPeers() {
 	// x.Checkf(err, "Error while populating shard")
 
 	conn := pool.Get()
-	defer pool.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
 	x.Printf("Calling JoinCluster")

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -71,7 +71,7 @@ func (p *peerPool) set(id uint64, addr string, pl *pool) {
 	defer p.Unlock()
 	if old, ok := p.peers[id]; ok {
 		if old.poolOrNil != nil {
-			pools().put(old.poolOrNil)
+			pools().release(old.poolOrNil)
 		}
 	}
 	p.peers[id] = peerPoolEntry{addr, pl}
@@ -478,7 +478,7 @@ func (n *node) doSendMessage(to uint64, data []byte) {
 	pool, err := pools().get(addr)
 	// TODO: No, don't fail like this?
 	x.Check(err)
-	defer pools().put(pool)
+	defer pools().release(pool)
 	conn := pool.Get()
 
 	c := protos.NewWorkerClient(conn)
@@ -672,7 +672,7 @@ func (n *node) retrieveSnapshot(rc protos.RaftContext) {
 	if err != nil {
 		log.Fatalf("Pool shouldn't be nil for address: %v for id: %v, error: %v\n", addr, rc.Id, err)
 	}
-	defer pools().put(pool)
+	defer pools().release(pool)
 
 	x.AssertTrue(rc.Group == n.gid)
 	// Get index of last committed.
@@ -871,7 +871,7 @@ func (n *node) joinPeers() {
 	if err != nil {
 		log.Fatalf("Unable to get pool for addr: %q for peer: %d, error: %v\n", paddr, pid, err)
 	}
-	defer pools().put(pool)
+	defer pools().release(pool)
 
 	// Bring the instance up to speed first.
 	// Raft would decide whether snapshot needs to fetched or not

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -48,7 +48,8 @@ const (
 
 type peerPoolEntry struct {
 	peer string
-	pool *pool
+	// An owning reference to a pool for this peer (or nil if self-peer).
+	poolOrNil *pool
 }
 
 // peerPool stores the peers per node and the addresses corresponding to them.
@@ -69,8 +70,8 @@ func (p *peerPool) set(id uint64, addr string, pl *pool) {
 	p.Lock()
 	defer p.Unlock()
 	if old, ok := p.peers[id]; ok {
-		if old.pool != nil {
-			pools().put(old.pool)
+		if old.poolOrNil != nil {
+			pools().put(old.poolOrNil)
 		}
 	}
 	p.peers[id] = peerPoolEntry{addr, pl}
@@ -238,8 +239,8 @@ func (n *node) GetPeer(pid uint64) (string, bool) {
 }
 
 // p can be nil
-func (n *node) SetPeer(pid uint64, addr string, p *pool) {
-	n.peers.set(pid, addr, p)
+func (n *node) SetPeer(pid uint64, addr string, poolOrNil *pool) {
+	n.peers.set(pid, addr, poolOrNil)
 }
 
 func (n *node) Connect(pid uint64, addr string) {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -47,7 +47,7 @@ const (
 )
 
 type peerPoolEntry struct {
-	peer string
+	addr string
 	// An owning reference to a pool for this peer (or nil if self-peer).
 	poolOrNil *pool
 }
@@ -63,7 +63,7 @@ func (p *peerPool) get(id uint64) (string, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	ret, ok := p.peers[id]
-	return ret.peer, ok
+	return ret.addr, ok
 }
 
 func (p *peerPool) set(id uint64, addr string, pl *pool) {

--- a/worker/export.go
+++ b/worker/export.go
@@ -379,7 +379,6 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("Relaying export request for group %d to %q", gid, pl.Addr)
 		}
-		defer pl.Put(conn)
 		break
 	}
 

--- a/worker/export.go
+++ b/worker/export.go
@@ -395,7 +395,7 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 			GroupId: gid,
 		}
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 
 	c := protos.NewWorkerClient(conn)
 	nr := &protos.ExportPayload{

--- a/worker/export.go
+++ b/worker/export.go
@@ -365,6 +365,7 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 		addrs = append(addrs, addr)
 	}
 
+	var pl *pool
 	var conn *grpc.ClientConn
 	for _, addr := range addrs {
 		pl, err := pools().get(addr)
@@ -394,6 +395,7 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 			GroupId: gid,
 		}
 	}
+	defer pools().put(pl)
 
 	c := protos.NewWorkerClient(conn)
 	nr := &protos.ExportPayload{

--- a/worker/export.go
+++ b/worker/export.go
@@ -374,13 +374,7 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 			}
 			continue
 		}
-		conn, err = pl.Get()
-		if err != nil {
-			if tr, ok := trace.FromContext(ctx); ok {
-				tr.LazyPrintf(err.Error())
-			}
-			continue
-		}
+		conn = pl.Get()
 
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("Relaying export request for group %d to %q", gid, pl.Addr)

--- a/worker/export.go
+++ b/worker/export.go
@@ -395,7 +395,7 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 			GroupId: gid,
 		}
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 
 	c := protos.NewWorkerClient(conn)
 	nr := &protos.ExportPayload{

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -570,7 +570,7 @@ func (g *groupi) applyMembershipUpdate(raftIdx uint64, mm *protos.Membership) {
 
 	sl := g.all[mm.GroupId]
 	if sl == nil {
-		sl = new(servers)
+		sl = &servers{byNodeID: make(map[uint64]int)}
 		g.all[mm.GroupId] = sl
 	}
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -106,7 +106,7 @@ func removeFromServersIfPresent(sl *servers, nodeID uint64) {
 	sl.list = sl.list[:back]
 	delete(sl.byNodeID, nodeID)
 	if pool != nil {
-		pools().put(pool)
+		pools().release(pool)
 	}
 }
 
@@ -144,7 +144,7 @@ func StartRaftNodes(walDir string) {
 			if !ok {
 				return
 			}
-			defer pools().put(p)
+			defer pools().release(p)
 
 			// Force run syncMemberships with this peer, so our nodes know if they have other
 			// servers who are serving the same groups. That way, they can talk to them
@@ -487,7 +487,7 @@ func (g *groupi) syncMemberships() {
 	var update *protos.MembershipUpdate
 	for {
 		func() {
-			defer pools().put(pl)
+			defer pools().release(pl)
 
 			conn := pl.Get()
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -91,6 +91,7 @@ func groups() *groupi {
 func StartRaftNodes(walDir string) {
 	gr = new(groupi)
 	gr.ctx, gr.cancel = context.WithCancel(context.Background())
+	gr.all = make(map[uint32]*servers)
 
 	if len(*myAddr) == 0 {
 		*myAddr = fmt.Sprintf("localhost:%d", workerPort())
@@ -232,9 +233,6 @@ func (g *groupi) newNode(groupId uint32, nodeId uint64, publicAddr string) *node
 func (g *groupi) Server(id uint64, groupId uint32) (rs server, found bool) {
 	g.RLock()
 	defer g.RUnlock()
-	if g.all == nil {
-		return server{}, false
-	}
 	sl := g.all[groupId]
 	if sl == nil {
 		return server{}, false
@@ -518,10 +516,6 @@ func (g *groupi) applyMembershipUpdate(raftIdx uint64, mm *protos.Membership) {
 	fmt.Println("----------------------------")
 	g.Lock()
 	defer g.Unlock()
-
-	if g.all == nil {
-		g.all = make(map[uint32]*servers)
-	}
 
 	sl := g.all[mm.GroupId]
 	if sl == nil {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -90,9 +90,7 @@ func groups() *groupi {
 }
 
 func swapServers(sl *servers, i int, j int) {
-	tmp := sl.list[i]
-	sl.list[i] = sl.list[j]
-	sl.list[j] = tmp
+	sl.list[i], sl.list[j] = sl.list[j], sl.list[i]
 	sl.byNodeID[sl.list[i].NodeId] = i
 	sl.byNodeID[sl.list[j].NodeId] = j
 }

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -437,11 +437,17 @@ func (g *groupi) syncMemberships() {
 
 	// Send an update to peer.
 	var pl *pool
+	var err error
 	addr := g.AnyServer(0)
 
 UPDATEMEMBERSHIP:
 	if len(addr) > 0 {
-		pl = pools().get(addr)
+		pl, err = pools().get(addr)
+		if err == errNoConnection {
+			fmt.Println("Unable to sync memberships. No valid connection")
+			return
+		}
+		x.Check(err)
 	} else {
 		pl = pools().any()
 	}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -436,26 +436,22 @@ func (g *groupi) syncMemberships() {
 	}
 
 	// Send an update to peer.
-	var pl *pool
-	var err error
 	addr := g.AnyServer(0)
 
 UPDATEMEMBERSHIP:
+	var pl *pool
+	var err error
 	if len(addr) > 0 {
 		pl, err = pools().get(addr)
-		if err == errNoConnection {
-			fmt.Println("Unable to sync memberships. No valid connection")
-			return
-		}
-		x.Check(err)
 	} else {
-		var ok bool
-		pl, ok = pools().any()
-		if !ok {
-			fmt.Println("Unable to sync memberships.  No valid connection")
-			return
-		}
+		pl, err = pools().any()
 	}
+	if err == errNoConnection {
+		fmt.Println("Unable to sync memberships. No valid connection")
+		return
+	}
+	x.Check(err)
+
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -92,6 +92,7 @@ func StartRaftNodes(walDir string) {
 	gr = new(groupi)
 	gr.ctx, gr.cancel = context.WithCancel(context.Background())
 	gr.all = make(map[uint32]*servers)
+	gr.local = make(map[uint32]*node)
 
 	if len(*myAddr) == 0 {
 		*myAddr = fmt.Sprintf("localhost:%d", workerPort())
@@ -218,9 +219,6 @@ func (g *groupi) ServesGroup(groupId uint32) bool {
 func (g *groupi) newNode(groupId uint32, nodeId uint64, publicAddr string) *node {
 	g.Lock()
 	defer g.Unlock()
-	if g.local == nil {
-		g.local = make(map[uint32]*node)
-	}
 
 	node := newNode(groupId, nodeId, publicAddr)
 	if _, has := g.local[groupId]; has {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -457,7 +457,6 @@ UPDATEMEMBERSHIP:
 		}
 	}
 	conn := pl.Get()
-	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
 	update, err := c.UpdateMembership(g.ctx, &mu)

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -59,12 +59,15 @@ type server struct {
 	Addr      string // The public address of the server serving this node.
 	Leader    bool   // Set to true if the node is a leader of the group.
 	RaftIdx   uint64 // The raft index which applied this membership update in group zero.
-	PoolOrNil *pool  // An owned reference to the server's Pool entry (nil if self-node).
+	PoolOrNil *pool  // An owned reference to the server's Pool entry (nil if Addr is our own).
 }
 
 type servers struct {
+	// A map of indices into list, allowing for random access by their NodeId field.
 	byNodeID map[uint64]int
-	list     []server
+	// Servers for the group, as determined by Raft group zero.
+	// list[0] is the (last-known) leader of that group.
+	list []server
 }
 
 type groupi struct {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -449,14 +449,14 @@ UPDATEMEMBERSHIP:
 		}
 		x.Check(err)
 	} else {
-		pl = pools().any()
+		var ok bool
+		pl, ok = pools().any()
+		if !ok {
+			fmt.Println("Unable to sync memberships.  No valid connection")
+			return
+		}
 	}
-	conn, err := pl.Get()
-	if err == errNoConnection {
-		fmt.Println("Unable to sync memberships. No valid connection")
-		return
-	}
-	x.Check(err)
+	conn := pl.Get()
 	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/index.go
+++ b/worker/index.go
@@ -222,7 +222,6 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
 	}
 	conn := pl.Get()
-	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)
 	}

--- a/worker/index.go
+++ b/worker/index.go
@@ -221,7 +221,7 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 	if err != nil {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/index.go
+++ b/worker/index.go
@@ -221,7 +221,7 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 	if err != nil {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/index.go
+++ b/worker/index.go
@@ -221,10 +221,7 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 	if err != nil {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
 	}
-	conn, err := pl.Get()
-	if err != nil {
-		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/index.go
+++ b/worker/index.go
@@ -217,8 +217,10 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 
 	// Send this over the network.
 	addr := groups().AnyServer(gid)
-	pl := pools().get(addr)
-
+	pl, err := pools().get(addr)
+	if err != nil {
+		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
+	}
 	conn, err := pl.Get()
 	if err != nil {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")

--- a/worker/index.go
+++ b/worker/index.go
@@ -221,6 +221,7 @@ func RebuildIndexOverNetwork(ctx context.Context, attr string) error {
 	if err != nil {
 		return x.Wrapf(err, "RebuildIndexOverNetwork: while retrieving connection.")
 	}
+	defer pools().put(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -333,7 +333,6 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		return
 	}
 	conn := pl.Get()
-	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
 	ch := make(chan error, 1)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -332,6 +332,7 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		che <- err
 		return
 	}
+	defer pools().put(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -332,7 +332,7 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		che <- err
 		return
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -332,7 +332,7 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		che <- err
 		return
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -324,7 +324,14 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 	}
 
 	_, addr := groups().Leader(gid)
-	pl := pools().get(addr)
+	pl, err := pools().get(addr)
+	if err != nil {
+		if tr, ok := trace.FromContext(ctx); ok {
+			tr.LazyPrintf(err.Error())
+		}
+		che <- err
+		return
+	}
 	conn, err := pl.Get()
 	if err != nil {
 		if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -332,14 +332,7 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		che <- err
 		return
 	}
-	conn, err := pl.Get()
-	if err != nil {
-		if tr, ok := trace.FromContext(ctx); ok {
-			tr.LazyPrintf(err.Error())
-		}
-		che <- err
-		return
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -125,10 +125,7 @@ func streamKeys(stream protos.Worker_PredicateAndSchemaDataClient, groupId uint3
 // PopulateShard gets data for predicate pred from server with id serverId and
 // writes it to RocksDB.
 func populateShard(ctx context.Context, pl *pool, group uint32) (int, error) {
-	conn, err := pl.Get()
-	if err != nil {
-		return 0, err
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 	c := protos.NewWorkerClient(conn)
 

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -126,7 +126,6 @@ func streamKeys(stream protos.Worker_PredicateAndSchemaDataClient, groupId uint3
 // writes it to RocksDB.
 func populateShard(ctx context.Context, pl *pool, group uint32) (int, error) {
 	conn := pl.Get()
-	defer pl.Put(conn)
 	c := protos.NewWorkerClient(conn)
 
 	stream, err := c.PredicateAndSchemaData(context.Background())

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -144,11 +144,7 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		ch <- resultErr{err: err}
 		return
 	}
-	conn, e := pl.Get()
-	if e != nil {
-		ch <- resultErr{err: e}
-		return
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -139,7 +139,11 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 	}
 
 	_, addr := groups().Leader(gid)
-	pl := pools().get(addr)
+	pl, err := pools().get(addr)
+	if err != nil {
+		ch <- resultErr{err: err}
+		return
+	}
 	conn, e := pl.Get()
 	if e != nil {
 		ch <- resultErr{err: e}

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -145,7 +145,6 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		return
 	}
 	conn := pl.Get()
-	defer pl.Put(conn)
 
 	c := protos.NewWorkerClient(conn)
 	schema, e := c.Schema(ctx, s)

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -144,7 +144,7 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		ch <- resultErr{err: err}
 		return
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -144,7 +144,7 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		ch <- resultErr{err: err}
 		return
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -144,6 +144,7 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		ch <- resultErr{err: err}
 		return
 	}
+	defer pools().put(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -56,10 +56,7 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 	if err != nil {
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
 	}
-	conn, err := pl.Get()
-	if err != nil {
-		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -56,7 +56,7 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 	if err != nil {
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -52,8 +52,10 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 	// Send this over the network.
 	// TODO: Send the request to multiple servers as described in Jeff Dean's talk.
 	addr := groups().AnyServer(gid)
-	pl := pools().get(addr)
-
+	pl, err := pools().get(addr)
+	if err != nil {
+		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
+	}
 	conn, err := pl.Get()
 	if err != nil {
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -56,6 +56,7 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 	if err != nil {
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
 	}
+	defer pools().put(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -57,7 +57,6 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
 	}
 	conn := pl.Get()
-	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)
 	}

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -56,7 +56,7 @@ func SortOverNetwork(ctx context.Context, q *protos.SortMessage) (*protos.SortRe
 	if err != nil {
 		return &emptySortResult, x.Wrapf(err, "SortOverNetwork: while retrieving connection.")
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/task.go
+++ b/worker/task.go
@@ -70,6 +70,7 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 	if err != nil {
 		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
 	}
+	defer pools().put(pl)
 
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/task.go
+++ b/worker/task.go
@@ -70,7 +70,7 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 	if err != nil {
 		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
 	}
-	defer pools().release(pl)
+	defer pools().decrRef(pl)
 
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/task.go
+++ b/worker/task.go
@@ -70,7 +70,7 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 	if err != nil {
 		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
 	}
-	defer pools().put(pl)
+	defer pools().release(pl)
 
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/task.go
+++ b/worker/task.go
@@ -72,7 +72,6 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 	}
 
 	conn := pl.Get()
-	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -71,10 +71,7 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
 	}
 
-	conn, err := pl.Get()
-	if err != nil {
-		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
-	}
+	conn := pl.Get()
 	defer pl.Put(conn)
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("Sending request to %v", addr)

--- a/worker/task.go
+++ b/worker/task.go
@@ -66,7 +66,10 @@ func ProcessTaskOverNetwork(ctx context.Context, q *protos.Query) (*protos.Resul
 	// Send this over the network.
 	// TODO: Send the request to multiple servers as described in Jeff Dean's talk.
 	addr := groups().AnyServer(gid)
-	pl := pools().get(addr)
+	pl, err := pools().get(addr)
+	if err != nil {
+		return &emptyResult, x.Wrapf(err, "ProcessTaskOverNetwork: while retrieving connection.")
+	}
 
 	conn, err := pl.Get()
 	if err != nil {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -23,6 +23,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"sync"
 	"time"
@@ -61,7 +62,8 @@ func Init(ps *badger.KV) {
 	pendingProposals = make(chan struct{}, *numPendingProposals)
 	workerServer = grpc.NewServer(
 		grpc.MaxRecvMsgSize(x.GrpcMaxSize),
-		grpc.MaxSendMsgSize(x.GrpcMaxSize))
+		grpc.MaxSendMsgSize(x.GrpcMaxSize),
+		grpc.MaxConcurrentStreams(math.MaxInt32))
 }
 
 // grpcWorker struct implements the gRPC server interface.


### PR DESCRIPTION
This makes the connection "pool" hold one gRPC connection per request.

The other thing it does is keep a refcount of what's using a given pool, so that we don't keep connection pools for dead servers forever.

This addresses part of #1121.  The part about tracking and using connection health is not addressed.

Connects to #1121.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1159)
<!-- Reviewable:end -->
