### PR TITLE
Fix Go client examples

### DIFF
--- a/client/example_set_object_test.go
+++ b/client/example_set_object_test.go
@@ -75,6 +75,7 @@ func Example_setObject() {
 
 	op := &api.Operation{}
 	op.Schema = `
+		name: string @index(exact) .
 		age: int .
 		married: bool .
 		loc: geo .
@@ -111,7 +112,7 @@ func Example_setObject() {
 			loc
 			raw_bytes
 			married
-			friend {
+			friend @filter(eq(name, "Bob")){
 				name
 				age
 			}
@@ -139,6 +140,6 @@ func Example_setObject() {
 	// R.Me would be same as the person that we set above.
 
 	fmt.Println(string(resp.Json))
-	// Output: {"me":[{"name":"Alice","dob":"1980-01-01T23:00:00Z","age":26,"loc":{"type":"Point","coordinates":[1.1,2]},"raw_bytes":"cmF3X2J5dGVz","married":true,"friend":[{"name":"Bob","age":24},{"name":"Charlie","age":29}],"school":[{"name":"Crown Public School"}]}]}
+	// Output: {"me":[{"name":"Alice","dob":"1980-01-01T23:00:00Z","age":26,"loc":{"type":"Point","coordinates":[1.1,2]},"raw_bytes":"cmF3X2J5dGVz","married":true,"friend":[{"name":"Bob","age":24}],"school":[{"name":"Crown Public School"}]}]}
 
 }

--- a/client/example_set_object_test.go
+++ b/client/example_set_object_test.go
@@ -46,13 +46,11 @@ func Example_setObject() {
 	dc := api.NewDgraphClient(conn)
 	dg := client.NewDgraphClient(dc)
 
+	dob := time.Date(1980, 01, 01, 23, 0, 0, 0, time.UTC)
 	// While setting an object if a struct has a Uid then its properties in the graph are updated
 	// else a new node is created.
-	// In the example below new nodes for Alice and Charlie and school are created (since they dont
-	// have a Uid).  Alice is also connected via the friend edge to an existing node with Uid
-	// 1000(Bob).  We also set Name and Age values for this node with Uid 1000.
-
-	dob := time.Date(1980, 01, 01, 23, 0, 0, 0, time.UTC)
+	// In the example below new nodes for Alice, Bob and Charlie and school are created (since they
+	// dont have a Uid).
 	p := Person{
 		Name:    "Alice",
 		Age:     26,
@@ -64,7 +62,6 @@ func Example_setObject() {
 		Dob: &dob,
 		Raw: []byte("raw_bytes"),
 		Friends: []Person{{
-			Uid:  "1000",
 			Name: "Bob",
 			Age:  24,
 		}, {
@@ -105,10 +102,9 @@ func Example_setObject() {
 	}
 
 	// Assigned uids for nodes which were created would be returned in the resp.AssignedUids map.
-	puid := assigned.Uids["blank-0"]
-	q := fmt.Sprintf(`{
-		me(func: uid(%s)) {
-			uid
+	variables := map[string]string{"$id": assigned.Uids["blank-0"]}
+	q := `query Me($id: string){
+		me(func: uid($id)) {
 			name
 			dob
 			age
@@ -116,7 +112,6 @@ func Example_setObject() {
 			raw_bytes
 			married
 			friend {
-				uid
 				name
 				age
 			}
@@ -124,9 +119,9 @@ func Example_setObject() {
 				name
 			}
 		}
-	}`, puid)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -140,6 +135,10 @@ func Example_setObject() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Me: %+v\n", r.Me)
+	// fmt.Printf("Me: %+v\n", r.Me)
 	// R.Me would be same as the person that we set above.
+
+	fmt.Println(string(resp.Json))
+	// Output: {"me":[{"name":"Alice","dob":"1980-01-01T23:00:00Z","age":26,"loc":{"type":"Point","coordinates":[1.1,2]},"raw_bytes":"cmF3X2J5dGVz","married":true,"friend":[{"name":"Bob","age":24},{"name":"Charlie","age":29}],"school":[{"name":"Crown Public School"}]}]}
+
 }

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -20,14 +20,64 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
 	"github.com/dgraph-io/dgraph/client"
 	"github.com/dgraph-io/dgraph/protos/api"
+	"github.com/dgraph-io/dgraph/x"
 	"google.golang.org/grpc"
 )
+
+func TestMain(m *testing.M) {
+	zw, err := ioutil.TempDir("", "")
+	x.Check(err)
+
+	cmd := exec.Command("go", "install", "github.com/dgraph-io/dgraph/dgraph")
+	cmd.Env = os.Environ()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		log.Fatalf("Could not run %q: %s", cmd.Args, string(out))
+	}
+	zero := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+		"zero",
+		"-w", zw,
+		"-o", "-2000",
+	)
+	zero.Stdout = os.Stdout
+	zero.Stderr = os.Stdout
+	x.Check(zero.Start())
+
+	p, err := ioutil.TempDir("", "")
+	x.Check(err)
+	w, err := ioutil.TempDir("", "")
+	x.Check(err)
+
+	server := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+		"server",
+		"-w", w,
+		"-p", p,
+		"--zero", "127.0.0.1:5080",
+		"--memory_mb", "2048",
+	)
+	server.Stdout = os.Stdout
+	server.Stderr = os.Stdout
+	x.Check(server.Start())
+	// Wait for servers to start and connect.
+	time.Sleep(5 * time.Second)
+	s := m.Run()
+
+	x.Check(zero.Process.Kill())
+	x.Check(server.Process.Kill())
+	os.RemoveAll(zw)
+	os.RemoveAll(w)
+	os.RemoveAll(p)
+	exec.Command("killall", "-9", "dgraph").Run()
+	os.Exit(s)
+}
 
 func ExampleTxn_Query_variables() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
@@ -75,7 +125,7 @@ func ExampleTxn_Query_variables() {
 
 	variables := make(map[string]string)
 	variables["$a"] = "Alice"
-	q := `{
+	q := `query Alice($a: string){
 		me(func: eq(name, $a)) {
 			name
 		}
@@ -95,7 +145,9 @@ func ExampleTxn_Query_variables() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Me: %+v\n", r.Me)
+
+	fmt.Println(string(resp.Json))
+	// Output: {"me":[{"name":"Alice"}]}
 }
 
 func ExampleDgraph_Alter_dropAll() {
@@ -115,6 +167,10 @@ func ExampleDgraph_Alter_dropAll() {
 	if err := dg.Alter(ctx, &op); err != nil {
 		log.Fatal(err)
 	}
+
+	fmt.Println(err)
+
+	// Output: <nil>
 }
 
 func ExampleTxn_Mutate() {
@@ -152,10 +208,8 @@ func ExampleTxn_Mutate() {
 
 	// While setting an object if a struct has a Uid then its properties in the graph are updated
 	// else a new node is created.
-	// In the example below new nodes for Alice and Charlie and school are created (since they dont
-	// have a Uid).  Alice is also connected via the friend edge to an existing node with Uid
-	// 1000(Bob).  We also set Name and Age values for this node with Uid 1000.
-
+	// In the example below new nodes for Alice, Bob and Charlie and school are created (since they
+	// dont have a Uid).
 	p := Person{
 		Name:    "Alice",
 		Age:     26,
@@ -166,7 +220,6 @@ func ExampleTxn_Mutate() {
 		},
 		Raw: []byte("raw_bytes"),
 		Friends: []Person{{
-			Uid:  "1000",
 			Name: "Bob",
 			Age:  24,
 		}, {
@@ -206,16 +259,14 @@ func ExampleTxn_Mutate() {
 
 	// Assigned uids for nodes which were created would be returned in the resp.AssignedUids map.
 	puid := assigned.Uids["blank-0"]
-	q := fmt.Sprintf(`{
-		me(func: uid(%s)) {
-			uid
+	const q = `query Me($id: string){
+		me(func: uid($id)) {
 			name
 			age
 			loc
 			raw_bytes
 			married
 			friend {
-				uid
 				name
 				age
 			}
@@ -223,9 +274,11 @@ func ExampleTxn_Mutate() {
 				name
 			}
 		}
-	}`, puid)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	variables := make(map[string]string)
+	variables["$id"] = puid
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -239,8 +292,13 @@ func ExampleTxn_Mutate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Me: %+v\n", r.Me)
+
 	// R.Me would be same as the person that we set above.
+	// fmt.Printf("Me: %+v\n", r.Me)
+
+	fmt.Println(string(resp.Json))
+	// Output: {"me":[{"name":"Alice","age":26,"loc":{"type":"Point","coordinates":[1.1,2]},"raw_bytes":"cmF3X2J5dGVz","married":true,"friend":[{"name":"Bob","age":24},{"name":"Charlie","age":29}],"school":[{"name":"Crown Public School"}]}]}
+
 }
 
 func ExampleTxn_Mutate_bytes() {
@@ -271,7 +329,7 @@ func ExampleTxn_Mutate_bytes() {
 	}
 
 	p := Person{
-		Name:  "Alice",
+		Name:  "Alice-new",
 		Bytes: []byte("raw_bytes"),
 	}
 
@@ -290,8 +348,7 @@ func ExampleTxn_Mutate_bytes() {
 	}
 
 	q := `{
-	q(func: eq(name, "Alice")) {
-		uid
+	q(func: eq(name, "Alice-new")) {
 		name
 		bytes
 	}
@@ -312,6 +369,8 @@ func ExampleTxn_Mutate_bytes() {
 		log.Fatal(err)
 	}
 	fmt.Printf("Me: %+v\n", r.Me)
+
+	// Output: Me: [{Uid: Name:Alice-new Bytes:[114 97 119 95 98 121 116 101 115]}]
 }
 
 func ExampleTxn_Query_unmarshal() {
@@ -390,16 +449,16 @@ func ExampleTxn_Query_unmarshal() {
 
 	// Assigned uids for nodes which were created would be returned in the resp.AssignedUids map.
 	puid := assigned.Uids["blank-0"]
-	q := fmt.Sprintf(`{
-		me(func: uid(%s)) {
-			uid
+	variables := make(map[string]string)
+	variables["$id"] = puid
+	const q = `query Me($id: string){
+		me(func: uid($id)) {
 			name
 			age
 			loc
 			raw_bytes
 			married
 			friend {
-				uid
 				name
 				age
 			}
@@ -407,9 +466,9 @@ func ExampleTxn_Query_unmarshal() {
 				name
 			}
 		}
-	}`, puid)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -423,10 +482,12 @@ func ExampleTxn_Query_unmarshal() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Me: %+v\n", r.Me)
+
+	fmt.Println(string(resp.Json))
+	// Output: {"me":[{"name":"Alice","age":26,"raw_bytes":"cmF3X2J5dGVz","married":true,"friend":[{"name":"Charlie","age":29},{"name":"Bob","age":24}],"school":[{"name":"Crown Public School"}]}]}
 }
 
-func ExampleTxn_Mutate_facets(t *testing.T) {
+func ExampleTxn_Mutate_facets() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	if err != nil {
 		log.Fatal("While trying to dial gRPC")
@@ -439,7 +500,7 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 	// This example shows example for SetObject using facets.
 	type School struct {
 		Name  string    `json:"name,omitempty"`
-		Since time.Time `json:"school:since,omitempty"`
+		Since time.Time `json:"school|since,omitempty"`
 	}
 
 	type Person struct {
@@ -495,13 +556,13 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 	}
 
 	auid := assigned.Uids["blank-0"]
+	variables := make(map[string]string)
+	variables["$id"] = auid
 
-	q := fmt.Sprintf(`
-    {
-
-        me(func: uid(%v)) {
+	const q = `query Me($id: string){
+        me(func: uid($id)) {
             name @facets
-            friend @facets {
+			friend(orderdesc: name) @facets {
                 name
             }
             school @facets {
@@ -509,9 +570,9 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
             }
 
         }
-    }`, auid)
+    }`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -527,9 +588,10 @@ func ExampleTxn_Mutate_facets(t *testing.T) {
 	}
 
 	fmt.Printf("Me: %+v\n", r.Me)
+	// Output: Me: [{Name:Alice NameOrigin:Indonesia Friends:[{Name:Charlie NameOrigin: Friends:[] Since:0001-01-01 00:00:00 +0000 UTC Family:maybe Age:16 Close:false School:[]} {Name:Bob NameOrigin: Friends:[] Since:2009-11-10 23:00:00 +0000 UTC Family:yes Age:13 Close:true School:[]}] Since:0001-01-01 00:00:00 +0000 UTC Family: Age:0 Close:false School:[{Name:Wellington School Since:2009-11-10 23:00:00 +0000 UTC}]}]
 }
 
-func ExampleTxn_Mutate_list(t *testing.T) {
+func ExampleTxn_Mutate_list() {
 	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	if err != nil {
 		log.Fatal("While trying to dial gRPC")
@@ -574,19 +636,17 @@ func ExampleTxn_Mutate_list(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	uid := assigned.Uids["blank-0"]
-
-	q := fmt.Sprintf(`
-	{
-		me(func: uid(%s)) {
-			uid
+	variables := map[string]string{"$id": assigned.Uids["blank-0"]}
+	const q = `
+	query Me($id: string){
+		me(func: uid($id)) {
 			address
 			phone_number
 		}
 	}
-	`, uid)
+	`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -601,7 +661,9 @@ func ExampleTxn_Mutate_list(t *testing.T) {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("Me: %+v\n", r.Me)
+	fmt.Println(string(resp.Json))
+	// Output: {"me":[{"address":["Riley Street","Redfern"],"phone_number":[9876,123]}]}
+
 }
 
 func ExampleDeleteEdges() {
@@ -673,15 +735,15 @@ func ExampleDeleteEdges() {
 	}
 
 	uid := assigned.Uids["blank-0"]
-	q := fmt.Sprintf(`{
-		me(func: uid(%s)) {
-			uid
+	variables := make(map[string]string)
+	variables["$id"] = uid
+	const q = `query Me($id: string){
+		me(func: uid($id)) {
 			name
 			age
 			loc
 			married
 			friends {
-				uid
 				name
 				age
 			}
@@ -690,14 +752,12 @@ func ExampleDeleteEdges() {
 				name@en
 			}
 		}
-	}`, uid)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	fmt.Println(string(resp.Json))
 
 	// Now lets delete the friend and location edge from Alice
 	mu = &api.Mutation{}
@@ -709,7 +769,7 @@ func ExampleDeleteEdges() {
 		log.Fatal(err)
 	}
 
-	resp, err = dg.NewTxn().Query(ctx, q)
+	resp, err = dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -720,7 +780,8 @@ func ExampleDeleteEdges() {
 
 	var r Root
 	err = json.Unmarshal(resp.Json, &r)
-	fmt.Printf("Resp: %+v\n", r)
+	fmt.Println(string(resp.Json))
+	// Output: yo
 }
 
 func ExampleTxn_Mutate_deleteNode() {
@@ -784,9 +845,10 @@ func ExampleTxn_Mutate_deleteNode() {
 		log.Fatal(err)
 	}
 
-	q := fmt.Sprintf(`{
-		me(func: uid(1000)) {
-			uid
+	variables := make(map[string]string)
+	variables["$id"] = "1000"
+	const q = `query Me($id: string){
+		me(func: uid($id)) {
 			name
 			age
 			married
@@ -808,9 +870,9 @@ func ExampleTxn_Mutate_deleteNode() {
 			name
 			age
 		}
-	}`)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -823,7 +885,6 @@ func ExampleTxn_Mutate_deleteNode() {
 
 	var r Root
 	err = json.Unmarshal(resp.Json, &r)
-	fmt.Printf("Resp after SetObject: %+v\n", r)
 
 	// Now lets try to delete Alice. This won't delete Bob and Charlie but just remove the
 	// connection between Alice and them.
@@ -845,7 +906,7 @@ func ExampleTxn_Mutate_deleteNode() {
 		log.Fatal(err)
 	}
 
-	resp, err = dg.NewTxn().Query(ctx, q)
+	resp, err = dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -854,7 +915,8 @@ func ExampleTxn_Mutate_deleteNode() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Resp after deleting node: %+v\n", r)
+	fmt.Printf("Resp after deleting node: %+v\n", string(resp.Json))
+	// Output: Resp after deleting node: {"me":[],"me2":[{"uid":"0x3e9","name":"Bob","age":24}],"me3":[{"uid":"0x3ea","name":"Charlie","age":29}]}
 }
 
 func ExampleTxn_Mutate_deletePredicate() {
@@ -917,8 +979,10 @@ func ExampleTxn_Mutate_deletePredicate() {
 		log.Fatal(err)
 	}
 
-	q := fmt.Sprintf(`{
-		me(func: uid(1000)) {
+	variables := make(map[string]string)
+	variables["$id"] = "1000"
+	const q = `query Me($id: string){
+		me(func: uid($id)) {
 			uid
 			name
 			age
@@ -929,9 +993,9 @@ func ExampleTxn_Mutate_deletePredicate() {
 				age
 			}
 		}
-	}`)
+	}`
 
-	resp, err := dg.NewTxn().Query(ctx, q)
+	resp, err := dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -944,7 +1008,6 @@ func ExampleTxn_Mutate_deletePredicate() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Response after SetObject: %+v\n\n", r)
 
 	op = &api.Operation{
 		DropAttr: "friend",
@@ -961,15 +1024,18 @@ func ExampleTxn_Mutate_deletePredicate() {
 	}
 
 	// Also lets run the query again to verify that predicate data was deleted.
-	resp, err = dg.NewTxn().Query(ctx, q)
+	resp, err = dg.NewTxn().QueryWithVars(ctx, q, variables)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	r = Root{}
 	err = json.Unmarshal(resp.Json, &r)
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	// Alice should have no friends and only two attributes now.
 	fmt.Printf("Response after deletion: %+v\n", r)
+	// Output: Response after deletion: {Me:[{Uid:0x3e8 Name:Alice Age:26 Married:false Friends:[]}]}
 }

--- a/client/examples_test.go
+++ b/client/examples_test.go
@@ -76,7 +76,9 @@ func TestMain(m *testing.M) {
 	os.RemoveAll(zw)
 	os.RemoveAll(w)
 	os.RemoveAll(p)
-	exec.Command("killall", "-9", "dgraph").Run()
+	if err := exec.Command("killall", "-9", "dgraph").Run(); err != nil {
+		log.Fatal(err)
+	}
 	os.Exit(s)
 }
 


### PR DESCRIPTION
Stop using `fmt.Sprintf`, instead use GraphQL query variables. Also, make the examples testable.

Resolves #1803.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1906)
<!-- Reviewable:end -->
