### PR TITLE
Let eq use string "uid" as value

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1384,9 +1384,9 @@ L:
 
 		}
 
-		val := collectName(it, item.Val)
+		name := collectName(it, item.Val)
 		function = &Function{
-			Name: strings.ToLower(val),
+			Name: strings.ToLower(name),
 		}
 		if _, ok := tryParseItemType(it, itemLeftRound); !ok {
 			return nil, x.Errorf("Expected ( after func name [%s]", function.Name)
@@ -1523,11 +1523,17 @@ L:
 				return nil, err
 			}
 			val += v
-			if val == "" && function.Name != "eq" { // allow eq(attr, "")
-				return nil, x.Errorf("Empty argument received")
-			}
-			if val == "uid" {
-				return nil, x.Errorf("Argument cannot be %q", val)
+
+			if function.Name != "eq" {
+				switch {
+				// allow eq(attr, "")
+				case val == "":
+					return nil, x.Errorf("Empty argument received")
+
+				// allow value of "uid" - issue#2827
+				case val == "uid":
+					return nil, x.Errorf("Argument cannot be %q", val)
+				}
 			}
 
 			if isDollar {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4245,6 +4245,19 @@ func TestParseUidAsArgument(t *testing.T) {
 	require.Contains(t, err.Error(), "Argument cannot be \"uid\"")
 }
 
+func TestParseUidAsValue(t *testing.T) {
+	// issue #2827
+	query := `
+		{
+			q(func: eq(name, "uid")) {
+				uid
+			}
+		}
+	`
+	_, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+}
+
 func parseNquads(b []byte) ([]*api.NQuad, error) {
 	var nqs []*api.NQuad
 	for _, line := range bytes.Split(b, []byte{'\n'}) {


### PR DESCRIPTION
This PR removes the error in `eq` queries for a value of `"uid"`.

Closes #2827

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2830)
<!-- Reviewable:end -->
