### PR TITLE
Default value for val() vars

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1598,8 +1598,8 @@ func (sg *SubGraph) fillVars(mp map[string]varValue) error {
 				// This var does not match any uids or vals but we are still trying to access it.
 				if v.Typ == gql.VALUE_VAR {
 					// Provide a default value for valueVarAggregation() to eval val().
-					// This is a noop for aggregation funcs that would fail. The zero aggs won't show
-					// because there are no uids matched.
+					// This is a noop for aggregation funcs that would fail.
+					// The zero aggs won't show because there are no uids matched.
 					mp[v.Name].Vals[0] = types.Val{Tid: types.FloatID, Value: 0.0}
 					sg.Params.uidToVal = mp[v.Name].Vals
 				}

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1442,6 +1442,27 @@ func TestAggregateRoot5(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"sum(val(m))":0.000000}]}}`, js)
 }
 
+func TestAggregateRoot6(t *testing.T) {
+	query := `
+		{
+			uids as var(func: anyofterms(name, "Rick Michonne Andrea"))
+
+			var(func: uid(uids)) @cascade {
+				reason {
+					killed_zombies as math(1)
+				}
+				zombie_count as sum(val(killed_zombies))
+			}
+
+			me(func: uid(uids)) {
+				money: val(zombie_count)
+			}
+		}
+	`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[]}}`, js)
+}
+
 func TestAggregateRootError(t *testing.T) {
 
 	query := `


### PR DESCRIPTION
This PR adds a default value for variables that don't have uids or existing child values. The only case that this should happen is with value vars at the bottom of the query, or aggregations.

Closes #2832

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2834)
<!-- Reviewable:end -->
