### PR TITLE
Allow more escape runes to be skipped over when parsing string literal.

### DIFF
--- a/lex/iri.go
+++ b/lex/iri.go
@@ -67,6 +67,15 @@ func HasUChars(r rune, l *Lexer) bool {
 	return times == l.AcceptRunTimes(isHex, times)
 }
 
+// XCHAR ::= '\x' HEX HEX
+func HasXChars(r rune, l *Lexer) bool {
+	if r != 'x' {
+		return false
+	}
+	times := 2
+	return times == l.AcceptRunTimes(isHex, times)
+}
+
 // HEX ::= [0-9] | [A-F] | [a-f]
 func isHex(r rune) bool {
 	switch {

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -259,10 +259,10 @@ const (
 	quote = '"'
 )
 
-// ECHAR ::= '\' [tbnrf"'\]
+// ECHAR ::= '\' [vtbnrf"'\]
 func (l *Lexer) IsEscChar(r rune) bool {
 	switch r {
-	case 't', 'b', 'n', 'r', 'f', '"', '\'', '\\':
+	case 'v', 't', 'b', 'n', 'r', 'f', '"', '\'', '\\':
 		return true
 	}
 	return false

--- a/rdf/parse_test.go
+++ b/rdf/parse_test.go
@@ -479,16 +479,29 @@ var testNQuads = []struct {
 		expectedErr: true, // should have 4 hex values after \u
 	},
 	{
+		input: `<alice> <lives> "\x02 wonderland" .`,
+		nq: api.NQuad{
+			Subject:     "alice",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "\x02 wonderland"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `<alice> <lives> "\x2 wonderland" .`,
+		expectedErr: true, // should have 2 hex values after \x
+	},
+	{
 		input:       `<alice> <lives> "wonderful land"@a- .`,
 		expectedErr: true, // object langtag can not end with -
 	},
 	{
-		input: `<alice> <lives> "\t\b\n\r\f\"\\"@a-b .`,
+		input: `<alice> <lives> "\v\t\b\n\r\f\"\\"@a-b .`,
 		nq: api.NQuad{
 			Subject:     "alice",
 			Predicate:   "lives",
 			Lang:        "a-b",
-			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "\t\b\n\r\f\"\\"}},
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "\v\t\b\n\r\f\"\\"}},
 		},
 	},
 	{

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -283,7 +283,7 @@ func lexLiteral(l *lex.Lexer) lex.StateFn {
 		r := l.Next()
 		if r == '\u005c' { // backslash
 			r = l.Next()
-			if l.IsEscChar(r) || lex.HasUChars(r, l) {
+			if l.IsEscChar(r) || lex.HasUChars(r, l) || lex.HasXChars(r, l) {
 				continue // This would skip over the escaped rune.
 			}
 			return l.Errorf("Invalid escape character : '%c' in literal", r)


### PR DESCRIPTION
This PR makes Dgraph to allow more escape runes to be skipped over when parsing string literal.
* `\v`
* `\xnn`


**Description**

Hi. I'm trying to upgrade Dgraph to 1.0.10 for HasFunction improvement.
But when bulk-load exported RDF files, we'd got following errors.
```
2018/11/07 12:41:02 while lexing <_:uid1234> <text> "I'm\x02\vAlice"^^<xs:string> .: Invalid escape character : 'v' in literal
while parsing line "..."
github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).processRDF
        /ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/bulk/mapper.go:188
github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).run
        /ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/bulk/mapper.go:135
github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*loader).mapStage.func1
        /ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/bulk/loader.go:237
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1333
```

And found that lexLiteral function in state.go validates the escape characters.
```
if r == '\u005c' { // backslash
    r = l.Next()
    if l.IsEscChar(r) || lex.HasUChars(r, l) {
        continue // This would skip over the escaped rune.
    }
    return l.Errorf("Invalid escape character : '%c' in literal", r)
}
```

Currently Dgraph allows [tbnrf] characters for escaped runes, but I think 'v' should be added like strconv.
https://golang.org/src/strconv/quote.go

Also, there are chances to store `\xnn` form of HEX values just like `\u` or `\U`.
Actually our Dgraph server have stored them but it doesn't allow `\xnn` when retrieving.

Please check this out. Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2734)
<!-- Reviewable:end -->
