### PR TITLE
Fix typo in ports usage table Dgraph Server

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -186,7 +186,7 @@ Dgraph cluster nodes use different ports to communicate over gRPC and http. User
  Dgraph Node Type | gRPC-internal  | gRPC-external | http-external
 ------------------|----------------|---------------|---------------
        zero       |  --Not Used--  |     5080      |     6080
-       server     |      7080      |     9090      |     8080
+       server     |      7080      |     9080      |     8080
        ratel      |  --Not Used--  | --Not Used--  |     8000
 
  Users have to modify security rules or open firewall depending up on their underlying network to allow communication between cluster nodes and between a server and a client. During development a general rule could be wide open *-external (gRPC/HTTP) ports to public and gRPC-internal to be open within the cluster nodes.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2524)
<!-- Reviewable:end -->
