### PR TITLE
Do not set nil value for log_backtrace_at flag

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -132,6 +132,15 @@ func setGlogFlags(conf *viper.Viper) {
 	for _, gflag := range glogFlags {
 		// Set value of flag to the value in config
 		if stringValue, ok := conf.Get(gflag).(string); ok {
+			// Special handling for log_backtrace_at flag because the flag is of
+			// type tracelocation. The nil value for tracelocation type is
+			// ":0"(See https://github.com/golang/glog/blob/master/glog.go#L322).
+			// But we can't set nil value for the flag because of
+			// https://github.com/golang/glog/blob/master/glog.go#L374
+			// Skip setting value if log_backstrace_at is nil in config.
+			if gflag == "log_backtrace_at" && stringValue == ":0" {
+				continue
+			}
 			x.Check(flag.Lookup(gflag).Value.Set(stringValue))
 		}
 	}


### PR DESCRIPTION
https://github.com/dgraph-io/dgraph/pull/3062 added capabilities to set flag values from config file (we need this for glog).
This caused an issue with the log_backtrace_at flag.
The flag is defined as `flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")` where tracelocation is

```
// traceLocation represents the setting of the -log_backtrace_at flag.
type traceLocation struct {
	file string
	line int
}
```
If the value isn't specified the nil value for tracelocation type is set in the config, which is tracelocation{"", 0}.
But this value can't be set to the flag because of the check on line https://github.com/golang/glog/blob/master/glog.go#L374

This PR adds skips setting the flag to nil value if it nil in the config.

Fixes https://github.com/dgraph-io/dgraph/issues/3076

Signed-off-by: Ibrahim Jarif <jarifibrahim@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3077)
<!-- Reviewable:end -->
