### PR TITLE
Line and position context to Lexer/Parser

### DIFF
--- a/gql/state.go
+++ b/gql/state.go
@@ -81,7 +81,10 @@ func lexInsideMutation(l *lex.Lexer) lex.StateFn {
 			if l.Depth >= 2 {
 				return lexTextMutation
 			}
-		case isSpace(r) || isEndOfLine(r):
+		case isEndOfLine(r):
+			l.Line++
+			l.Ignore()
+		case isSpace(r):
 			l.Ignore()
 		case isNameBegin(r):
 			return lexNameMutation
@@ -116,7 +119,10 @@ func lexInsideSchema(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemLeftSquare)
 		case r == rightSquare:
 			l.Emit(itemRightSquare)
-		case isSpace(r) || isEndOfLine(r):
+		case isEndOfLine(r):
+			l.Line++
+			l.Ignore()
+		case isSpace(r):
 			l.Ignore()
 		case isNameBegin(r):
 			return lexArgName
@@ -188,7 +194,10 @@ func lexFuncOrArg(l *lex.Lexer) lex.StateFn {
 			}
 		case r == lex.EOF:
 			return l.Errorf("Unclosed Brackets")
-		case isSpace(r) || isEndOfLine(r):
+		case isEndOfLine(r):
+			l.Line++
+			l.Ignore()
+		case isSpace(r):
 			l.Ignore()
 		case r == comma:
 			if empty {
@@ -251,7 +260,10 @@ Loop:
 			l.Emit(itemLeftRound)
 			l.ArgDepth++
 			return lexQuery
-		case isSpace(r) || isEndOfLine(r):
+		case isEndOfLine(r):
+			l.Line++
+			l.Ignore()
+		case isSpace(r):
 			l.Ignore()
 		case isNameBegin(r):
 			l.Backup()
@@ -283,7 +295,10 @@ func lexQuery(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemLeftCurl)
 		case r == lex.EOF:
 			return l.Errorf("Unclosed action")
-		case isSpace(r) || isEndOfLine(r):
+		case isEndOfLine(r):
+			l.Line++
+			l.Ignore()
+		case isSpace(r):
 			l.Ignore()
 		case r == comma:
 			l.Emit(itemComma)
@@ -378,6 +393,7 @@ func lexComment(l *lex.Lexer) lex.StateFn {
 	for {
 		r := l.Next()
 		if isEndOfLine(r) {
+			l.Line++
 			l.Ignore()
 			return l.Mode
 		}

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -129,6 +129,7 @@ type Lexer struct {
 	Depth    int     // nesting of {}
 	ArgDepth int     // nesting of ()
 	Mode     StateFn // Default state to go back to after reading a token.
+	Line     int     // current line of this item.
 }
 
 func (l *Lexer) Run(f StateFn) *Lexer {
@@ -144,7 +145,8 @@ func (l *Lexer) Run(f StateFn) *Lexer {
 func (l *Lexer) Errorf(format string, args ...interface{}) StateFn {
 	l.items = append(l.items, Item{
 		Typ: ItemError,
-		Val: fmt.Sprintf("while lexing %v: "+format, append([]interface{}{l.Input}, args...)...),
+		Val: fmt.Sprintf("line %d:%d: while lexing %v: "+format,
+			append([]interface{}{l.Line + 1, l.Pos + 1, l.Input}, args...)...),
 	})
 	return nil
 }

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -419,7 +419,11 @@ func lexComment(l *lex.Lexer) lex.StateFn {
 	l.Backup()
 	for {
 		r := l.Next()
-		if isEndOfLine(r) || r == lex.EOF {
+		if isEndOfLine(r) {
+			l.Line++
+			break
+		}
+		if r == lex.EOF {
 			break
 		}
 	}


### PR DESCRIPTION
This PR adds line counts to the lexer so that parsers can make use of it. Also, adds line counters for the GQL and RDF parsers (LF or CR). This information is tracked in the lexer struct and returned with lexer errors, along with the position where the error happened.

Example error ouput:
```
# line 2 position 48
line 2:48: while lexing {set { _:a1 <reg> \"a1 content\" . }}\n\t\tsomething: Invalid operation type: something
```

Ref: #2815

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2864)
<!-- Reviewable:end -->
