### PR TITLE
expand(_forward_)

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2524,7 +2524,8 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 					Args:       make(map[string]string),
 					IsInternal: true,
 				}
-				if item.Val == value {
+				switch item.Val {
+				case value:
 					count, err := parseVarList(it, child)
 					if err != nil {
 						return err
@@ -2534,9 +2535,13 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 					}
 					child.NeedsVar[len(child.NeedsVar)-1].Typ = LIST_VAR
 					child.Expand = child.NeedsVar[len(child.NeedsVar)-1].Name
-				} else if item.Val == "_all_" {
+				case "_all_":
 					child.Expand = "_all_"
-				} else {
+				case "_forward_":
+					child.Expand = "_forward_"
+				case "_reverse_":
+					child.Expand = "_reverse_"
+				default:
 					return x.Errorf("Invalid argument %v in expand()", item.Val)
 				}
 				it.Next() // Consume ')'

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -73,6 +73,34 @@ func TestParseQueryListPred1(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestParseQueryExpandForward(t *testing.T) {
+	query := `
+	{
+		var(func: uid( 0x0a)) {
+			friends {
+				expand(_forward_)
+			}
+		}
+	}
+`
+	_, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+}
+
+func TestParseQueryExpandReverse(t *testing.T) {
+	query := `
+	{
+		var(func: uid( 0x0a)) {
+			friends {
+				expand(_reverse_)
+			}
+		}
+	}
+`
+	_, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+}
+
 func TestParseQueryAliasListPred(t *testing.T) {
 	query := `
 	{

--- a/query/query.go
+++ b/query/query.go
@@ -1740,8 +1740,9 @@ func expandSubgraph(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 		}
 
 		var preds []string
-		// It could be expand(_all_) or expand(val(x)).
-		if child.Params.Expand == "_all_" {
+		switch child.Params.Expand {
+		// It could be expand(_all_), expand(_forward_), expand(_reverse_) or expand(val(x)).
+		case "_all_":
 			// Get the predicate list for expansion.
 			child.ExpandPreds, err = getNodePredicates(ctx, sg)
 			if err != nil {
@@ -1754,7 +1755,19 @@ func expandSubgraph(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 				return out, err
 			}
 			preds = append(preds, rpreds...)
-		} else {
+		case "_forward_":
+			child.ExpandPreds, err = getNodePredicates(ctx, sg)
+			if err != nil {
+				return out, err
+			}
+			preds = uniquePreds(child.ExpandPreds)
+		case "_reverse_":
+			rpreds, err := getReversePredicates(ctx)
+			if err != nil {
+				return out, err
+			}
+			preds = rpreds
+		default:
 			// We already have the predicates populated from the var.
 			preds = uniquePreds(child.ExpandPreds)
 		}

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1961,6 +1961,34 @@ func TestExpandAll(t *testing.T) {
 	require.JSONEq(t, `{"data":{"q":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"power":13.250000,"_xid_":"mich","noindex_name":"Michonne's name not indexed","son":[{"name":"Andre"},{"name":"Helmut"}],"address":"31, 32 street, Jupiter","dob_day":"1910-01-01T00:00:00Z","follow":[{"name":"Glenn Rhee"},{"name":"Andrea"}],"name":"Michonne","path":[{"name":"Glenn Rhee","path|weight":0.200000},{"name":"Andrea","path|weight":0.100000,"path|weight1":0.200000}],"school":[{"name":"School A"}],"full_name":"Michonne's large name for hashing","alive":true,"bin_data":"YmluLWRhdGE=","gender":"female","loc":{"type":"Point","coordinates":[1.1,2]},"graduation":["1932-01-01T00:00:00Z"],"age":38,"sword_present":"true","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000,"~friend":[{"name":"Rick Grimes"}]}]}}`, js)
 }
 
+func TestExpandForward(t *testing.T) {
+	query := `
+	{
+		q(func: uid(1)) {
+			expand(_forward_) {
+				name
+			}
+		}
+	}
+	`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data":{"q":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"power":13.250000,"_xid_":"mich","noindex_name":"Michonne's name not indexed","son":[{"name":"Andre"},{"name":"Helmut"}],"address":"31, 32 street, Jupiter","dob_day":"1910-01-01T00:00:00Z","follow":[{"name":"Glenn Rhee"},{"name":"Andrea"}],"name":"Michonne","path":[{"name":"Glenn Rhee","path|weight":0.200000},{"name":"Andrea","path|weight":0.100000,"path|weight1":0.200000}],"school":[{"name":"School A"}],"full_name":"Michonne's large name for hashing","alive":true,"bin_data":"YmluLWRhdGE=","gender":"female","loc":{"type":"Point","coordinates":[1.1,2]},"graduation":["1932-01-01T00:00:00Z"],"age":38,"sword_present":"true","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000}]}}`, js)
+}
+
+func TestExpandReverse(t *testing.T) {
+	query := `
+	{
+		q(func: uid(1)) {
+			expand(_reverse_) {
+				name
+			}
+		}
+	}
+	`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data":{"q":[{"~friend":[{"name":"Rick Grimes"}]}]}}`, js)
+}
+
 func TestUidWithoutDebug(t *testing.T) {
 
 	query := `

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1762,6 +1762,8 @@ Query Example: All predicates from actor Geoffrey Rush and the count of such pre
 Predicates can be stored in a variable and passed to `expand()` to expand all the predicates in the variable.
 
 If `_all_` is passed as an argument to `expand()`, all the predicates at that level are retrieved. More levels can be specfied in a nested fashion under `expand()`.
+If `_forward_` is passed as an argument to `expand()`, all predicates at that level (minus any reverse predicates) are retrieved.
+If `_reverse_` is passed as an argument to `expand()`, only the reverse predicates are retrieved.
 
 Query Example: Predicates saved to a variable and queried with `expand()`.
 {{< runnable >}}


### PR DESCRIPTION
This PR implements #2446 . In particular it adds as possible arguments `_forward_` and `_reverse_` to expand. 

* `expand(_forward_)` returns all the predicates of a node except for any reverse predicates
* `expand(_reverse_)` returns only the reverse predicates of a node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2595)
<!-- Reviewable:end -->
