### PR TITLE
Remove hacky test fix in ChecksumsMatch.

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -359,11 +359,6 @@ func (g *groupi) ServesGroup(gid uint32) bool {
 }
 
 func (g *groupi) ChecksumsMatch(ctx context.Context) error {
-	// HACK
-	// Add a GroupChecksum to make groups().ChecksumsMatch work. Hacky as hell.
-	if x.IsTestRun() {
-		return nil
-	}
 	if atomic.LoadUint64(&g.deltaChecksum) == atomic.LoadUint64(&g.membershipChecksum) {
 		return nil
 	}


### PR DESCRIPTION
All tests in the query package have been modified to use the cluster
instead of the old ad-hoc setup so this fix is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2985)
<!-- Reviewable:end -->
