### PR TITLE
Don't skip schema keys while calculating tablets served.

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -329,6 +329,7 @@ func (n *node) applyProposal(e raftpb.Entry) (uint32, error) {
 		}
 		group := state.Groups[p.Tablet.GroupId]
 		if p.Tablet.Remove {
+			x.Printf("Removing tablet for attr: [%v], gid: [%v]\n", p.Tablet.Predicate, p.Tablet.GroupId)
 			if group != nil {
 				delete(group.Tablets, p.Tablet.Predicate)
 			}


### PR DESCRIPTION
As we were not adding predicates for which we only had a schema to the tablets map, periodicMembershipUpdate ended up removing them from the tablets map. Now some other node with another group could end up serving them and we would lose the schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2258)
<!-- Reviewable:end -->
