### PR TITLE
Fix #1515

### DIFF
--- a/cmd/dgraph-bulk-loader/mapper.go
+++ b/cmd/dgraph-bulk-loader/mapper.go
@@ -261,6 +261,7 @@ func (m *mapper) addIndexMapEntries(nq gql.NQuad, de *protos.DirectedEdge) {
 
 		// Extract tokens.
 		toks, err := toker.Tokens(schemaVal)
+		x.Check(err)
 
 		// Store index posting.
 		for _, t := range toks {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -260,7 +260,7 @@ func populateGraph(t *testing.T) {
 	addGeoData(t, ps, 5105, poly, "Mountain View")
 	poly = geom.NewPolygon(geom.XY).MustSetCoords([][]geom.Coord{
 		{{-122.25, 37.49}, {-122.28, 37.49}, {-122.27, 37.51}, {-122.25, 37.52},
-			{-122.24, 37.51}},
+			{-122.25, 37.49}},
 	})
 	addGeoData(t, ps, 5106, poly, "San Carlos")
 

--- a/types/s2index.go
+++ b/types/s2index.go
@@ -134,6 +134,9 @@ func loopFromPolygon(p *geom.Polygon) (*s2.Loop, error) {
 	if n < 4 {
 		return nil, x.Errorf("Can't convert ring with less than 4 pts")
 	}
+	if !r.Coord(0).Equal(geom.XY, r.Coord(n-1)) {
+		return nil, x.Errorf("Last coordinate not same as first for polygon: %+v\n", p)
+	}
 	// S2 specifies that the orientation of the polygons should be CCW. However there is no
 	// restriction on the orientation in WKB (or geojson). To get the correct orientation we assume
 	// that the polygons are always less than one hemisphere. If they are bigger, we flip the

--- a/types/s2index_test.go
+++ b/types/s2index_test.go
@@ -114,6 +114,14 @@ func TestIndexCellsPolygon(t *testing.T) {
 	require.True(t, len(parents) > len(cover))
 }
 
+func TestIndexCellsPolygonError(t *testing.T) {
+	poly := geom.NewPolygon(geom.XY).MustSetCoords([][]geom.Coord{
+		{{-122, 37}, {-123, 37}, {-123, 38}, {-122, 38}, {-122, 38}}})
+	_, _, err := indexCells(poly)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Last coordinate not same as first")
+}
+
 func TestKeyGeneratorPoint(t *testing.T) {
 	p := geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{-122.082506, 37.4249518})
 	data, err := wkb.Marshal(p, binary.LittleEndian)


### PR DESCRIPTION
#1515 was caused by wrong data. We should be checking that polygon is closed before indexing it else it ends up covering the earth. Checking that now.

Also dgraph-bulk-loader wasn't checking error from `toker.Tokens`. Fixed that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1552)
<!-- Reviewable:end -->
