### PR TITLE
Reserved predicates should act as case-insensitive.

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -170,6 +170,14 @@ func alterReservedPredicates(t *testing.T, dg *dgo.Dgraph) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(),
 		"predicate dgraph.xid is reserved and is not allowed to be dropped")
+
+	// Test that reserved predicates act as case-insensitive.
+	err = dg.Alter(ctx, &api.Operation{
+		Schema: "dgraph.XID: int .",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(),
+		"predicate dgraph.XID is reserved and is not allowed to be modified")
 }
 
 func queryPredicateWithUserAccount(t *testing.T, dg *dgo.Dgraph, shouldFail bool) {

--- a/x/keys.go
+++ b/x/keys.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"strings"
 )
 
 const (
@@ -307,6 +308,6 @@ func IsReservedPredicate(pred string) bool {
 		"dgraph.group.acl":  {},
 		"type":              {},
 	}
-	_, ok := m[pred]
+	_, ok := m[strings.ToLower(pred)]
 	return ok
 }


### PR DESCRIPTION
Users should not be able to create preds that match the name of a
reserved predicate in everything except the case. For example a
predicate named Type or Dgraph.XID should be disallowed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2997)
<!-- Reviewable:end -->
