### PR TITLE
Make watermark not have WaitingFor

### DIFF
--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/badger"
@@ -29,6 +30,7 @@ import (
 type waterMark struct {
 	last uint64 // Last line number that was written to Badger.
 	mark *x.WaterMark
+	wg   *sync.WaitGroup
 }
 
 // A watermark for each file.
@@ -102,7 +104,7 @@ func (g syncMarks) create(file string) waterMark {
 	}
 	m := &x.WaterMark{Name: file}
 	m.Init()
-	wm := waterMark{mark: m}
+	wm := waterMark{mark: m, wg: new(sync.WaitGroup)}
 	g[file] = wm
 	return wm
 }

--- a/client/client.go
+++ b/client/client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"encoding/base64"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/dgraph/protos"
@@ -41,9 +42,10 @@ const (
 // multiple set, delete and schema mutations, and a single GraphQL+- query.  If the query contains
 // GraphQL variables, then it must be set with SetQueryWithVariables rather than SetQuery.
 type Req struct {
-	gr   protos.Request
-	mark *x.WaterMark
-	line uint64
+	gr     protos.Request
+	mark   *x.WaterMark
+	line   uint64
+	markWg *sync.WaitGroup // non-nil only if mark is non-nil
 }
 
 // Request returns the protos.Request backing the Req.

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -172,16 +172,6 @@ func (w *WaterMark) process() {
 		}
 		if !doWait {
 			atomic.StoreUint32(&w.waitingFor, 0)
-			for len(waiterIndices) > 0 {
-				min := waiterIndices[0]
-				// Some partly duplicated code with what's below.
-				heap.Pop(&waiterIndices)
-				toNotify := waiters[min]
-				for _, ch := range toNotify {
-					close(ch)
-				}
-				delete(waiters, min)
-			}
 		}
 
 		if until != doneUntil {

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -63,11 +63,10 @@ type mark struct {
 // An index may also become "done" by calling SetDoneUntil at a time such that it is not
 // inter-mingled with Begin/Done calls.
 type WaterMark struct {
-	Name       string
-	markCh     chan mark
-	doneUntil  uint64
-	elog       trace.EventLog
-	waitingFor uint32 // Are we waiting for some index?
+	Name      string
+	markCh    chan mark
+	doneUntil uint64
+	elog      trace.EventLog
 }
 
 // Init initializes a WaterMark struct. MUST be called before using it.
@@ -100,11 +99,6 @@ func (w *WaterMark) SetDoneUntil(val uint64) {
 	atomic.StoreUint64(&w.doneUntil, val)
 }
 
-// WaitingFor returns whether we are waiting for a task to be done.
-func (w *WaterMark) WaitingFor() bool {
-	return atomic.LoadUint32(&w.waitingFor) != 0
-}
-
 func (w *WaterMark) WaitForMark(index uint64) {
 	if w.DoneUntil() >= index {
 		return
@@ -133,8 +127,6 @@ func (w *WaterMark) process() {
 		prev, present := pending[index]
 		if !present {
 			heap.Push(&indices, index)
-			// indices now nonempty, update waitingFor.
-			atomic.StoreUint32(&w.waitingFor, 1)
 		}
 
 		delta := 1
@@ -157,12 +149,10 @@ func (w *WaterMark) process() {
 
 		until := doneUntil
 		loops := 0
-		var doWait bool
 
 		for len(indices) > 0 {
 			min := indices[0]
 			if done := pending[min]; done != 0 {
-				doWait = true
 				break // len(indices) will be > 0.
 			}
 			heap.Pop(&indices)
@@ -170,10 +160,6 @@ func (w *WaterMark) process() {
 			until = min
 			loops++
 		}
-		if !doWait {
-			atomic.StoreUint32(&w.waitingFor, 0)
-		}
-
 		if until != doneUntil {
 			for len(waiterIndices) > 0 {
 				min := waiterIndices[0]


### PR DESCRIPTION
This removes WaitingFor() from WaterMark.  Also the client code now uses a WaitGroup instead of using a WaterMark as one.

Connected to #1345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1377)
<!-- Reviewable:end -->
