### PR TITLE
fix expand(_all_) in recurse queries

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -317,6 +317,17 @@ office.room                    : uid .
 	addPassword(t, 1, "password", "123456")
 	addPassword(t, 23, "pass", "654321")
 
+	addEdgeToUID(t, "school", 32, 33, nil)
+	addEdgeToUID(t, "district", 33, 34, nil)
+	addEdgeToUID(t, "county", 34, 35, nil)
+	addEdgeToUID(t, "state", 35, 36, nil)
+
+	addEdgeToValue(t, "name", 33, "San Mateo High School", nil)
+	addEdgeToValue(t, "name", 34, "San Mateo School District", nil)
+	addEdgeToValue(t, "name", 35, "San Mateo County", nil)
+	addEdgeToValue(t, "name", 36, "California", nil)
+	addEdgeToValue(t, "abbr", 36, "CA", nil)
+
 	// So, user we're interested in has uid: 1.
 	// She has 5 friends: 23, 24, 25, 31, and 101
 	addEdgeToUID(t, "friend", 1, 23, nil)

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -51,6 +51,34 @@ func TestRecurseQuery(t *testing.T) {
 		`{"data": {"me":[{"name":"Michonne", "friend":[{"name":"Rick Grimes", "friend":[{"name":"Michonne"}]},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea", "friend":[{"name":"Glenn Rhee"}]}]}]}}`, js)
 }
 
+func TestRecurseExpand(t *testing.T) {
+
+	query := `
+		{
+			me(func: uid(32)) @recurse {
+				expand(_all_)
+			}
+		}`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"school":[{"name":"San Mateo High School","district":[{"name":"San Mateo School District","county":[{"state":[{"name":"California","abbr":"CA"}],"name":"San Mateo County"}]}]}]}]}}`, js)
+}
+
+func TestRecurseExpandRepeatedPredError(t *testing.T) {
+
+	query := `
+		{
+			me(func: uid(32)) @recurse {
+				name
+				expand(_all_)
+			}
+		}`
+
+	ctx := defaultContext()
+	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Repeated subgraph: [name] while using expand()")
+}
+
 func TestRecurseQueryOrder(t *testing.T) {
 
 	query := `


### PR DESCRIPTION
Fixes #2555 

Previously a recursive query containing an `expand(_all_)` would only expand the predicates of the root node. This PR introduces the correct behavior which is to expand the predicates for every node in the query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2600)
<!-- Reviewable:end -->
