### PR TITLE
Decrease tick interval to 20 ms.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -239,9 +239,9 @@ func newNode(gid uint32, id uint64, myAddr string) *node {
 		store: store,
 		cfg: &raft.Config{
 			ID: id,
-			// 500 ms if we call Tick() every 50 ms.
+			// 200 ms if we call Tick() every 20 ms.
 			ElectionTick: 10,
-			// 50 ms if we call Tick() every 50 ms.
+			// 20 ms if we call Tick() every 20 ms.
 			HeartbeatTick:   1,
 			Storage:         store,
 			MaxSizePerMsg:   4096,
@@ -711,9 +711,7 @@ func (n *node) retrieveSnapshot(peerID uint64) {
 func (n *node) Run() {
 	firstRun := true
 	var leader bool
-	// See also our configuration of HeartbeatTick and ElectionTick. For whatever reason, when
-	// bring up a node we can only replay one raft index entry every tick.  It would be nice to
-	// figure out why.
+	// See also our configuration of HeartbeatTick and ElectionTick.
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 	rcBytes, err := n.raftContext.Marshal()

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -714,7 +714,7 @@ func (n *node) Run() {
 	// See also our configuration of HeartbeatTick and ElectionTick. For whatever reason, when
 	// bring up a node we can only replay one raft index entry every tick.  It would be nice to
 	// figure out why.
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 	rcBytes, err := n.raftContext.Marshal()
 	x.Check(err)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -238,8 +238,10 @@ func newNode(gid uint32, id uint64, myAddr string) *node {
 		gid:   gid,
 		store: store,
 		cfg: &raft.Config{
-			ID:              id,
-			ElectionTick:    10,
+			ID: id,
+			// 500 ms if we call Tick() every 50 ms.
+			ElectionTick: 10,
+			// 50 ms if we call Tick() every 50 ms.
 			HeartbeatTick:   1,
 			Storage:         store,
 			MaxSizePerMsg:   4096,
@@ -709,7 +711,10 @@ func (n *node) retrieveSnapshot(peerID uint64) {
 func (n *node) Run() {
 	firstRun := true
 	var leader bool
-	ticker := time.NewTicker(time.Second)
+	// See also our configuration of HeartbeatTick and ElectionTick. For whatever reason, when
+	// bring up a node we can only replay one raft index entry every tick.  It would be nice to
+	// figure out why.
+	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 	rcBytes, err := n.raftContext.Marshal()
 	x.Check(err)


### PR DESCRIPTION
Note that etcd does 5 ms, and Cockroach does 200 ms by default.  Note that Cockroach has complicated usage of the library so things there might not be so simple.  I went with 20 ms because that's low enough to make us catch up a replica on the same order of time that an initial series of writes happened, on a particular piece of hardware with a particular usage pattern.

Connected to #1180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1269)
<!-- Reviewable:end -->
