### PR TITLE
Fix a small bug with respect to expand edges.

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -267,6 +267,7 @@ func (ld *loader) mapStage() {
 	for i := range ld.mappers {
 		ld.mappers[i] = nil
 	}
+	ld.xids.EvictAll()
 	x.Check(ld.xidDB.Close())
 	ld.xids = nil
 	runtime.GC()

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -75,6 +75,12 @@ func expandEdges(ctx context.Context, m *intern.Mutations) ([]*intern.DirectedEd
 			edgeCopy.Attr = pred
 			edges = append(edges, &edgeCopy)
 
+			// We only want to delete the pred from <uid> + <_predicate_> posting list if this is
+			// a SP* deletion operation. Otherwise we just continue.
+			if edge.Op == intern.DirectedEdge_DEL && string(edge.Value) != x.Star {
+				continue
+			}
+
 			e := &intern.DirectedEdge{
 				Op:     edge.Op,
 				Entity: edge.GetEntity(),


### PR DESCRIPTION
We were deleting `pred` from `<uid> + <_predicate_>` posting lists even for `S P O` deletions which caused `expand(_all_)` queries to return incorrect results. This fixes #2193.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2195)
<!-- Reviewable:end -->
