### PR TITLE
Reject requests with predicates larger than the max size allowed.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -856,7 +856,7 @@ func validateQuery(queries []*gql.GraphQuery) error {
 func validatePredName(name string) error {
 	if len(name) > math.MaxUint16 {
 		return fmt.Errorf("Predicate name length cannot be bigger than 2^16. Predicate: %v",
-		name[:80])
+			name[:80])
 	}
 	return nil
 }

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -1972,5 +1972,5 @@ func TestMaxPredicateSize(t *testing.T) {
 
 	_, err := processQuery(t, context.Background(), query)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+	require.Contains(t, err.Error(), "Predicate name length cannot be bigger than 2^16")
 }

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -19,6 +19,8 @@ package query
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1948,4 +1950,27 @@ func TestMultipleTypeDirectivesInPredicate(t *testing.T) {
 	`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"enemy":[{"name":"Margaret", "pet":[{"name":"Bear"}]}, {"name":"Leonard"}]}]}}`, js)
+}
+
+func TestMaxPredicateSize(t *testing.T) {
+	// Create a string that has more than than 2^16 chars.
+	var b strings.Builder
+	for i := 0; i < 10000; i++ {
+		b.WriteString("abcdefg")
+	}
+	largePred := b.String()
+
+	query := fmt.Sprintf(`
+		{
+			me(func: uid(0x2)) {
+				%s {
+					name
+				}
+			}
+		}
+	`, largePred)
+
+	_, err := processQuery(t, context.Background(), query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
 }

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -1694,7 +1694,7 @@ func MaxPredicateSize(t *testing.T, c *dgo.Dgraph) {
 		Schema: fmt.Sprintf(`%s: uid @reverse .`, largePred),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+	require.Contains(t, err.Error(), "Predicate name length cannot be bigger than 2^16")
 
 	// Verify that Mutate requests with predicates that are too large are rejected.
 	txn := c.NewTxn()
@@ -1703,7 +1703,7 @@ func MaxPredicateSize(t *testing.T, c *dgo.Dgraph) {
 		SetNquads: []byte(fmt.Sprintf(`_:test <%s> "value" .`, largePred)),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+	require.Contains(t, err.Error(), "Predicate name length cannot be bigger than 2^16")
 	_ = txn.Discard(ctx)
 
 	// Do the same thing as above but for the predicates in DelNquads.
@@ -1714,5 +1714,5 @@ func MaxPredicateSize(t *testing.T, c *dgo.Dgraph) {
 		DelNquads: []byte(fmt.Sprintf(`_:test <%s> "value" .`, largePred)),
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+	require.Contains(t, err.Error(), "Predicate name length cannot be bigger than 2^16")
 }

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -79,6 +79,7 @@ func TestSystem(t *testing.T) {
 	t.Run("has should not have deleted edge", wrap(HasDeletedEdge))
 	t.Run("has should have reverse edges", wrap(HasReverseEdge))
 	t.Run("facet json input supports anyofterms query", wrap(FacetJsonInputSupportsAnyOfTerms))
+	t.Run("max predicate size", wrap(MaxPredicateSize))
 }
 
 func FacetJsonInputSupportsAnyOfTerms(t *testing.T, c *dgo.Dgraph) {
@@ -1677,4 +1678,41 @@ func HasReverseEdge(t *testing.T, c *dgo.Dgraph) {
 
 	require.Equal(t, len(revs), 1)
 	require.Equal(t, revs[0].Name, "carol")
+}
+
+func MaxPredicateSize(t *testing.T, c *dgo.Dgraph) {
+	// Create a string that has more than than 2^16 chars.
+	var b strings.Builder
+	for i := 0; i < 10000; i++ {
+		b.WriteString("abcdefg")
+	}
+	largePred := b.String()
+
+	// Verify that Alter requests with predicates that are too large are rejected.
+	ctx := context.Background()
+	err := c.Alter(ctx, &api.Operation{
+		Schema: fmt.Sprintf(`%s: uid @reverse .`, largePred),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+
+	// Verify that Mutate requests with predicates that are too large are rejected.
+	txn := c.NewTxn()
+	_, err = txn.Mutate(ctx, &api.Mutation{
+		CommitNow: true,
+		SetNquads: []byte(fmt.Sprintf(`_:test <%s> "value" .`, largePred)),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
+	_ = txn.Discard(ctx)
+
+	// Do the same thing as above but for the predicates in DelNquads.
+	txn = c.NewTxn()
+	defer txn.Discard(ctx)
+	_, err = txn.Mutate(ctx, &api.Mutation{
+		CommitNow: true,
+		DelNquads: []byte(fmt.Sprintf(`_:test <%s> "value" .`, largePred)),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Predicate size cannot be bigger than 2^16")
 }


### PR DESCRIPTION
This change introduces checks in server.go to verify that Alter,
Mutation, and Query requests that includes predicates larger than 2^16
characters are rejected before being processed.

Fixes #3049

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3052)
<!-- Reviewable:end -->
