### PR TITLE
Export mutation errors.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -136,10 +136,10 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.Proposal) er
 	if proposal.Mutations != nil {
 		for _, edge := range proposal.Mutations.Edges {
 			if tablet := groups().Tablet(edge.Attr); tablet != nil && tablet.ReadOnly {
-				return errPredicateMoving
+				return ErrPredicateMoving
 			} else if tablet.GroupId != groups().groupId() {
 				// Tablet can move by the time request reaches here.
-				return errUnservedTablet
+				return ErrUnservedTablet
 			}
 
 			su, ok := schema.State().Get(edge.Attr)
@@ -151,7 +151,7 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *intern.Proposal) er
 		}
 		for _, schema := range proposal.Mutations.Schema {
 			if tablet := groups().Tablet(schema.Predicate); tablet != nil && tablet.ReadOnly {
-				return errPredicateMoving
+				return ErrPredicateMoving
 			}
 			if err := checkSchema(schema); err != nil {
 				return err
@@ -287,7 +287,7 @@ func (n *node) applyMutations(proposal *intern.Proposal, index uint64) error {
 			// would have proposed membershipstate, and all nodes would have the proposed state
 			// or some state after that before reaching here.
 			if tablet := groups().Tablet(supdate.Predicate); tablet != nil && tablet.ReadOnly {
-				return errPredicateMoving
+				return ErrPredicateMoving
 			}
 			if err := waitForConflictResolution(supdate.Predicate); err != nil {
 				return err
@@ -310,7 +310,7 @@ func (n *node) applyMutations(proposal *intern.Proposal, index uint64) error {
 	schemaMap := make(map[string]types.TypeID)
 	for _, edge := range proposal.Mutations.Edges {
 		if tablet := groups().Tablet(edge.Attr); tablet != nil && tablet.ReadOnly {
-			return errPredicateMoving
+			return ErrPredicateMoving
 		}
 		if edge.Entity == 0 && bytes.Equal(edge.Value, []byte(x.Star)) {
 			// We should only have one edge drop in one mutation call.

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -30,8 +30,8 @@ import (
 )
 
 var (
-	errUnservedTablet  = x.Errorf("Tablet isn't being served by this instance.")
-	errPredicateMoving = x.Errorf("Predicate is being moved, please retry later")
+	ErrUnservedTablet  = x.Errorf("Tablet isn't being served by this instance.")
+	ErrPredicateMoving = x.Errorf("Predicate is being moved, please retry later")
 )
 
 func deletePredicateEdge(edge *intern.DirectedEdge) bool {
@@ -43,7 +43,7 @@ func runMutation(ctx context.Context, edge *intern.DirectedEdge, txn *posting.Tx
 	if !groups().ServesTabletRW(edge.Attr) {
 		// Don't assert, can happen during replay of raft logs if server crashes immediately
 		// after predicate move and before snapshot.
-		return errUnservedTablet
+		return ErrUnservedTablet
 	}
 
 	su, ok := schema.State().Get(edge.Attr)
@@ -99,7 +99,7 @@ func runSchemaMutation(ctx context.Context, update *intern.SchemaUpdate, startTs
 func runSchemaMutationHelper(ctx context.Context, update *intern.SchemaUpdate, startTs uint64) error {
 	n := groups().Node
 	if !groups().ServesTablet(update.Predicate) {
-		return errUnservedTablet
+		return ErrUnservedTablet
 	}
 	if err := checkSchema(update); err != nil {
 		return err
@@ -512,7 +512,7 @@ func MutateOverNetwork(ctx context.Context, m *intern.Mutations) (*api.TxnContex
 	resCh := make(chan res, len(mutationMap))
 	for gid, mu := range mutationMap {
 		if gid == 0 {
-			return tctx, errUnservedTablet
+			return tctx, ErrUnservedTablet
 		}
 		mu.StartTs = m.StartTs
 		go proposeOrSend(ctx, gid, mu, resCh)

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -240,7 +240,7 @@ func (w *grpcWorker) MovePredicate(ctx context.Context,
 		return &emptyPayload, errEmptyPredicate
 	}
 	if !groups().ServesTablet(in.Predicate) {
-		return &emptyPayload, errUnservedTablet
+		return &emptyPayload, ErrUnservedTablet
 	}
 	n := groups().Node
 	if !n.AmLeader() {

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -169,7 +169,7 @@ func GetSchemaOverNetwork(ctx context.Context, schema *intern.SchemaRequest) ([]
 
 	for gid, s := range schemaMap {
 		if gid == 0 {
-			return schemaNodes, errUnservedTablet
+			return schemaNodes, ErrUnservedTablet
 		}
 		go getSchemaOverNetwork(ctx, gid, s, results)
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -128,7 +128,7 @@ func ProcessTaskOverNetwork(ctx context.Context, q *intern.Query) (*intern.Resul
 	attr := q.Attr
 	gid := groups().BelongsTo(attr)
 	if gid == 0 {
-		return &intern.Result{}, errUnservedTablet
+		return &intern.Result{}, ErrUnservedTablet
 	}
 	if tr, ok := trace.FromContext(ctx); ok {
 		tr.LazyPrintf("attr: %v groupId: %v, readTs: %d", attr, gid, q.ReadTs)
@@ -611,7 +611,7 @@ func processTask(ctx context.Context, q *intern.Query, gid uint32) (*intern.Resu
 	// There's no issue if a we are serving a particular tablet and we get partitioned away from
 	// group zero as long as it's not removed.
 	if !groups().ServesTablet(q.Attr) {
-		return &emptyResult, errUnservedTablet
+		return &emptyResult, ErrUnservedTablet
 	}
 	out, err := helpProcessTask(ctx, q, gid)
 	if err != nil {


### PR DESCRIPTION
Exporting errors so I could check for them in my application like:
```
if errString != ErrPredicateMoving.Error() {
  // don't cancel the ingest, it's safe to do a retry loop/backoff
}
```

rather than relying on the fact that the error message won't change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2498)
<!-- Reviewable:end -->
