### PR TITLE
Change counter of Mutations to be TX's to be more explicit

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -397,7 +397,7 @@ func run() {
 	// previous printed line.
 	fmt.Printf("%100s\r", "")
 
-	fmt.Printf("Number of mutations run   : %d\n", c.TxnsDone)
+	fmt.Printf("Number of TXs run         : %d\n", c.TxnsDone)
 	fmt.Printf("Number of RDFs processed  : %d\n", c.Rdfs)
 	fmt.Printf("Time spent                : %v\n", c.Elapsed)
 


### PR DESCRIPTION
It was a bit confusing that this tool said mutations when I was expecting it to read as transaction count.  Theoretically they could be equivalent but this is truly a count of transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2332)
<!-- Reviewable:end -->
