### PR TITLE
Set the Applied index in Raft directly

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -355,8 +355,7 @@ func (n *node) triggerLeaderChange() {
 }
 
 func (n *node) initAndStartNode() error {
-	idx, restart, err := n.PastLife()
-	n.Applied.SetDoneUntil(idx)
+	_, restart, err := n.PastLife()
 	x.Check(err)
 
 	if restart {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -931,9 +931,8 @@ func (n *node) retryUntilSuccess(fn func() error, pause time.Duration) {
 
 // InitAndStartNode gets called after having at least one membership sync with the cluster.
 func (n *node) InitAndStartNode() {
-	idx, restart, err := n.PastLife()
+	_, restart, err := n.PastLife()
 	x.Check(err)
-	n.Applied.SetDoneUntil(idx)
 
 	if _, hasPeer := groups().MyPeer(); !restart && hasPeer {
 		// The node has other peers, it might have crashed after joining the cluster and before

--- a/x/watermark.go
+++ b/x/watermark.go
@@ -56,7 +56,7 @@ type WaterMark struct {
 
 // Init initializes a WaterMark struct. MUST be called before using it.
 func (w *WaterMark) Init() {
-	w.markCh = make(chan mark, 10000)
+	w.markCh = make(chan mark, 100)
 	w.elog = trace.NewEventLog("Watermark", w.Name)
 	go w.process()
 }


### PR DESCRIPTION
Set the Applied index in Raft directly, so it does not pick up an index older than the snapshot. Ensure that it is in sync with the Applied watermark.

This fixes #2581.