### PR TITLE
query/query.go: var assignment was missing map init

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1419,6 +1419,7 @@ func (sg *SubGraph) populateUidValVar(doneVars map[string]varValue, sgPath []*Su
 		doneVars[sg.Params.Var] = varValue{
 			strList: sg.valueMatrix,
 			path:    sgPath,
+			Vals:    make(map[uint64]types.Val),
 		}
 	} else if len(sg.counts) > 0 {
 		// This implies it is a value variable.
@@ -1445,6 +1446,7 @@ func (sg *SubGraph) populateUidValVar(doneVars map[string]varValue, sgPath []*Su
 			doneVars[sg.Params.Var] = varValue{
 				Uids: uids,
 				path: sgPath,
+				Vals: make(map[uint64]types.Val),
 			}
 			return nil
 		}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1627,6 +1627,37 @@ func TestNestedFuncRoot4(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"name":"Rick Grimes"},{"name":"Andrea"}]}}`, js)
 }
 
+func TestDefaultValueVar1(t *testing.T) {
+	query := `
+	{
+		var(func: has(pred)) {
+			n as uid
+			cnt as count(_predicate_)
+		}
+
+		data(func: uid(n)) @filter(gt(val(cnt), 4)) {
+			expand(_all_)
+		}
+	}`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"data":[]}}`, js)
+}
+
+func TestDefaultValueVar2(t *testing.T) {
+	query := `
+	{
+		var(func: uid(0x1)) {
+			cnt as _predicate_
+		}
+
+		data(func: uid(0x1)) {
+			val(cnt)
+		}
+	}`
+	js := processToFastJsonNoErr(t, query)
+	require.JSONEq(t, `{"data": {"data":[]}}`, js)
+}
+
 var maxPendingCh chan uint64
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
varValue assignments were missing map initialization for Vars
field causing panic when accessed later in fillVars().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3043)
<!-- Reviewable:end -->
