### PR TITLE
TeamCity builds should be marked as failed when test.sh unit tests don't pass

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -14,10 +14,14 @@ function runAll {
   # go test -v .
   # popd
 
+  local testsFailed=0
   for PKG in $(go list ./...|grep -v -E 'vendor|contrib|wiki|customtok'); do
     echo "Running test for $PKG"
-    run $PKG
+    run $PKG || {
+        testsFailed=$((testsFailed+1))
+    }
   done
+  return $testsFailed
 }
 
 # For piped commands return non-zero status if any command
@@ -25,7 +29,7 @@ function runAll {
 set -o pipefail
 echo
 echo "Running tests. Ignoring vendor folder."
-runAll
+runAll || exit $?
 
 echo
 echo "Running load-test.sh"


### PR DESCRIPTION
TeamCity bulids can finish "successfully" even when a unit test fails. These are false positives and those builds should really be marked as unsuccessfully.

This change makes any failed `go test`s show up as failures in TeamCity with a non-zero exit code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2550)
<!-- Reviewable:end -->
