### PR TITLE
Clear only relevant type of key

### DIFF
--- a/posting/lru.go
+++ b/posting/lru.go
@@ -178,15 +178,16 @@ func (c *listCache) Reset() {
 	c.curSize = 0
 }
 
-func (c *listCache) clear(attr string) error {
+func (c *listCache) clear(attr string, typ byte) error {
 	c.Lock()
 	defer c.Unlock()
 	for k, e := range c.cache {
 		kv := e.Value.(*entry)
-		keyAttr := x.ParseAttr(kv.pl.key)
-		if keyAttr != attr {
+		pk := x.Parse(kv.pl.key)
+		if pk.Attr != attr || !pk.IsType(typ) {
 			continue
 		}
+
 		c.ll.Remove(e)
 		kv.pl.SetForDeletion()
 		if committed, _ := kv.pl.SyncIfDirty(true); !committed {

--- a/x/keys.go
+++ b/x/keys.go
@@ -241,12 +241,6 @@ func SchemaPrefix() []byte {
 	return buf
 }
 
-func ParseAttr(key []byte) string {
-	sz := int(binary.BigEndian.Uint16(key[1:3]))
-	k := key[3:]
-	return string(k[:sz])
-}
-
 func Parse(key []byte) *ParsedKey {
 	p := &ParsedKey{}
 


### PR DESCRIPTION
`lcache.clear()` now takes a second argument which tells it what kind of kind keys to delete. Earlier we were deleting all keys for a predicate from cache which was not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1258)
<!-- Reviewable:end -->
