### PR TITLE
Fix race with using upsert

### DIFF
--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -1683,7 +1683,7 @@ func TestUpsert2(t *testing.T) {
 
 	res, err := runQuery(query)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"data": {"uids":{"b":"0x271a","a":"0x2719"}}}`, res)
+	require.JSONEq(t, `{"data": {"uids":{"a":"0x271a","b":"0x2719"}}}`, res)
 
 	m := make(map[string]interface{})
 	require.NoError(t, json.Unmarshal([]byte(res), &m))
@@ -1764,6 +1764,64 @@ func TestDeleteAllSP2(t *testing.T) {
 	output, err = runQuery(q)
 	require.NoError(t, err)
 	require.Equal(t, `{"data": {}}`, output)
+}
+
+func TestUpsertRace(t *testing.T) {
+	s := `
+	mutation {
+		schema {
+			xid: string @index(exact) .
+		}
+	}
+	`
+	_, err := runQuery(s)
+	require.NoError(t, err)
+
+	q := `
+{
+  email as var(func: eq(xid, "<2519643.1075860072192.JavaMail.evans@thyme>")) @upsert
+  human as var(func: eq(xid, "mark.taylor@enron.com")) @upsert
+  human_to_0 as var(func: eq(xid, "leonardo.pacheco@enron.com")) @upsert
+  human_cc_0 as var(func: eq(xid, "jay.hawthorn@enron.com")) @upsert
+  human_cc_1 as var(func: eq(xid, "cynthia.harkness@enron.com")) @upsert
+  human_cc_2 as var(func: eq(xid, "jean.mrha@enron.com")) @upsert
+  human_cc_3 as var(func: eq(xid, "david.forster@enron.com")) @upsert
+  human_cc_4 as var(func: eq(xid, "julie.ferrara@enron.com")) @upsert
+  human_cc_5 as var(func: eq(xid, "kal.shah@enron.com")) @upsert
+  human_bcc_0 as var(func: eq(xid, "jay.hawthorn@enron.com")) @upsert
+  human_bcc_1 as var(func: eq(xid, "cynthia.harkness@enron.com")) @upsert
+  human_bcc_2 as var(func: eq(xid, "jean.mrha@enron.com")) @upsert
+  human_bcc_3 as var(func: eq(xid, "david.forster@enron.com")) @upsert
+  human_bcc_4 as var(func: eq(xid, "julie.ferrara@enron.com")) @upsert
+  human_bcc_5 as var(func: eq(xid, "kal.shah@enron.com")) @upsert
+}
+mutation {
+  set {
+   uid(email) <xid> "<2519643.1075860072192.JavaMail.evans@thyme>" .
+   uid(email) <filename> "data/maildir/taylor-m/sent/1018." .
+   uid(email) <date> "2000-05-01 01:31:00 -0700 PDT" .
+   uid(human) <sent> uid(email) .
+   uid(email) <from> "mark.taylor@enron.com" .
+   uid(email) <subject> "Re: Bandwidth Launch on EOL Website Ticker Text" .
+
+   uid(human_to_0) <xid> "leonardo.pacheco@enron.com" .
+   uid(human_cc_0) <xid> "jay.hawthorn@enron.com" .
+   uid(human_cc_1) <xid> "cynthia.harkness@enron.com" .
+   uid(human_cc_2) <xid> "jean.mrha@enron.com" .
+   uid(human_cc_3) <xid> "david.forster@enron.com" .
+   uid(human_cc_4) <xid> "julie.ferrara@enron.com" .
+   uid(human_cc_5) <xid> "kal.shah@enron.com" .
+   uid(human_bcc_0) <xid> "jay.hawthorn@enron.com" .
+   uid(human_bcc_1) <xid> "cynthia.harkness@enron.com" .
+   uid(human_bcc_2) <xid> "jean.mrha@enron.com" .
+   uid(human_bcc_3) <xid> "david.forster@enron.com" .
+   uid(human_bcc_4) <xid> "julie.ferrara@enron.com" .
+   uid(human_bcc_5) <xid> "kal.shah@enron.com" .
+  }
+}
+	`
+	_, err = runQuery(q)
+	require.NoError(t, err)
 }
 
 func TestMain(m *testing.M) {

--- a/contrib/cover.sh
+++ b/contrib/cover.sh
@@ -22,7 +22,11 @@ pushd $SRC &> /dev/null
 # create coverage output
 echo 'mode: atomic' > $OUT
 for PKG in $(go list ./...|grep -v -E 'vendor|contrib|wiki'); do
-  go test -covermode=atomic -coverprofile=$TMP $PKG
+  if [ $TRAVIS_BRANCH =~ master|release\/ ]; then
+    go test -race -covermode=atomic -coverprofile=$TMP $PKG
+  else
+    go test -covermode=atomic -coverprofile=$TMP $PKG
+  fi
   tail -n +2 $TMP >> $OUT
 done
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -3143,10 +3143,10 @@ func TestProcessGraph(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.NoError(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.NoError(t, r.err)
 
 	require.EqualValues(t, childAttrs(sg), []string{"friend", "name", "gender", "alive"})
 	require.EqualValues(t, childAttrs(sg.Children[0]), []string{"name"})
@@ -3410,11 +3410,10 @@ func TestFilterRegexError(t *testing.T) {
 	ctx := context.Background()
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
-
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestFilterRegex1(t *testing.T) {
@@ -4089,10 +4088,10 @@ func TestToFastJSONOrderNameError(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestToFastJSONFilterleOrder(t *testing.T) {
@@ -5687,10 +5686,10 @@ func TestNearGeneratorError(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestNearGeneratorErrorMissDist(t *testing.T) {
@@ -5709,10 +5708,10 @@ func TestNearGeneratorErrorMissDist(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestWithinGeneratorError(t *testing.T) {
@@ -5731,10 +5730,10 @@ func TestWithinGeneratorError(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestWithinGenerator(t *testing.T) {
@@ -5788,10 +5787,10 @@ func TestIntersectsGeneratorError(t *testing.T) {
 	sg, err := ToSubGraph(ctx, res.Query[0])
 	require.NoError(t, err)
 
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
-	require.Error(t, err)
+	resp := make(chan response)
+	go ProcessGraph(ctx, sg, nil, resp)
+	r := <-resp
+	require.Error(t, r.err)
 }
 
 func TestIntersectsGenerator(t *testing.T) {


### PR DESCRIPTION
The issue here was that after the Subgraph was executed, we were trying to access it using

```
sg := req.Subgraphs[i]
```
and that is wrong because the response doesn't belong to the subgraph at `i` index. Now the subgraph is part of the response along with the error. This does make the code a bit verbose which I don't like but I couldn't think of an easier way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1545)
<!-- Reviewable:end -->
