### PR TITLE
Prevent nil pointer exception crash

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2639,6 +2639,9 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				count = seenWithPred
 			}
 		case itemLeftCurl:
+			if curp == nil {
+				return x.Errorf("Query syntax invalid.")
+			}
 			if len(curp.Langs) > 0 {
 				return x.Errorf("Cannot have children for attr: %s with lang tags: %v", curp.Attr,
 					curp.Langs)

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4363,3 +4363,18 @@ func TestOrderByVarAndPred(t *testing.T) {
 	_, err = Parse(Request{Str: query, Http: true})
 	require.NoError(t, err)
 }
+
+func TestInvalidValUsage(t *testing.T) {
+	query := `
+		{
+			me(func: uid(0x01)) {
+				val(_uid_) {
+					nope
+				}
+			}
+		}
+	`
+	_, err := Parse(Request{Str: query, Http: true})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Query syntax invalid.")
+}


### PR DESCRIPTION
Prevent a parser crash when using `val` on a predicate while also trying to expand it:
```graphql
{
  brCharacters(func: eq(name@en, "Blade Runner")) {
    name@en
    initial_release_date
    starring {
      # This makes dgraph crash!!!
      val(performance.actor) {
        name@en  # actor name
      }
      performance.character {
        name@en  # character name
      }
    }
  }
}
```

PS: Sorry for crashing the doc server...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1558)
<!-- Reviewable:end -->
