### PR TITLE
Significant optimization of query test execution

### DIFF
--- a/query/query_test.go
+++ b/query/query_test.go
@@ -160,12 +160,9 @@ func populateGraph(t *testing.T) {
 	addEdgeToValue(t, "sword_present", 1, "true", nil)
 	addEdgeToValue(t, "_xid_", 1, "mich", nil)
 
-	addPassword(t, 1, "password", "123456")
-
 	// Now let's add a name for each of the friends, except 101.
 	addEdgeToTypedValue(t, "name", 23, types.StringID, []byte("Rick Grimes"), nil)
 	addEdgeToValue(t, "age", 23, "15", nil)
-	addPassword(t, 23, "pass", "654321")
 
 	src.Value = []byte(`{"Type":"Polygon", "Coordinates":[[[0.0,0.0], [2.0,0.0], [2.0, 2.0], [0.0, 2.0], [0.0, 0.0]]]}`)
 	coord, err = types.Convert(src, types.GeoID)
@@ -2620,6 +2617,8 @@ func TestSum(t *testing.T) {
 
 func TestQueryPassword(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	// Password is not fetchable
 	query := `
                 {
@@ -2640,6 +2639,8 @@ func TestQueryPassword(t *testing.T) {
 
 func TestCheckPassword(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(0x01)) {
@@ -2656,6 +2657,8 @@ func TestCheckPassword(t *testing.T) {
 
 func TestCheckPasswordIncorrect(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(0x01)) {
@@ -2673,6 +2676,8 @@ func TestCheckPasswordIncorrect(t *testing.T) {
 // ensure, that old and deprecated form is not allowed
 func TestCheckPasswordParseError(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(0x01)) {
@@ -2687,6 +2692,8 @@ func TestCheckPasswordParseError(t *testing.T) {
 
 func TestCheckPasswordDifferentAttr1(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(23)) {
@@ -2701,6 +2708,8 @@ func TestCheckPasswordDifferentAttr1(t *testing.T) {
 
 func TestCheckPasswordDifferentAttr2(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(23)) {
@@ -2715,6 +2724,8 @@ func TestCheckPasswordDifferentAttr2(t *testing.T) {
 
 func TestCheckPasswordInvalidAttr(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(0x1)) {
@@ -2731,6 +2742,8 @@ func TestCheckPasswordInvalidAttr(t *testing.T) {
 // test for old version of checkpwd with hardcoded attribute name
 func TestCheckPasswordQuery1(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(0x1)) {
@@ -2747,6 +2760,8 @@ func TestCheckPasswordQuery1(t *testing.T) {
 // test for improved version of checkpwd with custom attribute name
 func TestCheckPasswordQuery2(t *testing.T) {
 	populateGraph(t)
+	addPassword(t, 23, "pass", "654321")
+	addPassword(t, 1, "password", "123456")
 	query := `
                 {
                         me(func: uid(23)) {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -49,10 +49,17 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
+var passwordCache map[string]string = make(map[string]string, 2)
+
 func addPassword(t *testing.T, uid uint64, attr, password string) {
 	value := types.ValueForType(types.BinaryID)
 	src := types.ValueForType(types.PasswordID)
-	src.Value, _ = types.Encrypt(password)
+	encrypted, ok := passwordCache[password]
+	if !ok {
+		encrypted, _ = types.Encrypt(password)
+		passwordCache[password] = encrypted
+	}
+	src.Value = encrypted
 	err := types.Marshal(src, &value)
 	require.NoError(t, err)
 	addEdgeToTypedValue(t, attr, uid, types.PasswordID, value.Value.([]byte), nil)


### PR DESCRIPTION
Running `go test` in `query` directory is much to slow. After profiling, simple fix was applied to improve performance about 12 times (total time before change is about 60 seconds, and after about 5 seconds).
The most CPU consuming function in test is password encryption. But we can safely prepare encrypted passwords only for few tests. Running individual tests is also much faster (0.17s vs 0.01s).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1206)
<!-- Reviewable:end -->
