### PR TITLE
Refactor reindexing code to only reindex specific tokenizers.

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -18,6 +18,7 @@ package posting
 
 import (
 	"bytes"
+	"encoding/hex"
 	"math"
 	"strconv"
 	"sync/atomic"
@@ -214,7 +215,7 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 				return nil, err
 			}
 		} else {
-			x.Fatalf("unexpected meta: %d", item.UserMeta())
+			x.Fatalf("unexpected meta: %d %s", item.UserMeta(), hex.Dump(key))
 		}
 		if item.DiscardEarlierVersions() {
 			break

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -18,6 +18,7 @@ package tok
 
 import (
 	"encoding/binary"
+	"fmt"
 	"plugin"
 	"time"
 
@@ -111,6 +112,19 @@ func LoadCustomTokenizer(soFile string) {
 func GetTokenizer(name string) (Tokenizer, bool) {
 	t, found := tokenizers[name]
 	return t, found
+}
+
+// GetTokenizers returns a list of tokenizer given a list of unique names.
+func GetTokenizers(names []string) ([]Tokenizer, error) {
+	var tokenizers []Tokenizer
+	for _, name := range names {
+		t, found := GetTokenizer(name)
+		if !found {
+			return nil, fmt.Errorf("Invalid tokenizer %s", name)
+		}
+		tokenizers = append(tokenizers, t)
+	}
+	return tokenizers, nil
 }
 
 func registerTokenizer(t Tokenizer) {


### PR DESCRIPTION
Currently during reindexing, the whole index is being deleted and
rebuilt, even if there are tokenizers that did not change between
schemas. This change allows reindexing to happen only for tokenizers
that need it.