### PR TITLE
Add a docker_compose.yml

### DIFF
--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -3,17 +3,15 @@ services:
   zero:
     image: dgraph/dgraph:latest
     volumes:
-      - data:/dgraph
+      - /tmp/data:/dgraph
     ports:
       - 6080:6080
     command: dgraph zero --port_offset -2000 --my=zero:5080
   server:
     image: dgraph/dgraph:latest
     volumes:
-      - data:/dgraph
+      - /tmp/data:/dgraph
     ports:
       - 8080:8080
       - 9080:9080
     command: dgraph server --my=server:7080 --memory_mb=2048 --zero=zero:5080
-volumes:
-  data:

--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  zero:
+    image: dgraph/dgraph:latest
+    volumes:
+      - data:/dgraph
+    ports:
+      - 6080:6080
+    command: dgraph zero --port_offset -2000 --my=zero:5080
+  server:
+    image: dgraph/dgraph:latest
+    volumes:
+      - data:/dgraph
+    ports:
+      - 8080:8080
+      - 9080:9080
+    command: dgraph server --my=server:7080 --memory_mb=2048 --zero=zero:5080
+volumes:
+  data:

--- a/contrib/nightly/Dockerfile
+++ b/contrib/nightly/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /usr/local/share/dgraph/assets
 ADD assets.tar.gz /usr/local/share/dgraph/assets
 
 EXPOSE 8080
-EXPOSE 9090
+EXPOSE 9080
 WORKDIR /dgraph
 
 CMD ["dgraph"] # Shows the dgraph version and commands available.

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -100,7 +100,7 @@ func StartRaftNodes(walStore *badger.ManagedDB, bindall bool) {
 	var connState *protos.ConnectionState
 	m := &protos.Member{Id: Config.RaftId, Addr: Config.MyAddr}
 	delay := time.Second
-	for i := 0; i < 10; i++ { // Generous number of attempts.
+	for i := 0; i < 6; i++ { // Generous number of attempts.
 		var err error
 		connState, err = zc.Connect(gr.ctx, m)
 		if err == nil {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -99,13 +99,16 @@ func StartRaftNodes(walStore *badger.ManagedDB, bindall bool) {
 	zc := protos.NewZeroClient(p.Get())
 	var connState *protos.ConnectionState
 	m := &protos.Member{Id: Config.RaftId, Addr: Config.MyAddr}
-	for i := 0; i < 100; i++ { // Generous number of attempts.
+	delay := time.Second
+	for i := 0; i < 10; i++ { // Generous number of attempts.
 		var err error
 		connState, err = zc.Connect(gr.ctx, m)
 		if err == nil {
 			break
 		}
 		x.Printf("Error while connecting with group zero: %v", err)
+		time.Sleep(delay)
+		delay *= 2
 	}
 	if connState.GetMember() == nil || connState.GetState() == nil {
 		x.Fatalf("Unable to join cluster via dgraphzero")

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -99,8 +99,8 @@ func StartRaftNodes(walStore *badger.ManagedDB, bindall bool) {
 	zc := protos.NewZeroClient(p.Get())
 	var connState *protos.ConnectionState
 	m := &protos.Member{Id: Config.RaftId, Addr: Config.MyAddr}
-	delay := time.Second
-	for i := 0; i < 6; i++ { // Generous number of attempts.
+	delay := 100 * time.Millisecond
+	for i := 0; i < 9; i++ { // Generous number of attempts.
 		var err error
 		connState, err = zc.Connect(gr.ctx, m)
 		if err == nil {


### PR DESCRIPTION
This allows users do just do `docker compose up` which will start both Dgraph and Dgraph Zero exposing the correct ports.

More work needs to be done to start multiple Dgraph nodes. I am working on that and will raise a separate PR. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1814)
<!-- Reviewable:end -->
