### PR TITLE
Async/writes

### DIFF
--- a/client/mutations.go
+++ b/client/mutations.go
@@ -286,8 +286,8 @@ func (d *Dgraph) printCounters() {
 
 func (d *Dgraph) request(req *Req) {
 	counter := atomic.AddUint64(&d.mutations, 1)
-RETRY:
 	factor := time.Second
+RETRY:
 	_, err := d.dc[rand.Intn(len(d.dc))].Run(context.Background(), &req.gr)
 	if err != nil {
 		errString := err.Error()

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -145,7 +145,7 @@ func TestTokensTable(t *testing.T) {
 		Entity: 157,
 	}
 	addMutationWithIndex(t, l, edge, Set)
-	_, err := l.SyncIfDirty()
+	_, err := l.SyncIfDirty(false)
 	x.Check(err)
 	time.Sleep(10 * time.Second)
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -755,13 +755,9 @@ func (l *List) SyncIfDirty(delFromCache bool) (committed bool, err error) {
 			l.water.Ch <- x.Mark{Indices: pending, Done: true}
 		}
 		if delFromCache {
-			lcache.Lock()
-			ele := lcache.cache[l.ghash]
-			// We delete it from link list but if someone calls Get before callback is called it
-			// would be put back in the list. So safe to delete it here.
-			lcache.ll.Remove(ele)
-			delete(lcache.cache, l.ghash)
-			lcache.Unlock()
+			x.AssertTruef(atomic.LoadInt32(&l.deleteMe) == 1,
+				"List should have been SetForDeletion before deleting from cache.")
+			lcache.delete(l.ghash)
 			l.decr()
 		}
 	}

--- a/posting/list.go
+++ b/posting/list.go
@@ -653,6 +653,14 @@ func (l *List) Length(afterUid uint64) int {
 	return l.length(afterUid)
 }
 
+func doAsyncWrite(key []byte, data []byte, f func(error)) {
+	if data == nil {
+		pstore.DeleteAsync(key, f)
+	} else {
+		pstore.SetAsync(key, data, f)
+	}
+}
+
 func (l *List) SyncIfDirty(delFromCache bool) (committed bool, err error) {
 	l.Lock()
 	defer l.Unlock()
@@ -726,8 +734,22 @@ func (l *List) SyncIfDirty(delFromCache bool) (committed bool, err error) {
 		}
 	}
 
+	maxRetries := 5
+	retries := 0
 	pending := l.pending
-	f := func() {
+	var f func(error)
+	f = func(err error) {
+		if err != nil {
+			elog.Printf("Got err in while doing async writes in SyncIfDirty: %+v", err)
+			if retries > maxRetries {
+				x.Fatalf("Max retries exceeded while doing async write for key: %s, err: %+v",
+					l.key, err)
+			}
+			// Error from badger should be temporary, so we can retry.
+			retries += 1
+			doAsyncWrite(l.key, data, f)
+			return
+		}
 		if l.water != nil {
 			l.water.Ch <- x.Mark{Indices: pending, Done: true}
 		}
@@ -739,10 +761,7 @@ func (l *List) SyncIfDirty(delFromCache bool) (committed bool, err error) {
 		}
 	}
 
-	wb := make([]*badger.Entry, 0, 1)
-	wb = badger.EntriesSet(wb, l.key, data)
-	pstore.BatchSetAsync(wb, f)
-
+	doAsyncWrite(l.key, data, f)
 	// Now reset the mutation variables.
 	l.pending = make([]uint64, 0, 3)
 	l.mlayer = l.mlayer[:0]

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -121,7 +121,7 @@ func TestAddMutation(t *testing.T) {
 	p = getFirst(l)
 	require.NotNil(t, p, "Unable to retrieve posting")
 	require.EqualValues(t, "anti-testing", p.Label)
-	l.SyncIfDirty()
+	l.SyncIfDirty(false)
 	time.Sleep(time.Second)
 
 	// Try reading the same data in another PostingList.
@@ -156,7 +156,7 @@ func TestAddMutation_Value(t *testing.T) {
 	checkValue(t, ol, "oh hey there")
 
 	// Run the same check after committing.
-	_, err := ol.SyncIfDirty()
+	_, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	checkValue(t, ol, "oh hey there")
 	time.Sleep(time.Second)
@@ -180,7 +180,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 		Label: "jchiu",
 	}
 	addMutation(t, ol, edge, Set)
-	merged, err := ol.SyncIfDirty()
+	merged, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	require.True(t, merged)
 	time.Sleep(time.Second)
@@ -261,7 +261,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 	}
 	addMutation(t, ol, edge, Set)
 	require.Equal(t, 1, ol.Length(0))
-	merged, err := ol.SyncIfDirty()
+	merged, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	require.True(t, merged)
 	require.EqualValues(t, 1, ol.Length(0))
@@ -316,7 +316,7 @@ func TestAddMutation_mrjn1(t *testing.T) {
 		Label: "jchiu",
 	}
 	addMutation(t, ol, edge, Set)
-	merged, err := ol.SyncIfDirty()
+	merged, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	require.True(t, merged)
 	time.Sleep(time.Second)
@@ -386,7 +386,7 @@ func TestAddMutation_checksum(t *testing.T) {
 		}
 		addMutation(t, ol, edge, Set)
 
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -414,7 +414,7 @@ func TestAddMutation_checksum(t *testing.T) {
 		}
 		addMutation(t, ol, edge, Set)
 
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -449,7 +449,7 @@ func TestAddMutation_checksum(t *testing.T) {
 		}
 		addMutation(t, ol, edge, Set)
 
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -478,7 +478,7 @@ func TestAddMutation_gru(t *testing.T) {
 			Label:   "gru",
 		}
 		addMutation(t, ol, edge, Set)
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -495,7 +495,7 @@ func TestAddMutation_gru(t *testing.T) {
 			Label:   "gru",
 		}
 		addMutation(t, ol, edge, Del)
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -521,7 +521,7 @@ func TestAddMutation_gru2(t *testing.T) {
 			Label:   "gru",
 		}
 		addMutation(t, ol, edge, Set)
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -546,7 +546,7 @@ func TestAddMutation_gru2(t *testing.T) {
 		}
 		addMutation(t, ol, edge, Set)
 
-		merged, err := ol.SyncIfDirty()
+		merged, err := ol.SyncIfDirty(false)
 		require.NoError(t, err)
 		require.True(t, merged)
 		time.Sleep(time.Second)
@@ -681,7 +681,7 @@ func TestDelete(t *testing.T) {
 	ol.delete(context.Background(), "value")
 	ol.Unlock()
 	require.EqualValues(t, 0, ol.Length(0))
-	commited, err := ol.SyncIfDirty()
+	commited, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	require.True(t, commited)
 	time.Sleep(time.Second)
@@ -707,7 +707,7 @@ func TestAfterUIDCountWithCommit(t *testing.T) {
 	require.EqualValues(t, 0, ol.Length(300))
 
 	// Commit to database.
-	merged, err := ol.SyncIfDirty()
+	merged, err := ol.SyncIfDirty(false)
 	require.NoError(t, err)
 	require.True(t, merged)
 	time.Sleep(time.Second)

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -115,6 +115,7 @@ func gentleCommit(dirtyMap map[fingerPrint]time.Time, pending chan struct{},
 	commitFraction float64) {
 	select {
 	case pending <- struct{}{}:
+		elog.Printf("Skipping gentleCommit")
 	default:
 		return
 	}

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -115,8 +115,8 @@ func gentleCommit(dirtyMap map[fingerPrint]time.Time, pending chan struct{},
 	commitFraction float64) {
 	select {
 	case pending <- struct{}{}:
-		elog.Printf("Skipping gentleCommit")
 	default:
+		elog.Printf("Skipping gentleCommit")
 		return
 	}
 

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -111,7 +111,6 @@ func (c *listCache) removeOldest() {
 		// TODO: We should only remove the key after the PL is synced to disk.
 		e.pl.SetForDeletion()
 		e.pl.SyncIfDirty(true)
-		e.pl.decr()
 	}
 }
 

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -109,7 +109,11 @@ func (c *listCache) removeOldest() {
 		c.curSize -= e.size
 
 		e.pl.SetForDeletion()
-		e.pl.SyncIfDirty(true)
+		// If length of mutation layer is zero, then we won't call pstore.SetAsync and the
+		// key wont be deleted from cache. So lets delete it now if SyncIfDirty returns false.
+		if committed, _ := e.pl.SyncIfDirty(true); !committed {
+			delete(c.cache, e.key)
+		}
 	}
 }
 

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -108,7 +108,6 @@ func (c *listCache) removeOldest() {
 		e := ele.Value.(*entry)
 		c.curSize -= e.size
 
-		// TODO: We should only remove the key after the PL is synced to disk.
 		e.pl.SetForDeletion()
 		e.pl.SyncIfDirty(true)
 	}

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -110,8 +110,7 @@ func (c *listCache) removeOldest() {
 
 		// TODO: We should only remove the key after the PL is synced to disk.
 		e.pl.SetForDeletion()
-		e.pl.SyncIfDirty()
-		delete(c.cache, e.key)
+		e.pl.SyncIfDirty(true)
 		e.pl.decr()
 	}
 }
@@ -169,11 +168,10 @@ func (c *listCache) Reset() {
 func (c *listCache) Clear() error {
 	c.Lock()
 	defer c.Unlock()
-	for key, e := range c.cache {
+	for _, e := range c.cache {
 		kv := e.Value.(*entry)
 		kv.pl.SetForDeletion()
-		kv.pl.SyncIfDirty()
-		delete(c.cache, key)
+		kv.pl.SyncIfDirty(true)
 		kv.pl.decr()
 
 	}

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -170,8 +170,6 @@ func (c *listCache) Clear() error {
 		kv := e.Value.(*entry)
 		kv.pl.SetForDeletion()
 		kv.pl.SyncIfDirty(true)
-		kv.pl.decr()
-
 	}
 	c.ll = list.New()
 	c.cache = make(map[uint64]*list.Element)

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -184,3 +184,13 @@ func (c *listCache) Clear() error {
 	c.curSize = 0
 	return nil
 }
+
+// delete removes a key from cache
+func (c *listCache) delete(key uint64) {
+	c.Lock()
+	defer c.Unlock()
+
+	ele := c.cache[key]
+	c.ll.Remove(ele)
+	delete(c.cache, key)
+}

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -53,7 +53,7 @@ func writePLs(t *testing.T, pred string, count int, vid uint64, ps *badger.KV) {
 			Op:      protos.DirectedEdge_SET,
 		}
 		list.AddMutation(context.TODO(), de)
-		if merged, err := list.SyncIfDirty(); err != nil {
+		if merged, err := list.SyncIfDirty(false); err != nil {
 			t.Errorf("While merging: %v", err)
 		} else if !merged {
 			t.Errorf("No merge happened")


### PR DESCRIPTION
We get rid of syncCh and call BatchSetAsync for badger. Also, we delete posting list from lru cache after badger callback returns.

Corresponding PR for Badger https://github.com/dgraph-io/badger/pull/101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1178)
<!-- Reviewable:end -->
