### PR TITLE
Issue 3026: Don't blindly replace the bulk out directory.

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -155,10 +155,11 @@ func run() {
 		log.Fatal(http.ListenAndServe(opt.HttpAddr, nil))
 	}()
 
-	// Delete and recreate the output dirs to ensure they are empty.
-	x.Check(os.RemoveAll(opt.DgraphsDir))
+	// Delete and recreate the shard output dirs to ensure they are empty without destroying
+	// existing non-shard data, if any.
 	for i := 0; i < opt.ReduceShards; i++ {
 		dir := filepath.Join(opt.DgraphsDir, strconv.Itoa(i), "p")
+		x.Check(os.RemoveAll(dir))
 		x.Check(os.MkdirAll(dir, 0700))
 		opt.shardOutputDirs = append(opt.shardOutputDirs, dir)
 	}


### PR DESCRIPTION
Put the bulk shard directories in the out directory without destroying other data already there, if any.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3034)
<!-- Reviewable:end -->
