### PR TITLE
Update stale references to RocksDB

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -64,7 +64,7 @@ type Node struct {
 
 	// applied is used to keep track of the applied RAFT proposals.
 	// The stages are proposed -> committed (accepted by cluster) ->
-	// applied (to PL) -> synced (to RocksDB).
+	// applied (to PL) -> synced (to BadgerDB).
 	Applied x.WaterMark
 }
 

--- a/posting/doc.go
+++ b/posting/doc.go
@@ -16,5 +16,5 @@
  */
 
 // Package posting takes care of posting lists. It contains logic for mutation
-// layers, merging them with RocksDB, etc.
+// layers, merging them with BadgerDB, etc.
 package posting

--- a/posting/list.go
+++ b/posting/list.go
@@ -287,7 +287,7 @@ func (l *List) updateMutationLayer(startTs uint64, mpost *intern.Posting) bool {
 
 // AddMutation adds mutation to mutation layers. Note that it does not write
 // anything to disk. Some other background routine will be responsible for merging
-// changes in mutation layers to RocksDB. Returns whether any mutation happens.
+// changes in mutation layers to BadgerDB. Returns whether any mutation happens.
 func (l *List) AddMutation(ctx context.Context, txn *Txn, t *intern.DirectedEdge) (bool, error) {
 	t1 := time.Now()
 	l.Lock()

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -168,7 +168,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 	key := x.DataKey("value", 12)
 	ol := Get(key)
 
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Value: []byte("cars"),
 		Label: "jchiu",
@@ -266,7 +266,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 	key := x.DataKey("value", 29)
 	ol := Get(key)
 
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Value: []byte("cars"),
 		Label: "jchiu",
@@ -460,7 +460,7 @@ func TestAfterUIDCount(t *testing.T) {
 	key := x.DataKey("value", 22)
 	ol, err := getNew(key, ps)
 	require.NoError(t, err)
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Label: "jchiu",
 	}
@@ -535,7 +535,7 @@ func TestAfterUIDCount2(t *testing.T) {
 	ol, err := getNew(key, ps)
 	require.NoError(t, err)
 
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Label: "jchiu",
 	}
@@ -565,7 +565,7 @@ func TestDelete(t *testing.T) {
 	ol, err := getNew(key, ps)
 	require.NoError(t, err)
 
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Label: "jchiu",
 	}
@@ -592,7 +592,7 @@ func TestAfterUIDCountWithCommit(t *testing.T) {
 	ol, err := getNew(key, ps)
 	require.NoError(t, err)
 
-	// Set value to cars and merge to RocksDB.
+	// Set value to cars and merge to BadgerDB.
 	edge := &intern.DirectedEdge{
 		Label: "jchiu",
 	}

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -51,14 +51,14 @@ const (
 // syncMarks stores the watermark for synced RAFT proposals. Each RAFT proposal consists
 // of many individual mutations, which could be applied to many different posting lists.
 // Thus, each PL when being mutated would send an undone Mark, and each list would
-// accumulate all such pending marks. When the PL is synced to RocksDB, it would
+// accumulate all such pending marks. When the PL is synced to BadgerDB, it would
 // mark all the pending ones as done.
 // This ideally belongs to RAFT node struct (where committed watermark is being tracked),
 // but because the logic of mutations is
 // present here and to avoid a circular dependency, we've placed it here.
 // Note that there's one watermark for each RAFT node/group.
 // This watermark would be used for taking snapshots, to ensure that all the data and
-// index mutations have been syned to RocksDB, before a snapshot is taken, and previous
+// index mutations have been syned to BadgerDB, before a snapshot is taken, and previous
 // RAFT entries discarded.
 func init() {
 	x.AddInit(func() {

--- a/vendor/github.com/blevesearch/bleve/index/store/merge.go
+++ b/vendor/github.com/blevesearch/bleve/index/store/merge.go
@@ -15,7 +15,7 @@
 package store
 
 // At the moment this happens to be the same interface as described by
-// RocksDB, but this may not always be the case.
+// BadgerDB, but this may not always be the case.
 
 type MergeOperator interface {
 

--- a/wiki/content/design-concepts/index.md
+++ b/wiki/content/design-concepts/index.md
@@ -171,7 +171,7 @@ gets divided across two groups.
   Group 2:  (Predicate, Sj..z)
 ```
 
-Note that keys are sorted in RocksDB. So, the group split would be done in a way to maintain that
+Note that keys are sorted in BadgerDB. So, the group split would be done in a way to maintain that
 sorting order, i.e. it would be split in a way where the lexicographically earlier subjects would be
 in one group, and the later in the second.
 
@@ -185,7 +185,7 @@ establish connections, and transfer a subset of existing predicates to it based 
 by the new machine.
 
 ### Write Ahead Logs
-Every mutation upon hitting the database doesn't immediately make it on disk via RocksDB. We avoid
+Every mutation upon hitting the database doesn't immediately make it on disk via BadgerDB. We avoid
 re-generating the posting list too often, because all the postings need to be kept sorted, and it's
 expensive. Instead, every mutation gets logged and synced to disk via append only log files called
 `write-ahead logs`. So, any acknowledged writes would always be on disk. This allows us to recover
@@ -197,7 +197,7 @@ overlay over immutable `Posting list` in a mutation layer. This mutation layer a
 over `Posting`s as though they're sorted, without requiring re-creating the posting list.
 
 When a posting list has mutations in memory, it's considered a `dirty` posting list. Periodically,
-we re-generate the immutable version, and write to RocksDB. Note that the writes to RocksDB are
+we re-generate the immutable version, and write to BadgerDB. Note that the writes to BadgerDB are
 asynchronous, which means they don't get flushed out to disk immediately, but that wouldn't lead
 to data loss on a machine crash. When `Posting lists` are initialized, write-ahead logs get referred,
 and any missing writes get applied.

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -38,7 +38,7 @@ const (
 	MB = 1 << 20
 )
 
-// writeBatch performs a batch write of key value pairs to RocksDB.
+// writeBatch performs a batch write of key value pairs to BadgerDB.
 func writeBatch(ctx context.Context, pstore *badger.ManagedDB, kv chan *intern.KV, che chan error) {
 	var hasError int32
 	for i := range kv {
@@ -117,7 +117,7 @@ func streamKeys(pstore *badger.ManagedDB, stream intern.Worker_PredicateAndSchem
 }
 
 // PopulateShard gets data for predicate pred from server with id serverId and
-// writes it to RocksDB.
+// writes it to BadgerDB.
 func populateShard(ctx context.Context, ps *badger.ManagedDB, pl *conn.Pool, group uint32) (int, error) {
 	conn := pl.Get()
 	c := intern.NewWorkerClient(conn)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -149,7 +149,7 @@ func newQuery(attr string, uids []uint64, srcFunc []string) *intern.Query {
 
 // Index-related test. Similar to TestProcessTaskIndex but we call MergeLists only
 // at the end. In other words, everything is happening only in mutation layers,
-// and not committed to RocksDB until near the end.
+// and not committed to BadgerDB until near the end.
 func TestProcessTaskIndexMLayer(t *testing.T) {
 	initTest(t, `friend:string @index(term) .`)
 


### PR DESCRIPTION
Hi,
I did update various stale references to RocksDB to reference to BadgerDB instead. I changed only those which for me should clearly point to BadgerDB and left a couple of others (in Wiki content etc.) untouched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1901)
<!-- Reviewable:end -->
