### PR TITLE
Fix reverse delete

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -78,6 +78,7 @@ func IndexTokens(attr, lang string, src types.Val) ([]string, error) {
 
 // addIndexMutations adds mutation(s) for a single term, to maintain index.
 // t represents the original uid -> value edge.
+// TODO - See if we need to pass op as argument as t should already have Op.
 func addIndexMutations(ctx context.Context, t *protos.DirectedEdge, p types.Val,
 	op protos.DirectedEdge_Op) error {
 	attr := t.Attr

--- a/posting/index.go
+++ b/posting/index.go
@@ -202,8 +202,9 @@ func (l *List) handleDeleteAll(ctx context.Context, t *protos.DirectedEdge) erro
 	isReversed := schema.State().IsReversed(t.Attr)
 	isIndexed := schema.State().IsIndexed(t.Attr)
 	delEdge := &protos.DirectedEdge{
-		Attr: t.Attr,
-		Op:   t.Op,
+		Attr:   t.Attr,
+		Op:     t.Op,
+		Entity: t.Entity,
 	}
 	l.Iterate(0, func(p *protos.Posting) bool {
 		if isReversed {


### PR DESCRIPTION
Fixes #1271 

1. We were iterating correctly, but not passing the `uid` to delete to both `addReverseMutation` and `addIndexMutations`. 
2. This could have been caught we handled errors, doing that now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1272)
<!-- Reviewable:end -->
