### PR TITLE
Add support for ignoring parse errors in bulk loader

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -47,6 +47,7 @@ type options struct {
 	StoreXids     bool
 	ZeroAddr      string
 	HttpAddr      string
+	IgnoreErrors  bool
 
 	MapShards    int
 	ReduceShards int
@@ -202,17 +203,17 @@ func (ld *loader) mapStage() {
 		LRUSize:   1 << 19,
 	})
 
-	var readers []*bufio.Reader
+	readers := make(map[string]*bufio.Reader)
 	for _, rdfFile := range findRDFFiles(ld.opt.RDFDir) {
 		f, err := os.Open(rdfFile)
 		x.Check(err)
 		defer f.Close()
 		if !strings.HasSuffix(rdfFile, ".gz") {
-			readers = append(readers, bufio.NewReaderSize(f, 1<<20))
+			readers[rdfFile] = bufio.NewReaderSize(f, 1<<20)
 		} else {
 			gzr, err := gzip.NewReader(f)
 			x.Checkf(err, "Could not create gzip reader for RDF file %q.", rdfFile)
-			readers = append(readers, bufio.NewReader(gzr))
+			readers[rdfFile] = bufio.NewReader(gzr)
 		}
 	}
 
@@ -232,8 +233,11 @@ func (ld *loader) mapStage() {
 
 	// This is the main map loop.
 	thr := x.NewThrottle(ld.opt.NumGoroutines)
-	for _, r := range readers {
+	var fileCount int
+	for rdfFile, r := range readers {
 		thr.Start()
+		fileCount++
+		fmt.Printf("processing file (%d out of %d): %s\n", fileCount, len(readers), rdfFile)
 		go func(r *bufio.Reader) {
 			defer thr.Done()
 			for {

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -122,7 +122,14 @@ func (m *mapper) run() {
 			}
 			rdf = strings.TrimSpace(rdf)
 
-			x.Check(m.processRDF(rdf))
+			// process RDF line
+			if err := m.processRDF(rdf); err != nil {
+				atomic.AddInt64(&m.prog.errCount, 1)
+				if !m.opt.IgnoreErrors {
+					x.Check(err)
+				}
+			}
+
 			atomic.AddInt64(&m.prog.rdfCount, 1)
 			for i := range m.shards {
 				sh := &m.shards[i]

--- a/dgraph/cmd/bulk/progress.go
+++ b/dgraph/cmd/bulk/progress.go
@@ -25,6 +25,7 @@ const (
 
 type progress struct {
 	rdfCount        int64
+	errCount        int64
 	mapEdgeCount    int64
 	reduceEdgeCount int64
 	reduceKeyCount  int64
@@ -70,10 +71,12 @@ func (p *progress) reportOnce() {
 	case nothing:
 	case mapPhase:
 		rdfCount := atomic.LoadInt64(&p.rdfCount)
+		errCount := atomic.LoadInt64(&p.errCount)
 		elapsed := time.Since(p.start)
-		fmt.Printf("MAP %s rdf_count:%s rdf_speed:%s/sec edge_count:%s edge_speed:%s/sec\n",
+		fmt.Printf("MAP %s rdf_count:%s err_count:%s rdf_speed:%s/sec edge_count:%s edge_speed:%s/sec\n",
 			x.FixedDuration(elapsed),
 			niceFloat(float64(rdfCount)),
+			niceFloat(float64(errCount)),
 			niceFloat(float64(rdfCount)/elapsed.Seconds()),
 			niceFloat(float64(mapEdgeCount)),
 			niceFloat(float64(mapEdgeCount)/elapsed.Seconds()),

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -67,6 +67,7 @@ func init() {
 	// TODO: Potentially move http server to main.
 	flag.String("http", "localhost:8080",
 		"Address to serve http (pprof).")
+	flag.Bool("ignore_errors", false, "ignore line parsing errors in rdf files")
 	flag.Int("map_shards", 1,
 		"Number of map output shards. Must be greater than or equal to the number of reduce "+
 			"shards. Increasing allows more evenly sized reduce shards, at the expense of "+
@@ -93,6 +94,7 @@ func run() {
 		StoreXids:     Bulk.Conf.GetBool("store_xids"),
 		ZeroAddr:      Bulk.Conf.GetString("zero"),
 		HttpAddr:      Bulk.Conf.GetString("http"),
+		IgnoreErrors:  Bulk.Conf.GetBool("ignore_errors"),
 		MapShards:     Bulk.Conf.GetInt("map_shards"),
 		ReduceShards:  Bulk.Conf.GetInt("reduce_shards"),
 	}


### PR DESCRIPTION
By default, bulk loader fails when it is unable to parse
RDF lines. This behaviour can be changed by providing a
command line flag (--ignore_error) and the bulk loader
would ignore the parse errors. The progress status shows
the number of such errors to keep track of them.

The progress status now also prints the file that the bulk
loader is processing along with the count of files.

Signed-off-by: Aman Mangal <mangalaman93@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2599)
<!-- Reviewable:end -->
