### PR TITLE
Add checkpoint support for dgraphloader

### DIFF
--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Dgraph Labs, Inc.
+ * Copyright 2017 Dgraph Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -19,7 +19,6 @@ package client
 import (
 	"encoding/binary"
 	"fmt"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -44,7 +43,7 @@ func (d *Dgraph) storeCheckpoint() {
 		}
 
 		for file, w := range m {
-			var byte [10]buf
+			var buf []byte
 			n := binary.PutUvarint(buf, w)
 			wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])
 		}
@@ -60,11 +59,11 @@ func (d *Dgraph) storeCheckpoint() {
 	}
 }
 
-func NewSyncMarks(files []string) {
-	for _, file := range files {
-		bp := filepath.Base(file)
-	}
-}
+//func NewSyncMarks(files []string) {
+//	for _, file := range files {
+//		bp := filepath.Base(file)
+//	}
+//}
 
 type syncMarks struct {
 	sync.RWMutex

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -37,7 +37,7 @@ type syncMarks map[string]waterMark
 // Create syncmarks for files and store them in dgraphClient.
 func (d *Dgraph) NewSyncMarks(files []string) error {
 	if d.marks != nil {
-		return fmt.Errof("NewSyncMarks should only be called once.")
+		return fmt.Errorf("NewSyncMarks should only be called once.")
 	}
 
 	for _, file := range files {

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -33,7 +33,7 @@ func (d *Dgraph) Checkpoint(file string) uint64 {
 
 // Used to store checkpoints for various files.
 func (d *Dgraph) storeCheckpoint() {
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
 	wb := make([]*badger.Entry, 0, 5)
@@ -44,7 +44,6 @@ func (d *Dgraph) storeCheckpoint() {
 		}
 
 		for file, w := range m {
-			fmt.Println("Storing checkpoint for", file, w)
 			buf := make([]byte, 10)
 			n := binary.PutUvarint(buf, w)
 			wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -36,7 +36,7 @@ type syncMarks map[string]waterMark
 
 // Create syncmarks for files and store them in dgraphClient.
 func (d *Dgraph) NewSyncMarks(files []string) error {
-	if d.marks != nil {
+	if len(d.marks) > 0 {
 		return fmt.Errorf("NewSyncMarks should only be called once.")
 	}
 

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2016 Dgraph Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"sync"
+
+	"github.com/dgraph-io/dgraph/x"
+)
+
+type syncMarks struct {
+	sync.RWMutex
+	// A watermark for each file.
+	m map[string]*x.WaterMark
+}
+
+func (g *syncMarks) create(file string) *x.WaterMark {
+	g.Lock()
+	defer g.Unlock()
+	if g.m == nil {
+		g.m = make(map[string]*x.WaterMark)
+	}
+
+	if prev, present := g.m[file]; present {
+		return prev
+	}
+	w := &x.WaterMark{Name: file}
+	w.Init()
+	g.m[file] = w
+	return w
+}
+
+func (g *syncMarks) Get(file string) *x.WaterMark {
+	g.RLock()
+	if w, present := g.m[file]; present {
+		g.RUnlock()
+		return w
+	}
+	g.RUnlock()
+	return g.create(file)
+}
+
+func (d *Dgraph) SyncMarkFor(file string) *x.WaterMark {
+	return d.marks.Get(file)
+}

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -19,6 +19,7 @@ package client
 import (
 	"encoding/binary"
 	"fmt"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -43,7 +44,7 @@ func (d *Dgraph) storeCheckpoint() {
 		}
 
 		for file, w := range m {
-			buf := make([]byte, 10)
+			var byte [10]buf
 			n := binary.PutUvarint(buf, w)
 			wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])
 		}
@@ -56,6 +57,12 @@ func (d *Dgraph) storeCheckpoint() {
 			}
 		}
 		wb = wb[:0]
+	}
+}
+
+func NewSyncMarks(files []string) {
+	for _, file := range files {
+		bp := filepath.Base(file)
 	}
 }
 

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -36,6 +36,10 @@ type syncMarks map[string]waterMark
 
 // Create syncmarks for files and store them in dgraphClient.
 func (d *Dgraph) NewSyncMarks(files []string) error {
+	if d.marks != nil {
+		return fmt.Errof("NewSyncMarks should only be called once.")
+	}
+
 	for _, file := range files {
 		ap, err := filepath.Abs(file)
 		if err != nil {
@@ -79,7 +83,6 @@ func (d *Dgraph) writeCheckpoint() {
 		}
 		wm.last = doneUntil
 		d.marks[file] = wm
-		fmt.Printf("d.marks: %+v\n", d.marks)
 		var buf [10]byte
 		n := binary.PutUvarint(buf[:], doneUntil)
 		wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -39,11 +39,11 @@ func (d *Dgraph) storeCheckpoint() {
 	for range ticker.C {
 		m := d.marks.watermarks()
 		if m == nil {
-			return
+			continue
 		}
 
 		for file, w := range m {
-			var buf []byte
+			buf := make([]byte, 10)
 			n := binary.PutUvarint(buf, w)
 			wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])
 		}

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -46,13 +46,13 @@ func (d *Dgraph) storeCheckpoint() {
 			buf := make([]byte, 10)
 			n := binary.PutUvarint(buf, w)
 			wb = badger.EntriesSet(wb, []byte(fmt.Sprintf("checkpoint-%s", file)), buf[:n])
-			if err := d.alloc.kv.BatchSet(wb); err != nil {
+		}
+		if err := d.alloc.kv.BatchSet(wb); err != nil {
+			fmt.Printf("Error while writing to disk %v\n", err)
+		}
+		for _, wbe := range wb {
+			if err := wbe.Error; err != nil {
 				fmt.Printf("Error while writing to disk %v\n", err)
-			}
-			for _, wbe := range wb {
-				if err := wbe.Error; err != nil {
-					fmt.Printf("Error while writing to disk %v\n", err)
-				}
 			}
 		}
 		wb = wb[:0]

--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -26,9 +26,8 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-func (d *Dgraph) Checkpoint(file string) uint64 {
-	line, _ := d.alloc.getFromKV(fmt.Sprintf("checkpoint-%s", file))
-	return line
+func (d *Dgraph) Checkpoint(file string) (uint64, error) {
+	return d.alloc.getFromKV(fmt.Sprintf("checkpoint-%s", file))
 }
 
 // Used to store checkpoints for various files.

--- a/client/client.go
+++ b/client/client.go
@@ -37,15 +37,15 @@ const (
 	DEL
 )
 
-type rdfMeta struct {
-	file string
+type rdfEntry struct {
+	mark *x.WaterMark
 	line uint64
 }
 
 // Req wraps the protos.Request so that helper methods can be defined on it.
 type Req struct {
-	gr protos.Request
-	rm []rdfMeta
+	gr      protos.Request
+	entries []rdfEntry
 }
 
 // Request returns the graph request object which is sent to the server to perform
@@ -91,8 +91,6 @@ func (req *Req) addMutation(e Edge, op Op) {
 }
 
 func (req *Req) Set(e Edge) {
-	e.file = ""
-	e.line = 0
 	req.addMutation(e, SET)
 }
 
@@ -124,8 +122,10 @@ func (req *Req) reset() {
 }
 
 type nquadOp struct {
-	e  Edge
-	op Op
+	e    Edge
+	op   Op
+	mark *x.WaterMark
+	line uint64
 }
 
 type Node struct {
@@ -166,13 +166,10 @@ func (n *Node) Edge(pred string) Edge {
 
 type Edge struct {
 	nq protos.NQuad
-	// TODO - This should not be sent to server.
-	file string
-	line uint64
 }
 
-func NewEdge(nq protos.NQuad, file string, line uint64) Edge {
-	return Edge{nq, file, line}
+func NewEdge(nq protos.NQuad) Edge {
+	return Edge{nq}
 }
 
 func (e *Edge) ConnectTo(n Node) error {

--- a/client/client.go
+++ b/client/client.go
@@ -37,15 +37,11 @@ const (
 	DEL
 )
 
-type rdfEntry struct {
-	mark *x.WaterMark
-	line uint64
-}
-
 // Req wraps the protos.Request so that helper methods can be defined on it.
 type Req struct {
-	gr      protos.Request
-	entries []rdfEntry
+	gr   protos.Request
+	mark *x.WaterMark
+	line uint64
 }
 
 // Request returns the graph request object which is sent to the server to perform
@@ -119,14 +115,11 @@ func (req *Req) reset() {
 	req.gr.Mutation.Set = req.gr.Mutation.Set[:0]
 	req.gr.Mutation.Del = req.gr.Mutation.Del[:0]
 	req.gr.Mutation.Schema = req.gr.Mutation.Schema[:0]
-	req.entries = req.entries[:0]
 }
 
 type nquadOp struct {
-	e    Edge
-	op   Op
-	mark *x.WaterMark
-	line uint64
+	e  Edge
+	op Op
 }
 
 type Node struct {

--- a/client/client.go
+++ b/client/client.go
@@ -91,6 +91,8 @@ func (req *Req) addMutation(e Edge, op Op) {
 }
 
 func (req *Req) Set(e Edge) {
+	e.file = ""
+	e.line = 0
 	req.addMutation(e, SET)
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -119,6 +119,7 @@ func (req *Req) reset() {
 	req.gr.Mutation.Set = req.gr.Mutation.Set[:0]
 	req.gr.Mutation.Del = req.gr.Mutation.Del[:0]
 	req.gr.Mutation.Schema = req.gr.Mutation.Schema[:0]
+	req.entries = req.entries[:0]
 }
 
 type nquadOp struct {

--- a/client/client.go
+++ b/client/client.go
@@ -37,9 +37,15 @@ const (
 	DEL
 )
 
+type rdfMeta struct {
+	file string
+	line uint64
+}
+
 // Req wraps the protos.Request so that helper methods can be defined on it.
 type Req struct {
 	gr protos.Request
+	rm []rdfMeta
 }
 
 // Request returns the graph request object which is sent to the server to perform
@@ -158,10 +164,13 @@ func (n *Node) Edge(pred string) Edge {
 
 type Edge struct {
 	nq protos.NQuad
+	// TODO - This should not be sent to server.
+	file string
+	line uint64
 }
 
-func NewEdge(nq protos.NQuad) Edge {
-	return Edge{nq}
+func NewEdge(nq protos.NQuad, file string, line uint64) Edge {
+	return Edge{nq, file, line}
 }
 
 func (e *Edge) ConnectTo(n Node) error {

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -176,7 +176,7 @@ type Dgraph struct {
 	start time.Time
 
 	// Map of filename to x.Watermark. Used for checkpointing.
-	marks *syncMarks
+	marks syncMarks
 	reqs  chan Req
 }
 
@@ -215,7 +215,7 @@ func NewClient(clients []protos.DgraphClient, opts BatchMutationOptions, clientD
 		nquads: make(chan nquadOp, opts.Pending*opts.Size),
 		schema: make(chan protos.SchemaUpdate, opts.Pending*opts.Size),
 		alloc:  alloc,
-		marks:  new(syncMarks),
+		marks:  make(map[string]*x.WaterMark),
 		reqs:   make(chan Req, opts.Pending*2),
 	}
 

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -419,6 +419,10 @@ func (d *Dgraph) BatchFlush() {
 	close(d.nquads)
 	close(d.schema)
 	d.wg.Wait()
+	// Sync all marks so that we know final line that was completed.
+	d.syncAllMarks()
+	// Write final checkpoint before stopping.
+	d.writeCheckpoint()
 	if d.ticker != nil {
 		d.ticker.Stop()
 	}

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -319,6 +319,9 @@ RETRY:
 	}
 }
 
+// makeRequests can receive requests from batchNquads or directly from BatchSetWithMark.
+// It doesn't need to batch the requests anymore. Batching is already done for it by the
+// caller functions.
 func (d *Dgraph) makeRequests() {
 	for req := range d.reqs {
 		d.request(req)
@@ -355,6 +358,7 @@ LOOP:
 	d.wg.Done()
 }
 
+// Used to batch the nquads into Req of size given by user and send to d.reqs channel.
 func (d *Dgraph) batchNquads() {
 	var req Req
 	for n := range d.nquads {
@@ -384,6 +388,11 @@ func (d *Dgraph) BatchSet(e Edge) error {
 	return nil
 }
 
+// BatchSetWithMark takes a Req which has a batch of edges. It accepts a file to which the edges
+// belong and also the line number of the last line that the batch contains. This is used by the
+// dgraphloader to do checkpointing so that in case the loader crashes, we can skip the lines
+// which the server has already processed. Most users would only need BatchSet which does the
+// batching automatically.
 func (d *Dgraph) BatchSetWithMark(r Req, file string, line uint64) error {
 	sm := d.marks[file]
 	if sm != nil && line != 0 {

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -385,8 +385,8 @@ func (d *Dgraph) BatchSet(e Edge) error {
 }
 
 func (d *Dgraph) BatchSetWithMark(r Req, file string, line uint64) error {
-	sm := d.SyncMarkFor(file)
-	if len(file) > 0 && line != 0 {
+	sm := d.marks[file]
+	if sm != nil && line != 0 {
 		r.mark = sm
 		r.line = line
 		sm.Ch <- x.Mark{Index: line}

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -312,7 +312,6 @@ RETRY:
 		// Mark watermarks as done.
 		entry.mark.Ch <- x.Mark{Index: entry.line, Done: true}
 	}
-	req.entries = req.entries[:0]
 	req.reset()
 }
 

--- a/cmd/dgraphloader/.gitignore
+++ b/cmd/dgraphloader/.gitignore
@@ -1,1 +1,2 @@
 /dgraphloader
+c

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -159,7 +159,7 @@ func processFile(file string, dgraphClient *client.Dgraph) {
 	}
 
 	var line uint64
-	var r client.Req
+	r := new(client.Req)
 	var batchSize int
 	for {
 		err = readLine(bufReader, &buf)
@@ -191,7 +191,7 @@ func processFile(file string, dgraphClient *client.Dgraph) {
 				log.Fatal("While adding mutation to batch: ", err)
 			}
 			batchSize = 0
-			r = client.Req{}
+			r = new(client.Req)
 		}
 	}
 	if err != io.EOF {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -181,7 +181,7 @@ func processFile(file string, dgraphClient *client.Dgraph) {
 		if len(nq.ObjectId) > 0 {
 			nq.ObjectId = Node(nq.ObjectId, dgraphClient)
 		}
-		if err = dgraphClient.BatchSetWithMark(client.NewEdge(nq), basePath, line); err != nil {
+		if err = dgraphClient.BatchSet(client.NewEdge(nq)); err != nil {
 			log.Fatal("While adding mutation to batch: ", err)
 		}
 	}

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -154,7 +154,7 @@ func processFile(file string, dgraphClient *client.Dgraph) {
 	basePath := filepath.Base(file)
 	c := dgraphClient.Checkpoint(basePath)
 	if c != 0 {
-		fmt.Println("Found checkpoint for: %s. Skipping: %v lines", basePath, c)
+		fmt.Printf("Found checkpoint for: %s. Skipping: %v lines.\n", basePath, c)
 	}
 	var line uint64
 	for {

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -154,7 +154,7 @@ func processFile(file string, dgraphClient *client.Dgraph) {
 	checkpoint, err := dgraphClient.Checkpoint(basePath)
 	x.Check(err)
 	if checkpoint != 0 {
-		fmt.Printf("Found checkpoint for: %s. Skipping: %v lines.\n", basePath, checkpoint)
+		fmt.Printf("Found checkpoint for: %s. Skipping: %v lines.\n", file, checkpoint)
 	}
 
 	var line uint64
@@ -275,6 +275,7 @@ func main() {
 	// wait for schema changes to be done before starting mutations
 	time.Sleep(1 * time.Second)
 	var wg sync.WaitGroup
+	dgraphClient.NewSyncMarks(filesList)
 	for _, file := range filesList {
 		wg.Add(1)
 		go func(file string) {

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -71,7 +71,7 @@ type WaterMark struct {
 
 // Init initializes a WaterMark struct. MUST be called before using it.
 func (w *WaterMark) Init() {
-	w.Ch = make(chan Mark, 10000)
+	w.Ch = make(chan Mark, 100000)
 	w.elog = trace.NewEventLog("Watermark", w.Name)
 	go w.process()
 }

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -71,7 +71,7 @@ type WaterMark struct {
 
 // Init initializes a WaterMark struct. MUST be called before using it.
 func (w *WaterMark) Init() {
-	w.Ch = make(chan Mark, 100000)
+	w.Ch = make(chan Mark, 10000)
 	w.elog = trace.NewEventLog("Watermark", w.Name)
 	go w.process()
 }


### PR DESCRIPTION
Our each batch request has RDF's from different files and with non-sequential line numbers. So we need watermarks to keep track of the last line number for each file that the server has processed. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1174)
<!-- Reviewable:end -->
