### PR TITLE
Rename `SafeLock` to `SafeMutex` in comment in `x/lock.go`.

### DIFF
--- a/x/lock.go
+++ b/x/lock.go
@@ -21,7 +21,7 @@ import (
 	"sync/atomic"
 )
 
-// SafeLock can be used in place of sync.RWMutex
+// SafeMutex can be used in place of sync.RWMutex
 type SafeMutex struct {
 	m       sync.RWMutex
 	wait    *SafeWait


### PR DESCRIPTION
I was reading through the mutual exclusion code and came across a minor naming discrepancy in `x/lock.go`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2230)
<!-- Reviewable:end -->
