### PR TITLE
Decrease tick interval to 50 ms.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -238,8 +238,10 @@ func newNode(gid uint32, id uint64, myAddr string) *node {
 		gid:   gid,
 		store: store,
 		cfg: &raft.Config{
-			ID:              id,
-			ElectionTick:    10,
+			ID: id,
+			// 500 ms if we call Tick() every 50 ms.
+			ElectionTick: 10,
+			// 50 ms if we call Tick() every 50 ms.
 			HeartbeatTick:   1,
 			Storage:         store,
 			MaxSizePerMsg:   4096,
@@ -708,7 +710,10 @@ func (n *node) retrieveSnapshot(peerID uint64) {
 func (n *node) Run() {
 	firstRun := true
 	var leader bool
-	ticker := time.NewTicker(time.Second)
+	// See also our configuration of HeartbeatTick and ElectionTick. For whatever reason, when
+	// bring up a node we can only replay one raft index entry every tick.  It would be nice to
+	// figure out why.
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	rcBytes, err := n.raftContext.Marshal()
 	x.Check(err)


### PR DESCRIPTION
This is a stop-gap.  For whatever reason, we aren't replaying log entries any faster than one entry per tick.  This makes replaying the log be about 15x slower than loading the data initially cost (when running locally on a Thinkpad W520).  So, reducing the tick interval by a factor of 20 seems like it'll make the Raft tick frequency not be the bottleneck.

In general this won't be true, for example, if we did the initial writes more slowly, then they'd likewise be forwarded to other nodes more slowly (with fewer writes per raft index).  This generally doesn't fix the overall problem.

Connected to #1180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1191)
<!-- Reviewable:end -->
