### PR TITLE
Removed external id ref from mutation docs and fixed getting started guide

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -115,9 +115,6 @@ volumes:
   dgraph:
 ```
 
-{{% notice "note" %}}You should change `/tmp/data` to the path of the folder where you want your data to
-be persisted.{{% /notice %}}
-
 Save the contents of the snippet above in a file called `docker-compose.yml`, then run the following
 command from the folder containing the file.
 ```

--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -33,7 +33,7 @@ Represents that graph node with ID `0x01` has a `name` with string value `"Alice
 ```
 Represents that graph node with ID `0x01` is linked with the `friend` edge to node `0x02`.
 
-Dgraph creates a unique 64 bit identifier for every node in the graph - the node's UID.  A mutation either lets Dgraph create the UID as the identifier for the subject or object, using blank or external id nodes, or specifies a known UID from a previous mutation..
+Dgraph creates a unique 64 bit identifier for every blank node in the mutation - the node's UID.  A mutation can include a blank node as an identifier for the subject or object, or a known UID from a previous mutation.
 
 
 ## Blank Nodes and UID


### PR DESCRIPTION
* ExternalId is no longer supported, so removed its ref from mutation docs
* Getting started guide uses docker volumes, so the note showing /tmp/data is unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2150)
<!-- Reviewable:end -->
