### PR TITLE
Print the Dgraph version when running live or bulk loader.

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -70,7 +70,7 @@ func init() {
 	flag.Int("shufflers", 1,
 		"Number of shufflers to run concurrently. Increasing this can improve performance, and "+
 			"must be less than or equal to the number of reduce shards.")
-	flag.Bool("version", false, "Prints the version of Dgraph.")
+	flag.Bool("version", false, "Prints the version of Dgraph Bulk Loader.")
 	flag.BoolP("store_xids", "x", false, "Generate an xid edge for each node.")
 	flag.StringP("zero", "z", "localhost:5080", "gRPC address for Dgraph zero")
 	// TODO: Potentially move http server to main.

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -70,7 +70,7 @@ func init() {
 	flag.Int("shufflers", 1,
 		"Number of shufflers to run concurrently. Increasing this can improve performance, and "+
 			"must be less than or equal to the number of reduce shards.")
-	flag.Bool("version", false, "Prints the version of dgraph-bulk-loader.")
+	flag.Bool("version", false, "Prints the version of Dgraph.")
 	flag.BoolP("store_xids", "x", false, "Generate an xid edge for each node.")
 	flag.StringP("zero", "z", "localhost:5080", "gRPC address for Dgraph zero")
 	// TODO: Potentially move http server to main.
@@ -108,8 +108,8 @@ func run() {
 		ReduceShards:  Bulk.Conf.GetInt("reduce_shards"),
 	}
 
+	x.PrintVersion()
 	if opt.Version {
-		x.PrintVersion()
 		os.Exit(0)
 	}
 	if opt.RDFDir == "" || opt.SchemaFile == "" {

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -317,6 +317,7 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph) *loader {
 }
 
 func run() error {
+	x.PrintVersion()
 	opt = options{
 		files:               Live.Conf.GetString("rdfs"),
 		schemaFile:          Live.Conf.GetString("schema"),


### PR DESCRIPTION
Related to e2783d6ef1997a7af1be98b3145398b823759e54.

Would be useful to know when users are sharing their logs from the live or bulk loader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2736)
<!-- Reviewable:end -->
