### PR TITLE
Monitor connection health and switch servers accordingly.

### DIFF
--- a/cmd/dgraphzero/raft.go
+++ b/cmd/dgraphzero/raft.go
@@ -212,7 +212,6 @@ func (n *node) initAndStartNode(wal *raftwal.Wal) error {
 		if p == nil {
 			return errInvalidAddress
 		}
-		defer conn.Get().Release(p)
 
 		gconn := p.Get()
 		c := protos.NewRaftClient(gconn)

--- a/cmd/dgraphzero/zero.go
+++ b/cmd/dgraphzero/zero.go
@@ -166,8 +166,7 @@ func (s *Server) Connect(ctx context.Context,
 		return &emptyMembershipState, errInvalidAddress
 	}
 	// Create a connection and check validity of the address by doing an Echo.
-	pl := conn.Get().Connect(m.Addr)
-	defer conn.Get().Release(pl)
+	conn.Get().Connect(m.Addr)
 
 	createProposal := func() *protos.ZeroProposal {
 		s.Lock()

--- a/conn/pool.go
+++ b/conn/pool.go
@@ -23,7 +23,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"sync"
-	"sync/atomic"
+	"time"
 
 	"github.com/dgraph-io/dgraph/protos"
 	"github.com/dgraph-io/dgraph/x"
@@ -35,19 +35,19 @@ var (
 	ErrNoConnection    = fmt.Errorf("No connection exists")
 	errNoPeerPoolEntry = fmt.Errorf("no peerPool entry")
 	errNoPeerPool      = fmt.Errorf("no peerPool pool, could not connect")
+	echoDuration       = time.Minute
 )
 
 // "Pool" is used to manage the grpc client connection(s) for communicating with other
 // worker instances.  Right now it just holds one of them.
 type Pool struct {
+	sync.RWMutex
 	// A "pool" now consists of one connection.  gRPC uses HTTP2 transport to combine
 	// messages in the same TCP stream.
 	conn *grpc.ClientConn
 
-	Addr string
-	// Requires a lock on poolsi.
-	// TODO: Remove the refcounting. Let grpc take care of closing connections.
-	refcount int64
+	lastEcho time.Time
+	Addr     string
 }
 
 type Pools struct {
@@ -66,16 +66,6 @@ func Get() *Pools {
 	return pi
 }
 
-func (p *Pools) Any() (*Pool, error) {
-	p.RLock()
-	defer p.RUnlock()
-	for _, pool := range p.all {
-		pool.AddOwner()
-		return pool, nil
-	}
-	return nil, ErrNoConnection
-}
-
 func (p *Pools) Get(addr string) (*Pool, error) {
 	p.RLock()
 	defer p.RUnlock()
@@ -83,92 +73,33 @@ func (p *Pools) Get(addr string) (*Pool, error) {
 	if !ok {
 		return nil, ErrNoConnection
 	}
-	pool.AddOwner()
 	return pool, nil
 }
 
-// One of these must be called for each call to get(...).
-func (p *Pools) Release(pl *Pool) {
-	// We close the conn after unlocking p.
-	newRefcount := atomic.AddInt64(&pl.refcount, -1)
-	if newRefcount == 0 {
-		p.Lock()
-		delete(p.all, pl.Addr)
-		p.Unlock()
-
-		destroyPool(pl)
-	}
-}
-
-func destroyPool(pl *Pool) {
-	err := pl.conn.Close()
-	if err != nil {
-		x.Printf("Error closing cluster connection: %v\n", err.Error())
-	}
-}
-
-// Returns a pool that you should call put() on.
 func (p *Pools) Connect(addr string) *Pool {
 	p.RLock()
 	existingPool, has := p.all[addr]
 	if has {
 		p.RUnlock()
-		existingPool.AddOwner()
 		return existingPool
 	}
 	p.RUnlock()
 
 	pool, err := NewPool(addr)
-	// TODO: Rename newPool to newConn, rename pool.
-	// TODO: This can get triggered with totally bogus config.
-	x.Checkf(err, "Unable to connect to host %s", addr)
+	if err != nil {
+		x.Printf("Unable to connect to host: %s", addr)
+		return nil
+	}
 
 	p.Lock()
 	existingPool, has = p.all[addr]
 	if has {
 		p.Unlock()
-		destroyPool(pool)
-		existingPool.refcount++
 		return existingPool
 	}
 	p.all[addr] = pool
-	pool.AddOwner() // matches p.put() run by caller
 	p.Unlock()
-
-	// No need to block this thread just to print some messages.
-	pool.AddOwner() // matches p.put() in goroutine
-	go func() {
-		defer p.Release(pool)
-		err = TestConnection(pool)
-		if err != nil {
-			x.Printf("Connection to %q fails, got error: %v\n", addr, err)
-			// Don't return -- let's still put the empty pool in the map.  Its users
-			// have to handle errors later anyway.
-		} else {
-			x.Printf("Connection with %q healthy.\n", addr)
-		}
-	}()
-
 	return pool
-}
-
-// testConnection tests if we can run an Echo query on a connection.
-func TestConnection(p *Pool) error {
-	conn := p.Get()
-
-	query := new(protos.Payload)
-	query.Data = make([]byte, 10)
-	x.Check2(rand.Read(query.Data))
-
-	c := protos.NewRaftClient(conn)
-	resp, err := c.Echo(context.Background(), query)
-	if err != nil {
-		return err
-	}
-	// If a server is sending bad echos, do we have to freak out and die?
-	x.AssertTruef(bytes.Equal(resp.Data, query.Data),
-		"non-matching Echo response value from %v", p.Addr)
-	return nil
 }
 
 // NewPool creates a new "pool" with one gRPC connection, refcount 0.
@@ -181,70 +112,42 @@ func NewPool(addr string) (*Pool, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The pool hasn't been added to poolsi yet, so it gets no refcount.
-	return &Pool{conn: conn, Addr: addr, refcount: 0}, nil
+	pl := &Pool{conn: conn, Addr: addr}
+	go pl.MonitorHealth()
+	return pl, nil
 }
 
 // Get returns the connection to use from the pool of connections.
 func (p *Pool) Get() *grpc.ClientConn {
+	p.RLock()
+	defer p.RUnlock()
 	return p.conn
 }
 
-// AddOwner adds 1 to the refcount for the pool (atomically).
-func (p *Pool) AddOwner() {
-	atomic.AddInt64(&p.refcount, 1)
-}
+// MonitorHealth monitors the health of the connection via Echo. This function blocks forever.
+func (p *Pool) MonitorHealth() {
+	ticker := time.NewTicker(echoDuration)
+	for range ticker.C {
+		conn := p.Get()
 
-type PeerPoolEntry struct {
-	// Never the empty string.  Possibly a bogus address -- bad port number, the value
-	// of *myAddr, or some screwed up Raft config.
-	addr string
-	// An owning reference to a pool for this peer (or nil if addr is sufficiently bogus).
-	poolOrNil *Pool
-}
+		query := new(protos.Payload)
+		query.Data = make([]byte, 10)
+		x.Check2(rand.Read(query.Data))
 
-// peerPool stores the peers' addresses and our connections to them.  It has exactly one
-// entry for every peer other than ourselves.  Some of these peers might be unreachable or
-// have bogus (but never empty) addresses.
-type PeerPool struct {
-	sync.RWMutex
-	peers map[uint64]PeerPoolEntry
-}
-
-// getPool returns the non-nil pool for a peer.  This might error even if get(id)
-// succeeds, if the pool is nil.  This happens if the peer was configured so badly (it had
-// a totally bogus addr) we can't make a pool.  (A reasonable refactoring would have us
-// make a pool, one that has a nil gRPC connection.)
-//
-// You must call pools().release on the pool.
-func (p *PeerPool) getPool(id uint64) (*Pool, error) {
-	p.RLock()
-	defer p.RUnlock()
-	ent, ok := p.peers[id]
-	if !ok {
-		return nil, errNoPeerPoolEntry
-	}
-	if ent.poolOrNil == nil {
-		return nil, errNoPeerPool
-	}
-	ent.poolOrNil.AddOwner()
-	return ent.poolOrNil, nil
-}
-
-func (p *PeerPool) get(id uint64) (string, bool) {
-	p.RLock()
-	defer p.RUnlock()
-	ret, ok := p.peers[id]
-	return ret.addr, ok
-}
-
-func (p *PeerPool) set(id uint64, addr string, pl *Pool) {
-	p.Lock()
-	defer p.Unlock()
-	if old, ok := p.peers[id]; ok {
-		if old.poolOrNil != nil {
-			Get().Release(old.poolOrNil)
+		c := protos.NewRaftClient(conn)
+		resp, err := c.Echo(context.Background(), query)
+		if err == nil {
+			x.AssertTruef(bytes.Equal(resp.Data, query.Data),
+				"non-matching Echo response value from %v", p.Addr)
+			p.Lock()
+			p.lastEcho = time.Now()
+			p.Unlock()
 		}
 	}
-	p.peers[id] = PeerPoolEntry{addr, pl}
+}
+
+func (p *Pool) IsHealthy() bool {
+	p.RLock()
+	defer p.RUnlock()
+	return time.Since(p.lastEcho) < 3*echoDuration
 }

--- a/conn/pool.go
+++ b/conn/pool.go
@@ -32,10 +32,11 @@ import (
 )
 
 var (
-	ErrNoConnection    = fmt.Errorf("No connection exists")
-	errNoPeerPoolEntry = fmt.Errorf("no peerPool entry")
-	errNoPeerPool      = fmt.Errorf("no peerPool pool, could not connect")
-	echoDuration       = time.Minute
+	ErrNoConnection        = fmt.Errorf("No connection exists")
+	ErrUnhealthyConnection = fmt.Errorf("Unhealthy connection")
+	errNoPeerPoolEntry     = fmt.Errorf("no peerPool entry")
+	errNoPeerPool          = fmt.Errorf("no peerPool pool, could not connect")
+	echoDuration           = time.Minute
 )
 
 // "Pool" is used to manage the grpc client connection(s) for communicating with other
@@ -72,6 +73,9 @@ func (p *Pools) Get(addr string) (*Pool, error) {
 	pool, ok := p.all[addr]
 	if !ok {
 		return nil, ErrNoConnection
+	}
+	if !pool.IsHealthy() {
+		return nil, ErrUnhealthyConnection
 	}
 	return pool, nil
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -666,13 +666,9 @@ func (n *node) snapshot(skip uint64) {
 
 func (n *node) joinPeers() {
 	// Get leader information for MY group.
-	pid, paddr := groups().Leader(n.gid)
-	n.Connect(pid, paddr)
-	x.Printf("joinPeers connected with: %q with peer id: %d\n", paddr, pid)
-
-	pool, err := conn.Get().Get(paddr)
-	if err != nil {
-		log.Fatalf("Unable to get pool for addr: %q for peer: %d, error: %v\n", paddr, pid, err)
+	pl := groups().Leader(n.gid)
+	if pl == nil {
+		log.Fatalf("Unable to reach leader or any other server in group %d", n.gid)
 	}
 
 	// Bring the instance up to speed first.
@@ -681,11 +677,11 @@ func (n *node) joinPeers() {
 	// _, err := populateShard(n.ctx, pool, n.gid)
 	// x.Checkf(err, "Error while populating shard")
 
-	gconn := pool.Get()
+	gconn := pl.Get()
 
 	c := protos.NewRaftClient(gconn)
 	x.Printf("Calling JoinCluster")
-	_, err = c.JoinCluster(n.ctx, n.RaftContext)
+	_, err := c.JoinCluster(n.ctx, n.RaftContext)
 	// TODO: This should keep on indefinitely trying to join the cluster, instead of crashing.
 	x.Checkf(err, "Error while joining cluster")
 	x.Printf("Done with JoinCluster call\n")

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -358,13 +358,13 @@ func (n *node) processApplyCh() {
 }
 
 func (n *node) retrieveSnapshot(peerID uint64) {
-	pool, err := n.GetPeerPool(peerID)
+	addr, _ := n.Peer(peerID)
+	pool, err := conn.Get().Get(addr)
 	if err != nil {
 		// err is just going to be errNoConnection
 		log.Fatalf("Cannot retrieve snapshot from peer %v, no connection.  Error: %v\n",
 			peerID, err)
 	}
-	defer conn.Get().Release(pool)
 
 	// Get index of last committed.
 	lastIndex, err := n.Store.LastIndex()
@@ -674,7 +674,6 @@ func (n *node) joinPeers() {
 	if err != nil {
 		log.Fatalf("Unable to get pool for addr: %q for peer: %d, error: %v\n", paddr, pid, err)
 	}
-	defer conn.Get().Release(pool)
 
 	// Bring the instance up to speed first.
 	// Raft would decide whether snapshot needs to fetched or not

--- a/worker/export.go
+++ b/worker/export.go
@@ -411,7 +411,6 @@ func handleExportForGroup(ctx context.Context, reqId uint64, gid uint32) *protos
 			GroupId: gid,
 		}
 	}
-	defer conn.Get().Release(pl)
 
 	c := protos.NewWorkerClient(gconn)
 	nr := &protos.ExportPayload{

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -185,7 +185,6 @@ func (g *groupi) BelongsTo(key string) uint32 {
 }
 
 func (g *groupi) ServesTablet(key string) bool {
-	fmt.Printf("Asking if I serve tablet: %v\n", key)
 	g.RLock()
 	gid := g.tablets[key]
 	g.RUnlock()
@@ -196,8 +195,7 @@ func (g *groupi) ServesTablet(key string) bool {
 	// We don't know about this tablet.
 	// Check with dgraphzero if we can serve it.
 	pl := g.AnyServer(0)
-	if pl != nil {
-		fmt.Printf("Unable to get a connection to dgraphzero.")
+	if pl == nil {
 		return false
 	}
 	zc := protos.NewZeroClient(pl.Get())
@@ -205,7 +203,6 @@ func (g *groupi) ServesTablet(key string) bool {
 	tablet := &protos.Tablet{GroupId: g.groupId(), Predicate: key}
 	out, err := zc.ShouldServe(context.Background(), tablet)
 	if err != nil {
-		fmt.Printf("Error while asking if I should server: %v\n", err)
 		return false
 	}
 	g.Lock()

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -195,10 +195,9 @@ func (g *groupi) ServesTablet(key string) bool {
 
 	// We don't know about this tablet.
 	// Check with dgraphzero if we can serve it.
-	zaddr := g.AnyServer(0)
-	pl, err := conn.Get().Get(zaddr)
-	if err != nil {
-		fmt.Printf("Unable to get a connection to %v\n", zaddr)
+	pl := g.AnyServer(0)
+	if pl != nil {
+		fmt.Printf("Unable to get a connection to dgraphzero.")
 		return false
 	}
 	zc := protos.NewZeroClient(pl.Get())
@@ -260,14 +259,17 @@ func (g *groupi) members(gid uint32) map[uint64]*protos.Member {
 	return group.Members
 }
 
-func (g *groupi) AnyServer(gid uint32) string {
+func (g *groupi) AnyServer(gid uint32) *conn.Pool {
 	members := g.members(gid)
 	if members != nil {
 		for _, m := range members {
-			return m.Addr
+			pl, err := conn.Get().Get(m.Addr)
+			if err == nil {
+				return pl
+			}
 		}
 	}
-	return ""
+	return nil
 }
 
 func (g *groupi) MyPeer() (uint64, bool) {
@@ -284,21 +286,21 @@ func (g *groupi) MyPeer() (uint64, bool) {
 
 // Leader will try to return the leader of a given group, based on membership information.
 // There is currently no guarantee that the returned server is the leader of the group.
-func (g *groupi) Leader(gid uint32) (uint64, string) {
+func (g *groupi) Leader(gid uint32) *conn.Pool {
 	members := g.members(gid)
 	if members == nil {
-		return 0, ""
+		return nil
 	}
-	var first *protos.Member
 	for _, m := range members {
-		if first == nil {
-			first = m
-		}
 		if m.Leader {
-			return m.Id, m.Addr
+			if pl, err := conn.Get().Get(m.Addr); err == nil {
+				return pl
+			}
 		}
 	}
-	return first.Id, first.Addr
+	// Unable to find a healthy connection to leader. Get connection to any other server in the
+	// group.
+	return g.AnyServer(gid)
 }
 
 func (g *groupi) KnownGroups() (gids []uint32) {
@@ -316,20 +318,12 @@ func (g *groupi) syncMembershipState() {
 	// TODO: Instead of getting an address first, then finding a connection to that address,
 	// we should pick up a healthy connection from any server in the provided group.
 	// This way, if a server goes down, AnyServer can avoid giving a connection to that server.
-	addr := g.AnyServer(0)
+	pl := g.AnyServer(0)
 	// We should always have some connection to dgraphzero.
-	if len(addr) == 0 {
+	if pl == nil {
 		x.Printf("WARNING: We don't have address of any dgraphzero server.")
 		return
 	}
-	var pl *conn.Pool
-	pl, err := conn.Get().Get(addr)
-	if err == conn.ErrNoConnection {
-		x.Printf("Unable to sync memberships. No connection to dgraphzero server at: %v", addr)
-		go conn.Get().Connect(addr) // Try to connect in a goroutine.
-		return
-	}
-	x.Check(err)
 
 	member := &protos.Member{
 		Id:      Config.RaftId,

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -201,7 +201,6 @@ func (g *groupi) ServesTablet(key string) bool {
 		fmt.Printf("Unable to get a connection to %v\n", zaddr)
 		return false
 	}
-	defer conn.Get().Release(pl)
 	zc := protos.NewZeroClient(pl.Get())
 
 	tablet := &protos.Tablet{GroupId: g.groupId(), Predicate: key}
@@ -346,7 +345,6 @@ func (g *groupi) syncMembershipState() {
 
 	c := protos.NewZeroClient(pl.Get())
 	state, err := c.Update(context.Background(), group)
-	conn.Get().Release(pl)
 
 	if err != nil || state == nil {
 		x.Printf("Unable to sync memberships. Error: %v", err)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -325,7 +325,6 @@ func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.Assign
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Get().Release(p)
 
 	conn := p.Get()
 	c := protos.NewZeroClient(conn)
@@ -350,7 +349,6 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		che <- err
 		return
 	}
-	defer conn.Get().Release(pl)
 	conn := pl.Get()
 
 	c := protos.NewWorkerClient(conn)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -319,14 +319,12 @@ func ValidateAndConvert(edge *protos.DirectedEdge, schemaType types.TypeID) erro
 }
 
 func AssignUidsOverNetwork(ctx context.Context, num *protos.Num) (*protos.AssignedIds, error) {
-	_, addr := groups().Leader(0)
-	// TODO: Leader, AnyServer should both return a healthy connection back.
-	p, err := conn.Get().Get(addr)
-	if err != nil {
-		return nil, err
+	pl := groups().Leader(0)
+	if pl == nil {
+		return nil, conn.ErrNoConnection
 	}
 
-	conn := p.Get()
+	conn := pl.Get()
 	c := protos.NewZeroClient(conn)
 	return c.AssignUids(ctx, num)
 }
@@ -340,9 +338,9 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 		return
 	}
 
-	_, addr := groups().Leader(gid)
-	pl, err := conn.Get().Get(addr)
-	if err != nil {
+	pl := groups().Leader(gid)
+	if pl == nil {
+		err := conn.ErrNoConnection
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf(err.Error())
 		}
@@ -354,13 +352,13 @@ func proposeOrSend(ctx context.Context, gid uint32, m *protos.Mutations, che cha
 	c := protos.NewWorkerClient(conn)
 	ch := make(chan error, 1)
 	go func() {
-		_, err = c.Mutate(ctx, m)
+		_, err := c.Mutate(ctx, m)
 		ch <- err
 	}()
 	select {
 	case <-ctx.Done():
 		che <- ctx.Err()
-	case err = <-ch:
+	case err := <-ch:
 		che <- err
 	}
 }

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -141,10 +141,9 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		return
 	}
 
-	_, addr := groups().Leader(gid)
-	pl, err := conn.Get().Get(addr)
-	if err != nil {
-		ch <- resultErr{err: err}
+	pl := groups().Leader(gid)
+	if pl == nil {
+		ch <- resultErr{err: conn.ErrNoConnection}
 		return
 	}
 	conn := pl.Get()

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -147,7 +147,6 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *protos.SchemaReque
 		ch <- resultErr{err: err}
 		return
 	}
-	defer conn.Get().Release(pl)
 	conn := pl.Get()
 	c := protos.NewWorkerClient(conn)
 	schema, e := c.Schema(ctx, s)

--- a/worker/task.go
+++ b/worker/task.go
@@ -59,7 +59,6 @@ func invokeNetworkRequest(
 	if err != nil {
 		return &emptyResult, x.Wrapf(err, "dispatchTaskOverNetwork: while retrieving connection.")
 	}
-	defer conn.Get().Release(pl)
 
 	conn := pl.Get()
 	if tr, ok := trace.FromContext(ctx); ok {


### PR DESCRIPTION
- Periodically send Echo to a connection to test that it's working. If it doesn't, mark it as an unhealthy connection. A hung connection would also be marked as unhealthy after a timeout.
- When we need a connection to any server in a given group, pick a server whose connection is healthy.
- Similarly, apply the same connection health checking when retrieving the leader of a group. First try to find a healthy leader, if that fails, return any healthy peer, else return nil.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1462)
<!-- Reviewable:end -->
