### PR TITLE
Print go version along with Dgraph version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ version:
 	@echo Build: ${BUILD}
 	@echo Build date: ${BUILD_DATE}
 	@echo Branch: ${BUILD_BRANCH}
+	@echo Go version: $(shell go version)
 
 install:
 	@(set -e;for i in $(SUBDIRS); do \

--- a/x/init.go
+++ b/x/init.go
@@ -18,6 +18,7 @@ package x
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/golang/glog"
 )
@@ -64,6 +65,7 @@ Dgraph version   : %v
 Commit SHA-1     : %v
 Commit timestamp : %v
 Branch           : %v
+Go version       : %v
 
 For Dgraph official documentation, visit https://docs.dgraph.io.
 For discussions about Dgraph     , visit https://discuss.dgraph.io.
@@ -72,7 +74,7 @@ To say hi to the community       , visit https://dgraph.slack.com.
 Licensed under Apache 2.0. Copyright 2015-2018 Dgraph Labs, Inc.
 
 `,
-		dgraphVersion, lastCommitSHA, lastCommitTime, gitBranch)
+		dgraphVersion, lastCommitSHA, lastCommitTime, gitBranch, runtime.Version())
 }
 
 // PrintVersionOnly prints version and other helpful information if --version.


### PR DESCRIPTION
Helpful to know for things like custom tokenizers.

Example output:
```
$ ./dgraph version

Dgraph version   : v1.0.11-rc3-3-g57ac1cd4
Commit SHA-1     : 57ac1cd4
Commit timestamp : 2018-11-21 14:58:30 -0800
Branch           : danielmai/print_go_version
Go version       : go1.10.1

For Dgraph official documentation, visit https://docs.dgraph.io.
For discussions about Dgraph     , visit https://discuss.dgraph.io.
To say hi to the community       , visit https://dgraph.slack.com.

Licensed under Apache 2.0. Copyright 2015-2018 Dgraph Labs, Inc.

```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2768)
<!-- Reviewable:end -->
