### PR TITLE
docs: add note to Bulk Loading section about expected RDF format

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1123,6 +1123,8 @@ way to perform the initial import of large datasets into dgraph.
 You can [read some technical details](https://blog.dgraph.io/post/bulkloader/)
 about the bulk loader on the blog.
 
+See [Fast Data Loading]({{< relref "#fast-data-loading" >}}) for more about the expected N-Quads format.
+
 You need to determine the
 number of dgraph instances you want in your cluster. You should set the number
 of reduce shards to this number. You will also need to set the number of map


### PR DESCRIPTION
The expected format is N-Quads RDF serialisation, which I now see is right in that intro to the loaders section. The problem is I jumped straight to the bulk loader section in the docs and completely missed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1950)
<!-- Reviewable:end -->
