### PR TITLE
Return nil from x.Parse instead of panicking and skip these keys.

### DIFF
--- a/client_test/client_test.go
+++ b/client_test/client_test.go
@@ -63,7 +63,7 @@ func removeDirs(dirs []string) {
 var dgraphClient *client.Dgraph
 
 func TestMain(m *testing.M) {
-	x.Init()
+	x.Init(true)
 	x.Logger = log.New(ioutil.Discard, "", 0)
 	dirs, options := prepare()
 	defer removeDirs(dirs)

--- a/cmd/dgraph-bulk-loader/count_index.go
+++ b/cmd/dgraph-bulk-loader/count_index.go
@@ -28,7 +28,7 @@ type countIndexer struct {
 // sorted order.
 func (c *countIndexer) addUid(rawKey []byte, count int) {
 	key := x.Parse(rawKey)
-	if !key.IsData() && !key.IsReverse() {
+	if key == nil || (!key.IsData() && !key.IsReverse()) {
 		return
 	}
 	sameIndexKey := key.Attr == c.cur.pred && key.IsReverse() == c.cur.rev

--- a/cmd/dgraph/main.go
+++ b/cmd/dgraph/main.go
@@ -740,7 +740,7 @@ func main() {
 	runtime.GOMAXPROCS(128)
 
 	setupConfigOpts() // flag.Parse is called here.
-	x.Init()
+	x.Init(dgraph.Config.DebugMode)
 
 	setupProfiling()
 

--- a/cmd/dgraph/main_test.go
+++ b/cmd/dgraph/main_test.go
@@ -1943,7 +1943,7 @@ func TestMain(m *testing.M) {
 	dc := dgraph.DefaultConfig
 	dc.AllottedMemory = 2048.0
 	dgraph.SetConfiguration(dc)
-	x.Init()
+	x.Init(true)
 
 	dir1, dir2, _ := prepare()
 	time.Sleep(10 * time.Millisecond)

--- a/cmd/postingiterator/main.go
+++ b/cmd/postingiterator/main.go
@@ -32,7 +32,7 @@ var (
 
 func main() {
 	flag.Parse()
-	x.Init()
+	x.Init(true)
 
 	// All the writes to posting store should be synchronous. We use batched writers
 	// for posting lists, so the cost of sync writes is amortized.

--- a/dgraph/embedded.go
+++ b/dgraph/embedded.go
@@ -40,7 +40,7 @@ func NewEmbeddedDgraphClient(config Options, opts client.BatchMutationOptions,
 
 	SetConfiguration(config)
 
-	x.Init()
+	x.Init(config.DebugMode)
 	State = NewServerState()
 	schema.Init(State.Pstore)
 	posting.Init(State.Pstore)

--- a/posting/index.go
+++ b/posting/index.go
@@ -415,6 +415,9 @@ func deleteEntries(prefix []byte) error {
 
 func compareAttrAndType(key []byte, attr string, typ byte) bool {
 	pk := x.Parse(key)
+	if pk == nil {
+		return true
+	}
 	if pk.Attr == attr && pk.IsType(typ) {
 		return true
 	}
@@ -502,6 +505,9 @@ func rebuildCountIndex(ctx context.Context, attr string, reverse bool, errCh cha
 		iterItem := it.Item()
 		key := iterItem.Key()
 		pki := x.Parse(key)
+		if pki == nil {
+			continue
+		}
 		var pl protos.PostingList
 		err := iterItem.Value(func(val []byte) error {
 			UnmarshalOrCopy(val, iterItem.UserMeta(), &pl)
@@ -610,6 +616,9 @@ func RebuildReverseEdges(ctx context.Context, attr string) error {
 			break
 		}
 		pki := x.Parse(key)
+		if pki == nil {
+			continue
+		}
 		var pl protos.PostingList
 		err := iterItem.Value(func(val []byte) error {
 			UnmarshalOrCopy(val, iterItem.UserMeta(), &pl)
@@ -712,6 +721,9 @@ func RebuildIndex(ctx context.Context, attr string) error {
 			break
 		}
 		pki := x.Parse(key)
+		if pki == nil {
+			continue
+		}
 		var pl protos.PostingList
 		err := iterItem.Value(func(val []byte) error {
 			UnmarshalOrCopy(val, iterItem.UserMeta(), &pl)

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -665,7 +665,7 @@ func TestAfterUIDCountWithCommit(t *testing.T) {
 var ps *badger.KV
 
 func TestMain(m *testing.M) {
-	x.Init()
+	x.Init(true)
 	Config.AllottedMemory = 1024.0
 	Config.CommitFraction = 0.10
 

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -316,11 +316,13 @@ func getOrMutate(key []byte) (rlist *List) {
 		x.CacheRace.Add(1)
 	} else {
 		pk := x.Parse(key)
-		x.AssertTrue(pk.IsIndex() || pk.IsCount())
-		// This is a best effort set, hence we don't check error from callback.
-		if err := pstore.SetIfAbsentAsync(key, nil, 0x00, func(err error) {}); err != nil &&
-			err != badger.ErrKeyExists {
-			x.Fatalf("Got error while doing SetIfAbsent: %+v\n", err)
+		if pk != nil {
+			x.AssertTrue(pk.IsIndex() || pk.IsCount())
+			// This is a best effort set, hence we don't check error from callback.
+			if err := pstore.SetIfAbsentAsync(key, nil, 0x00, func(err error) {}); err != nil &&
+				err != badger.ErrKeyExists {
+				x.Fatalf("Got error while doing SetIfAbsent: %+v\n", err)
+			}
 		}
 	}
 	return lp

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -7030,7 +7030,7 @@ func StartDummyZero() *grpc.Server {
 }
 
 func TestMain(m *testing.M) {
-	x.Init()
+	x.Init(true)
 
 	StartDummyZero()
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -9629,3 +9629,18 @@ func TestPasswordError(t *testing.T) {
 	require.Contains(t,
 		err.Error(), "checkpwd fn can only be used on attr: [name] with schema type password. Got type: string")
 }
+
+func TestCountPanic(t *testing.T) {
+	populateGraph(t)
+	query := `
+	{
+		q(func: uid(1, 300)) {
+			_uid_
+			name
+			count(name)
+		}
+	}
+	`
+	js := processToFastJSON(t, query)
+	require.Equal(t, `{"data": {"q":[{"_uid_":"0x1","name":"Michonne","count(name)":1},{"_uid_":"0x12c","count(name)":0}]}}`, js)
+}

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -363,7 +363,7 @@ func TestParseScalarListError4(t *testing.T) {
 var ps *badger.KV
 
 func TestMain(m *testing.M) {
-	x.Init()
+	x.Init(true)
 
 	dir, err := ioutil.TempDir("", "storetest_")
 	x.Check(err)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -259,7 +259,11 @@ func LoadFromDb() error {
 		if !bytes.HasPrefix(key, prefix) {
 			break
 		}
-		attr := x.Parse(key).Attr
+		pk := x.Parse(key)
+		if pk == nil {
+			continue
+		}
+		attr := pk.Attr
 		var s protos.SchemaUpdate
 		err := item.Value(func(val []byte) error {
 			x.Checkf(s.Unmarshal(val), "Error while loading schema from db")

--- a/worker/export.go
+++ b/worker/export.go
@@ -270,6 +270,10 @@ func export(bdir string) error {
 		item := it.Item()
 		key := item.Key()
 		pk := x.Parse(key)
+		if pk == nil {
+			it.Next()
+			continue
+		}
 
 		if pk.IsIndex() || pk.IsReverse() || pk.IsCount() {
 			// Seek to the end of index, reverse and count keys.

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -150,6 +150,10 @@ func (g *groupi) calculateTabletSizes() map[string]*protos.Tablet {
 		item := itr.Item()
 
 		pk := x.Parse(item.Key())
+		if pk == nil {
+			itr.Next()
+			continue
+		}
 		if pk.IsSchema() {
 			itr.Seek(pk.SkipSchema())
 			continue
@@ -489,6 +493,10 @@ func (g *groupi) cleanupTablets() {
 				item := itr.Item()
 
 				pk := x.Parse(item.Key())
+				if pk == nil {
+					itr.Next()
+					continue
+				}
 
 				// Delete at most one predicate at a time.
 				// Tablet is not being served by me and is not read only.

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -217,7 +217,11 @@ BUCKETS:
 			return &sortresult{&emptySortResult, nil, ctx.Err()}
 		default:
 			k := x.Parse(key)
-			x.AssertTrue(k != nil)
+			if k == nil {
+				it.Next()
+				continue
+			}
+
 			x.AssertTrue(k.IsIndex())
 			token := k.Term
 			if tr, ok := trace.FromContext(ctx); ok {

--- a/worker/task.go
+++ b/worker/task.go
@@ -363,7 +363,11 @@ func handleValuePostings(ctx context.Context, args funcArgs) error {
 
 		if err != nil || len(vals) == 0 {
 			out.UidMatrix = append(out.UidMatrix, &emptyUIDList)
-			out.ValueMatrix = append(out.ValueMatrix, &emptyValueList)
+			if q.DoCount {
+				out.Counts = append(out.Counts, 0)
+			} else {
+				out.ValueMatrix = append(out.ValueMatrix, &emptyValueList)
+			}
 			continue
 		}
 

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -140,7 +140,6 @@ func getInequalityTokens(attr, f string, ineqValue types.Val) ([]string, string,
 		key := it.Item().Key()
 		k := x.Parse(key)
 		if k == nil {
-			it.Next()
 			continue
 		}
 		out = append(out, k.Term)

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -139,7 +139,10 @@ func getInequalityTokens(attr, f string, ineqValue types.Val) ([]string, string,
 	for it.Seek(x.IndexKey(attr, ineqToken)); it.ValidForPrefix(indexPrefix); it.Next() {
 		key := it.Item().Key()
 		k := x.Parse(key)
-		x.AssertTrue(k != nil)
+		if k == nil {
+			it.Next()
+			continue
+		}
 		out = append(out, k.Term)
 	}
 	return out, ineqToken, nil

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -615,7 +615,7 @@ func TestProcessSortOffsetCount(t *testing.T) {
 */
 
 func TestMain(m *testing.M) {
-	x.Init()
+	x.Init(true)
 	posting.Config.AllottedMemory = 1024.0
 	posting.Config.CommitFraction = 0.10
 	gr = new(groupi)

--- a/x/init.go
+++ b/x/init.go
@@ -51,7 +51,8 @@ func AddInit(f func()) {
 }
 
 // Init initializes flags and run all functions in initFunc.
-func Init() {
+func Init(debug bool) {
+	Config.DebugMode = debug
 	// Lets print the details of the current build on startup.
 	printBuildDetails()
 

--- a/x/keys.go
+++ b/x/keys.go
@@ -275,6 +275,10 @@ func Parse(key []byte) *ParsedKey {
 	case ByteIndex:
 		p.Term = string(k)
 	case ByteCount, ByteCountRev:
+		if len(k) < 4 {
+			fmt.Printf("Error: Count length < 4 for key: %q, parsed key: %+v\n", key, p)
+			return nil
+		}
 		p.Count = binary.BigEndian.Uint32(k)
 	case byteSchema:
 		break

--- a/x/keys.go
+++ b/x/keys.go
@@ -18,6 +18,7 @@ package x
 
 import (
 	"encoding/binary"
+	"fmt"
 	"math"
 )
 
@@ -265,9 +266,11 @@ func Parse(key []byte) *ParsedKey {
 	k = k[1:]
 
 	switch p.byteType {
-	case ByteData:
-		fallthrough
-	case ByteReverse:
+	case ByteData, ByteReverse:
+		if len(k) < 8 {
+			fmt.Printf("Error: Uid length < 8 for key: %q, parsed key: %+v\n", key, p)
+			return nil
+		}
 		p.Uid = binary.BigEndian.Uint64(k)
 	case ByteIndex:
 		p.Term = string(k)

--- a/x/keys.go
+++ b/x/keys.go
@@ -268,7 +268,9 @@ func Parse(key []byte) *ParsedKey {
 	switch p.byteType {
 	case ByteData, ByteReverse:
 		if len(k) < 8 {
-			fmt.Printf("Error: Uid length < 8 for key: %q, parsed key: %+v\n", key, p)
+			if Config.DebugMode {
+				fmt.Printf("Error: Uid length < 8 for key: %q, parsed key: %+v\n", key, p)
+			}
 			return nil
 		}
 		p.Uid = binary.BigEndian.Uint64(k)
@@ -276,7 +278,9 @@ func Parse(key []byte) *ParsedKey {
 		p.Term = string(k)
 	case ByteCount, ByteCountRev:
 		if len(k) < 4 {
-			fmt.Printf("Error: Count length < 4 for key: %q, parsed key: %+v\n", key, p)
+			if Config.DebugMode {
+				fmt.Printf("Error: Count length < 4 for key: %q, parsed key: %+v\n", key, p)
+			}
 			return nil
 		}
 		p.Count = binary.BigEndian.Uint32(k)


### PR DESCRIPTION
Silently skip keys instead of panicking while iterating and calling `x.Parse`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1626)
<!-- Reviewable:end -->
