### PR TITLE
Fix issue-2320: Add  "timeout" param to "KShortestPath"  function

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2104,7 +2104,7 @@ func validKeyAtRoot(k string) bool {
 	switch k {
 	case "func", "orderasc", "orderdesc", "first", "offset", "after":
 		return true
-	case "from", "to", "numpaths":
+	case "from", "to", "numpaths", "timeout":
 		// Specific to shortest path
 		return true
 	case "depth":

--- a/query/query.go
+++ b/query/query.go
@@ -123,6 +123,7 @@ type params struct {
 
 	From           uint64
 	To             uint64
+	Timeout        uint64
 	Facet          *intern.FacetParams
 	FacetOrder     string
 	FacetOrderDesc bool
@@ -797,6 +798,13 @@ func (args *params) fill(gq *gql.GraphQuery) error {
 			return err
 		}
 		args.numPaths = int(numPaths)
+	}
+	if v, ok := gq.Args["timeout"]; ok && args.Alias == "shortest" {
+		timeout, err := strconv.ParseUint(v, 0, 64)
+		if err != nil {
+			return err
+		}
+		args.Timeout = uint64(timeout)
 	}
 	if v, ok := gq.Args["from"]; ok && args.Alias == "shortest" {
 		from, err := strconv.ParseUint(v, 0, 64)
@@ -2303,7 +2311,7 @@ func (sg *SubGraph) sortAndPaginateUsingVar(ctx context.Context) error {
 // isValidArg checks if arg passed is valid keyword.
 func isValidArg(a string) bool {
 	switch a {
-	case "numpaths", "from", "to", "orderasc", "orderdesc", "first", "offset", "after", "depth":
+	case "numpaths", "from", "to", "orderasc", "orderdesc", "first", "offset", "after", "depth", "timeout":
 		return true
 	}
 	return false


### PR DESCRIPTION
Related issue 
https://github.com/dgraph-io/dgraph/issues/2320
query may like this:

```
 query x{
 path as shortest(from: 0x5, to: 0x29e81, depth:2 ,numpaths: 2,timeout:1000) {
  actor.film
  }
 entity(func: uid(path)) {
      uid
  } 
}
```
If the time-cost longer than the value `timeout`, an error `: context deadline exceeded` returns.
So we can fail fast instead of blocking system.
Somethings the blocking looks like a `DDOS` attack. High use of CPU, slow or none response.

With the param `timeout`, we can stop this kind of `DDOS`.

By the way, the unit here is `Millisecond`,
If the value is less or equal to zero, means no timeout ,or use the `context`'s default timeout value .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2561)
<!-- Reviewable:end -->
