### PR TITLE
store in proposal map if not present

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -631,6 +631,14 @@ func (n *node) processApplyCh() {
 
 		// One final applied and synced watermark would be emitted when proposal ctx ref count
 		// becomes zero.
+		if !n.props.Has(proposal.Id) {
+			pctx := &proposalCtx{
+				ch:  make(chan error, 1),
+				ctx: n.ctx,
+				n:   n,
+			}
+			n.props.Store(proposal.Id, pctx)
+		}
 		if proposal.Mutations != nil {
 			n.sch.schedule(proposal, e.Index)
 		} else if proposal.Membership != nil {


### PR DESCRIPTION
This would happen when logs are replayed after startup. We use proposal map to do reference counting and emit watermarks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1392)
<!-- Reviewable:end -->
