### PR TITLE
GroupBy uid shouldn't panic, and other logic fixes.

### DIFF
--- a/query/groupby.go
+++ b/query/groupby.go
@@ -214,12 +214,12 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 		if attr == "" {
 			attr = child.Attr
 		}
-		if len(child.DestUIDs.Uids) != 0 {
+		if child.DestUIDs != nil && len(child.DestUIDs.Uids) != 0 {
 			// It's a UID node.
 			for i := 0; i < len(child.uidMatrix); i++ {
 				srcUid := child.SrcUIDs.Uids[i]
 				// Ignore uids which are not part of srcUid.
-				if algo.IndexOf(ul, srcUid) < 0 {
+				if algo.IndexOf(ul, srcUid) == -1 {
 					continue
 				}
 				ul := child.uidMatrix[i]
@@ -231,7 +231,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 			// It's a value node.
 			for i, v := range child.valueMatrix {
 				srcUid := child.SrcUIDs.Uids[i]
-				if len(v.Values) == 0 || algo.IndexOf(ul, srcUid) < 0 {
+				if len(v.Values) == 0 || algo.IndexOf(ul, srcUid) == -1 {
 					continue
 				}
 				val, err := convertTo(v.Values[0])
@@ -271,10 +271,11 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 // that it considers the whole uidMatrix to do the grouping before assigning the variable.
 // TODO - Check if we can reduce this duplication.
 func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGraph) error {
-	childHasVar := false
+	var childHasVar bool
 	for _, child := range sg.Children {
 		if child.Params.Var != "" {
 			childHasVar = true
+			break
 		}
 	}
 

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -219,7 +219,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 			for i := 0; i < len(child.uidMatrix); i++ {
 				srcUid := child.SrcUIDs.Uids[i]
 				// Ignore uids which are not part of srcUid.
-				if algo.IndexOf(ul, srcUid) == -1 {
+				if algo.IndexOf(ul, srcUid) < 0 {
 					continue
 				}
 				ul := child.uidMatrix[i]
@@ -231,7 +231,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 			// It's a value node.
 			for i, v := range child.valueMatrix {
 				srcUid := child.SrcUIDs.Uids[i]
-				if len(v.Values) == 0 || algo.IndexOf(ul, srcUid) == -1 {
+				if len(v.Values) == 0 || algo.IndexOf(ul, srcUid) < 0 {
 					continue
 				}
 				val, err := convertTo(v.Values[0])

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -445,7 +445,7 @@ func processNodeUids(fj *fastJsonNode, sg *SubGraph) error {
 	lenList := len(sg.uidMatrix[0].Uids)
 	for i := 0; i < lenList; i++ {
 		uid := sg.uidMatrix[0].Uids[i]
-		if algo.IndexOf(sg.DestUIDs, uid) == -1 {
+		if algo.IndexOf(sg.DestUIDs, uid) < 0 {
 			// This UID was filtered. So Ignore it.
 			continue
 		}

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -445,7 +445,7 @@ func processNodeUids(fj *fastJsonNode, sg *SubGraph) error {
 	lenList := len(sg.uidMatrix[0].Uids)
 	for i := 0; i < lenList; i++ {
 		uid := sg.uidMatrix[0].Uids[i]
-		if algo.IndexOf(sg.DestUIDs, uid) < 0 {
+		if algo.IndexOf(sg.DestUIDs, uid) == -1 {
 			// This UID was filtered. So Ignore it.
 			continue
 		}

--- a/query/query.go
+++ b/query/query.go
@@ -416,7 +416,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 		}
 
 		idx := algo.IndexOf(pc.SrcUIDs, uid)
-		if idx < 0 {
+		if idx == -1 {
 			continue
 		}
 		if pc.Params.isGroupBy {
@@ -1371,8 +1371,7 @@ func (sg *SubGraph) updateUidMatrix() {
 			// We can't do intersection directly as the list is not sorted by UIDs.
 			// So do filter.
 			algo.ApplyFilter(l, func(uid uint64, idx int) bool {
-				i := algo.IndexOf(sg.DestUIDs, uid) // Binary search.
-				return i >= 0
+				return algo.IndexOf(sg.DestUIDs, uid) != -1 // Binary search.
 			})
 		} else {
 			// If we didn't order on UIDmatrix, it'll be sorted.
@@ -1753,12 +1752,12 @@ func (sg *SubGraph) ApplyIneqFunc() error {
 }
 
 func (sg *SubGraph) appendDummyValues() {
-	if sg.SrcUIDs == nil {
+	if sg.SrcUIDs == nil || len(sg.SrcUIDs.Uids) == 0 {
 		return
 	}
 	var l pb.List
 	var val pb.ValueList
-	for i := 0; i < len(sg.SrcUIDs.Uids); i++ {
+	for range sg.SrcUIDs.Uids {
 		// This is necessary so that preTraverse can be processed smoothly.
 		sg.uidMatrix = append(sg.uidMatrix, &l)
 		sg.valueMatrix = append(sg.valueMatrix, &val)

--- a/query/query.go
+++ b/query/query.go
@@ -416,7 +416,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst outputNode) error {
 		}
 
 		idx := algo.IndexOf(pc.SrcUIDs, uid)
-		if idx == -1 {
+		if idx < 0 {
 			continue
 		}
 		if pc.Params.isGroupBy {
@@ -1371,7 +1371,7 @@ func (sg *SubGraph) updateUidMatrix() {
 			// We can't do intersection directly as the list is not sorted by UIDs.
 			// So do filter.
 			algo.ApplyFilter(l, func(uid uint64, idx int) bool {
-				return algo.IndexOf(sg.DestUIDs, uid) != -1 // Binary search.
+				return algo.IndexOf(sg.DestUIDs, uid) >= 0 // Binary search.
 			})
 		} else {
 			// If we didn't order on UIDmatrix, it'll be sorted.


### PR DESCRIPTION
This PR fixes an issue with queries using `@groupby(uid)` directive that would cause Alpha to panic. 

1. The `@groupby` panic was due to the fact that we don't create tasks for children subgraphs using `uid` as attribute. Therefore, we don't generate `DestUIDs` list for them. When the groupby is processed the field is nil and we panic when it tries to access the uids from that list.
  - I have added an extra check that `DestUIDs` isn't nil. This will move the result list to use `SrcUIDs` instead which is expected.
  - No breaking changes expected from this change.


Closes #2936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2952)
<!-- Reviewable:end -->
