### PR TITLE
Fix loader interrupt

### DIFF
--- a/client/mutations.go
+++ b/client/mutations.go
@@ -57,7 +57,7 @@ type BatchMutationOptions struct {
 	Pending       int
 	PrintCounters bool
 	MaxRetries    uint32
-	// User could pass a context. We should stop retrying requests after ctx.Done()
+	// User could pass a context so that we can stop retrying requests once context is done.
 	Ctx context.Context
 }
 

--- a/client/mutations.go
+++ b/client/mutations.go
@@ -57,7 +57,7 @@ type BatchMutationOptions struct {
 	Pending       int
 	PrintCounters bool
 	MaxRetries    uint32
-	// User could pass a context so that we can stop retrying requests once context is done.
+	// User could pass a context so that we can stop retrying requests once context is done
 	Ctx context.Context
 }
 
@@ -232,7 +232,7 @@ func NewClient(clients []protos.DgraphClient, opts BatchMutationOptions, clientD
 	x.Checkf(err, "Error while creating badger KV posting store")
 	if opts.Ctx == nil {
 		// If the user doesn't give a context we supply one because we check ctx.Done().
-		opts.Ctx, _ = context.WithCancel(context.Background())
+		opts.Ctx = context.TODO()
 	}
 	alloc := &allocator{
 		dc:     clients[0],
@@ -341,11 +341,10 @@ func (d *Dgraph) request(req *Req) error {
 	counter := atomic.AddUint64(&d.mutations, 1)
 	factor := time.Second
 	var retries uint32
-	ctx := d.opts.Ctx
 RETRY:
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-d.opts.Ctx.Done():
+		return d.opts.Ctx.Err()
 	default:
 	}
 	_, err := d.dc[rand.Intn(len(d.dc))].Run(context.Background(), &req.gr)

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -271,7 +271,6 @@ func main() {
 		Size:          *numRdf,
 		Pending:       *concurrent,
 		PrintCounters: true,
-		Ctx:           ctx,
 	}
 	dgraphClient := client.NewDgraphClient(conns, bmOpts, *clientDir)
 	defer dgraphClient.Close()

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -325,11 +325,12 @@ func main() {
 	}
 
 	{
-		err := dgraphClient.BatchFlush()
-		if err == context.Canceled {
-			interrupted = true
-		} else {
-			log.Fatalf("While doing BatchFlush: %+v\n", err)
+		if err := dgraphClient.BatchFlush(); err != nil {
+			if err == context.Canceled {
+				interrupted = true
+			} else {
+				log.Fatalf("While doing BatchFlush: %+v\n", err)
+			}
 		}
 	}
 

--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -103,22 +103,22 @@ func processSchemaFile(ctx context.Context, file string, dgraphClient *client.Dg
 	return dgraphClient.SetSchemaBlocking(ctx, string(b))
 }
 
-func Node(val string, c *client.Dgraph) string {
+func Node(val string, c *client.Dgraph) (string, error) {
 	if uid, err := strconv.ParseUint(val, 0, 64); err == nil {
-		return c.NodeUid(uid).String()
+		return c.NodeUid(uid).String(), nil
 	}
 	if strings.HasPrefix(val, "_:") {
 		n, err := c.NodeBlank(val[2:])
 		if err != nil {
-			log.Fatal("Error while converting to node: %v", err)
+			return "", err
 		}
-		return n.String()
+		return n.String(), nil
 	}
 	n, err := c.NodeXid(val, *storeXid)
 	if err != nil {
-		log.Fatal("Error while converting to node: %v", err)
+		return "", err
 	}
-	return n.String()
+	return n.String(), nil
 }
 
 // processFile sends mutations for a given gz file.
@@ -169,9 +169,13 @@ func processFile(ctx context.Context, file string, dgraphClient *client.Dgraph) 
 		batchSize++
 		buf.Reset()
 
-		nq.Subject = Node(nq.Subject, dgraphClient)
+		if nq.Subject, err = Node(nq.Subject, dgraphClient); err != nil {
+			return err
+		}
 		if len(nq.ObjectId) > 0 {
-			nq.ObjectId = Node(nq.ObjectId, dgraphClient)
+			if nq.ObjectId, err = Node(nq.ObjectId, dgraphClient); err != nil {
+				return err
+			}
 		}
 		r.Set(client.NewEdge(nq))
 		if batchSize >= *numRdf {
@@ -267,6 +271,7 @@ func main() {
 		Size:          *numRdf,
 		Pending:       *concurrent,
 		PrintCounters: true,
+		Ctx:           ctx,
 	}
 	dgraphClient := client.NewDgraphClient(conns, bmOpts, *clientDir)
 	defer dgraphClient.Close()
@@ -318,7 +323,15 @@ func main() {
 			}
 		}
 	}
-	x.Check(dgraphClient.BatchFlush())
+
+	{
+		err := dgraphClient.BatchFlush()
+		if err == context.Canceled {
+			interrupted = true
+		} else {
+			log.Fatalf("While doing BatchFlush: %+v\n", err)
+		}
+	}
 
 	c := dgraphClient.Counter()
 	var rate uint64


### PR DESCRIPTION
Loader was getting stuck even on doing `Ctrl + C`. This was because we had an infinite loop in `fetchOne`. 

Now I pass the context that user gives us and check for it. We return error in case context is done so that clean shutdown can happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1299)
<!-- Reviewable:end -->
