### PR TITLE
Add bash shell completion command

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"flag"
+	"os"
 	"strings"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
@@ -105,6 +106,9 @@ func initCmds() {
 		// environment variable.
 		sc.Conf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	}
+	// For bash shell completion
+	RootCmd.AddCommand(bashCompletionCmd())
+
 	cobra.OnInitialize(func() {
 		cfg := rootConf.GetString("config")
 		if cfg == "" {
@@ -143,5 +147,24 @@ func setGlogFlags(conf *viper.Viper) {
 			}
 			x.Check(flag.Lookup(gflag).Value.Set(stringValue))
 		}
+	}
+}
+
+func bashCompletionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "bash-completion",
+		Short: "Generates bash completion scripts",
+		Long: `To load bash completion run:
+. < (dgraph completion)
+
+To configure your bash shell to load completions for each session,
+add to your bashrc:
+
+# ~/.bashrc or ~/.profile
+. < (dgraph completion)
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			RootCmd.GenBashCompletion(os.Stdout)
+		},
 	}
 }

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -107,7 +107,7 @@ func initCmds() {
 		sc.Conf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	}
 	// For bash shell completion
-	RootCmd.AddCommand(bashCompletionCmd())
+	RootCmd.AddCommand(shellCompletionCmd())
 
 	cobra.OnInitialize(func() {
 		cfg := rootConf.GetString("config")
@@ -150,21 +150,49 @@ func setGlogFlags(conf *viper.Viper) {
 	}
 }
 
-func bashCompletionCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "bash-completion",
-		Short: "Generates bash completion scripts",
+func shellCompletionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "completion",
+		Short: "Generates shell completion scripts for bash or zsh",
+	}
+
+	// bash subcommand
+	cmd.AddCommand(&cobra.Command{
+		Use:   "bash",
+		Short: "bash shell completion",
 		Long: `To load bash completion run:
-. < (dgraph completion)
+. < (dgraph completion bash)
 
 To configure your bash shell to load completions for each session,
 add to your bashrc:
 
 # ~/.bashrc or ~/.profile
-. < (dgraph completion)
+. < (dgraph completion bash)
 `,
-		Run: func(cmd *cobra.Command, args []string) {
-			RootCmd.GenBashCompletion(os.Stdout)
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RootCmd.GenBashCompletion(os.Stdout)
 		},
-	}
+	})
+
+	// zsh subcommand
+	cmd.AddCommand(&cobra.Command{
+		Use:   "zsh",
+		Short: "zsh shell completion",
+		Long: `To load bash completion run:
+. < (dgraph completion zsh)
+
+To configure your zsh shell to load completions for each session,
+add to your zshrc:
+
+# ~/.zshrc or ~/.profile
+. < (dgraph completion zsh)
+`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RootCmd.GenZshCompletion(os.Stdout)
+		},
+	})
+
+	return cmd
 }

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -161,13 +161,13 @@ func shellCompletionCmd() *cobra.Command {
 		Use:   "bash",
 		Short: "bash shell completion",
 		Long: `To load bash completion run:
-. < (dgraph completion bash)
+dgraph completion bash > dgraph-completion.sh
 
 To configure your bash shell to load completions for each session,
 add to your bashrc:
 
 # ~/.bashrc or ~/.profile
-. < (dgraph completion bash)
+. path/to/dgraph-completion.sh
 `,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -179,14 +179,14 @@ add to your bashrc:
 	cmd.AddCommand(&cobra.Command{
 		Use:   "zsh",
 		Short: "zsh shell completion",
-		Long: `To load bash completion run:
-. < (dgraph completion zsh)
+		Long: `To generate zsh completion run:
+dgraph completion zsh > _dgraph
 
-To configure your zsh shell to load completions for each session,
-add to your zshrc:
+Then install the completion file somewhere in your $fpath or
+$_compdir paths. You must enable the compinit and compinstall plugins.
 
-# ~/.zshrc or ~/.profile
-. < (dgraph completion zsh)
+For more information, see the official Zsh docs:
+http://zsh.sourceforge.net/Doc/Release/Completion-System.html
 `,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
This PR adds a new `completion` command to the Dgraph main binary. It is used to generate bash and zsh shell completion code.

Bash example:
```sh
$ dgraph completion bash > dgraph.sh

# source in .bashrc
source dgraph.sh
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3084)
<!-- Reviewable:end -->
