### PR TITLE
Added Java package option.

### DIFF
--- a/protos/bulkloader.proto
+++ b/protos/bulkloader.proto
@@ -4,6 +4,8 @@ import "types.proto";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message MapEntry {
 	bytes key = 1;
 

--- a/protos/facets.proto
+++ b/protos/facets.proto
@@ -19,6 +19,8 @@ syntax = "proto3";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message Facet {
 	enum ValType {
 	     STRING = 0;

--- a/protos/graphresponse.proto
+++ b/protos/graphresponse.proto
@@ -21,6 +21,8 @@ import "schema.proto";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 service Dgraph {
     rpc Run (Request) returns (Response) {};
     rpc CheckVersion(Check) returns (Version) {};

--- a/protos/payload.proto
+++ b/protos/payload.proto
@@ -22,6 +22,8 @@ import "task.proto";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message Payload {
 	bytes Data = 1;
 }

--- a/protos/schema.proto
+++ b/protos/schema.proto
@@ -19,6 +19,8 @@ syntax = "proto3";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message SchemaRequest {
 	uint32 group_id = 1;
 	repeated string predicates = 2;

--- a/protos/task.proto
+++ b/protos/task.proto
@@ -22,6 +22,8 @@ import "graphresponse.proto";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message List {
 	repeated fixed64 uids = 1;
 }

--- a/protos/types.proto
+++ b/protos/types.proto
@@ -20,6 +20,8 @@ import "facets.proto";
 
 package protos;
 
+option java_package = "io.dgraph.proto";
+
 message Posting {
 	fixed64 uid = 1;
 	bytes value = 2;


### PR DESCRIPTION
The current `.proto` files are missing a Java package demarcation. When used to generate Java protobug models and grpc stubs it has to be modified to avoid default package issues.

This option is only used by Java code generators (I'm using a Gradle plugin: https://github.com/google/protobuf-gradle-plugin).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1610)
<!-- Reviewable:end -->
