### PR TITLE
Update test cluster configuration with --data and --tmpfs options.

### DIFF
--- a/dgraph/docker-compose-data.yml
+++ b/dgraph/docker-compose-data.yml
@@ -1,0 +1,36 @@
+# Docker compose file for testing that includes Jaeger tracing. Use it with:
+# ./run.sh --data $HOME/dg
+# This would pick up dgraph binary from $GOPATH.
+
+version: "3.5"
+services:
+  zero1:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data
+  zero2:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data
+  zero3:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data
+  dg1:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data
+  dg2:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data
+  dg3:
+    volumes:
+      - type: bind
+        source: "${DATA}"
+        target: /data

--- a/dgraph/docker-compose-tmpfs.yml
+++ b/dgraph/docker-compose-tmpfs.yml
@@ -1,0 +1,24 @@
+# Docker compose file for testing WAL directories mounted in tmpfs. Use it with:
+# ./run.sh --tmpfs
+# This would pick up dgraph binary from $GOPATH.
+
+version: "3.5"
+services:
+  zero1:
+    tmpfs:
+      - /data/dg0.1/zw
+  zero2:
+    tmpfs:
+      - /data/dg0.2/zw
+  zero3:
+    tmpfs:
+      - /data/dg0.3/zw
+  dg1:
+    tmpfs:
+      - /data/dg1/w
+  dg2:
+    tmpfs:
+      - /data/dg2/w
+  dg3:
+    tmpfs:
+      - /data/dg3/w

--- a/dgraph/prometheus.yml
+++ b/dgraph/prometheus.yml
@@ -7,11 +7,14 @@ scrape_configs:
     static_configs:
       - targets:
         - 'bank-dg1:8180'
+        - 'bank-dg2:8182'
+        - 'bank-dg3:8183'
         - 'bank-dg0.1:6080'
+        - 'bank-dg0.2:6082'
+        - 'bank-dg0.3:6083'
   - job_name: 'node-exporter'
     scrape_interval: 15s
     metrics_path: '/metrics'
     static_configs:
       - targets:
         - 'node-exporter:9100'
-    

--- a/dgraph/run.sh
+++ b/dgraph/run.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 COMPOSE_FILES=( -f docker-compose.yml )
 SERVICES=()
-for o in $@; do
-    case $o in
+
+while (( "$#" )); do
+    case "$1" in
         '-h'|'--help' )
             cat <<EOF
 Runs the Dgraph test cluster.
 
 Available options:
 
-    --jaeger   Run with Jaeger tracing enabled.
-    --single   Run a single Zero and Alpha (2-node cluster).
-    --metrics  Run with metrics collection and dashboard (Prometheus/Grafana/Node Exporter).
+    --jaeger       Run with Jaeger tracing enabled.
+    --single       Run a single Zero and Alpha (2-node cluster).
+    --metrics      Run with metrics collection and dashboard (Prometheus/Grafana/Node Exporter).
+    --data <path>  Run with Dgraph data directories mounted to <path>.
+    --tmpfs        Run with WAL directories (w/zw) in-memory with tmpfs.
 EOF
             exit 0
             ;;
@@ -22,13 +25,29 @@ EOF
             COMPOSE_FILES+=( -f docker-compose-metrics.yml )
             ;;
         '--single' )
-            SERVICES=( zero1 dg1 )
+            SERVICES+=( zero1 dg1 )
             if [[ " ${COMPOSE_FILES[@]} " =~ "docker-compose-jaeger.yml" ]]; then
                 SERVICES+=( jaeger )
             fi
             if [[ " ${COMPOSE_FILES[@]} " =~ "docker-compose-metrics.yml" ]]; then
                 SERVICES+=( node-exporter prometheus grafana )
             fi
+            ;;
+        '--data' )
+            DATA="$2"
+            shift
+            if [ -z "${DATA}" ]; then
+                echo "--data option missing <path>"
+                exit 1
+            fi
+            if [ ! -d "$DATA" ]; then
+                echo "Directory does not exist: $DATA"
+            fi
+            COMPOSE_FILES+=( -f docker-compose-data.yml )
+            echo "Running with Dgraph data directories mounted at $DATA"
+            ;;
+        '--tmpfs' )
+            COMPOSE_FILES+=( -f docker-compose-tmpfs.yml )
             ;;
         *)
             echo "Unknown option $1"
@@ -40,5 +59,4 @@ done
 
 make install
 docker-compose ${COMPOSE_FILES[@]} down
-DATA=$HOME/dg docker-compose ${COMPOSE_FILES[@]} up --force-recreate --remove-orphans ${SERVICES[@]}
-
+DATA=$DATA docker-compose ${COMPOSE_FILES[@]} up --force-recreate --remove-orphans ${SERVICES[@]}


### PR DESCRIPTION
* ./run.sh --data <path> will mount all Zero and Alpha directories to the host
  path mounted at <path>.
* ./run.sh --tmpfs will mount WAL (w/zw) directories in tmpfs.
* docker-compose-data.yml extends the base docker-compose.yml to mount data directories.
* docker-compose-tmpfs.yml extends the base docker-compose.yml to mount WAL directories in tmpfs.
* Update prometheus.yml config to include all Zeros and Alphas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2984)
<!-- Reviewable:end -->
