### PR TITLE
Fix for 2137 and 2138

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -106,7 +106,7 @@ func StartRaftNodes(walStore *badger.ManagedDB, bindall bool) {
 	if connState.GetMember() == nil || connState.GetState() == nil {
 		x.Fatalf("Unable to join cluster via dgraphzero")
 	}
-	x.Printf("Connected to group zero. Connection state: %+v\n", connState)
+	x.Printf("Connected to group zero. Assigned group: %+v\n", connState.GetMember().GetGroupId())
 	Config.RaftId = connState.GetMember().GetId()
 	gr.applyState(connState.GetState())
 
@@ -418,9 +418,7 @@ func (g *groupi) Leader(gid uint32) *conn.Pool {
 			}
 		}
 	}
-	// Unable to find a healthy connection to leader. Get connection to any other server in the
-	// group.
-	return g.AnyServer(gid)
+	return nil
 }
 
 func (g *groupi) KnownGroups() (gids []uint32) {


### PR DESCRIPTION
#2137 was caused because retrieveSnapshot happens in a blocking fashion, and say when it is called the first time we don't have leader information, then because membership update doesn't happen we never get the leader.

#2138 happens because we might receive a request even before a node is initialized and even if we are not the leader. Now `Leader()` only returns leader for a group, so if we can't find one we will update state and retry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2140)
<!-- Reviewable:end -->
