### PR TITLE
Optionally start test cluster with Jaeger tracing enabled.

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/bulk"
@@ -99,6 +100,7 @@ func initCmds() {
 		sc.Conf.BindPFlags(RootCmd.PersistentFlags())
 		sc.Conf.AutomaticEnv()
 		sc.Conf.SetEnvPrefix(sc.EnvPrefix)
+		sc.Conf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	}
 	cobra.OnInitialize(func() {
 		cfg := rootConf.GetString("config")

--- a/dgraph/docker-compose-jaeger.yml
+++ b/dgraph/docker-compose-jaeger.yml
@@ -1,0 +1,34 @@
+# Docker compose file for testing that includes Jaeger tracing. Use it with:
+# ./run.sh --jaeger
+# This would pick up dgraph binary from $GOPATH.
+
+version: "3.5"
+services:
+  zero1:
+    environment:
+      - DGRAPH_ZERO_JAEGER_COLLECTOR=http://jaeger:14268
+  zero2:
+    environment:
+      - DGRAPH_ZERO_JAEGER_COLLECTOR=http://jaeger:14268
+  zero3:
+    environment:
+      - DGRAPH_ZERO_JAEGER_COLLECTOR=http://jaeger:14268
+  dg1:
+    environment:
+      - DGRAPH_ALPHA_JAEGER_COLLECTOR=http://jaeger:14268
+  dg2:
+    environment:
+      - DGRAPH_ALPHA_JAEGER_COLLECTOR=http://jaeger:14268
+  dg3:
+    environment:
+      - DGRAPH_ALPHA_JAEGER_COLLECTOR=http://jaeger:14268
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    container_name: jaeger
+    hostname: jaeger
+    ports:
+      - "16686:16686"
+    environment:
+      - COLLECTOR_ZIPKIN_HTTP_PORT=9411
+    # command:
+    #   - --memory.max-traces=1000

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -1,5 +1,5 @@
 # Docker compose file for testing. Use it with:
-# docker-compose up --force-recreate
+# ./run.sh
 # This would pick up dgraph binary from $GOPATH.
 
 version: "3.5"
@@ -24,6 +24,7 @@ services:
   zero2:
     image: dgraph/dgraph:latest
     container_name: bank-dg0.2
+    working_dir: /data/dg0.2
     depends_on:
       - zero1
     ports:
@@ -42,6 +43,7 @@ services:
   zero3:
     image: dgraph/dgraph:latest
     container_name: bank-dg0.3
+    working_dir: /data/dg0.3
     depends_on:
       - zero2
     ports:

--- a/dgraph/run.sh
+++ b/dgraph/run.sh
@@ -1,2 +1,16 @@
-md5sum ~/go/bin/dgraph; go build . && go install . && md5sum dgraph ~/go/bin/dgraph
-docker-compose down; DATA=$HOME/dg docker-compose up --force-recreate --remove-orphans
+#!/bin/bash
+for o in $@; do
+    case $o in
+        '--jaeger' )
+            EXTRA_COMPOSE=( -f docker-compose-jaeger.yml )
+            ;;
+        *)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+    esac
+    shift
+done
+make install
+docker-compose down
+DATA=$HOME/dg docker-compose -f docker-compose.yml ${EXTRA_COMPOSE[@]} up --force-recreate --remove-orphans


### PR DESCRIPTION
The test cluster with Jaeger can be run with `./run.sh --jaeger`.

docker-compose-jaeger.yml extends the base docker-compose.yml services to set
the --jaeger.collector flag for each Zero and Alpha by setting the corresponding
environment variable.

Environment variable parsing is updated to read DGRAPH_ZERO_JAEGER_COLLECTOR and
DGRAPH_ALPHA_JAEGER_COLLECTOR options by associating "_"-env vars with the
corresponding "."-options in Viper.