### PR TITLE
Get rid of sync.Pool in posting package.

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -118,13 +118,12 @@ func addIndexMutation(ctx context.Context, edge *protos.DirectedEdge,
 	}
 
 	t := time.Now()
-	plist, decr := GetOrCreate(key, groupId)
+	plist := GetOrCreate(key, groupId)
 	if dur := time.Since(t); dur > time.Millisecond {
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("GetOrCreate took %v", dur)
 		}
 	}
-	defer decr()
 
 	x.AssertTrue(plist != nil)
 	_, err := plist.AddMutation(ctx, edge)
@@ -154,8 +153,7 @@ func addReverseMutation(ctx context.Context, t *protos.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
 	groupId := group.BelongsTo(t.Attr)
 
-	plist, decr := GetOrCreate(key, groupId)
-	defer decr()
+	plist := GetOrCreate(key, groupId)
 
 	x.AssertTrue(plist != nil)
 	edge := &protos.DirectedEdge{
@@ -243,8 +241,7 @@ func addCountMutation(ctx context.Context, t *protos.DirectedEdge, count uint32,
 	key := x.CountKey(t.Attr, count, reverse)
 	groupId := group.BelongsTo(t.Attr)
 
-	plist, decr := GetOrCreate(key, groupId)
-	defer decr()
+	plist := GetOrCreate(key, groupId)
 
 	x.AssertTruef(plist != nil, "plist is nil [%s] %d",
 		t.Attr, t.ValueId)

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -199,7 +199,7 @@ func addEdgeToValue(t *testing.T, attr string, src uint64,
 		Entity: src,
 		Op:     protos.DirectedEdge_SET,
 	}
-	l, _ := GetOrCreate(x.DataKey(attr, src), 1)
+	l := GetOrCreate(x.DataKey(attr, src), 1)
 	// No index entries added here as we do not call AddMutationWithIndex.
 	ok, err := l.AddMutation(context.Background(), edge)
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 		Entity:  src,
 		Op:      protos.DirectedEdge_SET,
 	}
-	l, _ := GetOrCreate(x.DataKey(attr, src), 1)
+	l := GetOrCreate(x.DataKey(attr, src), 1)
 	// No index entries added here as we do not call AddMutationWithIndex.
 	ok, err := l.AddMutation(context.Background(), edge)
 	require.NoError(t, err)
@@ -286,10 +286,10 @@ func TestRebuildIndex(t *testing.T) {
 	require.EqualValues(t, 20, uids1[0])
 	require.EqualValues(t, 1, uids2[0])
 
-	l1, _ := GetOrCreate(x.DataKey("name", 1), 1)
+	l1 := GetOrCreate(x.DataKey("name", 1), 1)
 	deletePl(t)
 	ps.Delete(l1.key)
-	l2, _ := GetOrCreate(x.DataKey("name", 20), 1)
+	l2 := GetOrCreate(x.DataKey("name", 20), 1)
 	deletePl(t)
 	ps.Delete(l2.key)
 }

--- a/posting/list.go
+++ b/posting/list.go
@@ -677,7 +677,6 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 	if l.plist != emptyList {
 		l.plist.Uids = l.plist.Uids[:0]
 		l.plist.Postings = l.plist.Postings[:0]
-		//		postingListPool.Put(l.plist)
 	}
 
 	var data []byte

--- a/posting/list.go
+++ b/posting/list.go
@@ -26,7 +26,6 @@ import (
 	"log"
 	"math"
 	"sort"
-	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
@@ -96,14 +95,9 @@ func (l *List) decr() {
 	}
 
 	if l.plist != emptyList {
-		for _, p := range l.plist.Postings {
-			postingPool.Put(p)
-		}
 		l.plist.Postings = l.plist.Postings[:0]
 		l.plist.Uids = l.plist.Uids[:0]
-		//	postingListPool.Put(l.plist)
 	}
-	listPool.Put(l)
 }
 
 // calculateSize would give you the size estimate. Does not consider elements in mutation layer.
@@ -115,24 +109,6 @@ func (l *List) calculateSize() uint32 {
 	sz += cap(l.mlayer) * 8
 	sz += cap(l.pending) * 8
 	return uint32(sz)
-}
-
-var postingPool = sync.Pool{
-	New: func() interface{} {
-		return &protos.Posting{}
-	},
-}
-
-//var postingListPool = sync.Pool{
-//	New: func() interface{} {
-//		return &protos.PostingList{}
-//	},
-//}
-
-var listPool = sync.Pool{
-	New: func() interface{} {
-		return &List{}
-	},
 }
 
 type PIterator struct {
@@ -198,8 +174,7 @@ func (it *PIterator) Posting() *protos.Posting {
 }
 
 func getNew(key []byte, pstore *badger.KV) *List {
-	l := listPool.Get().(*List)
-	*l = List{}
+	l := new(List)
 	l.key = key
 	l.refcount = 1
 
@@ -297,8 +272,7 @@ func newPosting(t *protos.DirectedEdge) *protos.Posting {
 		postingType = protos.Posting_VALUE
 	}
 
-	p := postingPool.Get().(*protos.Posting)
-	*p = protos.Posting{}
+	p := new(protos.Posting)
 	p.Uid = t.ValueId
 	p.Value = t.Value
 	p.ValType = protos.Posting_ValType(t.ValueType)
@@ -539,12 +513,8 @@ func (l *List) addMutation(ctx context.Context, t *protos.DirectedEdge) (bool, e
 func (l *List) delete(ctx context.Context, attr string) error {
 	l.AssertLock()
 	if l.plist != emptyList {
-		for _, p := range l.plist.Postings {
-			postingPool.Put(p)
-		}
 		l.plist.Uids = l.plist.Uids[:0]
 		l.plist.Postings = l.plist.Postings[:0]
-		//	postingListPool.Put(l.plist)
 	}
 	l.plist = emptyList
 	l.mlayer = l.mlayer[:0] // Clear the mutation layer.

--- a/posting/list.go
+++ b/posting/list.go
@@ -101,7 +101,7 @@ func (l *List) decr() {
 		}
 		l.plist.Postings = l.plist.Postings[:0]
 		l.plist.Uids = l.plist.Uids[:0]
-		postingListPool.Put(l.plist)
+		//	postingListPool.Put(l.plist)
 	}
 	listPool.Put(l)
 }
@@ -123,11 +123,11 @@ var postingPool = sync.Pool{
 	},
 }
 
-var postingListPool = sync.Pool{
-	New: func() interface{} {
-		return &protos.PostingList{}
-	},
-}
+//var postingListPool = sync.Pool{
+//	New: func() interface{} {
+//		return &protos.PostingList{}
+//	},
+//}
 
 var listPool = sync.Pool{
 	New: func() interface{} {
@@ -220,7 +220,7 @@ func getNew(key []byte, pstore *badger.KV) *List {
 	val := item.Value()
 	x.BytesRead.Add(int64(len(val)))
 
-	l.plist = postingListPool.Get().(*protos.PostingList)
+	l.plist = new(protos.PostingList)
 	if item.UserMeta() == bitUidPostings {
 		l.plist.Uids = val
 	} else if val != nil {
@@ -544,7 +544,7 @@ func (l *List) delete(ctx context.Context, attr string) error {
 		}
 		l.plist.Uids = l.plist.Uids[:0]
 		l.plist.Postings = l.plist.Postings[:0]
-		postingListPool.Put(l.plist)
+		//	postingListPool.Put(l.plist)
 	}
 	l.plist = emptyList
 	l.mlayer = l.mlayer[:0] // Clear the mutation layer.
@@ -693,7 +693,7 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 		return false, nil
 	}
 
-	final := postingListPool.Get().(*protos.PostingList)
+	final := new(protos.PostingList)
 	numUids := l.length(0)
 	if cap(final.Uids) < 8*numUids {
 		final.Uids = make([]byte, 8*numUids)
@@ -728,7 +728,7 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 	if l.plist != emptyList {
 		l.plist.Uids = l.plist.Uids[:0]
 		l.plist.Postings = l.plist.Postings[:0]
-		postingListPool.Put(l.plist)
+		//		postingListPool.Put(l.plist)
 	}
 
 	var data []byte

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -77,8 +77,7 @@ func deletePl(t *testing.T) {
 func TestAddMutation(t *testing.T) {
 	key := x.DataKey("name", 1)
 
-	l, decr := GetOrCreate(key, 1)
-	defer decr()
+	l := GetOrCreate(key, 1)
 
 	edge := &protos.DirectedEdge{
 		ValueId: 9,
@@ -123,8 +122,7 @@ func TestAddMutation(t *testing.T) {
 	require.EqualValues(t, "anti-testing", p.Label)
 
 	// Try reading the same data in another PostingList.
-	dl, decr := GetOrCreate(key, 1)
-	defer decr()
+	dl := GetOrCreate(key, 1)
 	checkUids(t, dl, uids)
 	deletePl(t)
 	ps.Delete(dl.key)
@@ -170,7 +168,7 @@ func TestAddMutation_Value(t *testing.T) {
 
 func TestAddMutation_jchiu1(t *testing.T) {
 	key := x.DataKey("value", 10)
-	ol, _ := GetOrCreate(key, 1)
+	ol := GetOrCreate(key, 1)
 
 	// Set value to cars and merge to RocksDB.
 	edge := &protos.DirectedEdge{
@@ -218,7 +216,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 
 func TestAddMutation_jchiu2(t *testing.T) {
 	key := x.DataKey("value", 10)
-	ol, _ := GetOrCreate(key, 1)
+	ol := GetOrCreate(key, 1)
 
 	// Del a value cars and but don't merge.
 	edge := &protos.DirectedEdge{
@@ -249,7 +247,7 @@ func TestAddMutation_jchiu2(t *testing.T) {
 
 func TestAddMutation_jchiu3(t *testing.T) {
 	key := x.DataKey("value", 10)
-	ol, _ := GetOrCreate(key, 1)
+	ol := GetOrCreate(key, 1)
 
 	// Set value to cars and merge to RocksDB.
 	edge := &protos.DirectedEdge{
@@ -304,7 +302,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 
 func TestAddMutation_mrjn1(t *testing.T) {
 	key := x.DataKey("value", 10)
-	ol, _ := GetOrCreate(key, 1)
+	ol := GetOrCreate(key, 1)
 
 	// Set a value cars and merge.
 	edge := &protos.DirectedEdge{
@@ -367,7 +365,7 @@ func TestAddMutation_checksum(t *testing.T) {
 
 	{
 		key := x.DataKey("value", 10)
-		ol, _ := GetOrCreate(key, 1)
+		ol := GetOrCreate(key, 1)
 
 		edge := &protos.DirectedEdge{
 			ValueId: 1,
@@ -393,7 +391,7 @@ func TestAddMutation_checksum(t *testing.T) {
 
 	{
 		key := x.DataKey("value2", 10)
-		ol, _ := GetOrCreate(key, 1)
+		ol := GetOrCreate(key, 1)
 
 		// Add in reverse.
 		edge := &protos.DirectedEdge{
@@ -421,7 +419,7 @@ func TestAddMutation_checksum(t *testing.T) {
 
 	{
 		key := x.DataKey("value3", 10)
-		ol, _ := GetOrCreate(key, 1)
+		ol := GetOrCreate(key, 1)
 
 		// Add in reverse.
 		edge := &protos.DirectedEdge{

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -21,7 +21,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"math"
 	"os"
 	"os/exec"
@@ -190,7 +189,7 @@ func getMemUsage() int {
 
 	contents, err := ioutil.ReadFile("/proc/self/stat")
 	if err != nil {
-		log.Println("Can't read the proc file", err)
+		x.Println("Can't read the proc file", err)
 		return 0
 	}
 
@@ -198,13 +197,13 @@ func getMemUsage() int {
 	// 24th entry of the file is the RSS which denotes the number of pages
 	// used by the process.
 	if len(cont) < 24 {
-		log.Println("Error in RSS from stat")
+		x.Println("Error in RSS from stat")
 		return 0
 	}
 
 	rss, err := strconv.Atoi(cont[23])
 	if err != nil {
-		log.Println(err)
+		x.Println(err)
 		return 0
 	}
 

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -394,9 +394,6 @@ func EvictGroup(group uint32) {
 	// lcache.Each(func(k uint64, l *List) {
 	// 	l.SetForDeletion()
 	// })
-	CommitLists(1, group)
 	// TODO: Do we need to do this?
-	// lhmapFor(group).EachWithDelete(func(k uint64, l *List) {
-	// 	l.decr()
-	// })
+	CommitLists(1, group)
 }

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -85,7 +85,6 @@ func (c *listCache) PutIfMissing(key string, pl *List) (res *List) {
 	if ee, ok := c.cache[key]; ok {
 		c.ll.MoveToFront(ee)
 		res = ee.Value.(*entry).pl
-		res.incr()
 		return res
 	}
 
@@ -102,7 +101,6 @@ func (c *listCache) PutIfMissing(key string, pl *List) (res *List) {
 	c.cache[key] = ele
 	c.removeOldest()
 
-	e.pl.incr()
 	return e.pl
 }
 
@@ -124,7 +122,6 @@ func (c *listCache) removeOldest() {
 		// key wont be deleted from cache. So lets delete it now if SyncIfDirty returns false.
 		if committed, _ := e.pl.SyncIfDirty(true); !committed {
 			delete(c.cache, e.key)
-			e.pl.decr()
 		}
 	}
 }
@@ -140,7 +137,6 @@ func (c *listCache) Get(key string) (pl *List) {
 		est := uint64(e.pl.EstimatedSize())
 		c.curSize += est - e.size
 		e.size = est
-		e.pl.incr()
 		return e.pl
 	}
 	return nil
@@ -192,7 +188,6 @@ func (c *listCache) clear(attr string, typ byte) error {
 		kv.pl.SetForDeletion()
 		if committed, _ := kv.pl.SyncIfDirty(true); !committed {
 			delete(c.cache, k)
-			kv.pl.decr()
 		}
 	}
 	return nil
@@ -206,7 +201,5 @@ func (c *listCache) delete(key []byte) {
 	if ele, ok := c.cache[string(key)]; ok {
 		c.ll.Remove(ele)
 		delete(c.cache, string(key))
-		kv := ele.Value.(*entry)
-		kv.pl.decr()
 	}
 }

--- a/posting/lru_test.go
+++ b/posting/lru_test.go
@@ -30,7 +30,6 @@ func getPosting() *List {
 		plist: &protos.PostingList{},
 		water: marks.Get(1),
 	}
-	l.incr()
 	return l
 }
 

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -55,7 +55,7 @@ func taskValues(t *testing.T, v []*protos.TaskValue) []string {
 }
 
 func addEdge(t *testing.T, attr string, src uint64, edge *protos.DirectedEdge) {
-	l, _ := posting.GetOrCreate(x.DataKey(attr, src), 1)
+	l := posting.GetOrCreate(x.DataKey(attr, src), 1)
 	require.NoError(t,
 		l.AddMutationWithIndex(context.Background(), edge))
 }

--- a/worker/lease.go
+++ b/worker/lease.go
@@ -60,8 +60,7 @@ func (l *leaseManager) resetLease(group uint32) {
 	}
 	l.Lock()
 	defer l.Unlock()
-	plist, decr := posting.GetOrCreate(leaseKey, leaseGid)
-	defer decr()
+	plist := posting.GetOrCreate(leaseKey, leaseGid)
 	val, err := plist.Value()
 	if err == posting.ErrNoValue {
 		// starts from two, 1 is used for storing lease data

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -72,7 +72,7 @@ func runMutations(ctx context.Context, edges []*protos.DirectedEdge) error {
 		key := x.DataKey(edge.Attr, edge.Entity)
 
 		t := time.Now()
-		plist, decr := posting.GetOrCreate(key, gid)
+		plist := posting.GetOrCreate(key, gid)
 		if dur := time.Since(t); dur > time.Millisecond {
 			if tr, ok := trace.FromContext(ctx); ok {
 				tr.LazyPrintf("GetOrCreate took %v", dur)
@@ -80,10 +80,8 @@ func runMutations(ctx context.Context, edges []*protos.DirectedEdge) error {
 		}
 
 		if err = plist.AddMutationWithIndex(ctx, edge); err != nil {
-			decr()
 			return err // abort applying the rest of them.
 		}
-		decr()
 	}
 	return nil
 }

--- a/worker/predicate_test.go
+++ b/worker/predicate_test.go
@@ -45,7 +45,7 @@ func checkShard(ps *badger.KV) (int, []byte) {
 func writePLs(t *testing.T, pred string, count int, vid uint64, ps *badger.KV) {
 	for i := 0; i < count; i++ {
 		k := x.DataKey(pred, uint64(i))
-		list, _ := posting.GetOrCreate(k, 0)
+		list := posting.GetOrCreate(k, 0)
 
 		de := &protos.DirectedEdge{
 			ValueId: vid,

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -333,8 +333,7 @@ func intersectBucket(ctx context.Context, ts *protos.SortMessage, token string,
 
 	key := x.IndexKey(attr, token)
 	// Don't put the Index keys in memory.
-	pl, decr := posting.Get(key)
-	defer decr()
+	pl := posting.Get(key)
 
 	// For each UID list, we need to intersect with the index bucket.
 	for i, ul := range ts.UidMatrix {
@@ -436,8 +435,7 @@ func sortByValue(ctx context.Context, ts *protos.SortMessage, ul *protos.List,
 // fetchValue gets the value for a given UID.
 func fetchValue(uid uint64, attr string, langs []string, scalar types.TypeID) (types.Val, error) {
 	// Don't put the values in memory
-	pl, decr := posting.Get(x.DataKey(attr, uid))
-	defer decr()
+	pl := posting.Get(x.DataKey(attr, uid))
 
 	src, err := pl.ValueFor(langs)
 	if err != nil {

--- a/worker/task.go
+++ b/worker/task.go
@@ -293,7 +293,7 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 	for i := 0; i < srcFn.n; i++ {
 		select {
 		case <-ctx.Done():
-			return out, ctx.Err()
+			return nil, ctx.Err()
 		default:
 		}
 		var key []byte
@@ -325,7 +325,7 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 		isValueEdge := err == nil
 		typ := val.Tid
 		if val.Tid == types.PasswordID && srcFn.fnType != PasswordFn {
-			return out, x.Errorf("Attribute `%s` of type password cannot be fetched", attr)
+			return nil, x.Errorf("Attribute `%s` of type password cannot be fetched", attr)
 		}
 		newValue := &protos.TaskValue{ValType: int32(val.Tid), Val: x.Nilbyte}
 		if isValueEdge {
@@ -345,7 +345,7 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 		if srcFn.fnType == CompareAttrFn && isValueEdge {
 			// Lets convert the val to its type.
 			if val, err = types.Convert(val, typ); err != nil {
-				return out, err
+				return nil, err
 			}
 			if types.CompareVals(srcFn.fname, val, srcFn.ineqValue) {
 				filteredRes = append(filteredRes, &result{
@@ -373,11 +373,11 @@ func processTask(ctx context.Context, q *protos.Query, gid uint32) (*protos.Resu
 				return true // continue iteration.
 			})
 			if perr != nil {
-				return out, perr
+				return nil, perr
 			}
 		} else if q.FacetsFilter != nil { // else part means isValueEdge
 			// This is Value edge and we are asked to do facet filtering. Not supported.
-			return out, x.Errorf("Facet filtering is not supported on values.")
+			return nil, x.Errorf("Facet filtering is not supported on values.")
 		}
 
 		// add facets to result.

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -43,8 +43,7 @@ func uidsForRegex(attr string, gid uint32,
 
 	uidsForTrigram := func(trigram string) *protos.List {
 		key := x.IndexKey(attr, trigram)
-		pl, decr := posting.GetOrCreate(key, gid)
-		defer decr()
+		pl := posting.GetOrCreate(key, gid)
 		return pl.Uids(opts)
 	}
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -52,7 +52,7 @@ func delEdge(t *testing.T, edge *protos.DirectedEdge, l *posting.List) {
 }
 
 func getOrCreate(key []byte) *posting.List {
-	l, _ := posting.GetOrCreate(key, 1)
+	l := posting.GetOrCreate(key, 1)
 	return l
 }
 

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -47,6 +47,7 @@ var (
 	MemoryInUse      *expvar.Int
 	HeapIdle         *expvar.Int
 	TotalMemory      *expvar.Int
+	TotalOSMemory    *expvar.Int
 	ActiveMutations  *expvar.Int
 	ServerHealth     *expvar.Int
 	MaxPlLength      *expvar.Int
@@ -76,6 +77,7 @@ func init() {
 	MemoryInUse = expvar.NewInt("memoryInUse")
 	HeapIdle = expvar.NewInt("heapIdle")
 	TotalMemory = expvar.NewInt("totalMemory")
+	TotalOSMemory = expvar.NewInt("totalOSMemory")
 	ActiveMutations = expvar.NewInt("activeMutations")
 	PredicateStats = expvar.NewMap("predicateStats")
 	CacheHit = expvar.NewInt("cacheHit")
@@ -203,6 +205,11 @@ func init() {
 		"totalMemory": prometheus.NewDesc(
 			"totalMemory",
 			"totalMemory",
+			nil, nil,
+		),
+		"totalOSMemory": prometheus.NewDesc(
+			"totalOSMemory",
+			"totalOSMemory",
 			nil, nil,
 		),
 		"activeMutations": prometheus.NewDesc(


### PR DESCRIPTION
1. Removed all `sync.Pool`. Also as a consequence get rid of reference counting. This makes sure that memory usage doesn't blow up.
2. Add function to get total OS memory and expose it as a metric.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1288)
<!-- Reviewable:end -->
