### PR TITLE
Change /commit endpoint to accept a list of preds.

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -318,19 +318,20 @@ func commitHandler(w http.ResponseWriter, r *http.Request) {
 	tc.StartTs = ts
 
 	// Keys are sent as an array in the body.
-	keys := readRequest(w, r)
-	if keys == nil {
+	reqText := readRequest(w, r)
+	if reqText == nil {
 		return
 	}
 
-	var encodedKeys []string
-	if err := json.Unmarshal([]byte(keys), &encodedKeys); err != nil {
+	var reqMap map[string][]string
+	if err := json.Unmarshal(reqText, &reqMap); err != nil {
 		x.SetStatus(w, x.ErrorInvalidRequest,
 			"Error while unmarshalling keys header into array")
 		return
 	}
 
-	tc.Keys = encodedKeys
+	tc.Keys = reqMap["keys"]
+	tc.Preds = reqMap["preds"]
 
 	cts, err := worker.CommitOverNetwork(context.Background(), tc)
 	if err != nil {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -332,6 +333,8 @@ func commitHandler(w http.ResponseWriter, r *http.Request) {
 
 	tc.Keys = reqMap["keys"]
 	tc.Preds = reqMap["preds"]
+	sort.Strings(tc.Keys)
+	sort.Strings(tc.Preds)
 
 	cts, err := worker.CommitOverNetwork(context.Background(), tc)
 	if err != nil {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -273,6 +273,8 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 		Txn:     resp.Context,
 		Latency: resp.Latency,
 	}
+	sort.Strings(e.Txn.Keys)
+	sort.Strings(e.Txn.Preds)
 
 	// Don't send keys array which is part of txn context if its commit immediately.
 	if mu.CommitNow {
@@ -333,8 +335,6 @@ func commitHandler(w http.ResponseWriter, r *http.Request) {
 
 	tc.Keys = reqMap["keys"]
 	tc.Preds = reqMap["preds"]
-	sort.Strings(tc.Keys)
-	sort.Strings(tc.Preds)
 
 	cts, err := worker.CommitOverNetwork(context.Background(), tc)
 	if err != nil {

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -128,12 +128,12 @@ func runQuery(q string) (string, error) {
 }
 
 func runMutation(m string) error {
-	_, _, err := mutationWithTs(m, false, true, false, 0)
+	_, _, _, err := mutationWithTs(m, false, true, false, 0)
 	return err
 }
 
 func runJsonMutation(m string) error {
-	_, _, err := mutationWithTs(m, true, true, false, 0)
+	_, _, _, err := mutationWithTs(m, true, true, false, 0)
 	return err
 }
 


### PR DESCRIPTION
Previously the commit endpoint accepted a list of keys. Now it accepts a
map with two keys, one whose value represents the keys and the other
represents the preds.

Fixes #3012

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3020)
<!-- Reviewable:end -->
