### PR TITLE
Use lexer iterator to output error messages.

### DIFF
--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -232,8 +232,8 @@ func TestParse3_Error(t *testing.T) {
 func TestParse4_Error(t *testing.T) {
 	reset()
 	result, err := Parse("alive:bool @index(geo) .")
-	require.Equal(t, "Tokenizer: geo isn't valid for predicate: alive of type: bool",
-		err.Error())
+	require.Contains(t, err.Error(),
+		"Tokenizer: geo isn't valid for predicate: alive of type: bool")
 	require.Nil(t, result)
 }
 


### PR DESCRIPTION
Replace calls to x.Errorf with calls to it.Item().Errorf where possible
so that the error messages outputed by the schema parser contain the
line and column numbers of where the error occurred.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2986)
<!-- Reviewable:end -->
