### PR TITLE
Fix #1937

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -626,8 +626,10 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 		var uid uint64
 		if id, ok := uidVal.(float64); ok {
 			uid = uint64(id)
-		} else if id, ok := uidVal.(string); ok {
-			if u, err := strconv.ParseInt(id, 0, 64); err == nil {
+		} else if id, ok := uidVal.(string); ok && len(id) > 0 {
+			if u, err := strconv.ParseInt(id, 0, 64); err != nil {
+				return mr, err
+			} else {
 				uid = uint64(u)
 			}
 		}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -627,7 +627,9 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 		if id, ok := uidVal.(float64); ok {
 			uid = uint64(id)
 		} else if id, ok := uidVal.(string); ok && len(id) > 0 {
-			if u, err := strconv.ParseInt(id, 0, 64); err != nil {
+			// We need to check for length of id as empty string would give an error while
+			// calling ParseUint. We should assign a new uid if len == 0.
+			if u, err := strconv.ParseUint(id, 0, 64); err != nil {
 				return mr, err
 			} else {
 				uid = uint64(u)

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -159,7 +159,14 @@ func TestNquadsFromJson4(t *testing.T) {
 }
 
 func TestNquadsFromJson_UidOutofRangeError(t *testing.T) {
-	json := `{"uid":"0xa14222b693e4ba34","name":"Name","following":[{"name":"Bob"}],"school":[{"uid":"","name@en":"Crown Public School"}]}`
+	json := `{"uid":"0xa14222b693e4ba34123","name":"Name","following":[{"name":"Bob"}],"school":[{"uid":"","name@en":"Crown Public School"}]}`
+
+	_, err := nquadsFromJson([]byte(json), set)
+	require.Error(t, err)
+}
+
+func TestNquadsFromJson_NegativeUidError(t *testing.T) {
+	json := `{"uid":"-100","name":"Name","following":[{"name":"Bob"}],"school":[{"uid":"","name@en":"Crown Public School"}]}`
 
 	_, err := nquadsFromJson([]byte(json), set)
 	require.Error(t, err)

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -158,6 +158,24 @@ func TestNquadsFromJson4(t *testing.T) {
 	require.Contains(t, nq, makeNquad("_:blank-0", "name", oval))
 }
 
+func TestNquadsFromJson_UidOutofRangeError(t *testing.T) {
+	json := `{"uid":"0xa14222b693e4ba34","name":"Name","following":[{"name":"Bob"}],"school":[{"uid":"","name@en":"Crown Public School"}]}`
+
+	_, err := nquadsFromJson([]byte(json), set)
+	require.Error(t, err)
+}
+
+func TestNquadsFromJson_EmptyUid(t *testing.T) {
+	json := `{"uid":"","name":"Name","following":[{"name":"Bob"}],"school":[{"uid":"","name":"Crown Public School"}]}`
+
+	nq, err := nquadsFromJson([]byte(json), set)
+	require.NoError(t, err)
+
+	require.Equal(t, 5, len(nq))
+	oval := &api.Value{&api.Value_StrVal{"Name"}}
+	require.Contains(t, nq, makeNquad("_:blank-0", "name", oval))
+}
+
 func TestNquadsDeleteEdges(t *testing.T) {
 	json := `[{"uid": "0x1","name":null,"mobile":null,"car":null}]`
 	nq, err := nquadsFromJson([]byte(json), delete)


### PR DESCRIPTION
1. Return error if user uses a string uid that can't be parsed as `uint64`.
2. Update examples to not use a hardcoded uid as it causes confusion to users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1941)
<!-- Reviewable:end -->
