### PR TITLE
docs: Rename Server to Alpha.

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -4,7 +4,7 @@ title = "Get Started"
 
 ## Dgraph
 
-Dgraph cluster consists of different nodes (zero, server & ratel) and each node serves a different purpose.
+Dgraph cluster consists of different nodes (Zero, Alpha & Ratel) and each node serves a different purpose.
 
 **Dgraph Zero** controls the Dgraph cluster, assigns servers to a group and re-balances data between server groups.
 
@@ -12,7 +12,7 @@ Dgraph cluster consists of different nodes (zero, server & ratel) and each node 
 
 **Dgraph Ratel** serves the UI to run queries, mutations & altering schema.
 
-You need atleast one Dgraph zero and one Dgraph Alpha to get started.
+You need at least one Dgraph Zero and one Dgraph Alpha to get started.
 
 **Here's a 3 step tutorial to get you up and running.**
 


### PR DESCRIPTION
* Grammar fixes.
* Remove "`/` Browser UI and query visualization", which was the old behavior to show Ratel before
  the separate dgraph-ratel binary.
* Correct the environment variable prefix `DGRAPH_ALPHA`.
* gRPC/HTTP capitalization.
* Consistently name Dgraph Live Loader (instead of e.g., live-loader).
* Consistently name Dgraph Bulk Loader (instead of e.g., bulk-loader).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2743)
<!-- Reviewable:end -->
