### PR TITLE
Make posting list memory rollup happen right after disk

### DIFF
--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     ports:
       - 8180:8180
       - 9180:9180
-    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 --expose_trace  --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=3
+    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 --expose_trace  --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2
 
   dg2:
     image: dgraph/dgraph:latest
@@ -126,7 +126,7 @@ services:
     ports:
       - 8183:8183
       - 9183:9183
-    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 --expose_trace   --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=3
+    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 --expose_trace   --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2
 
   # dg4:
   #   image: debian:latest

--- a/posting/list.go
+++ b/posting/list.go
@@ -74,10 +74,8 @@ type List struct {
 	plist         *pb.PostingList
 	mutationMap   map[uint64]*pb.PostingList
 	minTs         uint64 // commit timestamp of immutable layer, reject reads before this ts.
-	commitTs      uint64 // last commitTs of this pl
 	deleteMe      int32  // Using atomic for this, to avoid expensive SetForDeletion operation.
 	estimatedSize int32
-	numCommits    int
 }
 
 // calculateSize would give you the size estimate. This is expensive, so run it carefully.
@@ -415,26 +413,13 @@ func (l *List) commitMutation(startTs, commitTs uint64) error {
 	for _, mpost := range plist.Postings {
 		mpost.CommitTs = commitTs
 	}
-	l.numCommits += len(plist.Postings)
-
-	if commitTs > l.commitTs {
-		// This is for rolling up the posting list.
-		l.commitTs = commitTs
-	}
 
 	// In general, a posting list shouldn't try to mix up it's job of keeping
 	// things in memory, with writing things to disk. A separate process can
 	// roll up and write them to disk. Posting list should only keep things in
 	// memory, to make it available for transactions. So, all we need to do here
-	// is to roll them up periodically.
-
-	numUids := (codec.ApproxLen(l.plist.Pack) * 15) / 100
-	if numUids < 1000 {
-		numUids = 1000
-	}
-	if l.numCommits > numUids {
-		return l.rollup()
-	}
+	// is to roll them up periodically, now being done by draft.go.
+	// For the PLs in memory, we roll them up after we do the disk rollup.
 	return nil
 }
 
@@ -444,10 +429,10 @@ func (l *List) commitMutation(startTs, commitTs uint64) error {
 // The function will loop until either the Posting List is fully iterated, or you return a false
 // in the provided function, which will indicate to the function to break out of the iteration.
 //
-// 	pl.Iterate(func(p *pb.Posting) bool {
+// 	pl.Iterate(..., func(p *pb.Posting) error {
 //    // Use posting p
-//    return true  // to continue iteration.
-//    return false // to break iteration.
+//    return nil // to continue iteration.
+//    return ErrStopIteration // to break iteration.
 //  })
 func (l *List) Iterate(readTs uint64, afterUid uint64, f func(obj *pb.Posting) error) error {
 	l.RLock()
@@ -649,7 +634,7 @@ func doAsyncWrite(commitTs uint64, key []byte, data []byte, meta byte, f func(er
 func (l *List) MarshalToKv() (*pb.KV, error) {
 	l.Lock()
 	defer l.Unlock()
-	if err := l.rollup(); err != nil {
+	if err := l.rollup(math.MaxUint64); err != nil {
 		return nil, err
 	}
 
@@ -673,18 +658,25 @@ func marshalPostingList(plist *pb.PostingList) (data []byte, meta byte) {
 
 const blockSize int = 256
 
+func (l *List) Rollup(readTs uint64) error {
+	l.Lock()
+	defer l.Unlock()
+	return l.rollup(readTs)
+}
+
 // Merge all entries in mutation layer with commitTs <= l.commitTs
 // into immutable layer.
-func (l *List) rollup() error {
+func (l *List) rollup(readTs uint64) error {
 	l.AssertLock()
 
 	// Pick all committed entries
-	x.AssertTrue(l.minTs <= l.commitTs)
+	x.AssertTrue(l.minTs <= readTs)
 
 	final := new(pb.PostingList)
 	enc := codec.Encoder{BlockSize: blockSize}
 
-	err := l.iterate(l.commitTs, 0, func(p *pb.Posting) error {
+	var maxCommitTs uint64
+	err := l.iterate(readTs, 0, func(p *pb.Posting) error {
 		// iterate already takes care of not returning entries whose commitTs is above l.commitTs.
 		// So, we don't need to do any filtering here. In fact, doing filtering here could result
 		// in a bug.
@@ -697,25 +689,26 @@ func (l *List) rollup() error {
 			// underlying data wouldn't be changed.
 			final.Postings = append(final.Postings, p)
 		}
+		maxCommitTs = x.Max(maxCommitTs, p.CommitTs)
 		return nil
 	})
 	x.Check(err)
+	x.AssertTrue(maxCommitTs >= l.minTs)
 	final.Pack = enc.Done()
 
 	// Keep all uncommited Entries or postings with commitTs > l.commitTs
 	// in mutation map. Discard all else.
 	for startTs, plist := range l.mutationMap {
 		cl := plist.CommitTs
-		if cl == 0 || cl > l.commitTs {
+		if cl == 0 || cl > maxCommitTs {
 			// Keep this.
 		} else {
 			delete(l.mutationMap, startTs)
 		}
 	}
 
-	l.minTs = l.commitTs
+	l.minTs = maxCommitTs
 	l.plist = final
-	l.numCommits = 0
 	atomic.StoreInt32(&l.estimatedSize, l.calculateSize())
 	return nil
 }

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -180,9 +180,6 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 		if !bytes.Equal(item.Key(), l.key) {
 			break
 		}
-		if l.commitTs == 0 {
-			l.commitTs = item.Version()
-		}
 
 		if item.UserMeta()&BitCompletePosting > 0 {
 			if err := unmarshalOrCopy(l.plist, item); err != nil {
@@ -239,7 +236,6 @@ func getNew(key []byte, pstore *badger.DB) (*List, error) {
 	if item.UserMeta()&BitCompletePosting > 0 {
 		err = unmarshalOrCopy(l.plist, item)
 		l.minTs = item.Version()
-		l.commitTs = item.Version()
 	} else {
 		iterOpts := badger.DefaultIteratorOptions
 		iterOpts.AllVersions = true


### PR DESCRIPTION
- Do not rollup posting lists right after commits, because it causes some strange race conditions which can cause a state mismatch between memory and disk.
- For the PLs in LRU cache, roll them up right after doing a successful roll up on disk.
- Modify Rollup function to take a `readTs`, which can be set to the roll up read ts.