### PR TITLE
Trim null character at end while doing exports

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -156,7 +156,7 @@ func (s *Server) chooseTablet() (predicate string, srcGroup uint32, dstGroup uin
 	// Sort all groups by their sizes.
 	type kv struct {
 		gid  uint32
-		size int64
+		size int64 // in bytes
 	}
 	var groups []kv
 	for k, v := range s.state.Groups {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -577,7 +577,8 @@ func handleBasicType(k string, v interface{}, op int, nq *api.NQuad) error {
 			return nil
 		}
 
-		nq.ObjectValue = &api.Value{&api.Value_StrVal{v.(string)}}
+		// We trim null character from null terminated strings.
+		nq.ObjectValue = &api.Value{&api.Value_StrVal{strings.TrimRight(v.(string), "\x00")}}
 	case float64:
 		if v == 0 && op == delete {
 			nq.ObjectValue = &api.Value{&api.Value_DefaultVal{x.Star}}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -577,8 +577,7 @@ func handleBasicType(k string, v interface{}, op int, nq *api.NQuad) error {
 			return nil
 		}
 
-		// We trim null character from null terminated strings.
-		nq.ObjectValue = &api.Value{&api.Value_StrVal{strings.TrimRight(v.(string), "\x00")}}
+		nq.ObjectValue = &api.Value{&api.Value_StrVal{v.(string)}}
 	case float64:
 		if v == 0 && op == delete {
 			nq.ObjectValue = &api.Value{&api.Value_DefaultVal{x.Star}}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -826,7 +826,7 @@ func nquadsFromJson(b []byte, op int) ([]*api.NQuad, error) {
 	return mr.nquads, err
 }
 
-func parseNQuads(b []byte, op int) ([]*api.NQuad, error) {
+func parseNQuads(b []byte) ([]*api.NQuad, error) {
 	var nqs []*api.NQuad
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
 		line = bytes.TrimSpace(line)
@@ -859,14 +859,14 @@ func parseMutationObject(mu *api.Mutation) (*gql.Mutation, error) {
 		res.Del = append(res.Del, nqs...)
 	}
 	if len(mu.SetNquads) > 0 {
-		nqs, err := parseNQuads(mu.SetNquads, set)
+		nqs, err := parseNQuads(mu.SetNquads)
 		if err != nil {
 			return nil, err
 		}
 		res.Set = append(res.Set, nqs...)
 	}
 	if len(mu.DelNquads) > 0 {
-		nqs, err := parseNQuads(mu.DelNquads, delete)
+		nqs, err := parseNQuads(mu.DelNquads)
 		if err != nil {
 			return nil, err
 		}

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -149,7 +149,7 @@ func TestNquadsFromJson3(t *testing.T) {
 }
 
 func TestNquadsFromJson4(t *testing.T) {
-	json := `[{"name":"Alice\u0000","mobile":"040123456","car":"MA0123"}]`
+	json := `[{"name":"Alice","mobile":"040123456","car":"MA0123"}]`
 
 	nq, err := nquadsFromJson([]byte(json), set)
 	require.NoError(t, err)

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -149,7 +149,7 @@ func TestNquadsFromJson3(t *testing.T) {
 }
 
 func TestNquadsFromJson4(t *testing.T) {
-	json := `[{"name":"Alice","mobile":"040123456","car":"MA0123"}]`
+	json := `[{"name":"Alice\u0000","mobile":"040123456","car":"MA0123"}]`
 
 	nq, err := nquadsFromJson([]byte(json), set)
 	require.NoError(t, err)

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -268,7 +268,7 @@ func TestParseNQuads(t *testing.T) {
 		# this line is a comment
 		_:a <join> _:b .
 	`
-	nqs, err := parseNQuads([]byte(nquads), set)
+	nqs, err := parseNQuads([]byte(nquads))
 	require.NoError(t, err)
 	require.Equal(t, []*api.NQuad{
 		makeNquad("_:a", "predA", &api.Value{&api.Value_DefaultVal{"A"}}),
@@ -279,7 +279,7 @@ func TestParseNQuads(t *testing.T) {
 
 func TestParseNQuadsWindowsNewline(t *testing.T) {
 	nquads := "_:a <predA> \"A\" .\r\n_:b <predB> \"B\" ."
-	nqs, err := parseNQuads([]byte(nquads), set)
+	nqs, err := parseNQuads([]byte(nquads))
 	require.NoError(t, err)
 	require.Equal(t, []*api.NQuad{
 		makeNquad("_:a", "predA", &api.Value{&api.Value_DefaultVal{"A"}}),
@@ -289,7 +289,7 @@ func TestParseNQuadsWindowsNewline(t *testing.T) {
 
 func TestParseNQuadsDelete(t *testing.T) {
 	nquads := `_:a * * .`
-	nqs, err := parseNQuads([]byte(nquads), delete)
+	nqs, err := parseNQuads([]byte(nquads))
 	require.NoError(t, err)
 	require.Equal(t, []*api.NQuad{
 		makeNquad("_:a", x.Star, &api.Value{&api.Value_DefaultVal{x.Star}}),

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -104,8 +104,6 @@ L:
 			if err != nil {
 				return rnq, x.Wrapf(err, "while unquoting")
 			}
-			// trim null character
-			oval = strings.TrimRight(oval, "\x00")
 			seenOval = true
 
 		case itemLanguage:

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -104,6 +104,8 @@ L:
 			if err != nil {
 				return rnq, x.Wrapf(err, "while unquoting")
 			}
+			// trim null character
+			oval = strings.TrimRight(oval, "\x00")
 			seenOval = true
 
 		case itemLanguage:

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -18,10 +18,7 @@
 package rdf
 
 import (
-	"bufio"
-	"bytes"
 	"errors"
-	"io"
 	"strconv"
 	"strings"
 	"unicode"
@@ -196,41 +193,6 @@ L:
 	}
 
 	return rnq, nil
-}
-
-// ConvertToNQuads parses multi line mutation string to a list of NQuads.
-func ConvertToNQuads(mutation string) ([]*api.NQuad, error) {
-	var nquads []*api.NQuad
-	r := strings.NewReader(mutation)
-	reader := bufio.NewReader(r)
-
-	var strBuf bytes.Buffer
-	var err error
-	for {
-		err = x.ReadLine(reader, &strBuf)
-		if err != nil {
-			break
-		}
-		ln := strings.Trim(strBuf.String(), " \t")
-		if len(ln) == 0 {
-			continue
-		}
-		nq, err := Parse(ln)
-		if len(nq.Predicate) > 0 && nq.Predicate[0] == '_' &&
-			nq.Predicate[len(nq.Predicate)-1] == '_' {
-			return nil, x.Errorf("Predicates starting and ending with _ are reserved intern.y.")
-		}
-		if err == ErrEmpty { // special case: comment/empty line
-			continue
-		} else if err != nil {
-			return nquads, x.Wrapf(err, "While parsing RDF: %s", strBuf.String())
-		}
-		nquads = append(nquads, &nq)
-	}
-	if err != io.EOF {
-		return nquads, err
-	}
-	return nquads, nil
 }
 
 func parseFacets(it *lex.ItemIterator, rnq *api.NQuad) error {

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -808,15 +808,6 @@ var testNQuads = []struct {
 		},
 	},
 	{
-		// null character at end should be trimmed.
-		input: `<alice> <lives> "A\tB\u0000" .`,
-		nq: api.NQuad{
-			Subject:     "alice",
-			Predicate:   "lives",
-			ObjectValue: &api.Value{&api.Value_DefaultVal{"A\tB"}},
-		},
-	},
-	{
 		input:       `<alice> <age> "NaN"^^<xs:double> .`,
 		expectedErr: true,
 	},

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -808,6 +808,15 @@ var testNQuads = []struct {
 		},
 	},
 	{
+		// null character at end should be trimmed.
+		input: `<alice> <lives> "A\tB\u0000" .`,
+		nq: api.NQuad{
+			Subject:     "alice",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{&api.Value_DefaultVal{"A\tB"}},
+		},
+	},
+	{
 		input:       `<alice> <age> "NaN"^^<xs:double> .`,
 		expectedErr: true,
 	},

--- a/worker/export.go
+++ b/worker/export.go
@@ -80,7 +80,10 @@ func toRDF(buf *bytes.Buffer, item kv, readTs uint64) {
 			src.Value = p.Value
 			str, err := types.Convert(src, types.StringID)
 			x.Check(err)
-			buf.WriteString(strconv.Quote(str.Value.(string)))
+
+			// trim null character at end
+			trimmed := strings.TrimRight(str.Value.(string), "\x00")
+			buf.WriteString(strconv.Quote(trimmed))
 			if p.PostingType == intern.Posting_VALUE_LANG {
 				buf.WriteByte('@')
 				buf.WriteString(string(p.LangTag))

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -48,7 +48,7 @@ func populateGraphExport(t *testing.T) {
 		`<3> <friend> <5> .`,
 		`<4> <friend> <5> <author0> (since=2005-05-02T15:04:05,close=true,` +
 			`age=33,game="football",poem="roses are red\nviolets are blue") .`,
-		`<1> <name> "pho\ton" <author0> .`,
+		`<1> <name> "pho\ton\u0000" <author0> .`,
 		`<2> <name> "pho\ton"@en <author0> .`,
 		`<3> <name> "First Line\nSecondLine" .`,
 		"<1> <friend_not_served> <5> <author0> .",


### PR DESCRIPTION
This fixes part of #2167. While exporting we trim the null character from the end of the string as it can cause issues while importing. 

I considered trimming it while importing data into Dgraph but that has to be done at 3 different places(RDF, JSON and NQuads from the client).

Also removed an unused function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2173)
<!-- Reviewable:end -->
