### PR TITLE
Fix an assorted list of goroutine leaks.

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -583,7 +583,7 @@ func (s *Server) UpdateMembership(ctx context.Context, group *pb.Group) (*api.Pa
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	errCh := make(chan error)
+	errCh := make(chan error, len(proposals))
 	for _, pr := range proposals {
 		go func(pr *pb.ZeroProposal) {
 			errCh <- s.Node.proposeAndWait(ctx, pr)

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -118,7 +118,7 @@ func BackupOverNetwork(pctx context.Context, dst string) error {
 
 	// This will dispatch the request to all groups and wait for their response.
 	// If we receive any failures, we cancel the process.
-	errCh := make(chan error, 1)
+	errCh := make(chan error, len(gids))
 	for _, gid := range gids {
 		go func(gid uint32) {
 			req.GroupId = gid

--- a/worker/task.go
+++ b/worker/task.go
@@ -353,7 +353,7 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	x.AssertTrue(width > 0)
 	span.Annotatef(nil, "Width: %d. NumGo: %d", width, numGo)
 
-	errCh := make(chan error, 1)
+	errCh := make(chan error, numGo)
 	outputs := make([]*pb.Result, numGo)
 	listType := schema.State().IsList(q.Attr)
 
@@ -544,7 +544,7 @@ func (qs *queryState) handleUidPostings(
 	x.AssertTrue(width > 0)
 	span.Annotatef(nil, "Width: %d. NumGo: %d", width, numGo)
 
-	errCh := make(chan error, 1)
+	errCh := make(chan error, numGo)
 	outputs := make([]*pb.Result, numGo)
 
 	calculate := func(start, end int) error {


### PR DESCRIPTION
In all of these channel allocs multiple goroutines are executed and returned early
in case of error. We don't wait for other goroutines to terminate while blocked on
sending to the channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3074)
<!-- Reviewable:end -->
