### PR TITLE
worker: remove "return" after log.Fatal call

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -81,7 +81,6 @@ func RunServer(bindall bool) {
 	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", laddr, workerPort()))
 	if err != nil {
 		log.Fatalf("While running server: %v", err)
-		return
 	}
 	x.Printf("Worker listening at address: %v", ln.Addr())
 


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#deadCodeAfterLogFatal-ref

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2591)
<!-- Reviewable:end -->
