### PR TITLE
Bulk loader doesn't need to write lease file anymore

### DIFF
--- a/cmd/dgraph-bulk-loader/loader.go
+++ b/cmd/dgraph-bulk-loader/loader.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -28,7 +27,6 @@ type options struct {
 	RDFDir        string
 	SchemaFile    string
 	DgraphsDir    string
-	LeaseFile     string
 	TmpDir        string
 	NumGoroutines int
 	MapBufSize    int64
@@ -264,20 +262,9 @@ func (ld *loader) mapStage() {
 	for i := range ld.mappers {
 		ld.mappers[i] = nil
 	}
-	ld.writeLease()
 	x.Check(ld.xidDB.Close())
 	ld.xids = nil
 	runtime.GC()
-}
-
-func (ld *loader) writeLease() {
-	// Obtain a fresh uid range - since uids are allocated in increasing order,
-	// the start of the new range can be used as the lease.
-	lease, _, err := ld.uidFetcher.ReserveUidRange()
-	x.Check(err)
-	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%d\n", lease)
-	x.Check(ioutil.WriteFile(ld.opt.LeaseFile, buf.Bytes(), 0644))
 }
 
 type shuffleOutput struct {

--- a/cmd/dgraph-bulk-loader/main.go
+++ b/cmd/dgraph-bulk-loader/main.go
@@ -31,8 +31,6 @@ func main() {
 		"Location of schema file to load.")
 	flag.StringVar(&opt.DgraphsDir, "out", "out",
 		"Location to write the final dgraph data directories.")
-	flag.StringVar(&opt.LeaseFile, "l", "LEASE",
-		"Location to write the lease file.")
 	flag.StringVar(&opt.TmpDir, "tmp", "tmp",
 		"Temp directory used to use for on-disk scratch space. Requires free space proportional"+
 			" to the size of the RDF file and the amount of indexing used.")


### PR DESCRIPTION
Lease management is now via zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1706)
<!-- Reviewable:end -->
