### PR TITLE
Improvements in loader

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -113,6 +113,10 @@ func (n *node) sendReadIndex(ri, id uint64) {
 var errReadIndex = x.Errorf("cannot get linerized read (time expired or no configured leader)")
 
 func (n *node) WaitLinearizableRead(ctx context.Context) error {
+	// This is possible if say Zero was restarted and Server tries to connect over stream.
+	if n.Raft() == nil {
+		return errReadIndex
+	}
 	// Read Request can get rejected then we would wait idefinitely on the channel
 	// so have a timeout of 1 second.
 	ctx, cancel := context.WithTimeout(ctx, time.Second)

--- a/systest/loader_test.go
+++ b/systest/loader_test.go
@@ -26,6 +26,7 @@ func TestLoaderXidmap(t *testing.T) {
 		"--rdfs", data,
 		"--dgraph", ":"+cluster.dgraphPort,
 		"--zero", ":"+cluster.zeroPort,
+		"-x", "x",
 	)
 	liveCmd.Dir = tmpDir
 	liveCmd.Stdout = os.Stdout
@@ -41,6 +42,7 @@ func TestLoaderXidmap(t *testing.T) {
 		"--rdfs", data,
 		"--dgraph", ":"+cluster.dgraphPort,
 		"--zero", ":"+cluster.zeroPort,
+		"-x", "x",
 	)
 	liveCmd.Dir = tmpDir
 	liveCmd.Stdout = os.Stdout

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1172,10 +1172,9 @@ this](https://www.w3.org/TR/n-quads/).{{% /notice %}}
 
 The `dgraph live` binary is a small helper program which reads RDF NQuads from a gzipped file, batches them up, creates mutations (using the go client) and shoots off to Dgraph.
 
-Live loader correctly handles assigning unique IDs to blank nodes across multiple files, and persists them to disk to save memory and in case the loader was re-run.
+Live loader correctly handles assigning unique IDs to blank nodes across multiple files, and can optionally persist them to disk to save memory, in case the loader was re-run.
 
-
-{{% notice "note" %}} Live loader writes the xid->uid mapping in the `x` directory, which can reused
+{{% notice "note" %}} Live loader can optionally write the xid->uid mapping to a directory specified using the `-x` flag, which can reused
 given that live loader completed successfully in the previous run.{{% /notice %}}
 
 ```sh

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -47,7 +47,7 @@ type proposalCtx struct {
 	// Since each proposal consists of multiple tasks we need to store
 	// non-nil error returned by task
 	err   error
-	index uint64
+	index uint64 // RAFT index for the proposal.
 	// Used for writing all deltas at end
 	txn *posting.Txn
 }


### PR DESCRIPTION
1. Only persist `xid` directory if the user explicitly specifies it using the flag. Many times users are just playing around with Dgraph and are not able reload their data even after clearing out `p` and `w` directories because of the uid < lease check.

2. Print counters after schema has been updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2165)
<!-- Reviewable:end -->
