### PR TITLE
Remove language tag from a query

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -278,7 +278,7 @@ Run this query to get all the movies. The query works below all the movies have 
 curl localhost:8080/query -XPOST -d $'
 {
  me(func: has(starring)) {
-   name@en
+   name
   }
 }
 ' | python -m json.tool | less


### PR DESCRIPTION
The query is under "Get all movies" section. This fixes #2552

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2557)
<!-- Reviewable:end -->
