### PR TITLE
Fix URLs for rdf.gz and schema files

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -380,7 +380,7 @@ $ dgraphloader -r <path-to-rdf-gzipped-file>
 $ dgraphloader -r <path-to-rdf-gzipped-file> -s <path-to-schema-file> -d <dgraph-server-address:port>
 
 # For example to load goldendata with the corresponding schema and convert URI to xid.
-$ dgraphloader -r github.com/dgraph-io/benchmarks/data/goldendata.rdf.gz -s github.com/dgraph-io/benchmarks/data/goldendata.schema -x
+$ dgraphloader -r goldendata.rdf.gz -s goldendata.schema -x
 ```
 
 ### `bulkloader`
@@ -473,7 +473,7 @@ scrape_configs:
       - 172.31.8.118:8080
 ```
 
-Install **[Grafana](http://docs.grafana.org/installation/)** to plot the metrics. Grafana runs at port 3000 in default settings. Create a prometheus datasource by following these **[steps](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source)**. Import **[grafana_dashboard.json](https://github.com/dgraph-io/benchmarks/blob/master/scripts/grafana_dashboard.json)** by following this **[link](http://docs.grafana.org/reference/export_import/#importing-a-dashboard)**. 
+Install **[Grafana](http://docs.grafana.org/installation/)** to plot the metrics. Grafana runs at port 3000 in default settings. Create a prometheus datasource by following these **[steps](https://prometheus.io/docs/visualization/grafana/#creating-a-prometheus-data-source)**. Import **[grafana_dashboard.json](https://github.com/dgraph-io/benchmarks/blob/master/scripts/grafana_dashboard.json)** by following this **[link](http://docs.grafana.org/reference/export_import/#importing-a-dashboard)**.
 
 ## Troubleshooting
 Here are some problems that you may encounter and some solutions to try.


### PR DESCRIPTION
(Not ready for merge.)

There were two broken URIs that I fixed. Unfortunately, this still does not work and returns the following error:

Processing https://raw.githubusercontent.com/dgraph-io/benchmarks/master/data/goldendata.schema
2017/10/08 11:09:42 open https://raw.githubusercontent.com/dgraph-io/benchmarks/master/data/goldendata.schema: no such file or directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1606)
<!-- Reviewable:end -->
