### PR TITLE
stats: translate Prometheus metrics to OpenCensus stats

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -455,7 +455,9 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (resp *api.Respons
 		if err == nil {
 			ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
 		} else {
-			ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, x.TagValueStatusError), tag.Upsert(x.KeyError, err.Error()))
+			ctx, _ = tag.New(ctx,
+				tag.Upsert(x.KeyStatus, x.TagValueStatusError),
+				tag.Upsert(x.KeyError, err.Error()))
 		}
 
 		timeSpentMs := x.SinceInMilliseconds(startTime)
@@ -467,6 +469,9 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (resp *api.Respons
 		return resp, err
 	}
 
+	// TODO: Perhaps use a global atomic int and then at the end
+	// of this loop record this value in a background goroutine.
+	// Investigate if we can optimize this.
 	ostats.Record(ctx, x.PendingQueries.M(1), x.NumQueries.M(1))
 	defer func() {
 		measurements = append(measurements, x.PendingQueries.M(-1))

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -256,7 +256,9 @@ func Cleanup() {
 // And watermark stuff would have to be located outside worker pkg, maybe in x.
 // That way, we don't have a dependency conflict.
 func Get(key []byte) (rlist *List, err error) {
-	ctx, _ := tag.New(context.Background(), tag.Upsert(x.KeyMethod, "lcache.Get"),
+	ctx := x.ObservabilityEnabledParentContext()
+	ctx, _ = tag.New(ctx,
+		tag.Upsert(x.KeyMethod, "lcache.Get"),
 		// For majority of the cases, the status is OK,
 		// if an error occurs this will be changed anyways.
 		tag.Upsert(x.KeyStatus, x.TagValueStatusOK))

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -17,6 +17,7 @@
 package posting
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -26,6 +27,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	ostats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/badger/y"
@@ -64,7 +68,14 @@ func init() {
 	})
 }
 
-func getMemUsage() int {
+func getMemUsage(ctx context.Context) (imem int) {
+	startTime := time.Now()
+	ctx, _ = tag.New(ctx, tag.Upsert(x.KeyMethod, "getMemUsage"))
+	defer func() {
+		timeSpentMs := float64(time.Since(startTime)) / 1e6
+		ostats.Record(ctx, x.LatencyMs.M(timeSpentMs), x.MemoryInUse.M(int64(imem)))
+	}()
+
 	if runtime.GOOS != "linux" {
 		pid := os.Getpid()
 		cmd := fmt.Sprintf("ps -ao rss,pid | grep %v", pid)
@@ -74,22 +85,37 @@ func getMemUsage() int {
 			var ms runtime.MemStats
 			runtime.ReadMemStats(&ms)
 			megs := ms.Alloc
+
+			// Otherwise we succeeded in getting the Memory usage from the runtime.
+			ctx, _ = tag.New(ctx, tag.Insert(x.KeyStatus, x.TagValueStatusOK))
+
 			return int(megs)
 		}
 
 		rss := strings.Split(string(c1), " ")[0]
 		kbs, err := strconv.Atoi(rss)
 		if err != nil {
+			ctx, _ = tag.New(ctx,
+				tag.Insert(x.KeyError, err.Error()),
+				tag.Insert(x.KeyStatus, x.TagValueStatusError))
 			return 0
 		}
 
 		megs := kbs << 10
+
+		// Otherwise we succeeded in getting the Memory usage
+		ctx, _ = tag.New(ctx, tag.Insert(x.KeyStatus, x.TagValueStatusOK))
+
 		return megs
 	}
 
 	contents, err := ioutil.ReadFile("/proc/self/stat")
 	if err != nil {
-		glog.Errorf("Can't read the proc file. Err: %v\n", err)
+		errMsg := fmt.Sprintf("Can't read the proc file. Err: %v\n", err)
+		ctx, _ = tag.New(ctx,
+			tag.Insert(x.KeyError, errMsg),
+			tag.Insert(x.KeyStatus, x.TagValueStatusError))
+		glog.Errorf(errMsg)
 		return 0
 	}
 
@@ -97,23 +123,40 @@ func getMemUsage() int {
 	// 24th entry of the file is the RSS which denotes the number of pages
 	// used by the process.
 	if len(cont) < 24 {
-		glog.Errorln("Error in RSS from stat")
+		errMsg := "Error in RSS from stat"
+		ctx, _ = tag.New(ctx,
+			tag.Insert(x.KeyError, errMsg),
+			tag.Insert(x.KeyStatus, x.TagValueStatusError))
+		glog.Errorln(errMsg)
 		return 0
 	}
 
 	rss, err := strconv.Atoi(cont[23])
 	if err != nil {
+		ctx, _ = tag.New(ctx,
+			tag.Insert(x.KeyError, err.Error()),
+			tag.Insert(x.KeyStatus, x.TagValueStatusError))
 		glog.Errorln(err)
 		return 0
 	}
 
+	// Otherwise we succeeded in getting the Memory usage
+	ctx, _ = tag.New(ctx, tag.Insert(x.KeyStatus, x.TagValueStatusOK))
+
 	return rss * os.Getpagesize()
 }
 
-func periodicUpdateStats(lc *y.Closer) {
+func periodicUpdateStats(ctx context.Context, lc *y.Closer) {
 	defer lc.Done()
-	ticker := time.NewTicker(10 * time.Second)
+
+	period := 10 * time.Second
+	ctx, _ = tag.New(ctx,
+		tag.Insert(x.KeyMethod, "periodicUpdateStats"),
+		tag.Insert(x.KeyPeriod, period.String()))
+
+	ticker := time.NewTicker(period)
 	defer ticker.Stop()
+
 	setLruMemory := true
 	var maxSize uint64
 	var lastUse float64
@@ -128,13 +171,15 @@ func periodicUpdateStats(lc *y.Closer) {
 			inUse := float64(megs)
 
 			stats := lcache.Stats()
-			x.LcacheEvicts.Set(int64(stats.NumEvicts))
-			x.LcacheSize.Set(int64(stats.Size))
-			x.LcacheLen.Set(int64(stats.Length))
+
+			ostats.Record(ctx,
+				x.LcacheEvicts.M(int64(stats.NumEvicts)),
+				x.LcacheSize.M(int64(stats.Size)),
+				x.LcacheLen.M(int64(stats.Length)),
+				x.NumGoRoutines.M(int64(runtime.NumGoroutine())))
 
 			// Okay, we exceed the max memory threshold.
 			// Stop the world, and deal with this first.
-			x.NumGoRoutines.Set(int64(runtime.NumGoroutine()))
 			Config.Mu.Lock()
 			mem := Config.AllottedMemory
 			Config.Mu.Unlock()
@@ -169,10 +214,16 @@ func periodicUpdateStats(lc *y.Closer) {
 	}
 }
 
-func updateMemoryMetrics(lc *y.Closer) {
+func updateMemoryMetrics(ctx context.Context, lc *y.Closer) {
 	defer lc.Done()
-	ticker := time.NewTicker(time.Minute)
+	period := time.Minute
+	ticker := time.NewTicker(period)
 	defer ticker.Stop()
+
+	ctx, _ = tag.New(ctx,
+		tag.Insert(x.KeyMethod, "updateMemoryMetrics"),
+		tag.Insert(x.KeyPeriod, period.String()))
+
 	for {
 		select {
 		case <-lc.HasBeenClosed():
@@ -191,9 +242,10 @@ func updateMemoryMetrics(lc *y.Closer) {
 			// transient spike in live heap size.
 			idle := ms.HeapIdle - ms.HeapReleased
 
-			x.MemoryInUse.Set(int64(inUse))
-			x.MemoryIdle.Set(int64(idle))
-			x.MemoryProc.Set(int64(getMemUsage()))
+			ostats.Record(context.Background(),
+				x.MemoryInUse.M(int64(inUse)),
+				x.MemoryIdle.M(int64(idle)),
+				x.MemoryProc.M(int64(getMemUsage(ctx))))
 		}
 	}
 }
@@ -208,12 +260,16 @@ var (
 func Init(ps *badger.DB) {
 	pstore = ps
 	lcache = newListCache(math.MaxUint64)
-	x.LcacheCapacity.Set(math.MaxInt64)
 
 	closer = y.NewCloser(2)
 
-	go periodicUpdateStats(closer)
-	go updateMemoryMetrics(closer)
+	// At the beginning add some distinguishing information
+	// to the context as tags that will be propagated when
+	// collecting metrics.
+	ctx := x.ObservabilityEnabledParentContext()
+
+	go periodicUpdateStats(ctx, closer)
+	go updateMemoryMetrics(ctx, closer)
 }
 
 func Cleanup() {
@@ -231,23 +287,33 @@ func Cleanup() {
 // And watermark stuff would have to be located outside worker pkg, maybe in x.
 // That way, we don't have a dependency conflict.
 func Get(key []byte) (rlist *List, err error) {
+	ctx, _ := tag.New(context.Background(), tag.Upsert(x.KeyMethod, "lcache.Get"),
+		// For majority of the cases, the status is OK,
+		// if an error occurs this will be changed anyways.
+		tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
+
 	lp := lcache.Get(string(key))
 	if lp != nil {
-		x.LcacheHit.Add(1)
+		ostats.Record(ctx, x.LcacheHit.M(1))
 		return lp, nil
 	}
-	x.LcacheMiss.Add(1)
+
+	// From this point on we encountered a cache miss.
 
 	// Any initialization for l must be done before PutIfMissing. Once it's added
 	// to the map, any other goroutine can retrieve it.
 	l, err := getNew(key, pstore)
 	if err != nil {
+		ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, x.TagValueStatusError), tag.Upsert(x.KeyError, err.Error()))
+		ostats.Record(ctx, x.LcacheMiss.M(1))
 		return nil, err
 	}
 	// We are always going to return lp to caller, whether it is l or not
 	lp = lcache.PutIfMissing(string(key), l)
 	if lp != l {
-		x.LcacheRace.Add(1)
+		ostats.Record(ctx, x.LcacheRace.M(1), x.LcacheMiss.M(1))
+	} else { // Otherwise we didn't race, so record the previously encountered cache niss.
+		ostats.Record(ctx, x.LcacheMiss.M(1))
 	}
 	return lp, nil
 }

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	ostats "go.opencensus.io/stats"
+
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -76,7 +78,7 @@ func (c *listCache) UpdateMaxSize(size uint64) uint64 {
 		size = 50 << 20
 	}
 	c.MaxSize = size
-	x.LcacheCapacity.Set(int64(c.MaxSize))
+	ostats.Record(x.ObservabilityEnabledParentContext(), x.LcacheCapacity.M(int64(c.MaxSize)))
 	return c.MaxSize
 }
 

--- a/posting/lru.go
+++ b/posting/lru.go
@@ -78,7 +78,8 @@ func (c *listCache) UpdateMaxSize(size uint64) uint64 {
 		size = 50 << 20
 	}
 	c.MaxSize = size
-	ostats.Record(x.ObservabilityEnabledParentContext(), x.LcacheCapacity.M(int64(c.MaxSize)))
+	ostats.Record(x.ObservabilityEnabledParentContext(),
+		x.LcacheCapacity.M(int64(c.MaxSize)))
 	return c.MaxSize
 }
 

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -255,7 +255,8 @@ func getNew(key []byte, pstore *badger.DB) (*List, error) {
 	l.Unlock()
 
 	// Record the size
-	stats.Record(x.ObservabilityEnabledParentContext(), x.BytesRead.M(int64(size)))
+	stats.Record(x.ObservabilityEnabledParentContext(),
+		x.BytesRead.M(int64(size)))
 
 	atomic.StoreInt32(&l.estimatedSize, size)
 	return l, nil

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.opencensus.io/stats"
+
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -251,7 +253,10 @@ func getNew(key []byte, pstore *badger.DB) (*List, error) {
 	l.Lock()
 	size := l.calculateSize()
 	l.Unlock()
-	x.BytesRead.Add(int64(size))
+
+	// Record the size
+	stats.Record(x.ObservabilityEnabledParentContext(), x.BytesRead.M(int64(size)))
+
 	atomic.StoreInt32(&l.estimatedSize, size)
 	return l, nil
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -164,8 +164,8 @@ func detectPendingTxns(attr string) error {
 func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (aerr error) {
 	startTime := time.Now()
 	span := otrace.FromContext(ctx)
-
-	octx := x.ObservabilityEnabledContextWithMethod(ctx, "worker/(*node).applyMutations")
+	octx := x.ObservabilityEnabledContextWithMethod(context.Background(),
+		"worker/(*node).applyMutations")
 	tr := trace.New("Dgraph.Node", "ApplyMutations")
 
 	var measurements []ostats.Measurement
@@ -174,7 +174,9 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (aerr 
 		if aerr == nil {
 			octx, _ = tag.New(octx, tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
 		} else {
-			octx, _ = tag.New(octx, tag.Upsert(x.KeyStatus, x.TagValueStatusError), tag.Upsert(x.KeyError, aerr.Error()))
+			octx, _ = tag.New(octx,
+				tag.Upsert(x.KeyStatus, x.TagValueStatusError),
+				tag.Upsert(x.KeyError, aerr.Error()))
 		}
 
 		timeSpentMs := x.SinceInMilliseconds(startTime)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -172,7 +172,8 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (aerr 
 	defer func() {
 		tr.Finish()
 		if aerr == nil {
-			octx, _ = tag.New(octx, tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
+			octx, _ = tag.New(octx,
+				tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
 		} else {
 			octx, _ = tag.New(octx,
 				tag.Upsert(x.KeyStatus, x.TagValueStatusError),

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -28,6 +28,9 @@ import (
 
 	"github.com/coreos/etcd/raft"
 	"github.com/coreos/etcd/raft/raftpb"
+
+	ostats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	otrace "go.opencensus.io/trace"
 
 	"github.com/dgraph-io/badger"
@@ -158,8 +161,26 @@ func detectPendingTxns(attr string) error {
 // We don't support schema mutations across nodes in a transaction.
 // Wait for all transactions to either abort or complete and all write transactions
 // involving the predicate are aborted until schema mutations are done.
-func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) error {
+func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (aerr error) {
+	startTime := time.Now()
 	span := otrace.FromContext(ctx)
+
+	octx := x.ObservabilityEnabledContextWithMethod(ctx, "worker/(*node).applyMutations")
+	tr := trace.New("Dgraph.Node", "ApplyMutations")
+
+	var measurements []ostats.Measurement
+	defer func() {
+		tr.Finish()
+		if aerr == nil {
+			octx, _ = tag.New(octx, tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
+		} else {
+			octx, _ = tag.New(octx, tag.Upsert(x.KeyStatus, x.TagValueStatusError), tag.Upsert(x.KeyError, aerr.Error()))
+		}
+
+		timeSpentMs := x.SinceInMilliseconds(startTime)
+		measurements = append(measurements, x.LatencyMs.M(timeSpentMs))
+		ostats.Record(octx, measurements...)
+	}()
 
 	if proposal.Mutations.DropAll {
 		// Ensures nothing get written to disk due to commit proposals.
@@ -230,8 +251,14 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) error 
 	}
 
 	total := len(proposal.Mutations.Edges)
-	x.ActiveMutations.Add(int64(total))
-	defer x.ActiveMutations.Add(-int64(total))
+
+	// TODO: Active mutations values can go up or down but with
+	// OpenCensus stats bucket boundaries start from 0, hence
+	// recording negative and positive values skews up values.
+	measurements = append(measurements, x.ActiveMutations.M(int64(total)))
+	defer func() {
+		measurements = append(measurements, x.ActiveMutations.M(int64(-total)))
+	}()
 
 	for attr, storageType := range schemaMap {
 		if _, err := schema.State().TypeOf(attr); err != nil {

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -59,7 +59,8 @@ type rateLimiter struct {
 // account. We however, limit solely based on feedback, allowing a certain
 // number of ops to remain pending, and not anymore.
 func (rl *rateLimiter) bleed(ctx context.Context) {
-	ctx, _ = tag.New(ctx, tag.Upsert(x.KeyMethod, "work/proposal/(*rateLimiter).bleed"))
+	ctx, _ = tag.New(ctx,
+		tag.Upsert(x.KeyMethod, "worker/proposal/(*rateLimiter).bleed"))
 
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
@@ -75,7 +76,8 @@ func (rl *rateLimiter) bleed(ctx context.Context) {
 }
 
 func (rl *rateLimiter) incr(ctx context.Context, retry int) error {
-	ctx, _ = tag.New(ctx, tag.Upsert(x.KeyMethod, "work/proposal/(*rateLimiter).incr"))
+	ctx, _ = tag.New(ctx,
+		tag.Upsert(x.KeyMethod, "worker/proposal/(*rateLimiter).incr"))
 
 	// Let's not wait here via time.Sleep or similar. Let pendingProposals
 	// channel do its natural rate limiting.
@@ -93,7 +95,8 @@ func (rl *rateLimiter) incr(ctx context.Context, retry int) error {
 
 // Done would slowly bleed the retries out.
 func (rl *rateLimiter) decr(ctx context.Context, retry int) {
-	ctx, _ = tag.New(ctx, tag.Upsert(x.KeyMethod, "work/proposal/(*rateLimiter).deccr"))
+	ctx, _ = tag.New(ctx,
+		tag.Upsert(x.KeyMethod, "worker/proposal/(*rateLimiter).deccr"))
 
 	if retry == 0 {
 		<-pendingProposals
@@ -123,7 +126,9 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr 
 		if perr == nil {
 			ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, x.TagValueStatusOK))
 		} else {
-			ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, x.TagValueStatusError), tag.Upsert(x.KeyError, perr.Error()))
+			ctx, _ = tag.New(ctx,
+				tag.Upsert(x.KeyStatus, x.TagValueStatusError),
+				tag.Upsert(x.KeyError, perr.Error()))
 		}
 
 		timeMs := x.SinceInMilliseconds(startTime)

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -85,81 +85,92 @@ var (
 )
 
 var (
-	defaultBytesDistribution     = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
-	defaultLatencyMsDistribution = view.Distribution(0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+	defaultBytesDistribution = view.Distribution(
+		0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304,
+		16777216, 67108864, 268435456, 1073741824, 4294967296)
+
+	defaultLatencyMsDistribution = view.Distribution(
+		0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16,
+		20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500,
+		650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
 )
 
-var Views = []*view.View{
+var allTagKeys = []tag.Key{
+	KeyPid, KeyOS, KeyArch, KeyStatus,
+	KeyError, KeyGoVersion, KeyMethod,
+}
+
+var AllViews = []*view.View{
 
 	{
 		Name:        "dgraph/latency",
 		Measure:     LatencyMs,
 		Description: "The latency distributions of the various methods",
 		Aggregation: defaultLatencyMsDistribution,
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/posting_reads",
 		Measure:     PostingReads,
 		Description: "The number of posting reads",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/posting_writes",
 		Measure:     PostingWrites,
 		Description: "The number of posting writes",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/bytes_read",
 		Measure:     BytesRead,
 		Description: "The number of bytes read",
 		Aggregation: defaultBytesDistribution,
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/bytes_write",
 		Measure:     BytesWrite,
 		Description: "The number of bytes written",
 		Aggregation: defaultBytesDistribution,
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/queries",
 		Measure:     NumQueries,
 		Description: "The number of queries",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_hit",
 		Measure:     LcacheHit,
 		Description: "The number of hits from the LRU cache",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_miss",
 		Measure:     LcacheMiss,
 		Description: "The number of misses from the LRU cache",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_evict",
 		Measure:     LcacheEvicts,
 		Description: "The number of evictions from the LRU cache",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_race",
 		Measure:     LcacheRace,
 		Description: "The number of races in the LRU cache",
 		Aggregation: view.Count(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 
 	// Last value aggregations
@@ -168,98 +179,98 @@ var Views = []*view.View{
 		Measure:     PendingQueries,
 		Description: "The number of pending queries",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/pending_proposals",
 		Measure:     PendingProposals,
 		Description: "The number of pending proposals",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_size",
 		Measure:     LcacheSize,
 		Description: "The size of the LRU cache",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_len",
 		Measure:     LcacheLen,
 		Description: "The length of the LRU cache",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/lcache_capcaity",
 		Measure:     LcacheCapacity,
 		Description: "The number of items in the LRU cache",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/dirtymap_size",
 		Measure:     DirtyMapSize,
 		Description: "The number of elements in the dirty map",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/goroutines",
 		Measure:     NumGoRoutines,
 		Description: "The number of goroutines",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/memory_in_use",
 		Measure:     MemoryInUse,
 		Description: "The amount of memory in use",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/memory_idle",
 		Measure:     MemoryIdle,
 		Description: "The amount of memory in idle spans",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/memory_proc",
 		Measure:     MemoryProc,
 		Description: "The amount of memory used in processes",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/active_mutations",
 		Measure:     ActiveMutations,
 		Description: "The number of active mutations",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/alpha_status",
 		Measure:     AlphaHealth,
 		Description: "The status of the alphas",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/max_list_bytes",
 		Measure:     MaxPlSize,
 		Description: "The maximum value of bytes of the list",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 	{
 		Name:        "dgraph/max_list_length",
 		Measure:     MaxPlLength,
 		Description: "The maximum length of the list",
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+		TagKeys:     allTagKeys,
 	},
 }
 
@@ -331,5 +342,8 @@ func SinceInMilliseconds(startTime time.Time) float64 {
 	return float64(durNs) / 1e6
 }
 
-func RegisterStatsViews() {
+// RegisterAllViews is a convenience function to be invoked when the
+// OpenCensus stats exporter is registered, to allow collection of stats.
+func RegisterAllViews() error {
+	return view.Register(AllViews...)
 }

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -17,270 +17,319 @@
 package x
 
 import (
+	"context"
 	"expvar"
+	"fmt"
+	"log"
 	"net/http"
+	"os"
+	"runtime"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"go.opencensus.io/exporter/prometheus"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 var (
 	// These are cumulative
-	PostingReads  *expvar.Int
-	PostingWrites *expvar.Int
-	BytesRead     *expvar.Int
-	BytesWrite    *expvar.Int
-	NumQueries    *expvar.Int
-	LcacheHit     *expvar.Int
-	LcacheMiss    *expvar.Int
-	LcacheRace    *expvar.Int
-	LcacheEvicts  *expvar.Int
+	PostingReads  = stats.Int64("dgraph/posting_reads", "The number of posting reads", "1")
+	PostingWrites = stats.Int64("dgraph/posting_writes", "The number of posting writes", "1")
+	BytesRead     = stats.Int64("dgraph/bytes_read", "The number of bytes read", "By")
+	BytesWrite    = stats.Int64("dgraph/bytes_written", "The number of bytes written", "By")
+	NumQueries    = stats.Int64("dgraph/queries", "The number of queries", "By")
+	LcacheHit     = stats.Int64("dgrap/lcache_hit", "The number of hits from the LRU cache", "1")
+	LcacheMiss    = stats.Int64("dgrap/lcache_miss", "The number of misses from the LRU cache", "1")
+	LcacheRace    = stats.Int64("dgrap/lcache_race", "The number of races from the LRU cache", "1")
+	LcacheEvicts  = stats.Int64("dgrap/lcache_evicts", "The number of evictions from the LRU cache", "1")
+	LatencyMs     = stats.Float64("dgrap/latency", "The latency of the various methods", "ms")
 
 	// value at particular point of time
-	PendingQueries   *expvar.Int
-	PendingProposals *expvar.Int
-	LcacheSize       *expvar.Int
-	LcacheLen        *expvar.Int
-	LcacheCapacity   *expvar.Int
-	DirtyMapSize     *expvar.Int
-	NumGoRoutines    *expvar.Int
-	MemoryInUse      *expvar.Int
-	MemoryIdle       *expvar.Int
-	MemoryProc       *expvar.Int
-	ActiveMutations  *expvar.Int
-	AlphaHealth      *expvar.Int
-	MaxPlSize        *expvar.Int
-	MaxPlLength      *expvar.Int
+	PendingQueries   = stats.Int64("dgrap/queries_pending", "The number of pending queries", "1")
+	PendingProposals = stats.Int64("dgrap/proposals_pending", "The number of pending proposals", "1")
+	LcacheSize       = stats.Int64("dgraph/lcache_size", "The size of the LRU cache", "By")
+	LcacheLen        = stats.Int64("dgraph/lcache_len", "The length of the LRU cache", "By")
+	LcacheCapacity   = stats.Int64("dgraph/lcache_capacity", "The number of items in LRU cache", "1")
+	DirtyMapSize     = stats.Int64("dgrap/dirtymap_size", "The number of elements in the dirty map", "1")
+	NumGoRoutines    = stats.Int64("dgraph/goroutines", "The number of goroutines", "1")
+	MemoryInUse      = stats.Int64("dgraph/memory_in_use", "The amount of memory in use", "By")
+	MemoryIdle       = stats.Int64("dgraph/memory_idle", "The amount of memory in idle spans", "By")
+	MemoryProc       = stats.Int64("dgraph/memory_proc", "The amount of memory used in processes", "By")
+	ActiveMutations  = stats.Int64("dgraph/active_mutations", "The number of active mutations", "1")
+	AlphaHealth      = stats.Int64("dgraph/alpha_status", "The status of the alphas", "1")
+	MaxPlSize        = stats.Int64("dgraph/max_list_bytes", "The maximum value of bytes of the list", "By")
+	MaxPlLength      = stats.Int64("dgraph/max_list_length", "The maximum length of the list", "1")
 
 	PredicateStats *expvar.Map
 	Conf           *expvar.Map
 
 	MaxPlSz int64
 	// TODO: Request statistics, latencies, 500, timeouts
-
 )
 
+var (
+	// Tag keys here
+	KeyOS, _        = tag.NewKey("goos")
+	KeyPid, _       = tag.NewKey("pid")
+	KeyArch, _      = tag.NewKey("goarch")
+	KeyStatus, _    = tag.NewKey("status")
+	KeyError, _     = tag.NewKey("error")
+	KeyGoVersion, _ = tag.NewKey("goversion")
+	KeyMethod, _    = tag.NewKey("method")
+	KeyPeriod, _    = tag.NewKey("period")
+
+	// Tag values here
+	TagValueStatusOK    = "ok"
+	TagValueStatusError = "error"
+)
+
+var (
+	defaultBytesDistribution     = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	defaultLatencyMsDistribution = view.Distribution(0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+var Views = []*view.View{
+
+	{
+		Name:        "dgraph/latency",
+		Measure:     LatencyMs,
+		Description: "The latency distributions of the various methods",
+		Aggregation: defaultLatencyMsDistribution,
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/posting_reads",
+		Measure:     PostingReads,
+		Description: "The number of posting reads",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/posting_writes",
+		Measure:     PostingWrites,
+		Description: "The number of posting writes",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/bytes_read",
+		Measure:     BytesRead,
+		Description: "The number of bytes read",
+		Aggregation: defaultBytesDistribution,
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/bytes_write",
+		Measure:     BytesWrite,
+		Description: "The number of bytes written",
+		Aggregation: defaultBytesDistribution,
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/queries",
+		Measure:     NumQueries,
+		Description: "The number of queries",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_hit",
+		Measure:     LcacheHit,
+		Description: "The number of hits from the LRU cache",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_miss",
+		Measure:     LcacheMiss,
+		Description: "The number of misses from the LRU cache",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_evict",
+		Measure:     LcacheEvicts,
+		Description: "The number of evictions from the LRU cache",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_race",
+		Measure:     LcacheRace,
+		Description: "The number of races in the LRU cache",
+		Aggregation: view.Count(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+
+	// Last value aggregations
+	{
+		Name:        "dgraph/pending_queries",
+		Measure:     PendingQueries,
+		Description: "The number of pending queries",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/pending_proposals",
+		Measure:     PendingProposals,
+		Description: "The number of pending proposals",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_size",
+		Measure:     LcacheSize,
+		Description: "The size of the LRU cache",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_len",
+		Measure:     LcacheLen,
+		Description: "The length of the LRU cache",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/lcache_capcaity",
+		Measure:     LcacheCapacity,
+		Description: "The number of items in the LRU cache",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/dirtymap_size",
+		Measure:     DirtyMapSize,
+		Description: "The number of elements in the dirty map",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/goroutines",
+		Measure:     NumGoRoutines,
+		Description: "The number of goroutines",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/memory_in_use",
+		Measure:     MemoryInUse,
+		Description: "The amount of memory in use",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/memory_idle",
+		Measure:     MemoryIdle,
+		Description: "The amount of memory in idle spans",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/memory_proc",
+		Measure:     MemoryProc,
+		Description: "The amount of memory used in processes",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/active_mutations",
+		Measure:     ActiveMutations,
+		Description: "The number of active mutations",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/alpha_status",
+		Measure:     AlphaHealth,
+		Description: "The status of the alphas",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/max_list_bytes",
+		Measure:     MaxPlSize,
+		Description: "The maximum value of bytes of the list",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+	{
+		Name:        "dgraph/max_list_length",
+		Measure:     MaxPlLength,
+		Description: "The maximum length of the list",
+		Aggregation: view.LastValue(),
+		TagKeys:     []tag.Key{KeyPid, KeyOS, KeyArch, KeyStatus, KeyError, KeyGoVersion, KeyMethod},
+	},
+}
+
 func init() {
-	PostingReads = expvar.NewInt("dgraph_posting_reads_total")
-	PostingWrites = expvar.NewInt("dgraph_posting_writes_total")
-	PendingProposals = expvar.NewInt("dgraph_pending_proposals_total")
-	BytesRead = expvar.NewInt("dgraph_read_bytes_total")
-	BytesWrite = expvar.NewInt("dgraph_written_bytes_total")
-	PendingQueries = expvar.NewInt("dgraph_pending_queries_total")
-	NumQueries = expvar.NewInt("dgraph_num_queries_total")
-	AlphaHealth = expvar.NewInt("dgraph_alpha_health_status")
-	DirtyMapSize = expvar.NewInt("dgraph_dirtymap_keys_total")
-	NumGoRoutines = expvar.NewInt("dgraph_goroutines_total")
-	MemoryInUse = expvar.NewInt("dgraph_memory_inuse_bytes")
-	MemoryIdle = expvar.NewInt("dgraph_memory_idle_bytes")
-	MemoryProc = expvar.NewInt("dgraph_memory_proc_bytes")
-	ActiveMutations = expvar.NewInt("dgraph_active_mutations_total")
 	PredicateStats = expvar.NewMap("dgraph_predicate_stats")
 	Conf = expvar.NewMap("dgraph_config")
-	LcacheHit = expvar.NewInt("dgraph_lru_hits_total")
-	LcacheMiss = expvar.NewInt("dgraph_lru_miss_total")
-	LcacheRace = expvar.NewInt("dgraph_lru_race_total")
-	LcacheEvicts = expvar.NewInt("dgraph_lru_evicted_total")
-	LcacheSize = expvar.NewInt("dgraph_lru_size_bytes")
-	LcacheLen = expvar.NewInt("dgraph_lru_keys_total")
-	LcacheCapacity = expvar.NewInt("dgraph_lru_capacity_bytes")
-	MaxPlSize = expvar.NewInt("dgraph_max_list_bytes")
-	MaxPlLength = expvar.NewInt("dgraph_max_list_length")
 
+	ctx := ObservabilityEnabledParentContext()
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
+				var tags []tag.Mutator
 				if err := HealthCheck(); err == nil {
-					AlphaHealth.Set(1)
+					tags = append(tags, tag.Upsert(KeyStatus, TagValueStatusOK))
 				} else {
-					AlphaHealth.Set(0)
+					tags = append(tags, tag.Upsert(KeyStatus, TagValueStatusError), tag.Upsert(KeyError, err.Error()))
 				}
+				cctx, _ := tag.New(ctx, tags...)
+				stats.Record(cctx, AlphaHealth.M(1))
 			}
 		}
 	}()
 
-	// TODO: prometheus.NewExpvarCollector is not production worthy (see godocs). Use a better
-	// way for exporting Prometheus metrics (like an OpenCensus metrics exporter).
-	expvarCollector := prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
-		"dgraph_lru_hits_total": prometheus.NewDesc(
-			"dgraph_lru_hits_total",
-			"dgraph_lru_hits_total",
-			nil, nil,
-		),
-		"dgraph_lru_miss_total": prometheus.NewDesc(
-			"dgraph_lru_miss_total",
-			"dgraph_lru_miss_total",
-			nil, nil,
-		),
-		"dgraph_lru_race_total": prometheus.NewDesc(
-			"dgraph_lru_race_total",
-			"dgraph_lru_race_total",
-			nil, nil,
-		),
-		"dgraph_lru_evicted_total": prometheus.NewDesc(
-			"dgraph_lru_evicted_total",
-			"dgraph_lru_evicted_total",
-			nil, nil,
-		),
-		"dgraph_lru_size_bytes": prometheus.NewDesc(
-			"dgraph_lru_size_bytes",
-			"dgraph_lru_size_bytes",
-			nil, nil,
-		),
-		"dgraph_lru_keys_total": prometheus.NewDesc(
-			"dgraph_lru_keys_total",
-			"dgraph_lru_keys_total",
-			nil, nil,
-		),
-		"dgraph_lru_capacity_bytes": prometheus.NewDesc(
-			"dgraph_lru_capacity_bytes",
-			"dgraph_lru_capacity_bytes",
-			nil, nil,
-		),
-		"dgraph_posting_reads_total": prometheus.NewDesc(
-			"dgraph_posting_reads_total",
-			"dgraph_posting_reads_total",
-			nil, nil,
-		),
-		"dgraph_posting_writes_total": prometheus.NewDesc(
-			"dgraph_posting_writes_total",
-			"dgraph_posting_writes_total",
-			nil, nil,
-		),
-		"dgraph_max_list_bytes": prometheus.NewDesc(
-			"dgraph_max_list_bytes",
-			"dgraph_max_list_bytes",
-			nil, nil,
-		),
-		"dgraph_max_list_length": prometheus.NewDesc(
-			"dgraph_max_list_length",
-			"dgraph_max_list_length",
-			nil, nil,
-		),
-		"dgraph_pending_proposals_total": prometheus.NewDesc(
-			"dgraph_pending_proposals_total",
-			"dgraph_pending_proposals_total",
-			nil, nil,
-		),
-		"dgraph_read_bytes_total": prometheus.NewDesc(
-			"dgraph_read_bytes_total",
-			"dgraph_read_bytes_total",
-			nil, nil,
-		),
-		"dgraph_written_bytes_total": prometheus.NewDesc(
-			"dgraph_written_bytes_total",
-			"dgraph_written_bytes_total",
-			nil, nil,
-		),
-		"dgraph_pending_queries_total": prometheus.NewDesc(
-			"dgraph_pending_queries_total",
-			"dgraph_pending_queries_total",
-			nil, nil,
-		),
-		"dgraph_num_queries_total": prometheus.NewDesc(
-			"dgraph_num_queries_total",
-			"dgraph_num_queries_total",
-			nil, nil,
-		),
-		"dgraph_alpha_health_status": prometheus.NewDesc(
-			"dgraph_alpha_health_status",
-			"dgraph_alpha_health_status",
-			nil, nil,
-		),
-		"dgraph_dirtymap_keys_total": prometheus.NewDesc(
-			"dgraph_dirtymap_keys_total",
-			"dgraph_dirtymap_keys_total",
-			nil, nil,
-		),
-		"dgraph_goroutines_total": prometheus.NewDesc(
-			"dgraph_goroutines_total",
-			"dgraph_goroutines_total",
-			nil, nil,
-		),
-		"dgraph_memory_inuse_bytes": prometheus.NewDesc(
-			"dgraph_memory_inuse_bytes",
-			"dgraph_memory_inuse_bytes",
-			nil, nil,
-		),
-		"dgraph_memory_idle_bytes": prometheus.NewDesc(
-			"dgraph_memory_idle_bytes",
-			"dgraph_memory_idle_bytes",
-			nil, nil,
-		),
-		"dgraph_memory_proc_bytes": prometheus.NewDesc(
-			"dgraph_memory_proc_bytes",
-			"dgraph_memory_proc_bytes",
-			nil, nil,
-		),
-		"dgraph_active_mutations_total": prometheus.NewDesc(
-			"dgraph_active_mutations_total",
-			"dgraph_active_mutations_total",
-			nil, nil,
-		),
-		"dgraph_predicate_stats": prometheus.NewDesc(
-			"dgraph_predicate_stats",
-			"dgraph_predicate_stats",
-			[]string{"name"}, nil,
-		),
-		"badger_disk_reads_total": prometheus.NewDesc(
-			"badger_disk_reads_total",
-			"badger_disk_reads_total",
-			nil, nil,
-		),
-		"badger_disk_writes_total": prometheus.NewDesc(
-			"badger_disk_writes_total",
-			"badger_disk_writes_total",
-			nil, nil,
-		),
-		"badger_read_bytes": prometheus.NewDesc(
-			"badger_read_bytes",
-			"badger_read_bytes",
-			nil, nil,
-		),
-		"badger_written_bytes": prometheus.NewDesc(
-			"badger_written_bytes",
-			"badger_written_bytes",
-			nil, nil,
-		),
-		"badger_lsm_level_gets_total": prometheus.NewDesc(
-			"badger_lsm_level_gets_total",
-			"badger_lsm_level_gets_total",
-			[]string{"level"}, nil,
-		),
-		"badger_lsm_bloom_hits_total": prometheus.NewDesc(
-			"badger_lsm_bloom_hits_total",
-			"badger_lsm_bloom_hits_total",
-			[]string{"level"}, nil,
-		),
-		"badger_gets_total": prometheus.NewDesc(
-			"badger_gets_total",
-			"badger_gets_total",
-			nil, nil,
-		),
-		"badger_puts_total": prometheus.NewDesc(
-			"badger_puts_total",
-			"badger_puts_total",
-			nil, nil,
-		),
-		"badger_memtable_gets_total": prometheus.NewDesc(
-			"badger_memtable_gets_total",
-			"badger_memtable_gets_total",
-			nil, nil,
-		),
-		"badger_lsm_size": prometheus.NewDesc(
-			"badger_lsm_size",
-			"badger_lsm_size",
-			[]string{"dir"}, nil,
-		),
-		"badger_vlog_size": prometheus.NewDesc(
-			"badger_vlog_size",
-			"badger_vlog_size",
-			[]string{"dir"}, nil,
-		),
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "dgraph", // TODO: read this namespace from flags
+		// TODO: Enable an on error that logs to Dgraph's logging output.
 	})
-	prometheus.MustRegister(expvarCollector)
-	http.Handle("/debug/prometheus_metrics", prometheus.Handler())
+	if err != nil {
+		log.Fatalf("Failed to create OpenCensus Prometheus exporter: %v", err)
+	}
+
+	http.Handle("/debug/prometheus_metrics", pe)
+}
+
+// ObservabilityEnabledParentContext returns a context with tags that are useful for
+// distinguishing the state of the running system. It contains tags such as:
+// * PID
+// * OS
+// * Architecture
+// This context will be used to derive other contexts.
+func ObservabilityEnabledParentContext() context.Context {
+	// At the beginning add some distinguishing information
+	// to the context as tags that will be propagated when
+	// collecting metrics.
+	ctx, _ := tag.New(context.Background(),
+		tag.Upsert(KeyPid, fmt.Sprintf("%d", os.Getpid())),
+		tag.Upsert(KeyOS, runtime.GOOS),
+		tag.Upsert(KeyGoVersion, runtime.Version()),
+		tag.Upsert(KeyArch, runtime.GOARCH))
+
+	return ctx
+}
+
+func ObservabilityEnabledContextWithMethod(parent context.Context, method string) context.Context {
+	ctx, _ := tag.New(parent,
+		tag.Upsert(KeyPid, fmt.Sprintf("%d", os.Getpid())),
+		tag.Upsert(KeyOS, runtime.GOOS),
+		tag.Upsert(KeyGoVersion, runtime.Version()),
+		tag.Upsert(KeyArch, runtime.GOARCH),
+		tag.Upsert(KeyMethod, method))
+	return ctx
+}
+
+func SinceInMilliseconds(startTime time.Time) float64 {
+	durNs := time.Since(startTime)
+	return float64(durNs) / 1e6
+}
+
+func RegisterStatsViews() {
 }


### PR DESCRIPTION
Translate Prometheus metrics to OpenCensus stats which has
the effect of democratizing stats; thus now anyone can configure
an exporter say for:
* Prometheus
* Stackdriver Monitoring
* DataDog
* NewRelic

etc as available and get stats there, instead of just only
sending to Prometheus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2771)
<!-- Reviewable:end -->
