### PR TITLE
Fix a couple of issues regarding RAFT

### DIFF
--- a/cmd/dgraph/groups.conf
+++ b/cmd/dgraph/groups.conf
@@ -1,2 +1,2 @@
 // Default formula for getting group where fp is the fingerprint of a predicate.
-default: fp % 1 + 1
+default: fp % 2 + 1

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -756,7 +756,7 @@ func main() {
 		}
 	}
 
-	group.ParseGroupConfig(gconf)
+	x.Checkf(group.ParseGroupConfig(gconf), "While parsing group config.")
 
 	// Posting will initialize index which requires schema. Hence, initialize
 	// schema before calling posting.Init().

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -80,7 +80,7 @@ func prepare() (dir1, dir2 string, rerr error) {
 	dgraph.State = dgraph.NewServerState()
 
 	posting.Init(dgraph.State.Pstore)
-	group.ParseGroupConfig("groups.conf")
+	x.Check(group.ParseGroupConfig(""))
 	schema.Init(dgraph.State.Pstore)
 	worker.Init(dgraph.State.Pstore)
 	worker.StartRaftNodes(dgraph.State.WALstore, false)

--- a/contrib/functions.sh
+++ b/contrib/functions.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function quit {
+  curl localhost:8080/admin/shutdown
+  curl localhost:8082/admin/shutdown
+  return $1
+}
+
+function start {
+  echo -e "Starting first server.\n"
+  ./dgraph -p $BUILD/p -w $BUILD/w -memory_mb 2048 --group_conf groups.conf --groups "0,1" --idx 1 --my "127.0.0.1:12345" > $BUILD/server.log &
+  sleep 5
+  echo -e "Starting second server.\n"
+  ./dgraph -p $BUILD/p2 -w $BUILD/w2 -memory_mb 2048 --group_conf groups.conf --groups "2" --idx 2 --my "127.0.0.1:12346" --peer "127.0.0.1:12345" --port 8082 --grpc_port 9082 --workerport 12346 > $BUILD/server2.log &
+  return 0
+}

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -144,7 +144,7 @@ echo -e "\nExport done."
 # This is count of RDF's in goldendata.rdf.gz + xids because we ran dgraphloader with -xid flag.
 dataCount="1475250"
 # Concat exported files to get total count.
-cat $(ls -t export/dgraph-1-* | head -1) $(ls -t export/dgraph-2-* | head -1) > dgraph-export.rdf.gz
+cat $(ls -t export/dgraph-1-* | head -1) $(ls -t export/dgraph-2-* | head -1) > export/dgraph-export.rdf.gz
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
   exportCount=$(zcat < export/dgraph-export.rdf.gz | wc -l)
 else

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -146,9 +146,9 @@ dataCount="1475250"
 # Concat exported files to get total count.
 cat $(ls -t export/dgraph-1-* | head -1) $(ls -t export/dgraph-2-* | head -1) > dgraph-export.rdf.gz
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-  exportCount=$(export/dgraph-export.rdf.gz | wc -l)
+  exportCount=$(zcat < export/dgraph-export.rdf.gz | wc -l)
 else
-  exportCount=$(export/dgraph-export.rdf.gz | wc -l)
+  exportCount=$(zcat export/dgraph-export.rdf.gz | wc -l)
 fi
 
 

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+function start {
+  echo -e "Starting first server.\n"
+  ./dgraph -p $BUILD/p -w $BUILD/w -memory_mb 2048 --group_conf groups.conf --groups "0,1" --idx 1 --my "127.0.0.1:12345" > $BUILD/server.log &
+  sleep 5
+  echo -e "Starting second server.\n"
+  ./dgraph -p $BUILD/p2 -w $BUILD/w2 -memory_mb 2048 --group_conf groups.conf --groups "2" --idx 2 --my "127.0.0.1:12346" --peer "127.0.0.1:12345" --port 8082 --grpc_port 9082 --workerport 12346 > $BUILD/server2.log &
+  return 0
+}
+
+
 SRC="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
 BUILD=$1
@@ -29,23 +39,24 @@ go build .
 
 ./dgraph --version
 if [ $? -eq 0 ]; then
-    echo -e "dgraph --version succeeded.\n"
+  echo -e "dgraph --version succeeded.\n"
 else
-    echo "dgraph --version command failed."
+  echo "dgraph --version command failed."
 fi
 
-./dgraph -gentlecommit 1.0 -p $BUILD/p -w $BUILD/loader/w -memory_mb 6000 > $BUILD/server.log &
+# Start Dgraph
+start
 popd &> /dev/null
 
-sleep 15
+sleep 10
 
 #Set Schema
 curl -X POST  -d 'mutation {
-  schema {
-    name: string @index(term) .
-		_xid_: string @index(exact,term) .
-    initial_release_date: datetime @index(year) .
-	}
+schema {
+name: string @index(term) .
+_xid_: string @index(exact,term) .
+initial_release_date: datetime @index(year) .
+  }
 }' "http://localhost:8080/query"
 
 echo -e "\nBuilding and running dgraphloader."
@@ -59,8 +70,9 @@ popd &> /dev/null
 pushd $GOPATH/src/github.com/dgraph-io/dgraph/contrib/indextest &> /dev/null
 
 function quit {
-	curl localhost:8080/admin/shutdown
-	return $1
+  curl localhost:8080/admin/shutdown
+  curl localhost:8082/admin/shutdown
+  return $1
 }
 
 function run_index_test {
@@ -70,8 +82,8 @@ function run_index_test {
   local exitCode=0
 
   X=$1
-	GREPFOR=$2
-	ANS=$3
+  GREPFOR=$2
+  ANS=$3
   echo "Running test: ${X}"
   while (( $attempt < $max_attempts ))
   do
@@ -93,9 +105,9 @@ function run_index_test {
   done
 
   NUM=$(echo $N | python -m json.tool | grep $GREPFOR | wc -l)
-	if [[ ! "$NUM" -eq "$ANS" ]]; then
-	  echo "Index test failed: ${X}  Expected: $ANS  Got: $NUM"
-	  quit 1
+  if [[ ! "$NUM" -eq "$ANS" ]]; then
+    echo "Index test failed: ${X}  Expected: $ANS  Got: $NUM"
+    quit 1
   else
     echo -e "Index test passed: ${X}\n"
   fi
@@ -122,19 +134,21 @@ sleep 20
 
 echo -e "\nTrying to restart Dgraph and match export count"
 pushd cmd/dgraph &> /dev/null
-./dgraph -p $BUILD/p -w $BUILD/loader/w -memory_mb 4000 &
+start
 # Wait to become leader.
-sleep 15
+sleep 5
 echo -e "\nTrying to export data."
 curl http://localhost:8080/admin/export
 echo -e "\nExport done."
 
 # This is count of RDF's in goldendata.rdf.gz + xids because we ran dgraphloader with -xid flag.
 dataCount="1475250"
+# Concat exported files to get total count.
+cat $(ls -t export/dgraph-1-* | head -1) $(ls -t export/dgraph-2-* | head -1) > dgraph-export.rdf.gz
 if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-  exportCount=$(zcat < $(ls -t export/dgraph-1-* | head -1) | wc -l)
+  exportCount=$(export/dgraph-export.rdf.gz | wc -l)
 else
-  exportCount=$(zcat $(ls -t export/dgraph-1-* | head -1) | wc -l)
+  exportCount=$(export/dgraph-export.rdf.gz | wc -l)
 fi
 
 

--- a/contrib/loader.sh
+++ b/contrib/loader.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
 
-function start {
-  echo -e "Starting first server.\n"
-  ./dgraph -p $BUILD/p -w $BUILD/w -memory_mb 2048 --group_conf groups.conf --groups "0,1" --idx 1 --my "127.0.0.1:12345" > $BUILD/server.log &
-  sleep 5
-  echo -e "Starting second server.\n"
-  ./dgraph -p $BUILD/p2 -w $BUILD/w2 -memory_mb 2048 --group_conf groups.conf --groups "2" --idx 2 --my "127.0.0.1:12346" --peer "127.0.0.1:12345" --port 8082 --grpc_port 9082 --workerport 12346 > $BUILD/server2.log &
-  return 0
-}
-
+source ./contrib/functions.sh
 
 SRC="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
 
@@ -68,12 +60,6 @@ go build .
 popd &> /dev/null
 
 pushd $GOPATH/src/github.com/dgraph-io/dgraph/contrib/indextest &> /dev/null
-
-function quit {
-  curl localhost:8080/admin/shutdown
-  curl localhost:8082/admin/shutdown
-  return $1
-}
 
 function run_index_test {
   local max_attempts=${ATTEMPTS-5}

--- a/contrib/queries.sh
+++ b/contrib/queries.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 set -e
 
+source ./contrib/functions.sh
+
 BUILD=$1
 
 pushd cmd/dgraph &> /dev/null
 go build .
 # Start dgraph in the background.
-./dgraph -w $BUILD/w2 -p $BUILD/p --memory_mb 4000 &
+start
+sleep 5
 
 # Wait for server to start in the background.
 until nc -z 127.0.0.1 8080;
@@ -16,6 +19,6 @@ done
 
 go test -v ../../contrib/freebase
 
-killall dgraph
+quit 0
 
 popd &> /dev/null

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -983,7 +983,7 @@ func (n *node) InitAndStartNode(wal *raftwal.Wal) {
 }
 
 func (n *node) AmLeader() bool {
-	if n.Raft() == nil {
+	if n == nil || n.Raft() == nil {
 		return false
 	}
 	r := n.Raft()

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -983,7 +983,7 @@ func (n *node) InitAndStartNode(wal *raftwal.Wal) {
 }
 
 func (n *node) AmLeader() bool {
-	if n == nil || n.Raft() == nil {
+	if n.Raft() == nil {
 		return false
 	}
 	r := n.Raft()

--- a/worker/export.go
+++ b/worker/export.go
@@ -337,7 +337,7 @@ func export(gid uint32, bdir string) error {
 
 func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos.ExportPayload {
 	n := groups().Node(gid)
-	if n.AmLeader() {
+	if n != nil && n.AmLeader() {
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("Leader of group: %d. Running export.", gid)
 		}

--- a/worker/export.go
+++ b/worker/export.go
@@ -373,8 +373,9 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 
 	var pl *pool
 	var conn *grpc.ClientConn
+	var err error
 	for _, addr := range addrs {
-		pl, err := pools().get(addr)
+		pl, err = pools().get(addr)
 		if err != nil {
 			if tr, ok := trace.FromContext(ctx); ok {
 				tr.LazyPrintf(err.Error())


### PR DESCRIPTION
Noticed these issues while exporting data in a cluster mode.

1. AmLeader is called by handleExportForGroup and the server calling it might not be serving the group hence we need to check if n is nil.
2. pool variable was shadowed inside the inner block and when  `defer pools().release(pl)` was called it paniced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1373)
<!-- Reviewable:end -->
