### PR TITLE
Add best-effort query to http endpoint

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -158,9 +158,17 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	d := r.URL.Query().Get("debug")
 	ctx := context.WithValue(context.Background(), query.DebugKey, d)
 	ctx = attachAccessJwt(ctx, r)
-	// If ro is set, run this as a readonly query.
-	if ro := r.URL.Query().Get("ro"); len(ro) > 0 && req.StartTs == 0 {
-		if ro == "true" || ro == "1" {
+
+	if req.StartTs == 0 {
+		// If be is set, run this as a best-effort query.
+		be, _ := strconv.ParseBool(r.URL.Query().Get("be"))
+		if be {
+			req.BestEffort = true
+			req.ReadOnly = true
+		}
+		// If ro is set, run this as a readonly query.
+		ro, _ := strconv.ParseBool(r.URL.Query().Get("ro"))
+		if ro {
 			req.ReadOnly = true
 		}
 	}


### PR DESCRIPTION
This change adds a new query parameter `be=` to support best effort queries using HTTP. Read-only is implied with best effort param, no need to set `ro=` also.

Usage:
```bash
$ curl 'localhost:8080/query?be=true' -d $'{ q(func:uid(0x1)) { uid }}'
```

Closes #3093 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3096)
<!-- Reviewable:end -->
