### PR TITLE
Remove deprecated logic

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -380,7 +380,6 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 	}
 
 	var invalidUids map[uint64]bool
-	var facetsNode outputNode
 	// We go through all predicate children of the subprotos.
 	for _, pc := range sg.Children {
 		if pc.Params.ignoreResult {
@@ -539,9 +538,6 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 	if sg.Params.IgnoreReflex {
 		// Lets pop the stack.
 		sg.Params.parentIds = (sg.Params.parentIds)[:len(sg.Params.parentIds)-1]
-	}
-	if facetsNode != nil && !facetsNode.IsEmpty() {
-		dst.AddMapChild("@facets", facetsNode, false)
 	}
 
 	// Only for shortest path query we wan't to return uid always if there is


### PR DESCRIPTION
This removes some unused logic that was deprecated by commit 7d3ceea1f
Found with the new Go [vet tool](https://golang.org/x/tools/go/analysis/cmd/vet)

Closes #2757

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2758)
<!-- Reviewable:end -->
