### PR TITLE
Change LiveLoader's flag 'conc' defaults to 1

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -71,7 +71,7 @@ func init() {
 	flag.StringP("schema", "s", "", "Location of schema file")
 	flag.StringP("dgraph", "d", "127.0.0.1:9080", "Dgraph gRPC server address")
 	flag.StringP("zero", "z", "127.0.0.1:5080", "Dgraphzero gRPC server address")
-	flag.IntP("conc", "c", 100,
+	flag.IntP("conc", "c", 1,
 		"Number of concurrent requests to make to Dgraph")
 	flag.IntP("batch", "b", 1000,
 		"Number of RDF N-Quads to send as part of a mutation.")


### PR DESCRIPTION
This makes LiveLoad faster by making concurrent higher value requests optional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2506)
<!-- Reviewable:end -->
