### PR TITLE
Add fix for panic

### DIFF
--- a/cmd/dgraph/dashboard.go
+++ b/cmd/dgraph/dashboard.go
@@ -92,6 +92,7 @@ func keywordHandler(w http.ResponseWriter, r *http.Request) {
 		"set",
 		"term",
 		"tokenizer",
+		"uid",
 		"within",
 	}
 

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1410,6 +1410,10 @@ L:
 						g.NeedsVar = append(g.NeedsVar, f.NeedsVar...)
 						g.NeedsVar[0].Typ = VALUE_VAR
 					} else {
+						if f.Name != "count" {
+							return nil,
+								x.Errorf("Only val/count allowed as function within another. Got: %s", f.Name)
+						}
 						g.Attr = f.Attr
 						g.Args = append(g.Args, f.Name)
 					}
@@ -1496,8 +1500,7 @@ L:
 					continue
 				}
 
-				// Unlike other functions, uid function has no attribute,
-				// everything is args.
+				// Unlike other functions, uid function has no attribute, everything is args.
 				if len(g.Attr) == 0 && g.Name != "uid" {
 					if strings.ContainsRune(itemInFunc.Val, '"') {
 						return nil, x.Errorf("Attribute in function must not be quoted with \": %s",

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3821,3 +3821,15 @@ func TestFilterVarErr(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
 }
+
+func TestEqUidFunctionErr(t *testing.T) {
+	query := `
+		{
+			me(func: eq(path_id, uid(x))) {
+				name
+			}
+		}
+	`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.Error(t, err)
+}

--- a/query/query.go
+++ b/query/query.go
@@ -1604,6 +1604,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			return
 		}
 
+		x.AssertTruef(sg.SrcUIDs != nil, "SrcUIDs shouldn't be nil.")
 		// If we have a filter SubGraph which only contains an operator,
 		// it won't have any attribute to work on.
 		// This is to allow providing SrcUIDs to the filter children.

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1594,7 +1594,7 @@ func TestVarInIneq2(t *testing.T) {
 	populateGraph(t)
 	query := `
     {
-			var(func: uid( 1)) {
+			var(func: uid(1)) {
 				friend {
 					a as age
 				}
@@ -8558,4 +8558,18 @@ func TestCascadeUid(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"_uid_":"0x17","friend":[{"age":38,"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"name":"Rick Grimes"},{"_uid_":"0x19","friend":[{"age":15,"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Daryl Dixon"},{"_uid_":"0x1f","friend":[{"age":15,"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`, js)
+}
+
+func TestEqUidFunctionErr(t *testing.T) {
+	query := `
+		{
+			me(func: eq(path_id, uid(x))) {
+				name
+			}
+		}
+	`
+	ctx := defaultContext()
+	ctx = context.WithValue(ctx, "debug", "true")
+	_, err := processToFastJsonReqCtx(t, query, ctx)
+	require.Error(t, err)
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -8559,17 +8559,3 @@ func TestCascadeUid(t *testing.T) {
 	js := processToFastJSON(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"_uid_":"0x17","friend":[{"age":38,"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"name":"Rick Grimes"},{"_uid_":"0x19","friend":[{"age":15,"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Daryl Dixon"},{"_uid_":"0x1f","friend":[{"age":15,"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`, js)
 }
-
-func TestEqUidFunctionErr(t *testing.T) {
-	query := `
-		{
-			me(func: eq(path_id, uid(x))) {
-				name
-			}
-		}
-	`
-	ctx := defaultContext()
-	ctx = context.WithValue(ctx, "debug", "true")
-	_, err := processToFastJsonReqCtx(t, query, ctx)
-	require.Error(t, err)
-}


### PR DESCRIPTION
Fixes #1284. 

We disallow functions other than `val` and `count` within other functions. Earlier the query below didn't result in an error but panics in ProcessGraph.
```
{
  me(func: eq(path_id, uid(0x1))) {
    ...
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1298)
<!-- Reviewable:end -->
