### PR TITLE
Avoid triggering log.Fatal if disposing server state encounters an error

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -312,9 +312,8 @@ func run() {
 	x.PrintVersion()
 	edgraph.InitServerState()
 	defer func() {
-		if err := edgraph.State.Dispose(); err != nil {
-			glog.Errorf("Error while disposing server state: %v", err)
-		}
+		edgraph.State.Dispose()
+		glog.Info("Finished disposing server state.")
 	}()
 
 	if Alpha.Conf.GetBool("expose_trace") {

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -312,7 +312,9 @@ func run() {
 	x.PrintVersion()
 	edgraph.InitServerState()
 	defer func() {
-		x.Check(edgraph.State.Dispose())
+		if err := edgraph.State.Dispose(); err != nil {
+			glog.Errorf("Error while disposing server state: %v", err)
+		}
 	}()
 
 	if Alpha.Conf.GetBool("expose_trace") {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -41,7 +41,6 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/codes"
@@ -178,16 +177,15 @@ func (s *ServerState) initStorage() {
 	go s.runVlogGC(s.WALstore)
 }
 
-func (s *ServerState) Dispose() error {
+func (s *ServerState) Dispose() {
 	if err := s.Pstore.Close(); err != nil {
-		return errors.Wrapf(err, "While closing postings store")
+		glog.Errorf("Error while closing postings store: %v", err)
 	}
 	if err := s.WALstore.Close(); err != nil {
-		return errors.Wrapf(err, "While closing WAL store")
+		glog.Errorf("Error while closing WAL store: %v", err)
 	}
 	s.vlogTicker.Stop()
 	s.mandatoryVlogTicker.Stop()
-	return nil
 }
 
 // Server implements protos.DgraphServer


### PR DESCRIPTION
Tested by hard killing the alpha server with Ctrl+C while loading data using live loader,
and verified that the p and w directories both can be opened successfully with 
`badger info --dir p`
and
`badger info --dir w`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2701)
<!-- Reviewable:end -->
