### PR TITLE
Client/retries

### DIFF
--- a/client/mutations.go
+++ b/client/mutations.go
@@ -310,6 +310,7 @@ RETRY:
 		if factor < 256*time.Second {
 			factor = factor * 2
 		}
+		atomic.AddUint64(&d.retries, 1)
 		goto RETRY
 	}
 	req.reset()

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -257,7 +257,9 @@ func main() {
 		}(file)
 	}
 	wg.Wait()
-	dgraphClient.BatchFlush()
+	if err := dgraphClient.BatchFlush(); err != nil {
+		log.Fatal(err)
+	}
 
 	c := dgraphClient.Counter()
 	var rate uint64


### PR DESCRIPTION
Add an option to limit the number of max retries performed by the client during doing Batch mutations. This fixes #796.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1182)
<!-- Reviewable:end -->
