### PR TITLE
Fix schema parse test.

### DIFF
--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -201,6 +201,7 @@ func TestSchemaIndexCustom(t *testing.T) {
 			Predicate: "friend",
 			Directive: pb.SchemaUpdate_REVERSE,
 			Count:     true,
+			List:      true,
 		}},
 	})
 	require.True(t, State().IsIndexed("name"))


### PR DESCRIPTION
Test failure introduced in #3002 when changing the schema from uid to [uid].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3086)
<!-- Reviewable:end -->
