### PR TITLE
Fix export worker missing @lang and @upsert

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -163,6 +163,12 @@ func toSchema(buf *bytes.Buffer, s *skv) {
 	if s.schema.Count {
 		buf.WriteString(" @count")
 	}
+	if s.schema.Lang {
+		buf.WriteString(" @lang")
+	}
+	if s.schema.Upsert {
+		buf.WriteString(" @upsert")
+	}
 	buf.WriteString(" . \n")
 }
 


### PR DESCRIPTION
- Fix the issue #2393 of missing `@lang` and `@upsert` when exporting schema.
- Add unit test for `toSchema(buf *bytes.Buffer, s *skv)`.

The `schema.State().IsList()` statement in `toSchema()` is hard to mock, so the `isList` condition can't be tested in unit test only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2395)
<!-- Reviewable:end -->
