### PR TITLE
Fix bug with S * *

### DIFF
--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -1624,6 +1624,59 @@ func TestUpsert2(t *testing.T) {
 		res)
 }
 
+func TestDeleteAllSP2(t *testing.T) {
+	var m = `
+	mutation {
+	  set {
+	    _:day1 <nodeType> "TRACKED_DAY" .
+	    _:day1 <name> "July 3 2017" .
+	    _:day1 <date> "2017-07-03T03:49:03+00:00" .
+	    _:day1 <weight> "262.3" .
+	    _:day1 <weightUnit> "pound" .
+	    _:day1 <lifeLoad> "5" .
+	    _:day1 <stressLevel> "3" .
+	    _:day1 <plan> "modest day" .
+	    _:day1 <postMortem> "win!" .
+	  }
+	}
+	`
+	output, err := runQuery(m)
+	require.NoError(t, err)
+	out := make(map[string]interface{})
+	require.NoError(t, json.Unmarshal([]byte(output), &out))
+	uid := out["data"].(map[string]interface{})["uids"].(map[string]interface{})["day1"].(string)
+
+	q := fmt.Sprintf(`
+	{
+	  all_tracked_days(func: uid(%s)) {
+		_predicate_
+		name
+	    date
+	    weight
+	    lifeLoad
+	    stressLevel
+	  }
+	}`, uid)
+
+	output, err = runQuery(q)
+	require.NoError(t, err)
+	require.Equal(t, `{"data": {"all_tracked_days":[{"_predicate_":["name","date","weightUnit","postMortem","lifeLoad","weight","stressLevel","nodeType","plan"],"name":"July 3 2017","date":"2017-07-03T03:49:03+00:00","weight":"262.3","lifeLoad":"5","stressLevel":"3"}]}}`, output)
+
+	m = fmt.Sprintf(`
+		mutation {
+			delete {
+				<%s> * * .
+			}
+		}`, uid)
+
+	output, err = runQuery(m)
+	require.NoError(t, err)
+
+	output, err = runQuery(q)
+	require.NoError(t, err)
+	require.Equal(t, `{"data": {}}`, output)
+}
+
 func TestMain(m *testing.M) {
 	dc := dgraph.DefaultConfig
 	dc.AllottedMemory = 2048.0
@@ -1631,6 +1684,7 @@ func TestMain(m *testing.M) {
 	x.Init()
 
 	dir1, dir2, _ := prepare()
+	time.Sleep(10 * time.Millisecond)
 
 	// Parse GQL into internal query representation.
 	r := m.Run()

--- a/gql/mutation.go
+++ b/gql/mutation.go
@@ -19,7 +19,6 @@ package gql
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 
 	"github.com/dgraph-io/dgraph/protos"
@@ -314,7 +313,7 @@ func (nq NQuad) ToEdgeUsing(newToUid map[string]uint64) (*protos.DirectedEdge, e
 	case x.ValuePlain, x.ValueMulti:
 		edge, err = nq.CreateValueEdge(sUid)
 	default:
-		return &emptyEdge, errors.New("unknow value type")
+		return &emptyEdge, x.Errorf("unknown value type for nquad: %+v", nq)
 	}
 	if err != nil {
 		return nil, err
@@ -372,7 +371,7 @@ func (nq *NQuad) ExpandVariables(newToUid map[string]uint64, subjectUids []uint6
 			edges = append(edges, edge)
 		}
 	default:
-		return edges, fmt.Errorf("unknown value type: %s", nq.String())
+		return edges, x.Errorf("unknown value type for nquad: %+v", nq)
 	}
 	return edges, nil
 

--- a/worker/index.go
+++ b/worker/index.go
@@ -33,8 +33,9 @@ func (n *node) rebuildOrDelIndex(ctx context.Context, attr string, rebuild bool)
 	// Raft index starts from 1
 	n.syncAllMarks(ctx, rv.Index-1)
 
-	x.AssertTruef(schema.State().IsIndexed(attr) == rebuild, "Predicate %s index mismatch, rebuild %v",
-		attr, rebuild)
+	if schema.State().IsIndexed(attr) != rebuild {
+		return x.Errorf("Predicate %s index mismatch, rebuild %v", attr, rebuild)
+	}
 	// Remove index edges
 	// For delete we since mutations would have been applied, we needn't
 	// wait for synced watermarks if we delete through mutations, but
@@ -56,7 +57,9 @@ func (n *node) rebuildOrDelRevEdge(ctx context.Context, attr string, rebuild boo
 	// Raft index starts from 1
 	n.syncAllMarks(ctx, rv.Index-1)
 
-	x.AssertTruef(schema.State().IsReversed(attr) == rebuild, "Predicate %s reverse mismatch", attr)
+	if schema.State().IsReversed(attr) != rebuild {
+		return x.Errorf("Predicate %s reverse mismatch, rebuild %v", attr, rebuild)
+	}
 	posting.DeleteReverseEdges(ctx, attr)
 	if rebuild {
 		// Remove reverse edges

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -240,6 +240,15 @@ func checkSchema(s *protos.SchemaUpdate) error {
 	if len(s.Predicate) == 0 {
 		return x.Errorf("No predicate specified in schema mutation")
 	}
+
+	if s.Directive == protos.SchemaUpdate_INDEX && len(s.Tokenizer) == 0 {
+		return x.Errorf("Tokenizer must be specified while indexing a predicate: %+v", s)
+	}
+
+	if len(s.Tokenizer) > 0 && s.Directive != protos.SchemaUpdate_INDEX {
+		return x.Errorf("Directive must be SchemaUpdate_INDEX when a tokenizer is specified")
+	}
+
 	typ := types.TypeID(s.ValueType)
 	if typ == types.UidID && s.Directive == protos.SchemaUpdate_INDEX {
 		// index on uid type

--- a/worker/mutation_test.go
+++ b/worker/mutation_test.go
@@ -149,7 +149,7 @@ func TestCheckSchema(t *testing.T) {
 	s1 = &protos.SchemaUpdate{Predicate: "name", ValueType: uint32(types.StringID), Directive: protos.SchemaUpdate_REVERSE}
 	require.Error(t, checkSchema(s1))
 
-	s1 = &protos.SchemaUpdate{Predicate: "name", ValueType: uint32(types.FloatID), Directive: protos.SchemaUpdate_INDEX}
+	s1 = &protos.SchemaUpdate{Predicate: "name", ValueType: uint32(types.FloatID), Directive: protos.SchemaUpdate_INDEX, Tokenizer: []string{"term"}}
 	require.NoError(t, checkSchema(s1))
 
 	s1 = &protos.SchemaUpdate{Predicate: "friend", ValueType: uint32(types.UidID), Directive: protos.SchemaUpdate_REVERSE}


### PR DESCRIPTION
`S * *` was broken after the multiple value change. Unfortunately, none of our tests properly tested the value returned. Fixed it now. 

Also removed a couple of asserts in the mutation path which disallow a restart the DB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1528)
<!-- Reviewable:end -->
