### PR TITLE
Fix flaky checks inn http_test.go

### DIFF
--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -262,7 +262,7 @@ func TestTransactionBasic(t *testing.T) {
 	require.Equal(t, 3, len(preds))
 	var parsedPreds []string
 	for _, pred := range preds {
-		parsedPreds = append(parsedPreds, strings.Split(pred, "-")[1])
+		parsedPreds = append(parsedPreds, strings.Join(strings.Split(pred, "-")[1:], "-"))
 	}
 	sort.Strings(parsedPreds)
 	require.Equal(t, "_predicate_", parsedPreds[0])

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -259,9 +260,14 @@ func TestTransactionBasic(t *testing.T) {
 	require.Equal(t, mts, ts)
 	require.Equal(t, 3, len(keys))
 	require.Equal(t, 3, len(preds))
-	require.Equal(t, "1-_predicate_", preds[0])
-	require.Equal(t, "1-balance", preds[1])
-	require.Equal(t, "1-name", preds[2])
+	var parsedPreds []string
+	for _, pred := range preds {
+		parsedPreds = append(parsedPreds, strings.Split(pred, "-")[1])
+	}
+	sort.Strings(parsedPreds)
+	require.Equal(t, "_predicate_", parsedPreds[0])
+	require.Equal(t, "balance", parsedPreds[1])
+	require.Equal(t, "name", parsedPreds[2])
 
 	data, _, err := queryWithTs(q1, 0)
 	require.NoError(t, err)


### PR DESCRIPTION
The list of predicates returned by the mutate endpoint are of the form
<group_id>-<predicate>. The existing test was assuming all predicates
landed in group 1, which is not always the case.

This change parsed those predicates to ensure that the checks pass
regardless of the group on which the predicates landed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3056)
<!-- Reviewable:end -->
