### PR TITLE
Get updated lease from Zero if uid > maxLeaseId

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -226,7 +226,7 @@ func (s *Server) moveTablet(ctx context.Context, predicate string, srcGroup uint
 		Force:     true,
 	}
 	if err := s.Node.proposeAndWait(context.Background(), p); err != nil {
-		x.Printf("Error while reverting group %d to RW", srcGroup)
+		x.Printf("Error while reverting group %d to RW: %+v\n", srcGroup, err)
 	}
 	return err
 }

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"golang.org/x/net/trace"
 
@@ -89,19 +88,18 @@ func expandEdges(ctx context.Context, m *intern.Mutations) ([]*intern.DirectedEd
 }
 
 func verifyUid(uid uint64) error {
-	var lease uint64
-	// Stream can wait upto 1 second waiting for read index, so we wait for around
-	// 2 seconds.
-	for wait := 16 * time.Millisecond; wait <= 1024*time.Millisecond; wait *= 2 {
-		// Wait for membership state to catch up before declaring that the uid
-		// is definitely greater than the lease.
-		lease = worker.MaxLeaseId()
-		if uid <= lease {
-			return nil
-		}
-		time.Sleep(wait)
+	if uid <= worker.MaxLeaseId() {
+		return nil
 	}
-	return fmt.Errorf("Uid: [%d] cannot be greater than lease: [%d]", uid, lease)
+	// Even though the uid is above the max lease id, it might just be because
+	// the membership state has fallen behind. Update the state and try again.
+	if err := worker.UpdateMembershipState(ctx); err != nil {
+		return x.Wrapf(err, "updating error state")
+	}
+	if lease := worker.MaxLeaseId(); uid > lease {
+		return fmt.Errorf("Uid: [%d] cannot be greater than lease: [%d]", uid, lease)
+	}
+	return nil
 }
 
 func AssignUids(ctx context.Context, nquads []*api.NQuad) (map[string]uint64, error) {

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -87,7 +87,7 @@ func expandEdges(ctx context.Context, m *intern.Mutations) ([]*intern.DirectedEd
 	return edges, nil
 }
 
-func verifyUid(uid uint64) error {
+func verifyUid(ctx context.Context, uid uint64) error {
 	if uid <= worker.MaxLeaseId() {
 		return nil
 	}
@@ -121,7 +121,7 @@ func AssignUids(ctx context.Context, nquads []*api.NQuad) (map[string]uint64, er
 		} else if uid, err = gql.ParseUid(nq.Subject); err != nil {
 			return newUids, err
 		}
-		if err = verifyUid(uid); err != nil {
+		if err = verifyUid(ctx, uid); err != nil {
 			return newUids, err
 		}
 
@@ -132,7 +132,7 @@ func AssignUids(ctx context.Context, nquads []*api.NQuad) (map[string]uint64, er
 			} else if uid, err = gql.ParseUid(nq.ObjectId); err != nil {
 				return newUids, err
 			}
-			if err = verifyUid(uid); err != nil {
+			if err = verifyUid(ctx, uid); err != nil {
 				return newUids, err
 			}
 		}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -212,6 +212,22 @@ func MaxLeaseId() uint64 {
 	return g.state.MaxLeaseId
 }
 
+func UpdateMembershipState(ctx context.Context) error {
+	g := groups()
+	p := g.AnyServer(0)
+	if p == nil {
+		return x.Errorf("don't have the address of any dgraphzero server")
+	}
+
+	c := intern.NewZeroClient(p.Get())
+	state, err := c.Connect(ctx, &intern.Member{ClusterInfoOnly: true})
+	if err != nil {
+		return err
+	}
+	g.applyState(state.GetState())
+	return nil
+}
+
 func (g *groupi) applyState(state *intern.MembershipState) {
 	x.AssertTrue(state != nil)
 	g.Lock()

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -214,7 +214,7 @@ func MaxLeaseId() uint64 {
 
 func UpdateMembershipState(ctx context.Context) error {
 	g := groups()
-	p := g.AnyServer(0)
+	p := g.Leader(0)
 	if p == nil {
 		return x.Errorf("don't have the address of any dgraphzero server")
 	}


### PR DESCRIPTION
We have had users complain that they get error uid > lease even when uid was returned by us. This can happen when there is some latency between Zero and Server. Users have to retry their mutation in this case which is worse than use making another RPC call to verify our state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2128)
<!-- Reviewable:end -->
