### PR TITLE
VerifyUid should wait for membership information

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -94,6 +94,9 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.ZeroProposal) er
 	// Overwrite ctx, so we no longer enforce the timeouts or cancels from ctx.
 	ctx = otrace.NewContext(context.Background(), span)
 
+	stop := x.SpanTimer(span, "n.proposeAndWait")
+	defer stop()
+
 	// propose runs in a loop. So, we should not do any checks inside, including n.AmLeader. This is
 	// to avoid the scenario where the first proposal times out and the second one gets returned
 	// due to node no longer being the leader. In this scenario, the first proposal can still get

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -156,6 +156,9 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) error 
 	proposal.Key = key
 	span := otrace.FromContext(ctx)
 
+	stop := x.SpanTimer(span, "n.proposeAndWait")
+	defer stop()
+
 	propose := func(timeout time.Duration) error {
 		cctx, cancel := context.WithCancel(ctx)
 		defer cancel()


### PR DESCRIPTION
Switch `verifyUid` to rely upon the membership information being streamed from Zero, instead of making a direct request to Zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2974)
<!-- Reviewable:end -->
