### PR TITLE
Change how facets are set and retrieved

### DIFF
--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -431,64 +431,47 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 	dg := client.NewDgraphClient(dc)
 
 	// This example shows example for SetObject using facets.
-	type friendFacet struct {
-		Since  time.Time `json:"since"`
-		Family string    `json:"family"`
-		Age    float64   `json:"age"`
-		Close  bool      `json:"close"`
-	}
-
-	type nameFacets struct {
-		Origin string `json:"origin"`
-	}
-
-	type schoolFacet struct {
-		Since time.Time `json:"since"`
-	}
-
 	type School struct {
-		Name   string      `json:"name"`
-		Facets schoolFacet `json:"@facets"`
+		Name  string    `json:"name,omitempty"`
+		Since time.Time `json:"school:since,omitempty"`
 	}
 
 	type Person struct {
-		Name       string      `json:"name"`
-		NameFacets nameFacets  `json:"name@facets"`
-		Facets     friendFacet `json:"@facets"`
-		Friends    []Person    `json:"friend"`
-		School     School      `json:"school"`
+		Name       string   `json:"name,omitempty"`
+		NameOrigin string   `json:"name:origin,omitempty"`
+		Friends    []Person `json:"friend,omitempty"`
+
+		// These are facets on the friend edge.
+		Since  time.Time `json:"friend:since,omitempty"`
+		Family string    `json:"friend:family,omitempty"`
+		Age    float64   `json:"friend:age,omitempty"`
+		Close  bool      `json:"friend:close,omitempty"`
+
+		School []School `json:"school,omitempty"`
 	}
 
 	ti := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
 	p := Person{
-		Name: "Alice",
-		NameFacets: nameFacets{
-			Origin: "Indonesia",
-		},
+		Name:       "Alice",
+		NameOrigin: "Indonesia",
 		Friends: []Person{
 			Person{
-				Name: "Bob",
-				Facets: friendFacet{
-					Since:  ti,
-					Family: "yes",
-					Age:    13,
-					Close:  true,
-				},
+				Name:   "Bob",
+				Since:  ti,
+				Family: "yes",
+				Age:    13,
+				Close:  true,
 			},
 			Person{
-				Name: "Charlie",
-				Facets: friendFacet{
-					Family: "maybe",
-					Age:    16,
-				},
+				Name:   "Charlie",
+				Family: "maybe",
+				Age:    16,
 			},
 		},
-		School: School{
-			Name: "Wellington School",
-			Facets: schoolFacet{
-				Since: ti,
-			},
-		},
+		School: []School{School{
+			Name:  "Wellington School",
+			Since: ti,
+		}},
 	}
 
 	ctx := context.Background()
@@ -528,9 +511,10 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 	}
 
 	type Root struct {
-		Me Person `json:"me"`
+		Me []Person `json:"me"`
 	}
 
+	fmt.Println(string(resp.Json))
 	var r Root
 	err = json.Unmarshal(resp.Json, &r)
 	if err != nil {

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -303,7 +303,6 @@ func ExampleTxn_Mutate_bytes() {
 		Me []Person `json:"q"`
 	}
 
-	fmt.Println(string(resp.Json))
 	var r Root
 	err = json.Unmarshal(resp.Json, &r)
 	if err != nil {
@@ -514,7 +513,6 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 		Me []Person `json:"me"`
 	}
 
-	fmt.Println(string(resp.Json))
 	var r Root
 	err = json.Unmarshal(resp.Json, &r)
 	if err != nil {

--- a/dgraph/server.go
+++ b/dgraph/server.go
@@ -555,7 +555,7 @@ func tryParseAsGeo(b []byte, nq *protos.NQuad) (bool, error) {
 }
 
 // TODO - Abstract these parameters to a struct.
-func mapToNquads(m map[string]interface{}, idx *int, op int, k string) (mapResponse, error) {
+func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) (mapResponse, error) {
 	var mr mapResponse
 	// Check field in map.
 	if uidVal, ok := m["_uid_"]; ok {
@@ -601,7 +601,7 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, k string) (mapRespo
 			}
 		}
 
-		prefix := fmt.Sprintf("%s:", pred)
+		prefix := pred + ":"
 		// TODO - Maybe do an initial pass and build facets for all predicates. Then we don't have
 		// to call parseFacets everytime.
 		fts, err := parseFacets(m, prefix)
@@ -698,7 +698,7 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, k string) (mapRespo
 		}
 	}
 
-	fts, err := parseFacets(m, fmt.Sprintf("%s:", k))
+	fts, err := parseFacets(m, parentPred+":")
 	mr.fcts = fts
 	return mr, err
 }

--- a/dgraph/server.go
+++ b/dgraph/server.go
@@ -432,7 +432,7 @@ func parseFacets(m map[string]interface{}, prefix string) ([]*protos.Facet, erro
 		return nil, nil
 	}
 
-	facetsForPred := make([]*protos.Facet, 0, 2)
+	var facetsForPred []*protos.Facet
 	var fv interface{}
 	for fname, facetVal := range m {
 		if facetVal == nil {

--- a/dgraph/server_test.go
+++ b/dgraph/server_test.go
@@ -168,7 +168,7 @@ func checkCount(t *testing.T, nq []*protos.NQuad, pred string, count int) {
 }
 
 func TestNquadsFromJsonFacets1(t *testing.T) {
-	json := `[{"name":"Alice","mobile":"040123456","car":"MA0123","mobile@facets":{"since":"2006-01-02T15:04:05Z"},"car@facets":{"first":"true"}}]`
+	json := `[{"name":"Alice","mobile":"040123456","car":"MA0123","mobile:since":"2006-01-02T15:04:05Z","car:first":"true"}]`
 
 	nq, err := nquadsFromJson([]byte(json), set)
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestNquadsFromJsonFacets1(t *testing.T) {
 
 func TestNquadsFromJsonFacets2(t *testing.T) {
 	// Dave has uid facets which should go on the edge between Alice and Dave
-	json := `[{"name":"Alice","friend":[{"name":"Dave","@facets":{"close":"true"}}]}]`
+	json := `[{"name":"Alice","friend":[{"name":"Dave","friend:close":"true"}]}]`
 
 	nq, err := nquadsFromJson([]byte(json), set)
 	require.NoError(t, err)

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -138,7 +138,7 @@ func addEdgeToTypedValue(t *testing.T, attr string, src uint64,
 	require.NoError(t, err)
 	edge := &protos.DirectedEdge{
 		Value:     value,
-		ValueType: uint32(typ),
+		ValueType: protos.Posting_ValType(typ),
 		Label:     "testing",
 		Attr:      attr,
 		Entity:    src,
@@ -157,7 +157,7 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 		ValueId: dst,
 		// This is used to set uid schema type for pred for the purpose of tests. Actual mutation
 		// won't set ValueType to types.UidID.
-		ValueType: uint32(types.UidID),
+		ValueType: protos.Posting_ValType(types.UidID),
 		Label:     "testing",
 		Attr:      attr,
 		Entity:    src,
@@ -170,7 +170,7 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 
 func delEdgeToUID(t *testing.T, attr string, src uint64, dst uint64) {
 	edge := &protos.DirectedEdge{
-		ValueType: uint32(types.UidID),
+		ValueType: protos.Posting_ValType(types.UidID),
 		ValueId:   dst,
 		Label:     "testing",
 		Attr:      attr,

--- a/query/query.go
+++ b/query/query.go
@@ -434,15 +434,12 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 
 				if pc.Params.Facet != nil && len(fcsList) > childIdx {
 					fs := fcsList[childIdx]
-					fc := dst.New(fieldName)
+					//		fc := dst.New(fieldName)
 					for _, f := range fs.Facets {
-						fc.AddValue(f.Key, facets.ValFor(f))
+						uc.AddValue(fmt.Sprintf("%s:%s", fieldName, f.Key),
+							facets.ValFor(f))
 					}
-					if !fc.IsEmpty() {
-						fcParent := dst.New("_")
-						fcParent.AddMapChild("_", fc, false)
-						uc.AddMapChild("@facets", fcParent, true)
-					}
+					//			dst.AddListChild(fieldName, fc)
 				}
 				if !uc.IsEmpty() {
 					dst.AddListChild(fieldName, uc)
@@ -472,16 +469,10 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 			}
 
 			if pc.Params.Facet != nil && len(pc.facetsMatrix[idx].FacetsList) > 0 {
-				fc := dst.New(fieldName)
 				// in case of Value we have only one Facets
 				for _, f := range pc.facetsMatrix[idx].FacetsList[0].Facets {
-					fc.AddValue(f.Key, facets.ValFor(f))
-				}
-				if !fc.IsEmpty() {
-					if facetsNode == nil {
-						facetsNode = dst.New("@facets")
-					}
-					facetsNode.AddMapChild(fieldName, fc, false)
+					dst.AddValue(fmt.Sprintf("%s:%s", fieldName, f.Key),
+						facets.ValFor(f))
 				}
 			}
 

--- a/query/query.go
+++ b/query/query.go
@@ -434,12 +434,10 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 
 				if pc.Params.Facet != nil && len(fcsList) > childIdx {
 					fs := fcsList[childIdx]
-					//		fc := dst.New(fieldName)
 					for _, f := range fs.Facets {
 						uc.AddValue(fmt.Sprintf("%s:%s", fieldName, f.Key),
 							facets.ValFor(f))
 					}
-					//			dst.AddListChild(fieldName, fc)
 				}
 				if !uc.IsEmpty() {
 					dst.AddListChild(fieldName, uc)

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -127,7 +127,7 @@ func TestOrderFacets(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"@facets":{"_":{"since":"2004-05-02T15:04:05Z"}},"name":"Glenn Rhee"},{"@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Rick Grimes"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"since":"2007-05-02T15:04:05Z"}},"name":"Daryl Dixon"}]}]}}`,
+		`{"data":{"me":[{"friend":[{"name":"Glenn Rhee","friend:since":"2004-05-02T15:04:05Z"},{"friend:since":"2005-05-02T15:04:05Z"},{"name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"name":"Daryl Dixon","friend:since":"2007-05-02T15:04:05Z"}]}]}}`,
 		js)
 }
 
@@ -147,7 +147,7 @@ func TestOrderdescFacets(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"@facets":{"_":{"since":"2007-05-02T15:04:05Z"}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Rick Grimes"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"@facets":{"_":{"since":"2004-05-02T15:04:05Z"}},"name":"Glenn Rhee"}]}]}}`,
+		`{"data":{"me":[{"friend":[{"name":"Daryl Dixon","friend:since":"2007-05-02T15:04:05Z"},{"name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"friend:since":"2005-05-02T15:04:05Z"},{"name":"Glenn Rhee","friend:since":"2004-05-02T15:04:05Z"}]}]}}`,
 		js)
 }
 
@@ -212,7 +212,7 @@ func TestRetrieveFacetsAll(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"@facets":{"name":{"origin":"french"}},"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"gender":"male","name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z","tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}],"gender":"female","name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name:origin":"french","name":"Michonne","friend":[{"name:origin":"french","name":"Rick Grimes","gender":"male","friend:since":"2006-01-02T15:04:05Z"},{"name:origin":"french","name":"Glenn Rhee","friend:close":true,"friend:family":true,"friend:since":"2004-05-02T15:04:05Z","friend:tag":"Domain3"},{"name":"Daryl Dixon","friend:close":false,"friend:family":true,"friend:since":"2007-05-02T15:04:05Z","friend:tag":34},{"name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"friend:age":33,"friend:close":true,"friend:family":false,"friend:since":"2005-05-02T15:04:05Z"}],"gender":"female"}]}}`,
 		js)
 }
 
@@ -275,7 +275,7 @@ func TestFetchingFewFacets(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"@facets":{"_":{"close":true}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false}},"name":"Daryl Dixon"},{"name":"Andrea"},{"@facets":{"_":{"close":true}}}],"name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name":"Michonne","friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee","friend:close":true},{"name":"Daryl Dixon","friend:close":false},{"name":"Andrea"},{"friend:close":true}]}]}}`,
 		js)
 }
 
@@ -317,7 +317,7 @@ func TestFacetsSortOrder(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true}},"name":"Daryl Dixon"},{"name":"Andrea"},{"@facets":{"_":{"close":true,"family":false}}}],"name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name":"Michonne","friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee","friend:close":true,"friend:family":true},{"name":"Daryl Dixon","friend:close":false,"friend:family":true},{"name":"Andrea"},{"friend:close":true,"friend:family":false}]}]}}`,
 		js)
 }
 
@@ -361,7 +361,7 @@ func TestFacetsMutation(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z","tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"close":false,"family":false,"since":"2001-11-10T00:00:00Z"}}}],"name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name":"Michonne","friend":[{"name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"name":"Daryl Dixon","friend:close":false,"friend:family":true,"friend:since":"2007-05-02T15:04:05Z","friend:tag":34},{"name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"friend:close":false,"friend:family":false,"friend:since":"2001-11-10T00:00:00Z"}]}]}}`,
 		js)
 }
 
@@ -817,7 +817,7 @@ func TestFacetsFilterAndRetrieval(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"@facets":{"_":{"family":true}},"_uid_":"0x18","name":"Glenn Rhee"},{"@facets":{"_":{"family":false}},"_uid_":"0x65"}],"name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name":"Michonne","friend":[{"name":"Glenn Rhee","_uid_":"0x18","friend:family":true},{"_uid_":"0x65","friend:family":false}]}]}}`,
 		js)
 }
 
@@ -833,7 +833,7 @@ func TestFacetWithLang(t *testing.T) {
 	`
 
 	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"@facets":{"name@en":{"type":"Test facet with lang"}},"name@en":"Test facet"}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name@en:type":"Test facet with lang","name@en":"Test facet"}]}}`, js)
 }
 
 func TestFilterUidFacetMismatch(t *testing.T) {
@@ -849,7 +849,7 @@ func TestFilterUidFacetMismatch(t *testing.T) {
 	}
 	`
 	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Glenn Rhee","@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"}}},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}]}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"friend":[{"name":"Glenn Rhee","friend:close":true,"friend:family":true,"friend:since":"2004-05-02T15:04:05Z","friend:tag":"Domain3"},{"friend:age":33,"friend:close":true,"friend:family":false,"friend:since":"2005-05-02T15:04:05Z"}]}]}}`, js)
 }
 
 func TestRecurseFacetOrder(t *testing.T) {
@@ -865,7 +865,7 @@ func TestRecurseFacetOrder(t *testing.T) {
 	}
   `
 	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": {"recurse":[{"friend":[{"_uid_":"0x19","name":"Daryl Dixon","@facets":{"_":{"since":"2007-05-02T15:04:05Z"}}},{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}}],"_uid_":"0x17","name":"Rick Grimes","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x1f","name":"Andrea","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x65","@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"_uid_":"0x18","name":"Glenn Rhee","@facets":{"_":{"since":"2004-05-02T15:04:05Z"}}}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"recurse":[{"friend":[{"_uid_":"0x19","name":"Daryl Dixon","friend:since":"2007-05-02T15:04:05Z"},{"friend":[{"friend:since":"2006-01-02T15:04:05Z"}],"_uid_":"0x17","name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"_uid_":"0x1f","name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"_uid_":"0x65","friend:since":"2005-05-02T15:04:05Z"},{"_uid_":"0x18","name":"Glenn Rhee","friend:since":"2004-05-02T15:04:05Z"}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
 
 	query = `
     {
@@ -877,5 +877,5 @@ func TestRecurseFacetOrder(t *testing.T) {
 	}
   `
 	js = processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": {"recurse":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee","@facets":{"_":{"since":"2004-05-02T15:04:05Z"}}},{"_uid_":"0x65","@facets":{"_":{"since":"2005-05-02T15:04:05Z"}}},{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}}],"_uid_":"0x17","name":"Rick Grimes","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x1f","name":"Andrea","@facets":{"_":{"since":"2006-01-02T15:04:05Z"}}},{"_uid_":"0x19","name":"Daryl Dixon","@facets":{"_":{"since":"2007-05-02T15:04:05Z"}}}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"recurse":[{"friend":[{"_uid_":"0x18","name":"Glenn Rhee","friend:since":"2004-05-02T15:04:05Z"},{"_uid_":"0x65","friend:since":"2005-05-02T15:04:05Z"},{"friend":[{"friend:since":"2006-01-02T15:04:05Z"}],"_uid_":"0x17","name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"_uid_":"0x1f","name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"_uid_":"0x19","name":"Daryl Dixon","friend:since":"2007-05-02T15:04:05Z"}],"_uid_":"0x1","name":"Michonne"}]}}`, js)
 }

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -107,7 +107,7 @@ func TestRetrieveFacetsSimple(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"@facets":{"name":{"origin":"french"}},"gender":"female","name":"Michonne"}]}}`,
+		`{"data":{"me":[{"name:origin":"french","name":"Michonne","gender":"female"}]}}`,
 		js)
 }
 
@@ -190,7 +190,7 @@ func TestRetrieveFacetsUidValues(t *testing.T) {
 
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"},"name":{"origin":"french"}},"name":"Rick Grimes"},{"@facets":{"_":{"close":true,"family":true,"since":"2004-05-02T15:04:05Z","tag":"Domain3"},"name":{"origin":"french"}},"name":"Glenn Rhee"},{"@facets":{"_":{"close":false,"family":true,"since":"2007-05-02T15:04:05Z", "tag":34}},"name":"Daryl Dixon"},{"@facets":{"_":{"since":"2006-01-02T15:04:05Z"}},"name":"Andrea"},{"@facets":{"_":{"age":33,"close":true,"family":false,"since":"2005-05-02T15:04:05Z"}}}]}]}}`,
+		`{"data":{"me":[{"friend":[{"name:origin":"french","name":"Rick Grimes","friend:since":"2006-01-02T15:04:05Z"},{"name:origin":"french","name":"Glenn Rhee","friend:close":true,"friend:family":true,"friend:since":"2004-05-02T15:04:05Z","friend:tag":"Domain3"},{"name":"Daryl Dixon","friend:close":false,"friend:family":true,"friend:since":"2007-05-02T15:04:05Z","friend:tag":34},{"name":"Andrea","friend:since":"2006-01-02T15:04:05Z"},{"friend:age":33,"friend:close":true,"friend:family":false,"friend:since":"2005-05-02T15:04:05Z"}]}]}}`,
 		js)
 }
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -511,7 +511,7 @@ func TestLevelBasedFacetVarAggSum(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"path":[{"@facets":{"_":{"weight":0.100000}}},{"@facets":{"_":{"weight":0.700000}}}],"sumw":0.800000}]}}`,
+		`{"data":{"friend":[{"path":[{"path:weight":0.100000},{"path:weight":0.700000}],"sumw":0.800000}]}}`,
 		js)
 }
 
@@ -535,7 +535,7 @@ func TestLevelBasedFacetVarSum(t *testing.T) {
 		}
 	`
 	js := processToFastJSON(t, query)
-	require.JSONEq(t, `{"data": {"friend":[{"path":[{"@facets":{"_":{"weight":0.100000}},"path":[{"@facets":{"_":{"weight":0.100000}},"count(follow)":1,"val(L4)":1.200000},{"@facets":{"_":{"weight":1.500000}},"count(follow)":1,"val(L4)":3.900000}]},{"@facets":{"_":{"weight":0.700000}},"path":[{"@facets":{"_":{"weight":0.600000}},"count(follow)":1,"val(L4)":3.900000}]}]}],"sum":[{"name":"John","val(L4)":3.900000},{"name":"Matt","val(L4)":1.200000}]}}`,
+	require.JSONEq(t, `{"data":{"friend":[{"path":[{"path":[{"count(follow)":1,"val(L4)":1.200000,"path:weight":0.100000},{"count(follow)":1,"val(L4)":3.900000,"path:weight":1.500000}],"path:weight":0.100000},{"path":[{"count(follow)":1,"val(L4)":3.900000,"path:weight":0.600000}],"path:weight":0.700000}]}],"sum":[{"name":"John","val(L4)":3.900000},{"name":"Matt","val(L4)":1.200000}]}}`,
 		js)
 }
 
@@ -557,7 +557,7 @@ func TestLevelBasedSumMix1(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"age":38,"path":[{"@facets":{"_":{"weight":0.200000}},"val(L2)":38.200000},{"@facets":{"_":{"weight":0.100000}},"val(L2)":38.100000}]}],"sum":[{"name":"Glenn Rhee","val(L2)":38.200000},{"name":"Andrea","val(L2)":38.100000}]}}`,
+		`{"data":{"friend":[{"age":38,"path":[{"val(L2)":38.200000,"path:weight":0.200000},{"val(L2)":38.100000,"path:weight":0.100000}]}],"sum":[{"name":"Glenn Rhee","val(L2)":38.200000},{"name":"Andrea","val(L2)":38.100000}]}}`,
 		js)
 }
 
@@ -581,7 +581,7 @@ func TestLevelBasedFacetVarSum1(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"path":[{"@facets":{"_":{"weight":0.100000}},"name":"Bob","path":[{"@facets":{"_":{"weight":0.100000}},"val(L3)":0.200000},{"@facets":{"_":{"weight":1.500000}},"val(L3)":2.900000}]},{"@facets":{"_":{"weight":0.700000}},"name":"Matt","path":[{"@facets":{"_":{"weight":0.600000}},"val(L3)":2.900000}]}]}],"sum":[{"name":"John","val(L3)":2.900000},{"name":"Matt","val(L3)":0.200000}]}}`,
+		`{"data":{"friend":[{"path":[{"name":"Bob","path":[{"val(L3)":0.200000,"path:weight":0.100000},{"val(L3)":2.900000,"path:weight":1.500000}],"path:weight":0.100000},{"name":"Matt","path":[{"val(L3)":2.900000,"path:weight":0.600000}],"path:weight":0.700000}]}],"sum":[{"name":"John","val(L3)":2.900000},{"name":"Matt","val(L3)":0.200000}]}}`,
 		js)
 }
 
@@ -606,7 +606,7 @@ func TestLevelBasedFacetVarSum2(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"path":[{"@facets":{"_":{"weight":0.100000}},"path":[{"@facets":{"_":{"weight":0.100000}},"path":[{"@facets":{"_":{"weight":0.600000}},"val(L4)":0.800000}]},{"@facets":{"_":{"weight":1.500000}},"path":[{"val(L4)":2.900000}]}]},{"@facets":{"_":{"weight":0.700000}},"path":[{"@facets":{"_":{"weight":0.600000}},"path":[{"val(L4)":2.900000}]}]}]}],"sum":[{"name":"Bob","val(L4)":2.900000},{"name":"John","val(L4)":0.800000}]}}`,
+		`{"data":{"friend":[{"path":[{"path":[{"path":[{"val(L4)":0.800000,"path:weight":0.600000}],"path:weight":0.100000},{"path":[{"val(L4)":2.900000}],"path:weight":1.500000}],"path:weight":0.100000},{"path":[{"path":[{"val(L4)":2.900000}],"path:weight":0.600000}],"path:weight":0.700000}]}],"sum":[{"name":"Bob","val(L4)":2.900000},{"name":"John","val(L4)":0.800000}]}}`,
 		js)
 }
 
@@ -1367,7 +1367,7 @@ func TestFilterFacetval(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"path":[{"@facets":{"_":{"weight":0.200000}},"name":"Glenn Rhee"},{"@facets":{"_":{"weight":0.100000}},"friend":[{"name":"Glenn Rhee","val(L)":0.200000}],"name":"Andrea"}]}]}}`,
+		`{"data":{"friend":[{"path":[{"name":"Glenn Rhee","path:weight":0.200000},{"name":"Andrea","friend":[{"name":"Glenn Rhee","val(L)":0.200000}],"path:weight":0.100000}]}]}}`,
 		js)
 }
 
@@ -1387,7 +1387,7 @@ func TestFilterFacetVar1(t *testing.T) {
 	`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"friend":[{"path":[{"name":"Glenn Rhee"},{"@facets":{"_":{"weight1":0.200000}},"name":"Andrea"}]}]}}`,
+		`{"data":{"friend":[{"path":[{"name":"Glenn Rhee"},{"name":"Andrea","path:weight1":0.200000}]}]}}`,
 		js)
 }
 
@@ -1824,7 +1824,7 @@ func TestKShortestPathWeighted(t *testing.T) {
 	// We only get one path in this case as the facet is present only in one path.
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"_path_":[{"_uid_":"0x1","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x1f","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e8","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e9"}]}]}]}]}}`,
+		`{"data":{"_path_":[{"_uid_":"0x1","path":[{"_uid_":"0x1f","path":[{"_uid_":"0x3e8","path":[{"_uid_":"0x3e9","path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}]}]}}`,
 		js)
 }
 
@@ -1853,7 +1853,7 @@ func TestKShortestPathWeighted1(t *testing.T) {
 		}`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"_path_":[{"_uid_":"0x1","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x1f","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e8","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e9","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3ea","path":[{"@facets":{"_":{"weight":0.600000}},"_uid_":"0x3eb"}]}]}]}]}]},{"_uid_":"0x1","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x1f","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e8","path":[{"@facets":{"_":{"weight":0.700000}},"_uid_":"0x3ea","path":[{"@facets":{"_":{"weight":0.600000}},"_uid_":"0x3eb"}]}]}]}]},{"_uid_":"0x1","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x1f","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e8","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e9","path":[{"@facets":{"_":{"weight":1.500000}},"_uid_":"0x3eb"}]}]}]}]}]}}`,
+		`{"data":{"_path_":[{"_uid_":"0x1","path":[{"_uid_":"0x1f","path":[{"_uid_":"0x3e8","path":[{"_uid_":"0x3e9","path":[{"_uid_":"0x3ea","path":[{"_uid_":"0x3eb","path:weight":0.600000}],"path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}]},{"_uid_":"0x1","path":[{"_uid_":"0x1f","path":[{"_uid_":"0x3e8","path":[{"_uid_":"0x3ea","path":[{"_uid_":"0x3eb","path:weight":0.600000}],"path:weight":0.700000}],"path:weight":0.100000}],"path:weight":0.100000}]},{"_uid_":"0x1","path":[{"_uid_":"0x1f","path":[{"_uid_":"0x3e8","path":[{"_uid_":"0x3e9","path":[{"_uid_":"0x3eb","path:weight":1.500000}],"path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}]}]}}`,
 		js)
 }
 
@@ -1980,7 +1980,7 @@ func TestShortestPathWeights(t *testing.T) {
 		}`
 	js := processToFastJSON(t, query)
 	require.JSONEq(t,
-		`{"data": {"_path_":[{"_uid_":"0x1","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x1f","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e8","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3e9","path":[{"@facets":{"_":{"weight":0.100000}},"_uid_":"0x3ea"}]}]}]}]}],"me":[{"name":"Michonne"},{"name":"Andrea"},{"name":"Alice"},{"name":"Bob"},{"name":"Matt"}]}}`,
+		`{"data":{"me":[{"name":"Michonne"},{"name":"Andrea"},{"name":"Alice"},{"name":"Bob"},{"name":"Matt"}],"_path_":[{"_uid_":"0x1","path":[{"_uid_":"0x1f","path":[{"_uid_":"0x3e8","path":[{"_uid_":"0x3e9","path":[{"_uid_":"0x3ea","path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}],"path:weight":0.100000}]}]}}`,
 		js)
 }
 
@@ -2517,12 +2517,12 @@ func TestMinSchema(t *testing.T) {
 		`{"data": {"me":[{"name":"Michonne","gender":"female","alive":true,"friend":[{"survival_rate":1.600000},{"survival_rate":1.600000},{"survival_rate":1.600000},{"survival_rate":1.600000}],"min(val(x))":1.600000}]}}`,
 		js)
 
-	schema.State().Set("survival_rate", protos.SchemaUpdate{ValueType: uint32(types.IntID)})
+	schema.State().Set("survival_rate", protos.SchemaUpdate{ValueType: protos.Posting_ValType(types.IntID)})
 	js = processToFastJSON(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female","alive":true,"friend":[{"survival_rate":1},{"survival_rate":1},{"survival_rate":1},{"survival_rate":1}],"min(val(x))":1}]}}`,
 		js)
-	schema.State().Set("survival_rate", protos.SchemaUpdate{ValueType: uint32(types.FloatID)})
+	schema.State().Set("survival_rate", protos.SchemaUpdate{ValueType: protos.Posting_ValType(types.FloatID)})
 }
 
 func TestAvg(t *testing.T) {


### PR DESCRIPTION
New response format is flatter.

```
{
    "data": {
        "me": [
            {
                "friend": [
                    {
                        "name:origin": "french",
                        "name": "Rick Grimes",
                        "friend:since": "2006-01-02T15:04:05Z"
                    },
                    {
                        "name:origin": "french",
                        "name": "Glenn Rhee",
                        "friend:close": true,
                        "friend:family": true,
                        "friend:since": "2004-05-02T15:04:05Z",
                        "friend:tag": "Domain3"
                    },
                    {
                        "name": "Daryl Dixon",
                        "friend:close": false,
                        "friend:family": true,
                        "friend:since": "2007-05-02T15:04:05Z",
                        "friend:tag": 34
                    },
                    {
                        "name": "Andrea",
                        "friend:since": "2006-01-02T15:04:05Z"
                    },
                    {
                        "friend:age": 33,
                        "friend:close": true,
                        "friend:family": false,
                        "friend:since": "2005-05-02T15:04:05Z"
                    }
                ]
            }
        ]
    }
}
```

- [x] Fix other query tests broken by this change.
- [ ] Fix UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1730)
<!-- Reviewable:end -->
