### PR TITLE
Feature/scheduler

### DIFF
--- a/worker/assign.go
+++ b/worker/assign.go
@@ -36,6 +36,9 @@ var (
 // In essence, we just want one server to be handing out new uids.
 func assignUids(ctx context.Context, num *protos.Num) (*protos.AssignedIds, error) {
 	node := groups().Node(leaseGid)
+	// TODO: Fix when we move to linearizable reads, need to check if we are the leader, might be
+	// based on leader leases. If this node gets partitioned and unless checkquorum is enabled, this
+	// node would still think that it's the leader.
 	if !node.AmLeader() {
 		return &emptyAssignedIds, x.Errorf("Assigning UIDs is only allowed on leader.")
 	}

--- a/worker/export.go
+++ b/worker/export.go
@@ -335,9 +335,12 @@ func export(gid uint32, bdir string) error {
 	return err
 }
 
+// TODO: How do we want to handle export for group, do we pause mutations, sync all and then export ?
 func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos.ExportPayload {
 	n := groups().Node(gid)
 	if n != nil && n.AmLeader() {
+		lastIndex, _ := n.store.LastIndex()
+		n.syncAllMarks(n.ctx, lastIndex)
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("Leader of group: %d. Running export.", gid)
 		}

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -39,9 +39,9 @@ const (
 	del = "delete"
 )
 
-// runMutations goes through all the edges and applies them. It returns the
+// runMutation goes through all the edges and applies them. It returns the
 // mutations which were not applied in left.
-func runMutations(ctx context.Context, edge *protos.DirectedEdge) error {
+func runMutation(ctx context.Context, edge *protos.DirectedEdge) error {
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("In run mutations")
 	}
@@ -86,7 +86,7 @@ func runMutations(ctx context.Context, edge *protos.DirectedEdge) error {
 
 // This is serialized with mutations, called after applied watermarks catch up
 // and further mutations are blocked until this is done.
-func runSchemaMutations(ctx context.Context, update *protos.SchemaUpdate) error {
+func runSchemaMutation(ctx context.Context, update *protos.SchemaUpdate) error {
 	rv := ctx.Value("raft").(x.RaftValue)
 	n := groups().Node(rv.Group)
 	// Wait for applied watermark to reach till previous index

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -41,117 +41,115 @@ const (
 
 // runMutations goes through all the edges and applies them. It returns the
 // mutations which were not applied in left.
-func runMutations(ctx context.Context, edges []*protos.DirectedEdge) error {
+func runMutations(ctx context.Context, edge *protos.DirectedEdge) error {
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("In run mutations")
 	}
-	for _, edge := range edges {
-		gid := group.BelongsTo(edge.Attr)
-		if !groups().ServesGroup(gid) {
-			return x.Errorf("Predicate fingerprint doesn't match this instance")
+	gid := group.BelongsTo(edge.Attr)
+	if !groups().ServesGroup(gid) {
+		return x.Errorf("Predicate fingerprint doesn't match this instance")
+	}
+
+	rv := ctx.Value("raft").(x.RaftValue)
+	x.AssertTruef(rv.Group == gid, "fingerprint mismatch between raft and group conf")
+
+	typ, err := schema.State().TypeOf(edge.Attr)
+	x.Checkf(err, "Schema is not present for predicate %s", edge.Attr)
+
+	if edge.Entity == 0 && bytes.Equal(edge.Value, []byte(x.Star)) {
+		waitForSyncMark(ctx, gid, rv.Index-1)
+		if err = posting.DeletePredicate(ctx, edge.Attr); err != nil {
+			return err
 		}
+		return nil
+	}
+	// Once mutation comes via raft we do best effort conversion
+	// Type check is done before proposing mutation, in case schema is not
+	// present, some invalid entries might be written initially
+	err = validateAndConvert(edge, typ)
 
-		rv := ctx.Value("raft").(x.RaftValue)
-		x.AssertTruef(rv.Group == gid, "fingerprint mismatch between raft and group conf")
+	key := x.DataKey(edge.Attr, edge.Entity)
 
-		typ, err := schema.State().TypeOf(edge.Attr)
-		x.Checkf(err, "Schema is not present for predicate %s", edge.Attr)
-
-		if edge.Entity == 0 && bytes.Equal(edge.Value, []byte(x.Star)) {
-			waitForSyncMark(ctx, gid, rv.Index-1)
-			if err = posting.DeletePredicate(ctx, edge.Attr); err != nil {
-				return err
-			}
-			continue
+	t := time.Now()
+	plist := posting.GetOrCreate(key, gid)
+	if dur := time.Since(t); dur > time.Millisecond {
+		if tr, ok := trace.FromContext(ctx); ok {
+			tr.LazyPrintf("GetOrCreate took %v", dur)
 		}
-		// Once mutation comes via raft we do best effort conversion
-		// Type check is done before proposing mutation, in case schema is not
-		// present, some invalid entries might be written initially
-		err = validateAndConvert(edge, typ)
+	}
 
-		key := x.DataKey(edge.Attr, edge.Entity)
-
-		t := time.Now()
-		plist := posting.GetOrCreate(key, gid)
-		if dur := time.Since(t); dur > time.Millisecond {
-			if tr, ok := trace.FromContext(ctx); ok {
-				tr.LazyPrintf("GetOrCreate took %v", dur)
-			}
-		}
-
-		if err = plist.AddMutationWithIndex(ctx, edge); err != nil {
-			return err // abort applying the rest of them.
-		}
+	if err = plist.AddMutationWithIndex(ctx, edge); err != nil {
+		return err // abort applying the rest of them.
 	}
 	return nil
 }
 
 // This is serialized with mutations, called after applied watermarks catch up
 // and further mutations are blocked until this is done.
-func runSchemaMutations(ctx context.Context, updates []*protos.SchemaUpdate) error {
+func runSchemaMutations(ctx context.Context, update *protos.SchemaUpdate) error {
 	rv := ctx.Value("raft").(x.RaftValue)
 	n := groups().Node(rv.Group)
-	for _, update := range updates {
-		if !groups().ServesGroup(group.BelongsTo(update.Predicate)) {
-			return x.Errorf("Predicate fingerprint doesn't match this instance")
+	// Wait for applied watermark to reach till previous index
+	// All mutations before this should use old schema and after this
+	// should use new schema
+	n.waitForSyncMark(n.ctx, rv.Index-1)
+	if !groups().ServesGroup(group.BelongsTo(update.Predicate)) {
+		return x.Errorf("Predicate fingerprint doesn't match this instance")
+	}
+	if err := checkSchema(update); err != nil {
+		return err
+	}
+	old, ok := schema.State().Get(update.Predicate)
+	current := schema.From(update)
+	updateSchema(update.Predicate, current, rv.Index, rv.Group)
+
+	// Once we remove index or reverse edges from schema, even though the values
+	// are present in db, they won't be used due to validation in work/task.go
+
+	// We don't want to use sync watermarks for background removal, because it would block
+	// linearizable read requests. Only downside would be on system crash, stale edges
+	// might remain, which is ok.
+
+	// Indexing can't be done in background as it can cause race conditons with new
+	// index mutations (old set and new del)
+	// We need watermark for index/reverse edge addition for linearizable reads.
+	// (both applied and synced watermarks).
+	defer x.Printf("Done schema update %+v\n", update)
+	if !ok {
+		if current.Directive == protos.SchemaUpdate_INDEX {
+			if err := n.rebuildOrDelIndex(ctx, update.Predicate, true); err != nil {
+				return err
+			}
+		} else if current.Directive == protos.SchemaUpdate_REVERSE {
+			if err := n.rebuildOrDelRevEdge(ctx, update.Predicate, true); err != nil {
+				return err
+			}
 		}
-		if err := checkSchema(update); err != nil {
+
+		if current.Count {
+			if err := n.rebuildOrDelCountIndex(ctx, update.Predicate, true); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	// schema was present already
+	if needReindexing(old, current) {
+		// Reindex if update.Index is true or remove index
+		if err := n.rebuildOrDelIndex(ctx, update.Predicate,
+			current.Directive == protos.SchemaUpdate_INDEX); err != nil {
 			return err
 		}
-		old, ok := schema.State().Get(update.Predicate)
-		current := schema.From(update)
-		updateSchema(update.Predicate, current, rv.Index, rv.Group)
-
-		// Once we remove index or reverse edges from schema, even though the values
-		// are present in db, they won't be used due to validation in work/task.go
-		// Removal can be done in background if we write a scheduler later which ensures
-		// that schema mutations are serialized, so that there won't be
-		// race conditions between deletion of edges and addition of edges.
-
-		// We don't want to use sync watermarks for background removal, because it would block
-		// linearizable read requests. Only downside would be on system crash, stale edges
-		// might remain, which is ok.
-
-		// Indexing can't be done in background as it can cause race conditons with new
-		// index mutations (old set and new del)
-		// We need watermark for index/reverse edge addition for linearizable reads.
-		// (both applied and synced watermarks).
-		if !ok {
-			if current.Directive == protos.SchemaUpdate_INDEX {
-				if err := n.rebuildOrDelIndex(ctx, update.Predicate, true); err != nil {
-					return err
-				}
-			} else if current.Directive == protos.SchemaUpdate_REVERSE {
-				if err := n.rebuildOrDelRevEdge(ctx, update.Predicate, true); err != nil {
-					return err
-				}
-			}
-
-			if current.Count {
-				if err := n.rebuildOrDelCountIndex(ctx, update.Predicate, true); err != nil {
-					return err
-				}
-			}
-			continue
+	} else if needsRebuildingReverses(old, current) {
+		// Add or remove reverse edge based on update.Reverse
+		if err := n.rebuildOrDelRevEdge(ctx, update.Predicate,
+			current.Directive == protos.SchemaUpdate_REVERSE); err != nil {
+			return err
 		}
-		// schema was present already
-		if needReindexing(old, current) {
-			// Reindex if update.Index is true or remove index
-			if err := n.rebuildOrDelIndex(ctx, update.Predicate,
-				current.Directive == protos.SchemaUpdate_INDEX); err != nil {
-				return err
-			}
-		} else if needsRebuildingReverses(old, current) {
-			// Add or remove reverse edge based on update.Reverse
-			if err := n.rebuildOrDelRevEdge(ctx, update.Predicate,
-				current.Directive == protos.SchemaUpdate_REVERSE); err != nil {
-				return err
-			}
-		}
+	}
 
-		if current.Count != old.Count {
-			if err := n.rebuildOrDelCountIndex(ctx, update.Predicate, current.Count); err != nil {
-			}
+	if current.Count != old.Count {
+		if err := n.rebuildOrDelCountIndex(ctx, update.Predicate, current.Count); err != nil {
 		}
 	}
 	return nil

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -56,19 +56,15 @@ func (s *scheduler) init(n *node) {
 }
 
 func (s *scheduler) processTasks() {
-	for t := range s.tch {
-		s.executeMutation(t)
-	}
-}
-
-func (s *scheduler) executeMutation(t *task) {
 	n := s.n
-	nextTask := t
-	for nextTask != nil {
-		err := s.n.processMutation(nextTask.pid, nextTask.rid, nextTask.edge)
-		n.props.Done(nextTask.pid, err)
-		x.ActiveMutations.Add(-1)
-		nextTask = s.nextTask(nextTask)
+	for t := range s.tch {
+		nextTask := t
+		for nextTask != nil {
+			err := s.n.processMutation(nextTask.pid, nextTask.rid, nextTask.edge)
+			n.props.Done(nextTask.pid, err)
+			x.ActiveMutations.Add(-1)
+			nextTask = s.nextTask(nextTask)
+		}
 	}
 }
 

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package worker
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/dgraph-io/dgraph/posting"
+	"github.com/dgraph-io/dgraph/protos"
+	"github.com/dgraph-io/dgraph/schema"
+	"github.com/dgraph-io/dgraph/types"
+	"github.com/dgraph-io/dgraph/x"
+	farm "github.com/dgryski/go-farm"
+)
+
+type task struct {
+	rid  uint64 // raft index corresponding to the task
+	pid  uint32 // proposal id corresponding to the task
+	edge *protos.DirectedEdge
+}
+
+type scheduler struct {
+	sync.Mutex
+	// stores the list of tasks per hash of subject,predicate. Even
+	// if there is collision it would create fake dependencies but
+	// the end result would be logically correct
+	tasks map[uint32][]*task
+	tch   chan *task
+	ptch  chan *task // priority task channel
+	// If we push proposals to a separate list while schema mutation is
+	// going on then we can't have the ordering guarantee even if we
+	// check in priority buffer first.
+	// For now doing a simple design where we block the scheduler loop
+	// if a mutation comes which is using the predicate. Dgraph would be
+	// under heavy load while doing schema mutations so it should be ok to block.
+	schemaMap     map[string]chan struct{}
+	pendingSchema chan struct{}
+
+	n *node
+}
+
+func (s *scheduler) init(n *node) {
+	s.n = n
+	s.tasks = make(map[uint32][]*task)
+	s.tch = make(chan *task, 10000)
+	s.ptch = make(chan *task, 10000)
+	s.schemaMap = make(map[string]chan struct{})
+	s.pendingSchema = make(chan struct{}, 10)
+	for i := 0; i < 1000; i++ {
+		go s.processTasks()
+	}
+}
+
+func (s *scheduler) processTasks() {
+	for {
+		// Check if something is there in priority channel
+		select {
+		case t := <-s.ptch:
+			s.executeMutation(t)
+		default:
+		}
+		select {
+		case t := <-s.ptch:
+			s.executeMutation(t)
+		case t := <-s.tch:
+			s.executeMutation(t)
+		}
+	}
+}
+
+func (s *scheduler) executeMutation(t *task) {
+	err := s.n.processMutation(t.pid, t.rid, t.edge)
+	s.n.props.Done(t.pid, err)
+	s.n.applied.Done(t.rid)
+	posting.SyncMarkFor(s.n.gid).Done(t.rid)
+	x.ActiveMutations.Add(-1)
+	if nextTask := s.nextTask(t); nextTask != nil {
+		s.ptch <- nextTask
+	}
+}
+
+func taskKey(attribute string, uid uint64) uint32 {
+	key := fmt.Sprintf("%s|%d", attribute, uid)
+	return farm.Fingerprint32([]byte(key))
+}
+
+func (s *scheduler) canSchedule(t *task) bool {
+	s.Lock()
+	defer s.Unlock()
+	key := taskKey(t.edge.Attr, t.edge.Entity)
+	if tasks, ok := s.tasks[key]; ok {
+		tasks = append(tasks, t)
+		s.tasks[key] = tasks
+		return false
+	} else {
+		tasks = []*task{t}
+		s.tasks[key] = tasks
+		return true
+	}
+}
+
+func (s *scheduler) markSchemaDone(predicate string) {
+	s.Lock()
+	defer s.Unlock()
+	ch, ok := s.schemaMap[predicate]
+	x.AssertTrue(ok)
+	ch <- struct{}{}
+	close(ch)
+}
+
+func (s *scheduler) waitForSchema(predicate string) {
+	s.Lock()
+	s.Unlock()
+	ch, ok := s.schemaMap[predicate]
+	if !ok {
+		return
+	}
+	<-ch
+}
+
+func (s *scheduler) schedule(proposal *protos.Proposal, index uint64) {
+	total := len(proposal.Mutations.Edges) + len(proposal.Mutations.Schema)
+	if total > 0 {
+		s.n.props.IncRef(proposal.Id, total)
+		x.ActiveMutations.Add(int64(total))
+		s.n.applied.BeginWithCount(index, total)
+		posting.SyncMarkFor(s.n.gid).BeginWithCount(index, total)
+	}
+	for _, supdate := range proposal.Mutations.Schema {
+		s.waitForSchema(supdate.Predicate)
+		s.scheduleSchema(proposal.Id, index, supdate)
+	}
+
+	// Scheduler tracks tasks at subject, predicate level, so doing
+	// schema stuff here simplies the design and we needn't worrying about
+	// serializing the mutations per predicate or schema mutations
+	// We derive the schema here if it's not present
+	// Since raft committed logs are serialized, we can derive
+	// schema here without any locking
+	// stores a map of predicate and type of first mutation for each predicate
+	schemaMap := make(map[string]types.TypeID)
+	for _, edge := range proposal.Mutations.Edges {
+		if _, ok := schemaMap[edge.Attr]; !ok {
+			schemaMap[edge.Attr] = posting.TypeID(edge)
+		}
+	}
+
+	for attr, storageType := range schemaMap {
+		if _, err := schema.State().TypeOf(attr); err != nil {
+			// Schema doesn't exist
+			// Since committed entries are serialized, updateSchemaIfMissing is not
+			// needed, In future if schema needs to be changed, it would flow through
+			// raft so there won't be race conditions between read and update schema
+			updateSchemaType(attr, storageType, index, s.n.gid)
+		}
+	}
+
+	for _, edge := range proposal.Mutations.Edges {
+		s.waitForSchema(edge.Attr)
+		s.scheduleMutation(&task{
+			rid:  index,
+			pid:  proposal.Id,
+			edge: edge,
+		})
+	}
+}
+
+func (s *scheduler) scheduleSchema(pid uint32, rid uint64, supdate *protos.SchemaUpdate) {
+	s.Lock()
+	s.schemaMap[supdate.Predicate] = make(chan struct{}, 1)
+	s.Unlock()
+
+	s.pendingSchema <- struct{}{}
+	go func() {
+		err := s.n.processSchemaMutations(pid, rid, supdate)
+		s.n.props.Done(pid, err)
+		s.markSchemaDone(supdate.Predicate)
+		s.n.applied.Done(rid)
+		posting.SyncMarkFor(s.n.gid).Done(rid)
+		<-s.pendingSchema
+	}()
+}
+
+func (s *scheduler) scheduleMutation(t *task) {
+	if s.canSchedule(t) {
+		s.tch <- t
+	}
+}
+
+func (s *scheduler) nextTask(t *task) *task {
+	s.Lock()
+	defer s.Unlock()
+	key := taskKey(t.edge.Attr, t.edge.Entity)
+	var nextTask *task
+	tasks, ok := s.tasks[key]
+	x.AssertTrue(ok)
+	tasks = tasks[1:]
+	if len(tasks) > 0 {
+		s.tasks[key] = tasks
+		nextTask = tasks[0]
+	} else {
+		delete(s.tasks, key)
+	}
+	return nextTask
+}

--- a/worker/task.go
+++ b/worker/task.go
@@ -34,7 +34,7 @@ import (
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos"
 	"github.com/dgraph-io/dgraph/schema"
-	"github.com/dgraph-io/dgraph/task"
+	ctask "github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
@@ -410,14 +410,14 @@ func handleValuePostings(ctx context.Context, args funcArgs) error {
 			newValue := out.ValueMatrix[lastPos].Values[0]
 			if len(newValue.Val) == 0 {
 				// TODO - Check that this is safe.
-				out.ValueMatrix[lastPos].Values[0] = task.FalseVal
+				out.ValueMatrix[lastPos].Values[0] = ctask.FalseVal
 			}
 			pwd := q.SrcFunc[2]
 			err = types.VerifyPassword(pwd, string(newValue.Val))
 			if err != nil {
-				out.ValueMatrix[lastPos].Values[0] = task.FalseVal
+				out.ValueMatrix[lastPos].Values[0] = ctask.FalseVal
 			} else {
-				out.ValueMatrix[lastPos].Values[0] = task.TrueVal
+				out.ValueMatrix[lastPos].Values[0] = ctask.TrueVal
 			}
 			// Add an empty UID list to make later processing consistent
 			out.UidMatrix = append(out.UidMatrix, &emptyUIDList)


### PR DESCRIPTION

Scheduler ensures that del and set for same uid,predicate pair always run in fifo order, schema mutations only blocks mtuations for corresponding predicates, if schema is not specified mutations for a given predicate wait on the first mutation.

TODO: Add Tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1372)
<!-- Reviewable:end -->
