### PR TITLE
Make sure at least 1 field is set in alter

### DIFF
--- a/dgraph/cmd/server/http.go
+++ b/dgraph/cmd/server/http.go
@@ -392,6 +392,11 @@ func alterHandler(w http.ResponseWriter, r *http.Request) {
 		op.Schema = string(b)
 	}
 
+	if err := checkOpValid(op); err != nil {
+		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
+		return
+	}
+
 	_, err = (&edgraph.Server{}).Alter(context.Background(), op)
 	if err != nil {
 		x.SetStatus(w, x.Error, err.Error())
@@ -410,4 +415,13 @@ func alterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(js)
+}
+
+func checkOpValid(op *api.Operation) error {
+	// Must have at least one field set. This helps users if they attempt to
+	// set a field but use the wrong name.
+	if op.Schema == "" && op.DropAttr == "" && !op.DropAll && op.StartTs == 0 {
+		return x.Errorf("Operation must have at least one field set")
+	}
+	return nil
 }

--- a/dgraph/cmd/server/http.go
+++ b/dgraph/cmd/server/http.go
@@ -392,11 +392,6 @@ func alterHandler(w http.ResponseWriter, r *http.Request) {
 		op.Schema = string(b)
 	}
 
-	if err := checkOpValid(op); err != nil {
-		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
-		return
-	}
-
 	_, err = (&edgraph.Server{}).Alter(context.Background(), op)
 	if err != nil {
 		x.SetStatus(w, x.Error, err.Error())
@@ -415,13 +410,4 @@ func alterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write(js)
-}
-
-func checkOpValid(op *api.Operation) error {
-	// Must have at least one field set. This helps users if they attempt to
-	// set a field but use the wrong name.
-	if op.Schema == "" && op.DropAttr == "" && !op.DropAll && op.StartTs == 0 {
-		return x.Errorf("Operation must have at least one field set")
-	}
-	return nil
 }

--- a/dgraph/cmd/server/http_test.go
+++ b/dgraph/cmd/server/http_test.go
@@ -191,5 +191,5 @@ func TestAlterAllFieldsShouldBeSet(t *testing.T) {
 	var qr x.QueryResWithData
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &qr))
 	require.Len(t, qr.Errors, 1)
-	require.Equal(t, qr.Errors[0].Code, "ErrorInvalidRequest")
+	require.Equal(t, qr.Errors[0].Code, "Error")
 }

--- a/dgraph/cmd/server/http_test.go
+++ b/dgraph/cmd/server/http_test.go
@@ -177,3 +177,19 @@ func TestTransactionBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"uid":"0x1","name":"Bob","balance":"110"}]}}`, data)
 }
+
+func TestAlterAllFieldsShouldBeSet(t *testing.T) {
+	req, err := http.NewRequest("PUT", "/alter", bytes.NewBufferString(
+		`{"dropall":true}`, // "dropall" is spelt incorrect - should be "drop_all"
+	))
+	require.NoError(t, err)
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(alterHandler)
+	handler.ServeHTTP(rr, req)
+
+	require.Equal(t, rr.Code, http.StatusOK)
+	var qr x.QueryResWithData
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &qr))
+	require.Len(t, qr.Errors, 1)
+	require.Equal(t, qr.Errors[0].Code, "ErrorInvalidRequest")
+}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -217,6 +217,12 @@ func (s *ServerState) getTimestamp() uint64 {
 }
 
 func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, error) {
+	if op.Schema == "" && op.DropAttr == "" && !op.DropAll && op.StartTs == 0 {
+		// Must have at least one field set. This helps users if they attempt
+		// to set a field but use the wrong name (could be decoded from JSON).
+		return nil, x.Errorf("Operation must have at least one field set")
+	}
+
 	empty := &api.Payload{}
 	if err := x.HealthCheck(); err != nil {
 		if tr, ok := trace.FromContext(ctx); ok {


### PR DESCRIPTION
I ended wasting a fair bit of time because I thought I was dropping all but was missing the underscore in the field name (JSON object). This change causes an error to come back to the user if the decoded Operation object has no fields set (if I make the mistake, then chances are someone else will make it as well).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1932)
<!-- Reviewable:end -->
