### PR TITLE
Optimize XidtoUID map used by live and bulk loader

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -224,7 +224,7 @@ func (ld *loader) mapStage() {
 	for i := range ld.mappers {
 		ld.mappers[i] = nil
 	}
-	// ld.xids.EvictAll()
+	x.Check(ld.xids.Flush())
 	x.Check(ld.xidDB.Close())
 	ld.xids = nil
 	runtime.GC()

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -147,6 +147,7 @@ func readSchema(filename string) []*pb.SchemaUpdate {
 func (ld *loader) mapStage() {
 	ld.prog.setPhase(mapPhase)
 
+	// TODO: Consider if we need to always store the XIDs in Badger. Things slow down if we do.
 	xidDir := filepath.Join(ld.opt.TmpDir, "xids")
 	x.Check(os.Mkdir(xidDir, 0755))
 	opt := badger.DefaultOptions
@@ -157,7 +158,7 @@ func (ld *loader) mapStage() {
 	var err error
 	ld.xidDB, err = badger.Open(opt)
 	x.Check(err)
-	ld.xids = xidmap.New(ld.xidDB, ld.zero)
+	ld.xids = xidmap.New(ld.zero, ld.xidDB)
 
 	var dir, ext string
 	var loaderType int

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -157,10 +157,7 @@ func (ld *loader) mapStage() {
 	var err error
 	ld.xidDB, err = badger.Open(opt)
 	x.Check(err)
-	ld.xids = xidmap.New(ld.xidDB, ld.zero, xidmap.Options{
-		NumShards: 1 << 10,
-		LRUSize:   1 << 19,
-	})
+	ld.xids = xidmap.New(ld.xidDB, ld.zero)
 
 	var dir, ext string
 	var loaderType int
@@ -226,7 +223,7 @@ func (ld *loader) mapStage() {
 	for i := range ld.mappers {
 		ld.mappers[i] = nil
 	}
-	ld.xids.EvictAll()
+	// ld.xids.EvictAll()
 	x.Check(ld.xidDB.Close())
 	ld.xids = nil
 	runtime.GC()

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -217,8 +217,8 @@ func (m *mapper) processNQuad(nq gql.NQuad) {
 }
 
 func (m *mapper) lookupUid(xid string) uint64 {
-	uid, isNew := m.xids.AssignUid(xid)
-	if !isNew || !m.opt.StoreXids {
+	uid := m.xids.AssignUid(xid)
+	if !m.opt.StoreXids {
 		return uid
 	}
 	if strings.HasPrefix(xid, "_:") {

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -188,15 +188,18 @@ func (l *loader) makeRequests() {
 }
 
 func (l *loader) printCounters() {
-	l.ticker = time.NewTicker(2 * time.Second)
+	period := 5 * time.Second
+	l.ticker = time.NewTicker(period)
 	start := time.Now()
 
+	var last Counter
 	for range l.ticker.C {
 		counter := l.Counter()
-		rate := float64(counter.Nquads) / counter.Elapsed.Seconds()
+		rate := float64(counter.Nquads-last.Nquads) / period.Seconds()
 		elapsed := time.Since(start).Round(time.Second)
-		fmt.Printf("[%6s] Txns: %d N-Quads: %d N-Quads/sec: %5.0f Aborts: %d\n",
+		fmt.Printf("[%6s] Txns: %d N-Quads: %d N-Quads/s [last 5s]: %5.0f Aborts: %d\n",
 			elapsed, counter.TxnsDone, counter.Nquads, rate, counter.Aborts)
+		last = counter
 	}
 }
 

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -63,7 +63,7 @@ type loader struct {
 	dc         *dgo.Dgraph
 	alloc      *xidmap.XidMap
 	ticker     *time.Ticker
-	kv         *badger.DB
+	db         *badger.DB
 	requestsWg sync.WaitGroup
 	// If we retry a request, we add one to retryRequestsWg.
 	retryRequestsWg sync.WaitGroup

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -244,10 +244,10 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph) *loader {
 	if len(opt.clientDir) > 0 {
 		x.Check(os.MkdirAll(opt.clientDir, 0700))
 		o := badger.DefaultOptions
-		o.SyncWrites = true // So that checkpoints are persisted immediately.
-		o.TableLoadingMode = bopt.MemoryMap
 		o.Dir = opt.clientDir
 		o.ValueDir = opt.clientDir
+		o.TableLoadingMode = bopt.MemoryMap
+		o.SyncWrites = false
 
 		var err error
 		db, err = badger.Open(o)
@@ -319,7 +319,6 @@ func run() error {
 
 	l := setup(bmOpts, dgraphClient)
 	defer l.zeroconn.Close()
-	defer l.db.Close()
 
 	if len(opt.schemaFile) > 0 {
 		if err := processSchemaFile(ctx, opt.schemaFile, dgraphClient); err != nil {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -290,7 +290,7 @@ func ValidateAndConvert(edge *pb.DirectedEdge, su *pb.SchemaUpdate) error {
 		return x.Errorf("Input for predicate %s of type uid is scalar", edge.Attr)
 
 	case schemaType.IsScalar() && !storageType.IsScalar():
-		return x.Errorf("Input for predicate %s of type scalar is uid", edge.Attr)
+		return x.Errorf("Input for predicate %s of type scalar is uid. Edge: %v", edge.Attr, edge)
 
 	// The suggested storage type matches the schema, OK!
 	case storageType == schemaType && schemaType != types.DefaultID:

--- a/x/x.go
+++ b/x/x.go
@@ -433,7 +433,7 @@ func SetupConnection(host string, tlsConf *TLSHelperConfig, useGz bool) (*grpc.C
 		grpc.WithBlock(),
 		grpc.WithTimeout(10*time.Second))
 
-	if tlsConf.CertRequired {
+	if tlsConf != nil && tlsConf.CertRequired {
 		tlsConf.ConfigType = TLSClientConfig
 		tlsCfg, _, err := GenerateTLSConfig(*tlsConf)
 		if err != nil {

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -17,7 +17,6 @@
 package xidmap
 
 import (
-	"container/list"
 	"context"
 	"encoding/binary"
 	"sync"
@@ -28,56 +27,32 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	farm "github.com/dgryski/go-farm"
 	"github.com/golang/glog"
 )
-
-// Options controls the performance characteristics of the XidMap.
-type Options struct {
-	// NumShards controls the number of shards the XidMap is broken into. More
-	// shards reduces lock contention.
-	NumShards int
-	// LRUSize controls the total size of the LRU cache. The LRU is split
-	// between all shards, so with 4 shards and an LRUSize of 100, each shard
-	// receives 25 LRU slots.
-	LRUSize int
-}
 
 // XidMap allocates and tracks mappings between Xids and Uids in a threadsafe
 // manner. It's memory friendly because the mapping is stored on disk, but fast
 // because it uses an LRU cache.
 type XidMap struct {
-	shards    []shard
-	kv        *badger.DB
-	opt       Options
-	newRanges chan *pb.AssignedIds
-
-	noMapMu sync.Mutex
-	noMap   block // block for allocating uids without an xid to uid mapping
-}
-
-type shard struct {
 	sync.Mutex
-	block
+	kv *badger.DB
+	// opt       Options
+	newRanges chan *pb.AssignedIds
+	uidMap    sync.Map
+	writer    *badger.WriteBatch
 
-	elems        map[string]*list.Element
-	queue        *list.List
-	beingEvicted map[string]uint64
-
-	xm *XidMap
-}
-
-type mapping struct {
-	xid       string
-	uid       uint64
-	persisted bool
+	block *block
 }
 
 type block struct {
+	sync.Mutex
 	start, end uint64
 }
 
 func (b *block) assign(ch <-chan *pb.AssignedIds) uint64 {
+	b.Lock()
+	defer b.Unlock()
+
 	if b.end == 0 || b.start > b.end {
 		newRange := <-ch
 		b.start, b.end = newRange.StartId, newRange.EndId
@@ -89,19 +64,14 @@ func (b *block) assign(ch <-chan *pb.AssignedIds) uint64 {
 }
 
 // New creates an XidMap with given badger and uid provider.
-func New(kv *badger.DB, zero *grpc.ClientConn, opt Options) *XidMap {
-	x.AssertTrue(opt.LRUSize != 0)
-	x.AssertTrue(opt.NumShards != 0)
+func New(kv *badger.DB, zero *grpc.ClientConn) *XidMap {
+	// x.AssertTrue(opt.LRUSize != 0)
+	// x.AssertTrue(opt.NumShards != 0)
 	xm := &XidMap{
-		shards:    make([]shard, opt.NumShards),
 		kv:        kv,
-		opt:       opt,
-		newRanges: make(chan *pb.AssignedIds),
-	}
-	for i := range xm.shards {
-		xm.shards[i].elems = make(map[string]*list.Element)
-		xm.shards[i].queue = list.New()
-		xm.shards[i].xm = xm
+		newRanges: make(chan *pb.AssignedIds, 10),
+		writer:    kv.NewWriteBatch(),
+		block:     new(block),
 	}
 	go func() {
 		zc := pb.NewZeroClient(zero)
@@ -110,7 +80,8 @@ func New(kv *badger.DB, zero *grpc.ClientConn, opt Options) *XidMap {
 		backoff := initBackoff
 		for {
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			assigned, err := zc.AssignUids(ctx, &pb.Num{Val: 10000})
+			assigned, err := zc.AssignUids(ctx, &pb.Num{Val: 1e5})
+			glog.V(1).Infof("Assigned Uids: %+v. Err: %v", assigned, err)
 			cancel()
 			if err == nil {
 				backoff = initBackoff
@@ -130,104 +101,61 @@ func New(kv *badger.DB, zero *grpc.ClientConn, opt Options) *XidMap {
 }
 
 // AssignUid creates new or looks up existing XID to UID mappings.
-func (m *XidMap) AssignUid(xid string) (uid uint64, isNew bool) {
-	fp := farm.Fingerprint64([]byte(xid))
-	idx := fp % uint64(m.opt.NumShards)
-	sh := &m.shards[idx]
-
-	sh.Lock()
-	defer sh.Unlock()
-
-	var ok bool
-	uid, ok = sh.lookup(xid)
+func (m *XidMap) AssignUid(xid string) (uid uint64) {
+	val, ok := m.uidMap.Load(xid)
 	if ok {
-		return uid, false
+		return val.(uint64)
 	}
+	// TODO: Load up the xid->uid map upfront.
 
-	x.Check(m.kv.View(func(txn *badger.Txn) error {
-		item, err := txn.Get([]byte(xid))
-		if err == badger.ErrKeyNotFound {
-			return nil
+	// fp := farm.Fingerprint64([]byte(xid))
+	// idx := fp % uint64(m.opt.NumShards)
+	// sh := &m.shards[idx]
+
+	// sh.Lock()
+	// defer sh.Unlock()
+
+	// var ok bool
+	// uid, ok = sh.lookup(xid)
+	// if ok {
+	// 	return uid, false
+	// }
+
+	// x.Check(m.kv.View(func(txn *badger.Txn) error {
+	// 	item, err := txn.Get([]byte(xid))
+	// 	if err == badger.ErrKeyNotFound {
+	// 		return nil
+	// 	}
+	// 	x.Check(err)
+	// 	return item.Value(func(uidBuf []byte) error {
+	// 		x.AssertTrue(len(uidBuf) > 0)
+	// 		var n int
+	// 		uid, n = binary.Uvarint(uidBuf)
+	// 		x.AssertTrue(n == len(uidBuf))
+	// 		ok = true
+	// 		return nil
+	// 	})
+	// }))
+	// if ok {
+	// 	sh.add(xid, uid, true)
+	// 	return uid, false
+	// }
+
+	uid = m.block.assign(m.newRanges)
+	val, loaded := m.uidMap.LoadOrStore(xid, uid)
+	uid = val.(uint64)
+	if !loaded {
+		// This uid was stored.
+		var uidBuf [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(uidBuf[:], uid)
+		if err := m.writer.Set([]byte(xid), uidBuf[:n], 0); err != nil {
+			panic(err)
 		}
-		x.Check(err)
-		return item.Value(func(uidBuf []byte) error {
-			x.AssertTrue(len(uidBuf) > 0)
-			var n int
-			uid, n = binary.Uvarint(uidBuf)
-			x.AssertTrue(n == len(uidBuf))
-			ok = true
-			return nil
-		})
-	}))
-	if ok {
-		sh.add(xid, uid, true)
-		return uid, false
 	}
-
-	uid = sh.assign(m.newRanges)
-	sh.add(xid, uid, false)
-	return uid, true
+	return uid
 }
 
 // AllocateUid gives a single uid without creating an xid to uid mapping.
 func (m *XidMap) AllocateUid() uint64 {
-	m.noMapMu.Lock()
-	defer m.noMapMu.Unlock()
-	return m.noMap.assign(m.newRanges)
-}
-
-func (s *shard) lookup(xid string) (uint64, bool) {
-	elem, ok := s.elems[xid]
-	if ok {
-		s.queue.MoveToBack(elem)
-		return elem.Value.(*mapping).uid, true
-	}
-	if uid, ok := s.beingEvicted[xid]; ok {
-		s.add(xid, uid, true)
-		return uid, true
-	}
-	return 0, false
-}
-
-func (s *shard) add(xid string, uid uint64, persisted bool) {
-	lruSizePerShard := s.xm.opt.LRUSize / s.xm.opt.NumShards
-	if s.queue.Len() >= lruSizePerShard && len(s.beingEvicted) == 0 {
-		s.evict(0.5)
-	}
-
-	m := &mapping{
-		xid:       xid,
-		uid:       uid,
-		persisted: persisted,
-	}
-	elem := s.queue.PushBack(m)
-	s.elems[xid] = elem
-}
-
-func (m *XidMap) EvictAll() {
-	for i := range make([]struct{}, len(m.shards)) {
-		m.shards[i].Lock()
-		m.shards[i].evict(1.0)
-		m.shards[i].Unlock()
-	}
-}
-
-func (s *shard) evict(ratio float64) {
-	evict := int(float64(s.queue.Len()) * ratio)
-	s.beingEvicted = make(map[string]uint64)
-	txn := s.xm.kv.NewTransaction(true)
-	defer txn.Discard()
-	for i := 0; i < evict; i++ {
-		m := s.queue.Remove(s.queue.Front()).(*mapping)
-		delete(s.elems, m.xid)
-		s.beingEvicted[m.xid] = m.uid
-		if !m.persisted {
-			var uidBuf [binary.MaxVarintLen64]byte
-			n := binary.PutUvarint(uidBuf[:], m.uid)
-			txn.Set([]byte(m.xid), uidBuf[:n])
-		}
-
-	}
-	x.Check(txn.Commit())
-	s.beingEvicted = nil
+	return m.block.assign(m.newRanges)
 }

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -153,8 +153,8 @@ func (m *XidMap) AssignUid(xid string) uint64 {
 	return newUid
 }
 
-// BumpUp can be used to make Zero allocate UIDs up to this given number.
-func (m *XidMap) BumpUp(uid uint64) {
+// BumpTo can be used to make Zero allocate UIDs up to this given number.
+func (m *XidMap) BumpTo(uid uint64) {
 	m.RLock()
 	end := m.block.end
 	m.RUnlock()
@@ -192,5 +192,8 @@ func (m *XidMap) AllocateUid() uint64 {
 
 // Flush must be called if DB is provided to XidMap.
 func (m *XidMap) Flush() error {
+	if m.writer == nil {
+		return nil
+	}
 	return m.writer.Flush()
 }

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -125,8 +125,8 @@ func New(zero *grpc.ClientConn, db *badger.DB) *XidMap {
 			glog.V(1).Infof("Assigned Uids: %+v. Err: %v", assigned, err)
 			cancel()
 			if err == nil {
-				xm.updateMaxSeen(assigned.EndId)
 				backoff = initBackoff
+				xm.updateMaxSeen(assigned.EndId)
 				xm.newRanges <- assigned
 				continue
 			}

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -57,7 +57,7 @@ type block struct {
 	start, end uint64
 }
 
-// This must already have a write lock.
+// assign assumes the write lock is already acquired.
 func (b *block) assign(ch <-chan *pb.AssignedIds) uint64 {
 	if b.end == 0 || b.start > b.end {
 		newRange := <-ch
@@ -195,7 +195,7 @@ func (m *XidMap) updateMaxSeen(max uint64) {
 }
 
 // BumpTo can be used to make Zero allocate UIDs up to this given number. Attempts are made to
-// ensure all future allocations of UIDs be higher than this one, but result is not guaranteed.
+// ensure all future allocations of UIDs be higher than this one, but results are not guaranteed.
 func (m *XidMap) BumpTo(uid uint64) {
 	curMax := atomic.LoadUint64(&m.maxUidSeen)
 	if uid <= curMax {

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -49,9 +49,8 @@ func TestXidmap(t *testing.T) {
 
 		to := xidmap.AllocateUid() + uint64(1e6+3)
 		xidmap.BumpTo(to)
-		uid := xidmap.AllocateUid()
+		uid := xidmap.AllocateUid() // Does not have to be above the bump.
 		t.Logf("bump up to: %d. allocated: %d", to, uid)
-		require.True(t, uid > to, "to: %d. Got: %d", to, uid)
 
 		require.NoError(t, xidmap.Flush())
 		xidmap = nil

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -4,8 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/x"
@@ -13,7 +16,7 @@ import (
 )
 
 // Opens a badger db and runs a a test on it.
-func runTest(t *testing.T, test func(t *testing.T, xidmap *XidMap)) {
+func withDB(t *testing.T, test func(db *badger.DB)) {
 	dir, err := ioutil.TempDir(".", "badger-test")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
@@ -26,44 +29,95 @@ func runTest(t *testing.T, test func(t *testing.T, xidmap *XidMap)) {
 	require.NoError(t, err)
 	defer db.Close()
 
+	test(db)
+}
+
+func TestXidmap(t *testing.T) {
 	conn, err := x.SetupConnection("localhost:5080", nil, false)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 
-	xidmap := New(db, conn)
-	test(t, xidmap)
-}
+	withDB(t, func(db *badger.DB) {
+		xidmap := New(conn, db)
 
-func TestXidmap(t *testing.T) {
-	runTest(t, func(t *testing.T, xidmap *XidMap) {
 		uida := xidmap.AssignUid("a")
 		require.Equal(t, uida, xidmap.AssignUid("a"))
 
 		uidb := xidmap.AssignUid("b")
 		require.True(t, uida != uidb)
 		require.Equal(t, uidb, xidmap.AssignUid("b"))
+
+		to := xidmap.block.end + 1e6 + 3
+		xidmap.BumpUp(to)
+		uid := xidmap.AllocateUid()
+		t.Logf("bump up to: %d. allocated: %d", to, uid)
+		require.True(t, uid > to, "to: %d. Got: %d", to, uid)
+
+		require.NoError(t, xidmap.Flush())
+		xidmap = nil
+
+		xidmap2 := New(conn, db)
+		require.Equal(t, uida, xidmap2.AssignUid("a"))
+		require.Equal(t, uidb, xidmap2.AssignUid("b"))
 	})
 }
 
+func TestXidmapMemory(t *testing.T) {
+	var loop uint32
+	bToMb := func(b uint64) uint64 {
+		return b / 1024 / 1024
+	}
+	printMemory := func() {
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		// For info on each, see: https://golang.org/pkg/runtime/#MemStats
+		fmt.Printf(" Heap = %v M", bToMb(m.HeapInuse))
+		fmt.Printf(" Alloc = %v M", bToMb(m.Alloc))
+		fmt.Printf(" Sys = %v M", bToMb(m.Sys))
+		fmt.Printf(" Loop = %.2fM", float64(atomic.LoadUint32(&loop))/1e6)
+		fmt.Printf(" NumGC = %v\n", m.NumGC)
+	}
+	go func() {
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			printMemory()
+		}
+	}()
+
+	conn, err := x.SetupConnection("localhost:5080", nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	xidmap := New(conn, nil)
+
+	start := time.Now()
+	var wg sync.WaitGroup
+	for numGo := 0; numGo < 32; numGo++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				i := atomic.AddUint32(&loop, 1)
+				if i > 50e6 {
+					return
+				}
+				xidmap.AssignUid(fmt.Sprintf("xid-%d", i))
+			}
+		}()
+	}
+	wg.Wait()
+	t.Logf("Time taken: %v", time.Since(start).Round(time.Millisecond))
+}
+
 func BenchmarkXidmap(b *testing.B) {
-	dir, err := ioutil.TempDir(".", "badger-test")
-	x.Check(err)
-	defer os.RemoveAll(dir)
-
-	opt := badger.LSMOnlyOptions
-	opt.Dir = dir
-	opt.ValueDir = dir
-
-	db, err := badger.Open(opt)
-	x.Check(err)
-	defer db.Close()
-
 	conn, err := x.SetupConnection("localhost:5080", nil, false)
 	x.Check(err)
 	x.AssertTrue(conn != nil)
 
 	var counter uint64
-	xidmap := New(db, conn)
+	xidmap := New(conn, nil)
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -47,7 +47,7 @@ func TestXidmap(t *testing.T) {
 		require.True(t, uida != uidb)
 		require.Equal(t, uidb, xidmap.AssignUid("b"))
 
-		to := xidmap.block.end + 1e6 + 3
+		to := xidmap.AllocateUid() + uint64(1e6+3)
 		xidmap.BumpTo(to)
 		uid := xidmap.AllocateUid()
 		t.Logf("bump up to: %d. allocated: %d", to, uid)

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -1,0 +1,75 @@
+package xidmap
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dgraph-io/badger"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+// Opens a badger db and runs a a test on it.
+func runTest(t *testing.T, test func(t *testing.T, xidmap *XidMap)) {
+	dir, err := ioutil.TempDir(".", "badger-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	opt := badger.LSMOnlyOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	db, err := badger.Open(opt)
+	require.NoError(t, err)
+	defer db.Close()
+
+	conn, err := x.SetupConnection("localhost:5080", nil, false)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+
+	xidmap := New(db, conn)
+	test(t, xidmap)
+}
+
+func TestXidmap(t *testing.T) {
+	runTest(t, func(t *testing.T, xidmap *XidMap) {
+		uida := xidmap.AssignUid("a")
+		require.Equal(t, uida, xidmap.AssignUid("a"))
+
+		uidb := xidmap.AssignUid("b")
+		require.True(t, uida != uidb)
+		require.Equal(t, uidb, xidmap.AssignUid("b"))
+	})
+}
+
+func BenchmarkXidmap(b *testing.B) {
+	dir, err := ioutil.TempDir(".", "badger-test")
+	x.Check(err)
+	defer os.RemoveAll(dir)
+
+	opt := badger.LSMOnlyOptions
+	opt.Dir = dir
+	opt.ValueDir = dir
+
+	db, err := badger.Open(opt)
+	x.Check(err)
+	defer db.Close()
+
+	conn, err := x.SetupConnection("localhost:5080", nil, false)
+	x.Check(err)
+	x.AssertTrue(conn != nil)
+
+	var counter uint64
+	xidmap := New(db, conn)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			xid := atomic.AddUint64(&counter, 1)
+			xidmap.AssignUid(fmt.Sprintf("xid-%d", xid))
+		}
+	})
+}

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -48,7 +48,7 @@ func TestXidmap(t *testing.T) {
 		require.Equal(t, uidb, xidmap.AssignUid("b"))
 
 		to := xidmap.block.end + 1e6 + 3
-		xidmap.BumpUp(to)
+		xidmap.BumpTo(to)
 		uid := xidmap.AllocateUid()
 		t.Logf("bump up to: %d. allocated: %d", to, uid)
 		require.True(t, uid > to, "to: %d. Got: %d", to, uid)


### PR DESCRIPTION
I've spent the last few days looking at how to optimize the live mutation path in Dgraph server. While trying many things in the server (past commits included), I realized my optimizations in the server are not improving things much, the throughput saturating at 20-30K NQuads/sec.

Turns out, it was the live loader which was causing the saturation. The XID to UID assigner was the bottleneck causing the throughput to stagnate, despite the server being underutilized.

This PR fixes that by optimizing the assigner. In particular, I've removed the slow LRU cache. Added buffer to `newRanges` channel to ensure we always have a range handy when we run out. Made passing badger DB instance optional, so we can avoid doing disk writes if not required. And made other optimizations around how we lock, etc. I also added benchmarks for the assigner, which shows each allocation (tested via parallel benchmark) takes 350 ns/op on my desktop.

With these changes, the live loader throughput jumps to 100K-120K NQuads/sec on my desktop. In particular, pre-assigning UIDs to the RDF/JSON file yields maximum throughput. I can load 140M friend graph RDFs in 25 mins.

Helps with #2975 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/2998)
<!-- Reviewable:end -->
