### PR TITLE
Move tests in query1_test.go and query2_test.go to use the cluster.

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -86,13 +86,94 @@ func processQueryNoErr(t *testing.T, query string) string {
 	return res
 }
 
-func addTriples(t *testing.T, triples string) {
+func processQueryWithVars(t *testing.T, query string,
+	vars map[string]string) (string, error) {
+	txn := client.NewTxn()
+	res, err := txn.QueryWithVars(context.Background(), query, vars)
+	if err != nil {
+		return "", err
+	}
+
+	response := map[string]interface{}{}
+	response["data"] = json.RawMessage(string(res.Json))
+
+	jsonResponse, err := json.Marshal(response)
+	require.NoError(t, err)
+	return string(jsonResponse), err
+}
+
+func addTriplesToCluster(t *testing.T, triples string) {
 	txn := client.NewTxn()
 	_, err := txn.Mutate(context.Background(), &api.Mutation{
 		SetNquads: []byte(triples),
 		CommitNow: true,
 	})
 	require.NoError(t, err)
+}
+
+func addGeoPointToCluster(t *testing.T, uid uint64, pred string, point []float64) {
+	triple := fmt.Sprintf(
+		`<%d> <%s> "{'type':'Point', 'coordinates':[%v, %v]}"^^<geo:geojson> .`,
+		uid, pred, point[0], point[1])
+	addTriplesToCluster(t, triple)
+}
+
+func addGeoPolygonToCluster(t *testing.T, uid uint64, pred string, polygon [][][]float64) {
+	coordinates := "["
+	for i, ring := range polygon {
+		coordinates += "["
+		for j, point := range ring {
+			coordinates += fmt.Sprintf("[%v, %v]", point[0], point[1])
+
+			if j != len(ring)-1 {
+				coordinates += ","
+			}
+		}
+
+		coordinates += "]"
+		if i != len(polygon)-1 {
+			coordinates += ","
+		}
+	}
+	coordinates += "]"
+
+	triple := fmt.Sprintf(
+		`<%d> <%s> "{'type':'Polygon', 'coordinates': %s}"^^<geo:geojson> .`,
+		uid, pred, coordinates)
+	addTriplesToCluster(t, triple)
+}
+
+func addGeoMultiPolygonToCluster(t *testing.T, uid uint64, polygons [][][][]float64) {
+	coordinates := "["
+	for i, polygon := range polygons {
+		coordinates += "["
+		for j, ring := range polygon {
+			coordinates += "["
+			for k, point := range ring {
+				coordinates += fmt.Sprintf("[%v, %v]", point[0], point[1])
+
+				if k != len(ring)-1 {
+					coordinates += ","
+				}
+			}
+
+			coordinates += "]"
+			if j != len(polygon)-1 {
+				coordinates += ","
+			}
+		}
+
+		coordinates += "]"
+		if i != len(polygons)-1 {
+			coordinates += ","
+		}
+	}
+	coordinates += "]"
+
+	triple := fmt.Sprintf(
+		`<%d> <geometry> "{'type':'MultiPolygon', 'coordinates': %s}"^^<geo:geojson> .`,
+		uid, coordinates)
+	addTriplesToCluster(t, triple)
 }
 
 func childAttrs(sg *SubGraph) []string {
@@ -390,28 +471,52 @@ type                           : string @index(exact) .
 func populateCluster(t *testing.T) {
 	require.NoError(t, client.Alter(context.Background(), &api.Operation{DropAll: true}))
 	setSchema(t, testSchema)
-	assignUids(t, 15000)
+	assignUids(t, 100000)
 
-	addTriples(t, `
+	addTriplesToCluster(t, `
 		<1> <name> "Michonne" .
 		<23> <name> "Rick Grimes" .
 		<24> <name> "Glenn Rhee" .
 		<25> <name> "Daryl Dixon" .
 		<31> <name> "Andrea" .
+		<110> <name> "Alice" .
 		<240> <name> "Andrea With no friends" .
 		<1000> <name> "Alice" .
 		<1001> <name> "Bob" .
 		<1002> <name> "Matt" .
 		<1003> <name> "John" .
+		<2300> <name> "Andre" .
+		<2301> <name> "Alice\"" .
+		<2333> <name> "Helmut" .
 		<3500> <name> "" .
 		<3500> <name@ko> "상현" .
+		<3501> <name> "Alex" .
+		<3501> <name@en> "Alex" .
 		<3502> <name> "" .
 		<3502> <name@en> "Amit" .
 		<3502> <name@hi> "अमित" .
 		<3503> <name@en> "Andrew" .
 		<3503> <name@hi> "" .
+		<4097> <name> "Badger" .
+		<4097> <name@en> "European badger" .
+		<4097> <name@xx> "European badger barger European" .
+		<4097> <name@pl> "Borsuk europejski" .
+		<4097> <name@de> "Europäischer Dachs" .
+		<4097> <name@ru> "Барсук" .
+		<4097> <name@fr> "Blaireau européen" .
+		<4098> <name@en> "Honey badger" .
+		<4099> <name@en> "Honey bee" .
+		<4100> <name@en> "Artem Tkachenko" .
+		<4100> <name@ru> "Артём Ткаченко" .
 		<5000> <name> "School A" .
 		<5001> <name> "School B" .
+		<5101> <name> "Googleplex" .
+		<5102> <name> "Shoreline Amphitheater" .
+		<5103> <name> "San Carlos Airport" .
+		<5104> <name> "SF Bay area" .
+		<5105> <name> "Mountain View" .
+		<5106> <name> "San Carlos" .
+		<5107> <name> "New York" .
 		<10000> <name> "Alice" .
 		<10001> <name> "Elizabeth" .
 		<10002> <name> "Alice" .
@@ -420,6 +525,10 @@ func populateCluster(t *testing.T) {
 		<10005> <name> "Bob" .
 		<10006> <name> "Colin" .
 		<10007> <name> "Elizabeth" .
+
+		<1> <full_name> "Michonne's large name for hashing" .
+
+		<1> <noindex_name> "Michonne's name not indexed" .
 
 		<1> <friend> <23> .
 		<1> <friend> <24> .
@@ -446,8 +555,12 @@ func populateCluster(t *testing.T) {
 		<10007> <age> "25" .
 
 		<1> <alive> "true" .
+		<23> <alive> "true" .
+		<25> <alive> "false" .
+		<31> <alive> "false" .
 
 		<1> <gender> "female" .
+		<23> <gender> "male" .
 
 		<4001> <office> "office 1" .
 		<4002> <room> "room 1" .
@@ -500,7 +613,93 @@ func populateCluster(t *testing.T) {
 		<25> <school> <5000> .
 		<31> <school> <5001> .
 		<101> <school> <5001> .
+
+		<1> <_xid_> "mich" .
+		<24> <_xid_> "g\"lenn" .
+		<110> <_xid_> "a.bc" .
+
+		<23> <alias> "Zambo Alice" .
+		<24> <alias> "John Alice" .
+		<25> <alias> "Bob Joe" .
+		<31> <alias> "Allan Matt" .
+		<101> <alias> "John Oliver" .
+
+		<1> <bin_data> "YmluLWRhdGE=" .
+
+		<1> <graduation> "1932-01-01" .
+		<31> <graduation> "1933-01-01" .
+		<31> <graduation> "1935-01-01" .
+
+		<10000> <salary> "10000" .
+		<10002> <salary> "10002" .
+
+		<1> <address> "31, 32 street, Jupiter" .
+		<23> <address> "21, mark street, Mars" .
+
+		<1> <dob_day> "1910-01-01" .
+		<23> <dob_day> "1910-01-02" .
+		<24> <dob_day> "1909-05-05" .
+		<25> <dob_day> "1909-01-10" .
+		<31> <dob_day> "1901-01-15" .
+
+		<1> <power> "13.25"^^<xs:float> .
+
+		<1> <sword_present> "true" .
+
+		<1> <son> <2300> .
+		<1> <son> <2333> .
+
+		<5010> <nick_name> "Two Terms" .
+
+		<4097> <lossy> "Badger" .
+		<4097> <lossy@en> "European badger" .
+		<4097> <lossy@xx> "European badger barger European" .
+		<4097> <lossy@pl> "Borsuk europejski" .
+		<4097> <lossy@de> "Europäischer Dachs" .
+		<4097> <lossy@ru> "Барсук" .
+		<4097> <lossy@fr> "Blaireau européen" .
+		<4098> <lossy@en> "Honey badger" .
+
+		<23> <film.film.initial_release_date> "1900-01-02" .
+		<24> <film.film.initial_release_date> "1909-05-05" .
+		<25> <film.film.initial_release_date> "1929-01-10" .
+		<31> <film.film.initial_release_date> "1801-01-15" .
+
+		<0x10000> <royal_title@en> "Her Majesty Elizabeth the Second, by the Grace of God of the United Kingdom of Great Britain and Northern Ireland and of Her other Realms and Territories Queen, Head of the Commonwealth, Defender of the Faith" .
+		<0x10000> <royal_title@fr> "Sa Majesté Elizabeth Deux, par la grâce de Dieu Reine du Royaume-Uni, du Canada et de ses autres royaumes et territoires, Chef du Commonwealth, Défenseur de la Foi" .
 	`)
+
+	addGeoPointToCluster(t, 1, "loc", []float64{1.1, 2.0})
+	addGeoPointToCluster(t, 24, "loc", []float64{1.10001, 2.000001})
+	addGeoPointToCluster(t, 25, "loc", []float64{1.1, 2.0})
+	addGeoPointToCluster(t, 5101, "geometry", []float64{-122.082506, 37.4249518})
+	addGeoPointToCluster(t, 5102, "geometry", []float64{-122.080668, 37.426753})
+	addGeoPointToCluster(t, 5103, "geometry", []float64{-122.2527428, 37.513653})
+
+	addGeoPolygonToCluster(t, 23, "loc", [][][]float64{
+		{{0.0, 0.0}, {2.0, 0.0}, {2.0, 2.0}, {0.0, 2.0}, {0.0, 0.0}},
+	})
+	addGeoPolygonToCluster(t, 5104, "geometry", [][][]float64{
+		{{-121.6, 37.1}, {-122.4, 37.3}, {-122.6, 37.8}, {-122.5, 38.3}, {-121.9, 38},
+			{-121.6, 37.1}},
+	})
+	addGeoPolygonToCluster(t, 5105, "geometry", [][][]float64{
+		{{-122.06, 37.37}, {-122.1, 37.36}, {-122.12, 37.4}, {-122.11, 37.43},
+			{-122.04, 37.43}, {-122.06, 37.37}},
+	})
+	addGeoPolygonToCluster(t, 5106, "geometry", [][][]float64{
+		{{-122.25, 37.49}, {-122.28, 37.49}, {-122.27, 37.51}, {-122.25, 37.52},
+			{-122.25, 37.49}},
+	})
+
+	addGeoMultiPolygonToCluster(t, 5107, [][][][]float64{
+		{{{-74.29504394531249, 40.19146303804063}, {-74.59716796875, 40.39258071969131},
+			{-74.6466064453125, 40.20824570152502}, {-74.454345703125, 40.06125658140474},
+			{-74.28955078125, 40.17467622056341}, {-74.29504394531249, 40.19146303804063}}},
+		{{{-74.102783203125, 40.8595252289932}, {-74.2730712890625, 40.718119379753446},
+			{-74.0478515625, 40.66813955408042}, {-73.98193359375, 40.772221877329024},
+			{-74.102783203125, 40.8595252289932}}},
+	})
 }
 
 func populateGraph(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -25,10 +25,10 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/protos/api"
-	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestSchemaBlock2(t *testing.T) {
@@ -41,14 +41,9 @@ func TestSchemaBlock2(t *testing.T) {
 			count
 		}
 	`
-	actual := processSchemaQuery(t, query)
-	expected := []*api.SchemaNode{
-		{Predicate: "name",
-			Type:      "string",
-			Index:     true,
-			Tokenizer: []string{"term", "exact", "trigram"},
-			Count:     true}}
-	checkSchemaNodes(t, expected, actual)
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"schema":[{"predicate":"name","type":"string","index":true,"tokenizer":["term","exact","trigram"],"count":true}]}}`, js)
 }
 
 func TestSchemaBlock3(t *testing.T) {
@@ -61,13 +56,8 @@ func TestSchemaBlock3(t *testing.T) {
 			count
 		}
 	`
-	actual := processSchemaQuery(t, query)
-	expected := []*api.SchemaNode{{Predicate: "age",
-		Type:      "int",
-		Index:     true,
-		Tokenizer: []string{"int"},
-		Count:     false}}
-	checkSchemaNodes(t, expected, actual)
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"schema":[{"predicate":"age","type":"int","index":true,"tokenizer":["int"]}]}}`, js)
 }
 
 func TestSchemaBlock4(t *testing.T) {
@@ -79,15 +69,8 @@ func TestSchemaBlock4(t *testing.T) {
 			tokenizer
 		}
 	`
-	actual := processSchemaQuery(t, query)
-	expected := []*api.SchemaNode{
-		{Predicate: "genre",
-			Type:    "uid",
-			Reverse: true}, {Predicate: "age",
-			Type:      "int",
-			Index:     true,
-			Tokenizer: []string{"int"}}}
-	checkSchemaNodes(t, expected, actual)
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"schema":[{"predicate":"age","type":"int","index":true,"tokenizer":["int"]},{"predicate":"genre","type":"uid","reverse":true}]}}`, js)
 }
 
 func TestSchemaBlock5(t *testing.T) {
@@ -95,16 +78,9 @@ func TestSchemaBlock5(t *testing.T) {
 		schema(pred: name) {
 		}
 	`
-	actual := processSchemaQuery(t, query)
-	expected := []*api.SchemaNode{
-		{Predicate: "name",
-			Type:      "string",
-			Index:     true,
-			Tokenizer: []string{"term", "exact", "trigram"},
-			Count:     true,
-			Lang:      true,
-		}}
-	checkSchemaNodes(t, expected, actual)
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"schema":[{"predicate":"name","type":"string","index":true,"tokenizer":["term","exact","trigram"],"count":true,"lang":true}]}}`, js)
 }
 
 // Duplicate implemention as in cmd/dgraph/main_test.go
@@ -147,7 +123,7 @@ func TestFilterNonIndexedPredicateFail(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -165,7 +141,7 @@ func TestMultipleSamePredicateInBlockFail(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -183,7 +159,7 @@ func TestMultipleSamePredicateInBlockFail2(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -203,7 +179,7 @@ func TestMultipleSamePredicateInBlockFail3(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -224,7 +200,7 @@ func TestXidInvalidJSON(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"_xid_":"mich","alive":true,"friend":[{"name":"Rick Grimes"},{"_xid_":"g\"lenn","name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -246,7 +222,7 @@ func TestToJSONReverseNegativeFirst(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Andrea","~friend":[{"gender":"female","name":"Michonne"}]},{"name":"Andrea With no friends"}]}}`,
 		js)
@@ -264,7 +240,7 @@ func TestToFastJSONOrderLang(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"alias":"Zambo Alice"},{"alias":"John Oliver"}]}]}}`,
 		js)
@@ -280,7 +256,7 @@ func TestBoolIndexEqRoot1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"alive":true,"name":"Michonne"},{"alive":true,"name":"Rick Grimes"}]}}`,
 		js)
@@ -296,7 +272,7 @@ func TestBoolIndexEqRoot2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"alive":false,"name":"Daryl Dixon"},{"alive":false,"name":"Andrea"}]}}`,
 		js)
@@ -316,8 +292,8 @@ func TestBoolIndexgeRoot(t *testing.T) {
 			}
 		}`
 
-	_, err := processToFastJson(t, q)
-	require.NotNil(t, err)
+	_, err := processQuery(t, context.Background(), q)
+	require.Error(t, err)
 }
 
 func TestBoolIndexEqChild(t *testing.T) {
@@ -334,7 +310,7 @@ func TestBoolIndexEqChild(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"alive":true,"friend":[{"alive":false,"name":"Daryl Dixon"},{"alive":false,"name":"Andrea"}],"name":"Michonne"},{"alive":true,"name":"Rick Grimes"}]}}`,
 		js)
@@ -351,8 +327,8 @@ func TestBoolSort(t *testing.T) {
 		}
 	`
 
-	_, err := processToFastJson(t, q)
-	require.NotNil(t, err)
+	_, err := processQuery(t, context.Background(), q)
+	require.Error(t, err)
 }
 
 func TestStringEscape(t *testing.T) {
@@ -364,7 +340,7 @@ func TestStringEscape(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Alice\""}]}}`,
 		js)
@@ -381,7 +357,7 @@ func TestJSONQueryVariables(t *testing.T) {
 			}
 		}
 	}`
-	js, err := processToFastJsonCtxVars(t, q, defaultContext(), map[string]string{"$a": "2"})
+	js, err := processQueryWithVars(t, q, map[string]string{"$a": "2"})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"}],"gender":"female","name":"Michonne"}]}}`, js)
 }
@@ -398,7 +374,7 @@ func TestOrderDescFilterCount(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"alias":"Zambo Alice"}]}]}}`,
 		js)
@@ -417,7 +393,7 @@ func TestHashTokEq(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"alive":true,"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"full_name":"Michonne's large name for hashing"}]}}`,
 		js)
@@ -436,9 +412,7 @@ func TestHashTokGeqErr(t *testing.T) {
 			}
 		}
 	`
-	res, _ := gql.Parse(gql.Request{Str: query})
-	queryRequest := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err := queryRequest.ProcessQuery(defaultContext())
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -455,9 +429,8 @@ func TestNameNotIndexed(t *testing.T) {
 			}
 		}
 	`
-	res, _ := gql.Parse(gql.Request{Str: query})
-	queryRequest := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err := queryRequest.ProcessQuery(defaultContext())
+
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -476,7 +449,7 @@ func TestMultipleMinMax(t *testing.T) {
 				max(val(n))
 			}
 		}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"age":15,"name":"Rick Grimes"},{"age":15,"name":"Glenn Rhee"},{"age":17,"name":"Daryl Dixon"},{"age":19,"name":"Andrea"}],"max(val(n))":"Rick Grimes","max(val(x))":19,"min(val(n))":"Andrea","min(val(x))":15}]}}`,
 		js)
@@ -494,9 +467,8 @@ func TestDuplicateAlias(t *testing.T) {
 				a: max(val(x))
 			}
 		}`
-	res, _ := gql.Parse(gql.Request{Str: query})
-	queryRequest := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err := queryRequest.ProcessQuery(defaultContext())
+
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -511,7 +483,7 @@ func TestGraphQLId(t *testing.T) {
 			}
 		}
 	}`
-	js, err := processToFastJsonCtxVars(t, q, defaultContext(), map[string]string{"$a": "[1, 31]"})
+	js, err := processQueryWithVars(t, q, map[string]string{"$a": "[1, 31]"})
 	require.NoError(t, err)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"}],"gender":"female","name":"Michonne"},{"friend":[{"name":"Glenn Rhee"}],"name":"Andrea"}]}}`, js)
 }
@@ -528,8 +500,12 @@ func TestDebugUid(t *testing.T) {
 				}
 			}
 		}`
-	ctx := context.WithValue(defaultContext(), DebugKey, "true")
-	buf, err := processToFastJsonCtxVars(t, query, ctx, nil)
+
+	md := metadata.Pairs("debug", "true")
+	ctx := context.Background()
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	buf, err := processQuery(t, ctx, query)
 	require.NoError(t, err)
 	var mp map[string]interface{}
 	require.NoError(t, json.Unmarshal([]byte(buf), &mp))
@@ -553,7 +529,7 @@ func TestUidAlias(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"alive":true,"friend":[{"name":"Rick Grimes","uid":"0x17"},{"name":"Glenn Rhee","uid":"0x18"},{"name":"Daryl Dixon","uid":"0x19"},{"name":"Andrea","uid":"0x1f"},{"uid":"0x65"}],"id":"0x1"}]}}`,
 		js)
@@ -568,7 +544,7 @@ func TestCountAtRoot(t *testing.T) {
 			}
         }
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"count": 3}]}}`, js)
 }
 
@@ -581,7 +557,7 @@ func TestCountAtRoot2(t *testing.T) {
 		}
         }
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"count": 4}]}}`, js)
 }
 
@@ -600,7 +576,7 @@ func TestCountAtRoot3(t *testing.T) {
 		}
         }
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"count":3},{"count(friend)":5,"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"},{"count":5}],"name":"Michonne"},{"count(friend)":1,"friend":[{"name":"Michonne"},{"count":1}],"name":"Rick Grimes"},{"count(friend)":0,"name":"Daryl Dixon"}]}}`, js)
 }
 
@@ -613,7 +589,7 @@ func TestCountAtRootWithAlias4(t *testing.T) {
 		}
         }
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": [{"personCount": 2}]}}`, js)
 }
 
@@ -633,7 +609,7 @@ func TestCountAtRoot5(t *testing.T) {
 
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"MichonneFriends":[{"count":5}],"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}]}}`, js)
 }
 
@@ -650,7 +626,7 @@ func TestHasFuncAtRoot(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"count":5}],"name":"Michonne"},{"friend":[{"count":1}],"name":"Rick Grimes"},{"friend":[{"count":1}],"name":"Andrea"}]}}`, js)
 }
 
@@ -668,7 +644,7 @@ func TestHasFuncAtRootWithAfter(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"count":1}],"name":"Rick Grimes","uid":"0x17"},{"friend":[{"count":1}],"name":"Andrea","uid":"0x1f"}]}}`, js)
 }
 
@@ -685,7 +661,7 @@ func TestHasFuncAtRootFilter(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"count":5}],"name":"Michonne"},{"friend":[{"count":1}],"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -702,7 +678,7 @@ func TestHasFuncAtChild1(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}}`, js)
 }
 
@@ -720,7 +696,7 @@ func TestHasFuncAtChild2(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"alias":"Zambo Alice","name":"Rick Grimes"},{"alias":"John Alice","name":"Glenn Rhee"},{"alias":"Bob Joe","name":"Daryl Dixon"},{"alias":"Allan Matt","name":"Andrea"},{"alias":"John Oliver"}],"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"friend":[{"alias":"John Alice","name":"Glenn Rhee"}],"name":"Andrea"}]}}`, js)
 }
 
@@ -734,189 +710,8 @@ func TestHasFuncAtRoot2(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name@en":"Alex"},{"name@en":"Amit"},{"name@en":"Andrew"},{"name@en":"European badger"},{"name@en":"Honey badger"},{"name@en":"Honey bee"},{"name@en":"Artem Tkachenko"}]}}`, js)
-}
-
-func getSubGraphs(t *testing.T, query string) (subGraphs []*SubGraph) {
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	for _, block := range res.Query {
-		subGraph, err := ToSubGraph(ctx, block)
-		require.NoError(t, err)
-		require.NotNil(t, subGraph)
-
-		subGraphs = append(subGraphs, subGraph)
-	}
-
-	return subGraphs
-}
-
-// simplest case
-func TestGetAllPredicatesSimple(t *testing.T) {
-	query := `
-	{
-		me(func: uid(0x1)) {
-			name
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 1, len(predicates))
-	require.Equal(t, "name", predicates[0])
-}
-
-// recursive SubGraph traversal; predicates should be unique
-func TestGetAllPredicatesUnique(t *testing.T) {
-	query := `
-	{
-		me(func: uid(0x1)) {
-			name
-			friend {
-				name
-				age
-			}
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 3, len(predicates))
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "friend")
-	require.Contains(t, predicates, "age")
-}
-
-// gather predicates from functions and filters
-func TestGetAllPredicatesFunctions(t *testing.T) {
-	query := `
-	{
-		me(func:anyofterms(name, "Alice")) @filter(le(age, 30)) {
-			alias
-			friend @filter(eq(school, 5000)) {
-				alias
-				follow
-			}
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 6, len(predicates))
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "age")
-	require.Contains(t, predicates, "alias")
-	require.Contains(t, predicates, "friend")
-	require.Contains(t, predicates, "school")
-	require.Contains(t, predicates, "follow")
-}
-
-// gather predicates from functions and filters
-func TestGetAllPredicatesFunctions2(t *testing.T) {
-	query := `
-	{
-		me(func:anyofterms(name, "Alice")) @filter(le(age, 30)) {
-			alias
-			friend @filter(uid(123, 5000)) {
-				alias
-				follow
-			}
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 5, len(predicates))
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "age")
-	require.Contains(t, predicates, "alias")
-	require.Contains(t, predicates, "friend")
-	require.Contains(t, predicates, "follow")
-}
-
-// gather predicates from order
-func TestGetAllPredicatesOrdering(t *testing.T) {
-	query := `
-	{
-		me(func:anyofterms(name, "Alice"), orderasc: age) {
-			name
-			friend(orderdesc: alias) {
-				name
-			}
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 4, len(predicates))
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "age")
-	require.Contains(t, predicates, "friend")
-	require.Contains(t, predicates, "alias")
-}
-
-// gather predicates from multiple query blocks (and var)
-func TestGetAllPredicatesVars(t *testing.T) {
-	query := `
-	{
-		IDS as var(func:anyofterms(name, "Alice"), orderasc: age) {}
-
-		me(func: uid(IDS)) {
-			alias
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 3, len(predicates))
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "age")
-	require.Contains(t, predicates, "alias")
-}
-
-// gather predicates from groupby
-func TestGetAllPredicatesGroupby(t *testing.T) {
-	query := `
-	{
-		me(func: uid(1)) {
-			friend @groupby(age) {
-				count(uid)
-			}
-			name
-		}
-	}
-	`
-
-	subGraphs := getSubGraphs(t, query)
-
-	predicates := GetAllPredicates(subGraphs)
-	require.NotNil(t, predicates)
-	require.Equal(t, 4, len(predicates))
-	require.Contains(t, predicates, "uid")
-	require.Contains(t, predicates, "name")
-	require.Contains(t, predicates, "age")
-	require.Contains(t, predicates, "friend")
 }
 
 func TestMathVarCrash(t *testing.T) {
@@ -930,11 +725,7 @@ func TestMathVarCrash(t *testing.T) {
 			}
 		}
 	`
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	queryRequest := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err = queryRequest.ProcessQuery(defaultContext())
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -948,7 +739,7 @@ func TestMathVarAlias(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"f":[{"a":76.000000,"age":38},{"a":30.000000,"age":15},{"a":38.000000,"age":19}]}}`, js)
 }
 
@@ -966,7 +757,7 @@ func TestMathVarAlias2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"age":38,"doubleAge":76.000000},{"age":15,"doubleAge":30.000000},{"age":19,"doubleAge":38.000000}],"me2":[{"val(a)":76.000000},{"val(a)":30.000000},{"val(a)":38.000000}]}}`, js)
 }
 
@@ -984,7 +775,7 @@ func TestMathVar3(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"age":38,"val(a)":76.000000},{"age":15,"val(a)":30.000000},{"age":19,"val(a)":38.000000}],"me2":[{"val(a)":76.000000},{"val(a)":30.000000},{"val(a)":38.000000}]}}`, js)
 }
 
@@ -1002,7 +793,7 @@ func TestMultipleEquality(t *testing.T) {
 
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Michonne"}],"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1019,7 +810,7 @@ func TestMultipleEquality2(t *testing.T) {
 	}
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Matt"},{"name":"Badger"}]}}`, js)
 }
 
@@ -1036,7 +827,7 @@ func TestMultipleEquality3(t *testing.T) {
 	}
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1053,7 +844,7 @@ func TestMultipleEquality4(t *testing.T) {
 	}
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Andrea"}],"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1067,7 +858,7 @@ func TestMultipleEquality5(t *testing.T) {
 	}
 
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name@en":"Honey badger"},{"name@en":"Honey bee"}]}}`, js)
 }
 
@@ -1084,11 +875,7 @@ func TestMultipleGtError(t *testing.T) {
 	}
 
   `
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	queryRequest := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err = queryRequest.ProcessQuery(defaultContext())
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1104,7 +891,7 @@ func TestMultipleEqQuote(t *testing.T) {
 		}
 	}
 `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"name":"Michonne"},{"name":"Alice\""}]}}`, js)
 }
 
@@ -1120,7 +907,7 @@ func TestMultipleEqInt(t *testing.T) {
 		}
 	}
 `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]},{"name":"Rick Grimes","friend":[{"name":"Michonne"}]},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"}]}}`, js)
 }
 
@@ -1132,7 +919,7 @@ func TestUidFunction(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}}`, js)
 }
 
@@ -1144,7 +931,7 @@ func TestUidFunctionInFilter(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1160,7 +947,7 @@ func TestUidFunctionInFilter2(t *testing.T) {
 			}
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","friend":[{"name":"Rick Grimes"}]},{"name":"Rick Grimes","friend":[{"name":"Michonne"}]},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}}`, js)
 }
 
@@ -1172,7 +959,7 @@ func TestUidFunctionInFilter3(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"}]}}`, js)
 }
 
@@ -1184,7 +971,7 @@ func TestUidFunctionInFilter4(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Andrea With no friends"}]}}`, js)
 }
 
@@ -1196,7 +983,7 @@ func TestUidInFunction(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"}]}}`, js)
 }
 
@@ -1208,7 +995,7 @@ func TestUidInFunction1(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1222,7 +1009,7 @@ func TestUidInFunction2(t *testing.T) {
 			}
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Glenn Rhee"},{"name":"Daryl Dixon"}]},{"friend":[{"name":"Michonne"}]}]}}`,
 		js)
 }
@@ -1236,12 +1023,7 @@ func TestUidInFunctionAtRoot(t *testing.T) {
 		}
 	}`
 
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := defaultContext()
-	qr := QueryRequest{Latency: &Latency{}, GqlQuery: &res}
-	err = qr.ProcessQuery(ctx)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1253,7 +1035,7 @@ func TestBinaryJSON(t *testing.T) {
 			bin_data
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","bin_data":"YmluLWRhdGE="}]}}`, js)
 }
 
@@ -1271,7 +1053,7 @@ func TestReflexive(t *testing.T) {
 			}
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"friend":[{"name":"Glenn Rhee"}],"name":"Andrea"}],"name":"Michonne"},{"friend":[{"friend":[{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"name":"Michonne"}],"name":"Rick Grimes"},{"name":"Daryl Dixon"}]}}`, js)
 }
 
@@ -1289,7 +1071,7 @@ func TestReflexive2(t *testing.T) {
 			}
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"friend":[{"name":"Glenn Rhee"}],"name":"Andrea"}],"name":"Michonne"},{"friend":[{"friend":[{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"name":"Michonne"}],"name":"Rick Grimes"},{"name":"Daryl Dixon"}]}}`, js)
 }
 
@@ -1307,7 +1089,7 @@ func TestReflexive3(t *testing.T) {
 			}
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"Friend":"Rick Grimes","Me":"Michonne"},{"Friend":"Glenn Rhee","Me":"Michonne"},{"Friend":"Daryl Dixon","Me":"Michonne"},{"Cofriend":"Glenn Rhee","Friend":"Andrea","Me":"Michonne"},{"Cofriend":"Glenn Rhee","Friend":"Michonne","Me":"Rick Grimes"},{"Cofriend":"Daryl Dixon","Friend":"Michonne","Me":"Rick Grimes"},{"Cofriend":"Andrea","Friend":"Michonne","Me":"Rick Grimes"},{"Me":"Daryl Dixon"}]}}`, js)
 }
 
@@ -1331,7 +1113,7 @@ func TestCascadeUid(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"uid":"0x17","friend":[{"age":38,"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"name":"Rick Grimes"},{"uid":"0x1f","friend":[{"age":15,"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`, js)
 }
 
@@ -1348,7 +1130,7 @@ func TestUseVariableBeforeDefinitionError(t *testing.T) {
 	}
 }`
 
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Contains(t, err.Error(), "Variable: [avgAge] used before definition.")
 }
 
@@ -1365,7 +1147,7 @@ func TestAggregateRoot1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"sum(val(a))":72}]}}`, js)
 }
 
@@ -1384,7 +1166,7 @@ func TestAggregateRoot2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"avg(val(a))":24.000000},{"min(val(a))":15},{"max(val(a))":38}]}}`, js)
 }
 
@@ -1401,7 +1183,7 @@ func TestAggregateRoot3(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me1":[{"age":38},{"age":15},{"age":19}],"me":[{"sum(val(a))":72}]}}`, js)
 }
 
@@ -1420,7 +1202,7 @@ func TestAggregateRoot4(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"min(val(a))":15},{"max(val(a))":38},{"Sum":53.000000}]}}`, js)
 }
 
@@ -1438,7 +1220,7 @@ func TestAggregateRoot5(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"sum(val(m))":0.000000}]}}`, js)
 }
 
@@ -1459,7 +1241,7 @@ func TestAggregateRoot6(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[]}}`, js)
 }
 
@@ -1480,8 +1262,7 @@ func TestAggregateRootError(t *testing.T) {
 			}
 		}
 	`
-	ctx := defaultContext()
-	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Only aggregated variables allowed within empty block.")
 }
@@ -1498,7 +1279,7 @@ func TestFilterLang(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@en":"European badger"},{"name@en":"Honey badger"},{"name@en":"Honey bee"}]}}`, js)
 }
@@ -1521,7 +1302,7 @@ func TestMathCeil1(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1543,7 +1324,7 @@ func TestMathCeil2(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"ceilAge":14.000000}]}}`, js)
 }
 
@@ -1556,7 +1337,7 @@ func TestAppendDummyValuesPanic(t *testing.T) {
 			count(uid)
 		}
 	}`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `Argument cannot be "uid"`)
 }
@@ -1571,7 +1352,7 @@ func TestMultipleValueFilter(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","graduation":["1932-01-01T00:00:00Z"]},{"name":"Andrea","graduation":["1935-01-01T00:00:00Z","1933-01-01T00:00:00Z"]}]}}`, js)
 }
 
@@ -1585,7 +1366,7 @@ func TestMultipleValueFilter2(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","graduation":["1932-01-01T00:00:00Z"]},{"name":"Andrea","graduation":["1935-01-01T00:00:00Z","1933-01-01T00:00:00Z"]}]}}`, js)
 }
 
@@ -1599,7 +1380,7 @@ func TestMultipleValueArray(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","graduation":["1932-01-01T00:00:00Z"]}]}}`, js)
 }
 
@@ -1613,7 +1394,7 @@ func TestMultipleValueArray2(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","graduation":["1932-01-01T00:00:00Z"]}]}}`, js)
 }
 
@@ -1628,7 +1409,7 @@ func TestMultipleValueHasAndCount(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","count(graduation)":1,"graduation":["1932-01-01T00:00:00Z"]},{"name":"Andrea","count(graduation)":2,"graduation":["1935-01-01T00:00:00Z","1933-01-01T00:00:00Z"]}]}}`, js)
 }
 
@@ -1642,8 +1423,7 @@ func TestMultipleValueSortError(t *testing.T) {
 		}
 	}
 	`
-	ctx := defaultContext()
-	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Sorting not supported on attr: graduation of type: [scalar]")
 }
@@ -1660,8 +1440,7 @@ func TestMultipleValueGroupByError(t *testing.T) {
 		}
 	}
 	`
-	ctx := defaultContext()
-	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Groupby not allowed for attr: graduation of type list")
 }
@@ -1677,7 +1456,7 @@ func TestMultiPolygonIntersects(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"},{"name":"San Carlos Airport"},{"name":"SF Bay area"},{"name":"Mountain View"},{"name":"San Carlos"}, {"name": "New York"}]}}`, js)
 }
 
@@ -1692,25 +1471,9 @@ func TestMultiPolygonWithin(t *testing.T) {
 	}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"},{"name":"San Carlos Airport"},{"name":"Mountain View"},{"name":"San Carlos"}]}}`, js)
 }
-
-// func TestMultiPolygonContains(t *testing.T) {
-// 	// We should get this back as a result as it should contain our Denver polygon.
-// 	multipoly, err := loadPolygon("testdata/us-coordinates.txt")
-// 	require.NoError(t, err)
-// 	addGeoData(t, 5108, multipoly, "USA")
-
-// 	query := `{
-// 		me(func: contains(geometry, "[[[ -1185.8203125, 41.27780646738183 ], [ -1189.1162109375, 37.64903402157866 ], [ -1182.1728515625, 36.84446074079564 ], [ -1185.8203125, 41.27780646738183 ]]]")) {
-// 			name
-// 		}
-// 	}`
-
-// 	js := processToFastJsonNoErr(t, query)
-// 	require.JSONEq(t, `{"data": {"me":[{"name":"USA"}]}}`, js)
-// }
 
 func TestNearPointMultiPolygon(t *testing.T) {
 
@@ -1720,7 +1483,7 @@ func TestNearPointMultiPolygon(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1735,7 +1498,7 @@ func TestMultiSort1(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25},{"name":"Alice","age":75},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
 }
 
@@ -1748,7 +1511,7 @@ func TestMultiSort2(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":75},{"name":"Alice","age":75},{"name":"Alice","age":25},{"name":"Bob","age":75},{"name":"Bob","age":25},{"name":"Colin","age":25},{"name":"Elizabeth","age":75},{"name":"Elizabeth","age":25}]}}`, js)
 }
 
@@ -1761,7 +1524,7 @@ func TestMultiSort3(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Elizabeth","age":25},{"name":"Colin","age":25},{"name":"Bob","age":25},{"name":"Alice","age":25},{"name":"Elizabeth","age":75},{"name":"Bob","age":75},{"name":"Alice","age":75},{"name":"Alice","age":75}]}}`, js)
 }
 
@@ -1774,7 +1537,7 @@ func TestMultiSort4(t *testing.T) {
 			salary
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	// Null value for third Alice comes at last.
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":75},{"name":"Bob","age":75},{"name":"Bob","age":25},{"name":"Colin","age":25},{"name":"Elizabeth","age":75},{"name":"Elizabeth","age":25}]}}`, js)
 }
@@ -1788,7 +1551,7 @@ func TestMultiSort5(t *testing.T) {
 			salary
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	// Null value for third Alice comes at first.
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":75},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":25,"salary":10000.000000},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
 }
@@ -1802,7 +1565,7 @@ func TestMultiSort6Paginate(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":75},{"name":"Alice","age":75},{"name":"Alice","age":25},{"name":"Bob","age":75},{"name":"Bob","age":25},{"name":"Colin","age":25},{"name":"Elizabeth","age":75}]}}`, js)
 }
 
@@ -1815,7 +1578,7 @@ func TestMultiSort7Paginate(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25},{"name":"Alice","age":75},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25}]}}`, js)
 }
 
@@ -1830,7 +1593,7 @@ func TestFilterRootOverride(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1843,7 +1606,7 @@ func TestFilterRoot(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1857,7 +1620,7 @@ func TestMathAlias(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"count(friend)":5,"score":6.000000,"name":"Michonne"}]}}`, js)
 }
 
@@ -1875,7 +1638,7 @@ func TestUidVariable(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}}`, js)
 }
 
@@ -1891,8 +1654,7 @@ func TestMultipleValueVarError(t *testing.T) {
 		}
 	}`
 
-	ctx := defaultContext()
-	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Value variables not supported for predicate with list type.")
 }
@@ -1910,7 +1672,7 @@ func TestReturnEmptyBlock(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[],"me2":[],"me3":[{"name":"Michonne"}]}}`, js)
 }
 
@@ -1927,7 +1689,7 @@ func TestExpandVal(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"me":[{"age":38,"full_name":"Michonne's large name for hashing","dob_day":"1910-01-01T00:00:00Z","power":13.250000,"noindex_name":"Michonne's name not indexed","survival_rate":98.990000,"name":"Michonne","sword_present":"true","alive":true,"dob":"1910-01-01T00:00:00Z","path":[{"path|weight":0.200000},{"path|weight":0.100000,"path|weight1":0.200000}],"bin_data":"YmluLWRhdGE=","loc":{"type":"Point","coordinates":[1.1,2]},"address":"31, 32 street, Jupiter","graduation":["1932-01-01T00:00:00Z"],"gender":"female","_xid_":"mich"}]}}`, js)
 }
 
@@ -1940,7 +1702,7 @@ func TestGroupByGeoCrash(t *testing.T) {
 	  }
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.Contains(t, js, `{"loc":{"type":"Point","coordinates":[1.1,2]},"count":2}`)
 }
 
@@ -1953,8 +1715,7 @@ func TestPasswordError(t *testing.T) {
 		}
 	}
 	`
-	ctx := defaultContext()
-	_, err := processToFastJsonCtxVars(t, query, ctx, nil)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 	require.Contains(t,
 		err.Error(), "checkpwd fn can only be used on attr: [name] with schema type password. Got type: string")
@@ -1971,7 +1732,7 @@ func TestCountPanic(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"q":[{"uid":"0x1","name":"Michonne","count(name)":1},{"uid":"0x12c","count(name)":0}]}}`, js)
 }
 
@@ -1986,7 +1747,7 @@ func TestExpandAll(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"q":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"power":13.250000,"_xid_":"mich","noindex_name":"Michonne's name not indexed","son":[{"name":"Andre"},{"name":"Helmut"}],"address":"31, 32 street, Jupiter","dob_day":"1910-01-01T00:00:00Z","follow":[{"name":"Glenn Rhee"},{"name":"Andrea"}],"name":"Michonne","path":[{"name":"Glenn Rhee","path|weight":0.200000},{"name":"Andrea","path|weight":0.100000,"path|weight1":0.200000}],"school":[{"name":"School A"}],"full_name":"Michonne's large name for hashing","alive":true,"bin_data":"YmluLWRhdGE=","gender":"female","loc":{"type":"Point","coordinates":[1.1,2]},"graduation":["1932-01-01T00:00:00Z"],"age":38,"sword_present":"true","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000,"~friend":[{"name":"Rick Grimes"}]}]}}`, js)
 }
 
@@ -2000,7 +1761,7 @@ func TestExpandForward(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"q":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}],"power":13.250000,"_xid_":"mich","noindex_name":"Michonne's name not indexed","son":[{"name":"Andre"},{"name":"Helmut"}],"address":"31, 32 street, Jupiter","dob_day":"1910-01-01T00:00:00Z","follow":[{"name":"Glenn Rhee"},{"name":"Andrea"}],"name":"Michonne","path":[{"name":"Glenn Rhee","path|weight":0.200000},{"name":"Andrea","path|weight":0.100000,"path|weight1":0.200000}],"school":[{"name":"School A"}],"full_name":"Michonne's large name for hashing","alive":true,"bin_data":"YmluLWRhdGE=","gender":"female","loc":{"type":"Point","coordinates":[1.1,2]},"graduation":["1932-01-01T00:00:00Z"],"age":38,"sword_present":"true","dob":"1910-01-01T00:00:00Z","survival_rate":98.990000}]}}`, js)
 }
 
@@ -2014,7 +1775,7 @@ func TestExpandReverse(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"q":[{"~friend":[{"name":"Rick Grimes"}]}]}}`, js)
 }
 
@@ -2028,7 +1789,7 @@ func TestUidWithoutDebug(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"q":[{"uid":"0x1"},{"uid":"0x18"}]}}`, js)
 }
 
@@ -2044,7 +1805,7 @@ func TestUidWithoutDebug2(t *testing.T) {
 		}
 	}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"q":[{"uid":"0x1","friend":[{"uid":"0x17"},{"uid":"0x18"},{"uid":"0x19"},{"uid":"0x1f"},{"uid":"0x65"}]}]}}`, js)
 }
 
@@ -2057,6 +1818,6 @@ func TestExpandAll_empty_panic(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"me":[]}}`, js)
 }

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -18,16 +18,9 @@ package query
 
 import (
 	"context"
-	"encoding/binary"
-	"fmt"
-	"reflect"
-	"sort"
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/protos/api"
-	"github.com/dgraph-io/dgraph/gql"
-	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +38,7 @@ func TestToFastJSONFilterUID(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female","friend":[{"uid":"0x1f"}]}]}}`,
 		js)
@@ -66,7 +59,7 @@ func TestToFastJSONFilterOrUID(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female","friend":[{"uid":"0x18","name":"Glenn Rhee"},{"uid":"0x1f","name":"Andrea"}]}]}}`,
 		js)
@@ -87,7 +80,7 @@ func TestToFastJSONFilterOrCount(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"count(friend)":2,"friend": [{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -107,7 +100,7 @@ func TestToFastJSONFilterOrFirst(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Glenn Rhee"},{"name":"Daryl Dixon"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -127,7 +120,7 @@ func TestToFastJSONFilterOrOffset(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Daryl Dixon"},{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -145,7 +138,7 @@ func TestToFastJSONFiltergeName(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"}]}]}}`,
 		js)
@@ -164,7 +157,7 @@ func TestToFastJSONFilterLtAlias(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"alias":"Allan Matt"},{"alias":"Bob Joe"},{"alias":"John Alice"},{"alias":"John Oliver"}]}]}}`,
 		js)
@@ -184,7 +177,7 @@ func TestToFastJSONFilterge1(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -204,7 +197,7 @@ func TestToFastJSONFilterge2(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -224,7 +217,7 @@ func TestToFastJSONFilterGt(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Rick Grimes"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -244,7 +237,7 @@ func TestToFastJSONFilterle(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Daryl Dixon"},{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -264,7 +257,7 @@ func TestToFastJSONFilterLt(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -284,7 +277,7 @@ func TestToFastJSONFilterEqualNoHit(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -303,7 +296,7 @@ func TestToFastJSONFilterEqualName(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Daryl Dixon"}], "gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -323,7 +316,7 @@ func TestToFastJSONFilterEqualNameNoHit(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -343,7 +336,7 @@ func TestToFastJSONFilterEqual(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Daryl Dixon"}], "gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -362,7 +355,7 @@ func TestToFastJSONOrderName(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"alias":"Allan Matt"},{"alias":"Bob Joe"},{"alias":"John Alice"},{"alias":"John Oliver"},{"alias":"Zambo Alice"}],"name":"Michonne"}]}}`,
 		js)
@@ -381,7 +374,7 @@ func TestToFastJSONOrderNameDesc(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"alias":"Zambo Alice"},{"alias":"John Oliver"},{"alias":"John Alice"},{"alias":"Bob Joe"},{"alias":"Allan Matt"}],"name":"Michonne"}]}}`,
 		js)
@@ -400,7 +393,7 @@ func TestToFastJSONOrderName1(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Andrea"},{"name":"Daryl Dixon"},{"name":"Glenn Rhee"},{"name":"Rick Grimes"}],"name":"Michonne"}]}}`,
 		js)
@@ -418,7 +411,7 @@ func TestToFastJSONOrderNameError(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -436,7 +429,7 @@ func TestToFastJSONFilterleOrder(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Andrea"},{"name":"Daryl Dixon"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -456,7 +449,7 @@ func TestToFastJSONFiltergeNoResult(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`, js)
 }
@@ -475,7 +468,7 @@ func TestToFastJSONFirstOffsetOutOfBound(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -496,7 +489,7 @@ func TestToFastJSONFirstOffset(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Glenn Rhee"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -516,7 +509,7 @@ func TestToFastJSONFilterOrFirstOffset(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Daryl Dixon"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -536,7 +529,7 @@ func TestToFastJSONFilterleFirstOffset(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -554,7 +547,7 @@ func TestToFastJSONFilterOrFirstOffsetCount(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"count(friend)":1,"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -576,7 +569,7 @@ func TestToFastJSONFilterOrFirstNegative(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -596,7 +589,7 @@ func TestToFastJSONFilterNot1(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Glenn Rhee"},{"name":"Daryl Dixon"}]}]}}`, js)
 }
@@ -615,7 +608,7 @@ func TestToFastJSONFilterNot2(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Glenn Rhee"}]}]}}`, js)
 }
@@ -634,7 +627,7 @@ func TestToFastJSONFilterNot3(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Daryl Dixon"}]}]}}`, js)
 }
@@ -656,7 +649,7 @@ func TestToFastJSONFilterNot4(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Daryl Dixon"}]}]}}`, js)
 }
@@ -683,7 +676,7 @@ func TestToFastJSONFilterNot4x1000000(t *testing.T) {
 	}
 	`
 
-		js := processToFastJSON(t, query)
+		js := processQueryNoErr(t, query)
 		require.JSONEq(t,
 			`{"data": {"me":[{"gender":"female","name":"Michonne","friend":[{"name":"Daryl Dixon"}]}]}}`, js,
 			"tzdybal: %d", i)
@@ -705,7 +698,7 @@ func TestToFastJSONFilterAnd(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female"}]}}`, js)
 }
@@ -720,7 +713,7 @@ func TestCountReverseFunc(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Glenn Rhee","count(~friend)":2}]}}`,
 		js)
@@ -736,7 +729,7 @@ func TestCountReverseFilter(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Glenn Rhee","count(~friend)":2}]}}`,
 		js)
@@ -752,7 +745,7 @@ func TestCountReverse(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Glenn Rhee","count(~friend)":2}]}}`,
 		js)
@@ -772,7 +765,7 @@ func TestToFastJSONReverse(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Glenn Rhee","~friend":[{"alive":true,"gender":"female","name":"Michonne"},{"alive": false, "name":"Andrea"}]}]}}`,
 		js)
@@ -791,7 +784,7 @@ func TestToFastJSONReverseFilter(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Glenn Rhee","~friend":[{"name":"Andrea"}]}]}}`,
 		js)
@@ -813,7 +806,7 @@ func TestToFastJSONOrder(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female","friend":[{"name":"Andrea","dob":"1901-01-15T00:00:00Z"},{"name":"Daryl Dixon","dob":"1909-01-10T00:00:00Z"},{"name":"Glenn Rhee","dob":"1909-05-05T00:00:00Z"},{"name":"Rick Grimes","dob":"1910-01-02T00:00:00Z"}]}]}}`,
 		js)
@@ -835,7 +828,7 @@ func TestToFastJSONOrderDesc1(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"dob":"1910-01-02T00:00:00Z","name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1901-01-15T00:00:00Z","name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -856,7 +849,7 @@ func TestToFastJSONOrderDesc2(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"dob":"1910-01-02T00:00:00Z","name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1901-01-15T00:00:00Z","name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -878,7 +871,7 @@ func TestToFastJSONOrderDesc_pawan(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"film.film.initial_release_date":"1929-01-10T00:00:00Z","name":"Daryl Dixon"},{"film.film.initial_release_date":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"film.film.initial_release_date":"1900-01-02T00:00:00Z","name":"Rick Grimes"},{"film.film.initial_release_date":"1801-01-15T00:00:00Z","name":"Andrea"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -900,7 +893,7 @@ func TestToFastJSONOrderDedup(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"dob":"1901-01-15T00:00:00Z","name":"Andrea"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1910-01-02T00:00:00Z","name":"Rick Grimes"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -919,7 +912,7 @@ func TestToFastJSONOrderDescCount(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"count(friend)":1,"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -940,7 +933,7 @@ func TestToFastJSONOrderOffset(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Glenn Rhee"},{"name":"Rick Grimes"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
@@ -961,66 +954,10 @@ func TestToFastJSONOrderOffsetCount(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"friend":[{"name":"Glenn Rhee"}],"gender":"female","name":"Michonne"}]}}`,
 		js)
-}
-
-// Mocking Subgraph and Testing fast-json with it.
-func ageSg(uidMatrix []*pb.List, srcUids *pb.List, ages []uint64) *SubGraph {
-	var as []*pb.ValueList
-	for _, a := range ages {
-		bs := make([]byte, 4)
-		binary.LittleEndian.PutUint64(bs, a)
-		as = append(as, &pb.ValueList{
-			Values: []*pb.TaskValue{
-				{Val: []byte(bs), ValType: 2},
-			},
-		})
-	}
-
-	return &SubGraph{
-		Attr:        "age",
-		uidMatrix:   uidMatrix,
-		SrcUIDs:     srcUids,
-		valueMatrix: as,
-		Params:      params{GetUid: true},
-	}
-}
-func nameSg(uidMatrix []*pb.List, srcUids *pb.List, names []string) *SubGraph {
-	var ns []*pb.ValueList
-	for _, n := range names {
-		ns = append(ns, &pb.ValueList{Values: []*pb.TaskValue{{Val: []byte(n), ValType: 0}}})
-	}
-	return &SubGraph{
-		Attr:        "name",
-		uidMatrix:   uidMatrix,
-		SrcUIDs:     srcUids,
-		valueMatrix: ns,
-		Params:      params{GetUid: true},
-	}
-
-}
-func friendsSg(uidMatrix []*pb.List, srcUids *pb.List, friends []*SubGraph) *SubGraph {
-	return &SubGraph{
-		Attr:      "friend",
-		uidMatrix: uidMatrix,
-		SrcUIDs:   srcUids,
-		Params:    params{GetUid: true},
-		Children:  friends,
-	}
-}
-func rootSg(uidMatrix []*pb.List, srcUids *pb.List, names []string, ages []uint64) *SubGraph {
-	nameSg := nameSg(uidMatrix, srcUids, names)
-	ageSg := ageSg(uidMatrix, srcUids, ages)
-
-	return &SubGraph{
-		Children:  []*SubGraph{nameSg, ageSg},
-		Params:    params{GetUid: true},
-		SrcUIDs:   srcUids,
-		uidMatrix: uidMatrix,
-	}
 }
 
 func TestSchema1(t *testing.T) {
@@ -1042,7 +979,7 @@ func TestSchema1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"person":[{"address":"31, 32 street, Jupiter","age":38,"alive":true,"friend":[{"address":"21, mark street, Mars","age":15,"name":"Rick Grimes"},{"name":"Glenn Rhee","age":15},{"age":17,"name":"Daryl Dixon"},{"age":19,"name":"Andrea"}],"name":"Michonne","survival_rate":98.990000}]}}`, js)
 }
@@ -1061,7 +998,7 @@ func TestMultiQuery(t *testing.T) {
 			}
 		}
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"gender":"female","name":"Michonne"}],"you":[{"name":"Andrea"},{"name":"Andrea With no friends"}]}}`, js)
 }
 
@@ -1078,7 +1015,7 @@ func TestMultiQueryError1(t *testing.T) {
       }
     }
   `
-	_, err := gql.Parse(gql.Request{Str: query})
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1097,7 +1034,7 @@ func TestMultiQueryError2(t *testing.T) {
       }
     }
   `
-	_, err := gql.Parse(gql.Request{Str: query})
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1111,7 +1048,7 @@ func TestGenerator(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`, js)
 }
 
@@ -1128,7 +1065,7 @@ func TestGeneratorMultiRootMultiQueryRootval(t *testing.T) {
 			}
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"you":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1147,7 +1084,7 @@ func TestGeneratorMultiRootMultiQueryVarFilter(t *testing.T) {
 			}
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"you":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"}]}]}}`, js)
 }
 
@@ -1163,7 +1100,7 @@ func TestGeneratorMultiRootMultiQueryRootVarFilter(t *testing.T) {
 			}
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"you":[{"name":"Michonne"}, {"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1180,7 +1117,7 @@ func TestGeneratorMultiRootMultiQuery(t *testing.T) {
 			}
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}], "you":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1197,7 +1134,7 @@ func TestGeneratorMultiRootVarOrderOffset(t *testing.T) {
 			}
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1210,7 +1147,7 @@ func TestGeneratorMultiRootVarOrderOffset1(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1226,7 +1163,7 @@ func TestGeneratorMultiRootOrderOffset(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1239,7 +1176,7 @@ func TestGeneratorMultiRootOrderdesc(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"},{"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1252,7 +1189,7 @@ func TestGeneratorMultiRootOrder(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Glenn Rhee"},{"name":"Michonne"},{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1265,7 +1202,7 @@ func TestGeneratorMultiRootOffset(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1278,7 +1215,7 @@ func TestGeneratorMultiRoot(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1289,7 +1226,7 @@ func TestRootList(t *testing.T) {
 		name
 	}
 }`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1300,7 +1237,7 @@ func TestRootList1(t *testing.T) {
 		name
 	}
 }`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Alice"}]}}`, js)
 }
 
@@ -1311,7 +1248,7 @@ func TestRootList2(t *testing.T) {
 		name
 	}
 }`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"},{"name":"Alice"}]}}`, js)
 }
 
@@ -1324,7 +1261,7 @@ func TestGeneratorMultiRootFilter1(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Daryl Dixon"}]}}`, js)
 }
 
@@ -1337,7 +1274,7 @@ func TestGeneratorMultiRootFilter2(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1350,7 +1287,7 @@ func TestGeneratorMultiRootFilter3(t *testing.T) {
       }
     }
   `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1363,10 +1300,7 @@ func TestGeneratorRootFilterOnCountGt(t *testing.T) {
                         }
                 }
         `
-	_, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"}]}}`, js)
 }
 
@@ -1379,10 +1313,8 @@ func TestGeneratorRootFilterOnCountle(t *testing.T) {
                         }
                 }
         `
-	_, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1398,10 +1330,7 @@ func TestGeneratorRootFilterOnCountChildLevel(t *testing.T) {
                         }
                 }
         `
-	_, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Michonne"}],"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1417,10 +1346,7 @@ func TestGeneratorRootFilterOnCountWithAnd(t *testing.T) {
                         }
                 }
         `
-	_, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Michonne"}],"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1435,7 +1361,7 @@ func TestGeneratorRootFilterOnCountError1(t *testing.T) {
                 }
         `
 
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.NotNil(t, err)
 }
 
@@ -1450,7 +1376,7 @@ func TestGeneratorRootFilterOnCountError2(t *testing.T) {
                 }
         `
 
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.NotNil(t, err)
 }
 
@@ -1465,7 +1391,7 @@ func TestGeneratorRootFilterOnCountError3(t *testing.T) {
                 }
         `
 
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1479,7 +1405,7 @@ func TestNearGenerator(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne","gender":"female"},{"name":"Rick Grimes","gender": "male"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1492,7 +1418,7 @@ func TestNearGeneratorFilter(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"gender":"female","name":"Michonne"}]}}`, js)
 }
 
@@ -1505,16 +1431,7 @@ func TestNearGeneratorError(t *testing.T) {
 		}
 	}`
 
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	sg, err := ToSubGraph(ctx, res.Query[0])
-	require.NoError(t, err)
-
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1527,16 +1444,7 @@ func TestNearGeneratorErrorMissDist(t *testing.T) {
 		}
 	}`
 
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	sg, err := ToSubGraph(ctx, res.Query[0])
-	require.NoError(t, err)
-
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1549,16 +1457,7 @@ func TestWithinGeneratorError(t *testing.T) {
 		}
 	}`
 
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	sg, err := ToSubGraph(ctx, res.Query[0])
-	require.NoError(t, err)
-
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1570,7 +1469,7 @@ func TestWithinGenerator(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1582,7 +1481,7 @@ func TestContainsGenerator(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1594,7 +1493,7 @@ func TestContainsGenerator2(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"}]}}`, js)
 }
 
@@ -1606,16 +1505,7 @@ func TestIntersectsGeneratorError(t *testing.T) {
 		}
 	}`
 
-	res, err := gql.Parse(gql.Request{Str: query})
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	sg, err := ToSubGraph(ctx, res.Query[0])
-	require.NoError(t, err)
-
-	ch := make(chan error)
-	go ProcessGraph(ctx, sg, nil, ch)
-	err = <-ch
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -1627,7 +1517,7 @@ func TestIntersectsGenerator(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"}, {"name":"Rick Grimes"}, {"name":"Glenn Rhee"}]}}`, js)
 }
 
@@ -1653,7 +1543,7 @@ func TestNormalizeDirective(t *testing.T) {
 		}
 	`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"d":"1910-01-02T00:00:00Z","fn":"Michonne","mn":"Michonne","n":"Rick Grimes","sn":"Andre"},{"d":"1910-01-02T00:00:00Z","fn":"Michonne","mn":"Michonne","n":"Rick Grimes","sn":"Helmut"},{"d":"1909-05-05T00:00:00Z","mn":"Michonne","n":"Glenn Rhee","sn":"Andre"},{"d":"1909-05-05T00:00:00Z","mn":"Michonne","n":"Glenn Rhee","sn":"Helmut"},{"d":"1909-01-10T00:00:00Z","mn":"Michonne","n":"Daryl Dixon","sn":"Andre"},{"d":"1909-01-10T00:00:00Z","mn":"Michonne","n":"Daryl Dixon","sn":"Helmut"},{"d":"1901-01-15T00:00:00Z","fn":"Glenn Rhee","mn":"Michonne","n":"Andrea","sn":"Andre"},{"d":"1901-01-15T00:00:00Z","fn":"Glenn Rhee","mn":"Michonne","n":"Andrea","sn":"Helmut"}]}}`,
 		js)
@@ -1667,7 +1557,7 @@ func TestNearPoint(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data": {"me":[{"name":"Googleplex"},{"name":"SF Bay area"},{"name":"Mountain View"}]}}`
 	require.JSONEq(t, expected, js)
 }
@@ -1679,7 +1569,7 @@ func TestWithinPolygon(t *testing.T) {
 			name
 		}
 	}`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data": {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"}]}}`
 	require.JSONEq(t, expected, js)
 }
@@ -1692,7 +1582,7 @@ func TestContainsPoint(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data": {"me":[{"name":"SF Bay area"},{"name":"Mountain View"}]}}`
 	require.JSONEq(t, expected, js)
 }
@@ -1705,7 +1595,7 @@ func TestNearPoint2(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data": {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"}, {"name": "SF Bay area"}, {"name": "Mountain View"}]}}`
 	require.JSONEq(t, expected, js)
 }
@@ -1718,7 +1608,7 @@ func TestIntersectsPolygon1(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data" : {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"},
 		{"name":"SF Bay area"},{"name":"Mountain View"}]}}`
 	require.JSONEq(t, expected, js)
@@ -1732,7 +1622,7 @@ func TestIntersectsPolygon2(t *testing.T) {
 		}
 	}`
 
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	expected := `{"data": {"me":[{"name":"Googleplex"},{"name":"Shoreline Amphitheater"},
 			{"name":"San Carlos Airport"},{"name":"SF Bay area"},
 			{"name":"Mountain View"},{"name":"San Carlos"}]}}`
@@ -1752,7 +1642,7 @@ func TestNotExistObject(t *testing.T) {
                         }
                 }
         `
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Michonne","gender":"female","alive":true}]}}`,
 		js)
@@ -1767,7 +1657,7 @@ func TestLangDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Badger"}]}}`,
 		js)
@@ -1784,7 +1674,7 @@ func TestLangMultiple_Alias(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"c":"Badger","a":"Borsuk europejski"}]}}`,
 		js)
@@ -1800,7 +1690,7 @@ func TestLangMultiple(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name":"Badger","name@pl":"Borsuk europejski"}]}}`,
 		js)
@@ -1815,7 +1705,7 @@ func TestLangSingle(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@pl":"Borsuk europejski"}]}}`,
 		js)
@@ -1830,7 +1720,7 @@ func TestLangSingleFallback(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1843,7 +1733,7 @@ func TestLangMany1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@ru:en:fr":"Барсук"}]}}`,
 		js)
@@ -1858,7 +1748,7 @@ func TestLangMany2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@hu:fi:fr":"Blaireau européen"}]}}`,
 		js)
@@ -1873,7 +1763,7 @@ func TestLangMany3(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@hu:fr:fi":"Blaireau européen"}]}}`,
 		js)
@@ -1888,7 +1778,7 @@ func TestLangManyFallback(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1901,7 +1791,7 @@ func TestLangNoFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1914,7 +1804,7 @@ func TestLangSingleNoFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1927,7 +1817,7 @@ func TestLangMultipleNoFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -1940,7 +1830,7 @@ func TestLangOnlyForcedFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	// this test is fragile - '.' may return value in any language (depending on data)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@.":"Artem Tkachenko"}]}}`,
@@ -1956,7 +1846,7 @@ func TestLangSingleForcedFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	// this test is fragile - '.' may return value in any language (depending on data)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@cn:.":"Artem Tkachenko"}]}}`,
@@ -1972,7 +1862,7 @@ func TestLangMultipleForcedFallbackNoDefault(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	// this test is fragile - '.' may return value in any language (depending on data)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@hi:cn:.":"Artem Tkachenko"}]}}`,
@@ -1988,7 +1878,7 @@ func TestLangFilterMatch1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@pl":"Borsuk europejski"}]}}`,
 		js)
@@ -2003,7 +1893,7 @@ func TestLangFilterMismatch1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -2016,7 +1906,7 @@ func TestLangFilterMismatch2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -2029,7 +1919,7 @@ func TestLangFilterMismatch3(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -2042,7 +1932,7 @@ func TestLangFilterMismatch5(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@en":"European badger"},{"name@en":"Honey badger"},{"name@en":"Honey bee"}]}}`,
 		js)
@@ -2057,7 +1947,7 @@ func TestLangFilterMismatch6(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -2070,7 +1960,7 @@ func TestEqWithTerm(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"uid":"0x1392"}]}}`,
 		js)
@@ -2086,7 +1976,7 @@ func TestLangLossyIndex1(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"lossy":"Badger","lossy@en":"European badger"}]}}`,
 		js)
@@ -2102,7 +1992,7 @@ func TestLangLossyIndex2(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"lossy":"Badger","lossy@en":"European badger"}]}}`,
 		js)
@@ -2118,7 +2008,7 @@ func TestLangLossyIndex3(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me": []}}`, js)
 }
 
@@ -2131,7 +2021,7 @@ func TestLangLossyIndex4(t *testing.T) {
 			}
 		}
 	`
-	_, err := processToFastJson(t, query)
+	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
 }
 
@@ -2157,8 +2047,7 @@ func TestLangBug1295(t *testing.T) {
 				}
 			}`
 
-				json, err := processToFastJson(t, query)
-				require.NoError(t, err)
+				json := processQueryNoErr(t, query)
 				if l == "" {
 					require.JSONEq(t, `{"data": {"q": []}}`, json)
 				} else {
@@ -2182,19 +2071,8 @@ func TestLangDotInFunction(t *testing.T) {
 			}
 		}
 	`
-	js := processToFastJsonNoErr(t, query)
+	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"name@pl":"Borsuk europejski","name@en":"European badger"},{"name@en":"Honey badger"},{"name@en":"Honey bee"}]}}`,
 		js)
-}
-
-func checkSchemaNodes(t *testing.T, expected []*api.SchemaNode, actual []*api.SchemaNode) {
-	sort.Slice(expected, func(i, j int) bool {
-		return expected[i].Predicate >= expected[j].Predicate
-	})
-	sort.Slice(actual, func(i, j int) bool {
-		return actual[i].Predicate >= actual[j].Predicate
-	})
-	require.True(t, reflect.DeepEqual(expected, actual),
-		fmt.Sprintf("Expected: %+v \nReceived: %+v \n", expected, actual))
 }


### PR DESCRIPTION
Some of the tests in query1_test.go were checking the subgraphs produced
by the query directly. I have removed these tests since such internal
state will not be available when we moved to use the cluster for all
tests and the queries being performed by these tests are simple and
should be already covered by the remaining tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2982)
<!-- Reviewable:end -->
