### PR TITLE
Let result of checkpwd to be aliased

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -326,16 +326,13 @@ func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
 
 func addCheckPwd(pc *SubGraph, vals []*pb.TaskValue, dst outputNode) {
 	c := types.ValueForType(types.BoolID)
-	if len(vals) == 0 {
-		// No value found for predicate.
-		c.Value = false
-	} else {
-		c.Value = task.ToBool(vals[0])
-	}
+	c.Value = task.ToBool(vals[0])
 
-	uc := dst.New(pc.Attr)
-	uc.AddValue("checkpwd", c)
-	dst.AddListChild(pc.Attr, uc)
+	fieldName := pc.Params.Alias
+	if fieldName == "" {
+		fieldName = fmt.Sprintf("checkpwd(%s)", pc.Attr)
+	}
+	dst.AddValue(fieldName, c)
 }
 
 func alreadySeen(parentIds []uint64, uid uint64) bool {

--- a/query/query.go
+++ b/query/query.go
@@ -326,7 +326,11 @@ func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
 
 func addCheckPwd(pc *SubGraph, vals []*pb.TaskValue, dst outputNode) {
 	c := types.ValueForType(types.BoolID)
-	c.Value = task.ToBool(vals[0])
+	if len(vals) == 0 {
+		c.Value = false
+	} else {
+		c.Value = task.ToBool(vals[0])
+	}
 
 	fieldName := pc.Params.Alias
 	if fieldName == "" {

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -1072,7 +1072,7 @@ func TestPasswordExpandAll2(t *testing.T) {
     }
 	`
 	js := processToFastJsonNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"_xid_":"mich","address":"31, 32 street, Jupiter","path":[{"path|weight":0.200000},{"path|weight":0.100000,"path|weight1":0.200000}],"sword_present":"true","dob_day":"1910-01-01T00:00:00Z","gender":"female","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000,"noindex_name":"Michonne's name not indexed","name":"Michonne","graduation":["1932-01-01T00:00:00Z"],"bin_data":"YmluLWRhdGE=","loc":{"type":"Point","coordinates":[1.1,2]},"age":38,"full_name":"Michonne's large name for hashing","alive":true,"power":13.250000,"password":[{"checkpwd":false}]}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"_xid_":"mich","address":"31, 32 street, Jupiter","path":[{"path|weight":0.200000},{"path|weight":0.100000,"path|weight1":0.200000}],"sword_present":"true","dob_day":"1910-01-01T00:00:00Z","gender":"female","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000,"noindex_name":"Michonne's name not indexed","name":"Michonne","graduation":["1932-01-01T00:00:00Z"],"bin_data":"YmluLWRhdGE=","loc":{"type":"Point","coordinates":[1.1,2]},"age":38,"full_name":"Michonne's large name for hashing","alive":true,"power":13.250000,"checkpwd(password)":false}]}}`, js)
 }
 
 func TestPasswordExpandError(t *testing.T) {
@@ -1099,9 +1099,7 @@ func TestCheckPassword(t *testing.T) {
                 }
 	`
 	js := processToFastJsonNoErr(t, query)
-	require.JSONEq(t,
-		`{"data": {"me":[{"name":"Michonne","password":[{"checkpwd":true}]}]}}`,
-		js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","checkpwd(password)":true}]}}`, js)
 }
 
 func TestCheckPasswordIncorrect(t *testing.T) {
@@ -1114,9 +1112,7 @@ func TestCheckPasswordIncorrect(t *testing.T) {
                 }
 	`
 	js := processToFastJsonNoErr(t, query)
-	require.JSONEq(t,
-		`{"data": {"me":[{"name":"Michonne","password":[{"checkpwd":false}]}]}}`,
-		js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","checkpwd(password)":false}]}}`, js)
 }
 
 // ensure, that old and deprecated form is not allowed
@@ -1144,7 +1140,7 @@ func TestCheckPasswordDifferentAttr1(t *testing.T) {
                 }
 	`
 	js := processToFastJsonNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes","pass":[{"checkpwd":true}]}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes","checkpwd(pass)":true}]}}`, js)
 }
 
 func TestCheckPasswordDifferentAttr2(t *testing.T) {
@@ -1158,7 +1154,7 @@ func TestCheckPasswordDifferentAttr2(t *testing.T) {
                 }
 	`
 	js := processToFastJsonNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes","pass":[{"checkpwd":false}]}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes","checkpwd(pass)":false}]}}`, js)
 }
 
 func TestCheckPasswordInvalidAttr(t *testing.T) {
@@ -1173,7 +1169,7 @@ func TestCheckPasswordInvalidAttr(t *testing.T) {
 	`
 	js := processToFastJsonNoErr(t, query)
 	// for id:0x1 there is no pass attribute defined (there's only password attribute)
-	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","pass":[{"checkpwd":false}]}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","checkpwd(pass)":false}]}}`, js)
 }
 
 // test for old version of checkpwd with hardcoded attribute name
@@ -1187,8 +1183,8 @@ func TestCheckPasswordQuery1(t *testing.T) {
                         }
                 }
 	`
-	_, err := processToFastJson(t, query)
-	require.NoError(t, err)
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"}]}}`, js)
 }
 
 // test for improved version of checkpwd with custom attribute name
@@ -1202,8 +1198,38 @@ func TestCheckPasswordQuery2(t *testing.T) {
                         }
                 }
 	`
-	_, err := processToFastJson(t, query)
-	require.NoError(t, err)
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
+}
+
+// test for improved version of checkpwd with alias for unknown attribute
+func TestCheckPasswordQuery3(t *testing.T) {
+
+	query := `
+                {
+                        me(func: uid(23)) {
+                                name
+																secret: checkpwd(pass, "123456")
+                        }
+                }
+	`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes","secret":false}]}}`, js)
+}
+
+// test for improved version of checkpwd with alias for known attribute
+func TestCheckPasswordQuery4(t *testing.T) {
+
+	query := `
+                {
+                        me(func: uid(0x01)) {
+                                name
+																secreto: checkpwd(password, "123456")
+                        }
+                }
+	`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","secreto":true}]}}`, js)
 }
 
 func TestToSubgraphInvalidFnName(t *testing.T) {


### PR DESCRIPTION
This changes query response to use any specified alias for response.
It also brings default checkpwd response to be in-line with count().
e.g.,

```
// before
"pass": [
  {
    "checkpwd": true
  }
]

// now
"checkpwd(pass)": true
```

Closes: #2630

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2641)
<!-- Reviewable:end -->
