### PR TITLE
Proper cleanup in test code

### DIFF
--- a/client_test/client_test.go
+++ b/client_test/client_test.go
@@ -59,7 +59,7 @@ func prepare() (res []string, options dgraph.Options) {
 
 func removeDirs(dirs []string) {
 	for _, dir := range dirs {
-		os.Remove(dir)
+		os.RemoveAll(dir)
 	}
 }
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -774,7 +774,10 @@ func TestMain(m *testing.M) {
 	Init(ps)
 
 	group.ParseGroupConfig("")
-	os.Exit(m.Run())
+	r := m.Run()
+
+	os.RemoveAll(dir)
+	os.Exit(r)
 }
 
 func BenchmarkAddMutations(b *testing.B) {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -6840,7 +6840,6 @@ func TestMain(m *testing.M) {
 
 	dir, err := ioutil.TempDir("", "storetest_")
 	x.Check(err)
-	defer os.RemoveAll(dir)
 
 	opt := badger.DefaultOptions
 	opt.Dir = dir
@@ -6873,9 +6872,12 @@ func TestMain(m *testing.M) {
 	// Load schema after nodes have started
 	err = schema.ParseBytes([]byte(schemaStr), 1)
 	x.Check(err)
-	defer os.RemoveAll(dir2)
 
-	os.Exit(m.Run())
+	r := m.Run()
+
+	os.RemoveAll(dir)
+	os.RemoveAll(dir2)
+	os.Exit(r)
 }
 
 func TestFilterNonIndexedPredicateFail(t *testing.T) {

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -277,10 +277,12 @@ func TestMain(m *testing.M) {
 	x.Check(err)
 	x.Check(group.ParseGroupConfig("groups.conf"))
 	Init(ps)
-	defer os.RemoveAll(dir)
-	defer ps.Close()
 
-	os.Exit(m.Run())
+	r := m.Run()
+
+	ps.Close()
+	os.RemoveAll(dir)
+	os.Exit(r)
 }
 
 func TestParseUnderscore(t *testing.T) {


### PR DESCRIPTION
As os.Exit() doesn't honor defer'ed statements, we need different way of
cleaning up after tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1317)
<!-- Reviewable:end -->
