### PR TITLE
Get rid of waitForSyncMark method and just use syncAllMarks

### DIFF
--- a/client_test/client_test.go
+++ b/client_test/client_test.go
@@ -34,12 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMain(m *testing.M) {
-	x.Init()
-	x.Logger = log.New(ioutil.Discard, "", 0)
-	os.Exit(m.Run())
-}
-
 func prepare() (res []string, options dgraph.Options) {
 	clientDir, err := ioutil.TempDir("", "client_")
 	x.Check(err)
@@ -66,6 +60,19 @@ func removeDirs(dirs []string) {
 	}
 }
 
+var dgraphClient *client.Dgraph
+
+func TestMain(m *testing.M) {
+	x.Init()
+	x.Logger = log.New(ioutil.Discard, "", 0)
+	dirs, options := prepare()
+	defer removeDirs(dirs)
+	dgraphClient = dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
+	r := m.Run()
+	dgraph.DisposeEmbeddedDgraph()
+	os.Exit(r)
+}
+
 type Person struct {
 	Name    string   `json:"name"`
 	Loc     string   `json:"loc"`
@@ -78,11 +85,6 @@ type Res struct {
 }
 
 func TestClientDelete(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -161,11 +163,6 @@ func TestClientDelete(t *testing.T) {
 }
 
 func TestClientAddFacets(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -189,11 +186,6 @@ func TestClientAddFacets(t *testing.T) {
 }
 
 func TestClientAddFacetsError(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -214,11 +206,6 @@ func TestClientAddFacetsError(t *testing.T) {
 }
 
 func TestClientDeletePredicate(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -273,11 +260,6 @@ func TestClientDeletePredicate(t *testing.T) {
 }
 
 func TestLangTag(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -329,12 +311,6 @@ func TestLangTag(t *testing.T) {
 }
 
 func TestSchemaError(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
-
 	req := client.Req{}
 	err := req.AddSchema(protos.SchemaUpdate{
 		Predicate: "dummy",
@@ -358,11 +334,6 @@ func TestSchemaError(t *testing.T) {
 }
 
 func TestEmptyString(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 	alice, err := dgraphClient.NodeBlank("")
 	require.NoError(t, err)
@@ -389,11 +360,6 @@ func TestSetObject(t *testing.T) {
 		School   *School  `json:"school,omitempty"`
 	}
 
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	loc := `{"type":"Point","coordinates":[1.1,2]}`
@@ -472,11 +438,6 @@ func TestSetObject(t *testing.T) {
 }
 
 func TestSetObject2(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	type School struct {
@@ -538,11 +499,6 @@ func TestDeleteObject1(t *testing.T) {
 		School   *School  `json:"school,omitempty"`
 	}
 
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	loc := `{"type":"Point","coordinates":[1.1,2]}`
@@ -653,11 +609,6 @@ func TestDeleteObject2(t *testing.T) {
 		School   *School  `json:"school"`
 	}
 
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	loc := `{"type":"Point","coordinates":[1.1,2]}`
@@ -755,11 +706,6 @@ func TestDeleteObject2(t *testing.T) {
 }
 
 func TestSetObjectWithFacets(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	type friendFacet struct {
@@ -861,11 +807,6 @@ func TestSetObjectWithFacets(t *testing.T) {
 }
 
 func TestSetObjectUpdateFacets(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	type friendFacet struct {
@@ -970,11 +911,6 @@ func TestDeleteObjectNode(t *testing.T) {
 		Friends []*Person `json:"friend,omitempty"`
 	}
 
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	p := Person{
@@ -1061,11 +997,6 @@ func TestDeleteObjectPredicate(t *testing.T) {
 		Friends []*Person `json:"friend,omitempty"`
 	}
 
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	p := Person{
@@ -1150,11 +1081,6 @@ func TestDeleteObjectPredicate(t *testing.T) {
 }
 
 func TestObjectList(t *testing.T) {
-	dirs, options := prepare()
-	defer removeDirs(dirs)
-
-	dgraphClient := dgraph.NewEmbeddedDgraphClient(options, client.DefaultOptions, dirs[0])
-	defer dgraph.DisposeEmbeddedDgraph()
 	req := client.Req{}
 
 	type Person struct {

--- a/worker/index.go
+++ b/worker/index.go
@@ -93,10 +93,6 @@ func (n *node) syncAllMarks(ctx context.Context, lastIndex uint64) error {
 	return waitForSyncMark(ctx, n.gid, lastIndex)
 }
 
-func (n *node) waitForSyncMark(ctx context.Context, lastIndex uint64) error {
-	return waitForSyncMark(ctx, n.gid, lastIndex)
-}
-
 func waitForSyncMark(ctx context.Context, gid uint32, lastIndex uint64) error {
 	// Wait for posting lists applying.
 	w := posting.SyncMarks()

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -55,7 +55,10 @@ func runMutation(ctx context.Context, edge *protos.DirectedEdge) error {
 	x.Checkf(err, "Schema is not present for predicate %s", edge.Attr)
 
 	if edge.Entity == 0 && bytes.Equal(edge.Value, []byte(x.Star)) {
-		waitForSyncMark(ctx, 0, rv.Index-1)
+		n := groups().Node
+		if err = n.syncAllMarks(ctx, rv.Index-1); err != nil {
+			return err
+		}
 		if err = posting.DeletePredicate(ctx, edge.Attr); err != nil {
 			return err
 		}
@@ -90,7 +93,9 @@ func runSchemaMutation(ctx context.Context, update *protos.SchemaUpdate) error {
 	// Wait for applied watermark to reach till previous index
 	// All mutations before this should use old schema and after this
 	// should use new schema
-	n.waitForSyncMark(n.ctx, rv.Index-1)
+	if err := n.syncAllMarks(n.ctx, rv.Index-1); err != nil {
+		return err
+	}
 	if !groups().ServesTablet(update.Predicate) {
 		return errUnservedTablet
 	}

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -97,7 +97,7 @@ func (s *scheduler) register(t *task) bool {
 
 func (s *scheduler) schedule(proposal *protos.Proposal, index uint64) error {
 	if proposal.Mutations.DropAll {
-		if err := s.n.waitForSyncMark(s.n.ctx, index-1); err != nil {
+		if err := s.n.syncAllMarks(s.n.ctx, index-1); err != nil {
 			s.n.props.Done(proposal.Id, err)
 			return err
 		}


### PR DESCRIPTION
Fix #1590 

waitForSyncMark wasn't applying the mutations to memory hence we were waiting for gentle commit to happen which can take upto 5 secs. Removed the function and now just calling `syncAllMarks` for delete predicate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1616)
<!-- Reviewable:end -->
