### PR TITLE
simplify `x = x <op> ...` to `x <op>= ...`

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -180,9 +180,9 @@ func IntersectWithJump(u, v []uint64, o *[]uint64) (int, int) {
 			k++
 			i++
 		} else if k+jump < m && uid > v[k+jump] {
-			k = k + jump
+			k += jump
 		} else if i+jump < n && vid > u[i+jump] {
-			i = i + jump
+			i += jump
 		} else if uid > vid {
 			for k = k + 1; k < m && v[k] < uid; k++ {
 			}

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -117,7 +117,7 @@ func run() {
 		os.Exit(1)
 	}
 
-	opt.MapBufSize = opt.MapBufSize << 20 // Convert from MB to B.
+	opt.MapBufSize <<= 20 // Convert from MB to B.
 
 	optBuf, err := json.MarshalIndent(&opt, "", "\t")
 	x.Check(err)

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -98,7 +98,7 @@ func (p *uidProvider) ReserveUidRange() (start, end uint64, err error) {
 			return 0, 0, p.ctx.Err()
 		}
 		if factor < 256*time.Second {
-			factor = factor * 2
+			factor *= 2
 		}
 	}
 }

--- a/posting/list.go
+++ b/posting/list.go
@@ -658,7 +658,7 @@ func (l *List) MarshalToKv() (*intern.KV, error) {
 func marshalPostingList(plist *intern.PostingList) (data []byte, meta byte) {
 	if len(plist.Uids) == 0 {
 		data = nil
-		meta = meta | BitEmptyPosting
+		meta |= BitEmptyPosting
 	} else if len(plist.Postings) > 0 {
 		var err error
 		data, err = plist.Marshal()
@@ -667,7 +667,7 @@ func marshalPostingList(plist *intern.PostingList) (data []byte, meta byte) {
 		data = plist.Uids
 		meta = BitUidPosting
 	}
-	meta = meta | BitCompletePosting
+	meta |= BitCompletePosting
 	return
 }
 

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -113,7 +113,7 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 			for mIdx, fromUID := range sg.SrcUIDs.Uids {
 				if allowLoop {
 					for _, ul := range sg.uidMatrix {
-						numEdges = numEdges + uint64(len(ul.Uids))
+						numEdges += uint64(len(ul.Uids))
 					}
 				} else {
 					algo.ApplyFilter(sg.uidMatrix[mIdx], func(uid uint64, i int) bool {


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#assignOp-ref

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2589)
<!-- Reviewable:end -->
