### PR TITLE
dynamic memory_mb via /admin/request endpoint

### DIFF
--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -466,8 +466,8 @@ func storeStatsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // handlerInit does some standard checks. Returns false if something is wrong.
-func handlerInit(w http.ResponseWriter, r *http.Request, allowedMethod string) bool {
-	if r.Method != allowedMethod {
+func handlerInit(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != http.MethodGet {
 		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
 		return false
 	}
@@ -481,7 +481,7 @@ func handlerInit(w http.ResponseWriter, r *http.Request, allowedMethod string) b
 }
 
 func shutDownHandler(w http.ResponseWriter, r *http.Request) {
-	if !handlerInit(w, r, http.MethodGet) {
+	if !handlerInit(w, r) {
 		return
 	}
 
@@ -510,7 +510,7 @@ func shutdownServer() {
 }
 
 func exportHandler(w http.ResponseWriter, r *http.Request) {
-	if !handlerInit(w, r, http.MethodGet) {
+	if !handlerInit(w, r) {
 		return
 	}
 	ctx := context.Background()

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -534,8 +534,13 @@ func memoryLimitHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func memoryLimitPutHandler(w http.ResponseWriter, r *http.Request) {
-	var memoryMB float64
-	if _, err := fmt.Fscanf(r.Body, "%f", &memoryMB); err != nil {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	memoryMB, err := strconv.ParseFloat(string(body), 64)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/dgraph/config.go
+++ b/dgraph/config.go
@@ -83,7 +83,10 @@ func SetConfiguration(newConfig Options) {
 
 	Config = newConfig
 
+	posting.Config.Mu.Lock()
 	posting.Config.AllottedMemory = Config.AllottedMemory
+	posting.Config.Mu.Unlock()
+
 	posting.Config.CommitFraction = Config.CommitFraction
 
 	worker.Config.BaseWorkerPort = Config.BaseWorkerPort

--- a/dgraph/config.go
+++ b/dgraph/config.go
@@ -102,6 +102,8 @@ func SetConfiguration(newConfig Options) {
 	x.Config.DebugMode = Config.DebugMode
 }
 
+const MinAllottedMemory = 1024.0
+
 func (o *Options) validate() {
 	pd, err := filepath.Abs(o.PostingDir)
 	x.Check(err)
@@ -110,6 +112,6 @@ func (o *Options) validate() {
 	x.AssertTruef(pd != wd, "Posting and WAL directory cannot be the same ('%s').", o.PostingDir)
 	x.AssertTruef(o.AllottedMemory != DefaultConfig.AllottedMemory,
 		"Allotted memory (--memory_mb) must be specified, with value greater than 1024 MB")
-	x.AssertTruef(o.AllottedMemory >= 1024.0,
-		"Allotted memory (--memory_mb) must be at least 1024 MB. Currently set to: %f", o.AllottedMemory)
+	x.AssertTruef(o.AllottedMemory >= MinAllottedMemory,
+		"Allotted memory (--memory_mb) must be at least %.0f MB. Currently set to: %f", MinAllottedMemory, o.AllottedMemory)
 }

--- a/posting/config.go
+++ b/posting/config.go
@@ -16,8 +16,12 @@
  */
 package posting
 
+import "sync"
+
 type Options struct {
+	Mu             sync.Mutex
 	AllottedMemory float64
+
 	CommitFraction float64
 }
 

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -251,7 +251,10 @@ func periodicCommit() {
 			// Okay, we exceed the max memory threshold.
 			// Stop the world, and deal with this first.
 			x.NumGoRoutines.Set(int64(runtime.NumGoroutine()))
-			if setLruMemory && inUse > 0.75*(Config.AllottedMemory) {
+			Config.Mu.Lock()
+			mem := Config.AllottedMemory
+			Config.Mu.Unlock()
+			if setLruMemory && inUse > 0.75*mem {
 				lcache.UpdateMaxSize()
 				setLruMemory = false
 			}

--- a/x/x.go
+++ b/x/x.go
@@ -56,17 +56,17 @@ var (
 // WhiteSpace Replacer removes spaces and tabs from a string.
 var WhiteSpace = strings.NewReplacer(" ", "", "\t", "")
 
-type ErrRes struct {
+type errRes struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 }
 
-type QueryRes struct {
-	Errors []ErrRes `json:"errors"`
+type queryRes struct {
+	Errors []errRes `json:"errors"`
 }
 
-func (q *QueryRes) AddStatus(code, msg string) {
-	q.Errors = append(q.Errors, ErrRes{Code: code, Message: msg})
+func (q *queryRes) AddStatus(code, msg string) {
+	q.Errors = append(q.Errors, errRes{Code: code, Message: msg})
 }
 
 // SetError sets the error logged in this package.
@@ -79,8 +79,8 @@ func SetError(prev *error, n error) {
 // SetStatus sets the error code, message and the newly assigned uids
 // in the http response.
 func SetStatus(w http.ResponseWriter, code, msg string) {
-	var qr QueryRes
-	qr.Errors = append(qr.Errors, ErrRes{Code: code, Message: msg})
+	var qr queryRes
+	qr.Errors = append(qr.Errors, errRes{Code: code, Message: msg})
 	if js, err := json.Marshal(qr); err == nil {
 		w.Write(js)
 	} else {
@@ -89,7 +89,7 @@ func SetStatus(w http.ResponseWriter, code, msg string) {
 }
 
 type queryResWithData struct {
-	Errors []ErrRes `json:"errors"`
+	Errors []errRes `json:"errors"`
 	Data   *string  `json:"data"`
 }
 
@@ -97,7 +97,7 @@ type queryResWithData struct {
 // key with null value according to GraphQL spec.
 func SetStatusWithData(w http.ResponseWriter, code, msg string) {
 	var qr queryResWithData
-	qr.Errors = append(qr.Errors, ErrRes{Code: code, Message: msg})
+	qr.Errors = append(qr.Errors, errRes{Code: code, Message: msg})
 	// This would ensure that data key is present with value null.
 	if js, err := json.Marshal(qr); err == nil {
 		w.Write(js)

--- a/x/x.go
+++ b/x/x.go
@@ -56,13 +56,17 @@ var (
 // WhiteSpace Replacer removes spaces and tabs from a string.
 var WhiteSpace = strings.NewReplacer(" ", "", "\t", "")
 
-type errRes struct {
+type ErrRes struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 }
 
-type queryRes struct {
-	Errors []errRes `json:"errors"`
+type QueryRes struct {
+	Errors []ErrRes `json:"errors"`
+}
+
+func (q *QueryRes) AddStatus(code, msg string) {
+	q.Errors = append(q.Errors, ErrRes{Code: code, Message: msg})
 }
 
 // SetError sets the error logged in this package.
@@ -75,8 +79,8 @@ func SetError(prev *error, n error) {
 // SetStatus sets the error code, message and the newly assigned uids
 // in the http response.
 func SetStatus(w http.ResponseWriter, code, msg string) {
-	var qr queryRes
-	qr.Errors = append(qr.Errors, errRes{Code: code, Message: msg})
+	var qr QueryRes
+	qr.Errors = append(qr.Errors, ErrRes{Code: code, Message: msg})
 	if js, err := json.Marshal(qr); err == nil {
 		w.Write(js)
 	} else {
@@ -85,7 +89,7 @@ func SetStatus(w http.ResponseWriter, code, msg string) {
 }
 
 type queryResWithData struct {
-	Errors []errRes `json:"errors"`
+	Errors []ErrRes `json:"errors"`
 	Data   *string  `json:"data"`
 }
 
@@ -93,7 +97,7 @@ type queryResWithData struct {
 // key with null value according to GraphQL spec.
 func SetStatusWithData(w http.ResponseWriter, code, msg string) {
 	var qr queryResWithData
-	qr.Errors = append(qr.Errors, errRes{Code: code, Message: msg})
+	qr.Errors = append(qr.Errors, ErrRes{Code: code, Message: msg})
 	// This would ensure that data key is present with value null.
 	if js, err := json.Marshal(qr); err == nil {
 		w.Write(js)

--- a/x/x.go
+++ b/x/x.go
@@ -65,10 +65,6 @@ type queryRes struct {
 	Errors []errRes `json:"errors"`
 }
 
-func (q *queryRes) AddStatus(code, msg string) {
-	q.Errors = append(q.Errors, errRes{Code: code, Message: msg})
-}
-
 // SetError sets the error logged in this package.
 func SetError(prev *error, n error) {
 	if prev == nil {


### PR DESCRIPTION
* Adds the /admin/request endpoint (PUT)
* I made it generic so that we could add things other than `memory_mb` easily later.
* It's a PUT endpoint. Parameters are encoded in the body in URL query parameter encoding.
* Even bad requests return Status OK (seems to be how the other endpoints do things). Is this what we want?

I did some manual testing to make sure everything works:

```
$ curl -d memory_mb=2000 -d foo=bar -X PUT localhost:8080/admin/request | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   165  100   143  100    22  22587   3474 --:--:-- --:--:-- --:--:-- 23833
{
  "errors": [
    {
      "code": "Success",
      "message": "memory_mb set to 2000.000000"
    },
    {
      "code": "ErrorInvalidRequest",
      "message": "Unknown parameter name: foo"
    }
  ]
}
```
```
$ curl -d memory_mb=1000 -d foo=bar -X PUT localhost:8080/admin/request | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   180  100   158  100    22  26870   3741 --:--:-- --:--:-- --:--:-- 31600
{
  "errors": [
    {
      "code": "ErrorInvalidRequest",
      "message": "memory_mb must be at least 1024"
    },
    {
      "code": "ErrorInvalidRequest",
      "message": "Unknown parameter name: foo"
    }
  ]
}
```
```
$ curl -d memory_mb=not_a_float -d foo=bar -X PUT localhost:8080/admin/request | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   190  100   161  100    29   8931   1608 --:--:-- --:--:-- --:--:--  9470
{
  "errors": [
    {
      "code": "ErrorInvalidRequest",
      "message": "Invalid for memory_mb: not_a_float"
    },
    {
      "code": "ErrorInvalidRequest",
      "message": "Unknown parameter name: foo"
    }
  ]
}
```

I haven't done any HTTP/REST stuff before, so please review extra carefully :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1338)
<!-- Reviewable:end -->
