### PR TITLE
Fix bug retrieving reverse edges of non-list uid predicates.

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -358,9 +358,6 @@ func populateCluster(t *testing.T) {
 		<31> <survival_rate> "1.6" .
 
 		<1> <school> <5000> .
-		<2> <school> <5000> .
-		<3> <school> <5000> .
-		<4> <school> <5001> .
 		<23> <school> <5001> .
 		<24> <school> <5000> .
 		<25> <school> <5000> .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -201,7 +201,7 @@ pass                           : password .
 symbol                         : string @index(exact) .
 room                           : string @index(term) .
 office.room                    : [uid] .
-best_friend                    : uid .
+best_friend                    : uid @reverse .
 `
 
 func populateCluster(t *testing.T) {
@@ -280,6 +280,8 @@ func populateCluster(t *testing.T) {
 		<23> <friend> <1> .
 
 		<2> <best_friend> <64> .
+		<3> <best_friend> <64> .
+		<4> <best_friend> <64> .
 
 		<1> <age> "38" .
 		<23> <age> "15" .
@@ -349,6 +351,9 @@ func populateCluster(t *testing.T) {
 		<31> <survival_rate> "1.6" .
 
 		<1> <school> <5000> .
+		<2> <school> <5000> .
+		<3> <school> <5000> .
+		<4> <school> <5001> .
 		<23> <school> <5001> .
 		<24> <school> <5000> .
 		<25> <school> <5000> .

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -229,7 +229,7 @@ func TestNonListUidPredicateReverse2(t *testing.T) {
 			me(func: uid(0x40)) {
 				uid
 				~best_friend {
-					school {
+					pet {
 						name
 					}
 					uid
@@ -240,9 +240,9 @@ func TestNonListUidPredicateReverse2(t *testing.T) {
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
 		`{"data": {"me":[{"uid":"0x40", "~best_friend": [
-			{"uid":"0x2","school":[{"name":"School A"}]},
-			{"uid":"0x3","school":[{"name":"School A"}]},
-			{"uid":"0x4","school":[{"name":"School B"}]}]}]}}`,
+			{"uid":"0x2","pet":[{"name":"Garfield"}]},
+			{"uid":"0x3","pet":[{"name":"Bear"}]},
+			{"uid":"0x4","pet":[{"name":"Nemo"}]}]}]}}`,
 		js)
 }
 

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -206,6 +206,46 @@ func TestGetNonListUidPredicate(t *testing.T) {
 		js)
 }
 
+func TestNonListUidPredicateReverse1(t *testing.T) {
+	query := `
+		{
+			me(func: uid(0x40)) {
+				uid
+				~best_friend {
+					uid
+				}
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"me":[{"uid":"0x40", "~best_friend": [{"uid":"0x2"},{"uid":"0x3"},{"uid":"0x4"}]}]}}`,
+		js)
+}
+
+func TestNonListUidPredicateReverse2(t *testing.T) {
+	query := `
+		{
+			me(func: uid(0x40)) {
+				uid
+				~best_friend {
+					school {
+						name
+					}
+					uid
+				}
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"me":[{"uid":"0x40", "~best_friend": [
+			{"uid":"0x2","school":[{"name":"School A"}]},
+			{"uid":"0x3","school":[{"name":"School A"}]},
+			{"uid":"0x4","school":[{"name":"School B"}]}]}]}}`,
+		js)
+}
+
 func TestGeAge(t *testing.T) {
 	query := `{
 		  senior_citizens(func: ge(age, 75)) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -770,6 +770,12 @@ func (qs *queryState) helpProcessTask(
 	out.List = schema.State().IsList(attr)
 	srcFn.atype = typ
 
+	// Reverse attributes might have more than 1 results even if the original attribute
+	// is not a list.
+	if q.Reverse {
+		out.List = true
+	}
+
 	opts := posting.ListOptions{
 		ReadTs:   q.ReadTs,
 		AfterUID: uint64(q.AfterUid),


### PR DESCRIPTION
Reverse edges of a non-list uid predicate were not being treated as a
list, causing parts of the results to be dropped and have a weird
format.

This change fixes the bug and adds a couple of regression tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3005)
<!-- Reviewable:end -->
