### PR TITLE
Retry when setting initial schema

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -158,8 +158,13 @@ func (g *groupi) proposeInitialSchema() {
 
 	// This would propose the schema mutation and make sure some node serves this predicate
 	// and has the schema defined above.
-	if _, err := MutateOverNetwork(gr.ctx, &m); err != nil {
+	for {
+		_, err := MutateOverNetwork(gr.ctx, &m)
+		if err == nil {
+			break
+		}
 		fmt.Println("Error while proposing initial schema: ", err)
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Sometimes when starting up, the initial schema would fail, which breaks expand(_all_) until the server is restarted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1831)
<!-- Reviewable:end -->
