### PR TITLE
Default value should not be nil

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1681,7 +1681,7 @@ func (sg *SubGraph) fillVars(mp map[string]varValue) error {
 					// Provide a default value for valueVarAggregation() to eval val().
 					// This is a noop for aggregation funcs that would fail.
 					// The zero aggs won't show because there are no uids matched.
-					mp[v.Name].Vals[0] = types.Val{Value: ""}
+					mp[v.Name].Vals[0] = types.Val{}
 					sg.Params.uidToVal = mp[v.Name].Vals
 				}
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -1681,7 +1681,7 @@ func (sg *SubGraph) fillVars(mp map[string]varValue) error {
 					// Provide a default value for valueVarAggregation() to eval val().
 					// This is a noop for aggregation funcs that would fail.
 					// The zero aggs won't show because there are no uids matched.
-					mp[v.Name].Vals[0] = types.Val{}
+					mp[v.Name].Vals[0] = types.Val{Value: ""}
 					sg.Params.uidToVal = mp[v.Name].Vals
 				}
 			}

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -353,6 +353,12 @@ func Marshal(from Val, to *Val) error {
 			return cantConvert(fromID, toID)
 		}
 	case StringID, DefaultID:
+		// This is a default value from sg.fillVars, don't convert it's empty.
+		// Fixes issue #2295.
+		if fromID == DefaultID && val == nil {
+			*res = ""
+			break
+		}
 		vc := val.(string)
 		switch toID {
 		case StringID, DefaultID:

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -344,7 +344,7 @@ func Marshal(from Val, to *Val) error {
 	// This is a default value from sg.fillVars, don't convert it's empty.
 	// Fixes issue #2980.
 	if val == nil {
-		*res = ValueForType(toID).Value
+		*to = ValueForType(toID)
 		return nil
 	}
 

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -354,7 +354,7 @@ func Marshal(from Val, to *Val) error {
 		}
 	case StringID, DefaultID:
 		// This is a default value from sg.fillVars, don't convert it's empty.
-		// Fixes issue #2295.
+		// Fixes issue #2980.
 		if fromID == DefaultID && val == nil {
 			*res = ""
 			break

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -341,6 +341,13 @@ func Marshal(from Val, to *Val) error {
 	val := from.Value
 	res := &to.Value
 
+	// This is a default value from sg.fillVars, don't convert it's empty.
+	// Fixes issue #2980.
+	if val == nil {
+		*res = ValueForType(toID).Value
+		return nil
+	}
+
 	switch fromID {
 	case BinaryID:
 		vc := val.([]byte)
@@ -353,12 +360,6 @@ func Marshal(from Val, to *Val) error {
 			return cantConvert(fromID, toID)
 		}
 	case StringID, DefaultID:
-		// This is a default value from sg.fillVars, don't convert it's empty.
-		// Fixes issue #2980.
-		if fromID == DefaultID && val == nil {
-			*res = ""
-			break
-		}
 		vc := val.(string)
 		switch toID {
 		case StringID, DefaultID:

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -336,6 +336,10 @@ func Convert(from Val, toID TypeID) (Val, error) {
 }
 
 func Marshal(from Val, to *Val) error {
+	if to == nil {
+		return x.Errorf("Invalid conversion %s to nil", from.Tid.Name())
+	}
+
 	fromID := from.Tid
 	toID := to.Tid
 	val := from.Value


### PR DESCRIPTION
`types.Marshal()` expects vars to have non-nil values, this change
set empty string as the default value for a referenced empty
var. This should prevent nil-reference panic in `types.Marshal()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2995)
<!-- Reviewable:end -->
