### PR TITLE
Use json.Marshal for strings and blobs

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -145,8 +145,10 @@ func (fj *fastJsonNode) IsEmpty() bool {
 
 func valToBytes(v types.Val) ([]byte, error) {
 	switch v.Tid {
-	case types.BinaryID, types.StringID, types.DefaultID:
+	case types.StringID, types.DefaultID:
 		return json.Marshal(v.Value)
+	case types.BinaryID:
+		return []byte(fmt.Sprintf("%q", v.Value)), nil
 	case types.IntID:
 		return []byte(fmt.Sprintf("%d", v.Value)), nil
 	case types.FloatID:

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -18,6 +18,7 @@ package query
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -145,7 +146,7 @@ func (fj *fastJsonNode) IsEmpty() bool {
 func valToBytes(v types.Val) ([]byte, error) {
 	switch v.Tid {
 	case types.BinaryID, types.StringID, types.DefaultID:
-		return []byte(fmt.Sprintf("%q", v.Value)), nil
+		return json.Marshal(v.Value)
 	case types.IntID:
 		return []byte(fmt.Sprintf("%d", v.Value)), nil
 	case types.FloatID:

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1246,7 +1246,6 @@ func TestUidInFunctionAtRoot(t *testing.T) {
 }
 
 func TestBinaryJSON(t *testing.T) {
-
 	query := `
 	{
 		me(func: uid(1)) {


### PR DESCRIPTION
Use json.Marshal for strings and blobs, because Go's strconv.Quote is incompatible with JSON.

Fixes https://github.com/dgraph-io/dgraph/issues/2662.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2833)
<!-- Reviewable:end -->
