### PR TITLE
Issue: 2926 whitelist by hostname

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -178,7 +178,7 @@ func setupCustomTokenizers() {
 // Parses a comma-delimited list of IP addresses, IP ranges, CIDR blocks, or hostnames
 // and returns a slice of []IPRange.
 //
-// e.g. "144.142.126.222:144.142.126.244,144.124.126.254,192.168.0.0/16,host.docker.internal"
+// e.g. "144.142.126.222:144.142.126.244,144.142.126.254,192.168.0.0/16,host.docker.internal"
 func getIPsFromString(str string) ([]worker.IPRange, error) {
 	if str == "" {
 		return []worker.IPRange{}, nil
@@ -212,9 +212,11 @@ func getIPsFromString(str string) ([]worker.IPRange, error) {
 					return nil, fmt.Errorf("invalid CIDR block: %s", s)
 				}
 
-				rangeHi := rangeLo
-				for i := 0; i < len(rangeHi); i++ {
-					rangeHi[i] |= ^network.Mask[i]
+				addrLen, maskLen := len(rangeLo), len(network.Mask)
+				rangeHi := make(net.IP, len(rangeLo))
+				copy(rangeHi, rangeLo)
+				for i := 1; i <= maskLen; i++ {
+					rangeHi[addrLen - i] |= ^network.Mask[maskLen - i]
 				}
 
 				ipRanges = append(ipRanges, worker.IPRange{Lower: rangeLo, Upper: rangeHi})

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -190,7 +190,8 @@ func getIPsFromString(str string) ([]worker.IPRange, error) {
 	for _, s := range rangeStrings {
 		isIPv6 := strings.Index(s, "::") >= 0
 		tuple := strings.Split(s, ":")
-		if isIPv6 || len(tuple) == 1 {
+		switch {
+		case isIPv6 || len(tuple) == 1:
 			if strings.Index(s, "/") < 0 {
 				// string is hostname like host.docker.internal,
 				// or IPv4 address like 144.124.126.254,
@@ -224,7 +225,7 @@ func getIPsFromString(str string) ([]worker.IPRange, error) {
 
 				ipRanges = append(ipRanges, worker.IPRange{Lower: rangeLo, Upper: rangeHi})
 			}
-		} else if len(tuple) == 2 {
+		case len(tuple) == 2:
 			// string is range like a.b.c.d:v.x.y.z
 			rangeLo := net.ParseIP(tuple[0])
 			rangeHi := net.ParseIP(tuple[1])
@@ -237,7 +238,7 @@ func getIPsFromString(str string) ([]worker.IPRange, error) {
 			} else {
 				ipRanges = append(ipRanges, worker.IPRange{Lower: rangeLo, Upper: rangeHi})
 			}
-		} else {
+		default:
 			return nil, fmt.Errorf("invalid IP address range: %s", s)
 		}
 	}

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1674,12 +1674,22 @@ func TestIPStringParsing(t *testing.T) {
 
 	addrRange, err = getIPsFromString("example.org")
 	require.NoError(t, err)
-	require.NotEqual(t, net.IPv4(0, 0, 0, 0), addrRange[0].Lower)
+	require.NotEqual(t, net.IPv4zero, addrRange[0].Lower)
 
 	addrRange, err = getIPsFromString("144.142.126.222:144.142.126.244,144.142.126.254" +
 		",192.168.0.0/16,example.org")
 	require.NoError(t, err)
 	require.NotEqual(t, 0, len(addrRange))
+
+	addrRange, err = getIPsFromString("fd03:b188:0f3c:9ec4::babe:face")
+	require.NoError(t, err)
+	require.NotEqual(t, net.IPv6zero, addrRange[0].Lower)
+	require.Equal(t, addrRange[0].Lower, addrRange[0].Upper)
+
+	addrRange, err = getIPsFromString("fd03:b188:0f3c:9ec4::/64")
+	require.NoError(t, err)
+	require.NotEqual(t, net.IPv6zero, addrRange[0].Lower)
+	require.NotEqual(t, addrRange[0].Lower, addrRange[0].Upper)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
Fixes #2926. In addition to addrLo:addrHi ranges, support whitelisting by

* a single IP address (e.g. 144.142.126.254)
* a CIDR block (e.g. 192.168.0.0/16)
* a hostname (e.g. host.docker.internal)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2953)
<!-- Reviewable:end -->
