### PR TITLE
Load schema after proposing kvs

### DIFF
--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -177,7 +177,6 @@ func batchAndProposeKeyValues(ctx context.Context, kvs chan *intern.KV) error {
 	proposal := &intern.Proposal{}
 	size := 0
 	firstKV := true
-	var predicate string
 
 	for kv := range kvs {
 		if size >= 32<<20 { // 32 MB
@@ -191,7 +190,6 @@ func batchAndProposeKeyValues(ctx context.Context, kvs chan *intern.KV) error {
 		if firstKV {
 			firstKV = false
 			pk := x.Parse(kv.Key)
-			predicate = pk.Attr
 			// Delete on all nodes.
 			p := &intern.Proposal{CleanPredicate: pk.Attr}
 			err := groups().Node.ProposeAndWait(ctx, p)
@@ -208,7 +206,7 @@ func batchAndProposeKeyValues(ctx context.Context, kvs chan *intern.KV) error {
 			return err
 		}
 	}
-	return
+	return nil
 }
 
 // Returns count which can be used to verify whether we have moved all keys


### PR DESCRIPTION
After a predicate move was done, we were loading schema for the predicate only on the leader which proposed the kvs. Changed it so that we load schema after writing kvs to db so that its loaded on all instances in the group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2096)
<!-- Reviewable:end -->
