### PR TITLE
Default/tok

### DIFF
--- a/cmd/dgraph/debug.yaml
+++ b/cmd/dgraph/debug.yaml
@@ -19,9 +19,6 @@ grpc_port: 9080
 # Port used by worker for internal communication.
 workerport: 12345
 
-# If RAM usage exceeds this, we evict LRU cache till its below the value.
-max_memory_mb: 1024
-
 # The ratio of queries to trace.
 trace: 1.0
 

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -232,7 +232,7 @@ func TestDeletePredicate(t *testing.T) {
 	mutation {
 		schema {
 			friend: uid @reverse .
-			name: string @index .
+			name: string @index(term) .
 		}
 	}
 	`
@@ -240,7 +240,7 @@ func TestDeletePredicate(t *testing.T) {
 	var s2 = `
 		mutation {
 			schema {
-				friend: string @index .
+				friend: string @index(term) .
 				name: uid @reverse .
 			}
 		}
@@ -301,10 +301,10 @@ func TestSchemaMutation(t *testing.T) {
 	var m = `
 	mutation {
 		schema {
-      name:string @index(term, exact) .
+			name:string @index(term, exact) .
 			alias:string @index(exact, term) .
-			dob:dateTime @index .
-			film.film.initial_release_date:dateTime @index .
+			dob:dateTime @index(year) .
+			film.film.initial_release_date:dateTime @index(year) .
 			loc:geo @index .
 			genre:uid @reverse .
 			survival_rate : float .
@@ -395,7 +395,7 @@ func TestSchemaMutationIndexAdd(t *testing.T) {
 	var s = `
 	mutation {
 		schema {
-            name:string @index .
+            name:string @index(term) .
 		}
 	}
 	`
@@ -436,7 +436,7 @@ func TestSchemaMutationIndexRemove(t *testing.T) {
 	var s1 = `
 	mutation {
 		schema {
-            name:string @index .
+            name:string @index(term) .
 		}
 	}
 	`
@@ -615,7 +615,7 @@ func TestDeleteAll(t *testing.T) {
 	mutation {
 		schema {
       friend:uid @reverse .
-			name: string @index .
+			name: string @index(term) .
 		}
 	}
 	`
@@ -715,7 +715,7 @@ func TestDeleteAllSP(t *testing.T) {
 	mutation {
 		schema {
 			friend:uid @reverse .
-			name: string @index .
+			name: string @index(term) .
 		}
 	}
 	`
@@ -939,7 +939,7 @@ func TestListPred(t *testing.T) {
 	var s = `
 	mutation {
 		schema {
-			name:string @index .
+			name:string @index(term) .
 		}
 	}
 	`
@@ -983,7 +983,7 @@ func TestExpandPredError(t *testing.T) {
 	var s = `
 	mutation {
 		schema {
-			name:string @index .
+			name:string @index(term) .
 		}
 	}
 	`
@@ -1025,7 +1025,7 @@ func TestExpandPred(t *testing.T) {
 	var s = `
 	mutation {
 		schema {
-			name:string @index .
+			name:string @index(term) .
 		}
 	}
 	`

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -305,14 +305,14 @@ func TestSchemaMutation(t *testing.T) {
 			alias:string @index(exact, term) .
 			dob:dateTime @index(year) .
 			film.film.initial_release_date:dateTime @index(year) .
-			loc:geo @index .
+			loc:geo @index(geo) .
 			genre:uid @reverse .
 			survival_rate : float .
 			alive         : bool .
 			age           : int .
 			shadow_deep   : int .
 			friend:uid @reverse .
-			geometry:geo @index .
+			geometry:geo @index(geo) .
 		}
 	}
 

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -34,9 +34,9 @@ sleep 15
 #Set Schema
 curl -X POST  -d 'mutation {
   schema {
-	  name: string @index .
+    name: string @index(term) .
 		_xid_: string @index(exact,term) .
-	  initial_release_date: datetime @index .
+    initial_release_date: datetime @index(year) .
 	}
 }' "http://localhost:8080/query"
 

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -48,21 +48,21 @@ func uids(pl *protos.PostingList) []uint64 {
 }
 
 func TestIndexingInt(t *testing.T) {
-	schema.ParseBytes([]byte("age:int @index ."), 1)
+	schema.ParseBytes([]byte("age:int @index(int) ."), 1)
 	a, err := IndexTokens("age", "", types.Val{types.StringID, []byte("10")})
 	require.NoError(t, err)
 	require.EqualValues(t, []byte{0x6, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa}, []byte(a[0]))
 }
 
 func TestIndexingIntNegative(t *testing.T) {
-	schema.ParseBytes([]byte("age:int @index ."), 1)
+	schema.ParseBytes([]byte("age:int @index(int) ."), 1)
 	a, err := IndexTokens("age", "", types.Val{types.StringID, []byte("-10")})
 	require.NoError(t, err)
 	require.EqualValues(t, []byte{0x6, 0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xf6}, []byte(a[0]))
 }
 
 func TestIndexingFloat(t *testing.T) {
-	schema.ParseBytes([]byte("age:float @index ."), 1)
+	schema.ParseBytes([]byte("age:float @index(float) ."), 1)
 	a, err := IndexTokens("age", "", types.Val{types.StringID, []byte("10.43")})
 	require.NoError(t, err)
 	require.EqualValues(t, []byte{0x7, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa}, []byte(a[0]))

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const schemaStr = `
-name:string @index .
+name:string @index(term) .
 `
 
 func uids(pl *protos.PostingList) []uint64 {
@@ -69,14 +69,14 @@ func TestIndexingFloat(t *testing.T) {
 }
 
 func TestIndexingTime(t *testing.T) {
-	schema.ParseBytes([]byte("age:dateTime @index ."), 1)
+	schema.ParseBytes([]byte("age:dateTime @index(year) ."), 1)
 	a, err := IndexTokens("age", "", types.Val{types.StringID, []byte("0010-01-01T01:01:01.000000001")})
 	require.NoError(t, err)
 	require.EqualValues(t, []byte{0x4, 0x0, 0xa}, []byte(a[0]))
 }
 
 func TestIndexing(t *testing.T) {
-	schema.ParseBytes([]byte("name:string @index ."), 1)
+	schema.ParseBytes([]byte("name:string @index(term) ."), 1)
 	a, err := IndexTokens("name", "", types.Val{types.StringID, []byte("abc")})
 	require.NoError(t, err)
 	require.EqualValues(t, "\x01abc", string(a[0]))
@@ -126,13 +126,14 @@ func addMutationWithIndex(t *testing.T, l *List, edge *protos.DirectedEdge, op u
 }
 
 const schemaVal = `
-name:string @index .
-dob:dateTime @index .
+name:string @index(term) .
+dob:dateTime @index(year) .
 friend:uid @reverse .
 	`
 
 func TestTokensTable(t *testing.T) {
-	schema.ParseBytes([]byte(schemaVal), 1)
+	err := schema.ParseBytes([]byte(schemaVal), 1)
+	require.NoError(t, err)
 
 	key := x.DataKey("name", 1)
 	l := getNew(key, ps)
@@ -145,7 +146,7 @@ func TestTokensTable(t *testing.T) {
 		Entity: 157,
 	}
 	addMutationWithIndex(t, l, edge, Set)
-	_, err := l.SyncIfDirty(false)
+	_, err = l.SyncIfDirty(false)
 	x.Check(err)
 
 	key = x.IndexKey("name", "david")

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -6658,9 +6658,9 @@ func TestSchemaBlock5(t *testing.T) {
 const schemaStr = `
 name                           : string @index(term, exact, trigram) @count .
 alias                          : string @index(exact, term, fulltext) .
-dob                            : dateTime @index .
+dob                            : dateTime @index(year) .
 dob_day                        : dateTime @index(day) .
-film.film.initial_release_date : dateTime @index .
+film.film.initial_release_date : dateTime @index(year) .
 loc                            : geo @index .
 genre                          : uid @reverse .
 survival_rate                  : float .

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -6661,14 +6661,14 @@ alias                          : string @index(exact, term, fulltext) .
 dob                            : dateTime @index(year) .
 dob_day                        : dateTime @index(day) .
 film.film.initial_release_date : dateTime @index(year) .
-loc                            : geo @index .
+loc                            : geo @index(geo) .
 genre                          : uid @reverse .
 survival_rate                  : float .
-alive                          : bool @index .
-age                            : int @index .
+alive                          : bool @index(bool) .
+age                            : int @index(int) .
 shadow_deep                    : int .
 friend                         : uid @reverse @count .
-geometry                       : geo @index .
+geometry                       : geo @index(geo) .
 value                          : string @index(trigram) .
 full_name                      : string @index(hash) .
 noindex_name                   : string .

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -155,7 +155,7 @@ func parseIndexDirective(it *lex.ItemIterator, predicate string,
 	}
 	if !it.Next() {
 		// Nothing to read.
-		return []string{tok.Default(typ).Name()}, nil
+		return []string{}, x.Errorf("Invalid ending.")
 	}
 	next := it.Item()
 	if next.Typ != itemLeftRound {
@@ -235,7 +235,12 @@ func resolveTokenizers(updates []*protos.SchemaUpdate) error {
 		}
 
 		if len(schema.Tokenizer) == 0 && schema.Directive == protos.SchemaUpdate_INDEX {
-			schema.Tokenizer = []string{tok.Default(typ).Name()}
+			def := tok.Default(typ)
+			if def == nil {
+				return x.Errorf("Require type of tokenizer for pred: %s of type: %s for indexing.",
+					schema.Predicate, typ.Name())
+			}
+			schema.Tokenizer = []string{def.Name()}
 		} else if len(schema.Tokenizer) > 0 && schema.Directive != protos.SchemaUpdate_INDEX {
 			return x.Errorf("Tokenizers present without indexing on attr %s", schema.Predicate)
 		}

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -160,7 +160,14 @@ func parseIndexDirective(it *lex.ItemIterator, predicate string,
 	next := it.Item()
 	if next.Typ != itemLeftRound {
 		it.Prev() // Backup.
-		return []string{tok.Default(typ).Name()}, nil
+		def := tok.Default(typ)
+		// For string, datatime we don't have default tokenizer so user should specify one.
+		if def == nil {
+			return []string{},
+				x.Errorf("Require type of tokenizer for pred: %s of type: %s for indexing.",
+					predicate, typ.Name())
+		}
+		return []string{def.Name()}, nil
 	}
 
 	expectArg := true

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -160,14 +160,8 @@ func parseIndexDirective(it *lex.ItemIterator, predicate string,
 	next := it.Item()
 	if next.Typ != itemLeftRound {
 		it.Prev() // Backup.
-		def := tok.Default(typ)
-		// For string, datatime we don't have default tokenizer so user should specify one.
-		if def == nil {
-			return []string{},
-				x.Errorf("Require type of tokenizer for pred: %s of type: %s for indexing.",
-					predicate, typ.Name())
-		}
-		return []string{def.Name()}, nil
+		return []string{}, x.Errorf("Require type of tokenizer for pred: %s for indexing.",
+			predicate)
 	}
 
 	expectArg := true
@@ -235,12 +229,8 @@ func resolveTokenizers(updates []*protos.SchemaUpdate) error {
 		}
 
 		if len(schema.Tokenizer) == 0 && schema.Directive == protos.SchemaUpdate_INDEX {
-			def := tok.Default(typ)
-			if def == nil {
-				return x.Errorf("Require type of tokenizer for pred: %s of type: %s for indexing.",
-					schema.Predicate, typ.Name())
-			}
-			schema.Tokenizer = []string{def.Name()}
+			return x.Errorf("Require type of tokenizer for pred: %s of type: %s for indexing.",
+				schema.Predicate, typ.Name())
 		} else if len(schema.Tokenizer) > 0 && schema.Directive != protos.SchemaUpdate_INDEX {
 			return x.Errorf("Tokenizers present without indexing on attr %s", schema.Predicate)
 		}

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -109,7 +109,7 @@ var schemaIndexVal1 = `
 age:int @index .
 
 name: string .
-address: string @index .`
+address: string @index(term) .`
 
 func TestSchemaIndex(t *testing.T) {
 	require.NoError(t, ParseBytes([]byte(schemaIndexVal1), 1))
@@ -248,6 +248,20 @@ func TestParse6_Error(t *testing.T) {
 	require.Nil(t, schemas)
 }
 
+func TestParse7_Error(t *testing.T) {
+	reset()
+	schemas, err := Parse("name:string @index .")
+	require.Error(t, err)
+	require.Nil(t, schemas)
+}
+
+func TestParse8_Error(t *testing.T) {
+	reset()
+	schemas, err := Parse("dob:dateTime @index .")
+	require.Error(t, err)
+	require.Nil(t, schemas)
+}
+
 var ps *badger.KV
 
 func TestMain(m *testing.M) {
@@ -271,6 +285,6 @@ func TestMain(m *testing.M) {
 
 func TestParseUnderscore(t *testing.T) {
 	reset()
-	_, err := Parse("_share_:string @index .")
+	_, err := Parse("_share_:string @index(term) .")
 	require.NoError(t, err)
 }

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -106,7 +106,7 @@ func TestSchema3_Error(t *testing.T) {
 }
 
 var schemaIndexVal1 = `
-age:int @index .
+age:int @index(int) .
 
 name: string .
 address: string @index(term) .`

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -62,7 +62,7 @@ func init() {
 	RegisterTokenizer(GeoTokenizer{})
 	RegisterTokenizer(IntTokenizer{})
 	RegisterTokenizer(FloatTokenizer{})
-	RegisterTokenizer(DateTimeTokenizer{})
+	RegisterTokenizer(YearTokenizer{})
 	RegisterTokenizer(HourTokenizer{})
 	RegisterTokenizer(MonthTokenizer{})
 	RegisterTokenizer(DayTokenizer{})
@@ -74,8 +74,6 @@ func init() {
 	SetDefault(types.GeoID, "geo")
 	SetDefault(types.IntID, "int")
 	SetDefault(types.FloatID, "float")
-	SetDefault(types.DateTimeID, "datetime")
-	SetDefault(types.StringID, "term")
 	SetDefault(types.BoolID, "bool")
 
 	// Check for duplicate prefix bytes.
@@ -99,9 +97,7 @@ func GetTokenizer(name string) (Tokenizer, bool) {
 
 // Default returns the default tokenizer for a given type.
 func Default(typ types.TypeID) Tokenizer {
-	t, found := defaults[typ]
-	x.AssertTruef(found, "No default tokenizer set for type %v", typ)
-	return t
+	return defaults[typ]
 }
 
 // SetDefault sets the default tokenizer for given typeID.
@@ -160,19 +156,19 @@ func (t FloatTokenizer) Identifier() byte { return 0x7 }
 func (t FloatTokenizer) IsSortable() bool { return true }
 func (t FloatTokenizer) IsLossy() bool    { return true }
 
-type DateTimeTokenizer struct{}
+type YearTokenizer struct{}
 
-func (t DateTimeTokenizer) Name() string       { return "datetime" }
-func (t DateTimeTokenizer) Type() types.TypeID { return types.DateTimeID }
-func (t DateTimeTokenizer) Tokens(sv types.Val) ([]string, error) {
+func (t YearTokenizer) Name() string       { return "year" }
+func (t YearTokenizer) Type() types.TypeID { return types.DateTimeID }
+func (t YearTokenizer) Tokens(sv types.Val) ([]string, error) {
 	tval := sv.Value.(time.Time)
 	buf := make([]byte, 2)
 	binary.BigEndian.PutUint16(buf[0:2], uint16(tval.Year()))
 	return []string{encodeToken(string(buf), t.Identifier())}, nil
 }
-func (t DateTimeTokenizer) Identifier() byte { return 0x4 }
-func (t DateTimeTokenizer) IsSortable() bool { return true }
-func (t DateTimeTokenizer) IsLossy() bool    { return true }
+func (t YearTokenizer) Identifier() byte { return 0x4 }
+func (t YearTokenizer) IsSortable() bool { return true }
+func (t YearTokenizer) IsLossy() bool    { return true }
 
 type MonthTokenizer struct{}
 

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -71,10 +71,6 @@ func init() {
 	RegisterTokenizer(BoolTokenizer{})
 	RegisterTokenizer(TrigramTokenizer{})
 	RegisterTokenizer(HashTokenizer{})
-	SetDefault(types.GeoID, "geo")
-	SetDefault(types.IntID, "int")
-	SetDefault(types.FloatID, "float")
-	SetDefault(types.BoolID, "bool")
 
 	// Check for duplicate prefix bytes.
 	usedIds := make(map[byte]struct{})
@@ -93,21 +89,6 @@ func init() {
 func GetTokenizer(name string) (Tokenizer, bool) {
 	t, found := tokenizers[name]
 	return t, found
-}
-
-// Default returns the default tokenizer for a given type.
-func Default(typ types.TypeID) Tokenizer {
-	return defaults[typ]
-}
-
-// SetDefault sets the default tokenizer for given typeID.
-func SetDefault(typ types.TypeID, name string) {
-	if defaults == nil {
-		defaults = make(map[types.TypeID]Tokenizer)
-	}
-	t, has := GetTokenizer(name)
-	x.AssertTruef(has && t.Type() == typ, "Type mismatch %v vs %v", t.Type(), typ)
-	defaults[typ] = t
 }
 
 // RegisterTokenizer adds your tokenizer to our list.

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -124,7 +124,7 @@ func TestMonthTokenizer(t *testing.T) {
 
 func TestDateTimeTokenizer(t *testing.T) {
 	var err error
-	tokenizer, has := GetTokenizer("datetime")
+	tokenizer, has := GetTokenizer("year")
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 	val := types.ValueForType(types.DateTimeID)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -153,7 +153,7 @@ func newQuery(attr string, uids []uint64, srcFunc []string) *protos.Query {
 // at the end. In other words, everything is happening only in mutation layers,
 // and not committed to RocksDB until near the end.
 func TestProcessTaskIndexMLayer(t *testing.T) {
-	dir, ps := initTest(t, `friend:string @index .`)
+	dir, ps := initTest(t, `friend:string @index(term) .`)
 	defer os.RemoveAll(dir)
 	defer ps.Close()
 
@@ -233,7 +233,7 @@ func TestProcessTaskIndexMLayer(t *testing.T) {
 // Index-related test. Similar to TestProcessTaskIndeMLayer except we call
 // MergeLists in between a lot of updates.
 func TestProcessTaskIndex(t *testing.T) {
-	dir, ps := initTest(t, `friend:string @index .`)
+	dir, ps := initTest(t, `friend:string @index(term) .`)
 	defer os.RemoveAll(dir)
 	defer ps.Close()
 


### PR DESCRIPTION
1. Remove default tokenizer for all types. Return an error to user if he doesn't specify what tokenizer to use.
2. Rename `DateTime` tokenizer to `Year` tokenizer.

Fixes #1265 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1274)
<!-- Reviewable:end -->
