### PR TITLE
Correctly handle a list of type geo in json (#2482)

### DIFF
--- a/edgraph/nquads_from_json.go
+++ b/edgraph/nquads_from_json.go
@@ -166,6 +166,26 @@ func checkForDeletion(mr *mapResponse, m map[string]interface{}, op int) {
 	}
 }
 
+func handleGeoType(val map[string]interface{}, nq *api.NQuad) (bool, error) {
+	_, hasType := val["type"]
+	_, hasCoordinates := val["coordinates"]
+	if len(val) == 2 && hasType && hasCoordinates {
+		b, err := json.Marshal(val)
+		if err != nil {
+			return false, x.Errorf("Error while trying to parse "+
+				"value: %+v as geo val", val)
+		}
+		ok, err := tryParseAsGeo(b, nq)
+		if err != nil && ok {
+			return true, err
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func tryParseAsGeo(b []byte, nq *api.NQuad) (bool, error) {
 	var g geom.T
 	err := geojson.Unmarshal(b, &g)
@@ -279,23 +299,13 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 				continue
 			}
 
-			// Geojson geometry should have type and coordinates.
-			_, hasType := val["type"]
-			_, hasCoordinates := val["coordinates"]
-			if len(val) == 2 && hasType && hasCoordinates {
-				b, err := json.Marshal(val)
-				if err != nil {
-					return mr, x.Errorf("Error while trying to parse "+
-						"value: %+v as geo val", val)
-				}
-				ok, err := tryParseAsGeo(b, &nq)
-				if err != nil {
-					return mr, err
-				}
-				if ok {
-					mr.nquads = append(mr.nquads, &nq)
-					continue
-				}
+			ok, err := handleGeoType(val, &nq)
+			if  err != nil {
+				return mr, err
+			}
+			if ok {
+				mr.nquads = append(mr.nquads, &nq)
+				continue
 			}
 
 			cr, err := mapToNquads(v.(map[string]interface{}), idx, op, pred)
@@ -324,23 +334,13 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 					mr.nquads = append(mr.nquads, &nq)
 				case map[string]interface{}:
 					// map[string]interface{} can mean geojson or a connecting entity.
-					val := item.(map[string]interface{})
-					_, hasType := val["type"]
-					_, hasCoordinates := val["coordinates"]
-					if len(val) == 2 && hasType && hasCoordinates {
-						b, err := json.Marshal(val)
-						if err != nil {
-							return mr, x.Errorf("Error while trying to parse "+
-								"value: %+v as geo val", val)
-						}
-						ok, err := tryParseAsGeo(b, &nq)
-						if err != nil {
-							return mr, err
-						}
-						if ok {
-							mr.nquads = append(mr.nquads, &nq)
-							continue
-						}
+					ok, err := handleGeoType(item.(map[string]interface{}), &nq)
+					if  err != nil {
+						return mr, err
+					}
+					if ok {
+						mr.nquads = append(mr.nquads, &nq)
+						continue
 					}
 
 					cr, err := mapToNquads(iv, idx, op, pred)

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -279,11 +279,11 @@ func TestNquadsFromJsonError1(t *testing.T) {
 }
 
 func TestNquadsFromJsonList(t *testing.T) {
-	json := `{"address":["Riley Street","Redfern"],"phone_number":[123,9876]}`
+	json := `{"address":["Riley Street","Redfern"],"phone_number":[123,9876],"points":[{"type":"Point", "coordinates":[1.1,2.0]},{"type":"Point", "coordinates":[2.0,1.1]}]}`
 
 	nq, err := nquadsFromJson([]byte(json), set)
 	require.NoError(t, err)
-	require.Equal(t, 4, len(nq))
+	require.Equal(t, 6, len(nq))
 }
 
 func TestNquadsFromJsonDelete(t *testing.T) {


### PR DESCRIPTION
When adding a list of geo types in a json string, the geojson string was being parsed as a list of connecting entities. I've added a check for geojson in the handling of the  []map[string]interface{} case.

Updated the list test to include a list of geojson.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2485)
<!-- Reviewable:end -->
