### PR TITLE
Bring in the latest Badger for race condition bug fix.

### DIFF
--- a/vendor/github.com/dgraph-io/badger/README.md
+++ b/vendor/github.com/dgraph-io/badger/README.md
@@ -2,7 +2,7 @@
 
 ![Badger mascot](images/diggy-shadow.png)
 
-BadgerDB is an embeddable, persistent, simple and fast key-value (KV) database
+BadgerDB is an embeddable, persistent and fast key-value (KV) database
 written in pure Go. It's meant to be a performant alternative to non-Go-based
 key-value stores like [RocksDB](https://github.com/facebook/rocksdb).
 
@@ -599,18 +599,19 @@ Values in SSD-conscious Storage][wisckey]_.
 [wisckey]: https://www.usenix.org/system/files/conference/fast16/fast16-papers-lu.pdf
 
 ### Comparisons
-| Feature             | Badger                                       | RocksDB                       | BoltDB    |
-| -------             | ------                                       | -------                       | ------    |
-| Design              | LSM tree with value log                      | LSM tree only                 | B+ tree   |
-| High Read throughput | Yes                                          | No                           | Yes        |
-| High Write throughput | Yes                                          | Yes                           | No        |
-| Designed for SSDs   | Yes (with latest research <sup>1</sup>)      | Not specifically <sup>2</sup> | No        |
-| Embeddable          | Yes                                          | Yes                           | Yes       |
-| Sorted KV access    | Yes                                          | Yes                           | Yes       |
-| Pure Go (no Cgo)    | Yes                                          | No                            | Yes       |
-| Transactions        | Yes, ACID, concurrent with SSI<sup>3</sup> | Yes (but non-ACID)            | Yes, ACID |
-| Snapshots           | Yes                                           | Yes                           | Yes       |
-| TTL support         | Yes                                           | Yes                           | No       |
+| Feature                        | Badger                                     | RocksDB                       | BoltDB    |
+| -------                        | ------                                     | -------                       | ------    |
+| Design                         | LSM tree with value log                    | LSM tree only                 | B+ tree   |
+| High Read throughput           | Yes                                        | No                            | Yes       |
+| High Write throughput          | Yes                                        | Yes                           | No        |
+| Designed for SSDs              | Yes (with latest research <sup>1</sup>)    | Not specifically <sup>2</sup> | No        |
+| Embeddable                     | Yes                                        | Yes                           | Yes       |
+| Sorted KV access               | Yes                                        | Yes                           | Yes       |
+| Pure Go (no Cgo)               | Yes                                        | No                            | Yes       |
+| Transactions                   | Yes, ACID, concurrent with SSI<sup>3</sup> | Yes (but non-ACID)            | Yes, ACID |
+| Snapshots                      | Yes                                        | Yes                           | Yes       |
+| TTL support                    | Yes                                        | Yes                           | No        |
+| 3D access (key-value-version)  | Yes<sup>4</sup>                            | No                            | No        |
 
 <sup>1</sup> The [WISCKEY paper][wisckey] (on which Badger is based) saw big
 wins with separating values from keys, significantly reducing the write
@@ -620,6 +621,8 @@ amplification compared to a typical LSM tree.
 As such RocksDB's design isn't aimed at SSDs.
 
 <sup>3</sup> SSI: Serializable Snapshot Isolation. For more details, see the blog post [Concurrent ACID Transactions in Badger](https://blog.dgraph.io/post/badger-txn/)
+<sup>4</sup> Badger provides direct access to value versions via its Iterator API.
+Users can also specify how many versions to keep per key via Options.
 
 ### Benchmarks
 We have run comprehensive benchmarks against RocksDB, Bolt and LMDB. The

--- a/vendor/github.com/dgraph-io/badger/db.go
+++ b/vendor/github.com/dgraph-io/badger/db.go
@@ -1267,6 +1267,10 @@ func (db *DB) DropAll() error {
 	}()
 	db.opt.Infof("Compactions stopped. Dropping all SSTables...")
 
+	// Block all foreign interactions with memory tables.
+	db.Lock()
+	defer db.Unlock()
+
 	// Remove inmemory tables. Calling DecrRef for safety. Not sure if they're absolutely needed.
 	db.mt.DecrRef()
 	db.mt = skl.NewSkiplist(arenaSize(db.opt)) // Set it up for future writes.

--- a/vendor/github.com/dgraph-io/badger/value.go
+++ b/vendor/github.com/dgraph-io/badger/value.go
@@ -579,12 +579,12 @@ func (vlog *valueLog) dropAll() (int, error) {
 			}
 			count++
 		}
+		vlog.filesMap = make(map[uint32]*logFile)
 		return nil
 	}
 	if err := deleteAll(); err != nil {
 		return count, err
 	}
-	vlog.filesMap = make(map[uint32]*logFile)
 
 	vlog.db.opt.Infof("Value logs deleted. Creating value log file: 0")
 	if _, err := vlog.createVlogFile(0); err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -421,10 +421,10 @@
 			"revisionTime": "2016-09-07T16:21:46Z"
 		},
 		{
-			"checksumSHA1": "fuvufSqYGrre6tMkec93K+5yKPQ=",
+			"checksumSHA1": "z3e8O0yprygNDdmRVXdZrpy16gc=",
 			"path": "github.com/dgraph-io/badger",
-			"revision": "e1a4906e6aedf90948306a09c6d342f0032f9e67",
-			"revisionTime": "2019-01-16T00:23:15Z",
+			"revision": "b9e379e59eac9b828431a6c8f7a553ae38ab88eb",
+			"revisionTime": "2019-01-17T00:16:07Z",
 			"version": "HEAD",
 			"versionExact": "HEAD"
 		},


### PR DESCRIPTION
From https://github.com/dgraph-io/badger/commit/b9e379e59eac9b828431a6c8f7a553ae38ab88eb:
>Fix a race condition caused by concurrent reads while Badger is replacing its inmemory tables during DropAll.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2907)
<!-- Reviewable:end -->
