### PR TITLE
Make release.sh work with ref names with slashes.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -12,6 +12,10 @@ rm -Rf $GOPATH
 mkdir $GOPATH
 
 TAG=$1
+# The Docker tag should not contain a slash e.g. feature/issue1234
+# The initial slash is taken from the repository dgraph/dgraph:tag
+DOCKERTAG=$(echo "$TAG" | tr '/' '-')
+
 
 # DO NOT change the /tmp/build directory, because Dockerfile also picks up binaries from there.
 TMP="/tmp/build"
@@ -139,7 +143,7 @@ createSum linux
 # Create Docker image.
 cp $basedir/dgraph/contrib/Dockerfile $TMP
 pushd $TMP
-  docker build -t dgraph/dgraph:$TAG .
+  docker build -t dgraph/dgraph:$DTAG .
 popd
 rm $TMP/Dockerfile
 
@@ -158,5 +162,5 @@ createTar darwin
 createTar linux
 
 echo "Release $TAG is ready."
-docker run -it dgraph/dgraph:$TAG dgraph
+docker run -it dgraph/dgraph:$DTAG dgraph
 ls -alh $TMP

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -13,8 +13,8 @@ mkdir $GOPATH
 
 TAG=$1
 # The Docker tag should not contain a slash e.g. feature/issue1234
-# The initial slash is taken from the repository dgraph/dgraph:tag
-DOCKERTAG=$(echo "$TAG" | tr '/' '-')
+# The initial slash is taken from the repository name dgraph/dgraph:tag
+DTAG=$(echo "$TAG" | tr '/' '-')
 
 
 # DO NOT change the /tmp/build directory, because Dockerfile also picks up binaries from there.


### PR DESCRIPTION
This would allow release builds to be created from feature branches that typically have a slash in the name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2722)
<!-- Reviewable:end -->
