### PR TITLE
Fix for #1965

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project will adhere to [Semantic Versioning](http://semver.org/spec/v2.
 
 * Always return predicates of list type in an array.
 * Edges without facet values are also returned when performing sort on facet.
+* Dont derive schema while deleting edges.
 
 ## [1.0.1] - 2017-12-20
 

--- a/contrib/nightly/upload.sh
+++ b/contrib/nightly/upload.sh
@@ -113,7 +113,8 @@ else
   fi
 
   pushd ratel
-  ./scripts/build.sh
+  nvm install --lts
+  ./scripts/build.prod.sh
   popd
   popd
 

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -60,7 +60,10 @@ func runMutation(ctx context.Context, edge *intern.DirectedEdge, txn *posting.Tx
 	}
 
 	typ, err := schema.State().TypeOf(edge.Attr)
-	x.Checkf(err, "Schema is not present for predicate %s", edge.Attr)
+
+	if edge.Op == intern.DirectedEdge_SET {
+		x.Checkf(err, "Schema is not present for predicate %s", edge.Attr)
+	}
 
 	if deletePredicateEdge(edge) {
 		return errors.New("We should never reach here")

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -184,6 +184,10 @@ func (s *scheduler) schedule(proposal *intern.Proposal, index uint64) (err error
 			posting.TxnMarks().Done(index)
 			return
 		}
+		// Dont derive schema when doing deletion.
+		if edge.Op == intern.DirectedEdge_DEL {
+			continue
+		}
 		if _, ok := schemaMap[edge.Attr]; !ok {
 			schemaMap[edge.Attr] = posting.TypeID(edge)
 		}


### PR DESCRIPTION
We were deriving schema even for delete mutations which lead to the issue mentioned in #1965. We don't do that anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/1976)
<!-- Reviewable:end -->
