### PR TITLE
Fix bug with vars in mutation

### DIFF
--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -1192,6 +1192,45 @@ func TestMutationObjectVariables(t *testing.T) {
 	require.JSONEq(t, `{"me":[{"count(likes)":3}]}`, r)
 }
 
+func TestMutationSubjectObjectVariables(t *testing.T) {
+	m1 := `
+		mutation {
+			set {
+                <0x600>    <friend>   <0x501> .
+                <0x600>    <friend>   <0x502> .
+                <0x600>    <friend>   <0x503> .
+				uid(user)    <likes>    uid(myfriend) .
+			}
+		}
+		{
+			user as var(func: uid(0x600))
+			me(func: uid( 0x600)) {
+				myfriend as friend
+			}
+		}
+    `
+
+	parsed, err := gql.Parse(gql.Request{Str: m1, Http: true})
+	require.NoError(t, err)
+
+	var l query.Latency
+	qr := query.QueryRequest{Latency: &l, GqlQuery: &parsed}
+	_, err = qr.ProcessWithMutation(defaultContext())
+
+	require.NoError(t, err)
+
+	q1 := `
+		{
+			me(func: uid(0x600)) {
+				count(likes)
+            }
+		}
+    `
+	r, err := runQuery(q1)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"me":[{"count(likes)":3}]}`, r)
+}
+
 func TestMutationObjectVariablesError(t *testing.T) {
 	m1 := `
 		mutation {

--- a/gql/mutation.go
+++ b/gql/mutation.go
@@ -59,14 +59,14 @@ func (m Mutation) HasOps() bool {
 }
 
 // NeededVars retrieves NQuads and variable names of NQuads that refer a variable.
-func (m Mutation) NeededVars() (res map[*protos.NQuad]string) {
-	res = make(map[*protos.NQuad]string)
+func (m Mutation) NeededVars() (res []string) {
+	res = make([]string, 0, 5)
 	addIfVar := func(nq *protos.NQuad) {
 		if len(nq.SubjectVar) > 0 {
-			res[nq] = nq.SubjectVar
+			res = append(res, nq.SubjectVar)
 		}
 		if len(nq.ObjectVar) > 0 {
-			res[nq] = nq.ObjectVar
+			res = append(res, nq.ObjectVar)
 		}
 	}
 	for _, s := range m.Set {

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -470,7 +470,7 @@ type Result struct {
 	Query        []*GraphQuery
 	QueryVars    []*Vars
 	Mutation     *Mutation
-	MutationVars map[*protos.NQuad]string
+	MutationVars []string
 	Schema       *protos.SchemaRequest
 }
 
@@ -578,11 +578,7 @@ func Parse(r Request) (res Result, rerr error) {
 
 		allVars := res.QueryVars
 		if len(res.MutationVars) > 0 {
-			var varNames []string
-			for _, v := range res.MutationVars {
-				varNames = append(varNames, v)
-			}
-			varNames = x.RemoveDuplicates(varNames)
+			varNames := x.RemoveDuplicates(res.MutationVars)
 
 			allVars = append(allVars, &Vars{Needs: varNames})
 		}

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3514,12 +3514,42 @@ func TestMutationVariables(t *testing.T) {
 
 	require.Equal(t, 1, len(res.MutationVars))
 
-	require.EqualValues(t, "adults", res.MutationVars[res.Mutation.Set[0]])
+	require.EqualValues(t, "adults", res.MutationVars[0])
 
 	expected := protos.NQuad{
 		Predicate:   "isadult",
 		ObjectValue: &protos.Value{&protos.Value_DefaultVal{"true"}},
 		SubjectVar:  "adults",
+	}
+	require.EqualValues(t, expected, *res.Mutation.Set[0])
+}
+
+func TestMutationVariables2(t *testing.T) {
+	query := `
+		mutation {
+			set {
+				uid(adults) <isadult> uid(engineer) .
+				<0x900> <b> <0x901> .
+			}
+		}
+		{
+			me(func: uid( 0x900)) {
+				adults as friends @filter(gt(age, 18))
+			}
+			engineer as me(func: uid(0x1))
+		}
+	`
+	res, err := Parse(Request{Str: query, Http: true})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(res.MutationVars))
+
+	require.EqualValues(t, []string{"adults", "engineer"}, res.MutationVars)
+
+	expected := protos.NQuad{
+		Predicate:  "isadult",
+		ObjectVar:  "engineer",
+		SubjectVar: "adults",
 	}
 	require.EqualValues(t, expected, *res.Mutation.Set[0])
 }


### PR DESCRIPTION
We were using a map which was per nquad, hence if both Subject and Object had a var, we took just the ObjectVar. Fixes #1217

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1220)
<!-- Reviewable:end -->
