### PR TITLE
Don't track zero count index

### DIFF
--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -1921,6 +1921,24 @@ func TestRecurseExpandAll(t *testing.T) {
 	require.JSONEq(t, `{"data": {"recurse":[{"name":"Alica","age":"13","friend":[{"name":"bob","age":"12"}]}]}}`, output)
 }
 
+func TestIllegalCountInQueryFn(t *testing.T) {
+	q := `
+	mutation{
+		schema{
+			friend: uid @count .
+		}
+	}
+	{
+		q(func: eq(count(friend), 0)) {
+			count
+		}
+	}`
+	_, err := runQuery(q)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count")
+	require.Contains(t, err.Error(), "zero")
+}
+
 func TestMain(m *testing.M) {
 	dc := dgraph.DefaultConfig
 	dc.AllottedMemory = 2048.0

--- a/posting/index.go
+++ b/posting/index.go
@@ -275,10 +275,12 @@ func updateCount(ctx context.Context, params countParams) error {
 		return err
 	}
 
-	edge.Op = protos.DirectedEdge_SET
-	if err := addCountMutation(ctx, &edge, uint32(params.countAfter),
-		params.reverse); err != nil {
-		return err
+	if params.countAfter > 0 {
+		edge.Op = protos.DirectedEdge_SET
+		if err := addCountMutation(ctx, &edge, uint32(params.countAfter),
+			params.reverse); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/query/query.go
+++ b/query/query.go
@@ -2232,15 +2232,7 @@ func isValidFuncName(f string) bool {
 		"has", "uid", "uid_in":
 		return true
 	}
-	return isCompareFn(f) || types.IsGeoFunc(f)
-}
-
-func isCompareFn(f string) bool {
-	switch f {
-	case "le", "ge", "lt", "gt", "eq":
-		return true
-	}
-	return false
+	return isInequalityFn(f) || types.IsGeoFunc(f)
 }
 
 func isInequalityFn(f string) bool {

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2474,6 +2474,30 @@ func TestCountError3(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestCountDoNotTrackZeroCount(t *testing.T) {
+	populateGraph(t)
+	query := `
+	mutation{
+		schema{
+			aoeu: uid @count .
+		}
+		set{
+			_:a <aoeu> _:b .
+		}
+		delete{
+			* <aoeu> * .
+		}
+	}
+	{
+		q(func: lt(count(aoeu), 5)) {
+			count
+		}
+	}
+	`
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"data": {"q":[]}}`, js)
+}
+
 func TestMultiCountSort(t *testing.T) {
 	populateGraph(t)
 	// Alright. Now we have everything set up. Let's create the query.

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -7795,7 +7795,7 @@ func TestCountAtRoot(t *testing.T) {
 	populateGraph(t)
 	query := `
         {
-        	me(func: ge(count(friend), 0)) {
+            me(func: gt(count(friend), 0)) {
 				count()
 			}
         }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1737,19 +1737,6 @@ func TestNestedFuncRoot2(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Andrea"}]}}`, js)
 }
 
-func TestNestedFuncRoot3(t *testing.T) {
-	populateGraph(t)
-	query := `
-		{
-			me(func: le(count(friend), -1)) {
-				name
-			}
-		}
-  `
-	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": { "me": []}}`, js)
-}
-
 func TestNestedFuncRoot4(t *testing.T) {
 	populateGraph(t)
 	query := `

--- a/worker/task.go
+++ b/worker/task.go
@@ -1392,8 +1392,8 @@ func (cp *countParams) evaluate(out *protos.Result) error {
 	count := cp.count
 	if count == 0 {
 		switch cp.fn {
-		case "eq", "ge", "lt", "le": // gt and ne 0 are allowed
-			return x.Errorf("count() can't evaluate to zero count nodes")
+		case "eq", "ge", "lt", "le": // gt and ne 0 are allowed, since they exclude the zero count.
+			return x.Errorf("count() cannot evaluate to zero count nodes")
 		}
 	}
 	countKey := x.CountKey(cp.attr, uint32(count), cp.reverse)

--- a/worker/task.go
+++ b/worker/task.go
@@ -1390,18 +1390,18 @@ type countParams struct {
 
 func (cp *countParams) evaluate(out *protos.Result) error {
 	count := cp.count
-	var zeroCheck bool
+	var illegal bool
 	switch cp.fn {
 	case "eq":
-		zeroCheck = count == 0
+		illegal = count == 0
 	case "lt":
-		zeroCheck = count == 0 || count == 1
+		illegal = count == 0 || count == 1
 	case "le":
-		zeroCheck = count == 0
+		illegal = count == 0
 	case "ge":
-		zeroCheck = count == 0
+		illegal = count == 0
 	}
-	if zeroCheck {
+	if illegal {
 		return x.Errorf("count(predicate) can only be used " +
 			"to search for nodes with non-zero counts.")
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -1402,6 +1402,8 @@ func (cp *countParams) evaluate(out *protos.Result) error {
 		illegal = count < 0
 	case "ge":
 		illegal = count <= 0
+	default:
+		x.AssertTruef(false, "unhandled count comparison fn: %v", cp.fn)
 	}
 	if illegal {
 		return x.Errorf("count(predicate) cannot be used to search for " +


### PR DESCRIPTION
Also makes some usages of count illegal rather than just returning an empty result set (so as to make it clear to users that zero counts aren't tracked).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1597)
<!-- Reviewable:end -->
