### PR TITLE
Fix Alpha config flag handling with Viper.

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -96,11 +96,11 @@ they form a Raft group and provide synchronous replication.
 		"Number of pending mutation proposals. Useful for rate limiting.")
 	flag.Float64("trace", 0.0, "The ratio of queries to trace.")
 	flag.String("my", "",
-		"IP_ADDRESS:PORT of this server, so other Dgraph Alphas can talk to this.")
+		"IP_ADDRESS:PORT of this Dgraph Alpha, so other Dgraph Alphas can talk to this.")
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
-		"IP_ADDRESS:PORT of a Dgraph Zero of the cluster.")
+		"IP_ADDRESS:PORT of a Dgraph Zero.")
 	flag.Uint64("idx", 0,
-		"Optional Raft ID that this server will use to join RAFT groups.")
+		"Optional Raft ID that this Dgraph Alpha will use to join RAFT groups.")
 	flag.Bool("expand_edge", true,
 		"Enables the expand() feature. This is very expensive for large data loads because it"+
 			" doubles the number of mutations going on in the system.")

--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -17,13 +17,8 @@
 package edgraph
 
 import (
-	"bytes"
-	"errors"
 	"expvar"
-	"fmt"
-	"net"
 	"path/filepath"
-	"strings"
 
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/worker"
@@ -39,8 +34,6 @@ type Options struct {
 	AuthToken    string
 
 	AllottedMemory float64
-
-	WhitelistedIPs string
 }
 
 var Config Options
@@ -98,14 +91,6 @@ func SetConfiguration(newConfig Options) {
 	posting.Config.Mu.Lock()
 	posting.Config.AllottedMemory = Config.AllottedMemory
 	posting.Config.Mu.Unlock()
-
-	ips, err := parseIPsFromString(Config.WhitelistedIPs)
-	if err != nil {
-		fmt.Println("IP ranges could not be parsed from --whitelist " + Config.WhitelistedIPs)
-		worker.Config.WhiteListedIPRanges = []worker.IPRange{}
-	} else {
-		worker.Config.WhiteListedIPRanges = ips
-	}
 }
 
 const MinAllottedMemory = 1024.0
@@ -115,53 +100,10 @@ func (o *Options) validate() {
 	x.Check(err)
 	wd, err := filepath.Abs(o.WALDir)
 	x.Check(err)
-	_, err = parseIPsFromString(o.WhitelistedIPs)
-	x.Check(err)
 	x.AssertTruef(pd != wd, "Posting and WAL directory cannot be the same ('%s').", o.PostingDir)
 	x.AssertTruefNoTrace(o.AllottedMemory != -1,
 		"LRU memory (--lru_mb) must be specified. (At least 1024 MB)")
 	x.AssertTruefNoTrace(o.AllottedMemory >= MinAllottedMemory,
 		"LRU memory (--lru_mb) must be at least %.0f MB. Currently set to: %f",
 		MinAllottedMemory, o.AllottedMemory)
-}
-
-// Parses the comma-delimited whitelist ip-range string passed in as an argument
-// from the command line and returns slice of []IPRange
-//
-// ex. "144.142.126.222:144.124.126.400,190.59.35.57:190.59.35.99"
-func parseIPsFromString(str string) ([]worker.IPRange, error) {
-	if str == "" {
-		return []worker.IPRange{}, nil
-	}
-
-	var ipRanges []worker.IPRange
-	ipRangeStrings := strings.Split(str, ",")
-
-	// Check that the each of the ranges are valid
-	for _, s := range ipRangeStrings {
-		ipsTuple := strings.Split(s, ":")
-
-		// Assert that the range consists of an upper and lower bound
-		if len(ipsTuple) != 2 {
-			return nil, errors.New("IP range must have a lower and upper bound")
-		}
-
-		lowerBoundIP := net.ParseIP(ipsTuple[0])
-		upperBoundIP := net.ParseIP(ipsTuple[1])
-
-		if lowerBoundIP == nil || upperBoundIP == nil {
-			// Assert that both upper and lower bound are valid IPs
-			return nil, errors.New(
-				ipsTuple[0] + " or " + ipsTuple[1] + " is not a valid IP address",
-			)
-		} else if bytes.Compare(lowerBoundIP, upperBoundIP) > 0 {
-			// Assert that the lower bound is less than the upper bound
-			return nil, errors.New(
-				ipsTuple[0] + " cannot be greater than " + ipsTuple[1],
-			)
-		} else {
-			ipRanges = append(ipRanges, worker.IPRange{Lower: lowerBoundIP, Upper: upperBoundIP})
-		}
-	}
-	return ipRanges, nil
 }

--- a/worker/config.go
+++ b/worker/config.go
@@ -22,11 +22,9 @@ type IPRange struct {
 }
 
 type Options struct {
-	BaseWorkerPort      int
 	ExportPath          string
 	NumPendingProposals int
 	Tracing             float64
-	GroupIds            string
 	MyAddr              string
 	ZeroAddr            string
 	RaftId              uint64


### PR DESCRIPTION
Passing a config file like the following works again:

```
$ cat config.json
{
  "lru_mb": "1024",
  "zero": "localhost:5080",
  "auth_token": "dgtok"
}
$ dgraph alpha --config config.json
```

Also, remove unused fields (BaseWorkerPort, GroupIds) and a var (config edgraph.Option).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2725)
<!-- Reviewable:end -->
