### PR TITLE
Allow tweaking Badger options

### DIFF
--- a/dgraph/cmd/server/run.go
+++ b/dgraph/cmd/server/run.go
@@ -64,6 +64,9 @@ func init() {
 		"Specifies how Badger LSM tree is stored. Options are loadtoram, memorymap and "+
 			"fileio; which consume most to least RAM while providing best to worst read"+
 			"performance respectively.")
+	flag.String("posting_vlog", defaults.PostingVlog,
+		"Specifies how Badger Value log is stored. Options are memorymap and fileio."+
+			" memorymap consumes more RAM, but provides better performance in some cases.")
 	flag.StringP("wal", "w", defaults.WALDir,
 		"Directory to store raft write-ahead logs.")
 	flag.Bool("nomutations", defaults.Nomutations,
@@ -278,6 +281,7 @@ func run() {
 	config := edgraph.Options{
 		PostingDir:          Server.Conf.GetString("postings"),
 		PostingTables:       Server.Conf.GetString("posting_tables"),
+		PostingVlog:         Server.Conf.GetString("posting_vlog"),
 		WALDir:              Server.Conf.GetString("wal"),
 		Nomutations:         Server.Conf.GetBool("nomutations"),
 		WhitelistedIPs:      Server.Conf.GetString("whitelist"),

--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -24,6 +24,7 @@ import (
 type Options struct {
 	PostingDir    string
 	PostingTables string
+	PostingVlog   string
 	WALDir        string
 	Nomutations   bool
 
@@ -48,6 +49,7 @@ var Config Options
 var DefaultConfig = Options{
 	PostingDir:    "p",
 	PostingTables: "memorymap",
+	PostingVlog:   "memorymap",
 	WALDir:        "w",
 	Nomutations:   false,
 
@@ -100,6 +102,7 @@ func setConfVar(conf Options) {
 
 	x.Conf.Set("posting_dir", newStr(conf.PostingDir))
 	x.Conf.Set("posting_tables", newStr(conf.PostingTables))
+	x.Conf.Set("posting_vlog", newStr(conf.PostingVlog))
 	x.Conf.Set("wal_dir", newStr(conf.WALDir))
 	x.Conf.Set("allotted_memory", newFloat(conf.AllottedMemory))
 	x.Conf.Set("tracing", newFloat(conf.Tracing))

--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -23,8 +23,9 @@ import (
 
 type Options struct {
 	PostingDir    string
-	PostingTables string
-	PostingVlog   string
+	BadgerTables  string
+	BadgerVlog    string
+	BadgerOptions string
 	WALDir        string
 	Nomutations   bool
 
@@ -48,8 +49,9 @@ var Config Options
 
 var DefaultConfig = Options{
 	PostingDir:    "p",
-	PostingTables: "memorymap",
-	PostingVlog:   "memorymap",
+	BadgerTables:  "memorymap",
+	BadgerVlog:    "memorymap",
+	BadgerOptions: "default",
 	WALDir:        "w",
 	Nomutations:   false,
 
@@ -100,9 +102,12 @@ func setConfVar(conf Options) {
 		return v
 	}
 
+	// This is so we can find these options in /debug/vars.
+	x.Conf.Set("badger.tables", newStr(conf.BadgerTables))
+	x.Conf.Set("badger.vlog", newStr(conf.BadgerVlog))
+	x.Conf.Set("badger.options", newStr(conf.BadgerOptions))
+
 	x.Conf.Set("posting_dir", newStr(conf.PostingDir))
-	x.Conf.Set("posting_tables", newStr(conf.PostingTables))
-	x.Conf.Set("posting_vlog", newStr(conf.PostingVlog))
 	x.Conf.Set("wal_dir", newStr(conf.WALDir))
 	x.Conf.Set("allotted_memory", newFloat(conf.AllottedMemory))
 	x.Conf.Set("tracing", newFloat(conf.Tracing))

--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -49,8 +49,8 @@ var Config Options
 
 var DefaultConfig = Options{
 	PostingDir:    "p",
-	BadgerTables:  "memorymap",
-	BadgerVlog:    "memorymap",
+	BadgerTables:  "mmap",
+	BadgerVlog:    "mmap",
 	BadgerOptions: "default",
 	WALDir:        "w",
 	Nomutations:   false,

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -118,6 +118,7 @@ func (s *ServerState) initStorage() {
 	opt.Dir = Config.PostingDir
 	opt.ValueDir = Config.PostingDir
 	opt.NumVersionsToKeep = math.MaxInt32
+	opt.ValueLogLoadingMode = options.FileIO
 	switch Config.PostingTables {
 	case "memorymap":
 		opt.TableLoadingMode = options.MemoryMap

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -118,7 +118,8 @@ func (s *ServerState) initStorage() {
 	opt.Dir = Config.PostingDir
 	opt.ValueDir = Config.PostingDir
 	opt.NumVersionsToKeep = math.MaxInt32
-	opt.ValueLogLoadingMode = options.FileIO
+
+	x.Printf("Setting posting table load option: %s", Config.PostingTables)
 	switch Config.PostingTables {
 	case "memorymap":
 		opt.TableLoadingMode = options.MemoryMap
@@ -129,6 +130,17 @@ func (s *ServerState) initStorage() {
 	default:
 		x.Fatalf("Invalid Posting Tables options")
 	}
+
+	x.Printf("Setting posting value log load option: %s", Config.PostingVlog)
+	switch Config.PostingVlog {
+	case "memorymap":
+		opt.ValueLogLoadingMode = options.MemoryMap
+	case "fileio":
+		opt.ValueLogLoadingMode = options.FileIO
+	default:
+		x.Fatalf("Invalid Posting Value log options")
+	}
+
 	s.Pstore, err = badger.OpenManaged(opt)
 	x.Checkf(err, "Error while creating badger KV posting store")
 	s.vlogTicker = time.NewTicker(1 * time.Minute)

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -113,34 +113,44 @@ func (s *ServerState) initStorage() {
 	// All the writes to posting store should be synchronous. We use batched writers
 	// for posting lists, so the cost of sync writes is amortized.
 	x.Check(os.MkdirAll(Config.PostingDir, 0700))
-	opt := badger.DefaultOptions
+	x.Printf("Setting Badger option: %s", Config.BadgerOptions)
+	var opt badger.Options
+	switch Config.BadgerOptions {
+	case "default":
+		opt = badger.DefaultOptions
+	case "lsmonly":
+		opt = badger.LSMOnlyOptions
+	default:
+		x.Fatalf("Invalid Badger options")
+	}
 	opt.SyncWrites = true
 	opt.Dir = Config.PostingDir
 	opt.ValueDir = Config.PostingDir
 	opt.NumVersionsToKeep = math.MaxInt32
 
-	x.Printf("Setting posting table load option: %s", Config.PostingTables)
-	switch Config.PostingTables {
-	case "memorymap":
+	x.Printf("Setting Badger table load option: %s", Config.BadgerTables)
+	switch Config.BadgerTables {
+	case "mmap":
 		opt.TableLoadingMode = options.MemoryMap
-	case "loadtoram":
+	case "ram":
 		opt.TableLoadingMode = options.LoadToRAM
-	case "fileio":
+	case "disk":
 		opt.TableLoadingMode = options.FileIO
 	default:
-		x.Fatalf("Invalid Posting Tables options")
+		x.Fatalf("Invalid Badger Tables options")
 	}
 
-	x.Printf("Setting posting value log load option: %s", Config.PostingVlog)
-	switch Config.PostingVlog {
-	case "memorymap":
+	x.Printf("Setting Badger value log load option: %s", Config.BadgerVlog)
+	switch Config.BadgerVlog {
+	case "mmap":
 		opt.ValueLogLoadingMode = options.MemoryMap
-	case "fileio":
+	case "disk":
 		opt.ValueLogLoadingMode = options.FileIO
 	default:
-		x.Fatalf("Invalid Posting Value log options")
+		x.Fatalf("Invalid Badger Value log options")
 	}
 
+	x.Printf("Opening postings Badger DB with options: %+v\n", opt)
 	s.Pstore, err = badger.OpenManaged(opt)
 	x.Checkf(err, "Error while creating badger KV posting store")
 	s.vlogTicker = time.NewTicker(1 * time.Minute)


### PR DESCRIPTION
Open up multiple Badger options, to allow users to tweak their memory usage.

- badger.tables to decide how to serve LSM tree: RAM, MMAP, or DISK (default: MMAP).
- badger.vlog to decide how to serve value log: MMAP, or DISK (default: MMAP).
- badger.options to decide how the disk access pattern should be: default or lsmonly (default: default).

WARNING: This PR renames some of the flags and their options. They should be straightforward to fix though.

Helps fix #2424 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2448)
<!-- Reviewable:end -->
