### PR TITLE
Un-export reindex functions that no longer need to be exported.

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -601,16 +601,16 @@ const (
 
 // Run rebuilds all indices that need it.
 func (rb *IndexRebuild) Run(ctx context.Context) error {
-	if err := RebuildListType(ctx, rb); err != nil {
+	if err := rebuildListType(ctx, rb); err != nil {
 		return err
 	}
-	if err := RebuildIndex(ctx, rb); err != nil {
+	if err := rebuildIndex(ctx, rb); err != nil {
 		return err
 	}
-	if err := RebuildCountIndex(ctx, rb); err != nil {
+	if err := rebuildCountIndex(ctx, rb); err != nil {
 		return err
 	}
-	return RebuildReverseEdges(ctx, rb)
+	return rebuildReverseEdges(ctx, rb)
 }
 
 type indexRebuildInfo struct {
@@ -687,9 +687,9 @@ func (rb *IndexRebuild) needsIndexRebuild() indexRebuildInfo {
 	}
 }
 
-// RebuildIndex rebuilds index for a given attribute.
+// rebuildIndex rebuilds index for a given attribute.
 // We commit mutations with startTs and ignore the errors.
-func RebuildIndex(ctx context.Context, rb *IndexRebuild) error {
+func rebuildIndex(ctx context.Context, rb *IndexRebuild) error {
 	// Exit early if indices do not need to be rebuilt.
 	rebuildInfo := rb.needsIndexRebuild()
 
@@ -784,8 +784,8 @@ func (rb *IndexRebuild) needsCountIndexRebuild() indexOp {
 	return indexRebuild
 }
 
-// RebuildCountIndex rebuilds the count index for a given attribute.
-func RebuildCountIndex(ctx context.Context, rb *IndexRebuild) error {
+// rebuildCountIndex rebuilds the count index for a given attribute.
+func rebuildCountIndex(ctx context.Context, rb *IndexRebuild) error {
 	op := rb.needsCountIndexRebuild()
 	if op == indexNoop {
 		return nil
@@ -865,8 +865,8 @@ func (rb *IndexRebuild) needsReverseEdgesRebuild() indexOp {
 	return indexDelete
 }
 
-// RebuildReverseEdges rebuilds the reverse edges for a given attribute.
-func RebuildReverseEdges(ctx context.Context, rb *IndexRebuild) error {
+// rebuildReverseEdges rebuilds the reverse edges for a given attribute.
+func rebuildReverseEdges(ctx context.Context, rb *IndexRebuild) error {
 	op := rb.needsReverseEdgesRebuild()
 	if op == indexNoop {
 		return nil
@@ -928,9 +928,9 @@ func (rb *IndexRebuild) needsListTypeRebuild() (bool, error) {
 	return false, nil
 }
 
-// RebuildListType rebuilds the index when the schema is changed from scalar to list type.
+// rebuildListType rebuilds the index when the schema is changed from scalar to list type.
 // We need to fingerprint the values to get the new ValueId.
-func RebuildListType(ctx context.Context, rb *IndexRebuild) error {
+func rebuildListType(ctx context.Context, rb *IndexRebuild) error {
 	if needsRebuild, err := rb.needsListTypeRebuild(); !needsRebuild || err != nil {
 		return err
 	}

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -268,7 +268,7 @@ func TestRebuildIndex(t *testing.T) {
 		OldSchema:     nil,
 		CurrentSchema: &currentSchema,
 	}
-	require.NoError(t, RebuildIndex(context.Background(), &rb))
+	require.NoError(t, rebuildIndex(context.Background(), &rb))
 
 	// Check index entries in data store.
 	txn := ps.NewTransactionAt(6, false)
@@ -318,7 +318,7 @@ func TestRebuildIndexWithDeletion(t *testing.T) {
 		OldSchema:     nil,
 		CurrentSchema: &currentSchema,
 	}
-	require.NoError(t, RebuildIndex(context.Background(), &rb))
+	require.NoError(t, rebuildIndex(context.Background(), &rb))
 
 	// Mutate the schema (the index in name2 is deleted) and rebuild the index.
 	require.NoError(t, schema.ParseBytes([]byte(mutatedSchemaVal), 1))
@@ -329,7 +329,7 @@ func TestRebuildIndexWithDeletion(t *testing.T) {
 		OldSchema:     &currentSchema,
 		CurrentSchema: &newSchema,
 	}
-	require.NoError(t, RebuildIndex(context.Background(), &rb))
+	require.NoError(t, rebuildIndex(context.Background(), &rb))
 
 	// Check index entries in data store.
 	txn := ps.NewTransactionAt(7, false)
@@ -374,7 +374,7 @@ func TestRebuildReverseEdges(t *testing.T) {
 		CurrentSchema: &currentSchema,
 	}
 	// TODO: Remove after fixing sync marks.
-	require.NoError(t, RebuildReverseEdges(context.Background(), &rb))
+	require.NoError(t, rebuildReverseEdges(context.Background(), &rb))
 
 	// Check index entries in data store.
 	txn := ps.NewTransactionAt(17, false)


### PR DESCRIPTION
These functions should only be accessible through the method Run inside
of IndexRebuild.