### PR TITLE
Use change in length of mutation layer to determine if rollup merged …

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -734,11 +734,14 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 		x.AssertTrue(len(l.activeTxns) == 0)
 	}
 
-	minTs := l.minTs
+	lmlayer := len(l.mlayer)
 	if err := l.rollup(); err != nil {
 		return false, err
 	}
-	if l.minTs == minTs && l.plist != emptyList { // Would be emptyList for s p *
+	// Check if length of mlayer has changed after rollup, else skip writing to disk
+	// minTs can remain same after rollup during schema mutations of large index, so
+	// don't check minTs.
+	if len(l.mlayer) == lmlayer && l.plist != emptyList { // Would be emptyList for s p *
 		// There was no change in immutable layer.
 		return false, nil
 	}
@@ -759,7 +762,7 @@ func (l *List) syncIfDirty(delFromCache bool) (committed bool, err error) {
 	}
 
 	// Copy this over because minTs can change by the time callback returns.
-	minTs = l.minTs
+	minTs := l.minTs
 	retries := 0
 	var f func(error)
 	f = func(err error) {


### PR DESCRIPTION
Fixes #1935 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1940)
<!-- Reviewable:end -->
