### PR TITLE
Run docker-compose dgraph as user

### DIFF
--- a/contrib/compose/main.go
+++ b/contrib/compose/main.go
@@ -87,7 +87,7 @@ func getService(basename string, idx, grpcPort int) Service {
 	svc.name = name(basename, idx)
 	svc.Image = "dgraph/dgraph:latest"
 	svc.ContainerName = svc.name
-	svc.WorkingDir = fmt.Sprintf("/data/%s", svc.name)
+	svc.WorkingDir = fmt.Sprintf("/working/%s", svc.name)
 	if idx > 1 {
 		svc.DependsOn = append(svc.DependsOn, name(basename, idx-1))
 	}

--- a/contrib/compose/main.go
+++ b/contrib/compose/main.go
@@ -133,7 +133,7 @@ func initService(basename string, idx, grpcPort int) Service {
 		if err != nil {
 			x.CheckfNoTrace(x.Errorf("unable to get current user: %v", err))
 		}
-		svc.User = fmt.Sprintf("%s", user.Uid)
+		svc.User = fmt.Sprintf("${UID:-%s}", user.Uid)
 		svc.WorkingDir = fmt.Sprintf("/working/%s", svc.name)
 		svc.Command += fmt.Sprintf(" --cwd=/data/%s", svc.name)
 	}

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -111,8 +111,8 @@ func initCmds() {
 	cobra.OnInitialize(func() {
 		// When run inside docker, the working_dir is created by root even if afterward
 		// the process is run as another user. Creating a new working directory here
-		// ensures that it can be cleaned up without requiring root permissions when
-		// using a bind volume (i.e. a mounted host directory).
+		// ensures that it is owned by the user instead, so it can be cleaned up without
+		// requiring root when using a bind volume (i.e. a mounted host directory).
 		if cwd := rootConf.GetString("cwd"); cwd != "" {
 			x.CheckfNoTrace(os.Mkdir(cwd, 0777))
 			x.CheckfNoTrace(os.Chdir(cwd))

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -114,7 +114,10 @@ func initCmds() {
 		// ensures that it is owned by the user instead, so it can be cleaned up without
 		// requiring root when using a bind volume (i.e. a mounted host directory).
 		if cwd := rootConf.GetString("cwd"); cwd != "" {
-			x.CheckfNoTrace(os.Mkdir(cwd, 0777))
+			err := os.Mkdir(cwd, 0777)
+			if err != nil && !os.IsExist(err) {
+				x.Fatalf("unable to create directory", err)
+			}
 			x.CheckfNoTrace(os.Chdir(cwd))
 		}
 

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"flag"
+	"os"
 	"strings"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
@@ -73,6 +74,8 @@ var subcommands = []*x.SubCommand{
 }
 
 func initCmds() {
+	RootCmd.PersistentFlags().String("cwd", "",
+		"Change working directory to the path specified. The parent must exist.")
 	RootCmd.PersistentFlags().String("profile_mode", "",
 		"Enable profiling mode, one of [cpu, mem, mutex, block]")
 	RootCmd.PersistentFlags().Int("block_rate", 0,
@@ -84,7 +87,7 @@ func initCmds() {
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
 	RootCmd.PersistentFlags().Bool("expose_trace", false,
 		"Allow trace endpoint to be accessible from remote")
-	rootConf.BindPFlags(RootCmd.PersistentFlags())
+	_ = rootConf.BindPFlags(RootCmd.PersistentFlags())
 
 	// Add all existing global flag (eg: from glog) to rootCmd's flags
 	RootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
@@ -106,6 +109,15 @@ func initCmds() {
 		sc.Conf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	}
 	cobra.OnInitialize(func() {
+		// When run inside docker, the working_dir is created by root even if afterward
+		// the process is run as another user. Creating a new working directory here
+		// ensures that it can be cleaned up without requiring root permissions when
+		// using a bind volume (i.e. a mounted host directory).
+		if cwd := rootConf.GetString("cwd"); cwd != "" {
+			x.CheckfNoTrace(os.Mkdir(cwd, 0777))
+			x.CheckfNoTrace(os.Chdir(cwd))
+		}
+
 		cfg := rootConf.GetString("config")
 		if cfg == "" {
 			return


### PR DESCRIPTION
Summary of changes:

* Add option to compose tool to create a docker-compose.yml that can run as the current user rather than root.

* Add option to dgraph to create a new working directory on start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3088)
<!-- Reviewable:end -->
