### PR TITLE
bulk-loader cmd options to be --zero instead --zero_addr

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -73,7 +73,7 @@ func init() {
 			"must be less than or equal to the number of reduce shards.")
 	flag.Bool("version", false, "Prints the version of dgraph-bulk-loader.")
 	flag.BoolP("store_xids", "x", false, "Generate an xid edge for each node.")
-	flag.StringP("zero_addr", "z", "localhost:8888", "gRPC address for dgraphzero")
+	flag.StringP("zero", "z", "localhost:8888", "gRPC address for dgraphzero")
 	// TODO: Potentially move http server to main.
 	flag.String("http", "localhost:8080",
 		"Address to serve http (pprof).")
@@ -101,7 +101,7 @@ func run() {
 		NumShufflers:  Bulk.Conf.GetInt("shufflers"),
 		Version:       Bulk.Conf.GetBool("version"),
 		StoreXids:     Bulk.Conf.GetBool("store_xids"),
-		ZeroAddr:      Bulk.Conf.GetString("zero_addr"),
+		ZeroAddr:      Bulk.Conf.GetString("zero"),
 		HttpAddr:      Bulk.Conf.GetString("http"),
 		MapShards:     Bulk.Conf.GetInt("map_shards"),
 		ReduceShards:  Bulk.Conf.GetInt("reduce_shards"),

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1143,12 +1143,12 @@ distribute predicates between the reduce shards). For this example, you could us
 2 reduce shards and 4 map shards.
 
 {{% notice "note" %}}
-Ports in the example below may have to be adjusted depending on how other
-processes have been set up.
+Ports in the example below may have to be adjusted depending on how other processes have been set up.
+If you are using Dgraph v1.0.2 (and older) the option would be `--zero_addr` instead of `--zero`.
 {{% /notice %}}
 
 ```sh
-$ dgraph bulk -r goldendata.rdf.gz -s goldendata.schema --map_shards=4 --reduce_shards=2 --http localhost:8000 --zero_addr=localhost:7080
+$ dgraph bulk -r goldendata.rdf.gz -s goldendata.schema --map_shards=4 --reduce_shards=2 --http localhost:8000 --zero=localhost:7080
 {
 	"RDFDir": "goldendata.rdf.gz",
 	"SchemaFile": "goldendata.schema",


### PR DESCRIPTION
  Updated command option for bulk-loader to take zero address as --zero
  instead of --zero_addr. To be aligned with server & live-loader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2029)
<!-- Reviewable:end -->
