### PR TITLE
Pull newest xgo-latest image for every release.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -52,6 +52,7 @@ go get -u github.com/prometheus/client_golang/prometheus
 go get -u github.com/dgraph-io/dgo
 # go get github.com/stretchr/testify/require
 go get -u github.com/karalabe/xgo
+docker pull karalabe/xgo-latest
 
 pushd $GOPATH/src/google.golang.org/grpc
   git checkout v1.13.0


### PR DESCRIPTION
This will pick up the latest Go version released by xgo. Without this, the xgo
command will could use a stale the image on the build machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2770)
<!-- Reviewable:end -->
