### PR TITLE
Make dgraphloader pass errors up

### DIFF
--- a/cmd/dgraphloader/main.go
+++ b/cmd/dgraphloader/main.go
@@ -193,7 +193,7 @@ func processFile(ctx context.Context, file string, dgraphClient *client.Dgraph) 
 		r.Set(client.NewEdge(nq))
 		if batchSize >= *numRdf {
 			if err = dgraphClient.BatchSetWithMark(r, absPath, line); err != nil {
-				log.Fatal("While adding mutation to batch: ", err)
+				return x.Wrapf(err, "While adding mutation to batch: ")
 			}
 			batchSize = 0
 			r = new(client.Req)
@@ -204,7 +204,7 @@ func processFile(ctx context.Context, file string, dgraphClient *client.Dgraph) 
 	}
 	if batchSize > 0 {
 		if err = dgraphClient.BatchSetWithMark(r, absPath, line); err != nil {
-			log.Fatal("While adding mutation to batch: ", err)
+			return x.Wrapf(err, "While adding mutation to batch: ")
 		}
 	}
 	return nil


### PR DESCRIPTION
We were aborting instead of expressing useful output semi-randomly when the user pressed Ctrl+C.

Connected to #1376.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1400)
<!-- Reviewable:end -->
