### PR TITLE
Stop Dgraph docker-compose cluster at the end of the tests

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-sleepTime=11
-
-function runCluster {
+function startCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph
     sudo rm -Rf /tmp/dg
@@ -14,4 +12,11 @@ function runCluster {
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6080
   $basedir/contrib/wait-for-it.sh -t 60 localhost:9180
   sleep 10 # Sleep 10 seconds to get things ready.
+}
+
+function stopCluster {
+  basedir=$GOPATH/src/github.com/dgraph-io/dgraph
+  pushd $basedir/dgraph
+    docker-compose down
+  popd
 }

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function startCluster {
+function restartCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph
     sudo rm -Rf /tmp/dg

--- a/contrib/scripts/loader.sh
+++ b/contrib/scripts/loader.sh
@@ -4,7 +4,7 @@ basedir=$GOPATH/src/github.com/dgraph-io/dgraph
 set -e
 
 source $basedir/contrib/scripts/functions.sh
-runCluster
+startCluster
 
 # Create a temporary directory to use for running live loader.
 mkdir -p tmp

--- a/contrib/scripts/loader.sh
+++ b/contrib/scripts/loader.sh
@@ -4,7 +4,7 @@ basedir=$GOPATH/src/github.com/dgraph-io/dgraph
 set -e
 
 source $basedir/contrib/scripts/functions.sh
-startCluster
+restartCluster
 
 # Create a temporary directory to use for running live loader.
 mkdir -p tmp

--- a/contrib/scripts/transactions.sh
+++ b/contrib/scripts/transactions.sh
@@ -7,7 +7,7 @@ set -e
 # go test -v $contrib/integration/testtxn/main_test.go
 
 source $contrib/scripts/functions.sh
-runCluster
+startCluster
 
 echo "*  Running transaction tests."
 

--- a/contrib/scripts/transactions.sh
+++ b/contrib/scripts/transactions.sh
@@ -7,7 +7,7 @@ set -e
 # go test -v $contrib/integration/testtxn/main_test.go
 
 source $contrib/scripts/functions.sh
-startCluster
+restartCluster
 
 echo "*  Running transaction tests."
 

--- a/test.sh
+++ b/test.sh
@@ -26,7 +26,7 @@ function runAll {
 # For piped commands return non-zero status if any command
 # in the pipe returns a non-zero status
 set -o pipefail
-startCluster
+restartCluster
 echo
 echo "Running tests. Ignoring vendor folder."
 runAll || exit $?

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,6 @@ function run {
 }
 
 function runAll {
-  runCluster
   # pushd dgraph/cmd/server
   # go test -v .
   # popd
@@ -27,6 +26,7 @@ function runAll {
 # For piped commands return non-zero status if any command
 # in the pipe returns a non-zero status
 set -o pipefail
+startCluster
 echo
 echo "Running tests. Ignoring vendor folder."
 runAll || exit $?
@@ -34,3 +34,5 @@ runAll || exit $?
 echo
 echo "Running load-test.sh"
 ./contrib/scripts/load-test.sh
+
+stopCluster


### PR DESCRIPTION
TeamCity builds run TLS tests after ./test.sh. Currently ./test.sh starts a Dgraph cluster via Docker Compose and uses that cluster to run tests. The TLS tests run standalone instances outside of Docker.

[One of the first things the test does is try to kill any existing Dgraph processes](https://github.com/dgraph-io/dgraph/blob/master/contrib/tlstest/test.sh#L3) so the tests run from a clean cluster. The TeamCity builds don't have permissions to kill the root-owned Dgraph processes running via Docker, so these messages clog up the build logs:

```
[02:10:18][Step 3/3] dgraph(13535): Operation not permitted
[02:10:18][Step 3/3] dgraph(13733): Operation not permitted
[02:10:18][Step 3/3] dgraph(13869): Operation not permitted
[02:10:18][Step 3/3] dgraph(14042): Operation not permitted
[02:10:18][Step 3/3] dgraph(14133): Operation not permitted
[02:10:18][Step 3/3] dgraph(14144): Operation not permitted
```

Tests still run as expected, but if we stop the Docker cluster before running TLS tests then the build logs are more readable.

* Run stopCluster at the end of test.sh
* Rename "runCluster" to "startCluster" for naming consistency
  of (stop|start)Cluster
* Remove unused sleepTime variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2571)
<!-- Reviewable:end -->
