### PR TITLE
Update DestUids when facetOrder is applied in recurse.

### DIFF
--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -1220,3 +1220,31 @@ func TestFilterUidFacetMismatch(t *testing.T) {
 	js := processToFastJSON(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Glenn Rhee","@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"}}},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}]}]}}`, js)
 }
+
+func TestRecurseFacetOrder(t *testing.T) {
+	populateGraphWithFacets(t)
+	defer teardownGraphWithFacets(t)
+	query := `
+    {
+		recurse(func: uid(1), depth: 2) {
+			friend @facets(orderdesc: since)
+			_uid_
+			name
+		}
+	}
+  `
+	js := processToFastJSON(t, query)
+	require.JSONEq(t, `{"data": {"recurse":[{"friend":[{"_uid_":"0x19","name":"Daryl Dixon","@facets":{"_":{"since":"2007-05-02T15:04:05Z"}}},{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}}],"_uid_":"0x17","name":"Rick Grimes","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x1f","name":"Andrea","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x65","@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"_uid_":"0x18","name":"Glenn Rhee","@facets":{"_":{"since":"2004-05-02T15:04:05Z"}}}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
+
+	query = `
+    {
+		recurse(func: uid(1), depth: 2) {
+			friend @facets(orderasc: since)
+			_uid_
+			name
+		}
+	}
+  `
+	js = processToFastJSON(t, query)
+	require.JSONEq(t, `{"data": {"recurse":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee","@facets":{"_":{"since":"2004-05-02T15:04:05Z"}}},{"_uid_":"0x65","@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}}],"_uid_":"0x17","name":"Rick Grimes","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x1f","name":"Andrea","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x19","name":"Daryl Dixon","@facets":{"_":{"since":"2007-05-02T15:04:05Z"}}}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
+}

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -133,7 +133,7 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 					}
 				})
 			}
-			if len(sg.Params.Order) > 0 {
+			if len(sg.Params.Order) > 0 || len(sg.Params.FacetOrder) > 0 {
 				// Can't use merge sort if the UIDs are not sorted.
 				sg.updateDestUids()
 			} else {


### PR DESCRIPTION
DestUids should always be sorted. We were not storing it in a sorted order when facet order was applied, hence this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1693)
<!-- Reviewable:end -->
