### PR TITLE
set '$HOME/go' as the default GOPATH for query tests

### DIFF
--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync/atomic"
 	"testing"
 
@@ -1634,7 +1635,14 @@ func TestMain(m *testing.M) {
 	zw, err := ioutil.TempDir("", "wal_")
 	x.Check(err)
 
-	zero := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+	var exists bool
+	var goPath string
+
+	if goPath, exists = os.LookupEnv("GOPATH"); !exists {
+		goPath = os.ExpandEnv("$HOME/go")
+	}
+
+	zero := exec.Command(filepath.Join(goPath, "/bin/dgraph"),
 		"zero",
 		"--wal", zw,
 		"-o", "10",


### PR DESCRIPTION
Under a default go installation, go does not set the GOPATH environment variable.
Instead go will default to using '$HOME/go' if the GOPATH is not explicitly set.
Hence testing code that uses the GOPATH environment variable should probably
default to this same behavior in order for the tests to run out-of-the-box. This
commit adds this exact behavior for all query tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2576)
<!-- Reviewable:end -->
