### PR TITLE
Add an endpoint in Zero to move a tablet to a group.

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -97,7 +97,8 @@ func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
 	}
 	if !isKnown {
 		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Group: [%d] is not a known group.", dstGroup))
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Group: [%d] is not a known group.",
+			dstGroup))
 		return
 	}
 

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -14,20 +14,27 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 )
 
+// intFromQueryParam checks for name as a query param, converts it to uint64 and returns it.
+// It also writes any errors to w. A bool is returned to indicate if the param was parsed
+// successfully.
 func intFromQueryParam(w http.ResponseWriter, r *http.Request, name string) (uint64, bool) {
 	str := r.URL.Query().Get(name)
 	if len(str) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
 		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("%s not passed", name))
 		return 0, false
 	}
 	val, err := strconv.ParseUint(str, 0, 64)
 	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
 		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Error while parsing %s", name))
 		return 0, false
 	}
 	return val, true
 }
 
+// removeNode can be used to remove a node from the cluster. It takes in the RAFT id of the node
+// and the group it belongs to. It can be used to remove Dgraph server and Zero nodes(group=0).
 func (st *state) removeNode(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
 	if r.Method == "OPTIONS" {
@@ -53,9 +60,10 @@ func (st *state) removeNode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Write([]byte(fmt.Sprintf("Removed node with group: %v, idx: %v", groupId, nodeId)))
-	return
 }
 
+// moveTablet can be used to move a tablet to a specific group. It takes in tablet and group as
+// argument.
 func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
 	if r.Method == "OPTIONS" {

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -1,0 +1,157 @@
+package zero
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/gogo/protobuf/jsonpb"
+)
+
+func intFromQueryParam(w http.ResponseWriter, r *http.Request, name string) (uint64, bool) {
+	str := r.URL.Query().Get(name)
+	if len(str) == 0 {
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("%s not passed", name))
+		return 0, false
+	}
+	val, err := strconv.ParseUint(str, 0, 64)
+	if err != nil {
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Error while parsing %s", name))
+		return 0, false
+	}
+	return val, true
+}
+
+func (st *state) removeNode(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
+	if r.Method == "OPTIONS" {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
+		return
+	}
+
+	nodeId, ok := intFromQueryParam(w, r, "id")
+	if !ok {
+		return
+	}
+	groupId, ok := intFromQueryParam(w, r, "group")
+	if !ok {
+		return
+	}
+
+	if err := st.zero.removeNode(context.Background(), nodeId, uint32(groupId)); err != nil {
+		x.SetStatus(w, x.Error, err.Error())
+		return
+	}
+	w.Write([]byte(fmt.Sprintf("Removed node with group: %v, idx: %v", groupId, nodeId)))
+	return
+}
+
+func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
+	if r.Method == "OPTIONS" {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
+		return
+	}
+
+	tablet := r.URL.Query().Get("tablet")
+	if len(tablet) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidRequest, "tablet is a mandatory query parameter")
+		return
+	}
+
+	groupId, ok := intFromQueryParam(w, r, "group")
+	if !ok {
+		return
+	}
+	dstGroup := uint32(groupId)
+	knownGroups := st.zero.KnownGroups()
+	var isKnown bool
+	for _, grp := range knownGroups {
+		if grp == dstGroup {
+			isKnown = true
+			break
+		}
+	}
+	if !isKnown {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Group: [%d] is not a known group.", dstGroup))
+		return
+	}
+
+	tab := st.zero.ServingTablet(tablet)
+	if tab == nil {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("No tablet found for: %s", tablet))
+		return
+	}
+
+	srcGroup := tab.GroupId
+	if srcGroup == dstGroup {
+		w.WriteHeader(http.StatusInternalServerError)
+		x.SetStatus(w, x.ErrorInvalidRequest,
+			fmt.Sprintf("Tablet: [%s] is already being served by group: [%d]", tablet, srcGroup))
+		return
+	}
+
+	if err := st.zero.movePredicate(tablet, srcGroup, dstGroup); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		x.SetStatus(w, x.Error, err.Error())
+		return
+	}
+
+	w.Write([]byte(fmt.Sprintf("Predicate: [%s] moved from group: [%d] to [%d]",
+		tablet, srcGroup, dstGroup)))
+}
+
+func (st *state) getState(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
+	w.Header().Set("Content-Type", "application/json")
+
+	mstate := st.zero.membershipState()
+	if mstate == nil {
+		x.SetStatus(w, x.ErrorNoData, "No membership state found.")
+		return
+	}
+
+	m := jsonpb.Marshaler{}
+	if err := m.Marshal(w, mstate); err != nil {
+		x.SetStatus(w, x.ErrorNoData, err.Error())
+		return
+	}
+}
+
+func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
+	srv := &http.Server{
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 600 * time.Second,
+		IdleTimeout:  2 * time.Minute,
+	}
+
+	go func() {
+		defer wg.Done()
+		err := srv.Serve(l)
+		log.Printf("Stopped taking more http(s) requests. Err: %s", err.Error())
+		ctx, cancel := context.WithTimeout(context.Background(), 630*time.Second)
+		defer cancel()
+		err = srv.Shutdown(ctx)
+		log.Printf("All http(s) requests finished.")
+		if err != nil {
+			log.Printf("Http(s) shutdown err: %v", err.Error())
+		}
+	}()
+}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -24,7 +24,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -38,7 +37,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/intern"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/gogo/protobuf/jsonpb"
 	"github.com/spf13/cobra"
 )
 
@@ -138,123 +136,6 @@ func (st *state) serveGRPC(l net.Listener, wg *sync.WaitGroup) {
 			s.Stop()
 		}
 	}()
-}
-
-func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
-	srv := &http.Server{
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 600 * time.Second,
-		IdleTimeout:  2 * time.Minute,
-	}
-
-	go func() {
-		defer wg.Done()
-		err := srv.Serve(l)
-		log.Printf("Stopped taking more http(s) requests. Err: %s", err.Error())
-		ctx, cancel := context.WithTimeout(context.Background(), 630*time.Second)
-		defer cancel()
-		err = srv.Shutdown(ctx)
-		log.Printf("All http(s) requests finished.")
-		if err != nil {
-			log.Printf("Http(s) shutdown err: %v", err.Error())
-		}
-	}()
-}
-
-func intFromQueryParam(w http.ResponseWriter, r *http.Request, name string) (uint64, bool) {
-	str := r.URL.Query().Get(name)
-	if len(str) == 0 {
-		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("%s not passed", name))
-		return 0, false
-	}
-	val, err := strconv.ParseUint(str, 0, 64)
-	if err != nil {
-		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("Error while parsing %s", name))
-		return 0, false
-	}
-	return val, true
-}
-
-func (st *state) removeNode(w http.ResponseWriter, r *http.Request) {
-	x.AddCorsHeaders(w)
-	if r.Method == "OPTIONS" {
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
-		return
-	}
-
-	nodeId, ok := intFromQueryParam(w, r, "id")
-	if !ok {
-		return
-	}
-	groupId, ok := intFromQueryParam(w, r, "group")
-	if !ok {
-		return
-	}
-
-	if err := st.zero.removeNode(context.Background(), nodeId, uint32(groupId)); err != nil {
-		x.SetStatus(w, x.Error, err.Error())
-		return
-	}
-	w.Write([]byte(fmt.Sprintf("Removed node with group: %v, idx: %v", groupId, nodeId)))
-	return
-}
-
-func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
-	x.AddCorsHeaders(w)
-	if r.Method == "OPTIONS" {
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
-		return
-	}
-
-	tablet := r.URL.Query().Get("tablet")
-	if len(tablet) == 0 {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidRequest, "tablet is a mandatory query parameter")
-		return
-	}
-
-	groupId, ok := intFromQueryParam(w, r, "group")
-	if !ok {
-		return
-	}
-	dstGroup := uint32(groupId)
-
-	tab := st.zero.ServingTablet(tablet)
-	if tab == nil {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf("No tablet found for: %s", tablet))
-		return
-	}
-
-	srcGroup := tab.GroupId
-	// TODO - Validate dstGroup
-	cancel := st.zero.movePredicate(tablet, srcGroup, dstGroup)
-	cancel()
-}
-
-func (st *state) getState(w http.ResponseWriter, r *http.Request) {
-	x.AddCorsHeaders(w)
-	w.Header().Set("Content-Type", "application/json")
-
-	mstate := st.zero.membershipState()
-	if mstate == nil {
-		x.SetStatus(w, x.ErrorNoData, "No membership state found.")
-		return
-	}
-
-	m := jsonpb.Marshaler{}
-	if err := m.Marshal(w, mstate); err != nil {
-		x.SetStatus(w, x.ErrorNoData, err.Error())
-		return
-	}
 }
 
 func run() {

--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -84,16 +84,21 @@ func (s *Server) rebalanceTablets() {
 			if len(predicate) == 0 {
 				break
 			}
-			x.Printf("Going to move predicate %v from %d to %d\n", predicate, srcGroup, dstGroup)
-			var ctx context.Context
-			ctx, cancel = context.WithTimeout(context.Background(), time.Minute*20)
-			if err := s.moveTablet(ctx, predicate, srcGroup, dstGroup); err != nil {
-				x.Printf("Error while trying to move predicate %v from %d to %d: %v\n",
-					predicate, srcGroup, dstGroup, err)
-			}
+			cancel = s.movePredicate(predicate, srcGroup, dstGroup)
 			cancel = nil
 		}
 	}
+}
+
+func (s *Server) movePredicate(predicate string, srcGroup, dstGroup uint32) context.CancelFunc {
+	x.Printf("Going to move predicate %v from %d to %d\n", predicate, srcGroup, dstGroup)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*20)
+	if err := s.moveTablet(ctx, predicate, srcGroup, dstGroup); err != nil {
+		x.Printf("Error while trying to move predicate %v from %d to %d: %v\n",
+			predicate, srcGroup, dstGroup, err)
+	}
+
+	return cancel
 }
 
 func (s *Server) runRecovery() {

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -221,13 +221,14 @@ func (s *Server) removeZero(nodeId uint64) {
 	s.state.Removed = append(s.state.Removed, m)
 }
 
-func (s *Server) ServingTablet(dst string) *intern.Tablet {
+// ServingTablet returns the Tablet called tablet.
+func (s *Server) ServingTablet(tablet string) *intern.Tablet {
 	s.RLock()
 	defer s.RUnlock()
 
 	for _, group := range s.state.Groups {
 		for key, tab := range group.Tablets {
-			if key == dst {
+			if key == tablet {
 				return tab
 			}
 		}
@@ -235,12 +236,12 @@ func (s *Server) ServingTablet(dst string) *intern.Tablet {
 	return nil
 }
 
-func (s *Server) servingTablet(dst string) *intern.Tablet {
+func (s *Server) servingTablet(tablet string) *intern.Tablet {
 	s.AssertRLock()
 
 	for _, group := range s.state.Groups {
 		for key, tab := range group.Tablets {
-			if key == dst {
+			if key == tablet {
 				return tab
 			}
 		}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -422,7 +422,7 @@ func (g *groupi) triggerMembershipSync() {
 }
 
 func (g *groupi) periodicMembershipUpdate() {
-	ticker := time.NewTicker(time.Minute * 1)
+	ticker := time.NewTicker(time.Minute * 5)
 	// Node might not be the leader when we are calculating size.
 	// We need to send immediately on start so no leader check inside calculatesize.
 	tablets := g.calculateTabletSizes()

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -422,6 +422,7 @@ func (g *groupi) triggerMembershipSync() {
 }
 
 func (g *groupi) periodicMembershipUpdate() {
+	// Calculating tablet sizes is expensive, hence we do it only every 5 mins.
 	ticker := time.NewTicker(time.Minute * 5)
 	// Node might not be the leader when we are calculating size.
 	// We need to send immediately on start so no leader check inside calculatesize.

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -422,7 +422,7 @@ func (g *groupi) triggerMembershipSync() {
 }
 
 func (g *groupi) periodicMembershipUpdate() {
-	ticker := time.NewTicker(time.Minute * 5)
+	ticker := time.NewTicker(time.Minute * 1)
 	// Node might not be the leader when we are calculating size.
 	// We need to send immediately on start so no leader check inside calculatesize.
 	tablets := g.calculateTabletSizes()


### PR DESCRIPTION
1. Refactored code and moved http handlers to `http.go`.

2. Added a `/moveTablet?tablet=<tablet>&group=<gid>` http endpoint.

3. Refactored some code around context cancellation in case of leadership change. The current code looked like it won't work. 

4. Changed the `membershipUpdate` interval to `time.Minute`. 

---
TODO 
- [x] Test whether predicate move is cancelled properly by simulating a leadership change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2093)
<!-- Reviewable:end -->
