### PR TITLE
Task convertion from bool to int was done using uint32

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1754,7 +1754,7 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			// We've consumed `'@facets' '(' <facetItem> ',' <facetItem>`, so this is definitely
 			// not a filter.  Return an error.
 			return res, false, x.Errorf(
-				"Expected ',' or ')' in facet list", item.Val)
+				"Expected ',' or ')' in facet list: %s", item.Val)
 		}
 	}
 }
@@ -2508,7 +2508,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				continue
 			} else if isExpandFunc(valLower) {
 				if varName != "" {
-					return x.Errorf("expand() cannot be used with a variable", val)
+					return x.Errorf("expand() cannot be used with a variable: %s", val)
 				}
 				if alias != "" {
 					return x.Errorf("expand() cannot have an alias")

--- a/task/conversion.go
+++ b/task/conversion.go
@@ -19,14 +19,14 @@ var (
 )
 
 func FromInt(val int) *intern.TaskValue {
-	bs := make([]byte, 4)
-	binary.LittleEndian.PutUint32(bs, uint32(val))
+	bs := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bs, uint64(val))
 	return &intern.TaskValue{Val: []byte(bs), ValType: intern.Posting_INT}
 }
 
-func ToInt(val *intern.TaskValue) int32 {
-	result := binary.LittleEndian.Uint32(val.Val)
-	return int32(result)
+func ToInt(val *intern.TaskValue) int64 {
+	result := binary.LittleEndian.Uint64(val.Val)
+	return int64(result)
 }
 
 func FromBool(val bool) *intern.TaskValue {


### PR DESCRIPTION
A type conversion check was failing because it expected 8 byte value
to convert to uint64, but the task conversion was returning 4 byte
as uint32. This change fixes that conversion issue.

Also fixed a couple of errors that had value but no format.

Closes #2620

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2621)
<!-- Reviewable:end -->
