### PR TITLE
Badger based Raft Storage

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -50,7 +50,7 @@ type Node struct {
 	messages    chan sendmsg
 	RaftContext *intern.RaftContext
 	Store       *raft.MemoryStorage
-	Wal         *raftwal.Wal
+	Wal         *raftwal.DiskStorage
 
 	// applied is used to keep track of the applied RAFT proposals.
 	// The stages are proposed -> committed (accepted by cluster) ->
@@ -200,11 +200,11 @@ func (n *Node) SaveToStorage(h raftpb.HardState, es []raftpb.Entry) {
 	n.Store.Append(es)
 }
 
-func (n *Node) InitFromWal(wal *raftwal.Wal) (idx uint64, restart bool, rerr error) {
+func (n *Node) InitFromWal(wal *raftwal.DiskStorage) (idx uint64, restart bool, rerr error) {
 	n.Wal = wal
 
 	var sp raftpb.Snapshot
-	sp, rerr = wal.Snapshot(n.RaftContext.Group)
+	sp, rerr = wal.Snapshot()
 	if rerr != nil {
 		return
 	}
@@ -220,7 +220,7 @@ func (n *Node) InitFromWal(wal *raftwal.Wal) (idx uint64, restart bool, rerr err
 	}
 
 	var hd raftpb.HardState
-	hd, rerr = wal.HardState(n.RaftContext.Group)
+	hd, rerr = wal.HardState()
 	if rerr != nil {
 		return
 	}

--- a/conn/node.go
+++ b/conn/node.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"log"
 	"math/rand"
 	"sync"
 	"time"
@@ -172,23 +171,6 @@ func (n *Node) Send(m raftpb.Message) {
 		// pass
 	default:
 		// ignore
-	}
-}
-
-func (n *Node) SaveSnapshot(s raftpb.Snapshot) {
-	if raft.IsEmptySnap(s) {
-		return
-	}
-	le, err := n.Store.LastIndex()
-	if err != nil {
-		log.Fatalf("While retrieving last index: %v\n", err)
-	}
-	if s.Metadata.Index <= le {
-		return
-	}
-
-	if err := n.Store.ApplySnapshot(s); err != nil {
-		log.Fatalf("Applying snapshot: %v", err)
 	}
 }
 

--- a/conn/node.go
+++ b/conn/node.go
@@ -176,18 +176,19 @@ func (n *Node) Send(m raftpb.Message) {
 }
 
 func (n *Node) SaveSnapshot(s raftpb.Snapshot) {
-	if !raft.IsEmptySnap(s) {
-		le, err := n.Store.LastIndex()
-		if err != nil {
-			log.Fatalf("While retrieving last index: %v\n", err)
-		}
-		if s.Metadata.Index <= le {
-			return
-		}
+	if raft.IsEmptySnap(s) {
+		return
+	}
+	le, err := n.Store.LastIndex()
+	if err != nil {
+		log.Fatalf("While retrieving last index: %v\n", err)
+	}
+	if s.Metadata.Index <= le {
+		return
+	}
 
-		if err := n.Store.ApplySnapshot(s); err != nil {
-			log.Fatalf("Applying snapshot: %v", err)
-		}
+	if err := n.Store.ApplySnapshot(s); err != nil {
+		log.Fatalf("Applying snapshot: %v", err)
 	}
 }
 

--- a/conn/node.go
+++ b/conn/node.go
@@ -192,11 +192,8 @@ func (n *Node) SaveSnapshot(s raftpb.Snapshot) {
 	}
 }
 
-func (n *Node) SaveToStorage(h raftpb.HardState, es []raftpb.Entry) {
-	if !raft.IsEmptyHardState(h) {
-		n.Store.SetHardState(h)
-	}
-	n.Store.Append(es)
+func (n *Node) SaveToStorage(h raftpb.HardState, es []raftpb.Entry, s raftpb.Snapshot) {
+	x.Check(n.Store.Save(h, es, s))
 }
 
 func (n *Node) PastLife() (idx uint64, restart bool, rerr error) {
@@ -227,7 +224,8 @@ func (n *Node) PastLife() (idx uint64, restart bool, rerr error) {
 		return
 	}
 	x.Printf("Group %d found %d entries\n", n.RaftContext.Group, num)
-	if num > 0 {
+	// We'll always have at least one entry.
+	if num > 1 {
 		restart = true
 	}
 	return

--- a/conn/node.go
+++ b/conn/node.go
@@ -203,45 +203,46 @@ func (n *Node) SaveToStorage(h raftpb.HardState, es []raftpb.Entry) {
 func (n *Node) InitFromWal(wal *raftwal.DiskStorage) (idx uint64, restart bool, rerr error) {
 	n.Wal = wal
 
-	var sp raftpb.Snapshot
-	sp, rerr = wal.Snapshot()
-	if rerr != nil {
-		return
-	}
-	var term uint64
-	if !raft.IsEmptySnap(sp) {
-		x.Printf("Found Snapshot, Metadata: %+v\n", sp.Metadata)
-		restart = true
-		if rerr = n.Store.ApplySnapshot(sp); rerr != nil {
-			return
-		}
-		term = sp.Metadata.Term
-		idx = sp.Metadata.Index
-	}
+	// TODO: Work on this.
+	// var sp raftpb.Snapshot
+	// sp, rerr = wal.Snapshot()
+	// if rerr != nil {
+	// 	return
+	// }
+	// var term uint64
+	// if !raft.IsEmptySnap(sp) {
+	// 	x.Printf("Found Snapshot, Metadata: %+v\n", sp.Metadata)
+	// 	restart = true
+	// 	if rerr = n.Store.ApplySnapshot(sp); rerr != nil {
+	// 		return
+	// 	}
+	// 	term = sp.Metadata.Term
+	// 	idx = sp.Metadata.Index
+	// }
 
-	var hd raftpb.HardState
-	hd, rerr = wal.HardState()
-	if rerr != nil {
-		return
-	}
-	if !raft.IsEmptyHardState(hd) {
-		x.Printf("Found hardstate: %+v\n", hd)
-		restart = true
-		if rerr = n.Store.SetHardState(hd); rerr != nil {
-			return
-		}
-	}
+	// var hd raftpb.HardState
+	// hd, rerr = wal.HardState()
+	// if rerr != nil {
+	// 	return
+	// }
+	// if !raft.IsEmptyHardState(hd) {
+	// 	x.Printf("Found hardstate: %+v\n", hd)
+	// 	restart = true
+	// 	if rerr = n.Store.SetHardState(hd); rerr != nil {
+	// 		return
+	// 	}
+	// }
 
-	var es []raftpb.Entry
-	es, rerr = wal.Entries(n.RaftContext.Group, term, idx)
-	if rerr != nil {
-		return
-	}
-	x.Printf("Group %d found %d entries\n", n.RaftContext.Group, len(es))
-	if len(es) > 0 {
-		restart = true
-	}
-	rerr = n.Store.Append(es)
+	// var es []raftpb.Entry
+	// es, rerr = wal.Entries(n.RaftContext.Group, term, idx)
+	// if rerr != nil {
+	// 	return
+	// }
+	// x.Printf("Group %d found %d entries\n", n.RaftContext.Group, len(es))
+	// if len(es) > 0 {
+	// 	restart = true
+	// }
+	// rerr = n.Store.Append(es)
 	return
 }
 

--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -1,0 +1,84 @@
+package conn
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/raft"
+	"github.com/coreos/etcd/raft/raftpb"
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/dgraph/protos/intern"
+	"github.com/dgraph-io/dgraph/raftwal"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+func openBadger(dir string) (*badger.DB, error) {
+	opt := badger.DefaultOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	return badger.Open(opt)
+}
+
+func (n *Node) run(wg *sync.WaitGroup) {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			n.Raft().Tick()
+		case rd := <-n.Raft().Ready():
+			n.SaveToStorage(rd.HardState, rd.Entries)
+			n.SaveSnapshot(rd.Snapshot)
+			fmt.Printf("Got committed: %d\n", len(rd.CommittedEntries))
+			for _, entry := range rd.CommittedEntries {
+				if entry.Type == raftpb.EntryConfChange {
+					var cc raftpb.ConfChange
+					cc.Unmarshal(entry.Data)
+					n.Raft().ApplyConfChange(cc)
+				} else if entry.Type == raftpb.EntryNormal {
+					if bytes.HasPrefix(entry.Data, []byte("hey")) {
+						wg.Done()
+					}
+				}
+			}
+			n.Raft().Advance()
+		}
+	}
+}
+
+func TestProposal(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := openBadger(dir)
+	require.NoError(t, err)
+	store := raftwal.Init(db, 0, 0)
+
+	rc := &intern.RaftContext{Id: 1}
+	n := NewNode(rc, store)
+
+	peers := []raft.Peer{{ID: n.Id}}
+	n.SetRaft(raft.StartNode(n.Cfg, peers))
+
+	loop := 5
+	var wg sync.WaitGroup
+	wg.Add(loop)
+	go n.run(&wg)
+
+	for i := 0; i < loop; i++ {
+		data := []byte(fmt.Sprintf("hey-%d", i))
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, n.Raft().Propose(ctx, data))
+	}
+	wg.Wait()
+}

--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -37,7 +37,6 @@ func (n *Node) run(wg *sync.WaitGroup) {
 		case rd := <-n.Raft().Ready():
 			n.SaveToStorage(rd.HardState, rd.Entries)
 			n.SaveSnapshot(rd.Snapshot)
-			fmt.Printf("Got committed: %d\n", len(rd.CommittedEntries))
 			for _, entry := range rd.CommittedEntries {
 				if entry.Type == raftpb.EntryConfChange {
 					var cc raftpb.ConfChange

--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -35,8 +35,7 @@ func (n *Node) run(wg *sync.WaitGroup) {
 		case <-ticker.C:
 			n.Raft().Tick()
 		case rd := <-n.Raft().Ready():
-			n.SaveToStorage(rd.HardState, rd.Entries)
-			n.SaveSnapshot(rd.Snapshot)
+			n.SaveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
 			for _, entry := range rd.CommittedEntries {
 				if entry.Type == raftpb.EntryConfChange {
 					var cc raftpb.ConfChange

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -10,6 +10,7 @@ package zero
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"log"
 	"math/rand"
 	"sync"
@@ -204,6 +205,7 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.ZeroProposal
 	cctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	// Propose the change.
+	fmt.Printf("proposing to raft: %+v\n", proposal)
 	if err := n.Raft().Propose(cctx, data); err != nil {
 		return x.Wrapf(err, "While proposing")
 	}
@@ -555,6 +557,7 @@ func (n *node) Run() {
 			n.Raft().Tick()
 
 		case rd := <-n.Raft().Ready():
+			fmt.Println("raft ready in zero")
 			for _, rs := range rd.ReadStates {
 				ri := binary.BigEndian.Uint64(rs.RequestCtx)
 				n.sendReadIndex(ri, rs.Index)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -523,11 +523,12 @@ func (n *node) trySnapshot(skip uint64) {
 	if tr, ok := trace.FromContext(n.ctx); ok {
 		tr.LazyPrintf("Taking snapshot of state at watermark: %d\n", idx)
 	}
-	s, err := n.Store.CreateSnapshot(idx, n.ConfState(), data)
+	_, err = n.Store.CreateSnapshot(idx, n.ConfState(), data)
 	x.Checkf(err, "While creating snapshot")
 	x.Checkf(n.Store.Compact(idx), "While compacting snapshot")
 	x.Printf("Writing snapshot at index: %d, applied mark: %d\n", idx, n.Applied.DoneUntil())
-	x.Check(n.Wal.StoreSnapshot(s))
+	// TODO: Work on this.
+	// x.Check(n.Wal.StoreSnapshot(s))
 }
 
 func (n *node) Run() {
@@ -569,7 +570,8 @@ func (n *node) Run() {
 				var state intern.MembershipState
 				x.Check(state.Unmarshal(rd.Snapshot.Data))
 				n.server.SetMembershipState(&state)
-				x.Check(n.Wal.StoreSnapshot(rd.Snapshot))
+				// TODO: Work on this.
+				// x.Check(n.Wal.StoreSnapshot(rd.Snapshot))
 				n.SaveSnapshot(rd.Snapshot)
 			}
 

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -102,6 +102,7 @@ func (st *state) serveGRPC(l net.Listener, wg *sync.WaitGroup, store *raftwal.Di
 	st.zero = &Server{NumReplicas: opts.numReplicas, Node: st.node}
 	st.zero.Init()
 	st.node.server = st.zero
+	x.Check(st.node.initAndStartNode())
 
 	intern.RegisterZeroServer(s, st.zero)
 	intern.RegisterRaftServer(s, st.rs)
@@ -166,7 +167,7 @@ func run() {
 	kvOpt.SyncWrites = true
 	kvOpt.Dir = opts.w
 	kvOpt.ValueDir = opts.w
-	kvOpt.TableLoadingMode = bopts.MemoryMap
+	kvOpt.ValueLogLoadingMode = bopts.FileIO
 	kv, err := badger.Open(kvOpt)
 	x.Checkf(err, "Error while opening WAL store")
 	defer kv.Close()
@@ -182,8 +183,6 @@ func run() {
 	http.HandleFunc("/state", st.getState)
 	http.HandleFunc("/removeNode", st.removeNode)
 	http.HandleFunc("/moveTablet", st.moveTablet)
-
-	x.Check(st.node.initAndStartNode())
 
 	sdCh := make(chan os.Signal, 1)
 	signal.Notify(sdCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -178,10 +178,10 @@ func run() {
 	kvOpt.Dir = opts.w
 	kvOpt.ValueDir = opts.w
 	kvOpt.TableLoadingMode = bopts.MemoryMap
-	kv, err := badger.OpenManaged(kvOpt)
+	kv, err := badger.Open(kvOpt)
 	x.Checkf(err, "Error while opening WAL store")
 	defer kv.Close()
-	wal := raftwal.Init(kv, opts.nodeId)
+	wal := raftwal.Init(kv, opts.nodeId, 0)
 	x.Check(st.node.initAndStartNode(wal))
 
 	sdCh := make(chan os.Signal, 1)

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -437,10 +437,8 @@ func (s *Server) Connect(ctx context.Context,
 	if proposal != nil {
 		fmt.Printf("prosing: %+v\n", proposal)
 		if err := s.Node.proposeAndWait(ctx, proposal); err != nil {
-			fmt.Printf("Err with proposal: %+v\n", err)
 			return &emptyConnectionState, err
 		}
-		fmt.Printf("Err with proposal: %+v\n", err)
 	}
 	resp = &intern.ConnectionState{
 		State:  s.membershipState(),

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -9,7 +9,6 @@ package zero
 
 import (
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -350,7 +349,6 @@ func (s *Server) Connect(ctx context.Context,
 		return cs, err
 	}
 	if len(m.Addr) == 0 {
-		fmt.Println("No address provided.")
 		return &emptyConnectionState, errInvalidAddress
 	}
 
@@ -377,7 +375,6 @@ func (s *Server) Connect(ctx context.Context,
 
 	// Create a connection and check validity of the address by doing an Echo.
 	conn.Get().Connect(m.Addr)
-	fmt.Printf("Connecting to %s", m.Addr)
 
 	createProposal := func() *intern.ZeroProposal {
 		s.Lock()
@@ -435,7 +432,6 @@ func (s *Server) Connect(ctx context.Context,
 
 	proposal := createProposal()
 	if proposal != nil {
-		fmt.Printf("prosing: %+v\n", proposal)
 		if err := s.Node.proposeAndWait(ctx, proposal); err != nil {
 			return &emptyConnectionState, err
 		}

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -377,6 +377,7 @@ func (s *Server) Connect(ctx context.Context,
 
 	// Create a connection and check validity of the address by doing an Echo.
 	conn.Get().Connect(m.Addr)
+	fmt.Printf("Connecting to %s", m.Addr)
 
 	createProposal := func() *intern.ZeroProposal {
 		s.Lock()
@@ -434,9 +435,12 @@ func (s *Server) Connect(ctx context.Context,
 
 	proposal := createProposal()
 	if proposal != nil {
+		fmt.Printf("prosing: %+v\n", proposal)
 		if err := s.Node.proposeAndWait(ctx, proposal); err != nil {
+			fmt.Printf("Err with proposal: %+v\n", err)
 			return &emptyConnectionState, err
 		}
+		fmt.Printf("Err with proposal: %+v\n", err)
 	}
 	resp = &intern.ConnectionState{
 		State:  s.membershipState(),

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/intern"
-	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/gogo/protobuf/proto"
 )
@@ -39,7 +38,6 @@ var (
 
 type Server struct {
 	x.SafeMutex
-	wal  *raftwal.DiskStorage
 	Node *node
 	orc  *Oracle
 

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -40,7 +40,7 @@ var (
 
 type Server struct {
 	x.SafeMutex
-	wal  *raftwal.Wal
+	wal  *raftwal.DiskStorage
 	Node *node
 	orc  *Oracle
 

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -6162,7 +6162,7 @@ func TestMain(m *testing.M) {
 	kvOpt.Dir = dir2
 	kvOpt.ValueDir = dir2
 	kvOpt.TableLoadingMode = options.LoadToRAM
-	walStore, err := badger.OpenManaged(kvOpt)
+	walStore, err := badger.Open(kvOpt)
 	x.Check(err)
 
 	worker.StartRaftNodes(walStore, false)

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -62,6 +62,9 @@ func RaftId(db *badger.DB) (uint64, error) {
 		id = binary.BigEndian.Uint64(val)
 		return nil
 	})
+	if err == badger.ErrKeyNotFound {
+		return 0, nil
+	}
 	return id, err
 }
 

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -342,29 +342,6 @@ func (w *DiskStorage) setSnapshot(u *txnUnifier, s pb.Snapshot) error {
 	return nil
 }
 
-// ApplySnapshot overwrites the contents of this Storage object with
-// those of the given snapshot.
-func (w *DiskStorage) ApplySnapshot(snap pb.Snapshot) error {
-	w.elog.Printf("ApplySnapshot")
-	defer w.elog.Printf("Done")
-	prev, err := w.Snapshot()
-	if err != nil {
-		return err
-	}
-	if prev.Metadata.Index >= snap.Metadata.Index {
-		return raft.ErrSnapOutOfDate
-	}
-	u := w.newUnifier()
-	defer u.Cancel()
-	if err := w.setSnapshot(u, snap); err != nil {
-		return err
-	}
-	if err := w.deleteFrom(u, snap.Metadata.Index+1); err != nil {
-		return err
-	}
-	return u.Done()
-}
-
 // SetHardState saves the current HardState.
 func (w *DiskStorage) setHardState(u *txnUnifier, st pb.HardState) error {
 	if raft.IsEmptyHardState(st) {

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -236,6 +236,10 @@ func (w *DiskStorage) seekEntry(e *pb.Entry, seekTo uint64, reverse bool) (uint6
 // possibly available via Entries (older entries have been incorporated
 // into the latest Snapshot).
 func (w *DiskStorage) FirstIndex() (uint64, error) {
+	snap := w.cache.snapshot()
+	if !raft.IsEmptySnap(snap) {
+		return snap.Metadata.Index + 1, nil
+	}
 	index, err := w.seekEntry(nil, 0, false)
 	return index + 1, err
 }

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -290,8 +290,6 @@ func (w *DiskStorage) compact(u *txnUnifier, compactIndex uint64) error {
 // so raft state machine could know that Storage needs some time to prepare
 // snapshot and call Snapshot later.
 func (w *DiskStorage) Snapshot() (snap pb.Snapshot, rerr error) {
-	w.elog.Printf("Snapshot")
-	defer w.elog.Printf("Done")
 	if s := w.cache.snapshot(); !raft.IsEmptySnap(s) {
 		return s, nil
 	}
@@ -571,8 +569,6 @@ func limitSize(ents []pb.Entry, maxSize uint64) []pb.Entry {
 }
 
 func (w *DiskStorage) CreateSnapshot(i uint64, cs *pb.ConfState, data []byte) error {
-	w.elog.Printf("CreateSnapshot: %d", i)
-	defer w.elog.Printf("Done")
 	first, err := w.FirstIndex()
 	if err != nil {
 		return err
@@ -609,8 +605,6 @@ func (w *DiskStorage) CreateSnapshot(i uint64, cs *pb.ConfState, data []byte) er
 }
 
 func (w *DiskStorage) Save(h pb.HardState, es []pb.Entry, snap pb.Snapshot) error {
-	w.elog.Printf("Save. Num entries: %d", len(es))
-	defer w.elog.Printf("Done")
 	u := w.newUnifier()
 	defer u.Cancel()
 

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -183,11 +183,11 @@ func (w *DiskStorage) StoreRaftId(id uint64) error {
 func (w *DiskStorage) Term(idx uint64) (uint64, error) {
 	w.elog.Printf("Term: %d", idx)
 	defer w.elog.Printf("Done")
-	first, err := w.seekEntry(nil, 0, false)
+	first, err := w.FirstIndex()
 	if err != nil {
 		return 0, err
 	}
-	if idx < first {
+	if idx < first-1 {
 		return 0, raft.ErrCompacted
 	}
 

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -345,36 +345,3 @@ func TestStorageAppend(t *testing.T) {
 		}
 	}
 }
-
-func TestStorageApplySnapshot(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	db, err := openBadger(dir)
-	require.NoError(t, err)
-	ds := Init(db, 0, 0)
-
-	cs := &pb.ConfState{Nodes: []uint64{1, 2, 3}}
-	data := []byte("data")
-
-	tests := []pb.Snapshot{{Data: data, Metadata: pb.SnapshotMetadata{Index: 4, Term: 4, ConfState: *cs}},
-		{Data: data, Metadata: pb.SnapshotMetadata{Index: 3, Term: 3, ConfState: *cs}},
-	}
-
-	//Apply Snapshot successful
-	i := 0
-	tt := tests[i]
-	err = ds.ApplySnapshot(tt)
-	if err != nil {
-		t.Errorf("#%d: err = %v, want %v", i, err, nil)
-	}
-
-	//Apply Snapshot fails due to ErrSnapOutOfDate
-	i = 1
-	tt = tests[i]
-	err = ds.ApplySnapshot(tt)
-	if err != raft.ErrSnapOutOfDate {
-		t.Errorf("#%d: err = %v, want %v", i, err, raft.ErrSnapOutOfDate)
-	}
-}

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -65,7 +65,7 @@ func TestStorageTerm(t *testing.T) {
 	snap.Metadata.Index = 3
 	snap.Metadata.Term = 3
 
-	require.NoError(t, ds.Store(pb.HardState{}, ents))
+	require.NoError(t, ds.reset(ents))
 	for i, tt := range tests {
 		func() {
 			defer func() {
@@ -120,7 +120,7 @@ func TestStorageEntries(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		require.NoError(t, ds.Store(pb.HardState{}, ents))
+		require.NoError(t, ds.reset(ents))
 
 		entries, err := ds.Entries(tt.lo, tt.hi, tt.maxsize)
 		if err != tt.werr {
@@ -142,7 +142,7 @@ func TestStorageLastIndex(t *testing.T) {
 	ds := Init(db, 0, 0)
 
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
-	require.NoError(t, ds.Store(pb.HardState{}, ents))
+	require.NoError(t, ds.reset(ents))
 
 	last, err := ds.LastIndex()
 	if err != nil {
@@ -152,7 +152,7 @@ func TestStorageLastIndex(t *testing.T) {
 		t.Errorf("term = %d, want %d", last, 5)
 	}
 
-	ds.Store(pb.HardState{}, []pb.Entry{{Index: 6, Term: 5}})
+	ds.reset([]pb.Entry{{Index: 6, Term: 5}})
 	last, err = ds.LastIndex()
 	if err != nil {
 		t.Errorf("err = %v, want nil", err)
@@ -172,7 +172,7 @@ func TestStorageFirstIndex(t *testing.T) {
 	ds := Init(db, 0, 0)
 
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
-	require.NoError(t, ds.Store(pb.HardState{}, ents))
+	require.NoError(t, ds.reset(ents))
 
 	first, err := ds.FirstIndex()
 	if err != nil {
@@ -202,7 +202,7 @@ func TestStorageCompact(t *testing.T) {
 	ds := Init(db, 0, 0)
 
 	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
-	require.NoError(t, ds.Store(pb.HardState{}, ents))
+	require.NoError(t, ds.reset(ents))
 
 	tests := []struct {
 		i uint64
@@ -262,7 +262,7 @@ func TestStorageCreateSnapshot(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		require.NoError(t, ds.Store(pb.HardState{}, ents))
+		require.NoError(t, ds.reset(ents))
 		snap, err := ds.CreateSnapshot(tt.i, cs, data)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
@@ -325,7 +325,7 @@ func TestStorageAppend(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		require.NoError(t, ds.Store(pb.HardState{}, ents))
+		require.NoError(t, ds.reset(ents))
 		err := ds.Append(tt.entries)
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -183,7 +183,7 @@ func TestStorageFirstIndex(t *testing.T) {
 	}
 
 	u := ds.newUnifier()
-	require.NoError(t, ds.compact(u, 4))
+	require.NoError(t, ds.deleteUntil(u, 4))
 	require.NoError(t, u.Done())
 	first, err = ds.FirstIndex()
 	if err != nil {
@@ -222,7 +222,7 @@ func TestStorageCompact(t *testing.T) {
 
 	for i, tt := range tests {
 		u := ds.newUnifier()
-		err := ds.compact(u, tt.i)
+		err := ds.deleteUntil(u, tt.i)
 		require.NoError(t, u.Done())
 		if err != tt.werr {
 			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -1,0 +1,307 @@
+// Copyright 2015 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Modified by Dgraph Labs to test DiskStorage.
+
+package raftwal
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/coreos/etcd/raft"
+	pb "github.com/coreos/etcd/raft/raftpb"
+	"github.com/dgraph-io/badger"
+	"github.com/stretchr/testify/require"
+)
+
+func openBadger(dir string) (*badger.DB, error) {
+	opt := badger.DefaultOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	return badger.Open(opt)
+}
+
+func TestStorageTerm(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := openBadger(dir)
+	require.NoError(t, err)
+	ds := Init(db, 0, 0)
+
+	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+	tests := []struct {
+		i uint64
+
+		werr   error
+		wterm  uint64
+		wpanic bool
+	}{
+		{2, raft.ErrCompacted, 0, false},
+		{3, nil, 3, false},
+		{4, nil, 4, false},
+		{5, nil, 5, false},
+		{6, raft.ErrUnavailable, 0, false},
+	}
+
+	for i, tt := range tests {
+		require.NoError(t, ds.Store(pb.HardState{}, ents))
+		// s := &raft.MemoryStorage{ents: ents}
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wpanic {
+						t.Errorf("%d: panic = %v, want %v", i, true, tt.wpanic)
+					}
+				}
+			}()
+
+			term, err := ds.Term(tt.i)
+			if err != tt.werr {
+				t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+			}
+			if term != tt.wterm {
+				t.Errorf("#%d: term = %d, want %d", i, term, tt.wterm)
+			}
+		}()
+	}
+}
+
+//func TestStorageEntries(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}}
+//	tests := []struct {
+//		lo, hi, maxsize uint64
+
+//		werr     error
+//		wentries []pb.Entry
+//	}{
+//		{2, 6, math.MaxUint64, raft.ErrCompacted, nil},
+//		{3, 4, math.MaxUint64, raft.ErrCompacted, nil},
+//		{4, 5, math.MaxUint64, nil, []pb.Entry{{Index: 4, Term: 4}}},
+//		{4, 6, math.MaxUint64, nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}}},
+//		{4, 7, math.MaxUint64, nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}}},
+//		// even if maxsize is zero, the first entry should be returned
+//		{4, 7, 0, nil, []pb.Entry{{Index: 4, Term: 4}}},
+//		// limit to 2
+//		{4, 7, uint64(ents[1].Size() + ents[2].Size()), nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}}},
+//		// limit to 2
+//		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()/2), nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}}},
+//		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size() - 1), nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}}},
+//		// all
+//		{4, 7, uint64(ents[1].Size() + ents[2].Size() + ents[3].Size()), nil, []pb.Entry{{Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 6}}},
+//	}
+
+//	for i, tt := range tests {
+//		s := &raft.MemoryStorage{ents: ents}
+//		entries, err := s.Entries(tt.lo, tt.hi, tt.maxsize)
+//		if err != tt.werr {
+//			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+//		}
+//		if !reflect.DeepEqual(entries, tt.wentries) {
+//			t.Errorf("#%d: entries = %v, want %v", i, entries, tt.wentries)
+//		}
+//	}
+//}
+
+//func TestStorageLastIndex(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+//	s := &raft.MemoryStorage{ents: ents}
+
+//	last, err := s.LastIndex()
+//	if err != nil {
+//		t.Errorf("err = %v, want nil", err)
+//	}
+//	if last != 5 {
+//		t.Errorf("term = %d, want %d", last, 5)
+//	}
+
+//	s.Append([]pb.Entry{{Index: 6, Term: 5}})
+//	last, err = s.LastIndex()
+//	if err != nil {
+//		t.Errorf("err = %v, want nil", err)
+//	}
+//	if last != 6 {
+//		t.Errorf("last = %d, want %d", last, 5)
+//	}
+//}
+
+//func TestStorageFirstIndex(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+//	s := &raft.MemoryStorage{ents: ents}
+
+//	first, err := s.FirstIndex()
+//	if err != nil {
+//		t.Errorf("err = %v, want nil", err)
+//	}
+//	if first != 4 {
+//		t.Errorf("first = %d, want %d", first, 4)
+//	}
+
+//	s.Compact(4)
+//	first, err = s.FirstIndex()
+//	if err != nil {
+//		t.Errorf("err = %v, want nil", err)
+//	}
+//	if first != 5 {
+//		t.Errorf("first = %d, want %d", first, 5)
+//	}
+//}
+
+//func TestStorageCompact(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+//	tests := []struct {
+//		i uint64
+
+//		werr   error
+//		windex uint64
+//		wterm  uint64
+//		wlen   int
+//	}{
+//		{2, ErrCompacted, 3, 3, 3},
+//		{3, ErrCompacted, 3, 3, 3},
+//		{4, nil, 4, 4, 2},
+//		{5, nil, 5, 5, 1},
+//	}
+
+//	for i, tt := range tests {
+//		s := &raft.MemoryStorage{ents: ents}
+//		err := s.Compact(tt.i)
+//		if err != tt.werr {
+//			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+//		}
+//		if s.ents[0].Index != tt.windex {
+//			t.Errorf("#%d: index = %d, want %d", i, s.ents[0].Index, tt.windex)
+//		}
+//		if s.ents[0].Term != tt.wterm {
+//			t.Errorf("#%d: term = %d, want %d", i, s.ents[0].Term, tt.wterm)
+//		}
+//		if len(s.ents) != tt.wlen {
+//			t.Errorf("#%d: len = %d, want %d", i, len(s.ents), tt.wlen)
+//		}
+//	}
+//}
+
+//func TestStorageCreateSnapshot(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+//	cs := &pb.ConfState{Nodes: []uint64{1, 2, 3}}
+//	data := []byte("data")
+
+//	tests := []struct {
+//		i uint64
+
+//		werr  error
+//		wsnap pb.Snapshot
+//	}{
+//		{4, nil, pb.Snapshot{Data: data, Metadata: pb.SnapshotMetadata{Index: 4, Term: 4, ConfState: *cs}}},
+//		{5, nil, pb.Snapshot{Data: data, Metadata: pb.SnapshotMetadata{Index: 5, Term: 5, ConfState: *cs}}},
+//	}
+
+//	for i, tt := range tests {
+//		s := &raft.MemoryStorage{ents: ents}
+//		snap, err := s.CreateSnapshot(tt.i, cs, data)
+//		if err != tt.werr {
+//			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+//		}
+//		if !reflect.DeepEqual(snap, tt.wsnap) {
+//			t.Errorf("#%d: snap = %+v, want %+v", i, snap, tt.wsnap)
+//		}
+//	}
+//}
+
+//func TestStorageAppend(t *testing.T) {
+//	ents := []pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}}
+//	tests := []struct {
+//		entries []pb.Entry
+
+//		werr     error
+//		wentries []pb.Entry
+//	}{
+//		{
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}},
+//		},
+//		{
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 6}, {Index: 5, Term: 6}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 6}, {Index: 5, Term: 6}},
+//		},
+//		{
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 5}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 5}},
+//		},
+//		// truncate incoming entries, truncate the existing entries and append
+//		{
+//			[]pb.Entry{{Index: 2, Term: 3}, {Index: 3, Term: 3}, {Index: 4, Term: 5}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 5}},
+//		},
+//		// truncate the existing entries and append
+//		{
+//			[]pb.Entry{{Index: 4, Term: 5}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 5}},
+//		},
+//		// direct append
+//		{
+//			[]pb.Entry{{Index: 6, Term: 5}},
+//			nil,
+//			[]pb.Entry{{Index: 3, Term: 3}, {Index: 4, Term: 4}, {Index: 5, Term: 5}, {Index: 6, Term: 5}},
+//		},
+//	}
+
+//	for i, tt := range tests {
+//		s := &raft.MemoryStorage{ents: ents}
+//		err := s.Append(tt.entries)
+//		if err != tt.werr {
+//			t.Errorf("#%d: err = %v, want %v", i, err, tt.werr)
+//		}
+//		if !reflect.DeepEqual(s.ents, tt.wentries) {
+//			t.Errorf("#%d: entries = %v, want %v", i, s.ents, tt.wentries)
+//		}
+//	}
+//}
+
+//func TestStorageApplySnapshot(t *testing.T) {
+//	cs := &pb.ConfState{Nodes: []uint64{1, 2, 3}}
+//	data := []byte("data")
+
+//	tests := []pb.Snapshot{{Data: data, Metadata: pb.SnapshotMetadata{Index: 4, Term: 4, ConfState: *cs}},
+//		{Data: data, Metadata: pb.SnapshotMetadata{Index: 3, Term: 3, ConfState: *cs}},
+//	}
+
+//	s := NewMemoryStorage()
+
+//	//Apply Snapshot successful
+//	i := 0
+//	tt := tests[i]
+//	err := s.ApplySnapshot(tt)
+//	if err != nil {
+//		t.Errorf("#%d: err = %v, want %v", i, err, nil)
+//	}
+
+//	//Apply Snapshot fails due to ErrSnapOutOfDate
+//	i = 1
+//	tt = tests[i]
+//	err = s.ApplySnapshot(tt)
+//	if err != ErrSnapOutOfDate {
+//		t.Errorf("#%d: err = %v, want %v", i, err, ErrSnapOutOfDate)
+//	}
+//}

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -10,6 +10,8 @@ package raftwal
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"math"
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
@@ -18,63 +20,23 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-type Wal struct {
-	wals *badger.DB
-	id   uint64
-	gid  uint32
+type DiskStorage struct {
+	db  *badger.DB
+	id  uint64
+	gid uint32
 }
 
-func Init(walStore *badger.DB, id uint64) *Wal {
-	w := &Wal{wals: walStore, id: id}
+func Init(db *badger.DB, id uint64, gid uint32) *DiskStorage {
+	w := &DiskStorage{db: db, id: id, gid: gid}
 	x.Check(w.StoreRaftId(id))
 	return w
 }
 
 var idKey = []byte("raftid")
 
-func (w *Wal) snapshotKey(gid uint32) []byte {
-	b := make([]byte, 14)
-	binary.BigEndian.PutUint64(b[0:8], w.id)
-	copy(b[8:10], []byte("ss"))
-	binary.BigEndian.PutUint32(b[10:14], gid)
-	return b
-}
-
-func (w *Wal) hardStateKey(gid uint32) []byte {
-	b := make([]byte, 14)
-	binary.BigEndian.PutUint64(b[0:8], w.id)
-	copy(b[8:10], []byte("hs"))
-	binary.BigEndian.PutUint32(b[10:14], gid)
-	return b
-}
-
-func (w *Wal) entryKey(gid uint32, term, idx uint64) []byte {
-	b := make([]byte, 28)
-	binary.BigEndian.PutUint64(b[0:8], w.id)
-	binary.BigEndian.PutUint32(b[8:12], gid)
-	binary.BigEndian.PutUint64(b[12:20], term)
-	binary.BigEndian.PutUint64(b[20:28], idx)
-	return b
-}
-
-func (w *Wal) prefix(gid uint32) []byte {
-	b := make([]byte, 12)
-	binary.BigEndian.PutUint64(b[0:8], w.id)
-	binary.BigEndian.PutUint32(b[8:12], gid)
-	return b
-}
-
-func (w *Wal) StoreRaftId(id uint64) error {
-	return w.wals.Update(func(txn *badger.Txn) error {
-		var b [8]byte
-		binary.BigEndian.PutUint64(b[:], id)
-		return txn.Set(idKey, b[:])
-	})
-}
-
-func RaftId(wals *badger.DB) (uint64, error) {
+func RaftId(db *badger.DB) (uint64, error) {
 	var id uint64
-	err := wals.View(func(txn *badger.Txn) error {
+	err := db.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(idKey)
 		if err != nil {
 			return err
@@ -89,8 +51,128 @@ func RaftId(wals *badger.DB) (uint64, error) {
 	return id, err
 }
 
-// TODO: Move gid within WAL.
-func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
+func (w *DiskStorage) snapshotKey() []byte {
+	b := make([]byte, 14)
+	binary.BigEndian.PutUint64(b[0:8], w.id)
+	copy(b[8:10], []byte("ss"))
+	binary.BigEndian.PutUint32(b[10:14], w.gid)
+	return b
+}
+
+func (w *DiskStorage) hardStateKey() []byte {
+	b := make([]byte, 14)
+	binary.BigEndian.PutUint64(b[0:8], w.id)
+	copy(b[8:10], []byte("hs"))
+	binary.BigEndian.PutUint32(b[10:14], w.gid)
+	return b
+}
+
+func (w *DiskStorage) entryKey(idx uint64) []byte {
+	b := make([]byte, 20)
+	binary.BigEndian.PutUint64(b[0:8], w.id)
+	binary.BigEndian.PutUint32(b[8:12], w.gid)
+	binary.BigEndian.PutUint64(b[12:20], idx)
+	return b
+}
+
+func (w *DiskStorage) prefix() []byte {
+	b := make([]byte, 12)
+	binary.BigEndian.PutUint64(b[0:8], w.id)
+	binary.BigEndian.PutUint32(b[8:12], w.gid)
+	return b
+}
+
+func (w *DiskStorage) StoreRaftId(id uint64) error {
+	return w.db.Update(func(txn *badger.Txn) error {
+		var b [8]byte
+		binary.BigEndian.PutUint64(b[:], id)
+		return txn.Set(idKey, b[:])
+	})
+}
+
+// Term returns the term of entry i, which must be in the range
+// [FirstIndex()-1, LastIndex()]. The term of the entry before
+// FirstIndex is retained for matching purposes even though the
+// rest of that entry may not be available.
+func (w *DiskStorage) Term(idx uint64) (uint64, error) {
+	snap, err := w.Snapshot()
+	if err != nil {
+		return 0, err
+	}
+	var e raftpb.Entry
+	if idx <= snap.Metadata.Index {
+		return 0, raft.ErrCompacted
+	}
+
+	err = w.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(w.entryKey(idx))
+		if err != nil {
+			return err
+		}
+		val, err := item.Value()
+		if err != nil {
+			return err
+		}
+		return e.Unmarshal(val)
+	})
+	if err == badger.ErrKeyNotFound {
+		return 0, raft.ErrUnavailable
+	}
+	if err != nil {
+		return 0, err
+	}
+	return e.Term, nil
+}
+
+var errNotFound = errors.New("Unable to find raft entry")
+
+// TODO: We could optimize this by not looking up value, and parsing the key only.
+func (w *DiskStorage) seekEntry(e *raftpb.Entry, reverse bool) error {
+	return w.db.View(func(txn *badger.Txn) error {
+		opt := badger.DefaultIteratorOptions
+		opt.PrefetchValues = false
+		opt.Reverse = reverse
+		itr := txn.NewIterator(opt)
+		defer itr.Close()
+
+		if reverse {
+			itr.Seek(w.entryKey(math.MaxUint64))
+		} else {
+			itr.Seek(w.entryKey(0))
+		}
+		if !itr.Valid() {
+			return errNotFound
+		}
+		item := itr.Item()
+		val, err := item.Value()
+		if err != nil {
+			return err
+		}
+		return e.Unmarshal(val)
+	})
+}
+
+// FirstIndex returns the index of the first log entry that is
+// possibly available via Entries (older entries have been incorporated
+// into the latest Snapshot).
+func (w *DiskStorage) FirstIndex() (uint64, error) {
+	var e raftpb.Entry
+	if err := w.seekEntry(&e, false); err != nil {
+		return 0, err
+	}
+	return e.Index, nil
+}
+
+// LastIndex returns the index of the last entry in the log.
+func (w *DiskStorage) LastIndex() (uint64, error) {
+	var e raftpb.Entry
+	if err := w.seekEntry(&e, true); err != nil {
+		return 0, err
+	}
+	return e.Index, nil
+}
+
+func (w *DiskStorage) StoreSnapshot(s raftpb.Snapshot) error {
 	if raft.IsEmptySnap(s) {
 		return nil
 	}
@@ -98,15 +180,15 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 	if err != nil {
 		return x.Wrapf(err, "wal.Store: While marshal snapshot")
 	}
-	txn := w.wals.NewTransaction(true)
+	txn := w.db.NewTransaction(true)
 	defer txn.Discard()
-	if err := txn.Set(w.snapshotKey(gid), data); err != nil {
+	if err := txn.Set(w.snapshotKey(), data); err != nil {
 		return err
 	}
 
 	// Delete all entries before this snapshot to save disk space.
-	start := w.entryKey(gid, 0, 0)
-	last := w.entryKey(gid, s.Metadata.Term, s.Metadata.Index)
+	start := w.entryKey(0)
+	last := w.entryKey(s.Metadata.Index)
 	opt := badger.DefaultIteratorOptions
 	opt.PrefetchValues = false
 	itr := txn.NewIterator(opt)
@@ -123,7 +205,7 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 			if err := txn.Commit(nil); err != nil {
 				return err
 			}
-			txn = w.wals.NewTransaction(true)
+			txn = w.db.NewTransaction(true)
 			defer txn.Discard()
 			if err := txn.Delete(newk); err != nil {
 				return err
@@ -137,8 +219,8 @@ func (w *Wal) StoreSnapshot(gid uint32, s raftpb.Snapshot) error {
 }
 
 // Store stores the hardstate and entries for a given RAFT group.
-func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
-	txn := w.wals.NewTransaction(true)
+func (w *DiskStorage) Store(h raftpb.HardState, es []raftpb.Entry) error {
+	txn := w.db.NewTransaction(true)
 	defer txn.Discard()
 
 	var t, i uint64
@@ -148,12 +230,12 @@ func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
 		if err != nil {
 			return x.Wrapf(err, "wal.Store: While marshal entry")
 		}
-		k := w.entryKey(gid, e.Term, e.Index)
+		k := w.entryKey(e.Index)
 		if err := txn.Set(k, data); err == badger.ErrTxnTooBig {
 			if err := txn.Commit(nil); err != nil {
 				return err
 			}
-			txn = w.wals.NewTransaction(true)
+			txn = w.db.NewTransaction(true)
 			defer txn.Discard()
 			if err := txn.Set(k, data); err != nil {
 				return err
@@ -168,7 +250,7 @@ func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
 		if err != nil {
 			return x.Wrapf(err, "wal.Store: While marshal hardstate")
 		}
-		if err := txn.Set(w.hardStateKey(gid), data); err != nil {
+		if err := txn.Set(w.hardStateKey(), data); err != nil {
 			return err
 		}
 	}
@@ -180,8 +262,8 @@ func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
 		// with Index >= i must be discarded.
 		// Ideally we should be deleting entries from previous term with index >= i,
 		// but to avoid complexity we remove them during reading from wal.
-		start := w.entryKey(gid, t, i+1)
-		prefix := w.prefix(gid)
+		start := w.entryKey(i + 1)
+		prefix := w.prefix()
 		opt := badger.DefaultIteratorOptions
 		opt.PrefetchValues = false
 		itr := txn.NewIterator(opt)
@@ -195,7 +277,7 @@ func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
 				if err := txn.Commit(nil); err != nil {
 					return err
 				}
-				txn = w.wals.NewTransaction(true)
+				txn = w.db.NewTransaction(true)
 				defer txn.Discard()
 				if err := txn.Delete(newk); err != nil {
 					return err
@@ -208,9 +290,13 @@ func (w *Wal) Store(gid uint32, h raftpb.HardState, es []raftpb.Entry) error {
 	return txn.Commit(nil)
 }
 
-func (w *Wal) Snapshot(gid uint32) (snap raftpb.Snapshot, rerr error) {
-	err := w.wals.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(w.snapshotKey(gid))
+// Snapshot returns the most recent snapshot.
+// If snapshot is temporarily unavailable, it should return ErrSnapshotTemporarilyUnavailable,
+// so raft state machine could know that Storage needs some time to prepare
+// snapshot and call Snapshot later.
+func (w *DiskStorage) Snapshot() (snap raftpb.Snapshot, rerr error) {
+	err := w.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(w.snapshotKey())
 		if err != nil {
 			return err
 		}
@@ -226,9 +312,9 @@ func (w *Wal) Snapshot(gid uint32) (snap raftpb.Snapshot, rerr error) {
 	return snap, err
 }
 
-func (w *Wal) HardState(gid uint32) (hd raftpb.HardState, rerr error) {
-	err := w.wals.View(func(txn *badger.Txn) error {
-		item, err := txn.Get(w.hardStateKey(gid))
+func (w *DiskStorage) HardState() (hd raftpb.HardState, rerr error) {
+	err := w.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(w.hardStateKey())
 		if err != nil {
 			return err
 		}
@@ -244,14 +330,33 @@ func (w *Wal) HardState(gid uint32) (hd raftpb.HardState, rerr error) {
 	return hd, err
 }
 
-func (w *Wal) Entries(gid uint32, fromTerm, fromIndex uint64) (es []raftpb.Entry, rerr error) {
-	start := w.entryKey(gid, fromTerm, fromIndex)
-	prefix := w.prefix(gid)
-	err := w.wals.View(func(txn *badger.Txn) error {
+// InitialState returns the saved HardState and ConfState information.
+func (w *DiskStorage) InitialState() (hs raftpb.HardState, cs raftpb.ConfState, err error) {
+	hs, err = w.HardState()
+	if err != nil {
+		return
+	}
+	var snap raftpb.Snapshot
+	snap, err = w.Snapshot()
+	if err != nil {
+		return
+	}
+	return hs, snap.Metadata.ConfState, nil
+}
+
+// Entries returns a slice of log entries in the range [lo,hi).
+// MaxSize limits the total size of the log entries returned, but
+// Entries returns at least one entry if any.
+func (w *DiskStorage) Entries(lo, hi, maxSize uint64) (es []raftpb.Entry, rerr error) {
+	err := w.db.View(func(txn *badger.Txn) error {
 		itr := txn.NewIterator(badger.DefaultIteratorOptions)
 		defer itr.Close()
 
-		var firstIndex uint64
+		start := w.entryKey(lo)
+		end := w.entryKey(hi) // Not included in results.
+		prefix := w.prefix()
+
+		var firstIndex, lastIndex uint64
 		for itr.Seek(start); itr.ValidForPrefix(prefix); itr.Next() {
 			item := itr.Item()
 			var e raftpb.Entry
@@ -262,16 +367,47 @@ func (w *Wal) Entries(gid uint32, fromTerm, fromIndex uint64) (es []raftpb.Entry
 			if err = e.Unmarshal(val); err != nil {
 				return err
 			}
-			if e.Index < fromIndex {
-				continue
-			}
 			if firstIndex == 0 {
 				firstIndex = e.Index
 			}
+			// If this Assert does not fail, then we can safely remove that strange append fix
+			// below.
+			x.AssertTrue(e.Index > lastIndex && e.Index >= lo)
+			lastIndex = e.Index
+			if bytes.Compare(item.Key(), end) >= 0 {
+				break
+			}
 			// When you see entry with Index i, ignore all entries with index >= i
+			//
+			// TODO: Do we still need this weird fix? We're no longer storing
+			// terms in the entry keys, so the entries would automatically get
+			// removed when storing anyway.
 			es = append(es[:e.Index-firstIndex], e)
+		}
+		if firstIndex == 0 || lo < firstIndex {
+			return raft.ErrCompacted
+		}
+		if hi > lastIndex {
+			return raft.ErrUnavailable
 		}
 		return nil
 	})
+	// TODO: This could be optimized to do a rough processing within.
+	es = limitSize(es, maxSize)
 	return es, err
+}
+
+func limitSize(ents []raftpb.Entry, maxSize uint64) []raftpb.Entry {
+	if len(ents) == 0 {
+		return ents
+	}
+	size := ents[0].Size()
+	var limit int
+	for limit = 1; limit < len(ents); limit++ {
+		size += ents[limit].Size()
+		if uint64(size) > maxSize {
+			break
+		}
+	}
+	return ents[:limit]
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -722,7 +722,7 @@ func (n *node) Run() {
 			}
 
 			// Store the hardstate and entries.
-			n.SaveToStorage(rd.HardState, rd.Entries)
+			n.SaveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
 
 			if !raft.IsEmptySnap(rd.Snapshot) {
 				// We don't send snapshots to other nodes. But, if we get one, that means
@@ -741,7 +741,6 @@ func (n *node) Run() {
 				} else {
 					x.Printf("-------> SNAPSHOT [%d] from %d [SELF]. Ignoring.\n", n.gid, rc.Id)
 				}
-				n.SaveSnapshot(rd.Snapshot)
 			}
 
 			lc := len(rd.CommittedEntries)
@@ -903,13 +902,10 @@ func (n *node) snapshot(skip uint64) {
 	rc, err := n.RaftContext.Marshal()
 	x.Check(err)
 
-	_, err = n.Store.CreateSnapshot(snapshotIdx, n.ConfState(), rc)
+	err = n.Store.CreateSnapshot(snapshotIdx, n.ConfState(), rc)
 	x.Checkf(err, "While creating snapshot")
-	x.Checkf(n.Store.Compact(snapshotIdx), "While compacting snapshot")
 	x.Printf("Writing snapshot at index: %d, applied mark: %d\n", snapshotIdx,
 		n.Applied.DoneUntil())
-	// TODO: Work on this.
-	// x.Check(n.Wal.StoreSnapshot(s))
 }
 
 func (n *node) joinPeers() error {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -722,7 +722,7 @@ func (n *node) Run() {
 			}
 
 			// First store the entries, then the hardstate and snapshot.
-			x.Check(n.Wal.Store(n.gid, rd.HardState, rd.Entries))
+			x.Check(n.Wal.Store(rd.HardState, rd.Entries))
 
 			// Now store them in the in-memory store.
 			n.SaveToStorage(rd.HardState, rd.Entries)
@@ -744,7 +744,7 @@ func (n *node) Run() {
 				} else {
 					x.Printf("-------> SNAPSHOT [%d] from %d [SELF]. Ignoring.\n", n.gid, rc.Id)
 				}
-				x.Check(n.Wal.StoreSnapshot(n.gid, rd.Snapshot))
+				x.Check(n.Wal.StoreSnapshot(rd.Snapshot))
 				n.SaveSnapshot(rd.Snapshot)
 			}
 
@@ -912,7 +912,7 @@ func (n *node) snapshot(skip uint64) {
 	x.Checkf(n.Store.Compact(snapshotIdx), "While compacting snapshot")
 	x.Printf("Writing snapshot at index: %d, applied mark: %d\n", snapshotIdx,
 		n.Applied.DoneUntil())
-	x.Check(n.Wal.StoreSnapshot(n.gid, s))
+	x.Check(n.Wal.StoreSnapshot(s))
 }
 
 func (n *node) joinPeers() error {
@@ -961,7 +961,7 @@ func (n *node) retryUntilSuccess(fn func() error, pause time.Duration) {
 }
 
 // InitAndStartNode gets called after having at least one membership sync with the cluster.
-func (n *node) InitAndStartNode(wal *raftwal.Wal) {
+func (n *node) InitAndStartNode(wal *raftwal.DiskStorage) {
 	idx, restart, err := n.InitFromWal(wal)
 	x.Check(err)
 	n.Applied.SetDoneUntil(idx)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -744,7 +744,8 @@ func (n *node) Run() {
 				} else {
 					x.Printf("-------> SNAPSHOT [%d] from %d [SELF]. Ignoring.\n", n.gid, rc.Id)
 				}
-				x.Check(n.Wal.StoreSnapshot(rd.Snapshot))
+				// TODO: Work on this.
+				// x.Check(n.Wal.StoreSnapshot(rd.Snapshot))
 				n.SaveSnapshot(rd.Snapshot)
 			}
 
@@ -907,12 +908,13 @@ func (n *node) snapshot(skip uint64) {
 	rc, err := n.RaftContext.Marshal()
 	x.Check(err)
 
-	s, err := n.Store.CreateSnapshot(snapshotIdx, n.ConfState(), rc)
+	_, err = n.Store.CreateSnapshot(snapshotIdx, n.ConfState(), rc)
 	x.Checkf(err, "While creating snapshot")
 	x.Checkf(n.Store.Compact(snapshotIdx), "While compacting snapshot")
 	x.Printf("Writing snapshot at index: %d, applied mark: %d\n", snapshotIdx,
 		n.Applied.DoneUntil())
-	x.Check(n.Wal.StoreSnapshot(s))
+	// TODO: Work on this.
+	// x.Check(n.Wal.StoreSnapshot(s))
 }
 
 func (n *node) joinPeers() error {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -32,7 +32,7 @@ type groupi struct {
 	// TODO: Is this context being used?
 	ctx       context.Context
 	cancel    context.CancelFunc
-	wal       *raftwal.Wal
+	wal       *raftwal.DiskStorage
 	state     *intern.MembershipState
 	Node      *node
 	gid       uint32
@@ -110,10 +110,10 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	posting.Oracle().SetMaxPending(connState.MaxPending)
 	gr.applyState(connState.GetState())
 
-	gr.wal = raftwal.Init(walStore, Config.RaftId)
+	gid := gr.groupId()
+	gr.wal = raftwal.Init(walStore, Config.RaftId, gid)
 	gr.triggerCh = make(chan struct{}, 1)
 	gr.delPred = make(chan struct{}, 1)
-	gid := gr.groupId()
 	gr.Node = newNode(gid, Config.RaftId, Config.MyAddr)
 	x.Checkf(schema.LoadFromDb(), "Error while initializing schema")
 	raftServer.Node = gr.Node.Node

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -51,7 +51,7 @@ func groups() *groupi {
 // and either start or restart RAFT nodes.
 // This function triggers RAFT nodes to be created, and is the entrace to the RAFT
 // world from main.go.
-func StartRaftNodes(walStore *badger.ManagedDB, bindall bool) {
+func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	gr = new(groupi)
 	gr.ctx, gr.cancel = context.WithCancel(context.Background())
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -487,10 +487,11 @@ START:
 	pl := g.AnyServer(0)
 	// We should always have some connection to dgraphzero.
 	if pl == nil {
-		x.Printf("WARNING: We don't have address of any dgraphzero server.")
+		x.Printf("WARNING: We don't have address of any Zero server.")
 		time.Sleep(time.Second)
 		goto START
 	}
+	x.Printf("Got address of a Zero server: %s", pl.Addr)
 
 	c := intern.NewZeroClient(pl.Get())
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Instead of using the default RAM based Raft Storage (MemoryStorage), build one based on Badger. This should significantly decrease the RAM usage by the Raft write-ahead log, potentially solving the replication OOM issue at #2424.

This also fixes #2417 .

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2433)
<!-- Reviewable:end -->
