### PR TITLE
Don't iterate simulatenously

### DIFF
--- a/vendor/github.com/dgraph-io/badger/backup.go
+++ b/vendor/github.com/dgraph-io/badger/backup.go
@@ -53,6 +53,8 @@ func (db *DB) Backup(w io.Writer, since uint64) (uint64, error) {
 		opts := DefaultIteratorOptions
 		opts.AllVersions = true
 		it := txn.NewIterator(opts)
+		defer it.Close()
+
 		for it.Rewind(); it.Valid(); it.Next() {
 			item := it.Item()
 			if item.Version() < since {

--- a/vendor/github.com/dgraph-io/badger/db.go
+++ b/vendor/github.com/dgraph-io/badger/db.go
@@ -1121,6 +1121,8 @@ func (op *MergeOperator) iterateAndMerge(txn *Txn) (val []byte, err error) {
 	opt := DefaultIteratorOptions
 	opt.AllVersions = true
 	it := txn.NewIterator(opt)
+	defer it.Close()
+
 	var numVersions int
 	for it.Rewind(); it.ValidForPrefix(op.key); it.Next() {
 		item := it.Item()

--- a/vendor/github.com/dgraph-io/badger/iterator.go
+++ b/vendor/github.com/dgraph-io/badger/iterator.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dgraph-io/badger/options"
@@ -316,6 +317,10 @@ type Iterator struct {
 // Using prefetch is highly recommended if you're doing a long running iteration.
 // Avoid long running iterations in update transactions.
 func (txn *Txn) NewIterator(opt IteratorOptions) *Iterator {
+	if atomic.AddInt32(&txn.numIterators, 1) > 1 {
+		panic("Only one iterator can be active at one time.")
+	}
+
 	tables, decr := txn.db.getMemTables()
 	defer decr()
 	txn.db.vlog.incrIteratorCount()
@@ -382,6 +387,7 @@ func (it *Iterator) Close() {
 
 	// TODO: We could handle this error.
 	_ = it.txn.db.vlog.decrIteratorCount()
+	atomic.AddInt32(&it.txn.numIterators, -1)
 }
 
 // Next would advance the iterator by one. Always check it.Valid() after a Next()

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -163,40 +163,52 @@
 			"revisionTime": "2016-09-07T16:21:46Z"
 		},
 		{
-			"checksumSHA1": "Z9ACXnmy9E2oP8htXk2/XUVAjag=",
+			"checksumSHA1": "xQ/fTdQtyWUpUEauK6Jr1F0I8QY=",
 			"path": "github.com/dgraph-io/badger",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "oOuT7ebEiZ1ViHLKdFxKFOvobAQ=",
 			"path": "github.com/dgraph-io/badger/options",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "gGTDnTVVw5kcT2P5NXZV1YSckOU=",
 			"path": "github.com/dgraph-io/badger/protos",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "00T6XbLV4d95J7hm6kTXDReaQHM=",
 			"path": "github.com/dgraph-io/badger/skl",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "I33KkP2lnYqJDasvvsAlebzkeko=",
 			"path": "github.com/dgraph-io/badger/table",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "v2pJQ5NbS034cLP+GM1WLlGnByY=",
 			"path": "github.com/dgraph-io/badger/y",
-			"revision": "3340933a01945fb517775a0e0f079a701d04f094",
-			"revisionTime": "2018-06-13T23:21:36Z"
+			"revision": "b1ad1e93e483bbfef123793ceedc9a7e34b09f79",
+			"revisionTime": "2018-06-19T00:07:00Z",
+			"version": "HEAD",
+			"versionExact": "HEAD"
 		},
 		{
 			"checksumSHA1": "a29TtOU87eZA0S6wL+rAkpqUEzc=",
@@ -259,10 +271,10 @@
 			"revisionTime": "2017-08-10T00:29:00Z"
 		},
 		{
-			"checksumSHA1": "Pyou8mceOASSFxc7GeXZuVdSMi0=",
+			"checksumSHA1": "JZV+pLo8Z/kIYExrZr1Zu9KSKyU=",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "b4deda0973fb4c70b50d226b1af49f3da59f5265",
-			"revisionTime": "2018-04-30T18:52:41Z"
+			"revision": "9f81198da99b79e14d70ca2c3cc1bbe44c6e69b6",
+			"revisionTime": "2018-06-16T23:00:25Z"
 		},
 		{
 			"checksumSHA1": "z4copNgeTN77OymdDKqLaIK/vSI=",
@@ -483,20 +495,20 @@
 		{
 			"checksumSHA1": "GtamqiJoL7PGHsN454AoffBFMa8=",
 			"path": "golang.org/x/net/context",
-			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
-			"revisionTime": "2018-05-08T00:58:03Z"
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
 		},
 		{
 			"checksumSHA1": "UxahDzW2v4mf/+aFxruuupaoIwo=",
 			"path": "golang.org/x/net/internal/timeseries",
-			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
-			"revisionTime": "2018-05-08T00:58:03Z"
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
 		},
 		{
 			"checksumSHA1": "rJn3m/27kO+2IU6KCCZ74Miby+8=",
 			"path": "golang.org/x/net/trace",
-			"revision": "f73e4c9ed3b7ebdd5f699a16a880c2b1994e50dd",
-			"revisionTime": "2018-05-08T00:58:03Z"
+			"revision": "db08ff08e8622530d9ed3a0e8ac279f6d4c02196",
+			"revisionTime": "2018-06-11T16:35:41Z"
 		},
 		{
 			"checksumSHA1": "nf+CWRQfmxmZkdYRpxEuA8u+qwI=",

--- a/worker/predicate.go
+++ b/worker/predicate.go
@@ -229,7 +229,7 @@ func (w *grpcWorker) PredicateAndSchemaData(m *intern.SnapshotMeta, stream inter
 		return err
 	}
 
-	sl := streamLists{stream: stream}
+	sl := streamLists{stream: stream, db: pstore}
 	sl.chooseKey = func(key []byte, version uint64) bool {
 		pk := x.Parse(key)
 		return version > clientTs || pk.IsSchema()
@@ -257,9 +257,7 @@ func (w *grpcWorker) PredicateAndSchemaData(m *intern.SnapshotMeta, stream inter
 		return l.MarshalToKv()
 	}
 
-	txn := pstore.NewTransactionAt(min_ts, false)
-	defer txn.Discard()
-	if err := sl.orchestrate(stream.Context(), "Sending SNAPSHOT", txn); err != nil {
+	if err := sl.orchestrate(stream.Context(), "Sending SNAPSHOT", min_ts); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Don't create multiple iterators for the same transaction, because badger.Txn object is not multi-threaded. We've added panics within Badger to catch multiple and unclosed iterators. This fixes some of the panics and blocks I've seen with predicate streaming.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2447)
<!-- Reviewable:end -->
