### PR TITLE
Update error and warning messages to glog

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	ErrDuplicateRaftId = x.Errorf("Node is already part of group")
-	ErrNoNode          = fmt.Errorf("No node has been set up yet")
+	ErrNoNode          = x.Errorf("No node has been set up yet")
 )
 
 type Node struct {


### PR DESCRIPTION
Replace x.Errorf log messages with glog.Errorf and glog.Warningf.

This was caught when running test.sh with go1.11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2629)
<!-- Reviewable:end -->
