### PR TITLE
Add .vscode directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ dgraph.iml
 
 # Output of the go coverage tool
 *.out
+
+# Vscode configuration files
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dgraph.iml
 
 # Output of the go coverage tool
 *.out
+.vscode


### PR DESCRIPTION
This PR adds `.vscode` directory to gitignore. 
The directory stores configuration files for vscode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3028)
<!-- Reviewable:end -->
