### PR TITLE
Make disk IO and processing concurrent

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -220,6 +220,9 @@ type plf struct {
 	decr func()
 }
 
+// fetchPl get the PLs for the specified keys and returns them in order.
+// NOTE: when using this function, never break or return from the channel loop
+// as we MUST decr() the reference for each PL fetched.
 func fetchPl(keyCh chan []byte, och chan plf, stop chan struct{}, gid uint32) {
 L:
 	for key := range keyCh {

--- a/worker/task.go
+++ b/worker/task.go
@@ -279,8 +279,15 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 		decr func()
 	}
 	plch := make(chan plf, 1000)
+	stopCh := make(chan struct{}, 1)
 	go func(q *protos.Query, srcFn *functionContext) {
+	L:
 		for i := 0; i < srcFn.n; i++ {
+			select {
+			case <-stopCh:
+				break L
+			default:
+			}
 			var key []byte
 			if srcFn.fnType == NotAFunction || srcFn.fnType == CompareScalarFn ||
 				srcFn.fnType == HasFn || srcFn.fnType == UidInFn {
@@ -303,16 +310,25 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 	}(q, srcFn)
 
 	i := -1
+	var lerr error
+	var lastDecr func()
+BL:
+	// NOTE: Never return inside this loop
 	for it := range plch {
 		i++
+		if lastDecr != nil {
+			lastDecr()
+		}
 		pl := it.pl
-		defer it.decr()
+		lastDecr = it.decr
 		// If a posting list contains a value, we store that or else we store a nil
 		// byte so that processing is consistent later.
 		val, err := pl.ValueFor(q.Langs)
 		isValueEdge := err == nil
 		if val.Tid == types.PasswordID && srcFn.fnType != PasswordFn {
-			return nil, x.Errorf("Attribute `%s` of type password cannot be fetched", attr)
+			lerr = x.Errorf("Attribute `%s` of type password cannot be fetched", attr)
+			stopCh <- struct{}{}
+			break BL
 		}
 		newValue := &protos.TaskValue{ValType: int32(val.Tid), Val: x.Nilbyte}
 		if isValueEdge {
@@ -346,11 +362,15 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 				return true // continue iteration.
 			})
 			if perr != nil {
-				return nil, perr
+				lerr = perr
+				stopCh <- struct{}{}
+				break BL
 			}
 		} else if q.FacetsFilter != nil { // else part means isValueEdge
 			// This is Value edge and we are asked to do facet filtering. Not supported.
-			return nil, x.Errorf("Facet filtering is not supported on values.")
+			lerr = x.Errorf("Facet filtering is not supported on values.")
+			stopCh <- struct{}{}
+			break BL
 		}
 
 		// add facets to result.
@@ -436,6 +456,15 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 			uidList.Uids = append(uidList.Uids, fres.uid)
 		}
 		out.UidMatrix = append(out.UidMatrix, uidList)
+	}
+
+	for it := range plch {
+		// Some items might be left after error. decr() their reference.
+		it.decr()
+	}
+
+	if lerr != nil {
+		return nil, lerr
 	}
 
 	if srcFn.fnType == HasFn && srcFn.isFuncAtRoot {


### PR DESCRIPTION
In `processTask` fetching the values and processing it were sequential which was slow when we had huge UID lists. 

For example, this query on SuperUser data (50M rdfs)  has ~350K UIDs which are of the type `Question`
```
{
  var(func: eq(Type, "Question")) {
    a as count(Upvote)
    b as count(Downvote)
    sc as math(cond(b > a/2, a, 0))
  }
    
  contr(func: uid(sc), orderdesc: val(sc), first:100) {
    val(a)
    val(b)
    val(sc)
    Title{
      Text
    }
  }
}
```
The processing time reduces from `~20s` to `~9s` when we make `GetOrCreate` and the processing concurrent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1244)
<!-- Reviewable:end -->
