### PR TITLE
Allow multiple values for binary operators

### DIFF
--- a/gql/math.go
+++ b/gql/math.go
@@ -167,7 +167,7 @@ func evalMathStack(opStack, valueStack *mathTreeStack, flip bool) error {
 // pass the eval to evalMathStack for normal eval.
 // Returns nil if the operation was added to the valueStack, otherwise an error.
 func evalMVBStack(opStack, valueStack *mathTreeStack, op string) error {
-	flip := isBinary(op) && valueStack.size() > 2
+	flip := (op == "min" || op == "max") && valueStack.size() > 2
 	if flip {
 		for valueStack.reverse(); valueStack.size() > 2; {
 			opStack.push(&MathTree{Fn: op})

--- a/gql/math.go
+++ b/gql/math.go
@@ -108,7 +108,7 @@ func evalMathStack(opStack, valueStack *mathTreeStack) error {
 		if err != nil {
 			return x.Errorf("Invalid math statement. Expected 1 operand")
 		}
-		if !opStack.empty() {
+		if opStack.size() > 1 {
 			peekOp := opStack.peek()
 			if (peekOp.Fn == "/" || peekOp.Fn == "%") && isZero(topOp.Fn, topVal.Const) {
 				return x.Errorf("Division by zero")

--- a/gql/math.go
+++ b/gql/math.go
@@ -161,12 +161,12 @@ func evalMathStack(opStack, valueStack *mathTreeStack, flip bool) error {
 	return nil
 }
 
-// evalMVBStack determines if op is a multi-value binary (MVB) operation.
+// evalMultiStack determines if op is a multi-value binary (MVB) operation.
 // If the operation is MVB, it will reverse value stack and flip order of operands to
 // do a commutative eval of the values in valueStack. If the operation is not MVB, it will
 // pass the eval to evalMathStack for normal eval.
 // Returns nil if the operation was added to the valueStack, otherwise an error.
-func evalMVBStack(opStack, valueStack *mathTreeStack, op string) error {
+func evalMultiStack(opStack, valueStack *mathTreeStack, op string) error {
 	flip := (op == "min" || op == "max") && valueStack.size() > 2
 	if flip {
 		for valueStack.reverse(); valueStack.size() > 2; {
@@ -295,7 +295,7 @@ func parseMathFunc(it *lex.ItemIterator, again bool, oper string) (*MathTree, bo
 				if topOp.Fn == "(" {
 					break
 				}
-				err := evalMVBStack(opStack, valueStack, oper)
+				err := evalMultiStack(opStack, valueStack, oper)
 				if err != nil {
 					return nil, false, err
 				}
@@ -322,7 +322,7 @@ func parseMathFunc(it *lex.ItemIterator, again bool, oper string) (*MathTree, bo
 				if topOp.Fn == "(" {
 					break
 				}
-				err := evalMVBStack(opStack, valueStack, oper)
+				err := evalMultiStack(opStack, valueStack, oper)
 				if err != nil {
 					return nil, false, err
 				}

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2549,7 +2549,7 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				if varName == "" && alias == "" {
 					return it.Errorf("Function math should be used with a variable or have an alias")
 				}
-				mathTree, again, err := parseMathFunc(it, false)
+				mathTree, again, err := parseMathFunc(it, false, "")
 				if err != nil {
 					return err
 				}

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -556,6 +556,21 @@ func TestBinaryMultipleValues5(t *testing.T) {
 	require.Contains(t, err.Error(), "Expected one item in value stack, but got 2")
 }
 
+func TestBinaryMultipleValues6(t *testing.T) {
+	query := `
+	{
+		var(func:uid(0x1)) {
+			z as math(max(1,2,3) - (3 / min(1,3)))
+		}
+		q(func:uid(0x1)) {
+			val(z)
+		}
+	}`
+	_, err := processQuery(t, context.Background(), query)
+	require.NoError(t, err)
+	// require.Contains(t, err.Error(), "Expected one item in value stack, but got 2")
+}
+
 func TestDuplicateAlias(t *testing.T) {
 
 	query := `

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -532,6 +532,38 @@ func TestBinaryMultipleValues3(t *testing.T) {
 	}`, js)
 }
 
+func TestBinaryMultipleValues4(t *testing.T) {
+	query := `
+	{
+		var(func:uid(0x1)) {
+			x0 as math(pow(pow(pow(2,2),3),4))
+			x1 as math(pow(2,2,3,4))
+  		y0 as math(logbase(logbase(16,2),2))
+			y1 as math(logbase(16,2,2))
+		}
+		q(func:uid(0x1)) {
+			val(x0)
+			val(x1)
+			val(y0)
+			val(y1)
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+	{
+		"data": {
+			"q": [
+				{
+					"val(x0)": 16777216.000000,
+					"val(x1)": 16777216.000000,
+					"val(y0)": 2.000000,
+					"val(y1)": 2.000000
+				}
+			]
+		}
+	}`, js)
+}
+
 func TestDuplicateAlias(t *testing.T) {
 
 	query := `

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -426,7 +426,7 @@ func TestMultipleMinMax(t *testing.T) {
 		js)
 }
 
-func TestBinaryMultipleValues(t *testing.T) {
+func TestBinaryMultipleValues1(t *testing.T) {
 	query := `
 	{
 		var(func:uid(0x1)) {
@@ -452,6 +452,80 @@ func TestBinaryMultipleValues(t *testing.T) {
 					"val(y)": 0.000000,
 					"val(z)": 256.000000,
 					"val(w)": 1.000000
+				}
+			]
+		}
+	}`, js)
+}
+
+func TestBinaryMultipleValues2(t *testing.T) {
+	query := `
+	{
+		var(func:uid(0x1)) {
+			x as math(max(max(max(3,5),20),1))
+			y as math(max(1,max(20,max(3,5))))
+			z as math(max(1,20,3,5))
+		}
+		q(func:uid(0x1)) {
+			val(x)
+			val(y)
+			val(z)
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+	{
+		"data": {
+			"q": [
+				{
+					"val(x)": 20.000000,
+					"val(y)": 20.000000,
+					"val(z)": 20.000000
+				}
+			]
+		}
+	}`, js)
+}
+
+func TestBinaryMultipleValues3(t *testing.T) {
+	query := `
+	{
+		var(func:uid(0x1)) {
+			x as math(
+				logbase(
+					pow(
+						max(1,2,3),
+						min(3,4,5)
+					),
+					max(1,2,3)
+				)
+			)
+			y as math(
+				min(
+					max(
+						min(1,2,3),
+						max(4,5,6)
+					),
+					min(
+						max(4,5,6),
+						min(7,8,9)
+					)
+				)
+			)
+		}
+		q(func:uid(0x1)) {
+			val(x)
+			val(y)
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+	{
+		"data": {
+			"q": [
+				{
+					"val(x)": 3.000000,
+					"val(y)": 6.000000
 				}
 			]
 		}

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -432,14 +432,10 @@ func TestBinaryMultipleValues1(t *testing.T) {
 		var(func:uid(0x1)) {
 			x as math(max(1,2,3,1,2,3,4,1,1,1,11,2,2,1,10))
 			y as math(min(1,2,3,4,0,5,6,7,1))
-			z as math(pow(2,2,2,2))
-			w as math(logbase(256,16,2))
 		}
 		q(func:uid(0x1)) {
 			val(x)
 			val(y)
-			val(z)
-			val(w)
 		}
 	}`
 	js := processQueryNoErr(t, query)
@@ -449,9 +445,7 @@ func TestBinaryMultipleValues1(t *testing.T) {
 			"q": [
 				{
 					"val(x)": 11.000000,
-					"val(y)": 0.000000,
-					"val(z)": 256.000000,
-					"val(w)": 1.000000
+					"val(y)": 0.000000
 				}
 			]
 		}
@@ -536,32 +530,30 @@ func TestBinaryMultipleValues4(t *testing.T) {
 	query := `
 	{
 		var(func:uid(0x1)) {
-			x0 as math(pow(pow(pow(2,2),3),4))
-			x1 as math(pow(2,2,3,4))
-  		y0 as math(logbase(logbase(16,2),2))
-			y1 as math(logbase(16,2,2))
+			z as math(pow(2,2,2,2))
 		}
 		q(func:uid(0x1)) {
-			val(x0)
-			val(x1)
-			val(y0)
-			val(y1)
+			val(z)
 		}
 	}`
-	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `
+	_, err := processQuery(t, context.Background(), query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected one item in value stack, but got 3")
+}
+
+func TestBinaryMultipleValues5(t *testing.T) {
+	query := `
 	{
-		"data": {
-			"q": [
-				{
-					"val(x0)": 16777216.000000,
-					"val(x1)": 16777216.000000,
-					"val(y0)": 2.000000,
-					"val(y1)": 2.000000
-				}
-			]
+		var(func:uid(0x1)) {
+			z as math(logbase(256,16,2))
 		}
-	}`, js)
+		q(func:uid(0x1)) {
+			val(z)
+		}
+	}`
+	_, err := processQuery(t, context.Background(), query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Expected one item in value stack, but got 2")
 }
 
 func TestDuplicateAlias(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -426,6 +426,38 @@ func TestMultipleMinMax(t *testing.T) {
 		js)
 }
 
+func TestBinaryMultipleValues(t *testing.T) {
+	query := `
+	{
+		var(func:uid(0x1)) {
+			x as math(max(1,2,3,1,2,3,4,1,1,1,11,2,2,1,10))
+			y as math(min(1,2,3,4,0,5,6,7,1))
+			z as math(pow(2,2,2,2))
+			w as math(logbase(256,16,2))
+		}
+		q(func:uid(0x1)) {
+			val(x)
+			val(y)
+			val(z)
+			val(w)
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+	{
+		"data": {
+			"q": [
+				{
+					"val(x)": 11.000000,
+					"val(y)": 0.000000,
+					"val(z)": 256.000000,
+					"val(w)": 1.000000
+				}
+			]
+		}
+	}`, js)
+}
+
 func TestDuplicateAlias(t *testing.T) {
 
 	query := `


### PR DESCRIPTION
This PR allows using multiple values in binary operations: `max()`, `min()`.
It works by pre-evaluating the stack when 2 values already exist for the same operator.
This usage does not extend to `pow()` or `logbase()`.

Example query:
```
{
  var(func:uid(0x1)) {
    x as math(max(max(max(3,5),20),1))
    y as math(max(1,max(20,max(3,5))))
    z as math(max(1,20,3,5))
  }
  q(func:uid(0x1)) {
    val(x)
    val(y)
    val(z)
  }
}
```
Result:
```json
{
  "data": {
    "q": [
      {
        "val(x)": 20.000000,
        "val(y)": 20.000000,
        "val(z)": 20.000000
      }
    ]
  }
}
```
~~No breaking changes expected.~~ The math eval logic has changed when min/max binary operators are used.

Closes #1050

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3008)
<!-- Reviewable:end -->
