### PR TITLE
Update test cluster configuration for jaeger and metrics.

### DIFF
--- a/dgraph/docker-compose-jaeger.yml
+++ b/dgraph/docker-compose-jaeger.yml
@@ -34,4 +34,4 @@ services:
     # --memory.max-traces to some number if you don't want to store all traces
     # indefinitely.
     command:
-      - --memory.max-traces=1000
+      - --memory.max-traces=1000000

--- a/dgraph/docker-compose-jaeger.yml
+++ b/dgraph/docker-compose-jaeger.yml
@@ -33,5 +33,5 @@ services:
     # The jaeger all-in-one container stores all traces in memory. Set
     # --memory.max-traces to some number if you don't want to store all traces
     # indefinitely.
-    # command:
-    #   - --memory.max-traces=1000
+    command:
+      - --memory.max-traces=1000

--- a/dgraph/docker-compose-metrics.yml
+++ b/dgraph/docker-compose-metrics.yml
@@ -1,4 +1,7 @@
 version: "3.5"
+volumes:
+  prometheus-volume:
+  grafana-volume:
 services:
   node-exporter:
     image: quay.io/prometheus/node-exporter
@@ -16,6 +19,9 @@ services:
     ports:
       - "9090:9090"
     volumes:
+      - type: volume
+        source: prometheus-volume
+        target: /prometheus
       - type: bind
         source: $GOPATH/src/github.com/dgraph-io/dgraph/dgraph/prometheus.yml
         target: /etc/prometheus/prometheus.yml
@@ -26,3 +32,11 @@ services:
     hostname: grafana
     ports:
      - "3000:3000"
+    environment:
+      # Skip login
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - type: volume
+        source: grafana-volume
+        target: /var/lib/grafana


### PR DESCRIPTION
- Fix bug where `--single` needed to be set last in the command line or else the
  other services from --jaeger or --metrics wouldn't start up.
- Prometheus and Grafana data is now stored in a Docker volume for persistence
  across test runs. Grafana is set for anonymous login to skip the default
  admin login page.
- Jaeger's in-memory store option `--memory.max-traces` is set to 1000 to store
  the most recent 1000 traces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2994)
<!-- Reviewable:end -->
