### PR TITLE
Bulkloader: Fix map/reduce shard merge bug

### DIFF
--- a/cmd/bulkloader/main.go
+++ b/cmd/bulkloader/main.go
@@ -101,6 +101,7 @@ func main() {
 	loader := newLoader(opt)
 	if !opt.SkipMapPhase {
 		loader.mapStage()
+		mergeMapShardsIntoReduceShards(opt)
 	}
 	loader.reduceStage()
 	loader.writeSchema()

--- a/cmd/bulkloader/merge_shards.go
+++ b/cmd/bulkloader/merge_shards.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/dgraph-io/dgraph/x"
+)
+
+func mergeMapShardsIntoReduceShards(opt options) {
+	mapShards := shardDirs(opt.TmpDir)
+
+	var reduceShards []string
+	for i := 0; i < opt.ReduceShards; i++ {
+		shardDir := filepath.Join(opt.TmpDir, fmt.Sprintf("shard_%d", i))
+		x.Check(os.MkdirAll(shardDir, 0755))
+		reduceShards = append(reduceShards, shardDir)
+	}
+
+	// Heuristic: put the largest map shard into the smallest reduce shard
+	// until there are no more map shards left. Should be a good approximation.
+	for _, shard := range mapShards {
+		sortBySize(reduceShards)
+		x.Check(os.Rename(shard, filepath.Join(
+			reduceShards[len(reduceShards)-1], filepath.Base(shard))))
+	}
+}
+
+func shardDirs(tmpDir string) []string {
+	dir, err := os.Open(tmpDir)
+	x.Check(err)
+	shards, err := dir.Readdirnames(0)
+	x.Check(err)
+	dir.Close()
+	for i, shard := range shards {
+		shards[i] = filepath.Join(tmpDir, shard)
+	}
+
+	// Allow largest shards to be shuffled first.
+	sortBySize(shards)
+	return shards
+}
+
+func filenamesInTree(dir string) []string {
+	var fnames []string
+	x.Check(filepath.Walk(dir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if strings.HasSuffix(path, ".map") {
+			fnames = append(fnames, path)
+		}
+		return nil
+	}))
+	return fnames
+}
+
+type sizedDir struct {
+	dir string
+	sz  int64
+}
+
+// sortBySize sorts the input directories by size of their content (biggest to smallest).
+func sortBySize(dirs []string) {
+	sizedDirs := make([]sizedDir, len(dirs))
+	for i, dir := range dirs {
+		sizedDirs[i] = sizedDir{dir: dir, sz: treeSize(dir)}
+	}
+	sort.SliceStable(sizedDirs, func(i, j int) bool {
+		return sizedDirs[i].sz > sizedDirs[j].sz
+	})
+	for i := range sizedDirs {
+		dirs[i] = sizedDirs[i].dir
+	}
+}
+
+func treeSize(dir string) int64 {
+	var sum int64
+	x.Check(filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		sum += info.Size()
+		return nil
+	}))
+	return sum
+}


### PR DESCRIPTION
If the -skip_map_phase flag is set to true, then the merging between map shards and reduce shards still happened. This fixes that my only running the shard merge if the flag is false.

I also moved the merge logic out of the reducer struct (doesn't make sense for it to be there since it's a fairly distinct step).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1489)
<!-- Reviewable:end -->
