### PR TITLE
Rework parseFacets, disallow 'a as orderdesc: b'

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1668,21 +1668,6 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			return res, ok, err
 		}
 
-		// Combine the facetitem with our result.
-		{
-			if facetItem.varName != "" {
-				facetVar[facetItem.facetName] = facetItem.varName
-			}
-			facets.Keys = append(facets.Keys, facetItem.facetName)
-			if facetItem.ordered {
-				if orderkey != "" {
-					return res, false, x.Errorf("Invalid use of orderasc/orderdesc in facets")
-				}
-				orderdesc = facetItem.orderdesc
-				orderkey = facetItem.facetName
-			}
-		}
-
 		// Now what?  Either close-paren or a comma.
 		if _, ok := tryParseItemType(it, itemRightRound); ok {
 			sort.Slice(facets.Keys, func(i, j int) bool {
@@ -1702,8 +1687,27 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
 			return res, true, nil
 		}
-		if _, ok := tryParseItemType(it, itemComma); !ok {
-			return res, false, nil
+		if item, ok := tryParseItemType(it, itemComma); !ok {
+			if len(facets.Keys) == 0 {
+				return res, false, nil
+			}
+			return res, false, x.Errorf(
+				"Expected ',' or ')' in facet list, got %q", item.Val)
+		}
+
+		// Combine the facetItem with our result.
+		{
+			if facetItem.varName != "" {
+				facetVar[facetItem.facetName] = facetItem.varName
+			}
+			facets.Keys = append(facets.Keys, facetItem.facetName)
+			if facetItem.ordered {
+				if orderkey != "" {
+					return res, false, x.Errorf("Invalid use of orderasc/orderdesc in facets")
+				}
+				orderdesc = facetItem.orderdesc
+				orderkey = facetItem.facetName
+			}
 		}
 	}
 }

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1672,6 +1672,10 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 		// Combine the facetitem with our result.
 		{
 			if facetItem.varName != "" {
+				if _, has := facetVar[facetItem.facetName]; has {
+					return res, false, x.Errorf("Duplicate variable mappings for facet %v",
+						facetItem.facetName)
+				}
 				facetVar[facetItem.facetName] = facetItem.varName
 			}
 			facets.Keys = append(facets.Keys, facetItem.facetName)

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1702,8 +1702,13 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
 			return res, true, nil
 		}
-		if _, ok := tryParseItemType(it, itemComma); !ok {
-			return res, false, nil
+		if item, ok := tryParseItemType(it, itemComma); !ok {
+			if len(facets.Keys) < 2 {
+				return res, false, nil
+			}
+			// We got a comma already, so this is definitely a facet list -- return an error.
+			return res, false, x.Errorf(
+				"Expected ',' or ')' in facet list", item.Val)
 		}
 	}
 }

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1655,11 +1655,8 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 	var orderkey string
 
 	if _, ok := tryParseItemType(it, itemRightRound); ok {
-		// TODO: Pre-existing code did all keys on @facets(), instead of no keys.  Might be a
-		// mistake.
-		facets.AllKeys = true
-		res.f = &facets
-		res.vmap = make(map[string]string)
+		// @facets() just parses to an empty set of facets.
+		res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
 		return res, true, nil
 	}
 

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -1666,7 +1665,6 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 		// Parse a facet item.
 		facetItem, ok, err := tryParseFacetItem(it)
 		if !ok || err != nil {
-			log.Printf("ret B")
 			return res, ok, err
 		}
 
@@ -1686,12 +1684,7 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 		}
 
 		// Now what?  Either close-paren or a comma.
-		if !it.Next() {
-			return res, false, x.Errorf("Unexpected EOF in facet list")
-		}
-
-		typ := it.Item().Typ
-		if typ == itemRightRound {
+		if _, ok := tryParseItemType(it, itemRightRound); ok {
 			sort.Slice(facets.Keys, func(i, j int) bool {
 				return facets.Keys[i] < facets.Keys[j]
 			})
@@ -1709,7 +1702,7 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
 			return res, true, nil
 		}
-		if typ != itemComma {
+		if _, ok := tryParseItemType(it, itemComma); !ok {
 			return res, false, nil
 		}
 	}

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1622,7 +1622,7 @@ func tryParseFacetItem(it *lex.ItemIterator) (res facetItem, parseOk bool, err e
 		return res, false, x.Errorf("Expected name in facet list")
 	}
 
-	res.facetName = collectName(it, it.Item().Val)
+	res.facetName = collectName(it, item.Val)
 	res.varName = name1
 	return res, true, nil
 }

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1571,7 +1571,7 @@ func parseFacets(it *lex.ItemIterator) (res facetRes, err error) {
 	return res, err
 }
 
-type facetThing struct {
+type facetItem struct {
 	facetName string
 	varName   string
 	ordered   bool
@@ -1579,8 +1579,8 @@ type facetThing struct {
 }
 
 // Either errors, fails to parse without an error (in which case nothing is consumed), or returns
-// an error.
-func tryParseFacetThing(it *lex.ItemIterator) (res facetThing, parseOk bool, err error) {
+// an error (which means to abort parsing)
+func tryParseFacetItem(it *lex.ItemIterator) (res facetItem, parseOk bool, err error) {
 	// We parse this:
 	// [{orderdesc|orderasc}:] [varname as] facetName
 
@@ -1667,25 +1667,25 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 		}
 		first = false
 
-		// Parse a thing.
-		thing, ok, err := tryParseFacetThing(it)
+		// Parse a facet item.
+		facetItem, ok, err := tryParseFacetItem(it)
 		if !ok || err != nil {
 			log.Printf("ret B")
 			return res, ok, err
 		}
 
-		// Combine the thing with our result.
+		// Combine the facetitem with our result.
 		{
-			if thing.varName != "" {
-				facetVar[thing.facetName] = thing.varName
+			if facetItem.varName != "" {
+				facetVar[facetItem.facetName] = facetItem.varName
 			}
-			facets.Keys = append(facets.Keys, thing.facetName)
-			if thing.ordered {
+			facets.Keys = append(facets.Keys, facetItem.facetName)
+			if facetItem.ordered {
 				if orderkey != "" {
 					return res, false, x.Errorf("Invalid use of orderasc/orderdesc in facets")
 				}
-				orderdesc = thing.orderdesc
-				orderkey = thing.facetName
+				orderdesc = facetItem.orderdesc
+				orderkey = facetItem.facetName
 			}
 		}
 

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1651,21 +1651,17 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 	var orderdesc bool
 	var orderkey string
 
-	first := true
-	for {
-		// We're after a '(' or a comma, we expect something.
+	if _, ok := tryParseItemType(it, itemRightRound); ok {
+		// TODO: Pre-existing code did all keys on @facets(), instead of no keys.  Might be a
+		// mistake.
+		facets.AllKeys = true
+		res.f = &facets
+		res.vmap = make(map[string]string)
+		return res, true, nil
+	}
 
-		if first {
-			if _, ok := tryParseItemType(it, itemRightRound); ok {
-				// TODO: Pre-existing code did all keys on @facets(), instead of no keys.  Might be a
-				// mistake.
-				facets.AllKeys = true
-				res.f = &facets
-				res.vmap = make(map[string]string)
-				return res, true, nil
-			}
-		}
-		first = false
+	for {
+		// We've just consumed a leftRound or a comma.
 
 		// Parse a facet item.
 		facetItem, ok, err := tryParseFacetItem(it)

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3034,7 +3034,7 @@ func TestParseFacetsOrderError3(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected ( after func name [orderdesc]")
+	require.Contains(t, err.Error(), "Expected ',' or ')'")
 }
 
 func TestParseFacetsOrderVar(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3004,6 +3004,7 @@ func TestParseFacetsOrderError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid use of order")
 }
 
 func TestParseFacetsOrderError2(t *testing.T) {
@@ -3018,6 +3019,7 @@ func TestParseFacetsOrderError2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid use of \"as\"")
 }
 
 func TestParseFacetsOrderError3(t *testing.T) {
@@ -3032,6 +3034,40 @@ func TestParseFacetsOrderError3(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected orderasc or orderdesc")
+}
+
+func TestParseFacetsOrderVar(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(orderdesc: a as b) {
+				name 
+			}
+		}
+		me(func: uid(a)) { }
+	}
+`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.NoError(t, err)
+}
+
+func TestParseFacetsOrderVar2(t *testing.T) {
+	// TODO: This should fail.
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(a as orderdesc: b) {
+				name 
+			}
+		}
+		me(func: uid(a)) {
+			
+		}
+	}
+`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.NoError(t, err)
 }
 
 func TestParseFacets(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3208,7 +3208,8 @@ func TestParseFacetsEmpty(t *testing.T) {
 	require.NotNil(t, res.Query[0])
 	require.Equal(t, []string{"friends", "hometown", "age"}, childAttrs(res.Query[0]))
 	require.NotNil(t, res.Query[0].Children[0].Facets)
-	require.Equal(t, true, res.Query[0].Children[0].Facets.AllKeys)
+	require.Equal(t, false, res.Query[0].Children[0].Facets.AllKeys)
+	require.Equal(t, 0, len(res.Query[0].Children[0].Facets.Keys))
 }
 
 func TestParseFacetsFail1(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3037,6 +3037,21 @@ func TestParseFacetsOrderError3(t *testing.T) {
 	require.Contains(t, err.Error(), "Expected ',' or ')'")
 }
 
+func TestParseFacetsDuplicateVarError(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(a as closeness, b as closeness) {
+				name 
+			}
+		}
+	}
+`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Duplicate variable mappings")
+}
+
 func TestParseFacetsOrderVar(t *testing.T) {
 	query := `
 	query {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3004,7 +3004,7 @@ func TestParseFacetsOrderError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Invalid use of order")
+	require.Contains(t, err.Error(), "Expected ( after func name [orderdesc]")
 }
 
 func TestParseFacetsOrderError2(t *testing.T) {
@@ -3019,7 +3019,7 @@ func TestParseFacetsOrderError2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Invalid use of \"as\"")
+	require.Contains(t, err.Error(), "Expected ( after func name [a]")
 }
 
 func TestParseFacetsOrderError3(t *testing.T) {
@@ -3034,7 +3034,7 @@ func TestParseFacetsOrderError3(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected orderasc or orderdesc")
+	require.Contains(t, err.Error(), "Expected ( after func name [orderdesc]")
 }
 
 func TestParseFacetsOrderVar(t *testing.T) {
@@ -3053,7 +3053,6 @@ func TestParseFacetsOrderVar(t *testing.T) {
 }
 
 func TestParseFacetsOrderVar2(t *testing.T) {
-	// TODO: This should fail.
 	query := `
 	query {
 		me(func: uid(0x1)) {
@@ -3067,7 +3066,8 @@ func TestParseFacetsOrderVar2(t *testing.T) {
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected ( after func name [a]")
 }
 
 func TestParseFacets(t *testing.T) {

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -110,6 +110,14 @@ func (p *ItemIterator) Peek(num int) ([]Item, error) {
 	return p.l.items[p.idx+1 : p.idx+num+1], nil
 }
 
+// PeekOne returns the next 1 item without consuming it.
+func (p *ItemIterator) PeekOne() (Item, bool) {
+	if p.idx+1 >= len(p.l.items) {
+		return Item{}, false
+	}
+	return p.l.items[p.idx+1], true
+}
+
 type Lexer struct {
 	// NOTE: Using a text scanner wouldn't work because it's designed for parsing
 	// Golang. It won't keep track of Start Position, or allow us to retrieve

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -39,12 +39,12 @@ const (
 // returns the next state.
 type StateFn func(*Lexer) StateFn
 
-type item struct {
+type Item struct {
 	Typ ItemType
 	Val string
 }
 
-func (i item) String() string {
+func (i Item) String() string {
 	switch i.Typ {
 	case 0:
 		return "EOF"
@@ -75,9 +75,9 @@ func (p *ItemIterator) Next() bool {
 }
 
 // Item returns the current item.
-func (p *ItemIterator) Item() item {
+func (p *ItemIterator) Item() Item {
 	if p.idx < 0 || p.idx >= len(p.l.items) {
-		return item{}
+		return Item{}
 	}
 	return (p.l.items)[p.idx]
 }
@@ -103,7 +103,7 @@ func (p *ItemIterator) Save() int {
 }
 
 // Peek returns the next n items without consuming them.
-func (p *ItemIterator) Peek(num int) ([]item, error) {
+func (p *ItemIterator) Peek(num int) ([]Item, error) {
 	if (p.idx + num + 1) > len(p.l.items) {
 		return nil, x.Errorf("Out of range for peek")
 	}
@@ -118,7 +118,7 @@ type Lexer struct {
 	Start    int     // Start Position of this item.
 	Pos      int     // current Position of this item.
 	Width    int     // Width of last rune read from input.
-	items    []item  // channel of scanned items.
+	items    []Item  // channel of scanned items.
 	Depth    int     // nesting of {}
 	ArgDepth int     // nesting of ()
 	Mode     StateFn // Default state to go back to after reading a token.
@@ -135,7 +135,7 @@ func (l *Lexer) Run(f StateFn) *Lexer {
 
 // Errorf returns the error state function.
 func (l *Lexer) Errorf(format string, args ...interface{}) StateFn {
-	l.items = append(l.items, item{
+	l.items = append(l.items, Item{
 		Typ: ItemError,
 		Val: fmt.Sprintf(format, args...),
 	})
@@ -148,7 +148,7 @@ func (l *Lexer) Emit(t ItemType) {
 		// Let ItemEOF go through.
 		return
 	}
-	l.items = append(l.items, item{
+	l.items = append(l.items, Item{
 		Typ: t,
 		Val: l.Input[l.Start:l.Pos],
 	})

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -383,6 +383,27 @@ func TestFetchingFewFacets(t *testing.T) {
 		js)
 }
 
+func TestFetchingNoFacets(t *testing.T) {
+	populateGraphWithFacets(t)
+	defer teardownGraphWithFacets(t)
+	// TestFetchingFewFacets but without the facet.  Returns no facets.
+	query := `
+		{
+			me(func: uid(0x1)) {
+				name
+				friend @facets() {
+					name
+				}
+			}
+		}
+	`
+
+	js := processToFastJSON(t, query)
+	require.JSONEq(t,
+		`{"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"name":"Michonne"}]}`,
+		js)
+}
+
 func TestFacetsSortOrder(t *testing.T) {
 	populateGraphWithFacets(t)
 	defer teardownGraphWithFacets(t)


### PR DESCRIPTION
A lot of parsing functions are implemented in the following style:

```
for it.Next() {
    if case1 {
        make sure case1 valid
        ...     
    } else if case2 {
        make sure case2 valid
        ...
    } else if case3 {
        make sure case3 valid
        ...
    } ...
}
```

This is really difficult to work with because each parsing case needs to handle any other possible parsing state.  There's basically n^2 stuff to think about.

It also does a poor job of expressing the intent of what is supposed to be parsed.  The reason is, all the code paths end up heading to the same place, and it's hard to tell which behaviors are intentional.  For example, was this supposed to be valid:  `@facets(a as orderasc: b)`  Probably not.  But is `@facets()` supposed to be treated the same as `@facets`, by setting AllKeys to true?  I have no idea -- the code just spills into that case, but there's nothing to indicate whether the possibility was contemplated by the developers.

It's much better to make parsing functions in a manner such that each point in the function body corresponds to a particular kind of place in the parse tree.  It's analogous to what happens when you replace an event loop with a stateful object with a goroutine.

It's also a good idea to make liberal use of helper functions like `tryParseItemType` and `trySkipItemVal`, or others as we might create.

It looks like due to the way the code was originally written, a lot of parsing code is using this `for it.Next()` style.  I think whenever we work on an old parsing function which uses that style and has gotten too complicated, we should consider refactoring it like this PR does, depending on the time/effort/correctness trade-off.

----

So anyway,

This PR has one material change to the behavior of parseFacets.  It disallows `@facets(a as orderasc: b)`.

But there's also the question:  Should `@facets()` still be treated like `@facets`?  Or should it be treated like an empty list of facets?  (My guess is we should change it to act like an empty list of facets, because I don't think users would appreciate having a special case.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1230)
<!-- Reviewable:end -->
