### PR TITLE
Retrieve and sync tablet sizes

### DIFF
--- a/cmd/dgraph/dashboard.go
+++ b/cmd/dgraph/dashboard.go
@@ -48,7 +48,7 @@ type keywords struct {
 
 // Used to return a list of keywords, so that UI can show them for autocompletion.
 func keywordHandler(w http.ResponseWriter, r *http.Request) {
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	if r.Method != "GET" {
 		http.Error(w, x.ErrorInvalidMethod, http.StatusBadRequest)
 		return

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -204,18 +204,8 @@ func stopProfiling() {
 	}
 }
 
-func addCorsHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers",
-		"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token,"+
-			"X-Auth-Token, Cache-Control, X-Requested-With")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Connection", "close")
-}
-
 func healthCheck(w http.ResponseWriter, r *http.Request) {
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	if err := x.HealthCheck(); err == nil {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
@@ -225,7 +215,7 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 }
 
 func queryHandler(w http.ResponseWriter, r *http.Request) {
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 
 	if err := x.HealthCheck(); err != nil {
@@ -412,7 +402,7 @@ func shareHandler(w http.ResponseWriter, r *http.Request) {
 	var rawQuery []byte
 
 	w.Header().Set("Content-Type", "application/json")
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	if r.Method != "POST" {
 		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
 		return
@@ -464,7 +454,7 @@ func shareHandler(w http.ResponseWriter, r *http.Request) {
 
 // storeStatsHandler outputs some basic stats for data store.
 func storeStatsHandler(w http.ResponseWriter, r *http.Request) {
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	w.Header().Set("Content-Type", "text/html")
 	w.Write([]byte("<pre>"))
 	w.Write([]byte(worker.StoreStats()))

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -698,6 +698,8 @@ func setupServer(che chan error) {
 		log.Fatal(err)
 	}
 
+	// TODO: Consider removing the cmux here. We already separated gprc and http listeners to
+	// different ports.
 	httpMux := cmux.New(httpListener)
 	httpl := httpMux.Match(cmux.HTTP1Fast())
 	http2 := httpMux.Match(cmux.HTTP2())

--- a/cmd/dgraphzero/main.go
+++ b/cmd/dgraphzero/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/gogo/protobuf/jsonpb"
 )
 
 var (
@@ -56,6 +57,7 @@ var (
 
 func setupListener(addr string, port int) (listener net.Listener, err error) {
 	laddr := fmt.Sprintf("%s:%d", addr, port)
+	fmt.Printf("Setting up listener at: %v\n", laddr)
 	return net.Listen("tcp", laddr)
 }
 
@@ -115,6 +117,33 @@ func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
 	}()
 }
 
+func addCorsHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers",
+		"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token,"+
+			"X-Auth-Token, Cache-Control, X-Requested-With")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Connection", "close")
+}
+
+func (st *state) getState(w http.ResponseWriter, r *http.Request) {
+	addCorsHeaders(w)
+	w.Header().Set("Content-Type", "application/json")
+
+	mstate := st.zero.membershipState()
+	if mstate == nil {
+		x.SetStatus(w, x.ErrorNoData, "No membership state found.")
+		return
+	}
+
+	m := jsonpb.Marshaler{}
+	if err := m.Marshal(w, mstate); err != nil {
+		x.SetStatus(w, x.ErrorNoData, err.Error())
+		return
+	}
+}
+
 func main() {
 	rand.Seed(time.Now().UnixNano())
 	flag.Parse()
@@ -137,10 +166,12 @@ func main() {
 
 	var wg sync.WaitGroup
 	wg.Add(3)
-	// Initilize the servers.
+	// Initialize the servers.
 	var st state
 	st.serveGRPC(grpcListener, &wg)
 	st.serveHTTP(httpListener, &wg)
+
+	http.HandleFunc("/state", st.getState)
 
 	// Open raft write-ahead log and initialize raft node.
 	x.Checkf(os.MkdirAll(*w, 0700), "Error while creating WAL dir.")

--- a/cmd/dgraphzero/main.go
+++ b/cmd/dgraphzero/main.go
@@ -117,18 +117,8 @@ func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
 	}()
 }
 
-func addCorsHeaders(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers",
-		"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token,"+
-			"X-Auth-Token, Cache-Control, X-Requested-With")
-	w.Header().Set("Access-Control-Allow-Credentials", "true")
-	w.Header().Set("Connection", "close")
-}
-
 func (st *state) getState(w http.ResponseWriter, r *http.Request) {
-	addCorsHeaders(w)
+	x.AddCorsHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 
 	mstate := st.zero.membershipState()

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -718,8 +718,6 @@ func (n *node) InitAndStartNode(wal *raftwal.Wal) {
 	}
 	go n.processApplyCh()
 	go n.Run()
-	// TODO: Find a better way to snapshot, so we don't lose the membership
-	// state information, which isn't persisted.
 	go n.snapshotPeriodically()
 	go n.BatchAndSendMessages()
 }

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -360,6 +360,8 @@ func (g *groupi) KnownGroups() (gids []uint32) {
 
 // TODO: This could be better done via a uni-directional or bi-directional stream, so it's
 // instantenous.
+// If node is the leader, every sync involves calculating tablet sizes and sending them to
+// dgraphzero.
 func (g *groupi) syncMembershipState() {
 	// TODO: Instead of getting an address first, then finding a connection to that address,
 	// we should pick up a healthy connection from any server in the provided group.
@@ -395,7 +397,7 @@ func (g *groupi) syncMembershipState() {
 }
 
 func (g *groupi) periodicSyncMemberships() {
-	t := time.NewTicker(10 * time.Second)
+	t := time.NewTicker(time.Minute)
 	// TODO: We don't need to send membership information every 10 seconds, if we get a stream of
 	// MembershipState from dgraphzero. That way, we'll have the latest state update.
 	for {

--- a/x/x.go
+++ b/x/x.go
@@ -87,6 +87,16 @@ func SetStatus(w http.ResponseWriter, code, msg string) {
 	}
 }
 
+func AddCorsHeaders(w http.ResponseWriter) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers",
+		"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token,"+
+			"X-Auth-Token, Cache-Control, X-Requested-With")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+	w.Header().Set("Connection", "close")
+}
+
 type QueryResWithData struct {
 	Errors []errRes `json:"errors"`
 	Data   *string  `json:"data"`


### PR DESCRIPTION
- If node is the leader of group zero, then calculate the tablet sizes and send them to group zero.
- Create an http handler to retrieve the current state of the cluster from zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1471)
<!-- Reviewable:end -->
