### PR TITLE
Use context with timeout while proposing to RAFT.

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -202,8 +202,10 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.ZeroProposal
 		return err
 	}
 
+	cctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
 	// Propose the change.
-	if err := n.Raft().Propose(ctx, data); err != nil {
+	if err := n.Raft().Propose(cctx, data); err != nil {
 		return x.Wrapf(err, "While proposing")
 	}
 
@@ -211,8 +213,8 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.ZeroProposal
 	select {
 	case err := <-che:
 		return err
-	case <-ctx.Done():
-		return ctx.Err()
+	case <-cctx.Done():
+		return cctx.Err()
 	}
 }
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -293,8 +293,12 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.Proposal) er
 		return err
 	}
 
-	// We don't timeout on a mutation which has already been proposed.
-	if err = n.Raft().Propose(ctx, slice[:upto]); err != nil {
+	// Some proposals can be stuck if leader change happens. For e.g. MsgProp proposal from follower
+	// to leader can be dropped/end up appearing with empty Data in CommittedEntries.
+	// Having a timeout here prevents the mutation being stuck forever.
+	cctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	if err = n.Raft().Propose(cctx, slice[:upto]); err != nil {
 		return x.Wrapf(err, "While proposing")
 	}
 
@@ -302,12 +306,17 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.Proposal) er
 		tr.LazyPrintf("Waiting for the proposal.")
 	}
 
-	err = <-che
-	if err != nil {
-		if tr, ok := trace.FromContext(ctx); ok {
-			tr.LazyPrintf("Raft Propose error: %v", err)
+	select {
+	case err = <-che:
+		if err != nil {
+			if tr, ok := trace.FromContext(ctx); ok {
+				tr.LazyPrintf("Raft Propose error: %v", err)
+			}
 		}
+	case <-cctx.Done():
+		return fmt.Errorf("While proposing to RAFT group, err: %+v\n", cctx.Err())
 	}
+
 	return err
 }
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -293,9 +293,10 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.Proposal) er
 		return err
 	}
 
-	// Some proposals can be stuck if leader change happens. For e.g. MsgProp proposal from follower
+	// Some proposals can be stuck if leader change happens. For e.g. MsgProp message from follower
 	// to leader can be dropped/end up appearing with empty Data in CommittedEntries.
-	// Having a timeout here prevents the mutation being stuck forever.
+	// Having a timeout here prevents the mutation being stuck forever in case they don't have a
+	// timeout.
 	cctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 	if err = n.Raft().Propose(cctx, slice[:upto]); err != nil {


### PR DESCRIPTION
This is easier than re-proposing all pending proposals. I will keep a lookout in the etcd-raft library and if they introduce a better way to recognize dropped proposals we can use that here. Takes care of #1931.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2324)
<!-- Reviewable:end -->
