### PR TITLE
An error was being returned when an empty response is expected.

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1634,7 +1634,8 @@ func (sg *SubGraph) replaceVarInFunc() error {
 
 func (sg *SubGraph) ApplyIneqFunc() error {
 	if sg.Params.uidToVal == nil {
-		x.Println("Expected a valid value map. But got empty.")
+		// Expected a valid value map. But got empty.
+		// Don't return error, return empty - issue #2610
 		return nil
 	}
 	var typ types.TypeID

--- a/query/query.go
+++ b/query/query.go
@@ -1634,7 +1634,8 @@ func (sg *SubGraph) replaceVarInFunc() error {
 
 func (sg *SubGraph) ApplyIneqFunc() error {
 	if sg.Params.uidToVal == nil {
-		return x.Errorf("Expected a valid value map. But got empty.")
+		x.Println("Expected a valid value map. But got empty.")
+		return nil
 	}
 	var typ types.TypeID
 	for _, v := range sg.Params.uidToVal {


### PR DESCRIPTION
When testing inequality value vars with non-matching values, the
response was sent as an error although it should return empty result
if the query has correct syntax.

Closes #2610

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2611)
<!-- Reviewable:end -->
