### PR TITLE
Fix various small things related to transaction.

### DIFF
--- a/cmd/dgraph/admin.go
+++ b/cmd/dgraph/admin.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net"
 	"net/http"
 	"os"
@@ -69,9 +68,8 @@ func exportHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := context.Background()
-	// TODO: Get timestamp from zero.
 	// Export logic can be moved to dgraphzero.
-	if err := worker.ExportOverNetwork(ctx, math.MaxUint64); err != nil {
+	if err := worker.ExportOverNetwork(ctx); err != nil {
 		x.SetStatus(w, err.Error(), "Export failed.")
 		return
 	}

--- a/cmd/dgraphzero/zero.go
+++ b/cmd/dgraphzero/zero.go
@@ -97,8 +97,6 @@ func (s *Server) Leader(gid uint32) *conn.Pool {
 	}
 	var healthyPool *conn.Pool
 	for _, m := range group.Members {
-		// TODO: Remove this and handle connections properly later.
-		conn.Get().Connect(m.Addr)
 		if pl, err := conn.Get().Get(m.Addr); err == nil {
 			healthyPool = pl
 			if m.Leader {

--- a/dgraph/server.go
+++ b/dgraph/server.go
@@ -195,7 +195,6 @@ func (s *Server) Alter(ctx context.Context, op *protos.Operation) (*protos.Paylo
 	empty := &protos.Payload{}
 	if op.DropAll {
 		m := protos.Mutations{DropAll: true}
-		// TODO: Handle delete as special case. Abort all pending transactions
 		_, err := query.ApplyMutations(ctx, &m)
 		return empty, err
 	}

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -302,7 +302,6 @@ func TestRebuildReverseEdges(t *testing.T) {
 	addEdgeToUID(t, "friend", 2, 23, uint64(14), uint64(15))
 
 	// TODO: Remove after fixing sync marks.
-	time.Sleep(time.Second)
 	RebuildReverseEdges(context.Background(), "friend", 16)
 	CommitLists(func(key []byte) bool {
 		pk := x.Parse(key)

--- a/posting/list.go
+++ b/posting/list.go
@@ -75,18 +75,18 @@ type List struct {
 	activeTxns    []uint64
 	deleteMe      int32 // Using atomic for this, to avoid expensive SetForDeletion operation.
 	markdeleteAll int32
-	estimatedSize uint32
+	estimatedSize int32
 	numCommits    int
 }
 
 // calculateSize would give you the size estimate. Does not consider elements in mutation layer.
 // Expensive, so don't run it carefully.
-func (l *List) calculateSize() uint32 {
+func (l *List) calculateSize() int32 {
 	sz := int(unsafe.Sizeof(l))
 	sz += l.plist.Size()
 	sz += cap(l.key)
 	sz += cap(l.mlayer) * 8
-	return uint32(sz)
+	return int32(sz)
 }
 
 type PIterator struct {
@@ -224,8 +224,8 @@ func NewPosting(t *protos.DirectedEdge) *protos.Posting {
 	}
 }
 
-func (l *List) EstimatedSize() uint32 {
-	return atomic.LoadUint32(&l.estimatedSize)
+func (l *List) EstimatedSize() int32 {
+	return atomic.LoadInt32(&l.estimatedSize)
 }
 
 // SetForDeletion will mark this List to be deleted, so no more mutations can be applied to this.
@@ -377,17 +377,21 @@ func (l *List) addMutation(ctx context.Context, txn *Txn, t *protos.DirectedEdge
 	mpost.StartTs = txn.StartTs
 	t1 := time.Now()
 	hasMutated := l.updateMutationLayer(txn.StartTs, mpost)
-	atomic.AddUint32(&l.estimatedSize, uint32(mpost.Size()+16 /* various overhead */))
+	atomic.AddInt32(&l.estimatedSize, int32(mpost.Size()+16 /* various overhead */))
 	if dur := time.Since(t1); dur > time.Millisecond {
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("updated mutation layer %v %v %v", dur, len(l.mlayer), len(l.plist.Uids))
 		}
 	}
 	tidx := sort.Search(len(l.activeTxns), func(idx int) bool {
-		return l.activeTxns[idx] == txn.StartTs
+		return l.activeTxns[idx] >= txn.StartTs
 	})
 	if tidx >= len(l.activeTxns) {
 		l.activeTxns = append(l.activeTxns, txn.StartTs)
+	} else if l.activeTxns[tidx] != txn.StartTs {
+		l.activeTxns = append(l.activeTxns, 0)
+		copy(l.activeTxns[tidx+1:], l.activeTxns[tidx:])
+		l.activeTxns[tidx] = txn.StartTs
 	}
 	txn.AddDelta(l.key, mpost)
 	return hasMutated, nil
@@ -413,7 +417,7 @@ func (l *List) abortTransaction(ctx context.Context, startTs uint64) error {
 			l.mlayer[midx] = mpost
 			midx++
 		}
-		// TODO: Estimate size
+		atomic.AddInt32(&l.estimatedSize, -1*int32(mpost.Size()+16 /* various overhead */))
 	}
 	l.mlayer = l.mlayer[:midx]
 	tidx := sort.Search(len(l.activeTxns), func(idx int) bool {
@@ -426,21 +430,31 @@ func (l *List) abortTransaction(ctx context.Context, startTs uint64) error {
 	return nil
 }
 
-func (l *List) CommitMutation(ctx context.Context, startTs, commitTs uint64) error {
+func (l *List) CommitMutation(ctx context.Context, startTs, commitTs uint64) (bool, error) {
 	l.Lock()
 	defer l.Unlock()
 	return l.commitMutation(ctx, startTs, commitTs)
 }
 
-func (l *List) commitMutation(ctx context.Context, startTs, commitTs uint64) error {
+func (l *List) commitMutation(ctx context.Context, startTs, commitTs uint64) (bool, error) {
 	if atomic.LoadInt32(&l.deleteMe) == 1 {
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("DELETEME set to true. Temporary error.")
 		}
-		return ErrRetry
+		return false, ErrRetry
 	}
 
 	l.AssertLock()
+	tidx := sort.Search(len(l.activeTxns), func(idx int) bool {
+		return l.activeTxns[idx] >= startTs
+	})
+	if tidx < len(l.activeTxns) && l.activeTxns[tidx] == startTs {
+		copy(l.activeTxns[tidx:], l.activeTxns[tidx+1:])
+		l.activeTxns = l.activeTxns[:len(l.activeTxns)-1]
+	} else {
+		// It was already committed, might be happening due to replay.
+		return false, nil
+	}
 	if l.markdeleteAll == 1 {
 		l.deleteHelper(ctx)
 		l.minTs = commitTs
@@ -453,13 +467,6 @@ func (l *List) commitMutation(ctx context.Context, startTs, commitTs uint64) err
 			}
 		}
 	}
-	tidx := sort.Search(len(l.activeTxns), func(idx int) bool {
-		return l.activeTxns[idx] == startTs
-	})
-	if tidx < len(l.activeTxns) {
-		copy(l.activeTxns[tidx:], l.activeTxns[tidx+1:])
-		l.activeTxns = l.activeTxns[:len(l.activeTxns)-1]
-	}
 	if commitTs > l.commitTs {
 		l.commitTs = commitTs
 	}
@@ -471,14 +478,14 @@ func (l *List) commitMutation(ctx context.Context, startTs, commitTs uint64) err
 	if l.numCommits > numUids {
 		l.syncIfDirty(false)
 	}
-	return nil
+	return true, nil
 }
 
 func (l *List) deleteHelper(ctx context.Context) error {
 	l.AssertLock()
 	l.plist = emptyList
 	l.mlayer = l.mlayer[:0] // Clear the mutation layer.
-	atomic.StoreUint32(&l.estimatedSize, l.calculateSize())
+	atomic.StoreInt32(&l.estimatedSize, l.calculateSize())
 	return nil
 }
 
@@ -727,13 +734,13 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 	if err := l.rollup(); err != nil {
 		return false, err
 	}
-	if l.minTs == minTs {
+	if l.minTs == minTs && l.plist != emptyList { // Would be emptyList for s p *
 		// There was no change in immutable layer.
 		return false, nil
 	}
 	x.AssertTrue(l.minTs > 0)
 	data, meta := marshalPostingList(l.plist)
-	atomic.StoreUint32(&l.estimatedSize, l.calculateSize())
+	atomic.StoreInt32(&l.estimatedSize, l.calculateSize())
 
 	for {
 		pLen := atomic.LoadInt64(&x.MaxPlSz)

--- a/posting/list.go
+++ b/posting/list.go
@@ -713,7 +713,11 @@ func (l *List) rollup() error {
 	}
 	l.mlayer = l.mlayer[:midx]
 	l.minTs = l.commitTs
-	l.plist = final
+	if sz > 0 {
+		// Don't overwrite plist if nothing new is merged.
+		// We set plist to emptyList when we do sp*
+		l.plist = final
+	}
 	l.numCommits = 0
 	return nil
 }

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -168,19 +168,11 @@ func updateMemoryMetrics() {
 
 var (
 	pstore *badger.ManagedDB
-	marks  *x.WaterMark
 	lcache *listCache
 )
 
-func SyncMarks() *x.WaterMark {
-	return marks
-}
-
 // Init initializes the posting lists package, the in memory and dirty list hash.
 func Init(ps *badger.ManagedDB) {
-	marks = &x.WaterMark{Name: "Synced watermark"}
-	marks.Init()
-
 	pstore = ps
 	lcache = newListCache(math.MaxUint64)
 	x.LcacheCapacity.Set(math.MaxInt64)

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -115,7 +115,7 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 	if err := txn.Set(w.snapshotKey(gid), data, 0x00); err != nil {
 		return err
 	}
-	x.Printf("Writing snapshot to WAL, metadata: %d\n", s.Metadata)
+	x.Printf("Writing snapshot to WAL, metadata: %+v, len(data): %d\n", s.Metadata, len(s.Data))
 
 	// Delete all entries before this snapshot to save disk space.
 	start := w.entryKey(gid, 0, 0)

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -268,8 +268,11 @@ func (w *grpcWorker) PredicateAndSchemaData(stream protos.Worker_PredicateAndSch
 		}
 	}
 
-	// TODO: Think about timestamp
-	txn := pstore.NewTransactionAt(math.MaxUint64, false)
+	// Any commit which happens in the future will have commitTs greater than
+	// this.
+	// TODO: Ensure all deltas have made to disk and read in memory before checking disk.
+	timestamp := posting.Oracle().MaxPending()
+	txn := pstore.NewTransactionAt(timestamp, false)
 	defer txn.Discard()
 	iterOpts := badger.DefaultIteratorOptions
 	iterOpts.AllVersions = true

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -164,7 +164,6 @@ func batchAndProposeKeyValues(ctx context.Context, kvs chan *protos.KV) error {
 
 	for kv := range kvs {
 		if size >= 32<<20 { // 32 MB
-			// TODO: Fix me
 			if err := n.ProposeAndWait(ctx, proposal); err != nil {
 				return err
 			}

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -109,7 +109,7 @@ func (s *scheduler) schedule(proposal *protos.Proposal, index uint64) (err error
 		schema.State().DeleteAll()
 		err = posting.DeleteAll()
 		posting.Txns().Reset()
-		posting.SyncMarks().Done(index)
+		posting.TxnMarks().Done(index)
 		return
 	}
 
@@ -147,7 +147,7 @@ func (s *scheduler) schedule(proposal *protos.Proposal, index uint64) (err error
 				break
 			}
 		}
-		posting.SyncMarks().Done(index)
+		posting.TxnMarks().Done(index)
 		return
 	}
 
@@ -181,7 +181,7 @@ func (s *scheduler) schedule(proposal *protos.Proposal, index uint64) (err error
 			} else {
 				err = posting.DeletePredicate(ctx, edge.Attr)
 			}
-			posting.SyncMarks().Done(index)
+			posting.TxnMarks().Done(index)
 			return
 		}
 		if _, ok := schemaMap[edge.Attr]; !ok {


### PR DESCRIPTION
Get Timestamp from zero for export.
Fix pl size estimate after aborting transaction.
Fix cmd/postingiterator
Handle replay of commit/abort proposals.
Rename syncMarks to TxnMarks.
Remove unused code.
Retry idefinitely on temporary error.
check transactionsmap before proposing commit/abort
store aborts in oracle and propose in a goroutine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1725)
<!-- Reviewable:end -->
