### PR TITLE
Redirect /master/foobar.html to /foobar.html

### DIFF
--- a/wiki/nginx/docs.conf
+++ b/wiki/nginx/docs.conf
@@ -5,6 +5,7 @@ server {
     add_header Cache-Control "no-cache";
 
     location / {
+      rewrite ^/master/(.*)$ /$1 last;
       try_files $uri $uri/index.html /404.html;
     }
 }


### PR DESCRIPTION
Google cache is full of old style urls, for example https://docs.dgraph.io/master/query-language/
Redirect rule sends users to the new location for latest docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2544)
<!-- Reviewable:end -->
