### PR TITLE
Make a bunch of changes to abort pending transactions so that snapshot happens more frequently..

### DIFF
--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -63,7 +63,7 @@ var DefaultConfig = Options{
 	Tracing:             0.0,
 	MyAddr:              "",
 	ZeroAddr:            fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
-	MaxPendingCount:     1000,
+	MaxPendingCount:     100,
 	ExpandEdge:          true,
 
 	DebugMode: false,


### PR DESCRIPTION
1. Try snapshotting every 100 entries.
2. If `lastApplied - txnWatermark > 10000`, try aborting older transactions. This gives us an estimate of the number of entries in WAL. Ideally, this should be done based on size of in-memory WAL but the interface doesn't provide any such function. This would still mean that if they are doing batch mutations then this condition would not trigger until very late.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2153)
<!-- Reviewable:end -->
