### PR TITLE
Handle non-UTF8 control characters in JSON response

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -119,11 +119,10 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 
 	response := map[string]interface{}{}
 
-	e := query.Extensions{
+	response["extensions"] = query.Extensions{
 		Txn:     resp.Txn,
 		Latency: resp.Latency,
 	}
-	response["extensions"] = e
 
 	// User can either ask for schema or have a query.
 	if len(resp.Schema) > 0 {
@@ -136,15 +135,13 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		mp := map[string]interface{}{}
-		mp["schema"] = json.RawMessage(string(js))
+		mp["schema"] = json.RawMessage(js)
 		response["data"] = mp
 	} else {
-		response["data"] = json.RawMessage(string(resp.Json))
+		response["data"] = x.SafeMessage(resp.Json)
 	}
 
-	if js, err := json.Marshal(response); err == nil {
-		w.Write(js)
-	} else {
+	if err := json.NewEncoder(w).Encode(response); err != nil {
 		x.SetStatusWithData(w, x.Error, "Unable to marshal response")
 	}
 }

--- a/x/json.go
+++ b/x/json.go
@@ -30,6 +30,6 @@ func (m SafeMessage) MarshalJSON() ([]byte, error) {
 		return []byte("null"), nil
 	}
 	// Dont change the message.
-	b := bytes.Replace(m, []byte(`\x`), []byte(`\\x`), -1)
+	b := bytes.Replace(m, []byte(`\x`), []byte(`\u00`), -1)
 	return b, nil
 }

--- a/x/json.go
+++ b/x/json.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package x
+
+import (
+	"bytes"
+)
+
+// SafeMessage is a raw encoded JSON value. Almost identical to json.RawMessage
+// but it double-escapes sequences that might get marshalled into non-UTF8 control sequences.
+type SafeMessage []byte
+
+// MarshalJSON returns m as the JSON encoding of m.
+func (m SafeMessage) MarshalJSON() ([]byte, error) {
+	if m == nil {
+		return []byte("null"), nil
+	}
+	// Dont change the message.
+	b := bytes.Replace(m, []byte(`\x`), []byte(`\\x`), -1)
+	return b, nil
+}


### PR DESCRIPTION
This PR adds a new JSON marshaler for handling responses that might include control sequences not allowed in JSON strings that break the Go JSON encoder.

It double escapes escaped hexadecimal values by replacing `\x` with `\\x`. This allows those values to be encoded into JSON strings.

Closes #2662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2831)
<!-- Reviewable:end -->
