### PR TITLE
Refactor and Optimize data streaming

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -10,6 +10,7 @@ package conn
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/rand"
 	"sync"
@@ -172,6 +173,13 @@ func (n *Node) Send(m raftpb.Message) {
 	default:
 		// ignore
 	}
+}
+
+func (n *Node) Snapshot() (raftpb.Snapshot, error) {
+	if n == nil || n.Store == nil {
+		return raftpb.Snapshot{}, errors.New("Uninitialized node or raft store.")
+	}
+	return n.Store.Snapshot()
 }
 
 func (n *Node) SaveToStorage(h raftpb.HardState, es []raftpb.Entry, s raftpb.Snapshot) {

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -384,6 +384,9 @@ func unmarshalOrCopy(plist *intern.PostingList, item *badger.Item) error {
 
 // constructs the posting list from the disk using the passed iterator.
 // Use forward iterator with allversions enabled in iter options.
+//
+// key would now be owned by the posting list. So, ensure that it isn't reused
+// elsewhere.
 func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 	l := new(List)
 	l.key = key

--- a/vendor/github.com/dgraph-io/badger/CHANGELOG.md
+++ b/vendor/github.com/dgraph-io/badger/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.1] - 2018-06-04
+Bug Fixes:
+* Fix for infinite yieldItemValue recursion. #503
+* Fix recursive addition of `badgerMove` prefix. https://github.com/dgraph-io/badger/commit/2e3a32f0ccac3066fb4206b28deb39c210c5266f
+* Use file size based window size for sampling, instead of fixing it to 10MB. #501
+
+Cleanup:
+* Clarify comments and documentation.
+* Move badger tool one directory level up.
+
 ## [1.5.0] - 2018-05-08
 * Introduce `NumVersionsToKeep` option. This option is used to discard many
   versions of the same key, which saves space.
@@ -28,7 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Introduce new `LSMOnlyOptions`, to make Badger act like a typical LSM based DB.
 
 Bug fix:
-* [Temporary] Check max version across all tables in Get (removed in next
+* (Temporary) Check max version across all tables in Get (removed in next
   release).
 * Update commit and read ts while loading from backup.
 * Ensure all transaction entries are part of the same value log file.
@@ -61,7 +71,10 @@ Bug fix:
 ## [1.0.1] - 2017-11-06
 * Fix an uint16 overflow when resizing key slice
 
-[Unreleased]: https://github.com/dgraph-io/badger/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/dgraph-io/badger/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/dgraph-io/badger/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/dgraph-io/badger/compare/v1.4.0...v1.5.0
+[1.4.0]: https://github.com/dgraph-io/badger/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/dgraph-io/badger/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/dgraph-io/badger/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/dgraph-io/badger/compare/v1.1.0...v1.1.1

--- a/vendor/github.com/dgraph-io/badger/README.md
+++ b/vendor/github.com/dgraph-io/badger/README.md
@@ -415,7 +415,22 @@ the following methods, which can be invoked at an appropriate time:
   LSM-tree compactions to pick files that are likely to lead to maximum space
   reclamation.
 
-  It is recommended that this method be called regularly.
+It is recommended that this method be called during periods of low activity in
+your system, or periodically. One call would only result in removal of at max
+one log file. As an optimization, you could also immediately re-run it whenever
+it returns nil error (indicating a successful value log GC).
+
+```go
+ticker := time.NewTicker(5 * time.Minute)
+defer ticker.Stop()
+for range ticker.C {
+again:
+  err := db.RunValueLogGC(0.7)
+  if err == nil {
+    goto again
+  }
+}
+```
 
 ### Database backup
 There are two public API methods `DB.Backup()` and `DB.Load()` which can be

--- a/vendor/github.com/dgraph-io/badger/iterator.go
+++ b/vendor/github.com/dgraph-io/badger/iterator.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/options"
+	"github.com/dgraph-io/dgraph/x"
 
 	"github.com/dgraph-io/badger/y"
 	farm "github.com/dgryski/go-farm"
@@ -167,7 +168,9 @@ func (item *Item) yieldItemValue() ([]byte, func(), error) {
 		// The value pointer is pointing to a deleted value log. Look for the
 		// move key and read that instead.
 		runCallback(cb)
+		prevSz := uint16(len(key))
 		key = append(badgerMove, y.KeyWithTs(item.Key(), item.Version())...)
+		x.AssertTruef(uint16(len(key)) > prevSz, "prev size: %d", prevSz)
 		// Note that we can't set item.key to move key, because that would
 		// change the key user sees before and after this call. Also, this move
 		// logic is internal logic and should not impact the external behavior

--- a/vendor/github.com/dgraph-io/badger/iterator.go
+++ b/vendor/github.com/dgraph-io/badger/iterator.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/badger/options"
-	"github.com/dgraph-io/dgraph/x"
 
 	"github.com/dgraph-io/badger/y"
 	farm "github.com/dgryski/go-farm"
@@ -168,9 +167,9 @@ func (item *Item) yieldItemValue() ([]byte, func(), error) {
 		// The value pointer is pointing to a deleted value log. Look for the
 		// move key and read that instead.
 		runCallback(cb)
-		prevSz := uint16(len(key))
-		key = append(badgerMove, y.KeyWithTs(item.Key(), item.Version())...)
-		x.AssertTruef(uint16(len(key)) > prevSz, "prev size: %d", prevSz)
+		// Do not put badgerMove on the left in append. It seems to cause some sort of manipulation.
+		key = append([]byte{}, badgerMove...)
+		key = append(key, y.KeyWithTs(item.Key(), item.Version())...)
 		// Note that we can't set item.key to move key, because that would
 		// change the key user sees before and after this call. Also, this move
 		// logic is internal logic and should not impact the external behavior

--- a/vendor/github.com/dgraph-io/badger/transaction.go
+++ b/vendor/github.com/dgraph-io/badger/transaction.go
@@ -408,13 +408,10 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 }
 
 func (txn *Txn) runCallbacks() {
-	if txn.callbacks == nil {
-		return
-	}
 	for _, cb := range txn.callbacks {
 		cb()
 	}
-	txn.callbacks = nil
+	txn.callbacks = txn.callbacks[:0]
 }
 
 // Discard discards a created transaction. This method is very important and must be called. Commit

--- a/vendor/github.com/dgraph-io/badger/transaction.go
+++ b/vendor/github.com/dgraph-io/badger/transaction.go
@@ -408,6 +408,9 @@ func (txn *Txn) Get(key []byte) (item *Item, rerr error) {
 }
 
 func (txn *Txn) runCallbacks() {
+	if txn.callbacks == nil {
+		return
+	}
 	for _, cb := range txn.callbacks {
 		cb()
 	}

--- a/vendor/github.com/dgraph-io/badger/value.go
+++ b/vendor/github.com/dgraph-io/badger/value.go
@@ -387,7 +387,8 @@ func (vlog *valueLog) rewrite(f *logFile, tr trace.Trace) error {
 			if bytes.HasPrefix(e.Key, badgerMove) {
 				ne.Key = append([]byte{}, e.Key...)
 			} else {
-				ne.Key = append(badgerMove, e.Key...)
+				ne.Key = append([]byte{}, badgerMove...)
+				ne.Key = append(ne.Key, e.Key...)
 			}
 
 			ne.Value = append([]byte{}, e.Value...)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -163,52 +163,40 @@
 			"revisionTime": "2016-09-07T16:21:46Z"
 		},
 		{
-			"checksumSHA1": "cy6MsL7H3EaR4rkvZq5xUwoZ/g4=",
+			"checksumSHA1": "Z9ACXnmy9E2oP8htXk2/XUVAjag=",
 			"path": "github.com/dgraph-io/badger",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "oOuT7ebEiZ1ViHLKdFxKFOvobAQ=",
 			"path": "github.com/dgraph-io/badger/options",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "gGTDnTVVw5kcT2P5NXZV1YSckOU=",
 			"path": "github.com/dgraph-io/badger/protos",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "00T6XbLV4d95J7hm6kTXDReaQHM=",
 			"path": "github.com/dgraph-io/badger/skl",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "I33KkP2lnYqJDasvvsAlebzkeko=",
 			"path": "github.com/dgraph-io/badger/table",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "v2pJQ5NbS034cLP+GM1WLlGnByY=",
 			"path": "github.com/dgraph-io/badger/y",
-			"revision": "690400e629977977ecddfa8ab3a7f9285e1041a8",
-			"revisionTime": "2018-06-04T20:44:01Z",
-			"version": "v1.5.1",
-			"versionExact": "v1.5.1"
+			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
+			"revisionTime": "2018-06-13T23:21:36Z"
 		},
 		{
 			"checksumSHA1": "a29TtOU87eZA0S6wL+rAkpqUEzc=",

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -40,8 +40,9 @@ func writeBatch(ctx context.Context, pstore *badger.ManagedDB, kvChan chan *inte
 		now := time.Now()
 		for range t.C {
 			dur := time.Since(now)
-			x.Printf("Getting SNAPSHOT: Time elapsed: %v, bytes written: %s, bytes/sec %d\n",
-				x.FixedDuration(dur), humanize.Bytes(bytesWritten), bytesWritten/uint64(dur.Seconds()))
+			speed := bytesWritten / uint64(dur.Seconds())
+			x.Printf("Getting SNAPSHOT: Time elapsed: %v, bytes written: %s, %s/s\n",
+				x.FixedDuration(dur), humanize.Bytes(bytesWritten), humanize.Bytes(speed))
 		}
 	}()
 

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -8,14 +8,12 @@
 package worker
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"golang.org/x/net/context"
 
@@ -25,7 +23,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/intern"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
-	humanize "github.com/dustin/go-humanize"
 )
 
 var (
@@ -76,108 +73,6 @@ func populateKeyValues(ctx context.Context, kvs []*intern.KV) error {
 	return schema.Load(predicate)
 }
 
-func produceKeys(ctx context.Context, txn *badger.Txn, predicate string, keys chan string) {
-	prefix := x.PredicatePrefix(predicate)
-	iterOpts := badger.DefaultIteratorOptions
-	iterOpts.PrefetchValues = false
-	it := txn.NewIterator(iterOpts)
-	defer it.Close()
-
-	var prevKey []byte
-	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
-		item := it.Item()
-		key := item.Key()
-
-		if bytes.Equal(key, prevKey) {
-			continue
-		}
-		prevKey = append(prevKey[:0], key...)
-		keys <- string(key)
-	}
-	close(keys)
-}
-
-func produceKVs(ctx context.Context, txn *badger.Txn, keys chan string,
-	kvChan chan *intern.KV) error {
-	for {
-		select {
-		case key, ok := <-keys:
-			if !ok {
-				// Done with the keys.
-				return nil
-			}
-			iterOpts := badger.DefaultIteratorOptions
-			// We don't know how many values do we really need to read this PL. We could stop at
-			// just one. So, let's not get more than necessary.
-			iterOpts.PrefetchValues = false
-			iterOpts.AllVersions = true
-			it := txn.NewIterator(iterOpts)
-			it.Seek([]byte(key))
-			l, err := posting.ReadPostingList([]byte(key), it)
-			it.Close()
-			if err != nil {
-				return err
-			}
-			kv, err := l.MarshalToKv()
-			if err != nil {
-				return err
-			}
-			kvChan <- kv
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-}
-
-func streamKVs(ctx context.Context, predicate string, kvChan chan *intern.KV,
-	stream intern.Worker_ReceivePredicateClient) error {
-	var count, batchSize int
-	var bytesSent uint64
-	kvs := &intern.KVS{}
-	t := time.NewTicker(time.Second)
-	defer t.Stop()
-	now := time.Now()
-
-outer:
-	for {
-		select {
-		case kv, ok := <-kvChan:
-			if !ok {
-				break outer
-			}
-			kvs.Kv = append(kvs.Kv, kv)
-			batchSize += kv.Size()
-			bytesSent += uint64(kv.Size())
-			count++
-			if batchSize < 4*MB {
-				continue
-			}
-			if err := stream.Send(kvs); err != nil {
-				return err
-			}
-			kvs = &intern.KVS{}
-			batchSize = 0
-
-		case <-t.C:
-			dur := time.Since(now)
-			speed := bytesSent / uint64(dur.Seconds())
-			x.Printf("Sending predicate: [%v] Time elapsed: %v, bytes sent: %s, speed: %v/sec\n",
-				predicate, x.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
-
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-	}
-
-	if len(kvs.Kv) > 0 {
-		if err := stream.Send(kvs); err != nil {
-			return err
-		}
-	}
-	x.Printf("Sent %d (+1 maybe for schema) keys for predicate %v\n", count, predicate)
-	return nil
-}
-
 func movePredicateHelper(ctx context.Context, predicate string, gid uint32) error {
 	pl := groups().Leader(gid)
 	if pl == nil {
@@ -193,44 +88,18 @@ func movePredicateHelper(ctx context.Context, predicate string, gid uint32) erro
 	txn := pstore.NewTransactionAt(math.MaxUint64, false)
 	defer txn.Discard()
 
-	keysCh := make(chan string, 1000)     // Contains keys for posting lists.
-	kvChan := make(chan *intern.KV, 1000) // Contains marshaled posting lists.
-	errCh := make(chan error, 1)          // Stores error by consumeKeys.
-
 	// Read the predicate keys and stream to keysCh.
-	go produceKeys(ctx, txn, predicate, keysCh)
-
-	// Read the posting lists corresponding to keys and send to kvChan.
-	var wg sync.WaitGroup
-	for i := 0; i < 16; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := produceKVs(ctx, txn, keysCh, kvChan); err != nil {
-				select {
-				case errCh <- err:
-				default:
-				}
-			}
-		}()
+	sl := streamLists{stream: stream, predicate: predicate}
+	sl.itemToKv = func(key string, itr *badger.Iterator) (*intern.KV, error) {
+		l, err := posting.ReadPostingList([]byte(key), itr)
+		if err != nil {
+			return nil, err
+		}
+		return l.MarshalToKv()
 	}
 
-	// Pick up key-values from kvChan and send to stream.
-	kvErr := make(chan error, 1)
-	go func() {
-		kvErr <- streamKVs(ctx, predicate, kvChan, stream)
-	}()
-	wg.Wait()     // Wait for produceKVs to be over.
-	close(kvChan) // Now we can close kvChan.
-
-	select {
-	case err := <-errCh: // Check error from produceKVs.
-		return err
-	default:
-	}
-
-	// Wait for key streaming to be over.
-	if err := <-kvErr; err != nil {
+	prefix := fmt.Sprintf("Sending predicate: [%s]", predicate)
+	if err := sl.orchestrate(ctx, prefix, txn); err != nil {
 		return err
 	}
 

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -90,8 +90,8 @@ func movePredicateHelper(ctx context.Context, predicate string, gid uint32) erro
 
 	// Read the predicate keys and stream to keysCh.
 	sl := streamLists{stream: stream, predicate: predicate}
-	sl.itemToKv = func(key string, itr *badger.Iterator) (*intern.KV, error) {
-		l, err := posting.ReadPostingList([]byte(key), itr)
+	sl.itemToKv = func(key []byte, itr *badger.Iterator) (*intern.KV, error) {
+		l, err := posting.ReadPostingList(key, itr)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -23,7 +23,6 @@ type kvStream interface {
 	Send(*intern.KVS) error
 }
 
-// TODO: Write tests.
 type streamLists struct {
 	stream    kvStream
 	predicate string

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -73,6 +73,10 @@ func (sl *streamLists) orchestrate(ctx context.Context, prefix string, txn *badg
 	return nil
 }
 
+// TODO: Change this so the first phase generates a key range, and passes it onto the second phase.
+// The 2nd phase would then use the iterator to iterate over that key range, generating the PLs, and
+// sending them over to kvChan. That way we reduce the Iterator::Seeks significantly, and can use
+// prefetch as well.
 func (sl *streamLists) produceKeys(ctx context.Context, txn *badger.Txn, keys chan string) {
 	var prefix []byte
 	if len(sl.predicate) > 0 {

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -65,9 +65,7 @@ func (sl *streamLists) orchestrate(ctx context.Context, prefix string, txn *badg
 	go func() {
 		kvErr <- sl.streamKVs(ctx, prefix, kvChan)
 	}()
-	x.Printf("waiting for produce and stream\n")
-	wg.Wait() // Wait for produceKVs to be over.
-	x.Printf("Closing kvchan\n")
+	wg.Wait()     // Wait for produceKVs to be over.
 	close(kvChan) // Now we can close kvChan.
 
 	select {
@@ -108,7 +106,6 @@ func (sl *streamLists) produceRanges(ctx context.Context, txn *badger.Txn, keyCh
 		if size > 4*MB {
 			kr := keyRange{start: start, end: item.KeyCopy(nil)}
 			keyCh <- kr
-			x.Printf("Output keyRange: %v of size: %d\n", kr, size)
 			start = item.KeyCopy(nil)
 			size = 0
 		}
@@ -196,7 +193,6 @@ func (sl *streamLists) streamKVs(ctx context.Context, prefix string, kvChan chan
 				x.AssertTrue(kvs != nil)
 				batch.Kv = append(batch.Kv, kvs.Kv...)
 			default:
-				x.Printf("Breaking loop at default\n")
 				break loop
 			}
 		}
@@ -207,7 +203,7 @@ func (sl *streamLists) streamKVs(ctx context.Context, prefix string, kvChan chan
 		if err := sl.stream.Send(batch); err != nil {
 			return err
 		}
-		x.Printf("Sent batch of size: %d in %v.\n", sz, time.Since(t))
+		x.Printf("Sent batch of size: %s in %v.\n", humanize.Bytes(sz), time.Since(t))
 		return nil
 	}
 

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc.
+ *
+ * This file is available under the Apache License, Version 2.0,
+ * with the Commons Clause restriction.
+ */
+
+package worker
+
+import (
+	"sync"
+	"time"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/dgraph/protos/intern"
+	"github.com/dgraph-io/dgraph/x"
+	humanize "github.com/dustin/go-humanize"
+	"golang.org/x/net/context"
+)
+
+type kvStream interface {
+	Send(*intern.KVS) error
+}
+
+type streamLists struct {
+	stream    kvStream
+	predicate string
+	chooseKey func(key []byte, version uint64) bool
+	itemToKv  func(key string, itr *badger.Iterator) (*intern.KV, error)
+}
+
+func (sl *streamLists) orchestrate(ctx context.Context, prefix string, txn *badger.Txn) error {
+	keysCh := make(chan string, 1000)     // Contains keys for posting lists.
+	kvChan := make(chan *intern.KV, 1000) // Contains marshaled posting lists.
+	errCh := make(chan error, 1)          // Stores error by consumeKeys.
+
+	// Read the predicate keys and stream to keysCh.
+	go sl.produceKeys(ctx, txn, keysCh)
+
+	// Read the posting lists corresponding to keys and send to kvChan.
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := sl.produceKVs(ctx, txn, keysCh, kvChan); err != nil {
+				select {
+				case errCh <- err:
+				default:
+				}
+			}
+		}()
+	}
+
+	// Pick up key-values from kvChan and send to stream.
+	kvErr := make(chan error, 1)
+	go func() {
+		kvErr <- sl.streamKVs(ctx, prefix, kvChan)
+	}()
+	wg.Wait()     // Wait for produceKVs to be over.
+	close(kvChan) // Now we can close kvChan.
+
+	select {
+	case err := <-errCh: // Check error from produceKVs.
+		return err
+	default:
+	}
+
+	// Wait for key streaming to be over.
+	if err := <-kvErr; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sl *streamLists) produceKeys(ctx context.Context, txn *badger.Txn, keys chan string) {
+	var prefix []byte
+	if len(sl.predicate) > 0 {
+		prefix = x.PredicatePrefix(sl.predicate)
+	}
+	iterOpts := badger.DefaultIteratorOptions
+	iterOpts.PrefetchValues = false
+	it := txn.NewIterator(iterOpts)
+	defer it.Close()
+
+	for it.Seek(prefix); it.ValidForPrefix(prefix); it.Next() {
+		item := it.Item()
+		key := item.Key()
+
+		if sl.chooseKey == nil || sl.chooseKey(key, item.Version()) {
+			keys <- string(key)
+		}
+	}
+	close(keys)
+}
+
+func (sl *streamLists) produceKVs(ctx context.Context, txn *badger.Txn,
+	keys chan string, kvChan chan *intern.KV) error {
+	for {
+		select {
+		case key, ok := <-keys:
+			if !ok {
+				// Done with the keys.
+				return nil
+			}
+			iterOpts := badger.DefaultIteratorOptions
+			// We don't know how many values do we really need to read this PL. We could stop at
+			// just one. So, let's not get more than necessary.
+			iterOpts.PrefetchValues = false
+			iterOpts.AllVersions = true
+			it := txn.NewIterator(iterOpts)
+			it.Seek([]byte(key))
+			if it.Valid() {
+				kv, err := sl.itemToKv(key, it)
+				it.Close()
+				if err != nil {
+					return err
+				}
+				kvChan <- kv
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (sl *streamLists) streamKVs(ctx context.Context, prefix string, kvChan chan *intern.KV) error {
+	var count, batchSize int
+	var bytesSent uint64
+	kvs := &intern.KVS{}
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+	now := time.Now()
+
+outer:
+	for {
+		select {
+		case kv, ok := <-kvChan:
+			if !ok {
+				break outer
+			}
+			kvs.Kv = append(kvs.Kv, kv)
+			batchSize += kv.Size()
+			bytesSent += uint64(kv.Size())
+			count++
+			if batchSize < 32*MB {
+				continue
+			}
+			if err := sl.stream.Send(kvs); err != nil {
+				return err
+			}
+			kvs = &intern.KVS{}
+			batchSize = 0
+
+		case <-t.C:
+			dur := time.Since(now)
+			speed := bytesSent / uint64(dur.Seconds())
+			x.Printf("%s Time elapsed: %v, bytes sent: %s, speed: %v/sec\n",
+				prefix, x.FixedDuration(dur), humanize.Bytes(bytesSent), humanize.Bytes(speed))
+
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	if len(kvs.Kv) > 0 {
+		if err := sl.stream.Send(kvs); err != nil {
+			return err
+		}
+	}
+	x.Printf("%s Sent %d (+1 maybe for schema) keys\n", prefix, count)
+	return nil
+}

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -143,7 +143,7 @@ outer:
 			batchSize += kv.Size()
 			bytesSent += uint64(kv.Size())
 			count++
-			if batchSize < 32*MB {
+			if batchSize < 16*MB {
 				continue
 			}
 			if err := sl.stream.Send(kvs); err != nil {

--- a/worker/stream_lists_test.go
+++ b/worker/stream_lists_test.go
@@ -1,0 +1,148 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/dgraph/protos/intern"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func openBadger(dir string) (*badger.DB, error) {
+	opt := badger.DefaultOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	return badger.Open(opt)
+}
+
+func value(k int) []byte {
+	return []byte(fmt.Sprintf("%08d", k))
+}
+
+type collector struct {
+	kv []*intern.KV
+}
+
+func (c *collector) Send(kvs *intern.KVS) error {
+	c.kv = append(c.kv, kvs.Kv...)
+	return nil
+}
+
+func TestOrchestrate(t *testing.T) {
+	dir, err := ioutil.TempDir("", "badger")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	db, err := openBadger(dir)
+	require.NoError(t, err)
+
+	for _, pred := range []string{"p0", "p1", "p2"} {
+		err = db.Update(func(txn *badger.Txn) error {
+			for i := 1; i <= 100; i++ {
+				key := x.DataKey(pred, uint64(i))
+				if err := txn.Set(key, value(i)); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	c := &collector{kv: make([]*intern.KV, 0, 100)}
+	sl := streamLists{stream: c}
+	sl.itemToKv = func(key []byte, itr *badger.Iterator) (*intern.KV, error) {
+		item := itr.Item()
+		val, err := item.ValueCopy(nil)
+		require.NoError(t, err)
+		kv := &intern.KV{Key: item.KeyCopy(nil), Val: val, Version: item.Version()}
+		itr.Next() // Just for fun.
+		return kv, nil
+	}
+
+	txn := db.NewTransaction(false)
+	defer txn.Discard()
+
+	// Test case 1. Retrieve everything.
+	err = sl.orchestrate(context.Background(), "Testing", txn)
+	require.NoError(t, err)
+	require.Equal(t, 300, len(c.kv), "Expected 300. Got: %d", len(c.kv))
+
+	m := make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Val)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 3, len(m))
+	for pred, count := range m {
+		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 2. Retrieve only 1 predicate.
+	sl.predicate = "p1"
+	c.kv = c.kv[:0]
+	err = sl.orchestrate(context.Background(), "Testing", txn)
+	require.NoError(t, err)
+	require.Equal(t, 100, len(c.kv), "Expected 100. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Val)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 1, len(m))
+	for pred, count := range m {
+		require.Equal(t, 100, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 3. Retrieve select keys within the predicate.
+	c.kv = c.kv[:0]
+	sl.chooseKey = func(key []byte, version uint64) bool {
+		pk := x.Parse(key)
+		return pk.Uid%2 == 0
+	}
+	err = sl.orchestrate(context.Background(), "Testing", txn)
+	require.NoError(t, err)
+	require.Equal(t, 50, len(c.kv), "Expected 50. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Val)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 1, len(m))
+	for pred, count := range m {
+		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	}
+
+	// Test case 4. Retrieve select keys from all predicates.
+	c.kv = c.kv[:0]
+	sl.predicate = ""
+	err = sl.orchestrate(context.Background(), "Testing", txn)
+	require.NoError(t, err)
+	require.Equal(t, 150, len(c.kv), "Expected 150. Got: %d", len(c.kv))
+
+	m = make(map[string]int)
+	for _, kv := range c.kv {
+		pk := x.Parse(kv.Key)
+		expected := value(int(pk.Uid))
+		require.Equal(t, expected, kv.Val)
+		m[pk.Attr]++
+	}
+	require.Equal(t, 3, len(m))
+	for pred, count := range m {
+		require.Equal(t, 50, count, "Count mismatch for pred: %s", pred)
+	}
+}

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -152,7 +152,9 @@ func (w *WaterMark) process() {
 		// Update mark by going through all indices in order; and checking if they have
 		// been done. Stop at the first index, which isn't done.
 		doneUntil := w.DoneUntil()
-		AssertTrue(doneUntil < index)
+		if doneUntil > index {
+			AssertTruef(false, "Name: %s doneUntil: %d. Index: %d", w.Name, doneUntil, index)
+		}
 
 		until := doneUntil
 		loops := 0


### PR DESCRIPTION
There are two kinds of data streaming going on. One is to do a predicate move on instructions from Zero. Other is when a replica server requests for a snapshot. Both were using different code, with very similar logic. So, refactored the two into one common file, stream_lists.go.

Also optimized the streaming, so we generate key ranges first, then have multiple goroutines pick up a range each, and iterate over it, generating one KVS per range. This output is then batched smartly and sent over the wire. This achieves pretty amazing transfer speeds (hard to say, because of the small data sets I'm playing with but, saw it spike to 20 Mbps before the data finishes).

Also fixed a whole bunch of bugs. Some in Badger related to key moves and nil txn.callbacks. And an assert failure in watermark.go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2442)
<!-- Reviewable:end -->
