### PR TITLE
WIP: Wal/index (Don't review)

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -282,6 +282,7 @@ func updateCount(ctx context.Context, params countParams) error {
 		Attr:    params.attr,
 		Op:      protos.DirectedEdge_DEL,
 	}
+	// Read from wal and remove this // TODO
 	if err := addCountMutation(ctx, &edge, uint32(params.countBefore),
 		params.reverse); err != nil {
 		return err

--- a/posting/list.go
+++ b/posting/list.go
@@ -631,6 +631,7 @@ func doAsyncWrite(key []byte, data []byte, uidOnlyPosting bool, f func(error)) {
 }
 
 // should be cheap for scalar values
+// Will refactor, might have to change approach for count index.
 func (l *List) MergedPostingList() *protos.PostingList {
 	l.RLock()
 	defer l.RUnlock()

--- a/posting/list.go
+++ b/posting/list.go
@@ -630,6 +630,43 @@ func doAsyncWrite(key []byte, data []byte, uidOnlyPosting bool, f func(error)) {
 	}
 }
 
+// should be cheap for scalar values
+func (l *List) MergedPostingList() *protos.PostingList {
+	l.RLock()
+	defer l.RUnlock()
+	if len(l.mlayer) == 0 {
+		return l.plist
+	}
+	final := new(protos.PostingList)
+	var bp bp128.BPackEncoder
+	buf := make([]uint64, 0, bp128.BlockSize)
+
+	l.iterate(0, func(p *protos.Posting) bool {
+		buf = append(buf, p.Uid)
+		if len(buf) == bp128.BlockSize {
+			bp.PackAppend(buf)
+			buf = buf[:0]
+		}
+
+		if p.Facets != nil || p.Value != nil || len(p.Metadata) != 0 || len(p.Label) != 0 {
+			// I think it's okay to take the pointer from the iterator, because we have a lock
+			// over List; which won't be released until final has been marshalled. Thus, the
+			// underlying data wouldn't be changed.
+			final.Postings = append(final.Postings, p)
+		}
+		return true
+	})
+	if len(buf) > 0 {
+		bp.PackAppend(buf)
+	}
+	sz := bp.Size()
+	if sz > 0 {
+		final.Uids = make([]byte, sz)
+		bp.WriteTo(final.Uids)
+	}
+	return final
+}
+
 func (l *List) SyncIfDirty(delFromCache bool) (committed bool, err error) {
 	l.Lock()
 	defer l.Unlock()

--- a/vendor/github.com/dgraph-io/badger/kv.go
+++ b/vendor/github.com/dgraph-io/badger/kv.go
@@ -40,18 +40,32 @@ var (
 
 // Options are params for creating DB object.
 type Options struct {
-	Dir      string // Directory to store the data in. Should exist and be writable.
-	ValueDir string // Directory to store the value log in. Can be the same as Dir.
-	// Should exist and be writable.
+	// 1. Mandatory flags
+	// -------------------
+	// Directory to store the data in. Should exist and be writable.
+	Dir string
+	// Directory to store the value log in. Can be the same as Dir. Should exist and be writable.
+	ValueDir string
 
+	// 2. Frequently modified flags
+	// -----------------------------
+	// Sync all writes to disk. Setting this to true would slow down data loading significantly.
+	SyncWrites bool
+	// How should LSM tree be accessed.
+	MapTablesTo int
+	// How often to run value log garbage collector. Every time it runs, there'd be a spike in LSM
+	// tree activity. But, running it frequently allows reclaiming disk space from an ever-growing
+	// value log.
+	ValueGCRunInterval time.Duration
+
+	// 3. Flags that user might want to review
+	// ----------------------------------------
 	// The following affect all levels of LSM tree.
 	MaxTableSize        int64 // Each table (or file) is at most this size.
 	LevelSizeMultiplier int   // Equals SizeOf(Li+1)/SizeOf(Li).
 	MaxLevels           int   // Maximum number of levels of compaction.
 	ValueThreshold      int   // If value size >= this threshold, only store value offsets in tree.
-	MapTablesTo         int   // How should LSM tree be accessed.
-
-	NumMemtables int // Maximum number of tables to keep in memory, before stalling.
+	NumMemtables        int   // Maximum number of tables to keep in memory, before stalling.
 
 	// The following affect how we handle LSM tree L0.
 	// Maximum number of Level 0 tables before we start compacting.
@@ -64,19 +78,15 @@ type Options struct {
 
 	// Run value log garbage collection if we can reclaim at least this much space. This is a ratio.
 	ValueGCThreshold float64
-	// How often to run value log garbage collector.
-	ValueGCRunInterval time.Duration
 
 	// Size of single value log file.
 	ValueLogFileSize int64
 
-	// Sync all writes to disk. Setting this to true would slow down data loading significantly.
-	SyncWrites bool
-
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
 
-	// Flags for testing purposes.
+	// 4. Flags for testing purposes
+	// ------------------------------
 	DoNotCompact bool // Stops LSM tree from compactions.
 
 	maxBatchSize int64 // max batch size in bytes
@@ -135,7 +145,6 @@ type KV struct {
 	// Incremented in the non-concurrently accessed write loop.  But also accessed outside. So
 	// we use an atomic op.
 	lastUsedCasCounter uint64
-	metricsTicker      *time.Ticker
 }
 
 // ErrInvalidDir is returned when Badger cannot find the directory
@@ -222,9 +231,10 @@ func NewKV(optParam *Options) (out *KV, err error) {
 		elog:          trace.NewEventLog("Badger", "KV"),
 		dirLockGuard:  dirLockGuard,
 		valueDirGuard: valueDirLockGuard,
-		metricsTicker: time.NewTicker(5 * time.Minute),
 	}
-	go out.updateSize()
+
+	lc := out.closer.Register("updateSize")
+	go out.updateSize(lc)
 	out.mt = skl.NewSkiplist(arenaSize(&opt))
 
 	// newLevelsController potentially loads files in directory.
@@ -232,14 +242,14 @@ func NewKV(optParam *Options) (out *KV, err error) {
 		return nil, err
 	}
 
-	lc := out.closer.Register("compactors")
+	lc = out.closer.Register("compactors")
 	out.lc.startCompact(lc)
 
 	lc = out.closer.Register("memtable")
 	go out.flushMemtable(lc) // Need levels controller to be up.
 
 	if err = out.vlog.Open(out, &opt); err != nil {
-		return out, err
+		return nil, err
 	}
 
 	var item KVItem
@@ -288,7 +298,7 @@ func NewKV(optParam *Options) (out *KV, err error) {
 			nv = make([]byte, len(e.Value))
 			copy(nv, e.Value)
 		} else {
-			nv = make([]byte, 16)
+			nv = make([]byte, valuePointerEncodedSize)
 			vp.Encode(nv)
 			meta = meta | BitValuePointer
 		}
@@ -327,30 +337,6 @@ func NewKV(optParam *Options) (out *KV, err error) {
 // Close closes a KV. It's crucial to call it to ensure all the pending updates
 // make their way to disk.
 func (s *KV) Close() (err error) {
-	defer func() {
-		if guardErr := s.dirLockGuard.Release(); err == nil {
-			err = errors.Wrap(guardErr, "KV.Close")
-		}
-		if s.valueDirGuard != nil {
-			if guardErr := s.valueDirGuard.Release(); err == nil {
-				err = errors.Wrap(guardErr, "KV.Close")
-			}
-		}
-		if manifestErr := s.manifest.close(); err == nil {
-			err = errors.Wrap(manifestErr, "KV.Close")
-		}
-
-		// Fsync directories to ensure that lock file, and any other removed files whose directory
-		// we haven't specifically fsynced, are guaranteed to have their directory entry removal
-		// persisted to disk.
-		if syncErr := syncDir(s.opt.Dir); err == nil {
-			err = errors.Wrap(syncErr, "KV.Close")
-		}
-		if syncErr := syncDir(s.opt.ValueDir); err == nil {
-			err = errors.Wrap(syncErr, "KV.Close")
-		}
-	}()
-
 	s.elog.Printf("Closing database")
 	// Stop value GC first.
 	lc := s.closer.Get("value-gc")
@@ -361,8 +347,8 @@ func (s *KV) Close() (err error) {
 	lc.SignalAndWait()
 
 	// Now close the value log.
-	if err := s.vlog.Close(); err != nil {
-		return errors.Wrapf(err, "KV.Close")
+	if vlogErr := s.vlog.Close(); err == nil {
+		err = errors.Wrap(vlogErr, "KV.Close")
 	}
 
 	// Make sure that block writer is done pushing stuff into memtable!
@@ -406,16 +392,38 @@ func (s *KV) Close() (err error) {
 	lc.SignalAndWait()
 	s.elog.Printf("Compaction finished")
 
-	if err := s.lc.close(); err != nil {
-		return errors.Wrap(err, "KV.Close")
+	if lcErr := s.lc.close(); err == nil {
+		err = errors.Wrap(lcErr, "KV.Close")
 	}
-	s.metricsTicker.Stop()
 	s.elog.Printf("Waiting for closer")
 	s.closer.SignalAll()
 	s.closer.WaitForAll()
+
 	s.elog.Finish()
 
-	return nil
+	if guardErr := s.dirLockGuard.Release(); err == nil {
+		err = errors.Wrap(guardErr, "KV.Close")
+	}
+	if s.valueDirGuard != nil {
+		if guardErr := s.valueDirGuard.Release(); err == nil {
+			err = errors.Wrap(guardErr, "KV.Close")
+		}
+	}
+	if manifestErr := s.manifest.close(); err == nil {
+		err = errors.Wrap(manifestErr, "KV.Close")
+	}
+
+	// Fsync directories to ensure that lock file, and any other removed files whose directory
+	// we haven't specifically fsynced, are guaranteed to have their directory entry removal
+	// persisted to disk.
+	if syncErr := syncDir(s.opt.Dir); err == nil {
+		err = errors.Wrap(syncErr, "KV.Close")
+	}
+	if syncErr := syncDir(s.opt.ValueDir); err == nil {
+		err = errors.Wrap(syncErr, "KV.Close")
+	}
+
+	return err
 }
 
 const (
@@ -484,12 +492,7 @@ func (s *KV) FillValue(item *KVItem) error {
 }
 
 func (s *KV) fillItem(item *KVItem) error {
-	if item.meta == 0 && item.vptr == nil {
-		item.val = nil // key not found
-		return nil
-	}
-	if (item.meta & BitDelete) != 0 {
-		// Tombstone encountered.
+	if !item.hasValue() {
 		item.val = nil
 		return nil
 	}
@@ -607,7 +610,6 @@ func (s *KV) shouldWriteValueToLSM(e Entry) bool {
 }
 
 func (s *KV) writeToLSM(b *request) error {
-	var offsetBuf [10]byte
 	if len(b.Ptrs) != len(b.Entries) {
 		return errors.Errorf("Ptrs and Entries don't match: %+v", b)
 	}
@@ -647,6 +649,7 @@ func (s *KV) writeToLSM(b *request) error {
 					UserMeta:   entry.UserMeta,
 					CASCounter: entry.casCounter})
 		} else {
+			var offsetBuf [valuePointerEncodedSize]byte
 			s.mt.Put(entry.Key,
 				y.ValueStruct{
 					Value:      b.Ptrs[i].Encode(offsetBuf[:]),
@@ -875,8 +878,11 @@ func (s *KV) BatchSetAsync(entries []*Entry, f func(error)) {
 	}()
 }
 
-// Set sets the provided value for a given key. If key is not present, it is created.
-// If it is present, the existing value is overwritten with the one provided.
+// Set sets the provided value for a given key. If key is not present, it is created.  If it is
+// present, the existing value is overwritten with the one provided.
+// Along with key and value, Set can also take an optional userMeta byte. This byte is stored
+// alongside the key, and can be used as an aid to interpret the value or store other contextual
+// bits corresponding to the key-value pair.
 func (s *KV) Set(key, val []byte, userMeta byte) error {
 	e := &Entry{
 		Key:      key,
@@ -1144,7 +1150,7 @@ func (s *KV) flushMemtable(lc *y.LevelCloser) error {
 
 		if !ft.vptr.IsZero() {
 			s.elog.Printf("Storing offset: %+v\n", ft.vptr)
-			offset := make([]byte, 10)
+			offset := make([]byte, valuePointerEncodedSize)
 			ft.vptr.Encode(offset)
 			// CAS counter is needed and is desirable -- it's the first value log entry
 			// we replay, so to speak, perhaps the only, and we use it to re-initialize
@@ -1211,7 +1217,12 @@ func exists(path string) (bool, error) {
 	return true, err
 }
 
-func (s *KV) updateSize() {
+func (s *KV) updateSize(lc *y.LevelCloser) {
+	defer lc.Done()
+
+	metricsTicker := time.NewTicker(5 * time.Minute)
+	defer metricsTicker.Stop()
+
 	getNewInt := func(val int64) *expvar.Int {
 		v := new(expvar.Int)
 		v.Add(val)
@@ -1238,14 +1249,18 @@ func (s *KV) updateSize() {
 		return lsmSize, vlogSize
 	}
 
-	for range s.metricsTicker.C {
-		lsmSize, vlogSize := totalSize(s.opt.Dir)
-		y.LSMSize.Set(s.opt.Dir, getNewInt(lsmSize))
-		// If valueDir is different from dir, we'd have to do another walk.
-		if s.opt.ValueDir != s.opt.Dir {
-			_, vlogSize = totalSize(s.opt.ValueDir)
+	for {
+		select {
+		case <-metricsTicker.C:
+			lsmSize, vlogSize := totalSize(s.opt.Dir)
+			y.LSMSize.Set(s.opt.Dir, getNewInt(lsmSize))
+			// If valueDir is different from dir, we'd have to do another walk.
+			if s.opt.ValueDir != s.opt.Dir {
+				_, vlogSize = totalSize(s.opt.ValueDir)
+			}
+			y.VlogSize.Set(s.opt.Dir, getNewInt(vlogSize))
+		case <-lc.HasBeenClosed():
+			return
 		}
-		y.VlogSize.Set(s.opt.Dir, getNewInt(vlogSize))
 	}
-
 }

--- a/vendor/github.com/dgraph-io/badger/level_handler.go
+++ b/vendor/github.com/dgraph-io/badger/level_handler.go
@@ -189,12 +189,13 @@ func (s *levelHandler) numTables() int {
 func (s *levelHandler) close() error {
 	s.RLock()
 	defer s.RUnlock()
+	var err error
 	for _, t := range s.tables {
-		if err := t.Close(); err != nil {
-			return errors.Wrap(err, "levelHandler.Close")
+		if closeErr := t.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
 	}
-	return nil
+	return errors.Wrap(err, "levelHandler.close")
 }
 
 // getTableForKey acquires a read-lock to access s.tables. It returns a list of tableHandlers.

--- a/vendor/github.com/dgraph-io/badger/value.go
+++ b/vendor/github.com/dgraph-io/badger/value.go
@@ -65,10 +65,13 @@ const (
 )
 
 type logFile struct {
-	sync.RWMutex
-	path   string
+	path string
+	// This is a lock on the file descriptor's value and the file's existence.  Use shared
+	// ownership when reading/writing the file, use exclusive ownership to open/close the
+	// descriptor or remove the file.
+	fdLock sync.RWMutex
 	fd     *os.File
-	fid    uint16
+	fid    uint32
 	offset uint32
 	size   uint32
 }
@@ -89,10 +92,8 @@ func (lf *logFile) openReadOnly() error {
 	return nil
 }
 
+// lf must be RLocked (or exclusively locked) if you call this.
 func (lf *logFile) read(buf []byte, offset int64) error {
-	lf.RLock()
-	defer lf.RUnlock()
-
 	nbr, err := lf.fd.ReadAt(buf, offset)
 	y.NumReads.Add(1)
 	y.NumBytesRead.Add(int64(nbr))
@@ -100,11 +101,19 @@ func (lf *logFile) read(buf []byte, offset int64) error {
 }
 
 func (lf *logFile) doneWriting() error {
-	lf.Lock()
-	defer lf.Unlock()
+	// Sync before acquiring lock.  (We call this from write() and thus know we have shared access
+	// to the fd.)
 	if err := lf.fd.Sync(); err != nil {
 		return errors.Wrapf(err, "Unable to sync value log: %q", lf.path)
 	}
+	// Close and reopen the file read-only.  Acquire lock because fd will become invalid for a bit.
+	// Acquiring the lock is bad because, while we don't hold the lock for a long time, it forces
+	// one batch of readers wait for the preceding batch of readers to finish.
+	//
+	// If there's a benefit to reopening the file read-only, it might be on Windows.  I don't know
+	// what the benefit is.  Consider keeping the file read-write, or use fcntl to change permissions.
+	lf.fdLock.Lock()
+	defer lf.fdLock.Unlock()
 	if err := lf.fd.Close(); err != nil {
 		return errors.Wrapf(err, "Unable to close value log: %q", lf.path)
 	}
@@ -112,9 +121,8 @@ func (lf *logFile) doneWriting() error {
 	return lf.openReadOnly()
 }
 
+// You must hold lf.lock to sync()
 func (lf *logFile) sync() error {
-	lf.RLock()
-	defer lf.RUnlock()
 	return lf.fd.Sync()
 }
 
@@ -276,6 +284,12 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		if vp.Fid == f.fid && vp.Offset == e.offset {
 			// This new entry only contains the key, and a pointer to the value.
 			ne := new(Entry)
+			if e.Meta == BitSetIfAbsent {
+				// If we rewrite this entry without removing BitSetIfAbsent, lsm would see that
+				// the key is already present, which would be this same entry and won't update
+				// the vptr to point to the new file.
+				e.Meta = 0
+			}
 			y.AssertTruef(e.Meta == 0, "Got meta: 0")
 			ne.Meta = e.Meta
 			ne.UserMeta = e.UserMeta
@@ -319,19 +333,21 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 	elog.Printf("Removing fid: %d", f.fid)
 	// Entries written to LSM. Remove the older file now.
 	{
-		vlog.Lock()
-		idx := sort.Search(len(vlog.files), func(idx int) bool {
-			return vlog.files[idx].fid >= f.fid
-		})
-		if idx == len(vlog.files) || vlog.files[idx].fid != f.fid {
+		vlog.filesLock.Lock()
+		// Just a sanity-check.
+		if _, ok := vlog.filesMap[f.fid]; !ok {
+			vlog.filesLock.Unlock()
 			return errors.Errorf("Unable to find fid: %d", f.fid)
 		}
-		vlog.files = append(vlog.files[:idx], vlog.files[idx+1:]...)
-		vlog.Unlock()
+		delete(vlog.filesMap, f.fid)
+		vlog.filesLock.Unlock()
 	}
 
+	// Exclusively lock the file so that there are no readers before closing/destroying it
+	f.fdLock.Lock()
 	rem := vlog.fpath(f.fid)
 	f.fd.Close() // close file previous to remove it
+	f.fdLock.Unlock()
 
 	elog.Printf("Removing %s", rem)
 	return os.Remove(rem)
@@ -423,7 +439,7 @@ func (h *header) Decode(buf []byte) {
 }
 
 type valuePointer struct {
-	Fid    uint16
+	Fid    uint32
 	Len    uint32
 	Offset uint32
 }
@@ -442,36 +458,43 @@ func (p valuePointer) IsZero() bool {
 	return p.Fid == 0 && p.Offset == 0 && p.Len == 0
 }
 
+const valuePointerEncodedSize = 12
+
 // Encode encodes Pointer into byte buffer.
 func (p valuePointer) Encode(b []byte) []byte {
-	y.AssertTrue(len(b) >= 10)
-	binary.BigEndian.PutUint16(b[:2], p.Fid)
-	binary.BigEndian.PutUint32(b[2:6], p.Len)
-	binary.BigEndian.PutUint32(b[6:10], p.Offset)
-	return b[:10]
+	binary.BigEndian.PutUint32(b[:4], p.Fid)
+	binary.BigEndian.PutUint32(b[4:8], p.Len)
+	binary.BigEndian.PutUint32(b[8:valuePointerEncodedSize], p.Offset)
+	return b[:valuePointerEncodedSize]
 }
 
 func (p *valuePointer) Decode(b []byte) {
-	y.AssertTrue(len(b) >= 10)
-	p.Fid = binary.BigEndian.Uint16(b[:2])
-	p.Len = binary.BigEndian.Uint32(b[2:6])
-	p.Offset = binary.BigEndian.Uint32(b[6:10])
+	p.Fid = binary.BigEndian.Uint32(b[:4])
+	p.Len = binary.BigEndian.Uint32(b[4:8])
+	p.Offset = binary.BigEndian.Uint32(b[8:valuePointerEncodedSize])
 }
 
 type valueLog struct {
-	sync.RWMutex
 	buf     bytes.Buffer
 	dirPath string
 	elog    trace.EventLog
-	files   []*logFile
-	kv      *KV
-	maxFid  uint32
-	offset  uint32
-	opt     Options
+
+	// guards our view of which files exist
+	filesLock sync.RWMutex
+	filesMap  map[uint32]*logFile
+
+	kv     *KV
+	maxFid uint32
+	offset uint32
+	opt    Options
 }
 
-func (vlog *valueLog) fpath(fid uint16) string {
-	return fmt.Sprintf("%s%s%06d.vlog", vlog.dirPath, string(os.PathSeparator), fid)
+func vlogFilePath(dirPath string, fid uint32) string {
+	return fmt.Sprintf("%s%s%06d.vlog", dirPath, string(os.PathSeparator), fid)
+}
+
+func (vlog *valueLog) fpath(fid uint32) string {
+	return vlogFilePath(vlog.dirPath, fid)
 }
 
 func (vlog *valueLog) openOrCreateFiles() error {
@@ -480,13 +503,14 @@ func (vlog *valueLog) openOrCreateFiles() error {
 		return errors.Wrapf(err, "Error while opening value log")
 	}
 
-	found := make(map[int]struct{})
+	found := make(map[uint64]struct{})
+	var maxFid uint32 // Beware len(files) == 0 case, this starts at 0.
 	for _, file := range files {
 		if !strings.HasSuffix(file.Name(), ".vlog") {
 			continue
 		}
 		fsz := len(file.Name())
-		fid, err := strconv.Atoi(file.Name()[:fsz-5])
+		fid, err := strconv.ParseUint(file.Name()[:fsz-5], 10, 32)
 		if err != nil {
 			return errors.Wrapf(err, "Error while parsing value log id for file: %q", file.Name())
 		}
@@ -495,26 +519,22 @@ func (vlog *valueLog) openOrCreateFiles() error {
 		}
 		found[fid] = struct{}{}
 
-		lf := &logFile{fid: uint16(fid), path: vlog.fpath(uint16(fid))}
-		vlog.files = append(vlog.files, lf)
-
+		lf := &logFile{fid: uint32(fid), path: vlog.fpath(uint32(fid))}
+		vlog.filesMap[uint32(fid)] = lf
+		if uint32(fid) > maxFid {
+			maxFid = uint32(fid)
+		}
 	}
-
-	sort.Slice(vlog.files, func(i, j int) bool {
-		return vlog.files[i].fid < vlog.files[j].fid
-	})
+	vlog.maxFid = uint32(maxFid)
 
 	// Open all previous log files as read only. Open the last log file
 	// as read write.
-	for i := range vlog.files {
-		lf := vlog.files[i]
-		if i == len(vlog.files)-1 {
-			lf.fd, err = y.OpenExistingSyncedFile(vlog.fpath(lf.fid), vlog.opt.SyncWrites)
+	for fid, lf := range vlog.filesMap {
+		if fid == maxFid {
+			lf.fd, err = y.OpenExistingSyncedFile(vlog.fpath(fid), vlog.opt.SyncWrites)
 			if err != nil {
 				return errors.Wrapf(err, "Unable to open value log file as RDWR")
 			}
-			vlog.maxFid = uint32(lf.fid)
-
 		} else {
 			if err := lf.openReadOnly(); err != nil {
 				return err
@@ -523,7 +543,8 @@ func (vlog *valueLog) openOrCreateFiles() error {
 	}
 
 	// If no files are found, then create a new file.
-	if len(vlog.files) == 0 {
+	if len(vlog.filesMap) == 0 {
+		// We already set vlog.maxFid above
 		_, err := vlog.createVlogFile(0)
 		if err != nil {
 			return err
@@ -532,7 +553,7 @@ func (vlog *valueLog) openOrCreateFiles() error {
 	return nil
 }
 
-func (vlog *valueLog) createVlogFile(fid uint16) (*logFile, error) {
+func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 	path := vlog.fpath(fid)
 	lf := &logFile{fid: fid, offset: 0, path: path}
 	var err error
@@ -544,9 +565,9 @@ func (vlog *valueLog) createVlogFile(fid uint16) (*logFile, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to sync value log file dir")
 	}
-	vlog.Lock()
-	vlog.files = append(vlog.files, lf)
-	vlog.Unlock()
+	vlog.filesLock.Lock()
+	vlog.filesMap[fid] = lf
+	vlog.filesLock.Unlock()
 	return lf, nil
 }
 
@@ -554,6 +575,7 @@ func (vlog *valueLog) Open(kv *KV, opt *Options) error {
 	vlog.dirPath = opt.ValueDir
 	vlog.opt = *opt
 	vlog.kv = kv
+	vlog.filesMap = make(map[uint32]*logFile)
 	if err := vlog.openOrCreateFiles(); err != nil {
 		return errors.Wrapf(err, "Unable to open value log")
 	}
@@ -567,12 +589,25 @@ func (vlog *valueLog) Close() error {
 	vlog.elog.Printf("Stopping garbage collection of values.")
 	defer vlog.elog.Finish()
 
-	for _, f := range vlog.files {
-		if err := f.fd.Close(); err != nil {
-			return err
+	var err error
+	for _, f := range vlog.filesMap {
+		if closeErr := f.fd.Close(); closeErr != nil && err == nil {
+			err = closeErr
 		}
 	}
-	return nil
+	return err
+}
+
+// sortedFids returns the file id's, sorted.  Assumes we have shared access to filesMap.
+func (vlog *valueLog) sortedFids() []uint32 {
+	ret := make([]uint32, 0, len(vlog.filesMap))
+	for fid := range vlog.filesMap {
+		ret = append(ret, fid)
+	}
+	sort.Slice(ret, func(i, j int) bool {
+		return ret[i] < ret[j]
+	})
+	return ret
 }
 
 // Replay replays the value log. The kv provided is only valid for the lifetime of function call.
@@ -581,14 +616,17 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 	offset := ptr.Offset + ptr.Len
 	vlog.elog.Printf("Seeking at value pointer: %+v\n", ptr)
 
-	for _, f := range vlog.files {
-		if f.fid < fid {
+	fids := vlog.sortedFids()
+
+	for _, id := range fids {
+		if id < fid {
 			continue
 		}
 		of := offset
-		if f.fid > fid {
+		if id > fid {
 			of = 0
 		}
+		f := vlog.filesMap[id]
 		err := f.iterate(of, fn)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to replay value log: %q", f.path)
@@ -597,7 +635,7 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 
 	// Seek to the end to start writing.
 	var err error
-	last := vlog.files[len(vlog.files)-1]
+	last := vlog.filesMap[vlog.maxFid]
 	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
 	last.offset = uint32(lastOffset)
 	return errors.Wrapf(err, "Unable to seek to end of value log: %q", last.path)
@@ -618,17 +656,19 @@ func (vlog *valueLog) sync() error {
 		return nil
 	}
 
-	vlog.RLock()
-	if len(vlog.files) == 0 {
-		vlog.RUnlock()
+	vlog.filesLock.RLock()
+	if len(vlog.filesMap) == 0 {
+		vlog.filesLock.RUnlock()
 		return nil
 	}
-	curlf := vlog.files[len(vlog.files)-1]
-	vlog.RUnlock()
+	curlf := vlog.filesMap[vlog.maxFid]
+	curlf.fdLock.RLock()
+	vlog.filesLock.RUnlock()
 
 	dirSyncCh := make(chan error)
 	go func() { dirSyncCh <- syncDir(vlog.opt.ValueDir) }()
 	err := curlf.sync()
+	curlf.fdLock.RUnlock()
 	dirSyncErr := <-dirSyncCh
 	if err != nil {
 		err = dirSyncErr
@@ -638,9 +678,9 @@ func (vlog *valueLog) sync() error {
 
 // write is thread-unsafe by design and should not be called concurrently.
 func (vlog *valueLog) write(reqs []*request) error {
-	vlog.RLock()
-	curlf := vlog.files[len(vlog.files)-1]
-	vlog.RUnlock()
+	vlog.filesLock.RLock()
+	curlf := vlog.filesMap[vlog.maxFid]
+	vlog.filesLock.RUnlock()
 
 	toDisk := func() error {
 		if vlog.buf.Len() == 0 {
@@ -665,7 +705,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 			newid := atomic.AddUint32(&vlog.maxFid, 1)
 			y.AssertTruef(newid < 1<<16, "newid will overflow uint16: %v", newid)
-			newlf, err := vlog.createVlogFile(uint16(newid))
+			newlf, err := vlog.createVlogFile(newid)
 			if err != nil {
 				return err
 			}
@@ -710,25 +750,26 @@ func (vlog *valueLog) write(reqs []*request) error {
 	// an invalid file descriptor.
 }
 
-func (vlog *valueLog) getFile(fid uint16) (*logFile, error) {
-	vlog.RLock()
-	defer vlog.RUnlock()
-
-	idx := sort.Search(len(vlog.files), func(idx int) bool {
-		return vlog.files[idx].fid >= fid
-	})
-	if idx == len(vlog.files) || vlog.files[idx].fid != fid {
+// Gets the logFile and acquires an RLock() on it too.  You must call RUnlock on the file (if
+// non-nil).
+func (vlog *valueLog) getFileRLocked(fid uint32) (*logFile, error) {
+	vlog.filesLock.RLock()
+	defer vlog.filesLock.RUnlock()
+	ret, ok := vlog.filesMap[fid]
+	if !ok {
 		return nil, ErrCorrupt
 	}
-	return vlog.files[idx], nil
+	ret.fdLock.RLock()
+	return ret, nil
 }
 
 // Read reads the value log at a given location.
 func (vlog *valueLog) Read(p valuePointer, s *y.Slice) (e Entry, err error) {
-	lf, err := vlog.getFile(p.Fid)
+	lf, err := vlog.getFileRLocked(p.Fid)
 	if err != nil {
 		return e, err
 	}
+	defer lf.fdLock.RUnlock()
 
 	if s == nil {
 		s = new(y.Slice)
@@ -770,17 +811,18 @@ func (vlog *valueLog) runGCInLoop(lc *y.LevelCloser) {
 }
 
 func (vlog *valueLog) pickLog() *logFile {
-	vlog.RLock()
-	defer vlog.RUnlock()
-	if len(vlog.files) <= 1 {
+	vlog.filesLock.RLock()
+	defer vlog.filesLock.RUnlock()
+	if len(vlog.filesMap) <= 1 {
 		return nil
 	}
+	fids := vlog.sortedFids()
 	// This file shouldn't be being written to.
-	lfi := rand.Intn(len(vlog.files))
-	if lfi > 0 {
-		lfi = rand.Intn(lfi) // Another level of rand to favor smaller fids.
+	idx := rand.Intn(len(fids))
+	if idx > 0 {
+		idx = rand.Intn(idx) // Another level of rand to favor smaller fids.
 	}
-	return vlog.files[lfi]
+	return vlog.filesMap[fids[idx]]
 }
 
 func (vlog *valueLog) doRunGC() error {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -169,34 +169,34 @@
 			"revisionTime": "2016-09-07T16:21:46Z"
 		},
 		{
-			"checksumSHA1": "H1aNBjX8W9HQuo0fcjoFQF5Rbsg=",
+			"checksumSHA1": "jTqsZfQ6lDmp/wdlwPC7g7N+FAo=",
 			"path": "github.com/dgraph-io/badger",
-			"revision": "828818c96d9260040ebf79c5ec29d5342b0b884e",
-			"revisionTime": "2017-08-31T07:53:51Z"
+			"revision": "666d5b7dfdd570f39f651bf7a1f3999770b69602",
+			"revisionTime": "2017-09-06T02:38:13Z"
 		},
 		{
 			"checksumSHA1": "FB7rDZgiLfpIGi9RqWbgxjZ0Vjg=",
 			"path": "github.com/dgraph-io/badger/protos",
-			"revision": "828818c96d9260040ebf79c5ec29d5342b0b884e",
-			"revisionTime": "2017-08-31T07:53:51Z"
+			"revision": "666d5b7dfdd570f39f651bf7a1f3999770b69602",
+			"revisionTime": "2017-09-06T02:38:13Z"
 		},
 		{
 			"checksumSHA1": "DqFosafuhUYdRhCpNRAe57ph4ms=",
 			"path": "github.com/dgraph-io/badger/skl",
-			"revision": "828818c96d9260040ebf79c5ec29d5342b0b884e",
-			"revisionTime": "2017-08-31T07:53:51Z"
+			"revision": "666d5b7dfdd570f39f651bf7a1f3999770b69602",
+			"revisionTime": "2017-09-06T02:38:13Z"
 		},
 		{
-			"checksumSHA1": "eQhOsB1q3Le/PbKaP0mupNkGdN0=",
+			"checksumSHA1": "RVcU54uHQoApQUkWYKd8dTxSsb8=",
 			"path": "github.com/dgraph-io/badger/table",
-			"revision": "828818c96d9260040ebf79c5ec29d5342b0b884e",
-			"revisionTime": "2017-08-31T07:53:51Z"
+			"revision": "666d5b7dfdd570f39f651bf7a1f3999770b69602",
+			"revisionTime": "2017-09-06T02:38:13Z"
 		},
 		{
 			"checksumSHA1": "Hh1XYhKkiFCGfMg63aHeKG4Toj8=",
 			"path": "github.com/dgraph-io/badger/y",
-			"revision": "828818c96d9260040ebf79c5ec29d5342b0b884e",
-			"revisionTime": "2017-08-31T07:53:51Z"
+			"revision": "666d5b7dfdd570f39f651bf7a1f3999770b69602",
+			"revisionTime": "2017-09-06T02:38:13Z"
 		},
 		{
 			"checksumSHA1": "a29TtOU87eZA0S6wL+rAkpqUEzc=",


### PR DESCRIPTION
problem:
1. we do a schema mutation, we update the schema but if we crash before index is rebuilt then on restart we don't rebuild because on replay we will see that it's already indexed so we don't do anything.
2. Similarly for indexing on scalar values.

We store the current value of schema in wal on schema mutation, current pl(should be small for scalar values) for indexed predicates on mutation. On restart we can restore the schema and postings for scalar predicates to the value they should have been at snapshot using our wal.
So we can replay normally after restoring using our wal.

3. reverse edges - no issues if we add the reverse edge always(we don't rely on hasmutated).

4. count edges - WIP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1408)
<!-- Reviewable:end -->
