### PR TITLE
Tiny fix: Update link to api.proto in wiki.

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -15,7 +15,7 @@ Clients can communicate with the server in two different ways:
 - **Via [gRPC](http://www.grpc.io/).** Internally this uses [Protocol
   Buffers](https://developers.google.com/protocol-buffers) (the proto file
 used by Dgraph is located at
-[api.proto](https://github.com/dgraph-io/dgraph/blob/master/protos/api.proto)).
+[api.proto](https://github.com/dgraph-io/dgo/blob/master/protos/api.proto)).
 
 - **Via HTTP.** There are various endpoints, each accepting and returning JSON.
   There is a one to one correspondence between the HTTP endpoints and the gRPC
@@ -399,10 +399,10 @@ client's initial `lin_read` is should be an empty map.
        client level `lin_read`). Any `lin_read` maps received in server
 responses *associated with the transaction* should be merged into the
 transactions `lin_read` map.
-  
+
     2. A start timestamp (`start_ts`). This uniquely identifies a transaction,
        and doesn't change over the transaction lifecycle.
-  
+
     3. The set of keys modified by the transaction (`keys`). This aids in
        transaction conflict detection.
 


### PR DESCRIPTION
Fixes the link to `api.proto` at the top of the page of the client wiki, which is outdated.

Closes issue https://github.com/dgraph-io/dgraph/issues/2418

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2456)
<!-- Reviewable:end -->
