### PR TITLE
More consistent logging with x.Print* functions

### DIFF
--- a/posting/lists.go
+++ b/posting/lists.go
@@ -20,7 +20,6 @@ package posting
 import (
 	"crypto/md5"
 	"fmt"
-	"log"
 	"math"
 	"runtime"
 	"sync"
@@ -309,7 +308,7 @@ func commitOne(l *List) {
 		return
 	}
 	if _, err := l.SyncIfDirty(); err != nil {
-		log.Printf("Error while committing dirty list: %v\n", err)
+		x.Printf("Error while committing dirty list: %v\n", err)
 	}
 }
 

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -22,7 +22,6 @@ package posting
 import (
 	"container/list"
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/dgraph-io/dgraph/x"
@@ -69,7 +68,7 @@ func (c *listCache) UpdateMaxSize() {
 	defer c.Unlock()
 	if c.curSize < (50 << 20) {
 		c.MaxSize = 50 << 20
-		fmt.Println("LRU cache max size is being set to 50 MB")
+		x.Println("LRU cache max size is being set to 50 MB")
 		return
 	}
 	x.LcacheCapacity.Set(int64(50 << 0))

--- a/query/query.go
+++ b/query/query.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -459,7 +458,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst, parent outputNode) error {
 						continue // next UID.
 					}
 					// Some other error.
-					log.Printf("Error while traversal: %v", rerr)
+					x.Printf("Error while traversal: %v", rerr)
 					return rerr
 				}
 

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -20,7 +20,6 @@ package raftwal
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -82,7 +81,7 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 	if err := w.wals.Set(w.snapshotKey(gid), data); err != nil {
 		return err
 	}
-	fmt.Printf("Writing snapshot to WAL: %+v\n", s)
+	x.Printf("Writing snapshot to WAL: %+v\n", s)
 
 	go func() {
 		// Delete all entries before this snapshot to save disk space.
@@ -105,11 +104,11 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 		// Failure to delete entries is not a fatal error, so should be
 		// ok to ignore
 		if err := w.wals.BatchSet(wb); err != nil {
-			fmt.Printf("Error while deleting entries %v\n", err)
+			x.Printf("Error while deleting entries %v\n", err)
 		}
 		for _, wbe := range wb {
 			if err := wbe.Error; err != nil {
-				fmt.Printf("Error while deleting entries %v\n", err)
+				x.Printf("Error while deleting entries %v\n", err)
 			}
 		}
 	}()

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -107,7 +107,7 @@ func (s *stateGroup) update(se SyncEntry) {
 	syncCh <- se
 	s.elog.Printf("Setting schema type for attr %s: %v, tokenizer: %v, directive: %v\n", se.Attr,
 		types.TypeID(se.Schema.ValueType).Name(), se.Schema.Tokenizer, se.Schema.Directive)
-	fmt.Printf("Setting schema type for attr %s: %v, tokenizer: %v, directive: %v\n", se.Attr,
+	x.Printf("Setting schema type for attr %s: %v, tokenizer: %v, directive: %v\n", se.Attr,
 		types.TypeID(se.Schema.ValueType).Name(), se.Schema.Tokenizer, se.Schema.Directive)
 }
 

--- a/worker/conn.go
+++ b/worker/conn.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"log"
 	"sync"
 	"sync/atomic"
 
@@ -101,7 +100,7 @@ func (p *poolsi) release(pl *pool) {
 func destroyPool(pl *pool) {
 	err := pl.conn.Close()
 	if err != nil {
-		log.Printf("Error closing cluster connection: %v\n", err.Error())
+		x.Printf("Error closing cluster connection: %v\n", err.Error())
 	}
 }
 
@@ -142,11 +141,11 @@ func (p *poolsi) connect(addr string) (*pool, bool) {
 		defer p.release(pool)
 		err = TestConnection(pool)
 		if err != nil {
-			log.Printf("Connection to %q fails, got error: %v\n", addr, err)
+			x.Printf("Connection to %q fails, got error: %v\n", addr, err)
 			// Don't return -- let's still put the empty pool in the map.  Its users
 			// have to handle errors later anyway.
 		} else {
-			fmt.Printf("Connection with %q healthy.\n", addr)
+			x.Printf("Connection with %q healthy.\n", addr)
 		}
 	}()
 

--- a/worker/export.go
+++ b/worker/export.go
@@ -194,7 +194,7 @@ func export(gid uint32, bdir string) error {
 		time.Now().Format("2006-01-02-15-04")))
 	fspath := path.Join(bdir, fmt.Sprintf("dgraph-schema-%d-%s.rdf.gz", gid,
 		time.Now().Format("2006-01-02-15-04")))
-	fmt.Printf("Exporting to: %v, schema at %v\n", fpath, fspath)
+	x.Printf("Exporting to: %v, schema at %v\n", fpath, fspath)
 	chb := make(chan []byte, 1000)
 	errChan := make(chan error, 2)
 	go func() {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -140,10 +140,10 @@ func StartRaftNodes(walStore *badger.KV) {
 			gr.syncMemberships()
 			for gr.LastUpdate() == 0 {
 				time.Sleep(time.Second)
-				fmt.Println("Last update raft index for membership information is zero. Syncing...")
+				x.Println("Last update raft index for membership information is zero. Syncing...")
 				gr.syncMemberships()
 			}
-			fmt.Printf("Last update is now: %d\n", gr.LastUpdate())
+			x.Printf("Last update is now: %d\n", gr.LastUpdate())
 		}()
 	}
 
@@ -453,7 +453,7 @@ func (g *groupi) syncMemberships() {
 		pl, err = pools().any()
 	}
 	if err == errNoConnection {
-		fmt.Println("Unable to sync memberships. No valid connection")
+		x.Println("Unable to sync memberships. No valid connection")
 		return
 	}
 	x.Check(err)
@@ -482,7 +482,7 @@ func (g *groupi) syncMemberships() {
 		if len(addr) == 0 {
 			return
 		}
-		fmt.Printf("Got redirect for: %q\n", addr)
+		x.Printf("Got redirect for: %q\n", addr)
 		var ok bool
 		pl, ok = pools().connect(addr)
 		if !ok {
@@ -536,9 +536,9 @@ func (g *groupi) applyMembershipUpdate(raftIdx uint64, mm *protos.Membership) {
 		x.AssertTrue(ok)
 	}
 
-	fmt.Println("----------------------------")
-	fmt.Printf("====== APPLYING MEMBERSHIP UPDATE: %+v\n", update)
-	fmt.Println("----------------------------")
+	x.Println("----------------------------")
+	x.Printf("====== APPLYING MEMBERSHIP UPDATE: %+v\n", update)
+	x.Println("----------------------------")
 	g.Lock()
 	defer g.Unlock()
 
@@ -553,7 +553,7 @@ func (g *groupi) applyMembershipUpdate(raftIdx uint64, mm *protos.Membership) {
 
 	// Print out the entire list.
 	for gid, sl := range g.all {
-		fmt.Printf("Group: %v. List: %+v\n", gid, sl.list)
+		x.Printf("Group: %v. List: %+v\n", gid, sl.list)
 	}
 }
 

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -69,7 +69,7 @@ func newServer(port string) (*grpc.Server, net.Listener, error) {
 		log.Fatalf("While running server: %v", err)
 		return nil, nil, err
 	}
-	log.Printf("Worker listening at address: %v", ln.Addr())
+	x.Printf("Worker listening at address: %v", ln.Addr())
 
 	s := grpc.NewServer()
 	return s, ln, nil

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -97,7 +97,7 @@ func RunServer(bindall bool) {
 	if bindall {
 		laddr = "0.0.0.0"
 	} else if len(Config.MyAddr) > 0 {
-		fmt.Printf("--my flag is provided without bindall, Did you forget to specify bindall?\n")
+		x.Printf("--my flag is provided without bindall, Did you forget to specify bindall?\n")
 	}
 	var err error
 	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", laddr, workerPort()))
@@ -105,7 +105,7 @@ func RunServer(bindall bool) {
 		log.Fatalf("While running server: %v", err)
 		return
 	}
-	log.Printf("Worker listening at address: %v", ln.Addr())
+	x.Printf("Worker listening at address: %v", ln.Addr())
 
 	protos.RegisterWorkerServer(workerServer, &grpcWorker{})
 	workerServer.Serve(ln)

--- a/x/log.go
+++ b/x/log.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package x
+
+import (
+	"fmt"
+	"log"
+	"os"
+)
+
+var (
+	Logger = log.New(os.Stderr, "", log.Lshortfile|log.Flags())
+)
+
+// Printf does a log.Printf. We often do printf for debugging but has to keep
+// adding import "fmt" or "log" and removing them after we are done.
+// Let's add Printf to "x" and include "x" almost everywhere. Caution: Do remember
+// to call x.Init. For tests, you need a TestMain that calls x.Init.
+func Printf(format string, args ...interface{}) {
+	Logger.Output(2, fmt.Sprintf(format, args...))
+}
+
+func Println(args ...interface{}) {
+	Logger.Output(2, fmt.Sprintln(args...))
+}

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -22,7 +22,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -339,7 +338,7 @@ func (c *wrapperTLSConfig) reloadConfig() {
 	// Loading new certificate
 	cert, err := parseCertificate(c.helperConfig.CertRequired, c.helperConfig.Cert, c.helperConfig.Key, c.helperConfig.KeyPassphrase)
 	if err != nil {
-		log.Printf("Error reloading certificate. %s\nUsing current certificate\n", err.Error())
+		Printf("Error reloading certificate. %s\nUsing current certificate\n", err.Error())
 	} else if cert != nil {
 		if c.helperConfig.ConfigType == TLSServerConfig {
 			c.cert.Lock()
@@ -352,7 +351,7 @@ func (c *wrapperTLSConfig) reloadConfig() {
 	if len(c.helperConfig.ClientCACerts) > 0 || c.helperConfig.UseSystemClientCACerts {
 		pool, err := generateCertPool(c.helperConfig.ClientCACerts, c.helperConfig.UseSystemClientCACerts)
 		if err != nil {
-			log.Printf("Error reloading CAs. %s\nUsing current Client CAs\n", err.Error())
+			Printf("Error reloading CAs. %s\nUsing current Client CAs\n", err.Error())
 		} else {
 			c.clientCAPool.Lock()
 			c.clientCAPool.pool = pool


### PR DESCRIPTION
fmt.Print* and log.Print* functions are replaced by x.Print* functions.
It uses logger (from log package) that can be configured, and makes it
possible to control logging from Dgraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1190)
<!-- Reviewable:end -->
