### PR TITLE
x/keys.go: added IsPredicateReserved to replace x.InitialPreds

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -320,7 +320,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 
 	if len(op.DropAttr) > 0 {
 		// Reserved predicates cannot be dropped.
-		if _, ok := x.InitialPreds[op.DropAttr]; ok {
+		if x.IsPredicateReserved(op.DropAttr) {
 			err := fmt.Errorf("predicate %s is reserved and is not allowed to be dropped",
 				op.DropAttr)
 			return nil, err
@@ -349,7 +349,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 
 	// Reserved predicates cannot be altered.
 	for _, update := range result.Schemas {
-		if _, ok := x.InitialPreds[update.Predicate]; ok {
+		if IsPredicateReserved(update.Predicate) {
 			err := fmt.Errorf("predicate %s is reserved and is not allowed to be modified",
 				update.Predicate)
 			return nil, err

--- a/posting/index.go
+++ b/posting/index.go
@@ -989,8 +989,7 @@ func DeleteAll() error {
 			return true
 		} else if pk.IsSchema() {
 			// Don't delete schema for _predicate_
-			_, isInitialPred := x.InitialPreds[pk.Attr]
-			return !isInitialPred
+			return !x.IsPredicateReserved(pk.Attr)
 		}
 		return true
 	})

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -59,8 +59,7 @@ func (s *state) DeleteAll() {
 
 	for pred := range s.predicate {
 		// We set schema for _predicate_, hence it shouldn't be deleted.
-		_, isInitialPred := x.InitialPreds[pred]
-		if !isInitialPred {
+		if !x.IsPredicateReserved(pred) {
 			delete(s.predicate, pred)
 		}
 	}

--- a/x/keys.go
+++ b/x/keys.go
@@ -296,3 +296,17 @@ func Parse(key []byte) *ParsedKey {
 	}
 	return p
 }
+
+// IsPredicateReserved returns true if 'pred' is in the reserved predicate list.
+func IsPredicateReserved(pred string) bool {
+	var m = map[string]struct{}{
+		PredicateListAttr:   {},
+		"dgraph.xid":        {},
+		"dgraph.password":   {},
+		"dgraph.user.group": {},
+		"dgraph.group.acl":  {},
+		"type":              {},
+	}
+	_, ok := m[pred]
+	return ok
+}

--- a/x/x.go
+++ b/x/x.go
@@ -83,15 +83,7 @@ const (
 var (
 	// Useful for running multiple servers on the same machine.
 	regExpHostName = regexp.MustCompile(ValidHostnameRegex)
-	InitialPreds   = map[string]struct{}{
-		PredicateListAttr:   {},
-		"dgraph.xid":        {},
-		"dgraph.password":   {},
-		"dgraph.user.group": {},
-		"dgraph.group.acl":  {},
-		"type":              {},
-	}
-	Nilbyte []byte
+	Nilbyte        []byte
 )
 
 func ShouldCrash(err error) bool {


### PR DESCRIPTION
Updated all references to x.InitialPreds with IsPredicateReserved()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2992)
<!-- Reviewable:end -->
