### PR TITLE
Fix for TestLoaderXidMap on OSX

### DIFF
--- a/systest/cluster_test.go
+++ b/systest/cluster_test.go
@@ -108,7 +108,7 @@ func TestClusterSnapshot(t *testing.T) {
 
 	dataFile, err := findFile(filepath.Join(dgraphDir, "export"), ".rdf.gz")
 	quickCheck(err)
-	cmd := fmt.Sprintf("zcat %s | wc -l", dataFile)
+	cmd := fmt.Sprintf("gunzip -c %s | wc -l", dataFile)
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	quickCheck(err)
 	if string(out) != "1120879\n" {
@@ -118,7 +118,7 @@ func TestClusterSnapshot(t *testing.T) {
 
 	schemaFile, err := findFile(filepath.Join(dgraphDir, "export"), ".schema.gz")
 	quickCheck(err)
-	cmd = fmt.Sprintf("zcat %s | wc -l", schemaFile)
+	cmd = fmt.Sprintf("gunzip -c %s | wc -l", schemaFile)
 	out, err = exec.Command("sh", "-c", cmd).Output()
 	quickCheck(err)
 	if string(out) != "10\n" {

--- a/systest/cluster_test.go
+++ b/systest/cluster_test.go
@@ -111,9 +111,10 @@ func TestClusterSnapshot(t *testing.T) {
 	cmd := fmt.Sprintf("gunzip -c %s | wc -l", dataFile)
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	quickCheck(err)
-	if string(out) != "1120879\n" {
+	count := strings.TrimSpace(string(out))
+	if count != "1120879" {
 		shutdownCluster()
-		t.Fatalf("Export count mismatch. Got: %s", string(out))
+		t.Fatalf("Export count mismatch. Got: %s", count)
 	}
 
 	schemaFile, err := findFile(filepath.Join(dgraphDir, "export"), ".schema.gz")
@@ -121,9 +122,10 @@ func TestClusterSnapshot(t *testing.T) {
 	cmd = fmt.Sprintf("gunzip -c %s | wc -l", schemaFile)
 	out, err = exec.Command("sh", "-c", cmd).Output()
 	quickCheck(err)
-	if string(out) != "10\n" {
+	count = strings.TrimSpace(string(out))
+	if count != "10" {
 		shutdownCluster()
-		t.Fatalf("Schema export count mismatch. Got: %s", string(out))
+		t.Fatalf("Schema export count mismatch. Got: %s", count)
 	}
 }
 

--- a/systest/loader_test.go
+++ b/systest/loader_test.go
@@ -81,7 +81,7 @@ func TestLoaderXidmap(t *testing.T) {
 		cluster.Close()
 		t.Fatalf("While trying to find exported file: %v", err)
 	}
-	cmd := fmt.Sprintf("zcat %s | sort", dataFile)
+	cmd := fmt.Sprintf("gunzip -c %s | sort", dataFile)
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	if err != nil {
 		cluster.Close()


### PR DESCRIPTION
   zcat on osx seems to add .Z when running in POSIX mode (refer man zcat).
   So changing the test to use `gunzip -c filename.gz`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2035)
<!-- Reviewable:end -->
