### PR TITLE
Enforce odd value for --replicas, also disallow 0

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -141,6 +141,10 @@ func run() {
 		rebalanceInterval: Zero.Conf.GetDuration("rebalance_interval"),
 	}
 
+	if opts.numReplicas % 2 == 0 {
+		log.Fatalf("Invalid flag value --replicas=%d - number of replicas cannot be divisible by 2", opts.numReplicas)
+	}
+	
 	if Zero.Conf.GetBool("expose_trace") {
 		trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
 			return true, true


### PR DESCRIPTION
It is currently possible to start zero with --replicas=4 or --replicas=0
Even number means it's impossible to reach quorum.
No replicas doesn't make much sense at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2527)
<!-- Reviewable:end -->
