### PR TITLE
Include RDF in lexer error

### DIFF
--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -145,7 +145,7 @@ func (l *Lexer) Run(f StateFn) *Lexer {
 func (l *Lexer) Errorf(format string, args ...interface{}) StateFn {
 	l.items = append(l.items, Item{
 		Typ: ItemError,
-		Val: fmt.Sprintf(format, args...),
+		Val: fmt.Sprintf("while lexing %v: "+format, append([]interface{}{l.Input}, args...)...),
 	})
 	return nil
 }


### PR DESCRIPTION
Include the RDF that we were parsing at the time we see an error.

This is useful for when there are multiple RDFs being parsed and it's not clear to the user where the error is. It should be clear which RDF is the problem since the RDF itself is included in the error message.

e.g.
```
mutation{
  set{
    _s:abc <name> "hello" .
  }
```
```
while lexing _s:abc <name> "hello" .: Invalid character after _. Expected :, found 115
```
(the problem with displaying ascii code instead of char is fixed in a separate PR)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1517)
<!-- Reviewable:end -->
