### PR TITLE
Zero server shutdown endpoint

### DIFF
--- a/dgraph/cmd/zero/assign.go
+++ b/dgraph/cmd/zero/assign.go
@@ -26,10 +26,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var (
-	emptyNum         pb.Num
-	emptyAssignedIds pb.AssignedIds
-)
+var emptyAssignedIds pb.AssignedIds
 
 const (
 	leaseBandwidth = uint64(10000)

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -22,9 +22,9 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"sync"
 	"time"
 
+	"github.com/dgraph-io/badger/y"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/gogo/protobuf/jsonpb"
@@ -239,7 +239,7 @@ func (st *state) shutdown(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte("Server is shutting down...\n"))
 }
 
-func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
+func (st *state) serveHTTP(l net.Listener, closer *y.Closer) {
 	srv := &http.Server{
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 600 * time.Second,
@@ -247,7 +247,7 @@ func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
 	}
 
 	go func() {
-		defer wg.Done()
+		defer closer.Done()
 		err := srv.Serve(l)
 		glog.Errorf("Stopped taking more http(s) requests. Err: %v", err)
 		ctx, cancel := context.WithTimeout(context.Background(), 630*time.Second)

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -236,7 +236,7 @@ func (st *state) shutdown(w http.ResponseWriter, r *http.Request) {
 	}
 
 	st.zero.shutDownCh <- struct{}{}
-	w.Write([]byte("Server is shutting down"))
+	w.Write([]byte("Server is shutting down...\n"))
 }
 
 func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -224,6 +224,21 @@ func (st *state) getState(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (st *state) shutdown(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
+	if r.Method == "OPTIONS" {
+		return
+	}
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
+		return
+	}
+
+	st.zero.shutDownCh <- struct{}{}
+	w.Write([]byte("Server is shutting down"))
+}
+
 func (st *state) serveHTTP(l net.Listener, wg *sync.WaitGroup) {
 	srv := &http.Server{
 		ReadTimeout:  10 * time.Second,

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -223,21 +223,6 @@ func (st *state) getState(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (st *state) shutdown(w http.ResponseWriter, r *http.Request) {
-	x.AddCorsHeaders(w)
-	if r.Method == "OPTIONS" {
-		return
-	}
-	if r.Method != http.MethodGet {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
-		return
-	}
-
-	st.zero.closer.Signal()
-	w.Write([]byte("Server is shutting down...\n"))
-}
-
 func (st *state) serveHTTP(l net.Listener) {
 	srv := &http.Server{
 		ReadTimeout:  10 * time.Second,

--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -448,7 +448,7 @@ func (s *Server) Oracle(unused *api.Payload, server pb.Zero_OracleServer) error 
 			}
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-s.shutDownCh:
+		case <-s.closer.HasBeenClosed():
 			return errServerShutDown
 		}
 	}

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -25,6 +25,7 @@ import (
 	otrace "go.opencensus.io/trace"
 	"golang.org/x/net/context"
 
+	"github.com/dgraph-io/badger/y"
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -56,8 +57,8 @@ type Server struct {
 	// groupMap    map[uint32]*Group
 	nextGroup      uint32
 	leaderChangeCh chan struct{}
-	shutDownCh     chan struct{} // Used to tell stream to close.
-	connectLock    sync.Mutex    // Used to serialize connect requests from servers.
+	closer         *y.Closer  // Used to tell stream to close.
+	connectLock    sync.Mutex // Used to serialize connect requests from servers.
 
 	blockCommitsOn map[string]struct{}
 }
@@ -76,7 +77,7 @@ func (s *Server) Init() {
 	s.nextTxnTs = 1
 	s.nextGroup = 1
 	s.leaderChangeCh = make(chan struct{}, 1)
-	s.shutDownCh = make(chan struct{}, 1)
+	s.closer = y.NewCloser(2) // grpc and http
 	s.blockCommitsOn = make(map[string]struct{})
 	go s.rebalanceTablets()
 }
@@ -614,7 +615,7 @@ func (s *Server) StreamMembership(_ *api.Payload, stream pb.Zero_StreamMembershi
 			}
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-s.shutDownCh:
+		case <-s.closer.HasBeenClosed():
 			return errServerShutDown
 		}
 	}


### PR DESCRIPTION
This PR adds a new HTTP endpoint at **/shutdown** to handle graceful service shutdowns. It also changes the process signal handling to work together with this command.

Example:
```sh
$ curl localhost:6080/shutdown
Server is shutting down...
# Done.
```

Closes #2285 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2928)
<!-- Reviewable:end -->
