### PR TITLE
Suppress `logging before flag.Parse` from glog

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -18,8 +18,6 @@ package cmd
 
 import (
 	goflag "flag"
-	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
@@ -61,10 +59,7 @@ func Execute() {
 	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
 	x.Check(goflag.CommandLine.Parse([]string{}))
 
-	if err := RootCmd.Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
+	x.Check(RootCmd.Execute())
 }
 
 var rootConf = viper.New()

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -56,7 +56,11 @@ cluster.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	initCmds()
-	goflag.Parse()
+
+	// Convinces goflags that we have called Parse() to avoid noisy logs.
+	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
+	goflag.CommandLine.Parse([]string{})
+
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -57,10 +57,9 @@ cluster.
 func Execute() {
 	initCmds()
 
-	// Convinces goflags that we have called Parse() to avoid noisy logs.
+	// Convinces goflags that Parse() has been called to avoid noisy logs.
 	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
-	// We don't need to check the error here.
-	_ = goflag.CommandLine.Parse([]string{})
+	x.Check(goflag.CommandLine.Parse([]string{}))
 
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -59,7 +59,8 @@ func Execute() {
 
 	// Convinces goflags that we have called Parse() to avoid noisy logs.
 	// https://github.com/kubernetes/kubernetes/issues/17162#issuecomment-225596212
-	goflag.CommandLine.Parse([]string{})
+	// We don't need to check the error here.
+	_ = goflag.CommandLine.Parse([]string{})
 
 	if err := RootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Replace `goflag.Parse()` call with `goflag.CommandLine.Parse([]string{})`
This serves multiple purposes
1. We don't actually parse the os.Args (which Parse() method internally does). This ensures that the command line arguments are parsed only by RootCmd.Execute() call (which is the parent command)
2. We suppress the `Error: Logging before flag.Parse...` warning messages. https://github.com/golang/glog/blob/master/glog.go#L679 causes the warning message and we suppress this warning by calling the Parse method on the underlying flagset.

Signed-off-by: Ibrahim Jarif <jarifibrahim@gmail.com>

Before this PR
```
➜  dgraph git:(master) ./dgraph -h                                        
Usage of ./dgraph:
  -alsologtostderr
    	log to standard error as well as files
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```

with this PR
```
➜  dgraph git:(goflag-parse) ✗ ./dgraph -h

Dgraph is a horizontally scalable and distributed graph database,
providing ACID transactions, consistent replication and linearizable reads.
...
cluster.

Dgraph version   : v1.0.12-rc3-58-g3401ace6
...
Go version       : go1.11.4

....
Usage:
  dgraph [command]

Available Commands:
  acl         Run the Dgraph acl tool
  ...
  zero        Run Dgraph Zero

Flags:
      --alsologtostderr                  log to standard error as well as files
      --bindall                          Use 0.0.0.0 instead of localhost to bind to all addresses on local machine. (default true)
      --block_rate int                   Block profiling rate. Must be used along with block profile_mode
      --config string                    Configuration file. Takes precedence over default values, but is overridden to values set with environment variables and flags.
      --enterprise_features              Enable Dgraph enterprise features. If you set this to true, you agree to the Dgraph Community License.
      --expose_trace                     Allow trace endpoint to be accessible from remote
  -h, --help                             help for dgraph
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory
      --logtostderr                      log to standard error instead of files
      --profile_mode string              Enable profiling mode, one of [cpu, mem, mutex, block]
  -v, --v Level                          log level for V logs
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "dgraph [command] --help" for more information about a command.
➜  dgraph git:(goflag-parse) ✗ 

```

Related to https://github.com/dgraph-io/dgraph/issues/2890

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2970)
<!-- Reviewable:end -->
