### PR TITLE
Add simple script to build and upload binaries.

### DIFF
--- a/contrib/nightly/build.sh
+++ b/contrib/nightly/build.sh
@@ -82,8 +82,8 @@ echo -e "\n\033[1;34mSize of tar file: $(du -sh $tar_file.tar.gz)\033[0m"
 
 mv $tmp_dir ./
 
-# Only run this locally.
-if [[ $TRAVIS != true ]]; then
+# Only run this locally, if DOCKER environment variable is set to true.
+if [[ $DOCKER == true ]]; then
   docker build -t dgraph/dgraph:master -f $GOPATH/src/github.com/dgraph-io/dgraph/contrib/nightly/Dockerfile .
 fi
 

--- a/contrib/nightly/transfer.sh
+++ b/contrib/nightly/transfer.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script builds the dgraph binary with the version information, packages it into a tarball,
+# uploads it to https://transfer.sh and prints the URL of the uploaded file. This URL can be
+# supplied to Jepsen tests to use the current HEAD for the tests.
+
+$GOPATH/src/github.com/dgraph-io/dgraph/contrib/nightly/build.sh
+
+echo -e "\nUploading the tar file to https://transfer.sh\n\n"
+curl --upload-file dgraph-linux-amd64.tar.gz https://transfer.sh/dgraph-linux-amd64.tar.gz

--- a/contrib/nightly/transfer.sh
+++ b/contrib/nightly/transfer.sh
@@ -4,7 +4,7 @@
 # uploads it to https://transfer.sh and prints the URL of the uploaded file. This URL can be
 # supplied to Jepsen tests to use the current HEAD for the tests.
 
-$GOPATH/src/github.com/dgraph-io/dgraph/contrib/nightly/build.sh
+$GOPATH/src/github.com/dgraph-io/dgraph/contrib/nightly/build.sh "-dev"
 
 echo -e "\nUploading the tar file to https://transfer.sh\n\n"
 curl --upload-file dgraph-linux-amd64.tar.gz https://transfer.sh/dgraph-linux-amd64.tar.gz

--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -226,6 +226,12 @@ This should start 5 jepsen nodes in docker containers.
 
 3. Now ssh into `jepsen-control` container and run the tests.
 
+{{% notice "note" %}}
+You can use the [transfer](https://github.com/dgraph-io/dgraph/blob/master/contrib/nightly/transfer.sh) script to build the Dgraph binary and upload the tarball to https://transfer.sh, which gives you a url that can then be used in the Jepsen tests (using --package-url flag).
+{{% /notice %}}
+
+
+
 ```sh
 docker exec -it jepsen-control bash
 ```


### PR DESCRIPTION
The `./contrib/nightly/transfer.sh` script can be used to build and upload binaries. It gives you a URL which can be used to run Jepsen tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2364)
<!-- Reviewable:end -->
