### PR TITLE
Remove timeout from JoinCluster.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -714,11 +714,7 @@ func (n *node) joinPeers() error {
 	gconn := pl.Get()
 	c := intern.NewRaftClient(gconn)
 	x.Printf("Calling JoinCluster")
-	ctx, cancel := context.WithTimeout(n.ctx, time.Second)
-	defer cancel()
-	// JoinCluster can block indefinitely, raft ignores conf change proposal
-	// if it has pending configuration.
-	if _, err := c.JoinCluster(ctx, n.RaftContext); err != nil {
+	if _, err := c.JoinCluster(n.ctx, n.RaftContext); err != nil {
 		return x.Errorf("Error while joining cluster: %+v\n", err)
 	}
 	x.Printf("Done with JoinCluster call\n")


### PR DESCRIPTION
I couldn't find any issues about RAFT dropping pending conf change entries and therefore I feel this timeout is unnecessary. 

What does happen is that all entries that were proposed need to be applied, even if with [id as `Raft.None`](https://github.com/coreos/etcd/blob/c8cfdb3b558f758367b8f0c4566fce88b56c9aec/etcdserver/server.go#L1499).  So that might have been happening earlier, we could have been returning an error from applyConfChange without applying the pending entry, hence further proposals would be dropped. We don't do that now, so we don't need the timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2251)
<!-- Reviewable:end -->