### PR TITLE
Fixing some spelling mistakes in the docs (v1.0.3)

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -196,7 +196,7 @@ returns an error in case the transaction could not be committed.
 
 ### Complete Example
 
-This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgraph/client). It shows how to to create a Node with name Alice, while also creating his relationships with other nodes. Note `loc` predicate is of type `geo` and can be easily marshalled and unmarshalled into a Go struct. More such examples are present as part of the GoDoc.
+This is an example from the [GoDoc](https://godoc.org/github.com/dgraph-io/dgraph/client). It shows how to to create a Node with name Alice, while also creating her relationships with other nodes. Note `loc` predicate is of type `geo` and can be easily marshalled and unmarshalled into a Go struct. More such examples are present as part of the GoDoc.
 
 ```go
 type School struct {
@@ -346,7 +346,7 @@ working example of how to use the Java client.
 
 ## Javascript
 
-The offical Javascipt client [can be found here](https://github.com/dgraph-io/dgraph-js)
+The official Javascript client [can be found here](https://github.com/dgraph-io/dgraph-js)
 and it fully supports Dgraph v0.9.4. Follow the instructions in the
 [README](https://github.com/dgraph-io/dgraph-js#readme) to get it up and running.
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -291,11 +291,11 @@ docker run -it -p 5080:5080 -p 6080:6080 -v ~/zero:/dgraph dgraph/dgraph:latest 
 
 **Run dgraph server**
 ```sh
-mkdir ~/sever1 # Or any other directory where data should be stored.
+mkdir ~/server1 # Or any other directory where data should be stored.
 
 docker run -it -p 7080:7080 -p 8080:8080 -p 9080:9080 -v ~/server1:/dgraph dgraph/dgraph:latest dgraph server --memory_mb=<typically half the RAM> --zero=HOSTIPADDR:5080 --my=HOSTIPADDR:7080
 
-mkdir ~/sever2 # Or any other directory where data should be stored.
+mkdir ~/server2 # Or any other directory where data should be stored.
 
 docker run -it -p 7081:7081 -p 8081:8081 -p 9081:9081 -v ~/server2:/dgraph dgraph/dgraph:latest dgraph server --memory_mb=<typically half the RAM> --zero=HOSTIPADDR:5080 --my=HOSTIPADDR:7081  -o=1
 ```
@@ -321,7 +321,7 @@ Instructions for running with TLS refer [TLS instructions](#tls-configuration).{
 
 Here we'll go through an example of deploying Dgraph zero, server and ratel on an AWS instance.
 
-* Make sure you have Docker Machine installed by following [instructions](https://docs.docker.com/machine/install-machine/), provisioning an instance on AWS is just one step away. You'll have to [configure your AWS credentials](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html) for programatic access to the Amazon API.
+* Make sure you have Docker Machine installed by following [instructions](https://docs.docker.com/machine/install-machine/), provisioning an instance on AWS is just one step away. You'll have to [configure your AWS credentials](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/setup-credentials.html) for programmatic access to the Amazon API.
 
 * Create a new docker machine.
 
@@ -1029,7 +1029,7 @@ statefulset "dgraph-server" created
 deployment "dgraph-ratel" created
 ```
 
-After this you can follow other steps from [Relicated Cluster]({{< relref "#replicated-cluster">}}) to verify
+After this you can follow other steps from [Replicated Cluster]({{< relref "#replicated-cluster">}}) to verify
 that your setup is working as expected.
 
 ## More about Dgraph


### PR DESCRIPTION
Just realized that the spelling mistakes I found in the docs need to be merged in releases also. So creating PRs for v1.0.4 and v1.0.3.