### PR TITLE
lex: replace 0 literal with ItemEOF named constant

### DIFF
--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -36,7 +36,7 @@ type Item struct {
 
 func (i Item) String() string {
 	switch i.Typ {
-	case 0:
+	case ItemEOF:
 		return "EOF"
 	}
 	return fmt.Sprintf("lex.Item [%v] %q", i.Typ, i.Val)


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#namedConst-ref

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2590)
<!-- Reviewable:end -->
