### PR TITLE
Don't remove _predicate_'s schema from disk during drop all

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -230,7 +230,7 @@ func (n *Node) InitFromWal(wal *raftwal.Wal) (idx uint64, restart bool, rerr err
 	}
 	var term uint64
 	if !raft.IsEmptySnap(sp) {
-		x.Printf("Found Snapshot: %+v\n", sp)
+		x.Printf("Found Snapshot, Metadata: %+v\n", sp.Metadata)
 		restart = true
 		if rerr = n.Store.ApplySnapshot(sp); rerr != nil {
 			return

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -677,6 +677,7 @@ START:
 		// Do Immediately so that index keys are written.
 		g.proposeDelta(oracleDelta)
 	}
+	time.Sleep(time.Second)
 	goto START
 }
 


### PR DESCRIPTION
Add sleep between retries if group zero doesn't have active leader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1943)
<!-- Reviewable:end -->
