### PR TITLE
Make syncMarks::create assert non-nil map

### DIFF
--- a/client/checkpoint.go
+++ b/client/checkpoint.go
@@ -93,9 +93,7 @@ func (d *Dgraph) writeCheckpoint() {
 }
 
 func (g syncMarks) create(file string) waterMark {
-	if g == nil {
-		g = make(map[string]waterMark)
-	}
+	x.AssertTrue(g != nil)
 
 	if prev, present := g[file]; present {
 		return prev


### PR DESCRIPTION
Its behavior didn't really make sense on a nil map, because it assigned to a local var.

But, my question is: Is the case of a nil map supposed to be handled somehow?  Is the assertion wrong?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1378)
<!-- Reviewable:end -->
