### PR TITLE
Change package and outer class name for Java code

### DIFF
--- a/protos/task.proto
+++ b/protos/task.proto
@@ -19,7 +19,8 @@ syntax = "proto3";
 
 package protos;
 
-option java_package = "io.dgraph.proto";
+option java_package = "io.dgraph";
+option java_outer_classname = "DgraphProto";
 
 message List {
 	repeated fixed64 uids = 1;


### PR DESCRIPTION
Following the convention of the sample code, I have used `DgraphProtos` (the sample code had `AddressBookProtos`). I could use `Protos` (as proposed in chat) if there is a strong preference for it, but I think `DgraphProtos` works.

As for concerns about verbosity, I discovered that Java actually allows us to import inner classes directly. For example:

```java
import io.dgraph.DgraphProtos.*;

…<snip>…

static LinRead mergeLinReads(LinRead dst, LinRead src) {
    LinRead.Builder result = LinRead.newBuilder(dst);
…
```
So, sticking to a slightly longer name won’t cause the code to have annoyingly long class names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1746)
<!-- Reviewable:end -->
