### PR TITLE
Remove retry logic when altering schema in tests.

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -142,14 +142,7 @@ func alterSchema(s string) error {
 	if err != nil {
 		return err
 	}
-	for {
-		// keep retrying until we succeed or receive a non-retriable error
-		_, _, err = runRequest(req)
-		if err == nil || !strings.Contains(err.Error(), "Please retry operation") {
-			break
-		}
-	}
-
+	_, _, err = runRequest(req)
 	return err
 }
 
@@ -499,12 +492,12 @@ func TestSchemaMutationUidError1(t *testing.T) {
 	var s1 = `
             friend: [uid] .
 	`
-	require.NoError(t, alterSchema(s1))
+	require.NoError(t, alterSchemaWithRetry(s1))
 
 	var s2 = `
             friend: uid .
 	`
-	require.Error(t, alterSchema(s2))
+	require.Error(t, alterSchemaWithRetry(s2))
 }
 
 // add index


### PR DESCRIPTION
When re-running an HTTP request the body payload becomes empty after the first
run.

    --- FAIL: TestSchemaMutationUidError1 (0.01s) [m
            assertions.go:237:

            Error Trace:    run_test.go:502

            Error:          Received unexpected error:
                            Put http://localhost:8180/alter: http: ContentLength=30 with Body length 0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3079)
<!-- Reviewable:end -->
