### PR TITLE
removed commented-out code which lacks TODO comments

### DIFF
--- a/conn/raft_server.go
+++ b/conn/raft_server.go
@@ -208,7 +208,6 @@ func (w *RaftServer) RaftMessage(ctx context.Context,
 		}
 		idx += sz
 	}
-	// fmt.Printf("Got %d messages\n", count)
 	return &api.Payload{}, nil
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -650,7 +650,6 @@ func treeCopy(gq *gql.GraphQuery, sg *SubGraph) error {
 	// node, because of the way we're dealing with the root node.
 	// So, we work on the children, and then recurse for grand children.
 	attrsSeen := make(map[string]struct{})
-	// sg.ReadTs = readTs
 
 	for _, gchild := range gq.Children {
 		if sg.Params.Alias == "shortest" && gchild.Expand != "" {

--- a/worker/stream_lists.go
+++ b/worker/stream_lists.go
@@ -127,7 +127,6 @@ func (sl *streamLists) produceKVs(ctx context.Context, ts uint64,
 	defer txn.Discard()
 	iterate := func(kr keyRange) error {
 		iterOpts := badger.DefaultIteratorOptions
-		// iterOpts.PrefetchSize = 10
 		iterOpts.AllVersions = true
 		iterOpts.PrefetchValues = false
 		it := txn.NewIterator(iterOpts)


### PR DESCRIPTION
Code that is disabled without explanation is not very
useful. If git log is required to understand it, might
remove it completely as it still be available inside
repository history.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2587)
<!-- Reviewable:end -->
