### PR TITLE
Refactor index rebuild process

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -20,6 +20,8 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/badger/y"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
@@ -113,18 +115,13 @@ func (txn *Txn) addIndexMutation(ctx context.Context, edge *pb.DirectedEdge,
 	token string) error {
 	key := x.IndexKey(edge.Attr, token)
 
-	t := time.Now()
-	plist, err := Get(key)
-	if dur := time.Since(t); dur > time.Millisecond {
-		if tr, ok := trace.FromContext(ctx); ok {
-			tr.LazyPrintf("getOrMutate took %v", dur)
-		}
-	}
+	plist, err := txn.Get(key)
 	if err != nil {
 		return err
 	}
 
 	x.AssertTrue(plist != nil)
+	fmt.Printf("Adding edge: %+v to pl: %q\n", edge, plist.key)
 	if err = plist.AddMutation(ctx, txn, edge); err != nil {
 		if tr, ok := trace.FromContext(ctx); ok {
 			tr.LazyPrintf("Error adding/deleting %s for attr %s entity %d: %v",
@@ -179,12 +176,13 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 
 func (txn *Txn) addReverseMutation(ctx context.Context, t *pb.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
-	plist, err := Get(key)
+	plist, err := txn.Get(key)
 	if err != nil {
 		return err
 	}
 
 	x.AssertTrue(plist != nil)
+	// We must create a copy here.
 	edge := &pb.DirectedEdge{
 		Entity:  t.ValueId,
 		ValueId: t.Entity,
@@ -272,7 +270,7 @@ func (l *List) handleDeleteAll(ctx context.Context, t *pb.DirectedEdge,
 func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count uint32,
 	reverse bool) error {
 	key := x.CountKey(t.Attr, count, reverse)
-	plist, err := Get(key)
+	plist, err := txn.Get(key)
 	if err != nil {
 		return err
 	}
@@ -502,109 +500,179 @@ func DeleteCountIndex(attr string) error {
 	return nil
 }
 
-func rebuildCountIndex(ctx context.Context, attr string, reverse bool, errCh chan error,
-	startTs uint64) {
-	ch := make(chan item, 10000)
-	che := make(chan error, 1000)
-	for i := 0; i < 1000; i++ {
-		go func() {
-			var err error
-			txn := &Txn{StartTs: startTs}
-			for it := range ch {
-				l := it.list
-				t := &pb.DirectedEdge{
-					ValueId: it.uid,
-					Attr:    attr,
-					Op:      pb.DirectedEdge_SET,
-				}
-				len := l.Length(txn.StartTs, 0)
-				if len == -1 {
-					continue
-				}
-				err = txn.addCountMutation(ctx, t, uint32(len), reverse)
-				for err == ErrRetry {
-					time.Sleep(10 * time.Millisecond)
-					err = txn.addCountMutation(ctx, t, uint32(len), reverse)
-				}
-				if err == nil {
-					err = txn.CommitToMemory(txn.StartTs)
-				}
-				if err != nil {
-					txn.CommitToMemory(0)
-				}
-				txn.deltas = nil
-			}
-			che <- err
-		}()
+// Index rebuilding logic here.
+type rebuild struct {
+	prefix  []byte
+	startTs uint64
+	fn      func(uid uint64, pl *List, txn *Txn) error
+}
+
+func (r *rebuild) Run(ctx context.Context) error {
+	t := pstore.NewTransactionAt(r.startTs, false)
+	defer t.Discard()
+
+	opts := badger.DefaultIteratorOptions
+	opts.AllVersions = true
+	it := t.NewIterator(opts)
+	defer it.Close()
+
+	// We create one txn for all the mutations to be housed in. We also create a
+	// localized posting list cache, to avoid stressing or mixing up with the
+	// global lcache (the LRU cache).
+	cache := make(map[string]*List)
+	txn := &Txn{StartTs: r.startTs}
+	var numGets int
+	txn.getList = func(key []byte) (*List, error) {
+		numGets++
+		if numGets%1000 == 0 {
+			glog.V(2).Infof("During rebuild, local cache hit %d times\n", numGets)
+		}
+		if pl, ok := cache[string(key)]; ok {
+			return pl, nil
+		}
+		pl, err := getNew(key, pstore)
+		if err != nil {
+			return nil, err
+		}
+		cache[string(key)] = pl
+		return pl, nil
 	}
+
+	var prevKey []byte
+	for it.Seek(r.prefix); it.ValidForPrefix(r.prefix); {
+		item := it.Item()
+		if bytes.Equal(item.Key(), prevKey) {
+			it.Next()
+			continue
+		}
+		key := item.KeyCopy(nil)
+		prevKey = key
+
+		pk := x.Parse(key)
+		if pk == nil {
+			it.Next()
+			continue
+		}
+
+		// We should return quickly if the context is no longer valid.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		l, err := ReadPostingList(key, it)
+		if err != nil {
+			return err
+		}
+		if err := r.fn(pk.Uid, l, txn); err != nil {
+			return err
+		}
+	}
+
+	// We must commit all the posting lists to memory, so they'd be picked up
+	// during posting list rollup below.
+	if err := txn.CommitToMemory(r.startTs); err != nil {
+		return err
+	}
+
+	// Now we write all the created posting lists to disk.
+	writer := x.TxnWriter{DB: pstore}
+	for key := range txn.deltas {
+		pl, err := txn.Get([]byte(key))
+		if err != nil {
+			return err
+		}
+		pl.Lock() // We shouldn't need to release this lock.
+		le := pl.length(r.startTs, 0)
+		y.AssertTruef(le > 0, "pl of size zero: %q", key)
+		if err := pl.rollup(); err != nil {
+			return err
+		}
+		data, meta := marshalPostingList(pl.plist)
+		if err = writer.SetAt([]byte(key), data, meta, r.startTs); err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
+}
+
+// RebuildIndex rebuilds index for a given attribute.
+// We commit mutations with startTs and ignore the errors.
+func RebuildIndex(ctx context.Context, attr string, startTs uint64) error {
+	x.AssertTruef(schema.State().IsIndexed(attr), "Attr %s not indexed", attr)
 
 	pk := x.ParsedKey{Attr: attr}
-	prefix := pk.DataPrefix()
-	if reverse {
-		prefix = pk.ReversePrefix()
+	builder := rebuild{prefix: pk.DataPrefix(), startTs: startTs}
+	builder.fn = func(uid uint64, pl *List, txn *Txn) error {
+		edge := pb.DirectedEdge{Attr: attr, Entity: uid}
+		var rerr error
+		pl.Iterate(txn.StartTs, 0, func(p *pb.Posting) bool {
+			// Add index entries based on p.
+			val := types.Val{
+				Value: p.Value,
+				Tid:   types.TypeID(p.ValType),
+			}
+
+			for {
+				err := txn.addIndexMutations(ctx, &edge, val, pb.DirectedEdge_SET)
+				switch err {
+				case nil:
+					return true
+				case ErrRetry:
+					time.Sleep(10 * time.Millisecond)
+					// Continue the for loop.
+				default:
+					rerr = err
+					return false
+				}
+			}
+		})
+		return rerr
 	}
-
-	t := pstore.NewTransactionAt(startTs, false)
-	defer t.Discard()
-	iterOpts := badger.DefaultIteratorOptions
-	iterOpts.AllVersions = true
-	it := t.NewIterator(iterOpts)
-	defer it.Close()
-	var prevKey []byte
-	it.Seek(prefix)
-	for it.ValidForPrefix(prefix) {
-		iterItem := it.Item()
-		key := iterItem.Key()
-		if bytes.Equal(key, prevKey) {
-			it.Next()
-			continue
-		}
-		nk := make([]byte, len(key))
-		copy(nk, key)
-		prevKey = nk
-		pki := x.Parse(key)
-		if pki == nil {
-			it.Next()
-			continue
-		}
-		// readPostingList advances the iterator until it finds complete pl
-		l, err := ReadPostingList(nk, it)
-		if err != nil {
-			continue
-		}
-
-		ch <- item{
-			uid:  pki.Uid,
-			list: l,
-		}
-	}
-	close(ch)
-
-	for i := 0; i < 1000; i++ {
-		if err := <-che; err != nil {
-			errCh <- x.Errorf("While rebuilding count index for attr: [%v], error: [%v]", attr, err)
-			return
-		}
-	}
-
-	errCh <- nil
+	return builder.Run(ctx)
 }
 
 func RebuildCountIndex(ctx context.Context, attr string, startTs uint64) error {
 	x.AssertTruef(schema.State().HasCount(attr), "Attr %s doesn't have count index", attr)
-	che := make(chan error, 2)
 	// Lets rebuild forward and reverse count indexes concurrently.
-	go rebuildCountIndex(ctx, attr, false, che, startTs)
-	go rebuildCountIndex(ctx, attr, true, che, startTs)
 
-	var err error
-	for i := 0; i < 2; i++ {
-		if e := <-che; e != nil {
-			err = e
+	var reverse bool
+	fn := func(uid uint64, pl *List, txn *Txn) error {
+		t := &pb.DirectedEdge{
+			ValueId: uid,
+			Attr:    attr,
+			Op:      pb.DirectedEdge_SET,
+		}
+		sz := pl.Length(startTs, 0)
+		if sz == -1 {
+			return nil
+		}
+		for {
+			err := txn.addCountMutation(ctx, t, uint32(sz), reverse)
+			switch err {
+			case nil:
+				return nil
+			case ErrRetry:
+				time.Sleep(10 * time.Millisecond)
+				// Continue the for loop.
+			default:
+				return err
+			}
 		}
 	}
 
-	return err
+	pk := x.ParsedKey{Attr: attr}
+	builder := rebuild{prefix: pk.DataPrefix(), startTs: startTs}
+	builder.fn = fn
+	if err := builder.Run(ctx); err != nil {
+		return err
+	}
+
+	reverse = true
+	builder = rebuild{prefix: pk.ReversePrefix(), startTs: startTs}
+	builder.fn = fn
+	return builder.Run(ctx)
 }
 
 type item struct {
@@ -615,20 +683,12 @@ type item struct {
 // RebuildReverseEdges rebuilds the reverse edges for a given attribute.
 func RebuildReverseEdges(ctx context.Context, attr string, startTs uint64) error {
 	x.AssertTruef(schema.State().IsReversed(attr), "Attr %s doesn't have reverse", attr)
-	// Add index entries to data store.
-	pk := x.ParsedKey{Attr: attr}
-	prefix := pk.DataPrefix()
-	t := pstore.NewTransactionAt(startTs, false)
-	defer t.Discard()
-	iterOpts := badger.DefaultIteratorOptions
-	iterOpts.AllVersions = true
-	it := t.NewIterator(iterOpts)
-	defer it.Close()
 
-	// Helper function - Add reverse entries for values in posting list
-	addReversePostings := func(uid uint64, pl *List, txn *Txn) {
+	pk := x.ParsedKey{Attr: attr}
+	builder := rebuild{prefix: pk.DataPrefix(), startTs: startTs}
+	builder.fn = func(uid uint64, pl *List, txn *Txn) error {
 		edge := pb.DirectedEdge{Attr: attr, Entity: uid}
-		var err error
+		var rerr error
 		pl.Iterate(txn.StartTs, 0, func(pp *pb.Posting) bool {
 			puid := pp.Uid
 			// Add reverse entries based on p.
@@ -636,71 +696,23 @@ func RebuildReverseEdges(ctx context.Context, attr string, startTs uint64) error
 			edge.Op = pb.DirectedEdge_SET
 			edge.Facets = pp.Facets
 			edge.Label = pp.Label
-			err = txn.addReverseMutation(ctx, &edge)
-			for err == ErrRetry {
-				time.Sleep(10 * time.Millisecond)
-				err = txn.addReverseMutation(ctx, &edge)
-			}
-			if err != nil {
-				x.Printf("Error while adding reverse mutation: %v\n", err)
-			}
-			return true
-		})
-	}
 
-	ch := make(chan item, 10000)
-	che := make(chan error, 1000)
-	for i := 0; i < 1000; i++ {
-		go func() {
-			var err error
-			txn := &Txn{StartTs: startTs}
-			for it := range ch {
-				addReversePostings(it.uid, it.list, txn)
-				err = txn.CommitToMemory(txn.StartTs)
-				if err != nil {
-					txn.CommitToMemory(0)
+			for {
+				err := txn.addReverseMutation(ctx, &edge)
+				switch err {
+				case nil:
+					return true
+				case ErrRetry:
+					time.Sleep(10 * time.Millisecond)
+				default:
+					rerr = err
+					return false
 				}
-				txn.deltas = nil
 			}
-			che <- err
-		}()
+		})
+		return rerr
 	}
-
-	var prevKey []byte
-	it.Seek(prefix)
-	for it.ValidForPrefix(prefix) {
-		iterItem := it.Item()
-		key := iterItem.Key()
-		if bytes.Equal(key, prevKey) {
-			it.Next()
-			continue
-		}
-		nk := make([]byte, len(key))
-		copy(nk, key)
-		prevKey = nk
-		pki := x.Parse(key)
-		if pki == nil {
-			it.Next()
-			continue
-		}
-		l, err := ReadPostingList(nk, it)
-		if err != nil {
-			continue
-		}
-
-		ch <- item{
-			uid:  pki.Uid,
-			list: l,
-		}
-	}
-	close(ch)
-
-	for i := 0; i < 1000; i++ {
-		if err := <-che; err != nil {
-			return x.Errorf("While rebuilding reverse edges for attr: [%v], error: [%v]", attr, err)
-		}
-	}
-	return nil
+	return builder.Run(ctx)
 }
 
 func DeleteIndex(attr string) error {
@@ -811,100 +823,6 @@ func RebuildListType(ctx context.Context, attr string, startTs uint64) error {
 	for i := 0; i < 1000; i++ {
 		if err := <-che; err != nil {
 			return x.Errorf("While rebuilding list type for attr: [%v], error: [%v]", attr, err)
-		}
-	}
-	return nil
-}
-
-// RebuildIndex rebuilds index for a given attribute.
-// We commit mutations with startTs and ignore the errors.
-func RebuildIndex(ctx context.Context, attr string, startTs uint64) error {
-	x.AssertTruef(schema.State().IsIndexed(attr), "Attr %s not indexed", attr)
-	// Add index entries to data store.
-	pk := x.ParsedKey{Attr: attr}
-	prefix := pk.DataPrefix()
-	t := pstore.NewTransactionAt(startTs, false)
-	defer t.Discard()
-	iterOpts := badger.DefaultIteratorOptions
-	iterOpts.AllVersions = true
-	it := t.NewIterator(iterOpts)
-	defer it.Close()
-
-	// Helper function - Add index entries for values in posting list
-	addPostingsToIndex := func(uid uint64, pl *List, txn *Txn) {
-		edge := pb.DirectedEdge{Attr: attr, Entity: uid}
-		var err error
-		pl.Iterate(txn.StartTs, 0, func(p *pb.Posting) bool {
-			// Add index entries based on p.
-			val := types.Val{
-				Value: p.Value,
-				Tid:   types.TypeID(p.ValType),
-			}
-			err = txn.addIndexMutations(ctx, &edge, val, pb.DirectedEdge_SET)
-			for err == ErrRetry {
-				time.Sleep(10 * time.Millisecond)
-				err = txn.addIndexMutations(ctx, &edge, val, pb.DirectedEdge_SET)
-			}
-			if err != nil {
-				x.Printf("Error while adding index mutation: %v\n", err)
-			}
-			return true
-		})
-	}
-
-	type item struct {
-		uid  uint64
-		list *List
-	}
-	ch := make(chan item, 10000)
-	che := make(chan error, 1000)
-	for i := 0; i < 1000; i++ {
-		go func() {
-			var err error
-			txn := &Txn{StartTs: startTs}
-			for it := range ch {
-				addPostingsToIndex(it.uid, it.list, txn)
-				err = txn.CommitToMemory(txn.StartTs)
-				if err != nil {
-					txn.CommitToMemory(0)
-				}
-				txn.deltas = nil
-			}
-			che <- err
-		}()
-	}
-
-	var prevKey []byte
-	it.Seek(prefix)
-	for it.ValidForPrefix(prefix) {
-		iterItem := it.Item()
-		key := iterItem.Key()
-		if bytes.Equal(key, prevKey) {
-			it.Next()
-			continue
-		}
-		nk := make([]byte, len(key))
-		copy(nk, key)
-		prevKey = nk
-		pki := x.Parse(key)
-		if pki == nil {
-			it.Next()
-			continue
-		}
-		l, err := ReadPostingList(nk, it)
-		if err != nil {
-			continue
-		}
-
-		ch <- item{
-			uid:  pki.Uid,
-			list: l,
-		}
-	}
-	close(ch)
-	for i := 0; i < 1000; i++ {
-		if err := <-che; err != nil {
-			return x.Errorf("While rebuilding index for attr: [%v], error: [%v]", attr, err)
 		}
 	}
 	return nil

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -10,6 +10,7 @@ package posting
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -256,14 +257,14 @@ func TestRebuildIndex(t *testing.T) {
 	}
 
 	require.NoError(t, DeleteIndex("name2"))
-	RebuildIndex(context.Background(), "name2", 5)
-	CommitLists(func(key []byte) bool {
-		pk := x.Parse(key)
-		if pk.Attr == "name2" {
-			return true
-		}
-		return false
-	})
+	require.NoError(t, RebuildIndex(context.Background(), "name2", 5))
+	// CommitLists(func(key []byte) bool {
+	// 	pk := x.Parse(key)
+	// 	if pk.Attr == "name2" {
+	// 		return true
+	// 	}
+	// 	return false
+	// })
 
 	// Check index entries in data store.
 	txn := ps.NewTransactionAt(6, false)
@@ -280,7 +281,9 @@ func TestRebuildIndex(t *testing.T) {
 		if !bytes.HasPrefix(key, prefix) {
 			break
 		}
+		fmt.Printf("Got key: %q\n", key)
 		if item.UserMeta()&BitEmptyPosting == BitEmptyPosting {
+			fmt.Printf("Continuing here\n")
 			continue
 		}
 		idxKeys = append(idxKeys, string(key))

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -10,7 +10,6 @@ package posting
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -258,13 +257,6 @@ func TestRebuildIndex(t *testing.T) {
 
 	require.NoError(t, DeleteIndex("name2"))
 	require.NoError(t, RebuildIndex(context.Background(), "name2", 5))
-	// CommitLists(func(key []byte) bool {
-	// 	pk := x.Parse(key)
-	// 	if pk.Attr == "name2" {
-	// 		return true
-	// 	}
-	// 	return false
-	// })
 
 	// Check index entries in data store.
 	txn := ps.NewTransactionAt(6, false)
@@ -281,9 +273,7 @@ func TestRebuildIndex(t *testing.T) {
 		if !bytes.HasPrefix(key, prefix) {
 			break
 		}
-		fmt.Printf("Got key: %q\n", key)
 		if item.UserMeta()&BitEmptyPosting == BitEmptyPosting {
-			fmt.Printf("Continuing here\n")
 			continue
 		}
 		idxKeys = append(idxKeys, string(key))

--- a/posting/list.go
+++ b/posting/list.go
@@ -40,11 +40,12 @@ var (
 	// In such a case, retry.
 	ErrRetry = fmt.Errorf("Temporary Error. Please retry.")
 	// ErrNoValue would be returned if no value was found in the posting list.
-	ErrNoValue     = fmt.Errorf("No value found")
-	ErrInvalidTxn  = fmt.Errorf("Invalid transaction")
-	errUncommitted = fmt.Errorf("Posting List has uncommitted data")
-	emptyPosting   = &pb.Posting{}
-	emptyList      = &pb.PostingList{}
+	ErrNoValue       = fmt.Errorf("No value found")
+	ErrInvalidTxn    = fmt.Errorf("Invalid transaction")
+	ErrStopIteration = errors.New("Stop iteration")
+	errUncommitted   = fmt.Errorf("Posting List has uncommitted data")
+	emptyPosting     = &pb.Posting{}
+	emptyList        = &pb.PostingList{}
 )
 
 const (
@@ -538,8 +539,6 @@ func (l *List) pickPostings(readTs uint64) (*pb.PostingList, []*pb.Posting) {
 	})
 	return storedList, posts
 }
-
-var ErrStopIteration = errors.New("Stop iteration")
 
 func (l *List) iterate(readTs uint64, afterUid uint64, f func(obj *pb.Posting) error) error {
 	l.AssertRLock()

--- a/posting/list.go
+++ b/posting/list.go
@@ -432,13 +432,13 @@ func (l *List) commitMutation(startTs, commitTs uint64) error {
 	}
 
 	// Calculate 10% of immutable layer
-	numUids := (bp128.NumIntegers(l.plist.Uids) * 10) / 100
-	if numUids < 1000 {
-		numUids = 1000
-	}
-	if l.numCommits > numUids {
-		l.syncIfDirty(false)
-	}
+	// numUids := (bp128.NumIntegers(l.plist.Uids) * 10) / 100
+	// if numUids < 1000 {
+	// 	numUids = 1000
+	// }
+	// if l.numCommits > numUids {
+	// 	l.syncIfDirty(false)
+	// }
 	return nil
 }
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -119,7 +119,7 @@ func TestAddMutation(t *testing.T) {
 func getFirst(l *List, readTs uint64) (res pb.Posting) {
 	l.Iterate(readTs, 0, func(p *pb.Posting) error {
 		res = *p
-		return nil
+		return ErrStopIteration
 	})
 	return res
 }

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -32,9 +32,9 @@ func (l *List) PostingList() *pb.PostingList {
 
 func listToArray(t *testing.T, afterUid uint64, l *List, readTs uint64) []uint64 {
 	out := make([]uint64, 0, 10)
-	l.Iterate(readTs, afterUid, func(p *pb.Posting) bool {
+	l.Iterate(readTs, afterUid, func(p *pb.Posting) error {
 		out = append(out, p.Uid)
-		return true
+		return nil
 	})
 	return out
 }
@@ -117,9 +117,9 @@ func TestAddMutation(t *testing.T) {
 }
 
 func getFirst(l *List, readTs uint64) (res pb.Posting) {
-	l.Iterate(readTs, 0, func(p *pb.Posting) bool {
+	l.Iterate(readTs, 0, func(p *pb.Posting) error {
 		res = *p
-		return false
+		return nil
 	})
 	return res
 }

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -126,10 +126,10 @@ func (tx *Txn) CommitToMemory(commitTs uint64) error {
 			}
 			err = plist.CommitMutation(tx.StartTs, commitTs)
 			switch err {
-			case ErrRetry:
-				time.Sleep(5 * time.Millisecond)
 			case nil:
 				break inner
+			case ErrRetry:
+				time.Sleep(5 * time.Millisecond)
 			default:
 				glog.Warningf("Error while committing to memory: %v\n", err)
 				return err

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -50,8 +50,8 @@ type Txn struct {
 	// determine unhealthy, stale txns.
 	lastUpdate time.Time
 
-	// getList is the function to use to retrieve and store posting lists in a
-	// cache. This can be left nil to use the global lru cache.
+	// getList can be set for a txn, to isolate the retrieval and storage of
+	// posting lists in a separate cache. If nil, global LRU cache is used.
 	getList func(key []byte) (*List, error)
 }
 

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -49,6 +49,17 @@ type Txn struct {
 	// Keeps track of last update wall clock. We use this fact later to
 	// determine unhealthy, stale txns.
 	lastUpdate time.Time
+
+	// getList is the function to use to retrieve and store posting lists in a
+	// cache. This can be left nil to use the global lru cache.
+	getList func(key []byte) (*List, error)
+}
+
+func (txn *Txn) Get(key []byte) (*List, error) {
+	if txn.getList == nil {
+		return Get(key)
+	}
+	return txn.getList(key)
 }
 
 type oracle struct {

--- a/worker/export.go
+++ b/worker/export.go
@@ -33,7 +33,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-const numExportRoutines = 100
+const numExportRoutines = 10
 
 type kv struct {
 	prefix string
@@ -235,7 +235,10 @@ func export(bdir string, readTs uint64) error {
 			buf.Grow(50000)
 			for item := range chkv {
 				// TODO: Add error handling in toRDF.
-				toRDF(buf, item, readTs)
+				if err := toRDF(buf, item, readTs); err != nil {
+					glog.Errorf("Error while converting to RDF: %v. Ignoring...\n", err)
+					continue
+				}
 				if buf.Len() >= 40000 {
 					tmp := make([]byte, buf.Len())
 					copy(tmp, buf.Bytes())

--- a/worker/task.go
+++ b/worker/task.go
@@ -509,18 +509,18 @@ func handleUidPostings(ctx context.Context, args funcArgs, opts posting.ListOpti
 
 		var perr error
 		filteredRes = make([]*result, 0)
-		err = pl.Postings(opts, func(p *pb.Posting) bool {
+		err = pl.Postings(opts, func(p *pb.Posting) error {
 			res := true
 			res, perr = applyFacetsTree(p.Facets, facetsTree)
 			if perr != nil {
-				return false // break loop.
+				return posting.ErrStopIteration
 			}
 			if res {
 				filteredRes = append(filteredRes, &result{
 					uid:    p.Uid,
 					facets: facets.CopyFacets(p.Facets, q.FacetParam)})
 			}
-			return true // continue iteration.
+			return nil // continue iteration.
 		})
 		if err != nil {
 			return err
@@ -1641,9 +1641,9 @@ func handleHasFunction(ctx context.Context, q *pb.Query, out *pb.Result) error {
 		}
 		pk := x.Parse(key)
 		var num int
-		if err := pl.Iterate(q.ReadTs, 0, func(_ *pb.Posting) bool {
+		if err := pl.Iterate(q.ReadTs, 0, func(_ *pb.Posting) error {
 			num++
-			return false
+			return posting.ErrStopIteration
 		}); err != nil {
 			return err
 		}
@@ -1692,9 +1692,9 @@ func handleHasFunction(ctx context.Context, q *pb.Query, out *pb.Result) error {
 			return err
 		}
 		var num int
-		if err = l.Iterate(q.ReadTs, 0, func(_ *pb.Posting) bool {
+		if err = l.Iterate(q.ReadTs, 0, func(_ *pb.Posting) error {
 			num++
-			return false
+			return posting.ErrStopIteration
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
The index rebuilding code was a mess, copied many times over for each use case. Refactor all that into one "framework", which takes in function holding the core logic, while removing the boilerplate out of each invocation (similar to how orchestrate works).

The index building is done via a single txn object, which now holds all the mutations in memory. Once the rebuild is done, the posting lists are rolled up and flushed to disk at the timestamp provided. Honestly, this simplification took a while to occur to me. To avoid polluting the LRU cache, txn struct now exposes a getList API, which defaults to posting.Get, but the rebuild code above uses a local cache; so we can isolate the rebuild proces.

Also, posting list iterate which takes in a function, that function should really be returning an error, so it can be sent back to the caller; instead of the caller doing their own error catching outside of the function call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2650)
<!-- Reviewable:end -->
