### PR TITLE
Bulk multi-shard DBs fix 

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -238,9 +238,16 @@ func (ld *loader) reduceStage() {
 }
 
 func (ld *loader) writeSchema() {
+	m := make(map[string]struct{})
 	for _, db := range ld.dbs {
-		ld.schema.write(db)
+		preds := ld.schema.getPredicates(db)
+		ld.schema.write(db, preds)
+		for _, p := range preds {
+			m[p] = struct{}{}
+		}
 	}
+	// Diff against the schema provided, and write those out.
+
 }
 
 func (ld *loader) cleanup() {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -125,9 +125,15 @@ func run() {
 	if opt.SchemaFile == "" {
 		fmt.Fprint(os.Stderr, "Schema file must be specified.\n")
 		os.Exit(1)
+	} else if _, err := os.Stat(opt.SchemaFile); err != nil && os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Schema path(%v) does not exist.\n", opt.SchemaFile)
+		os.Exit(1)
 	}
 	if opt.DataFiles == "" {
 		fmt.Fprint(os.Stderr, "RDF or JSON file(s) location must be specified.\n")
+		os.Exit(1)
+	} else if _, err := os.Stat(opt.DataFiles); err != nil && os.IsNotExist(err) {
+		fmt.Fprintf(os.Stderr, "Data path(%v) does not exist .\n", opt.DataFiles)
 		os.Exit(1)
 	}
 	if opt.ReduceShards > opt.MapShards {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -133,7 +133,7 @@ func run() {
 		fmt.Fprint(os.Stderr, "RDF or JSON file(s) location must be specified.\n")
 		os.Exit(1)
 	} else if _, err := os.Stat(opt.DataFiles); err != nil && os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Data path(%v) does not exist .\n", opt.DataFiles)
+		fmt.Fprintf(os.Stderr, "Data path(%v) does not exist.\n", opt.DataFiles)
 		os.Exit(1)
 	}
 	if opt.ReduceShards > opt.MapShards {

--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -117,7 +117,7 @@ func (s *schemaStore) getPredicates(db *badger.DB) []string {
 	return preds
 }
 
-func (s *schemaStore) write(db *badger.DB) {
+func (s *schemaStore) write(db *badger.DB, preds []string) {
 	// Write schema always at timestamp 1, s.state.writeTs may not be equal to 1
 	// if bulk loader was restarted or other similar scenarios.
 

--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -123,18 +123,22 @@ func (s *schemaStore) write(db *badger.DB) {
 
 	// Get predicates from the schema store so that the db includes all
 	// predicates from the schema file.
-	preds := make([]string, 0, len(s.m))
-	for pred := range s.m {
-		preds = append(preds, pred)
-	}
+
+	// TODO: This should not happen here.
+	// preds := make([]string, 0, len(s.m))
+	// for pred := range s.m {
+	// 	preds = append(preds, pred)
+	// }
 
 	// Add predicates from the db so that final schema includes predicates
 	// used in the rdf file but not included in the schema file.
-	for _, pred := range s.getPredicates(db) {
-		if _, ok := s.m[pred]; !ok {
-			preds = append(preds, pred)
-		}
-	}
+
+	// TODO: Done by the caller.
+	// for _, pred := range s.getPredicates(db) {
+	// 	if _, ok := s.m[pred]; !ok {
+	// 		preds = append(preds, pred)
+	// 	}
+	// }
 
 	txn := db.NewTransactionAt(math.MaxUint64, true)
 	defer txn.Discard()

--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -118,28 +118,6 @@ func (s *schemaStore) getPredicates(db *badger.DB) []string {
 }
 
 func (s *schemaStore) write(db *badger.DB, preds []string) {
-	// Write schema always at timestamp 1, s.state.writeTs may not be equal to 1
-	// if bulk loader was restarted or other similar scenarios.
-
-	// Get predicates from the schema store so that the db includes all
-	// predicates from the schema file.
-
-	// TODO: This should not happen here.
-	// preds := make([]string, 0, len(s.m))
-	// for pred := range s.m {
-	// 	preds = append(preds, pred)
-	// }
-
-	// Add predicates from the db so that final schema includes predicates
-	// used in the rdf file but not included in the schema file.
-
-	// TODO: Done by the caller.
-	// for _, pred := range s.getPredicates(db) {
-	// 	if _, ok := s.m[pred]; !ok {
-	// 		preds = append(preds, pred)
-	// 	}
-	// }
-
 	txn := db.NewTransactionAt(math.MaxUint64, true)
 	defer txn.Discard()
 	for _, pred := range preds {
@@ -152,5 +130,8 @@ func (s *schemaStore) write(db *badger.DB, preds []string) {
 		x.Check(err)
 		x.Check(txn.SetWithMeta(k, v, posting.BitCompletePosting))
 	}
+
+	// Write schema always at timestamp 1, s.state.writeTs may not be equal to 1
+	// if bulk loader was restarted or other similar scenarios.
 	x.Check(txn.CommitAt(1, nil))
 }

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -14,6 +14,11 @@ FATAL() { ERROR "$@"; exit 1; }
 
 set -e
 
+INFO "rebuilding dgraph"
+
+cd $SRCROOT
+make install >/dev/null
+
 INFO "running bulk load schema test"
 
 WORKDIR=$(mktemp --tmpdir -d $ME.tmp-XXXXXX)

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -128,7 +128,7 @@ function BulkLoadExportedData
               -s ../dir1/export/*/g01.schema.gz \
               -f ../dir1/export/*/g01.rdf.gz \
      >$LOGFILE 2>&1 </dev/null
-  rm -f $LOGFILE
+  mv $LOGFILE $LOGFILE.export
 }
 
 function BulkLoadFixtureData
@@ -157,7 +157,7 @@ EOF
 
   dgraph bulk -z localhost:$ZERO_PORT -s fixture.schema -f fixture.rdf \
      >$LOGFILE 2>&1 </dev/null
-  rm -f $LOGFILE
+  mv $LOGFILE $LOGFILE.fixture
 }
 
 function StopServers

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -189,7 +189,7 @@ EOF
 
   dgraph debug -p out/0/p 2>|/dev/null | grep '{s}' | cut -d' ' -f4  > all_dbs.out
   dgraph debug -p out/1/p 2>|/dev/null | grep '{s}' | cut -d' ' -f4 >> all_dbs.out
-  diff <(sort all_dbs.out | uniq -c) - <<EOF
+  diff <(LC_ALL=C sort all_dbs.out | uniq -c) - <<EOF
       1 _predicate_
       1 genre
       1 language

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -115,12 +115,10 @@ function QuerySchema
 function DoExport
 {
   INFO "running export"
-  set -x
   docker exec -it bank-dg1 curl localhost:$HTTP_PORT/admin/export &>/dev/null
   sleep 2
   docker cp bank-dg1:/data/dg1/export .
   sleep 1
-  set +x
 }
 
 function BulkLoadExportedData

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -159,6 +159,40 @@ EOF
   mv $LOGFILE $LOGFILE.fixture
 }
 
+function TestBulkLoadMultiShard
+{
+  INFO "bulk loading into multiple shards"
+
+  cat >fixture.schema <<EOF
+name:string @index(term) .
+genre:default .
+language:string .
+EOF
+
+  cat >fixture.rdf <<EOF
+_:et <name> "E.T. the Extra-Terrestrial" .
+_:et <genre> "Science Fiction" .
+_:et <revenue> "792.9" .
+EOF
+
+  dgraph bulk -z localhost:$ZERO_PORT -s fixture.schema -f fixture.rdf \
+              --map_shards 2 --reduce_shards 2 \
+     >$LOGFILE 2>&1 </dev/null
+  mv $LOGFILE $LOGFILE.multi
+
+  INFO "checking that each predicate appears in only one shard"
+
+  dgraph debug -p out/0/p 2>|/dev/null | grep '{s}' | cut -d' ' -f4  > all_dbs.out
+  dgraph debug -p out/1/p 2>|/dev/null | grep '{s}' | cut -d' ' -f4 >> all_dbs.out
+  diff <(sort all_dbs.out | uniq -c) - <<EOF
+      1 _predicate_
+      1 genre
+      1 language
+      1 name
+      1 revenue
+EOF
+}
+
 function StopServers
 {
   INFO "stoping containers"
@@ -237,6 +271,10 @@ diff -b - dir3/schema.out <<EOF || FATAL "schema incorrect"
   ]
 }
 EOF
+
+StartZero
+TestBulkLoadMultiShard
+StopServers
 
 INFO "schema is correct"
 


### PR DESCRIPTION
Change summary:

* Each shard's schema contains only the predicates found in that shard rather than all preds.

* Test case for above fix.

* More user-friendly "file not found" messages rather than stack traces when bulk schema or data paths invalid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3065)
<!-- Reviewable:end -->
