### PR TITLE
Prefill the label regex to be 'Name'

### DIFF
--- a/dashboard/src/actions/frames.js
+++ b/dashboard/src/actions/frames.js
@@ -28,7 +28,7 @@ export function discardAllFrames() {
   };
 }
 
-// IDEA: the schema for frame object is getting complext. maybe use class optionally
+// IDEA: the schema for frame object is getting complex. maybe use class optionally
 // with flow?
 export function updateFrame({ id, type, meta, data }) {
   return {

--- a/dashboard/src/actions/index.js
+++ b/dashboard/src/actions/index.js
@@ -77,10 +77,14 @@ function executeQueryAndUpdateFrame(dispatch, { frameId, query }) {
           })
         );
       } else if (isNotEmpty(result.data)) {
+        // default regex for displaying labels for node
+        const regexStr = "Name";
+
         const { nodes, edges, labels, nodesIndex, edgesIndex } = processGraph(
           result.data,
           false,
-          query
+          query,
+          regexStr
         );
 
         dispatch(
@@ -100,6 +104,9 @@ function executeQueryAndUpdateFrame(dispatch, { frameId, query }) {
                 treeView: false,
                 data: result
               }
+            },
+            meta: {
+              regexStr
             }
           })
         );

--- a/dashboard/src/assets/css/SessionFooterProperties.scss
+++ b/dashboard/src/assets/css/SessionFooterProperties.scss
@@ -5,6 +5,7 @@
 .property-pair {
   margin-right: 12px;
   vertical-align: middle;
+  display: inline-block;
 }
 
 .properties-container {

--- a/dashboard/src/components/EntitySelector.js
+++ b/dashboard/src/components/EntitySelector.js
@@ -7,7 +7,7 @@ const EntitySelector = ({
   response,
   onInitNodeTypeConfig,
   onUpdateLabelRegex,
-  labelRegex,
+  labelRegexStr,
   onUpdateLabels
 }) => {
   return (
@@ -32,7 +32,7 @@ const EntitySelector = ({
               type="text"
               className="form-control"
               placeholder="Enter regex for labels"
-              value={labelRegex}
+              value={labelRegexStr}
               onChange={e => {
                 onUpdateLabelRegex(e.target.value);
               }}

--- a/dashboard/src/components/FrameItem.js
+++ b/dashboard/src/components/FrameItem.js
@@ -15,7 +15,7 @@ import FrameLoading from "./FrameLoading";
 // getFrameContent returns React Component for a given frame depending on its type
 function getFrameContent(frame) {
   if (frame.type === FRAME_TYPE_SESSION) {
-    return <FrameSession session={frame.data} />;
+    return <FrameSession frame={frame} />;
   } else if (frame.type === FRAME_TYPE_ERROR) {
     return <FrameError data={frame.data} />;
   } else if (frame.type === FRAME_TYPE_SUCCESS) {

--- a/dashboard/src/containers/App.js
+++ b/dashboard/src/containers/App.js
@@ -111,13 +111,13 @@ class App extends React.Component {
     _handleRunQuery(query, () => {
       const { queryExecutionCounter } = this.state;
 
-      if (queryExecutionCounter === 5) {
+      if (queryExecutionCounter === 7) {
         if (!readCookie("nps-survery-done")) {
           /* global delighted */
           delighted.survey();
           createCookie("nps-survery-done", true, 180);
         }
-      } else {
+      } else if (queryExecutionCounter < 7) {
         this.setState({ queryExecutionCounter: queryExecutionCounter + 1 });
       }
     });

--- a/dashboard/src/lib/graph.js
+++ b/dashboard/src/lib/graph.js
@@ -52,7 +52,8 @@ function findAndMerge(nodes, n) {
     return;
   }
 
-  let node = nodes[idx], props = JSON.parse(node.title);
+  let node = nodes[idx],
+    props = JSON.parse(node.title);
   _.merge(props, properties);
   node.title = JSON.stringify(props);
   // For shortest path, this would overwrite the color and this is fine
@@ -87,7 +88,8 @@ function aggregationPrefix(properties) {
 }
 
 export function shortenName(label) {
-  let words = label.split(" "), firstWord = words[0];
+  let words = label.split(" "),
+    firstWord = words[0];
   if (firstWord.length > 20) {
     label = [firstWord.substr(0, 9), firstWord.substr(9, 7) + "..."].join(
       "-\n"
@@ -321,7 +323,8 @@ export function renderNetwork({
 export function processGraph(
   response: Object,
   treeView: boolean,
-  query: string
+  query: string,
+  regexStr: string
 ) {
   let nodesQueue: Array<ResponseNode> = [],
     // Contains map of a lable to its shortform thats displayed.
@@ -445,9 +448,9 @@ export function processGraph(
     }
 
     let properties: MapOfStrings = {
-      attrs: {},
-      facets: {}
-    },
+        attrs: {},
+        facets: {}
+      },
       id: string,
       edgeAttributes = {
         facets: {}
@@ -476,7 +479,8 @@ export function processGraph(
         properties["attrs"][prop] = JSON.stringify(val);
       } else if (Array.isArray(val)) {
         // These are child nodes, lets add them to the queue.
-        let arr = val, xposition = 1;
+        let arr = val,
+          xposition = 1;
         for (let j = 0; j < arr.length; j++) {
           // X position makes sure that nodes are rendered in the order they are received
           // in the response.
@@ -510,8 +514,9 @@ export function processGraph(
     if (aggrTerm !== "") {
       displayLabel = nodeAttrs[aggrPred];
     } else {
-      //fullName = regex === "" ? "" : getNodeLabel(nodeAttrs, regexEx);
-      fullName = "";
+      fullName = regexStr
+        ? getNodeLabel(nodeAttrs, new RegExp(regexStr, "i"))
+        : "";
       displayLabel = shortenName(fullName);
     }
 
@@ -561,7 +566,8 @@ export function processGraph(
         continue;
       }
 
-      let oldEdge = edges[edgeIdx], edgeTitle = JSON.parse(oldEdge.title);
+      let oldEdge = edges[edgeIdx],
+        edgeTitle = JSON.parse(oldEdge.title);
       // This is helpful in case of shortest path results so that we can get
       // the edge weights.
       _.merge(edgeAttributes, edgeTitle);


### PR DESCRIPTION
Now stores regex for node labels in a frame (a frame is an individual window in the query timeline in the UI) with a default value of `Name`.

When a new query is run, display labels matching `/Name/i`

![dgraph_browser](https://user-images.githubusercontent.com/8265228/28902346-a0550df0-7841-11e7-9384-fc5c73985f7a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1301)
<!-- Reviewable:end -->
