### PR TITLE
Bulkloader stage 2 (shuffle)

### DIFF
--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -113,7 +113,7 @@ func (ld *loader) run() {
 		flatPostingChs[i] = make(chan *protos.FlatPosting, 1<<10)
 		go readFlatFile(tmpPostingsDir, i, flatPostingChs[i])
 	}
-	shuffleFlatFiles(tmpPostingsDir, flatPostingChs)
+	shuffleFlatFiles(tmpPostingsDir, flatPostingChs, ld.prog)
 
 	ld.prog.endSummary()
 }

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -3,9 +3,7 @@ package main
 import (
 	"bufio"
 	"compress/gzip"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -121,26 +119,4 @@ func (ld *loader) run() {
 	shuffleFlatFiles(tmpPostingsDir, flatPostingChs, ld.prog)
 
 	ld.prog.endSummary()
-
-	fa, err := os.OpenFile("/ssd/debug.txt", os.O_CREATE|os.O_RDWR, 0644)
-	x.Check(err)
-	defer func() { x.Check(fa.Close()) }()
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000000.bin"), fa)
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000001.bin"), fa)
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000002.bin"), fa)
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000003.bin"), fa)
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000004.bin"), fa)
-}
-
-func catFlatFile(filename string, w io.Writer) {
-	x.Check2(w.Write([]byte(filename)))
-	x.Check2(w.Write([]byte{'\n'}))
-	ch := make(chan *protos.FlatPosting)
-	go func() {
-		readFlatFile(filename, ch)
-	}()
-	for p := range ch {
-		x.Check2(w.Write([]byte(hex.Dump(p.Key))))
-		x.Check2(w.Write([]byte{'\n'}))
-	}
 }

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -112,7 +112,13 @@ func (ld *loader) run() {
 		flatPostingChs[i] = make(chan *protos.FlatPosting, 1000)
 		go readFlatFile(mappedFile, flatPostingChs[i])
 	}
-	shuffleFlatFiles(tmpPostingsDir, flatPostingChs, ld.prog)
+	batchCh := make(chan []*protos.FlatPosting, 10)
+	go func() {
+		for _ = range batchCh {
+			// TODO: Reduce stage initiated from here.
+		}
+	}()
+	shuffleFlatFiles(batchCh, flatPostingChs, ld.prog)
 
 	ld.prog.endSummary()
 }

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -113,7 +113,7 @@ func (ld *loader) run() {
 	flatPostingChs := make([]chan *protos.FlatPosting, numFlatFiles)
 	for i := 0; i < numFlatFiles; i++ {
 		flatPostingChs[i] = make(chan *protos.FlatPosting, 1<<10)
-		filename := filepath.Join(tmpPostingsDir, fmt.Sprintf("%06d.bin", i))
+		filename := filepath.Join(tmpPostingsDir, fmt.Sprintf("map_%06d.bin", i))
 		go readFlatFile(filename, flatPostingChs[i])
 	}
 	shuffleFlatFiles(tmpPostingsDir, flatPostingChs, ld.prog)

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -113,12 +113,10 @@ func (ld *loader) run() {
 		go readFlatFile(mappedFile, flatPostingChs[i])
 	}
 	batchCh := make(chan []*protos.FlatPosting, 10)
-	go func() {
-		for _ = range batchCh {
-			// TODO: Reduce stage initiated from here.
-		}
-	}()
-	shuffleFlatFiles(batchCh, flatPostingChs, ld.prog)
+	go shuffleFlatFiles(batchCh, flatPostingChs, ld.prog)
+	for _ = range batchCh {
+		// TODO: Reduce stage initiated from here.
+	}
 
 	ld.prog.endSummary()
 }

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -127,6 +127,8 @@ func (ld *loader) run() {
 	defer func() { x.Check(fa.Close()) }()
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000000.bin"), fa)
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000001.bin"), fa)
+	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000002.bin"), fa)
+	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000004.bin"), fa)
 }
 
 func catFlatFile(filename string, w io.Writer) {

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -71,8 +71,8 @@ func (ld *loader) run() {
 
 	var mappedFiles []string
 	go func() {
-		mappedFiles = writePostings(tmpPostingsDir, ld.postingsCh, ld.prog)
-		writePostings(tmpPostingsDir, ld.postingsCh, ld.prog)
+		mappedFiles = writeMappedFile(tmpPostingsDir, ld.postingsCh, ld.prog)
+		writeMappedFile(tmpPostingsDir, ld.postingsCh, ld.prog)
 		postingWriterWg.Done()
 	}()
 

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -128,7 +128,7 @@ func (ld *loader) run() {
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000000.bin"), fa)
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000001.bin"), fa)
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000002.bin"), fa)
-	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000004.bin"), fa)
+	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000003.bin"), fa)
 }
 
 func catFlatFile(filename string, w io.Writer) {

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -71,8 +71,8 @@ func (ld *loader) run() {
 
 	var mappedFiles []string
 	go func() {
-		mappedFiles = writeMappedFile(tmpPostingsDir, ld.postingsCh, ld.prog)
-		writeMappedFile(tmpPostingsDir, ld.postingsCh, ld.prog)
+		mappedFiles = writeMappedFiles(tmpPostingsDir, ld.postingsCh, ld.prog)
+		writeMappedFiles(tmpPostingsDir, ld.postingsCh, ld.prog)
 		postingWriterWg.Done()
 	}()
 

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -110,7 +110,7 @@ func (ld *loader) run() {
 
 	flatPostingChs := make([]chan *protos.FlatPosting, len(mappedFiles))
 	for i, mappedFile := range mappedFiles {
-		flatPostingChs[i] = make(chan *protos.FlatPosting, 1<<10)
+		flatPostingChs[i] = make(chan *protos.FlatPosting, 1000)
 		go readFlatFile(mappedFile, flatPostingChs[i])
 	}
 	shuffleFlatFiles(tmpPostingsDir, flatPostingChs, ld.prog)

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -72,7 +72,6 @@ func (ld *loader) run() {
 	var mappedFiles []string
 	go func() {
 		mappedFiles = writeMappedFiles(tmpPostingsDir, ld.postingsCh, ld.prog)
-		writeMappedFiles(tmpPostingsDir, ld.postingsCh, ld.prog)
 		postingWriterWg.Done()
 	}()
 

--- a/cmd/bulkloader/loader.go
+++ b/cmd/bulkloader/loader.go
@@ -129,6 +129,7 @@ func (ld *loader) run() {
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000001.bin"), fa)
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000002.bin"), fa)
 	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000003.bin"), fa)
+	catFlatFile(filepath.Join(tmpPostingsDir, "merged_000004.bin"), fa)
 }
 
 func catFlatFile(filename string, w io.Writer) {

--- a/cmd/bulkloader/main.go
+++ b/cmd/bulkloader/main.go
@@ -24,5 +24,7 @@ func main() {
 	flag.Parse()
 
 	loader := newLoader(opt)
-	loader.run()
+	loader.mapStage()
+	loader.reduceStage()
+	loader.cleanup()
 }

--- a/cmd/bulkloader/mapper.go
+++ b/cmd/bulkloader/mapper.go
@@ -27,7 +27,7 @@ func (m *mapper) run() {
 }
 
 func (m *mapper) addPosting(key []byte, posting *protos.Posting) {
-	atomic.AddInt64(&m.prog.edgeCount, 1)
+	atomic.AddInt64(&m.prog.mapEdgeCount, 1)
 
 	p := &protos.FlatPosting{
 		Key: key,

--- a/cmd/bulkloader/progress.go
+++ b/cmd/bulkloader/progress.go
@@ -43,9 +43,9 @@ func (p *progress) report() {
 func (p *progress) reportOnce() {
 
 	mapEdgeCount := atomic.LoadInt64(&p.mapEdgeCount)
-	shuffleEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
+	reduceEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
 
-	if shuffleEdgeCount == 0 {
+	if reduceEdgeCount == 0 {
 		rdfCount := atomic.LoadInt64(&p.rdfCount)
 		elapsed := time.Since(p.start)
 		fmt.Printf("[MAP] [%s] [RDF count: %d] [Edge count: %d] "+
@@ -63,12 +63,12 @@ func (p *progress) reportOnce() {
 			p.startReduce = time.Now()
 			elapsed = time.Second
 		}
-		shuffleEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
+		reduceEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
 		fmt.Printf("[REDUCE] [%s] [%.2f%%] [Edge count: %d] [Edges per second: %d]\n",
 			round(now.Sub(p.start)).String(),
-			100*float64(shuffleEdgeCount)/float64(mapEdgeCount),
-			shuffleEdgeCount,
-			int(float64(shuffleEdgeCount)/elapsed.Seconds()),
+			100*float64(reduceEdgeCount)/float64(mapEdgeCount),
+			reduceEdgeCount,
+			int(float64(reduceEdgeCount)/elapsed.Seconds()),
 		)
 	}
 }

--- a/cmd/bulkloader/progress.go
+++ b/cmd/bulkloader/progress.go
@@ -41,7 +41,6 @@ func (p *progress) report() {
 }
 
 func (p *progress) reportOnce() {
-
 	mapEdgeCount := atomic.LoadInt64(&p.mapEdgeCount)
 	reduceEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
 

--- a/cmd/bulkloader/progress.go
+++ b/cmd/bulkloader/progress.go
@@ -7,12 +7,12 @@ import (
 )
 
 type progress struct {
-	rdfCount         int64
-	mapEdgeCount     int64
-	shuffleEdgeCount int64
+	rdfCount        int64
+	mapEdgeCount    int64
+	reduceEdgeCount int64
 
-	start        time.Time
-	startShuffle time.Time
+	start       time.Time
+	startReduce time.Time
 
 	// shutdown is a bidirectional channel used to manage the stopping of the
 	// report goroutine. It handles both the request to stop the report
@@ -43,7 +43,7 @@ func (p *progress) report() {
 func (p *progress) reportOnce() {
 
 	mapEdgeCount := atomic.LoadInt64(&p.mapEdgeCount)
-	shuffleEdgeCount := atomic.LoadInt64(&p.shuffleEdgeCount)
+	shuffleEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
 
 	if shuffleEdgeCount == 0 {
 		rdfCount := atomic.LoadInt64(&p.rdfCount)
@@ -58,13 +58,13 @@ func (p *progress) reportOnce() {
 		)
 	} else {
 		now := time.Now()
-		elapsed := time.Since(p.startShuffle)
-		if p.startShuffle.IsZero() {
-			p.startShuffle = time.Now()
+		elapsed := time.Since(p.startReduce)
+		if p.startReduce.IsZero() {
+			p.startReduce = time.Now()
 			elapsed = time.Second
 		}
-		shuffleEdgeCount := atomic.LoadInt64(&p.shuffleEdgeCount)
-		fmt.Printf("[SHUFFLE] [%s] [%.2f%%] [Edge count: %d] [Edges per second: %d]\n",
+		shuffleEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
+		fmt.Printf("[REDUCE] [%s] [%.2f%%] [Edge count: %d] [Edges per second: %d]\n",
 			round(now.Sub(p.start)).String(),
 			100*float64(shuffleEdgeCount)/float64(mapEdgeCount),
 			shuffleEdgeCount,

--- a/cmd/bulkloader/reduce.go
+++ b/cmd/bulkloader/reduce.go
@@ -1,0 +1,6 @@
+package main
+
+import "github.com/dgraph-io/dgraph/protos"
+
+func reduce(batch []*protos.FlatPosting, prog *progress) {
+}

--- a/cmd/bulkloader/reduce.go
+++ b/cmd/bulkloader/reduce.go
@@ -1,6 +1,14 @@
 package main
 
-import "github.com/dgraph-io/dgraph/protos"
+import (
+	"sync/atomic"
+
+	"github.com/dgraph-io/dgraph/protos"
+)
 
 func reduce(batch []*protos.FlatPosting, prog *progress) {
+	for _ = range batch {
+		// TODO: Reduction logic goes here.
+		atomic.AddInt64(&prog.reduceEdgeCount, 1)
+	}
 }

--- a/cmd/bulkloader/speed_tests/run.sh
+++ b/cmd/bulkloader/speed_tests/run.sh
@@ -40,7 +40,7 @@ function run_test {
 	echo "$schema" > $tmpDir/sch.schema
 
 	# Run bulk loader.
-	bulkloader -tmp "$tmp" -b "$tmpDir" -s "$tmpDir/sch.schema" -r "$dataFile"
+	$GOPATH/bin/bulkloader -tmp "$tmp" -b "$tmpDir" -s "$tmpDir/sch.schema" -r "$dataFile"
 
 	# Cleanup
 	rm -rf $tmpDir

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -113,18 +114,18 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 		heap.Push(&ph, heapNode{<-ch, ch})
 	}
 
+	var buf proto.Buffer
 	writeBuf := func() {
 		filename := filepath.Join(dir, fmt.Sprintf("merged_%06d.bin", fileNum))
 		fileNum++
 		wg.Add(1)
 		go func(buf []byte) {
-			x.Check(outil.WriteFile(filename, buf, 0644))
+			x.Check(ioutil.WriteFile(filename, buf, 0644))
 			wg.Done()
 		}(buf.Bytes())
 		buf.SetBuf(nil)
 	}
 
-	var buf proto.Buffer
 	for len(ph.data) > 0 {
 		msg := ph.data[0].head
 		var ok bool

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -7,7 +7,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -67,11 +66,7 @@ func sortAndWrite(filename string, postings []*protos.FlatPosting, prog *progres
 		x.Check(buf.EncodeMessage(posting))
 	}
 
-	fd, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
-	x.Checkf(err, "Could not open tmp file.")
-	x.Check2(fd.Write(buf.Bytes()))
-	x.Check(fd.Sync())
-	x.Check(fd.Close())
+	x.Check(x.WriteFileSync(filename, buf.Bytes(), 0644))
 }
 
 func readFlatFile(filename string, postingCh chan<- *protos.FlatPosting) {
@@ -121,7 +116,7 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 		fileNum++
 		wg.Add(1)
 		go func(buf []byte) {
-			x.Check(ioutil.WriteFile(filename, buf, 0644))
+			x.Check(x.WriteFileSync(filename, buf, 0644))
 			wg.Done()
 		}(buf.Bytes())
 		buf.SetBuf(nil)

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -29,7 +29,7 @@ func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *prog
 
 	processBatch := func() {
 		wg.Add(1)
-		filename := filepath.Join(dir, fmt.Sprintf("%06d.bin", fileNum))
+		filename := filepath.Join(dir, fmt.Sprintf("map_%06d.bin", fileNum))
 		fileNum++
 		ps := postings
 		postings = nil
@@ -116,7 +116,7 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 
 	var buf proto.Buffer
 	writeBuf := func() {
-		filename := filepath.Join(dir, fmt.Sprintf("merged_%06d.bin", fileNum))
+		filename := filepath.Join(dir, fmt.Sprintf("shu_%06d.bin", fileNum))
 		fileNum++
 		wg.Add(1)
 		go func(buf []byte) {

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -125,9 +125,6 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 			heap.Pop(&ph)
 		}
 
-		x.Check(buf.EncodeMessage(msg))
-		atomic.AddInt64(&prog.shuffleEdgeCount, 1)
-
 		if len(buf.Bytes()) > 32<<20 && bytes.Compare(prevKey, msg.Key) != 0 {
 			filename := filepath.Join(dir, fmt.Sprintf("merged_%06d.bin", fileNum))
 			fileNum++
@@ -139,8 +136,13 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 			buf.SetBuf(nil)
 		}
 		prevKey = msg.Key
+
+		x.Check(buf.EncodeMessage(msg))
+		atomic.AddInt64(&prog.shuffleEdgeCount, 1)
 	}
 	wg.Wait()
+
+	// TODO: Write remainder of buf to last file.
 }
 
 type heapNode struct {

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -20,8 +20,9 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) int {
+func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) []string {
 
+	var filenames []string
 	var fileNum int
 	var postings []*protos.FlatPosting
 	var wg sync.WaitGroup
@@ -31,6 +32,7 @@ func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *prog
 		wg.Add(1)
 		filename := filepath.Join(dir, fmt.Sprintf("map_%06d.bin", fileNum))
 		fileNum++
+		filenames = append(filenames, filename)
 		ps := postings
 		postings = nil
 		sz = 0
@@ -52,7 +54,7 @@ func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *prog
 	}
 
 	wg.Wait()
-	return fileNum
+	return filenames
 }
 
 func sortAndWrite(filename string, postings []*protos.FlatPosting, prog *progress) {

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -20,7 +20,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) []string {
+func writeMappedFile(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) []string {
 
 	var filenames []string
 	var fileNum int
@@ -96,8 +96,7 @@ func readFlatFile(filename string, postingCh chan<- *protos.FlatPosting) {
 		for len(unmarshalBuf) < int(sz) {
 			unmarshalBuf = make([]byte, 2*len(unmarshalBuf))
 		}
-		n, err = io.ReadFull(r, unmarshalBuf[:sz])
-		x.Check(err)
+		x.Check2(io.ReadFull(r, unmarshalBuf[:sz]))
 
 		flatPosting := new(protos.FlatPosting)
 		x.Check(proto.Unmarshal(unmarshalBuf[:sz], flatPosting))

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func writeMappedFile(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) []string {
+func writeMappedFiles(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) []string {
 
 	var filenames []string
 	var fileNum int

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -1,8 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
+	"container/heap"
+	"encoding/binary"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,7 +19,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 )
 
-func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) {
+func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *progress) int {
 
 	var fileNum int
 	var postings []*protos.FlatPosting
@@ -45,6 +51,7 @@ func writePostings(dir string, postingsCh <-chan *protos.FlatPosting, prog *prog
 	}
 
 	wg.Wait()
+	return fileNum
 }
 
 func sortAndWrite(filename string, postings []*protos.FlatPosting, prog *progress) {
@@ -62,4 +69,102 @@ func sortAndWrite(filename string, postings []*protos.FlatPosting, prog *progres
 	x.Check2(fd.Write(buf.Bytes()))
 	x.Check(fd.Sync())
 	x.Check(fd.Close())
+}
+
+func readFlatFile(dir string, fid int, postingCh chan<- *protos.FlatPosting) {
+	filename := filepath.Join(dir, fmt.Sprintf("%06d.bin", fid))
+	fd, err := os.Open(filename)
+	x.Check(err)
+	defer fd.Close()
+	r := bufio.NewReaderSize(fd, 1<<20)
+
+	unmarshalBuf := make([]byte, 1<<10)
+	for {
+		buf, err := r.Peek(binary.MaxVarintLen64)
+		if err == io.EOF {
+			break
+		}
+		x.Check(err)
+		sz, n := binary.Uvarint(buf)
+		if n <= 0 {
+			log.Fatal("Could not read varint: %d", n)
+		}
+		x.Check2(r.Discard(n))
+
+		for len(unmarshalBuf) < int(sz) {
+			unmarshalBuf = make([]byte, 2*len(unmarshalBuf))
+		}
+		n, err = io.ReadFull(r, unmarshalBuf[:sz])
+		x.Check(err)
+
+		flatPosting := new(protos.FlatPosting)
+		x.Check(proto.Unmarshal(unmarshalBuf[:sz], flatPosting))
+		postingCh <- flatPosting
+	}
+	close(postingCh)
+}
+
+func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting) {
+	var fileNum int
+	var wg sync.WaitGroup
+	var prevKey []byte
+
+	var ph postingHeap
+	for _, ch := range postingChs {
+		heap.Push(&ph, heapNode{<-ch, ch})
+	}
+
+	var buf proto.Buffer
+	for len(ph.data) > 0 {
+		msg := ph.data[0].head
+		var ok bool
+		ph.data[0].head, ok = <-ph.data[0].ch
+		if ok {
+			heap.Fix(&ph, 0)
+		} else {
+			heap.Pop(&ph)
+		}
+
+		x.Check(buf.EncodeMessage(msg))
+
+		if len(buf.Bytes()) > 32<<20 && bytes.Compare(prevKey, msg.Key) != 0 {
+			filename := filepath.Join(dir, fmt.Sprintf("merged_%6d.bin", fileNum))
+			fileNum++
+			wg.Add(1)
+			go func(buf []byte) {
+				ioutil.WriteFile(filename, buf, 0644)
+				wg.Done()
+			}(buf.Bytes())
+			buf.SetBuf(nil)
+		}
+		prevKey = msg.Key
+	}
+	wg.Wait()
+}
+
+type heapNode struct {
+	head *protos.FlatPosting
+	ch   <-chan *protos.FlatPosting
+}
+
+type postingHeap struct {
+	data []heapNode
+}
+
+func (h *postingHeap) Len() int {
+	return len(h.data)
+}
+func (h *postingHeap) Less(i, j int) bool {
+	return bytes.Compare(h.data[i].head.Key, h.data[j].head.Key) < 0
+}
+func (h *postingHeap) Swap(i, j int) {
+	h.data[i], h.data[j] = h.data[j], h.data[i]
+}
+func (h *postingHeap) Push(x interface{}) {
+	h.data = append(h.data, x.(heapNode))
+}
+func (h *postingHeap) Pop() interface{} {
+	elem := h.data[len(h.data)-1]
+	h.data = h.data[:len(h.data)-1]
+	return elem
 }

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
-	"sync/atomic"
 
 	"github.com/dgraph-io/dgraph/protos"
 	"github.com/dgraph-io/dgraph/x"
@@ -100,8 +99,8 @@ func readFlatFile(filename string, postingCh chan<- *protos.FlatPosting) {
 	close(postingCh)
 }
 
-func shuffleFlatFiles(batchCh chan []*protos.FlatPosting,
-	postingChs []chan *protos.FlatPosting, prog *progress) {
+func shuffleFlatFiles(batchCh chan<- []*protos.FlatPosting,
+	postingChs []<-chan *protos.FlatPosting, prog *progress) {
 
 	var ph postingHeap
 	for _, ch := range postingChs {
@@ -129,7 +128,6 @@ func shuffleFlatFiles(batchCh chan []*protos.FlatPosting,
 		prevKey = p.Key
 
 		batch = append(batch, p)
-		atomic.AddInt64(&prog.shuffleEdgeCount, 1)
 	}
 	if len(batch) > 0 {
 		batchCh <- batch

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -128,7 +128,7 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting) {
 		x.Check(buf.EncodeMessage(msg))
 
 		if len(buf.Bytes()) > 32<<20 && bytes.Compare(prevKey, msg.Key) != 0 {
-			filename := filepath.Join(dir, fmt.Sprintf("merged_%6d.bin", fileNum))
+			filename := filepath.Join(dir, fmt.Sprintf("merged_%06d.bin", fileNum))
 			fileNum++
 			wg.Add(1)
 			go func(buf []byte) {

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -72,8 +72,7 @@ func sortAndWrite(filename string, postings []*protos.FlatPosting, prog *progres
 	x.Check(fd.Close())
 }
 
-func readFlatFile(dir string, fid int, postingCh chan<- *protos.FlatPosting) {
-	filename := filepath.Join(dir, fmt.Sprintf("%06d.bin", fid))
+func readFlatFile(filename string, postingCh chan<- *protos.FlatPosting) {
 	fd, err := os.Open(filename)
 	x.Check(err)
 	defer fd.Close()

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -134,6 +134,7 @@ func shuffleFlatFiles(batchCh chan []*protos.FlatPosting,
 	if len(batch) > 0 {
 		batchCh <- batch
 	}
+	close(batchCh)
 }
 
 type heapNode struct {

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -29,7 +29,7 @@ func writeMappedFiles(dir string, postingsCh <-chan *protos.FlatPosting, prog *p
 
 	processBatch := func() {
 		wg.Add(1)
-		filename := filepath.Join(dir, fmt.Sprintf("map_%06d.bin", fileNum))
+		filename := filepath.Join(dir, fmt.Sprintf("%06d.bin", fileNum))
 		fileNum++
 		filenames = append(filenames, filename)
 		ps := postings

--- a/cmd/bulkloader/write_flat.go
+++ b/cmd/bulkloader/write_flat.go
@@ -107,7 +107,7 @@ func shuffleFlatFiles(dir string, postingChs []chan *protos.FlatPosting, prog *p
 
 	var ph postingHeap
 	for _, ch := range postingChs {
-		heap.Push(&ph, heapNode{<-ch, ch})
+		heap.Push(&ph, heapNode{head: <-ch, ch: ch})
 	}
 
 	var buf proto.Buffer

--- a/x/file.go
+++ b/x/file.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package x
+
+import (
+	"os"
+)
+
+// WriteFileSync is the same as bufio.WriteFile, but syncs the data before closing.
+func WriteFileSync(filename string, data []byte, perm os.FileMode) error {
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
- After N sorted files are dumped to disk, the shuffle phase begins.
- Each file is opened in its own goroutine.
- Parse each file for flat postings.
- Push each posting onto a channel (1 channel per posting file).
- A min-heap data structure knows about each of the channels.
- Reads off the channels to provide the final sorted stream of flat postings.
- Completely sorted flat postings are batched up and sent to the reduce phase (currently stubbed out -- to be completed in the next phase).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1406)
<!-- Reviewable:end -->
