### PR TITLE
docs: Update source installation instructions in docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@
 
 ### Setup Dgraph from source repo
 
-    $ go get -u -v -t github.com/dgraph-io/dgraph/...
+    $ go get -v -t github.com/dgraph-io/dgraph/...
 
 This will put the source code in a Git repo under `$GOPATH/src/github.com/dgraph-io/dgraph` and compile the binaries to `$GOPATH/bin`.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ docker pull dgraph/dgraph:latest
 If you want to install from source, you can use `go get` to install to `$GOPATH/bin`.
 
 ```bash
-go get -u -v github.com/dgraph-io/dgraph/dgraph
+go get -v github.com/dgraph-io/dgraph/dgraph
 ```
 
 ## Get Started

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -59,7 +59,7 @@ After installing Go, run
 ```sh
 # This should install dgraph binary in your $GOPATH/bin.
 
-go get -u -v github.com/dgraph-io/dgraph/dgraph
+go get -v github.com/dgraph-io/dgraph/dgraph
 ```
 
 If you get errors related to `grpc` while building them, your


### PR DESCRIPTION
With the addition of OpenCensus, `go get -u ...` no longer works:

```
$ GOPATH=$(mktemp -d)
$ go get -u -v github.com/dgraph-io/dgraph/dgraph
...
# cd .; git ls-remote https://go.opencensus.io/vendor/git.apache.org/thrift
fatal: https://go.opencensus.io/vendor/git.apache.org/thrift/info/refs not valid: is this a git repository?
# cd .; git ls-remote git+ssh://go.opencensus.io/vendor/git.apache.org/thrift
ssh: connect to host go.opencensus.io port 22: Connection timed out
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

There's this closed opencensus-go issue ["cmd/go: get doesn't work with repositories from git.apache.org #10797"](https://github.com/census-instrumentation/opencensus-go/issues/888) that says `go get -u` is not meant to be used.

Running without the `-u` works. e.g., `go get -v github.com/dgraph-io/dgraph/dgraph`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2821)
<!-- Reviewable:end -->
