### PR TITLE
Add JSON mutations to raw HTTP

### DIFF
--- a/dgraph/cmd/server/http_test.go
+++ b/dgraph/cmd/server/http_test.go
@@ -64,7 +64,7 @@ func queryWithTs(q string, ts uint64) (string, uint64, error) {
 	return string(output), startTs, err
 }
 
-func mutationWithTs(m string, commitNow bool, ignoreIndexConflict bool,
+func mutationWithTs(m string, isJson bool, commitNow bool, ignoreIndexConflict bool,
 	ts uint64) ([]string, uint64, error) {
 	url := "/mutate"
 	if ts != 0 {
@@ -76,6 +76,9 @@ func mutationWithTs(m string, commitNow bool, ignoreIndexConflict bool,
 		return keys, 0, err
 	}
 
+	if isJson {
+		req.Header.Set("X-Dgraph-MutationType", "json")
+	}
 	if commitNow {
 		req.Header.Set("X-Dgraph-CommitNow", "true")
 	}
@@ -158,7 +161,7 @@ func TestTransactionBasic(t *testing.T) {
 	}
 	`
 
-	keys, mts, err := mutationWithTs(m1, false, true, ts)
+	keys, mts, err := mutationWithTs(m1, false, false, true, ts)
 	require.NoError(t, err)
 	require.Equal(t, mts, ts)
 	expected := []string{"321112eei4n9g", "321112eei4n9g", "3fk4wxiwz6h3r", "3mlibw7eeno0x"}

--- a/dgraph/cmd/server/run_test.go
+++ b/dgraph/cmd/server/run_test.go
@@ -681,7 +681,15 @@ func TestSchemaMutationCountAdd(t *testing.T) {
 func TestJsonMutation(t *testing.T) {
 	var q1 = `
 	{
-		user(func: has(name)) {
+		q(func: has(name)) {
+			uid
+			name
+		}
+	}
+	`
+	var q2 = `
+	{
+		q(func: has(name)) {
 			name
 		}
 	}
@@ -698,6 +706,16 @@ func TestJsonMutation(t *testing.T) {
 		]
 	}
 	`
+	var m2 = `
+	{
+		"delete": [
+			{
+				"uid": "%s",
+				"name": null
+			}
+		]
+	}
+	`
 	var s1 = `
             name: string @index(exact) .
 	`
@@ -710,15 +728,30 @@ func TestJsonMutation(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := runQuery(q1)
-	require.NoError(t, err)
-	require.JSONEq(t, `{"data": {"user":[{"name":"Alice"},{"name":"Bob"}]}}`, output)
+	q1Result := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal([]byte(output), &q1Result))
+	queryResults := q1Result["data"].(map[string]interface{})["q"].([]interface{})
+	require.Equal(t, 2, len(queryResults))
 
-	err = deletePredicate("name")
+	var uid string
+	count := 0
+	for i := 0; i < 2; i++ {
+		name := queryResults[i].(map[string]interface{})["name"].(string)
+		if name == "Alice" {
+			uid = queryResults[i].(map[string]interface{})["uid"].(string)
+			count++
+		} else {
+			require.Equal(t, "Bob", name)
+		}
+	}
+	require.Equal(t, 1, count)
+
+	err = runJsonMutation(fmt.Sprintf(m2, uid))
 	require.NoError(t, err)
 
-	output, err = runQuery(q1)
+	output, err = runQuery(q2)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"data": {"user":[]}}`, output)
+	require.JSONEq(t, `{"data": {"q":[{"name":"Bob"}]}}`, output)
 }
 
 func TestDeleteAll(t *testing.T) {


### PR DESCRIPTION
This adds Json mutations to Dgraph's HTTP server.

Syntax:
```json
{
    "set": [{ "name": "Alice" }],
    "delete": { "uid": "0x1", "name": null }
}
```

Possible limitations/problems:
- Parses the JSON twice: first for veryfing json and separating set and delete and second time to actually perform the mutation on api.Mutation
- Requires header indicating the type is JSON so that error handling is better and json mutations are not slowed down because of first checking for nquad mutations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2396)
<!-- Reviewable:end -->
