### PR TITLE
Optimize has function

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -601,10 +601,18 @@ func (l *List) iterate(readTs uint64, afterUid uint64, f func(obj *pb.Posting) e
 	return err
 }
 
-func (l *List) IsEmpty() bool {
+func (l *List) IsEmpty(readTs, afterUid uint64) (bool, error) {
 	l.RLock()
 	defer l.RUnlock()
-	return codec.ApproxLen(l.plist.Pack) == 0 && len(l.mutationMap) == 0
+	var count int
+	err := l.iterate(readTs, afterUid, func(p *pb.Posting) error {
+		count++
+		return ErrStopIteration
+	})
+	if err != nil {
+		return false, err
+	}
+	return count == 0, nil
 }
 
 func (l *List) length(readTs, afterUid uint64) int {

--- a/posting/list.go
+++ b/posting/list.go
@@ -655,7 +655,7 @@ func (l *List) MarshalToKv() (*pb.KV, error) {
 }
 
 func marshalPostingList(plist *pb.PostingList) (data []byte, meta byte) {
-	if plist.Pack == nil {
+	if plist.Pack == nil || len(plist.Pack.Blocks) == 0 {
 		return nil, BitEmptyPosting
 	}
 	data, err := plist.Marshal()

--- a/worker/task.go
+++ b/worker/task.go
@@ -1639,6 +1639,8 @@ func handleHasFunction(ctx context.Context, q *pb.Query, out *pb.Result) error {
 	it := txn.NewIterator(itOpt)
 	defer it.Close()
 
+	// TODO
+	// Switch this to stream list interface.
 	for it.Seek(startKey); it.ValidForPrefix(prefix); {
 		item := it.Item()
 		if bytes.Equal(item.Key(), prevKey) {
@@ -1661,6 +1663,8 @@ func handleHasFunction(ctx context.Context, q *pb.Query, out *pb.Result) error {
 		if err != nil {
 			return err
 		}
+		// TODO: Create a list.HasAny() function, which can provide this. This
+		// func can then be used elsewhere, we're using list.Length right now.
 		var num int
 		if err = l.Iterate(q.ReadTs, 0, func(_ *pb.Posting) error {
 			num++


### PR DESCRIPTION
Since the last change to make `has(...)` function to work correctly with transactions, things have been slow due to the need to build the entire posting list to determine if it has a posting or not. This PR optimizes that by utilizing BitCompletePosting. If this bit is found, then there must be a valid posting in the list, so we don't need to recreate the entire list.

This speeds up `handleHasFunction` considerably, for all predicates which don't have `@lang` index. For the predicates which have the lang index set, they're slowed down by `filterStringFunction`, but there's no easy fix there. Added a TODO for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2724)
<!-- Reviewable:end -->
