### PR TITLE
Add Contains to parser tests.

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2213,7 +2213,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 			valLower := strings.ToLower(val)
 			if gq.IsGroupby && (!isAggregator(val) && val != "count" && count != seen) {
 				// Only aggregator or count allowed inside the groupby block.
-				return x.Errorf("Only aggrgator/count functions allowed inside @groupby. Got: %v", val)
+				return x.Errorf("Only aggregator/count functions allowed inside @groupby. Got: %v", val)
 			}
 			if valLower == "checkpwd" {
 				child := &GraphQuery{

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1138,7 +1138,7 @@ func parseArguments(it *lex.ItemIterator, gq *GraphQuery) (result []pair, rerr e
 			expectArg = false
 		} else if item.Typ == itemRightRound {
 			if expectArg {
-				return result, x.Errorf("Unexpected comma before ).")
+				return result, x.Errorf("Expected argument but got ')'.")
 			}
 			break
 		} else if item.Typ == itemComma {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -161,7 +161,7 @@ func TestParseQueryListPred_MultiVarError(t *testing.T) {
 func TestParseQueryWithNoVarValError(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(), orderasc: val(n) )) {
+		me(func: uid(), orderasc: val(n)) {
 			name
 		}
 
@@ -173,8 +173,8 @@ func TestParseQueryWithNoVarValError(t *testing.T) {
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
-	require.Error(t, err)
-	// TODO: What was this supposed to test?  Now dying on ':'.
+	require.NoError(t, err)
+	// TODO: What was this supposed to test?
 }
 
 func TestParseQueryAggChild(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1091,6 +1091,7 @@ func TestParseError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid operation type: me")
 }
 
 func TestParseXid(t *testing.T) {
@@ -1147,6 +1148,8 @@ func TestParseIdListError(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This one complains about "Unrecognized character in lexText: U+005D ']'" which is a
+	// weird place to fail
 }
 
 func TestParseFirst(t *testing.T) {
@@ -1176,6 +1179,8 @@ func TestParseFirst_error(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expecting argument value")
+	require.Contains(t, err.Error(), "\")\"")
 }
 
 func TestParseAfter(t *testing.T) {
@@ -1223,6 +1228,8 @@ func TestParseOffset_error(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expecting argument value")
+	require.Contains(t, err.Error(), "\")\"")
 }
 
 func TestParse_error2(t *testing.T) {
@@ -1235,6 +1242,9 @@ func TestParse_error2(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected Left round brackets") // TODO capitalization
+	require.Contains(t, err.Error(), "\"{\"")
+
 }
 
 func TestParse_pass1(t *testing.T) {
@@ -1464,6 +1474,7 @@ func TestParseSchemaAndQuery(t *testing.T) {
 
 	_, err = Parse(Request{Str: query2, Http: true})
 	require.Error(t, err)
+	// TODO: Continue adding Contains to parser tests from here
 
 }
 

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -210,7 +210,7 @@ func TestParseQueryWithXIDError(t *testing.T) {
       }
     }`
 	_, err := Parse(Request{Str: query, Http: true})
-	require.NoError(t, err)
+	require.Error(t, err)
 	// TODO: What is this testing?  "alice-in-wonderland" having "-in" is the source of error here
 }
 
@@ -1981,7 +1981,7 @@ func TestParseVariablesError2(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected value for variable $c")
-	// TODO: Continue adding code to check for the right error message from this point onward.
+	// TODO: Complains about '\"'.
 }
 
 func TestParseVariablesError3(t *testing.T) {
@@ -1993,6 +1993,7 @@ func TestParseVariablesError3(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type for variable $b")
+	// TODO: Complains about '\"'.
 }
 
 func TestParseVariablesError4(t *testing.T) {
@@ -2002,6 +2003,7 @@ func TestParseVariablesError4(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type error")
+	// TODO: Complains about '\"'.
 }
 
 func TestParseVariablesError5(t *testing.T) {
@@ -2011,15 +2013,17 @@ func TestParseVariablesError5(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected error: Query with variables should be named")
+	require.Contains(t, err.Error(), "Variables can be defined only in named queries")
 }
 
 func TestParseVariablesError6(t *testing.T) {
 	query := `{
-		"query": "query ($a: int, $b: random){root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}}",
+		"query": "query testQuery($a: int, $b: random){root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}}",
 		"variables": {"$a": "6", "$b": "5" }
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected error: Type random not supported")
+	require.Contains(t, err.Error(), "Type random not supported")
 }
 
 func TestParseVariablesError7(t *testing.T) {
@@ -2031,6 +2035,7 @@ func TestParseVariablesError7(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type for variable $d")
+	// TODO: Complains about '\"'
 }
 
 func TestParseVariablesiError8(t *testing.T) {
@@ -2039,7 +2044,8 @@ func TestParseVariablesiError8(t *testing.T) {
 		"variables": {"$b": "5" }
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
-	require.Error(t, err, "Variables type ending with ! cant have default value")
+	require.Error(t, err, "Variables type ending with ! can't have default value")
+	require.Contains(t, err.Error(), "Type ending with ! can't have default value")
 }
 
 func TestParseFilter_root(t *testing.T) {
@@ -2121,6 +2127,7 @@ func TestParseFilter_root_Error(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: Add Contains checks after this point.
 }
 
 func TestParseFilter_root_Error2(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -57,14 +57,14 @@ func TestParseVarError(t *testing.T) {
 			a as friends 
 		}
 
-		me(id: uid(a)) {
+		me(func: uid(a)) {
 			uid(a)
 		}
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot do uid() of a variable")
+	require.Contains(t, err.Error(), "Cannot do uid() of a variable")
 }
 
 func TestParseQueryListPred1(t *testing.T) {
@@ -232,6 +232,7 @@ func TestParseQueryWithMultiVarValError(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
 	// TODO: This is about the colon after orderasc
+	require.Contains(t, err.Error(), "blah")
 }
 
 func TestParseQueryWithVarValAggErr(t *testing.T) {
@@ -251,6 +252,7 @@ func TestParseQueryWithVarValAggErr(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This is about the colon after orderasc
 }
 
 func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
@@ -272,6 +274,7 @@ func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This is about the colon after orderasc
 }
 
 func TestParseQueryWithVarValAgg_Error2(t *testing.T) {
@@ -293,6 +296,7 @@ func TestParseQueryWithVarValAgg_Error2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This is about the colon after orderasc
 }
 
 func TestParseQueryWithVarValAgg_Error3(t *testing.T) {
@@ -316,6 +320,7 @@ func TestParseQueryWithVarValAgg_Error3(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This is about the colon after orderasc
 }
 func TestParseQueryWithVarValAggNested(t *testing.T) {
 	query := `

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -195,9 +195,9 @@ func TestParseQueryAggChild(t *testing.T) {
 func TestParseQueryWithXIDError(t *testing.T) {
 	query := `
 {
-      me(func: uid( alice-in-wonderland)) {
+      me(func: uid(aliceInWonderland)) {
         type
-        written-in
+        writtenIn
         name
         character {
                 name
@@ -211,7 +211,8 @@ func TestParseQueryWithXIDError(t *testing.T) {
     }`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: What is this testing?  "alice-in-wonderland" having "-in" is the source of error here
+	require.Contains(t, err.Error(), "Some variables are used but not defined")
+	require.Contains(t, err.Error(), "Used:[aliceInWonderland]")
 }
 
 func TestParseQueryWithMultiVarValError(t *testing.T) {
@@ -251,7 +252,7 @@ func TestParseQueryWithVarValAggErr(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This now says, "Unexpected comma before )."
+	require.Contains(t, err.Error(), "Expected argument but got ')'")
 }
 
 func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
@@ -1972,26 +1973,25 @@ func TestParseVariablesError1(t *testing.T) {
 
 func TestParseVariablesError2(t *testing.T) {
 	query := `{
-		"query": "query testQuery($a: int, $b: int, $c: int!){
-			root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}
-		}",
+		"query": "query testQuery($a: int, $b: int, $c: int!){` +
+		`   root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}` +
+		`}",
 		"variables": {"$a": "6", "$b": "5" }
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected value for variable $c")
-	// TODO: Complains about '\"'.
+	require.Contains(t, err.Error(), "Variable $c should be initialised")
 }
 
 func TestParseVariablesError3(t *testing.T) {
 	query := `{
-		"query": "query testQuery($a: int, $b: , $c: int!){
-			root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}
-		}",
+		"query": "query testQuery($a: int, $b: , $c: int!){` +
+		`   root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}` +
+		`}",
 		"variables": {"$a": "6", "$b": "5" }
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type for variable $b")
-	// TODO: Complains about '\"'.
 }
 
 func TestParseVariablesError4(t *testing.T) {
@@ -2001,7 +2001,7 @@ func TestParseVariablesError4(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type error")
-	// TODO: Complains about '\"'.
+	require.Contains(t, err.Error(), "Type ending with ! can't have default value")
 }
 
 func TestParseVariablesError5(t *testing.T) {
@@ -2026,14 +2026,15 @@ func TestParseVariablesError6(t *testing.T) {
 
 func TestParseVariablesError7(t *testing.T) {
 	query := `{
-		"query": "query testQuery($a: int, $b: int, $c: int!){
-			root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}
-		}",
+		"query": "query testQuery($a: int, $b: int, $c: int!){` +
+		`    root(func: uid( 0x0a) {name(first: $b, after: $a)){english}}` +
+		`}",
 		"variables": {"$a": "6", "$b": "5", "$d": "abc" }
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err, "Expected type for variable $d")
-	// TODO: Complains about '\"'
+	require.Contains(t, err.Error(), "Type of variable $d not specified")
+	// TODO: We're intermittently getting "Variable $c should be initialised" here.
 }
 
 func TestParseVariablesiError8(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -2112,24 +2112,6 @@ func TestParseFilter_root2(t *testing.T) {
 	require.Nil(t, res.Query[0].Children[0].Filter)
 }
 
-func TestParseFilter_root_Error(t *testing.T) {
-	query := `
-	query {
-		me(func: uid(0x0a)) @filter(allofterms(name, "alice")) {
-			friends @filter() {
-				name @filter(namefilter(name, "a"))
-			}
-			gender @filter(eq(g, "a")),age @filter(neq(a, "b"))
-			hometown
-		}
-	}
-`
-	_, err := Parse(Request{Str: query, Http: true})
-	require.NoError(t, err)
-	// TODO: This was an error, but I don't think it was supposed to be a lexing-on-@ error.  Now
-	// there's no error.
-}
-
 func TestParseFilter_root_Error2(t *testing.T) {
 	// filter-by-count only support first argument as function
 	query := `

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -478,7 +478,7 @@ func TestParseQueryWithVarValAggNested_Error1(t *testing.T) {
 	// No args to mulvar.
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(d) )) {
+		me(func: uid(L), orderasc: val(d)) {
 			name
 		}
 
@@ -492,12 +492,13 @@ func TestParseQueryWithVarValAggNested_Error1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected 2 operands")
 }
 
 func TestParseQueryWithVarValAggNested_Error2(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(d) )) {
+		me(func: uid(L), orderasc: val(d)) {
 			name
 		}
 
@@ -513,6 +514,7 @@ func TestParseQueryWithVarValAggNested_Error2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected 2 operands")
 }
 
 func TestParseQueryWithLevelAgg(t *testing.T) {
@@ -616,7 +618,7 @@ func TestParseQueryWithVarValAgg(t *testing.T) {
 func TestParseQueryWithVarValAggError(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: uid(n))) {
+		me(func: uid(L), orderasc: uid(n)) {
 			name
 		}
 
@@ -630,6 +632,7 @@ func TestParseQueryWithVarValAggError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected val(). Got uid() with order.")
 }
 
 func TestParseQueryWithVarValAggError2(t *testing.T) {
@@ -649,6 +652,7 @@ func TestParseQueryWithVarValAggError2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: When I fix this test, it passes!  No error.
 }
 
 func TestParseQueryWithVarValCount(t *testing.T) {
@@ -760,8 +764,8 @@ func TestParseQueryWithVar(t *testing.T) {
 func TestParseQueryWithVarError1(t *testing.T) {
 	query := `
 	{
-		him(func: uid( uid(J))) {name}
-		you(func: uid( uid(K))) {name}
+		him(func: uid(J)) {name}
+		you(func: uid(K)) {name}
 		var(func: uid(0x0a)) {L AS friends}
 		var(func: uid(0x0a)) {J AS friends}
 		var(func: uid(0x0a)) {K AS friends}
@@ -769,20 +773,22 @@ func TestParseQueryWithVarError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Some variables are defined but not used")
 }
 
 func TestParseQueryWithVarError2(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L))) {name}
-		him(func: uid( uid(J))) {name}
-		you(func: uid( uid(K))) {name}
+		me(func: uid(L)) {name}
+		him(func: uid(J)) {name}
+		you(func: uid(K)) {name}
 		var(func: uid(0x0a)) {L AS friends}
 		var(func: uid(0x0a)) {K AS friends}
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Some variables are used but not defined")
 }
 
 func TestParseQueryFilterError1(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -210,8 +210,8 @@ func TestParseQueryWithXIDError(t *testing.T) {
       }
     }`
 	_, err := Parse(Request{Str: query, Http: true})
-	require.Error(t, err)
-	// TODO: What is this testing?  "written-in" is the error here
+	require.NoError(t, err)
+	// TODO: What is this testing?  "alice-in-wonderland" having "-in" is the source of error here
 }
 
 func TestParseQueryWithMultiVarValError(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -791,28 +791,43 @@ func TestParseQueryWithVarError2(t *testing.T) {
 	require.Contains(t, err.Error(), "Some variables are used but not defined")
 }
 
-func TestParseQueryFilterError1(t *testing.T) {
+func TestParseQueryFilterError1A(t *testing.T) {
 	query := `
 	{
-		me(func: uid( abc) @filter(anyof(name"alice"))) {
+		me(func: uid(1) @filter(anyof(name, "alice"))) {
 		 name
 		}
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "\"@\"")
+}
+
+func TestParseQueryFilterError1B(t *testing.T) {
+	query := `
+	{
+		me(func: uid(1)) @filter(anyof(name"alice")) {
+		 name
+		}
+	}
+`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected comma or language but got: \"alice\"")
 }
 
 func TestParseQueryFilterError2(t *testing.T) {
 	query := `
 	{
-		me(func: uid( abc) @filter(anyof(name "alice"))) {
+		me(func: uid(1)) @filter(anyof(name "alice")) {
 		 name
 		}
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected comma or language but got: \"alice\"")
 }
 
 func TestParseQueryWithVarAtRootFilterID(t *testing.T) {
@@ -868,7 +883,7 @@ func TestParseQueryWithVarInIneqError(t *testing.T) {
 			}
 		}
 
-		me(func: uid( uid(fr)) @filter(gt(val(a, b), 10))) {
+		me(func: uid(fr)) @filter(gt(val(a, b), 10)) {
 		 name
 		}
 	}
@@ -876,6 +891,7 @@ func TestParseQueryWithVarInIneqError(t *testing.T) {
 	// Multiple vars not allowed.
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Multiple variables not allowed in a function")
 }
 
 func TestParseQueryWithVarInIneq(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -2445,7 +2445,7 @@ func TestParseGeneratorError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "expecting a colon")
+	require.Contains(t, err.Error(), "Expecting a colon")
 }
 
 func TestParseQuotedFunctionAttributeError(t *testing.T) {
@@ -2461,7 +2461,7 @@ func TestParseQuotedFunctionAttributeError(t *testing.T) {
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "Attribute in function must not be quoted")
 }
 
@@ -3733,7 +3733,7 @@ func TestParseGraphQLVarId(t *testing.T) {
 		"variables" : {"$a": "3", "$b": "3", "$c": "3"}
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "Invalid use of comma")
 	// TODO: What should this be here?
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -34,25 +34,26 @@ func childAttrs(g *GraphQuery) []string {
 	return out
 }
 
-func TestParseCountVarError(t *testing.T) {
+func TestParseCountValError(t *testing.T) {
 	query := `
 {
-  me(id: 1) {
+  me(func: uid(1)) {
     Upvote {
        u as Author
     }
-    count(var(u))
+    count(val(u))
   }
 }
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "count of a variable is not allowed")
 }
 
 func TestParseVarError(t *testing.T) {
 	query := `
 	{
-		var(id: 0x0a) {
+		var(func: uid(0x0a)) {
 			a as friends 
 		}
 
@@ -63,6 +64,7 @@ func TestParseVarError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot do uid() of a variable")
 }
 
 func TestParseQueryListPred1(t *testing.T) {
@@ -153,6 +155,7 @@ func TestParseQueryListPred_MultiVarError(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	// Only one variable allowed in expand.
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Exactly one variable expected")
 }
 
 func TestParseQueryWithNoVarValError(t *testing.T) {
@@ -171,6 +174,7 @@ func TestParseQueryWithNoVarValError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: What was this supposed to test?  Now dying on ':'.
 }
 
 func TestParseQueryAggChild(t *testing.T) {
@@ -185,6 +189,7 @@ func TestParseQueryAggChild(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only variables allowed in aggregate functions")
 }
 
 func TestParseQueryWithXIDError(t *testing.T) {
@@ -206,6 +211,7 @@ func TestParseQueryWithXIDError(t *testing.T) {
     }`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: What is this testing?  "written-in" is the error here
 }
 
 func TestParseQueryWithMultiVarValError(t *testing.T) {
@@ -225,6 +231,7 @@ func TestParseQueryWithMultiVarValError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: This is about the colon after orderasc
 }
 
 func TestParseQueryWithVarValAggErr(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -217,7 +217,7 @@ func TestParseQueryWithXIDError(t *testing.T) {
 func TestParseQueryWithMultiVarValError(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(n, d) )) {
+		me(func: uid(L), orderasc: val(n, d)) {
 			name
 		}
 
@@ -231,14 +231,13 @@ func TestParseQueryWithMultiVarValError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This is about the colon after orderasc
-	require.Contains(t, err.Error(), "blah")
+	require.Contains(t, err.Error(), "Expected only one variable but got: 2")
 }
 
 func TestParseQueryWithVarValAggErr(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(c) )) {
+		me(func: uid(L), orderasc: val(c)) {
 			name
 		}
 
@@ -252,13 +251,13 @@ func TestParseQueryWithVarValAggErr(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This is about the colon after orderasc
+	// TODO: This now says, "Unexpected comma before )."
 }
 
 func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(d) )) {
+		me(func: uid(L), orderasc: val(d)) {
 			name
 		}
 
@@ -274,13 +273,14 @@ func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This is about the colon after orderasc
+	require.Contains(t, err.Error(), "Empty () not allowed in math block")
+	// TODO: ^^ more like, exp() requires a parameter.  That's a weird way to fail at parsing.
 }
 
 func TestParseQueryWithVarValAgg_Error2(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(d) )) {
+		me(func: uid(L), orderasc: val(d)) {
 			name
 		}
 
@@ -296,13 +296,13 @@ func TestParseQueryWithVarValAgg_Error2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This is about the colon after orderasc
+	require.Contains(t, err.Error(), "Unknown math function: log")
 }
 
 func TestParseQueryWithVarValAgg_Error3(t *testing.T) {
 	query := `
 	{
-		me(func: uid( uid(L), orderasc: val(d) )) {
+		me(func: uid(L), orderasc: val(d)) {
 			name
 			val(f)
 		}
@@ -320,7 +320,8 @@ func TestParseQueryWithVarValAgg_Error3(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: This is about the colon after orderasc
+	require.Contains(t, err.Error(), "Empty () not allowed in math block")
+	// TODO: ^^ Possibly a bad way to fail at parsing.
 }
 func TestParseQueryWithVarValAggNested(t *testing.T) {
 	query := `

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -174,7 +174,7 @@ func TestParseQueryWithNoVarValError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.NoError(t, err)
-	// TODO: What was this supposed to test?
+	// TODO: This used to error.  What was this supposed to test?
 }
 
 func TestParseQueryAggChild(t *testing.T) {
@@ -274,7 +274,6 @@ func TestParseQueryWithVarValAgg_Error1(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Empty () not allowed in math block")
-	// TODO: ^^ more like, exp() requires a parameter.  That's a weird way to fail at parsing.
 }
 
 func TestParseQueryWithVarValAgg_Error2(t *testing.T) {
@@ -321,7 +320,6 @@ func TestParseQueryWithVarValAgg_Error3(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Empty () not allowed in math block")
-	// TODO: ^^ Possibly a bad way to fail at parsing.
 }
 func TestParseQueryWithVarValAggNested(t *testing.T) {
 	query := `
@@ -1242,7 +1240,7 @@ func TestParse_error2(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected Left round brackets") // TODO capitalization
+	require.Contains(t, err.Error(), "Expected Left round brackets")
 	require.Contains(t, err.Error(), "\"{\"")
 
 }
@@ -2116,7 +2114,7 @@ func TestParseFilter_root2(t *testing.T) {
 func TestParseFilter_root_Error(t *testing.T) {
 	query := `
 	query {
-		me(func: uid(0x0a) @filter(allofterms(name, "alice")) {
+		me(func: uid(0x0a)) @filter(allofterms(name, "alice")) {
 			friends @filter() {
 				name @filter(namefilter(name, "a"))
 			}
@@ -2126,8 +2124,9 @@ func TestParseFilter_root_Error(t *testing.T) {
 	}
 `
 	_, err := Parse(Request{Str: query, Http: true})
-	require.Error(t, err)
-	// TODO: Add Contains checks after this point.
+	require.NoError(t, err)
+	// TODO: This was an error, but I don't think it was supposed to be a lexing-on-@ error.  Now
+	// there's no error.
 }
 
 func TestParseFilter_root_Error2(t *testing.T) {
@@ -2464,7 +2463,8 @@ func TestParseGeneratorError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: Says "expecting a colon", I don't know what the error really is.  Should be me(func: ...) I guess.
+	// TODO: Says "expecting a colon".  Should be me(func: ...).  Then it complains about "name"
+	// being quoted.  What's this supposed to test?
 }
 
 func TestParseCountAsFuncMultiple(t *testing.T) {
@@ -2545,7 +2545,6 @@ func TestParseCountError2(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Predicate name cannot be empty")
-	// TODO: that's a bad error message
 }
 
 func TestParseCheckPwd(t *testing.T) {
@@ -2875,7 +2874,7 @@ func TestLangsInvalid6(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: We get 'Expected 3 periods ("..."), got 2.', which is bonkers.
+	// TODO: We get 'Expected 3 periods ("..."), got 2.'.
 }
 
 func TestLangsInvalid7(t *testing.T) {
@@ -2889,7 +2888,7 @@ func TestLangsInvalid7(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-	// TODO: We get 'Expected 3 periods ("..."), got 2.', which is bonkers.
+	// TODO: We get 'Expected 3 periods ("..."), got 2.'.
 }
 
 func TestLangsFilter(t *testing.T) {
@@ -2949,8 +2948,6 @@ func TestLangsFilter_error2(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Expected arg after func [alloftext]")
 	require.Contains(t, err.Error(), "','")
-	// TODO: That's a bad error message
-
 }
 
 func TestLangsFunction(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3114,9 +3114,9 @@ func TestParseGroupbyError(t *testing.T) {
 		}
 	}
 `
-	// TODO: Add assertions of error messages after this point
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only aggregator/count functions allowed inside @groupby")
 }
 
 func TestParseFacetsError1(t *testing.T) {
@@ -3133,6 +3133,7 @@ func TestParseFacetsError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected ( after func name [facet1]")
 }
 
 func TestParseFacetsVarError(t *testing.T) {
@@ -3149,6 +3150,7 @@ func TestParseFacetsVarError(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected name in facet list")
 }
 func TestParseFacetsError2(t *testing.T) {
 	query := `
@@ -3164,6 +3166,7 @@ func TestParseFacetsError2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected ( after func name [facet1]")
 }
 
 func TestParseFacetsOrderError1(t *testing.T) {
@@ -3415,6 +3418,7 @@ func TestParseFacetsFail1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected ( after func name [key1]")
 }
 
 func TestParseRepeatArgsError1(t *testing.T) {
@@ -3428,6 +3432,7 @@ func TestParseRepeatArgsError1(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only one function allowed at root")
 }
 
 func TestParseRepeatArgsError2(t *testing.T) {
@@ -3441,6 +3446,7 @@ func TestParseRepeatArgsError2(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Got repeated key \"first\"")
 }
 
 // Test facets parsing for filtering..
@@ -3521,6 +3527,7 @@ func TestFacetsFilterFail(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only one facets allowed")
 }
 
 func TestFacetsFilterFail2(t *testing.T) {
@@ -3539,6 +3546,7 @@ func TestFacetsFilterFail2(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only one facets filter allowed")
 }
 
 func TestFacetsFilterFail3(t *testing.T) {
@@ -3548,8 +3556,8 @@ func TestFacetsFilterFail3(t *testing.T) {
 		K as var(func: uid(0x0a)) {
 			L AS friends
 		}
-		me(func: uid( uid(K))) {
-			friend @facets(id(L)) {
+		me(func: uid(K)) {
+			friend @facets(uid(L)) {
 				name
 			}
 		}
@@ -3558,13 +3566,14 @@ func TestFacetsFilterFail3(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "variables are not allowed in facets filter")
+	// TODO: This used "id(L)" before.  What is that?
 }
 
 func TestFacetsFilterFailRoot(t *testing.T) {
-	// vars are not allowed in facets filtering.
 	query := `
 	{
-		me(func: uid(0x1) @facets(eq(some-facet, true))) {
+		me(func: uid(0x1)) @facets(eq(some-facet, true)) {
 			friend	{
 				name
 			}
@@ -3574,6 +3583,7 @@ func TestFacetsFilterFailRoot(t *testing.T) {
 
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unknown directive [facets]")
 }
 
 func TestFacetsFilterAtValue(t *testing.T) {
@@ -3694,6 +3704,7 @@ func TestParseRegexp4(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	// only [a-zA-Z] characters can be used as flags
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected comma or language but got: 123")
 }
 
 func TestParseRegexp5(t *testing.T) {
@@ -3707,6 +3718,7 @@ func TestParseRegexp5(t *testing.T) {
 	_, err := Parse(Request{Str: query, Http: true})
 	// only [a-zA-Z] characters can be used as flags
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected comma or language but got: 123")
 }
 
 func TestParseRegexp6(t *testing.T) {
@@ -3719,6 +3731,8 @@ func TestParseRegexp6(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected arg after func [regexp]")
+	require.Contains(t, err.Error(), "Unclosed Brackets")
 }
 
 func TestParseGraphQLVarId(t *testing.T) {
@@ -3728,6 +3742,7 @@ func TestParseGraphQLVarId(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	// TODO: I'm not sure what this test is supposed to be testing.
 }
 
 func TestMain(m *testing.M) {
@@ -3755,6 +3770,7 @@ func TestCountAtRootErr(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Cannot have children attributes when asking for count")
 }
 
 func TestCountAtRootErr2(t *testing.T) {
@@ -3765,6 +3781,7 @@ func TestCountAtRootErr2(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Cannot assign variable to count()")
 }
 
 func TestHasFuncAtRoot(t *testing.T) {
@@ -3807,6 +3824,7 @@ func TestDotsEOF(t *testing.T) {
 			..`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected 3 periods")
 }
 
 func TestMutationVariables(t *testing.T) {
@@ -3877,6 +3895,7 @@ func TestMathWithoutVarAlias(t *testing.T) {
 		}`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Function math should be used with a variable or have an alias")
 }
 
 func TestMultipleEqual(t *testing.T) {
@@ -3943,7 +3962,7 @@ func TestMultipleSetBlocks(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
-
+	require.Contains(t, err.Error(), "Multiple 'set' blocks not allowed")
 }
 
 func TestMultipleDelBlocks(t *testing.T) {
@@ -3955,6 +3974,7 @@ func TestMultipleDelBlocks(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Multiple 'delete' blocks not allowed")
 
 }
 
@@ -3962,11 +3982,12 @@ func TestMultipleSchemaBlocks(t *testing.T) {
 	query := `
 	mutation {
 		schema { name: string @index(term) }
-		schama { tag: string @index(exact) }
+		schema { tag: string @index(exact) }
     }
 `
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Multiple 'schema' blocks not allowed")
 }
 
 func TestIdErr(t *testing.T) {
@@ -3979,6 +4000,7 @@ func TestIdErr(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid syntax using id. Use func: uid()")
 }
 
 func TestFilterVarErr(t *testing.T) {
@@ -3994,6 +4016,7 @@ func TestFilterVarErr(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unexpected var()")
 }
 
 func TestEqUidFunctionErr(t *testing.T) {
@@ -4006,4 +4029,5 @@ func TestEqUidFunctionErr(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query, Http: true})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "Only val/count allowed as function within another. Got: uid")
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -138,7 +138,7 @@ func TestParseQueryListPred_MultiVarError(t *testing.T) {
 			f as friends
 		}
 
-		var(func: uid( uid(f))) {
+		var(func: uid(f)) {
 			l as _predicate_
 			friend {
 				g as _predicate_


### PR DESCRIPTION
This adds Contains to a bunch of parser tests, to make sure they're failing where they're supposed to be failing.

Also fixes some tests which had spurious parse errors.

In parser_test.go I added some TODO comments for test cases I didn't understand.

My advice for reviewing this is to focus on the TODO's in the diff.  The rest of the tests were straightforward enough.

Connected to #1229.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1307)
<!-- Reviewable:end -->
