### PR TITLE
Go docs for client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,9 +38,9 @@ const (
 	DEL
 )
 
-// A Req represents a single request to the backend Dgraph instance.  Each request may contain multiple set, delete and
-// schema mutations, and a single GraphQL+- query.  IF the query contains GraphQL variables, then the map giving values to these
-// must be stored in the request with the query.
+// A Req represents a single request to the backend Dgraph instance.  Each request may contain 
+// multiple set, delete and schema mutations, and a single GraphQL+- query.  If the query contains 
+// GraphQL variables, then it must be set with SetQueryWithVariables rather than SetQuery.
 type Req struct {
 	gr protos.Request
 }
@@ -91,10 +91,11 @@ func (req *Req) addMutation(e Edge, op opType) {
 	}
 }
 
-// Set adds edge e to the set mutation of request req, thus scheduling the edge to be added to the graph when the request is run.
-// The edge must be syntactically valid: have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.
-// The edge is not checked agaist the schema until the request is run --- so setting a UID edge to a value, for example, doesn't result in an
-// error until the request is run.
+// Set adds edge e to the set mutation of request req, thus scheduling the edge to be added to the 
+// graph when the request is run.  The edge must have a valid target (a Node or value), otherwise 
+// an error is returned.  The edge is not checked agaist the schema until the request is 
+// run --- so setting a UID edge to a value, for example, doesn't result in an error until 
+// the request is run.
 func (req *Req) Set(e Edge) error {
 	if err := e.validate(); err != nil {
 		return err
@@ -103,8 +104,9 @@ func (req *Req) Set(e Edge) error {
 	return nil
 }
 
-// Delete adds edge e to the delete mutation of request req, thus scheduling the edge to be removed from the graph when the request is run.
-// The edge must have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.  The edge need not represent
+// Delete adds edge e to the delete mutation of request req, thus scheduling the edge to be removed
+// from the graph when the request is run. The edge must have a valid target (a Node or value), 
+// otherwise an error is returned.  The edge need not represent
 // an edge in the graph --- applying such a mutation simply has no effect.
 func (req *Req) Delete(e Edge) error {
 	if err := e.validate(); err != nil {
@@ -212,7 +214,7 @@ func (n *Node) Edge(pred string) Edge {
 	return e
 }
 
-// An Edge represents an edge between a source node and a target (either a node or a value.)
+// An Edge represents an edge between a source node and a target (either a node or a value).
 // Facets are stored in the edge.  See Node.Edge(), Node.ConnectTo(), Edge.ConnecTo(),
 // Edge.AddFacet and the Edge.SetValue...() functions to
 // make a valid edge for a set or delete mutation.
@@ -220,7 +222,7 @@ type Edge struct {
 	nq protos.NQuad
 }
 
-// NewEdge creates and Edge from an NQuad.
+// NewEdge creates an Edge from an NQuad.
 func NewEdge(nq protos.NQuad) Edge {
 	return Edge{nq}
 }
@@ -257,10 +259,11 @@ func validateStr(val string) error {
 	return nil
 }
 
-// SetValueString sets the value of Edge e as string val and sets the type of the edge to types.StringID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
-// The string must escape " with \, otherwise the edge and type are left unchanged and an error returned.
+// SetValueString sets the value of Edge e as string val and sets the type of the edge to 
+// types.StringID.  If the edge had previous been assigned another value (even of another type), 
+// the value and type are overwritten.  If the edge has previously been connected to a node, the 
+// edge and type are left unchanged and ErrConnected is returned.  The string must 
+// escape " with \, otherwise the edge and type are left unchanged and an error returned.
 func (e *Edge) SetValueString(val string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -279,8 +282,9 @@ func (e *Edge) SetValueString(val string) error {
 }
 
 // SetValueInt sets the value of Edge e as int64 val and sets the type of the edge to types.IntID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// If the edge had previous been assigned another value (even of another type), the value and type
+// are overwritten.  If the edge has previously been connected to a node, the edge and type are 
+// left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueInt(val int64) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -294,9 +298,10 @@ func (e *Edge) SetValueInt(val int64) error {
 	return nil
 }
 
-// SetValueFloat sets the value of Edge e as float64 val and sets the type of the edge to types.FloatID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// SetValueFloat sets the value of Edge e as float64 val and sets the type of the edge to 
+// types.FloatID.  If the edge had previous been assigned another value (even of another type), 
+// the value and type are overwritten.  If the edge has previously been connected to a node, the
+// edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueFloat(val float64) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -311,8 +316,9 @@ func (e *Edge) SetValueFloat(val float64) error {
 }
 
 // SetValueBool sets the value of Edge e as bool val and sets the type of the edge to types.BoolID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// If the edge had previous been assigned another value (even of another type), the value and type
+// are overwritten.  If the edge has previously been connected to a node, the edge and type are 
+// left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueBool(val bool) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -326,9 +332,10 @@ func (e *Edge) SetValueBool(val bool) error {
 	return nil
 }
 
-// SetValuePassword sets the value of Edge e as password string val and sets the type of the edge to types.PasswordID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// SetValuePassword sets the value of Edge e as password string val and sets the type of the edge 
+// to types.PasswordID.  If the edge had previous been assigned another value (even of another 
+// type), the value and type are overwritten.  If the edge has previously been connected to a 
+// node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValuePassword(val string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -342,9 +349,10 @@ func (e *Edge) SetValuePassword(val string) error {
 	return nil
 }
 
-// SetValueDatetime sets the value of Edge e as time.Time dateTime and sets the type of the edge to types.DateTimeID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// SetValueDatetime sets the value of Edge e as time.Time dateTime and sets the type of the edge 
+// to types.DateTimeID.  If the edge had previous been assigned another value (even of another 
+// type), the value and type are overwritten.  If the edge has previously been connected to a node,
+// the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueDatetime(dateTime time.Time) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -358,10 +366,11 @@ func (e *Edge) SetValueDatetime(dateTime time.Time) error {
 	return nil
 }
 
-// SetValueGeoJson sets the value of Edge e as the GeoJSON object parsed from json string and sets the type of the edge to types.GeoID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
-// If the string fails to parse with geojson.Unmarshal() the edge is left unchanged and an error returned.
+// SetValueGeoJson sets the value of Edge e as the GeoJSON object parsed from json string and sets
+// the type of the edge to types.GeoID.  If the edge had previous been assigned another value (even
+// of another type), the value and type are overwritten.  If the edge has previously been connected
+// to a node, the edge and type are left unchanged and ErrConnected is returned. If the string 
+// fails to parse with geojson.Unmarshal() the edge is left unchanged and an error returned.
 func (e *Edge) SetValueGeoJson(json string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -383,9 +392,10 @@ func (e *Edge) SetValueGeoJson(json string) error {
 	return nil
 }
 
-// SetValueDefault sets the value of Edge e as string val and sets the type of the edge to types.DefaultID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// SetValueDefault sets the value of Edge e as string val and sets the type of the edge to 
+// types.DefaultID.  If the edge had previous been assigned another value (even of another 
+// type), the value and type are overwritten.  If the edge has previously been connected to 
+// a node, the edge and type are left unchanged and ErrConnected is returned.
 // The string must escape " with \, otherwise the edge and type are left unchanged and an error returned.
 func (e *Edge) SetValueDefault(val string) error {
 	if len(e.nq.ObjectId) > 0 {
@@ -404,10 +414,10 @@ func (e *Edge) SetValueDefault(val string) error {
 	return nil
 }
 
-// SetValueBytes allows setting the value of an edge to raw bytes and sets the type of the edge to types.BinaryID.
-// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
-// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
-// the bytes are encoded as base64.
+// SetValueBytes allows setting the value of an edge to raw bytes and sets the type of the edge 
+// to types.BinaryID.  If the edge had previous been assigned another value (even of another type),
+// the value and type are overwritten.  If the edge has previously been connected to a node, the 
+// edge and type are left unchanged and ErrConnected is returned. the bytes are encoded as base64.
 func (e *Edge) SetValueBytes(val []byte) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected

--- a/client/client.go
+++ b/client/client.go
@@ -92,7 +92,7 @@ func (req *Req) addMutation(e Edge, op opType) {
 }
 
 // Set adds edge e to the set mutation of request req, thus scheduling the edge to be added to the graph when the request is run.
-// The edge must be syntatically valid: have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.
+// The edge must be syntactically valid: have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.
 // The edge is not checked agaist the schema until the request is run --- so setting a UID edge to a value, for example, doesn't result in an
 // error until the request is run.
 func (req *Req) Set(e Edge) {
@@ -160,7 +160,7 @@ type nquadOp struct {
 	op opType
 }
 
-// Node representes a single node in the graph.
+// Node represents a single node in the graph.
 type Node struct {
 	uid uint64
 	// We can do variables in mutations.
@@ -191,7 +191,7 @@ func (n *Node) ConnectTo(pred string, n1 Node) Edge {
 // Edge create an edge with source Node n and predicate pred, but without a target.
 // The edge needs to be completed by calling Edge.ConnectTo() if the edge is a
 // UID edge, or one of the Edge.SetValue...() functions if the edge is of a scalar type.
-// The edge can't be commited to the store --- calling Req.Set() to add the edge to
+// The edge can't be committed to the store --- calling Req.Set() to add the edge to
 // a request will result in an error --- until it is completed.
 func (n *Node) Edge(pred string) Edge {
 	e := Edge{}

--- a/client/client.go
+++ b/client/client.go
@@ -28,22 +28,24 @@ import (
 	"github.com/twpayne/go-geom/encoding/geojson"
 )
 
-type Op int
+
+type opType int
 
 const (
 	// SET indicates a Set mutation.
-	SET Op = iota
+	SET opType = iota
 	// DEL indicates a Delete mutation.
 	DEL
 )
 
-// Req wraps the protos.Request so that helper methods can be defined on it.
+// A Req represents a single request to the backend Dgraph instance.  Each request may contain multiple set, delete and
+// schema mutations, and a single GraphQL+- query.  IF the query contains GraphQL variables, then the map giving values to these 
+// must be stored in the request with the query.
 type Req struct {
 	gr protos.Request
 }
 
-// Request returns the graph request object which is sent to the server to perform
-// a query/mutation.
+// Request returns the protos.Request backing the Req.
 func (req *Req) Request() *protos.Request {
 	return &req.gr
 }
@@ -61,18 +63,23 @@ func checkSchema(schema protos.SchemaUpdate) error {
 	return nil
 }
 
-// SetQuery sets a query with graphQL variables as part of the request.
+// SetQuery sets the query in req to the given string.  
+// The query string is not checked until the request is 
+// run, when it is parsed and checked server-side.
 func (req *Req) SetQuery(q string) {
 	req.gr.Query = q
 }
 
-// SetQueryWithVariables sets a query with graphQL variables as part of the request.
+// SetQueryWithVariables sets query q (which contains graphQL variables mapped 
+// in vars) as the query in req and sets vars as the corresponding query variables.
+// Neither the query string nor the variables are checked until the request is run, 
+// when it is parsed and checked server-side.
 func (req *Req) SetQueryWithVariables(q string, vars map[string]string) {
 	req.gr.Query = q
 	req.gr.Vars = vars
 }
 
-func (req *Req) addMutation(e Edge, op Op) {
+func (req *Req) addMutation(e Edge, op opType) {
 	if req.gr.Mutation == nil {
 		req.gr.Mutation = new(protos.Mutation)
 	}
@@ -84,10 +91,18 @@ func (req *Req) addMutation(e Edge, op Op) {
 	}
 }
 
+// Set adds edge e to the set mutation of request req, thus scheduling the edge to be added to the graph when the request is run.  
+// The edge must be syntatically valid: have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.  
+// The edge is not checked agaist the schema until the request is run --- so setting a UID edge to a value, for example, doesn't result in an
+// error until the request is run.
 func (req *Req) Set(e Edge) {
 	req.addMutation(e, SET)
 }
 
+
+// Delete adds edge e to the delete mutation of request req, thus scheduling the edge to be removed from the graph when the request is run.  
+// The edge must have a valid source (a Node), predicate and target (a Node or value), otherwise an error is returned.  The edge need not represent
+// an edge in the graph --- applying such a mutation simply has no effect.
 func (req *Req) Delete(e Edge) {
 	req.addMutation(e, DEL)
 }
@@ -117,15 +132,17 @@ func (req *Req) reset() {
 
 type nquadOp struct {
 	e  Edge
-	op Op
+	op opType
 }
 
+// Node representes a single node in the graph. 
 type Node struct {
 	uid uint64
 	// We can do variables in mutations.
 	varName string
 }
 
+// String returns Node n as a string
 func (n Node) String() string {
 	if n.uid != 0 {
 		return fmt.Sprintf("%#x", uint64(n.uid))
@@ -133,6 +150,7 @@ func (n Node) String() string {
 	return n.varName
 }
 
+// ConnectTo creates an edge labelled pred from Node n to Node n1
 func (n *Node) ConnectTo(pred string, n1 Node) Edge {
 	e := Edge{}
 	if len(n.varName) != 0 {
@@ -145,6 +163,11 @@ func (n *Node) ConnectTo(pred string, n1 Node) Edge {
 	return e
 }
 
+// Edge create an edge with source Node n and predicate pred, but without a target.  
+// The edge needs to be completed by calling Edge.ConnectTo() if the edge is a 
+// UID edge, or one of the Edge.SetValue...() functions if the edge is of a scalar type.
+// The edge can't be commited to the store --- calling Req.Set() to add the edge to 
+// a request will result in an error --- until it is completed.
 func (n *Node) Edge(pred string) Edge {
 	e := Edge{}
 	if len(n.varName) != 0 {
@@ -156,14 +179,23 @@ func (n *Node) Edge(pred string) Edge {
 	return e
 }
 
+// An Edge represents an edge between a source node and a target (either a node or a value.)
+// Facets are stored in the edge.  See Node.Edge(), Node.ConnectTo(), Edge.ConnecTo(), 
+// Edge.AddFacet and the Edge.SetValue...() functions to 
+// make a valid edge for a set or delete mutation.
 type Edge struct {
 	nq protos.NQuad
 }
 
+
+// NewEdge creates and Edge from an NQuad.
 func NewEdge(nq protos.NQuad) Edge {
 	return Edge{nq}
 }
 
+
+// ConnectTo adds Node n as the target of the edge.  If the edge already has a known scalar type, 
+// for example if Edge.SetValue...() had been called on the edge, then an error is returned.
 func (e *Edge) ConnectTo(n Node) error {
 	if e.nq.ObjectType > 0 {
 		return ErrValue
@@ -185,6 +217,11 @@ func validateStr(val string) error {
 	return nil
 }
 
+
+// SetValueString sets the value of Edge e as string val and sets the type of the edge to types.StringID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// The string must escape " with \, otherwise the edge and type are left unchanged and an error returned.  
 func (e *Edge) SetValueString(val string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -202,6 +239,10 @@ func (e *Edge) SetValueString(val string) error {
 	return nil
 }
 
+
+// SetValueInt sets the value of Edge e as int64 val and sets the type of the edge to types.IntID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueInt(val int64) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -215,6 +256,9 @@ func (e *Edge) SetValueInt(val int64) error {
 	return nil
 }
 
+// SetValueFloat sets the value of Edge e as float64 val and sets the type of the edge to types.FloatID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueFloat(val float64) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -228,6 +272,10 @@ func (e *Edge) SetValueFloat(val float64) error {
 	return nil
 }
 
+
+// SetValueBool sets the value of Edge e as bool val and sets the type of the edge to types.BoolID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueBool(val bool) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -241,6 +289,10 @@ func (e *Edge) SetValueBool(val bool) error {
 	return nil
 }
 
+
+// SetValuePassword sets the value of Edge e as password string val and sets the type of the edge to types.PasswordID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValuePassword(val string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -254,6 +306,10 @@ func (e *Edge) SetValuePassword(val string) error {
 	return nil
 }
 
+
+// SetValueDatetime sets the value of Edge e as time.Time dateTime and sets the type of the edge to types.DateTimeID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
 func (e *Edge) SetValueDatetime(dateTime time.Time) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -267,6 +323,12 @@ func (e *Edge) SetValueDatetime(dateTime time.Time) error {
 	return nil
 }
 
+
+
+// SetValueGeoJson sets the value of Edge e as the GeoJSON object parsed from json string and sets the type of the edge to types.GeoID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// If the string fails to parse with geojson.Unmarshal() the edge is left unchanged and an error returned.
 func (e *Edge) SetValueGeoJson(json string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -288,6 +350,12 @@ func (e *Edge) SetValueGeoJson(json string) error {
 	return nil
 }
 
+
+
+// SetValueDefault sets the value of Edge e as string val and sets the type of the edge to types.DefaultID.  
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// The string must escape " with \, otherwise the edge and type are left unchanged and an error returned.  
 func (e *Edge) SetValueDefault(val string) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -305,6 +373,11 @@ func (e *Edge) SetValueDefault(val string) error {
 	return nil
 }
 
+
+// SetValueBytes allows setting the value of an edge to raw bytes and sets the type of the edge to types.BinaryID.
+// If the edge had previous been assigned another value (even of another type), the value and type are overwritten.
+// If the edge has previously been connected to a node, the edge and type are left unchanged and ErrConnected is returned.
+// the bytes are encoded as base64.  
 func (e *Edge) SetValueBytes(val []byte) error {
 	if len(e.nq.ObjectId) > 0 {
 		return ErrConnected
@@ -320,6 +393,7 @@ func (e *Edge) SetValueBytes(val []byte) error {
 	return nil
 }
 
+// AddFacet adds the key, value pair as facets on Edge e.  No checking is done.
 func (e *Edge) AddFacet(key, val string) {
 	e.nq.Facets = append(e.nq.Facets, &protos.Facet{
 		Key: key,

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/protos"
-	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	geom "github.com/twpayne/go-geom"
@@ -125,31 +124,6 @@ func (req *Req) AddSchema(s protos.SchemaUpdate) error {
 	return nil
 }
 
-// AddSchemaFromString parses s for schema mutations and adds each update in s
-// to the request using AddSchema.  The given string should be of the form:
-// edgename: uid @reverse .
-// edge2: string @index(exact) .
-// etc.
-// to use the form "mutuation { schema { ... }}" issue the mutation through
-// SetQuery.
-func (req *Req) AddSchemaFromString(s string) error {
-	schemaUpdate, err := schema.Parse(s)
-	if err != nil {
-		return err
-	}
-
-	if len(schemaUpdate) == 0 {
-		return nil
-	}
-
-	for _, smut := range schemaUpdate {
-		if err = req.AddSchema(*smut); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 func (req *Req) size() int {
 	if req.gr.Mutation == nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/dgraph/protos"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,24 +32,27 @@ func TestSetMutation(t *testing.T) {
 	req := Req{}
 
 	s := graphValue("Alice")
-	req.Set(Edge{protos.NQuad{
+	err := req.Set(Edge{protos.NQuad{
 		Subject:     "alice",
 		Predicate:   "name",
 		ObjectValue: s,
 	}})
+	x.Check(err)
 
 	s = graphValue("rabbithole")
-	req.Set(Edge{protos.NQuad{
+	err = req.Set(Edge{protos.NQuad{
 		Subject:     "alice",
 		Predicate:   "falls.in",
 		ObjectValue: s,
 	}})
+	x.Check(err)
 
-	req.Delete(Edge{protos.NQuad{
+	err = req.Delete(Edge{protos.NQuad{
 		Subject:     "alice",
 		Predicate:   "falls.in",
 		ObjectValue: s,
 	}})
+	x.Check(err)
 
 	assert.Equal(t, len(req.gr.Mutation.Set), 2, "Set should have 2 entries")
 	assert.Equal(t, len(req.gr.Mutation.Del), 1, "Del should have 1 entry")
@@ -57,7 +61,7 @@ func TestSetMutation(t *testing.T) {
 func TestAddSchema(t *testing.T) {
 	req := Req{}
 
-	if err := req.addSchema(protos.SchemaUpdate{Predicate: "name"}); err != nil {
+	if err := req.AddSchema(protos.SchemaUpdate{Predicate: "name"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/client/doc.go
+++ b/client/doc.go
@@ -14,102 +14,35 @@
  * limitations under the License.
  */
 
-/*
-Package client provides helper function for interacting with the Dgraph server.
-You can use it to run mutations and queries. You can also use BatchMutation
-to upload data concurrently. It communicates with the server using gRPC.
 
-In this example, we first create a node, add a name (Steven Spielberg) and age
-attribute to it. We then create another node, add a name attribute (William Jones),
-we then add a friend edge between the two nodes.
-	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
-	dgraphClient := protos.NewDgraphClient(conn)
-	req := client.Req{}
+/* 
+Package client is used to interact with a Dgraph server.  Queries and
+mutations can be run from the client.  There are esentially two modes
+of client interaction:
 
-	nq := protos.NQuad{
-		Subject:   "_:person1",
-		Predicate: "name",
-	}
-	client.Str("Steven Spielberg", &nq)
-	req.AddMutation(nq, client.SET)
+- Request based interaction mode where the client builds requests and recieves
+responses immediately after running, and
 
-	nq = protos.NQuad{
-		Subject:   "_:person1",
-		Predicate: "age",
-	}
-	if err = client.Int(25, &nq); err != nil {
-		log.Fatal(err)
-	}
-	req.AddMutation(nq, client.SET)
+- Batch mode where clients submit many requests and let the client package
+batch those requests to the server.
 
-	nq = protos.NQuad{
-		Subject:   "_:person2",
-		Predicate: "name",
-	}
-	client.Str("William Jones", &nq)
-	req.AddMutation(nq, client.SET)
-
-	nq = protos.NQuad{
-		Subject:   "_:person1",
-		Predicate: "friend",
-		ObjectId:  "_:person2",
-	}
-	req.AddMutation(nq, client.SET)
-
-	resp, err := dgraphClient.Run(context.Background(), req.Request())
-	if err != nil {
-		log.Fatalf("Error in getting response from server, %s", err)
-	}
+Request Mode: 
 
 
-Dgraph would have assigned uids to these nodes.
-See https://docs.dgraph.io/master/query-language/#assigning-uid for more details
-on how assigning a new uid works.
-We now query for these things.
-	person1Uid := resp.AssignedUids["person1"]
-	person2Uid := resp.AssignedUids["person2"]
+Batch Mode:  On creating a new client with NewDgraphClient users submit
+BatchMutationOptions specifying the size of batches and number of concurrent 
+batches.  Edges are added to the batch with BatchSet; deletions are added
+with BatchDelete; and schema mutations with AddSchema.
 
-	req = client.Req{}
-	req.SetQuery(fmt.Sprintf(`
-	{
-		me(id: %v) {
-			_uid_
-			name
-			age
-			friend {
-				_uid_
-				name
-			}
-		}
-	}`, client.Uid(person1Uid)))
-	resp, err = dgraphClient.Run(context.Background(), req.Request())
-	if err != nil {
-		log.Fatalf("Error in getting response from server, %s", err)
-	}
+Submitted mutations are nondeterministically added to batches and there are
+no guarantees about which batch a mutation will be scheduled for (e.g. two
+successive calls to BatchSet won't guarantee the edges to be in the same batch).
 
-	person1 := resp.N[0].Children[0]
-	props := person1.Properties
-	name := props[0].Value.GetStrVal()
-	fmt.Println("Name: ", name)
+Finishing and interaction with BatchFlush flushes all buffers and ends the
+client interaction.
 
-	fmt.Println("Age: ", props[1].Value.GetIntVal())
 
-	person2 := person1.Children[0]
-	fmt.Printf("%v name: %v\n", person2.Attribute, person2.Properties[0].Value.GetStrVal())
 
-This is how we delete the friend edge between the two nodes.
-	nq = protos.NQuad{
-		Subject:   client.Uid(person1Uid),
-		Predicate: "friend",
-		ObjectId:  client.Uid(person2Uid),
-	}
-	req = client.Req{}
-	req.AddMutation(nq, client.DEL)
-	resp, err = dgraphClient.Run(context.Background(), req.Request())
-	if err != nil {
-		log.Fatalf("Error in getting response from server, %s", err)
-	}
-
-For more details checkout https://docs.dgraph.io/master/clients/#go.
+For more details checkout https://docs.dgraph.io/clients/#go.
 */
 package client

--- a/client/doc.go
+++ b/client/doc.go
@@ -21,7 +21,7 @@ mutations can be run from the client.  There are essentially two modes
 of client interaction:
 
 - Request based interaction mode where the user program builds requests 
-and recieves responses immediately after running, and
+and receives responses immediately after running, and
 
 - Batch mode where clients submit many requests and let the client package
 batch those requests to the server.

--- a/client/doc.go
+++ b/client/doc.go
@@ -41,7 +41,7 @@ Submitted mutations are nondeterministically added to batches and there are
 no guarantees about which batch a mutation will be scheduled for (e.g. two
 successive calls to BatchSet won't guarantee the edges to be in the same batch).
 
-Finishing and interaction with BatchFlush flushes all buffers and ends the
+Finishing an interaction with BatchFlush flushes all buffers and ends the
 client interaction.
 
 For more details checkout https://docs.dgraph.io/clients/#go.

--- a/client/doc.go
+++ b/client/doc.go
@@ -17,17 +17,20 @@
 
 /* 
 Package client is used to interact with a Dgraph server.  Queries and
-mutations can be run from the client.  There are esentially two modes
+mutations can be run from the client.  There are essentially two modes
 of client interaction:
 
-- Request based interaction mode where the client builds requests and recieves
-responses immediately after running, and
+- Request based interaction mode where the user program builds requests 
+and recieves responses immediately after running, and
 
 - Batch mode where clients submit many requests and let the client package
 batch those requests to the server.
 
-Request Mode: 
-
+Request Mode: User programs create a NewDgraphClient, create a request
+with req := client.Req{} and then add edges, deletion, schema and
+queries to the request with Set, Delete, AddSchema/AddSchemaFromString and
+SetQuery/SetQueryWithVariables.  Once the request is built, it is run with
+Run.  
 
 Batch Mode:  On creating a new client with NewDgraphClient users submit
 BatchMutationOptions specifying the size of batches and number of concurrent 
@@ -40,8 +43,6 @@ successive calls to BatchSet won't guarantee the edges to be in the same batch).
 
 Finishing and interaction with BatchFlush flushes all buffers and ends the
 client interaction.
-
-
 
 For more details checkout https://docs.dgraph.io/clients/#go.
 */

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -71,14 +71,16 @@ func ExampleReq_Set() {
 	// Add edges for name and salary to person1
 	e := person1.Edge("name")
 	e.SetValueString("Steven Spielberg")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	// If the old variable was written over or outof scope we can lookup person1 again,
 	// the string->node mapping is remembered by the client for this session.
 	p, err := dgraphClient.NodeBlank("person1")
 	e = p.Edge("salary")
 	e.SetValueFloat(13333.6161)
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	if err != nil {
@@ -143,7 +145,8 @@ func ExampleEdge_AddFacet() {
 	e.AddFacet("since", "2006-01-02T15:04:05")
 	e.AddFacet("alias", `"Steve"`)
 
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	person2, err := dgraphClient.NodeXid("person2", false)
 	if err != nil {
@@ -151,13 +154,15 @@ func ExampleEdge_AddFacet() {
 	}
 	e = person2.Edge("name")
 	e.SetValueString("William Jones")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	e = person1.ConnectTo("friend", person2)
 
 	// Facet on a node-node edge.
 	e.AddFacet("close", "true")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	req.AddSchemaFromString(`
 name: string @index(exact) .
@@ -236,11 +241,13 @@ func ExampleReq_SetQuery() {
 	}
 	e := alice.Edge("name")
 	e.SetValueString("Alice")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	e = alice.Edge("falls.in")
 	e.SetValueString("Rabbit hole")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	req.AddSchemaFromString(`name: string @index(exact) .`)
 	if err != nil {
@@ -259,7 +266,6 @@ func ExampleReq_SetQuery() {
 	}
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 }
-
 
 func ExampleReq_SetQueryWithVariables() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
@@ -283,11 +289,13 @@ func ExampleReq_SetQueryWithVariables() {
 	}
 	e := alice.Edge("name")
 	e.SetValueString("Alice")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	e = alice.Edge("falls.in")
 	e.SetValueString("Rabbit hole")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	req.AddSchemaFromString(`name: string @index(exact) .`)
 
@@ -300,12 +308,9 @@ func ExampleReq_SetQueryWithVariables() {
 		}
 	}`, variables)
 
-
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 }
-
-
 
 func ExampleDgraph_NodeUidVar() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
@@ -330,7 +335,8 @@ func ExampleDgraph_NodeUidVar() {
 	}
 	e := alice.Edge("name")
 	e.SetValueString("Alice")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	req.AddSchemaFromString(`name: string @index(exact) .`)
 
@@ -341,7 +347,7 @@ func ExampleDgraph_NodeUidVar() {
 
 	// Now issue a query and mutation using client interface
 
-    req.SetQuery(`{
+	req.SetQuery(`{
     a as var(func: eq(name, "Alice"))
     me(func: uid(a)) {
         name
@@ -349,34 +355,33 @@ func ExampleDgraph_NodeUidVar() {
 }`)
 
 	// Get a node for the variable a in the query above.
-    n, _ := dgraphClient.NodeUidVar("a")
-    e = n.Edge("falls.in")
+	n, _ := dgraphClient.NodeUidVar("a")
+	e = n.Edge("falls.in")
 	e.SetValueString("Rabbit hole")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
-    resp, err = dgraphClient.Run(context.Background(), &req)
+	resp, err = dgraphClient.Run(context.Background(), &req)
 	if err != nil {
 		log.Fatalf("Error in getting response from server, %s", err)
 	}
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 
-
-	// This is equivalent to the single query and mutation 
+	// This is equivalent to the single query and mutation
 	//
 	// {
-    //		a as var(func: eq(name, "Alice"))
-    //		me(func: uid(a)) {
+	//		a as var(func: eq(name, "Alice"))
+	//		me(func: uid(a)) {
 	//			name
-    //		}
+	//		}
 	// }
 	// mutation { set {
 	//		var(a) <falls.in> "Rabbit hole" .
-	// }} 
+	// }}
 	//
 	// It's often easier to construct such things with client functions that
 	// by manipulating raw strings.
 }
-
 
 func ExampleEdge_SetValueBytes() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
@@ -395,12 +400,14 @@ func ExampleEdge_SetValueBytes() {
 	}
 	e := alice.Edge("name")
 	e.SetValueString("Alice")
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	e = alice.Edge("somestoredbytes")
 	err = e.SetValueBytes([]byte(`\xbd\xb2\x3d\xbc\x20\xe2\x8c\x98`))
 	x.Check(err)
-	req.Set(e)
+	err = req.Set(e)
+	x.Check(err)
 
 	req.AddSchemaFromString(`name: string @index(exact) .`)
 
@@ -417,7 +424,6 @@ func ExampleEdge_SetValueBytes() {
 	}
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 }
-
 
 func ExampleUnmarshal() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
@@ -453,7 +459,7 @@ mutation {
 			name
 		}
 	}	
-}`)	
+}`)
 
 	// Run the request in the Dgraph server.  The mutations are added, then
 	// the query is exectuted.
@@ -461,19 +467,19 @@ mutation {
 	if err != nil {
 		log.Fatalf("Error in getting response from server, %s", err)
 	}
-	
+
 	// Unmarshal the response into a custom struct
 
 	// A type representing information in the graph.
 	type person struct {
-		Name string `dgraph:"name"`
+		Name    string   `dgraph:"name"`
 		Friends []person `dgraph:"friend"`
 	}
 
 	// A helper type matching the query root.
 	type friends struct {
 		Root person `dgraph:"friends"`
-	} 
+	}
 
 	var f friends
 	err = client.Unmarshal(resp.N, &f)
@@ -485,7 +491,7 @@ mutation {
 	fmt.Print("Friends : ")
 	for _, p := range f.Root.Friends {
 		fmt.Print(p.Name, " ")
-	} 
+	}
 	fmt.Println()
 
 }

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -37,42 +37,46 @@ func Node(val string, c *client.Dgraph) string {
 	if strings.HasPrefix(val, "_:") {
 		n, err := c.NodeBlank(val[2:])
 		if err != nil {
-			log.Fatal("Error while converting to node: %v", err)
+			log.Fatalf("Error while converting to node: %v", err)
 		}
 		return n.String()
 	}
 	n, err := c.NodeXid(val, false)
 	if err != nil {
-		log.Fatal("Error while converting to node: %v", err)
+		log.Fatalf("Error while converting to node: %v", err)
 	}
 	return n.String()
 }
 
-func ExampleReq_AddMutation() {
+func ExampleReq_Set() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
-	bmOpts := client.BatchMutationOptions{
-		Size:          1000,
-		Pending:       100,
-		PrintCounters: false,
-	}
 	clientDir, err := ioutil.TempDir("", "client_")
 	x.Check(err)
-	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
+	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, client.DefaultOptions, clientDir)
 
+	// Create new request
 	req := client.Req{}
+
+	// Create a node for person1 (the blank node label "person1" exists
+	// client-side so the mutation can correctly link nodes.  It is not
+	// persisted in the server)
 	person1, err := dgraphClient.NodeBlank("person1")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Creating a person node, and adding a name attribute to it.
+	// Add edges for name and salary to person1
 	e := person1.Edge("name")
 	e.SetValueString("Steven Spielberg")
 	req.Set(e)
-	e = person1.Edge("salary")
+
+	// If the old variable was written over or outof scope we can lookup person1 again,
+	// the string->node mapping is remembered by the client for this session.
+	p, err := dgraphClient.NodeBlank("person1")
+	e = p.Edge("salary")
 	e.SetValueFloat(13333.6161)
 	req.Set(e)
 
@@ -83,7 +87,7 @@ func ExampleReq_AddMutation() {
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 }
 
-func ExampleReq_BatchMutation() {
+func ExampleReq_BatchSet() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
@@ -97,12 +101,15 @@ func ExampleReq_BatchMutation() {
 	x.Check(err)
 	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
 
+	// Create a node for person1 (the blank node label "person1" exists
+	// client-side so the mutation can correctly link nodes.  It is not
+	// persisted in the server)
 	person1, err := dgraphClient.NodeBlank("person1")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	// Creating a person node, and adding a name attribute to it.
+	// Add edges for name and salary to the batch mutation
 	e := person1.Edge("name")
 	e.SetValueString("Steven Spielberg")
 	dgraphClient.BatchSet(e)
@@ -110,30 +117,29 @@ func ExampleReq_BatchMutation() {
 	e.SetValueFloat(13333.6161)
 	dgraphClient.BatchSet(e)
 
-	dgraphClient.BatchFlush()
+	dgraphClient.BatchFlush() // Must be called to flush buffers after all mutations are added.
 }
 
-func ExampleReq_AddMutation_facets() {
+func ExampleReq_AddFacet() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
 
-	bmOpts := client.BatchMutationOptions{
-		Size:          1000,
-		Pending:       100,
-		PrintCounters: false,
-	}
 	clientDir, err := ioutil.TempDir("", "client_")
 	x.Check(err)
-	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
+	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, client.DefaultOptions, clientDir)
 
 	req := client.Req{}
+
+	// Create a node for person1 add an edge for name.
 	person1, err := dgraphClient.NodeXid("person1", false)
 	if err != nil {
 		log.Fatal(err)
 	}
 	e := person1.Edge("name")
 	e.SetValueString("Steven Spielberg")
+
+	// Add facets since and alias to the edge.
 	e.AddFacet("since", "2006-01-02T15:04:05")
 	e.AddFacet("alias", `"Steve"`)
 
@@ -148,6 +154,8 @@ func ExampleReq_AddMutation_facets() {
 	req.Set(e)
 
 	e = person1.ConnectTo("friend", person2)
+
+	// Facet on a node-node edge.
 	e.AddFacet("close", "true")
 	req.Set(e)
 
@@ -160,6 +168,8 @@ func ExampleReq_AddMutation_facets() {
 		}
 	}`)
 
+	// Run the request in the Dgraph server.  The mutations are added, then
+	// the query is exectuted.
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	if err != nil {
 		log.Fatalf("Error in getting response from server, %s", err)
@@ -167,7 +177,7 @@ func ExampleReq_AddMutation_facets() {
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
 }
 
-func ExampleReq_AddMutation_schema() {
+func ExampleReq_AddSchemaFromString() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	x.Checkf(err, "While trying to dial gRPC")
 	defer conn.Close()
@@ -182,17 +192,15 @@ func ExampleReq_AddMutation_schema() {
 	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
 
 	req := client.Req{}
-	// Doing mutation and setting schema, then getting schema.
-	req.SetQuery(`
-mutation {
- schema {
-  name: string @index .
-  release_date: date @index .
- }
-}
 
-schema {}
+	// Add a schema mutation to the request
+	req.AddSchemaFromString(`
+name: string @index .
+release_date: date @index .
 `)
+
+	// Query the changed schema
+	req.SetQuery(`schema {}`)
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	if err != nil {
 		log.Fatalf("Error in getting response from server, %s", err)
@@ -227,8 +235,10 @@ func ExampleReq_SetQuery() {
 	e.SetValueString("Rabbit hole")
 	req.Set(e)
 
+	req.AddSchemaFromString(`name: string @index(exact) .`)
+
 	req.SetQuery(`{
-		me(id: alice) {
+		me(func: eq(name, "Alice")) {
 			name
 			falls.in
 		}
@@ -252,18 +262,101 @@ func ExampleReq_SetQueryWithVariables() {
 	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
 
 	req := client.Req{}
+
+	alice, err := dgraphClient.NodeXid("alice", false)
+	if err != nil {
+		log.Fatal(err)
+	}
+	e := alice.Edge("name")
+	e.SetValueString("Alice")
+	req.Set(e)
+
+	e = alice.Edge("falls.in")
+	e.SetValueString("Rabbit hole")
+	req.Set(e)
+
+	req.AddSchemaFromString(`name: string @index(exact) .`)
+
 	variables := make(map[string]string)
-	variables["$a"] = "3"
-	req.SetQueryWithVariables(`
-		query test ($a: int = 1) {
-			me(id: 0x01) {
-				name
-				gender
-				friend(first: $a) {
-					name
-				}
-			}
-		}`, variables)
+	variables["$a"] = "Alice"
+	req.SetQueryWithVariables(`{
+		me(func: eq(name, $a)) {
+			name
+			falls.in
+		}
+	}`, variables)
+
+
 	resp, err := dgraphClient.Run(context.Background(), &req)
 	fmt.Printf("%+v\n", proto.MarshalTextString(resp))
+}
+
+
+
+func ExampleReq_NodeUidVar() {
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
+	x.Checkf(err, "While trying to dial gRPC")
+	defer conn.Close()
+
+	bmOpts := client.BatchMutationOptions{
+		Size:          1000,
+		Pending:       100,
+		PrintCounters: false,
+	}
+	clientDir, err := ioutil.TempDir("", "client_")
+	x.Check(err)
+	dgraphClient := client.NewDgraphClient([]*grpc.ClientConn{conn}, bmOpts, clientDir)
+
+	req := client.Req{}
+
+	// Add some data
+	alice, err := dgraphClient.NodeXid("alice", false)
+	if err != nil {
+		log.Fatal(err)
+	}
+	e := alice.Edge("name")
+	e.SetValueString("Alice")
+	req.Set(e)
+
+	req.AddSchemaFromString(`name: string @index(exact) .`)
+
+	resp, err := dgraphClient.Run(context.Background(), &req)
+
+	// New request
+	req = client.Req{}
+
+	// Now issue a query and mutation using client interface
+
+    req.SetQuery(`{
+    a as var(func: eq(name, "Alice"))
+    me(func: uid(a)) {
+        name
+    }
+}`)
+
+	// Get a node for the variable a in the query above.
+    n, _ := dgraphClient.NodeUidVar("a")
+    e := n.Edge("falls.in")
+	e.SetValueString("Rabbit hole")
+	req.Set(e)
+
+    resp, err := dgraphClient.Run(context.Background(), &req)
+    x.Check(err)
+    fmt.Printf("Resp: %+v\n", resp)
+
+
+	// This is equivalent to the single query and mutation 
+	//
+	// {
+    //		a as var(func: eq(name, "Alice"))
+    //		me(func: uid(a)) {
+	//			name
+    //		}
+	// }
+	// mutation { set {
+	//		var(a) <falls.in> "Rabbit hole" .
+	// }} 
+	//
+	// It's often easier to construct such things with client functions that
+	// by manipulating raw strings.
 }

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -35,7 +35,6 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/badger/table"
 	"github.com/dgraph-io/dgraph/protos"
-	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -402,32 +401,7 @@ func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 	return nil
 }
 
-// AddSchemaFromString parses s for schema mutations and adds each update in s
-// to the batch using AddSchema.  The given string should be of the form:
-//
-// 	edgename: uid @reverse . 
-// 	edge2: string @index(exact) .
-// 
-// to use the form "mutation { schema { ... }}" issue the mutation through
-// SetQuery rather than as a batch.
-func (d *Dgraph) AddSchemaFromString(s string) error {
-	schemaUpdate, err := schema.Parse(s)
-	if err != nil {
-		return err
-	}
 
-	if len(schemaUpdate) == 0 {
-		return nil
-	}
-
-	for _, su := range schemaUpdate {
-		if err = d.AddSchema(*su); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // BatchFlush waits for all pending requests to complete. It should always be called after all 
 // BatchSet and BatchDeletes have been called.  Calling BatchFlush ends the client session and 

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -49,7 +49,7 @@ var (
 )
 
 // BatchMutationOptions sets the clients batch mode to Pending number of buffers
-// each of Size.  Running counters of number of rdfs procesessed, total time and
+// each of Size.  Running counters of number of rdfs processed, total time and
 // mutations per second are printed if PrintCounters is set true.
 // See Counter.
 type BatchMutationOptions struct {
@@ -383,7 +383,7 @@ func (d *Dgraph) BatchSet(e Edge) error {
 }
 
 // BatchDelete adds Edge e as a delete to the current batch mutation.  Once added,
-// the client will apply the mutation to the dgraph server when it is ready
+// the client will apply the mutation to the Dgraph server when it is ready
 // to flush its buffers.  The edge will be added to one of the batches as
 // specified in d's BatchMutationOptions.  If that batch fills, it eventually
 // flushes.  But there is no guarantee of delivery before BatchFlush() is
@@ -397,7 +397,7 @@ func (d *Dgraph) BatchDelete(e Edge) error {
 	return nil
 }
 
-// AddSchema adds the given schema mutatation to the batch of schema mutations.
+// AddSchema adds the given schema mutation to the batch of schema mutations.
 // If the schema mutation applies an index to a UID edge, or if it adds
 // reverse to a scalar edge, then the mutation is not added to the batch and an
 // error is returned. Once added, the client will apply the schema mutation when
@@ -415,7 +415,7 @@ func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 // edgename: uid @reverse .
 // edge2: string @index(exact) .
 // etc.
-// to use the form "mutuation { schema { ... }}" issue the mutation through 
+// to use the form "mutation { schema { ... }}" issue the mutation through 
 // SetQuery rather than as a batch.
 func (d *Dgraph) AddSchemaFromString(s string) error {
 	schemaUpdate, err := schema.Parse(s)
@@ -488,7 +488,7 @@ func (d *Dgraph) NodeUid(uid uint64) Node {
 }
 
 // NodeBlank creates or returns a Node given a string name for the blank node.
-// Blank nodes do not exist as labelled nodes in dgraph. Blank nodes are used
+// Blank nodes do not exist as labelled nodes in Dgraph. Blank nodes are used
 // as labels client side for loading and linking nodes correctly.  If the
 // label is new in this session a new UID is allocated and assigned to the
 // label.  If the label has already been assigned, the corresponding Node

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -40,12 +40,13 @@ import (
 )
 
 var (
-	ErrConnected   = errors.New("Edge already connected to another node.")
-	ErrValue       = errors.New("Edge already has a value.")
-	ErrEmptyXid    = errors.New("Empty XID node.")
-	ErrInvalidType = errors.New("Invalid value type")
-	ErrEmptyVar    = errors.New("Empty variable name.")
-	emptyEdge      Edge
+	ErrConnected    = errors.New("Edge already connected to another node.")
+	ErrValue        = errors.New("Edge already has a value.")
+	ErrEmptyXid     = errors.New("Empty XID node.")
+	ErrInvalidType  = errors.New("Invalid value type")
+	ErrEmptyVar     = errors.New("Empty variable name.")
+	ErrNotConnected = errors.New("Edge needs to be connected to another node or a value.")
+	emptyEdge       Edge
 )
 
 // BatchMutationOptions sets the clients batch mode to Pending number of buffers
@@ -415,7 +416,7 @@ func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 // edgename: uid @reverse .
 // edge2: string @index(exact) .
 // etc.
-// to use the form "mutation { schema { ... }}" issue the mutation through 
+// to use the form "mutation { schema { ... }}" issue the mutation through
 // SetQuery rather than as a batch.
 func (d *Dgraph) AddSchemaFromString(s string) error {
 	schemaUpdate, err := schema.Parse(s)

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -49,10 +49,9 @@ var (
 	emptyEdge       Edge
 )
 
-// BatchMutationOptions sets the clients batch mode to Pending number of buffers
-// each of Size.  Running counters of number of rdfs processed, total time and
-// mutations per second are printed if PrintCounters is set true.
-// See Counter.
+// BatchMutationOptions sets the clients batch mode to Pending number of buffers each of Size.  
+// Running counters of number of rdfs processed, total time and mutations per second are printed 
+// if PrintCounters is set true.  See Counter.
 type BatchMutationOptions struct {
 	Size          int
 	Pending       int
@@ -153,9 +152,8 @@ func (a *allocator) assignOrGet(id string) (uid uint64, isNew bool, err error) {
 	return
 }
 
-// Counter keeps a track of various parameters about a batch mutation.
-// Running totals are printed if BatchMutationOptions
-// PrintCounters is set to true.
+// Counter keeps a track of various parameters about a batch mutation. Running totals are printed 
+// if BatchMutationOptions PrintCounters is set to true.
 type Counter struct {
 	// Number of RDF's processed by server.
 	Rdfs uint64
@@ -165,9 +163,8 @@ type Counter struct {
 	Elapsed time.Duration
 }
 
-// A Dgraph is the data structure held by the user program for all
-// interactions with the Dgraph server.  After making grpc
-// connection a new Dgraph is created by function NewDgraphClient.
+// A Dgraph is the data structure held by the user program for all interactions with the Dgraph 
+// server.  After making grpc connection a new Dgraph is created by function NewDgraphClient.
 type Dgraph struct {
 	opts BatchMutationOptions
 
@@ -187,10 +184,9 @@ type Dgraph struct {
 	start time.Time
 }
 
-// NewDgraphClient creates a new Dgraph for interacting with
-// the Dgraph store connected to in conns.  The Dgraph
-// client stores blanknode to uid, and XIDnode to uid
-// mappings on disk in clientDir.
+// NewDgraphClient creates a new Dgraph for interacting with the Dgraph store connected to in 
+// conns.  The Dgraph client stores blanknode to uid, and XIDnode to uid mappings on disk 
+// in clientDir.
 func NewDgraphClient(conns []*grpc.ClientConn, opts BatchMutationOptions, clientDir string) *Dgraph {
 	var clients []protos.DgraphClient
 	for _, conn := range conns {
@@ -368,12 +364,10 @@ LOOP:
 	d.wg.Done()
 }
 
-// BatchSet adds Edge e as a set to the current batch mutation.  Once added,
-// the client will apply the mutation to the Dgraph server when it is ready
-// to flush its buffers.  The edge will be added to one of the batches as
-// specified in d's BatchMutationOptions.  If that batch fills, it eventually
-// flushes.  But there is no guarantee of delivery before BatchFlush() is
-// called.
+// BatchSet adds Edge e as a set to the current batch mutation.  Once added, the client will apply 
+// the mutation to the Dgraph server when it is ready to flush its buffers.  The edge will be added
+// to one of the batches as specified in d's BatchMutationOptions.  If that batch fills, it 
+// eventually flushes.  But there is no guarantee of delivery before BatchFlush() is called.
 func (d *Dgraph) BatchSet(e Edge) error {
 	d.nquads <- nquadOp{
 		e:  e,
@@ -383,12 +377,10 @@ func (d *Dgraph) BatchSet(e Edge) error {
 	return nil
 }
 
-// BatchDelete adds Edge e as a delete to the current batch mutation.  Once added,
-// the client will apply the mutation to the Dgraph server when it is ready
-// to flush its buffers.  The edge will be added to one of the batches as
-// specified in d's BatchMutationOptions.  If that batch fills, it eventually
-// flushes.  But there is no guarantee of delivery before BatchFlush() is
-// called.
+// BatchDelete adds Edge e as a delete to the current batch mutation.  Once added, the client will 
+// apply the mutation to the Dgraph server when it is ready to flush its buffers.  The edge will 
+// be added to one of the batches as specified in d's BatchMutationOptions.  If that batch fills, 
+// it eventually flushes.  But there is no guarantee of delivery before BatchFlush() is called.
 func (d *Dgraph) BatchDelete(e Edge) error {
 	d.nquads <- nquadOp{
 		e:  e,
@@ -398,11 +390,10 @@ func (d *Dgraph) BatchDelete(e Edge) error {
 	return nil
 }
 
-// AddSchema adds the given schema mutation to the batch of schema mutations.
-// If the schema mutation applies an index to a UID edge, or if it adds
-// reverse to a scalar edge, then the mutation is not added to the batch and an
-// error is returned. Once added, the client will apply the schema mutation when
-// it is ready to flush its buffers.
+// AddSchema adds the given schema mutation to the batch of schema mutations.  If the schema 
+// mutation applies an index to a UID edge, or if it adds reverse to a scalar edge, then the 
+// mutation is not added to the batch and an error is returned. Once added, the client will 
+// apply the schema mutation when it is ready to flush its buffers.
 func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 	if err := checkSchema(s); err != nil {
 		return err
@@ -413,9 +404,10 @@ func (d *Dgraph) AddSchema(s protos.SchemaUpdate) error {
 
 // AddSchemaFromString parses s for schema mutations and adds each update in s
 // to the batch using AddSchema.  The given string should be of the form:
-// edgename: uid @reverse .
-// edge2: string @index(exact) .
-// etc.
+//
+// 	edgename: uid @reverse . 
+// 	edge2: string @index(exact) .
+// 
 // to use the form "mutation { schema { ... }}" issue the mutation through
 // SetQuery rather than as a batch.
 func (d *Dgraph) AddSchemaFromString(s string) error {
@@ -437,10 +429,9 @@ func (d *Dgraph) AddSchemaFromString(s string) error {
 	return nil
 }
 
-// BatchFlush waits for all pending requests to complete. It should always be called
-// after all BatchSet and BatchDeletes have been called.  Calling BatchFlush
-// ends the client session and will cause a panic if further AddSchema,
-// BatchSet or BatchDelete functions are called.
+// BatchFlush waits for all pending requests to complete. It should always be called after all 
+// BatchSet and BatchDeletes have been called.  Calling BatchFlush ends the client session and 
+// will cause a panic if further AddSchema, BatchSet or BatchDelete functions are called.
 func (d *Dgraph) BatchFlush() {
 	close(d.nquads)
 	close(d.schema)
@@ -450,8 +441,11 @@ func (d *Dgraph) BatchFlush() {
 	}
 }
 
-// Run runs the request in req and returns with the completed response from
-// the server.  Calling Run has no effect on batched mutations.
+// Run runs the request in req and returns with the completed response from the server.  Calling 
+// Run has no effect on batched mutations.
+//
+// Mutations in the request are run before a query --- except when query variables link the 
+// mutation and query (see for example NodeUidVar) when the query is run first.
 func (d *Dgraph) Run(ctx context.Context, req *Req) (*protos.Response, error) {
 	return d.dc[rand.Intn(len(d.dc))].Run(ctx, &req.gr)
 }
@@ -465,9 +459,9 @@ func (d *Dgraph) Counter() Counter {
 	}
 }
 
-// CheckVersion checks if the version of dgraph and dgraphloader are the same.
-// If either the versions don't match or the version information could not be
-// obtained an error message is printed.
+// CheckVersion checks if the version of dgraph and dgraphloader are the same.  If either the 
+// versions don't match or the version information could not be obtained an error message is 
+// printed.
 func (d *Dgraph) CheckVersion(ctx context.Context) {
 	v, err := d.dc[rand.Intn(len(d.dc))].CheckVersion(ctx, &protos.Check{})
 	if err != nil {
@@ -488,11 +482,10 @@ func (d *Dgraph) NodeUid(uid uint64) Node {
 	return Node{uid: uid}
 }
 
-// NodeBlank creates or returns a Node given a string name for the blank node.
-// Blank nodes do not exist as labelled nodes in Dgraph. Blank nodes are used
-// as labels client side for loading and linking nodes correctly.  If the
-// label is new in this session a new UID is allocated and assigned to the
-// label.  If the label has already been assigned, the corresponding Node
+// NodeBlank creates or returns a Node given a string name for the blank node. Blank nodes do not 
+// exist as labelled nodes in Dgraph. Blank nodes are used as labels client side for loading and 
+// linking nodes correctly.  If the label is new in this session a new UID is allocated and 
+// assigned to the label.  If the label has already been assigned, the corresponding Node
 // is returned.
 func (d *Dgraph) NodeBlank(varname string) (Node, error) {
 	if len(varname) == 0 {
@@ -511,12 +504,11 @@ func (d *Dgraph) NodeBlank(varname string) (Node, error) {
 	return Node{uid: uid}, nil
 }
 
-// NodeXid creates or returns a Node given a string name for an XID node.
-// An XID node identifies a node with an edge _xid_, as in
-// node --- _xid_ ---> XID string
-// See https://docs.dgraph.io/query-language/#external-ids
-// If the XID has already been allocated in this client session
-// the allocated UID is returned, otherwise a new UID is allocated
+// NodeXid creates or returns a Node given a string name for an XID node. An XID node identifies a
+// node with an edge _xid_, as in
+// 	node --- _xid_ ---> XID string
+// See https://docs.dgraph.io/query-language/#external-ids If the XID has already been allocated 
+// in this client session the allocated UID is returned, otherwise a new UID is allocated
 // for xid and returned.
 func (d *Dgraph) NodeXid(xid string, storeXid bool) (Node, error) {
 	if len(xid) == 0 {
@@ -535,16 +527,14 @@ func (d *Dgraph) NodeXid(xid string, storeXid bool) (Node, error) {
 	return n, nil
 }
 
-// NodeUidVar creates a Node from a variable name.  When building a request,
-// set and delete mutations may depend on the request's query, as in:
-// https://docs.dgraph.io/query-language/#variables-in-mutations
-// Such query variables in mutations could be built into the raw query string,
-// but it is often more convenient to use client functions than manipulate
-// strings.
+// NodeUidVar creates a Node from a variable name.  When building a request, set and delete 
+// mutations may depend on the request's query, as in:
+// https://docs.dgraph.io/query-language/#variables-in-mutations Such query variables in mutations
+// could be built into the raw query string, but it is often more convenient to use client 
+// functions than manipulate strings.
 //
-// A request with a query and mutations (including variables in mutations)
-// will run in the same manner as if the query and mutations were set into
-// the query string.
+// A request with a query and mutations (including variables in mutations) will run in the same 
+// manner as if the query and mutations were set into the query string.
 func (d *Dgraph) NodeUidVar(name string) (Node, error) {
 	if len(name) == 0 {
 		return Node{}, ErrEmptyVar

--- a/client/unmarshal.go
+++ b/client/unmarshal.go
@@ -224,7 +224,7 @@ func fieldMap(typ reflect.Type) map[string]reflect.StructField {
 // will try to match named query blocks with tags in s and then unmarshall the
 // the matched block into the matched fields of s.
 // 
-// Unmarshal does have to be called at resp.N.  Clients can navigate to a 
+// Unmarshal does not have to be called at resp.N.  Clients can navigate to a 
 // particular part of the response and unmarshal the children.
 func Unmarshal(n []*protos.Node, v interface{}) error {
 	rv := reflect.ValueOf(v)

--- a/client/unmarshal.go
+++ b/client/unmarshal.go
@@ -210,10 +210,22 @@ func fieldMap(typ reflect.Type) map[string]reflect.StructField {
 	return fmap
 }
 
-// Unmarshal is used to convert the query response to a custom struct.
-// Response has 4 fields, L(Latency), Schema, AssignedUids and N(Nodes).
-// This function takes in the nodes part of the response and tries to
-// unmarshal it into the given struct.
+// Unmarshal is used to unpack a query response into a custom struct.  The 
+// response from Dgraph.Run (a *protos.Response) has 4 fields, L(Latency), 
+// Schema, AssignedUids and N(Nodes). This function takes in the nodes part of
+// the response and tries to unmarshal it into the given struct v.
+//
+// protos.Response.N is a slice of Nodes, one for each named query block in the
+// request.  Each node in that slice has attribute "_root_" and a child for 
+// each node returned as a result by that query block.  For a response resp,
+// and struct variable v, with a field tagged with the same name as a query
+// block:
+// Unmarshal(resp.N, s)
+// will try to match named query blocks with tags in s and then unmarshall the
+// the matched block into the matched fields of s.
+// 
+// Unmarshal does have to be called at resp.N.  Clients can navigate to a 
+// particular part of the response and unmarshal the children.
 func Unmarshal(n []*protos.Node, v interface{}) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {


### PR DESCRIPTION
Go docs for 0.8 release.  With examples_test updated

As well as the go docs I made type Op not visible and added two functions (2X AddSchemaFromString) which seemed more convenient that the client parsing and issuing protos updates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1197)
<!-- Reviewable:end -->
