### PR TITLE
Fix missing alpha health metric.

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -168,9 +168,9 @@ func init() {
 			"dgraph_num_queries_total",
 			nil, nil,
 		),
-		"dgraph_server_health_status": prometheus.NewDesc(
-			"dgraph_server_health_status",
-			"dgraph_server_health_status",
+		"dgraph_alpha_health_status": prometheus.NewDesc(
+			"dgraph_alpha_health_status",
+			"dgraph_alpha_health_status",
 			nil, nil,
 		),
 		"dgraph_dirtymap_keys_total": prometheus.NewDesc(


### PR DESCRIPTION
Missed this change for #2670 (7150815f6de54e104a515b2d0afdba15fb1a692d).

The `dgraph_alpha_health_status` disappeared from /debug/prometheus_metrics in v1.0.10-rc1. It's available in /debug/vars, but not in /debug/prometheus_metrics.

This should fix it.

Steps to reproduce:

1. Run an Alpha
2. `curl localhost:8080/debug/prometheus_metrics | grep dgraph_alpha_health_status` should return output.
3. `curl localhost:8080/debug/vars | grep dgraph_alpha_health_status` should return output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2700)
<!-- Reviewable:end -->
