### PR TITLE
Throw error instead of asserting in query

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -1258,8 +1258,10 @@ func (w *grpcWorker) ServeTask(ctx context.Context, q *intern.Query) (*intern.Re
 		tr.LazyPrintf("Attribute: %q NumUids: %v groupId: %v ServeTask", q.Attr, numUids, gid)
 	}
 
-	x.AssertTruef(groups().ServesGroup(gid),
-		"attr: %q groupId: %v Request sent to wrong server.", q.Attr, gid)
+	if !groups().ServesGroup(gid) {
+		return nil, fmt.Errorf("Temporary error, attr: %q groupId: %v Request sent to wrong server",
+			q.Attr, gid)
+	}
 
 	type reply struct {
 		result *intern.Result

--- a/worker/task.go
+++ b/worker/task.go
@@ -1259,6 +1259,7 @@ func (w *grpcWorker) ServeTask(ctx context.Context, q *intern.Query) (*intern.Re
 	}
 
 	if !groups().ServesGroup(gid) {
+		// TODO(pawan) - Log this when we have debug logs.
 		return nil, fmt.Errorf("Temporary error, attr: %q groupId: %v Request sent to wrong server",
 			q.Attr, gid)
 	}


### PR DESCRIPTION
Fixes #2227.

It's a simple change but opening a PR to mention the two cases where I think this could happen.

1. It can happen during predicate move where when the request is received by a server it is no longer serving the predicate.
2. It can also happen when we `Remove` a tablet if there isn't any data for it.

Essentially, whenever a tablet changes groups, this temporary error can happen. When we have debug logs, we could log this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2243)
<!-- Reviewable:end -->
