### PR TITLE
Fix proposeTxn and calculateSnapshot

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -63,10 +63,10 @@ pushd $basedir/dgraph
   git pull
   git checkout $TAG
   # HEAD here points to whatever is checked out.
-  lastCommitSHA1=$(git rev-parse --short HEAD);
+  lastCommitSHA1=$(git rev-parse --short HEAD)
   gitBranch=$(git rev-parse --abbrev-ref HEAD)
   lastCommitTime=$(git log -1 --format=%ci)
-  release_version=$(git describe --abbrev=0);
+  release_version=$TAG
 popd
 
 # Clone ratel repo.

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -355,8 +355,7 @@ func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (resp *api.Assign
 		// ApplyMutations failed. We now want to abort the transaction,
 		// ignoring any error that might occur during the abort (the user would
 		// care more about the previous error).
-		ctxn := resp.Context
-		ctxn.Aborted = true
+		ctxn := &api.TxnContext{StartTs: mu.StartTs, Aborted: true}
 		_, _ = worker.CommitOverNetwork(ctx, ctxn)
 
 		if err == y.ErrConflict {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -355,8 +355,11 @@ func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (resp *api.Assign
 		// ApplyMutations failed. We now want to abort the transaction,
 		// ignoring any error that might occur during the abort (the user would
 		// care more about the previous error).
-		ctxn := &api.TxnContext{StartTs: mu.StartTs, Aborted: true}
-		_, _ = worker.CommitOverNetwork(ctx, ctxn)
+		if resp.Context == nil {
+			resp.Context = &api.TxnContext{StartTs: mu.StartTs}
+		}
+		resp.Context.Aborted = true
+		_, _ = worker.CommitOverNetwork(ctx, resp.Context)
 
 		if err == y.ErrConflict {
 			// We have already aborted the transaction, so the error message should reflect that.

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -19,6 +19,8 @@ import (
 
 var o *oracle
 
+// TODO: Oracle should probably be located in worker package, instead of posting
+// package now that we don't run inSnapshot anymore.
 func Oracle() *oracle {
 	return o
 }
@@ -81,8 +83,8 @@ func (o *oracle) RegisterStartTs(ts uint64) *Txn {
 	return txn
 }
 
-// minPendingStartTs returns the min start ts which is currently pending a commit or abort decision.
-func (o *oracle) minPendingStartTs() uint64 {
+// MinPendingStartTs returns the min start ts which is currently pending a commit or abort decision.
+func (o *oracle) MinPendingStartTs() uint64 {
 	o.RLock()
 	defer o.RUnlock()
 	min := uint64(math.MaxUint64)
@@ -100,7 +102,7 @@ func (o *oracle) PurgeTs() uint64 {
 	// o.MinPendingStartTs can be inf, but we don't want Zero to delete new
 	// records that haven't yet reached us. So, we also consider MaxAssigned
 	// that we have received so far, so only records below MaxAssigned are purged.
-	return x.Min(o.minPendingStartTs()-1, o.MaxAssigned())
+	return x.Min(o.MinPendingStartTs()-1, o.MaxAssigned())
 }
 
 func (o *oracle) TxnOlderThan(dur time.Duration) (res []uint64) {


### PR DESCRIPTION
- Fix up proposeTxn, so we are updating the CommitTs as per the status in Zero oracle.
- Fix #2474 by dealing with a nil resp.Context in server.go
- Fix calculateSnapshot. It is not a given that every StartTs in Mutation proposal would have a corresponding commit/abort decision. So, use Oracle's MinPendingStartTs to decide how to calculate snapshot.
- Remove o.aborts in Zero. The work can be done by o.commits map.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2493)
<!-- Reviewable:end -->
