### PR TITLE
Support comments in schema

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -948,7 +948,7 @@ func parseSchemaFields(it *lex.ItemIterator, s *pb.SchemaRequest) error {
 			return item.Errorf("Invalid schema block.")
 		}
 	}
-	return it.Errorf("Expecting }  to end fields list, but none was found")
+	return it.Errorf("Expecting } to end fields list, but none was found")
 }
 
 func getSchema(it *lex.ItemIterator) (*pb.SchemaRequest, error) {

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -526,7 +526,7 @@ func TestParseScalarType(t *testing.T) {
 		type Person {
 			Name: string
 			Nickname: [String]
-			Alive: Bool 
+			Alive: Bool
 		}
 	`)
 	require.NoError(t, err)
@@ -741,6 +741,66 @@ func TestParseTypeErrMissingType(t *testing.T) {
 	`)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Missing field type in type declaration")
+}
+
+func TestParseComments(t *testing.T) {
+	reset()
+	_, err := Parse(`
+		#
+		# This is a test
+		#
+		user: bool .
+		user.name: string @index(exact) . # this should be unique
+		user.email: string @index(exact) . # this should be unique and lower-cased
+		user.password: password .
+		user.code: string . # for password recovery (can be null)
+		node: bool .
+		node.hashid: string @index(exact) . # @username/hashid
+		node.owner: uid @reverse . # (can be null)
+		node.parent: uid . # [uid] (use facet)
+		node.xdata: string . # store custom json data
+		#
+		# End of test
+		#
+	`)
+	require.NoError(t, err)
+}
+
+func TestParseCommentsNoop(t *testing.T) {
+	reset()
+	_, err := Parse(`
+# Spicy jalapeno bacon ipsum dolor amet t-bone kevin spare ribs sausage jowl cow pastrami short.
+# Leberkas alcatra kielbasa chicken pastrami swine bresaola. Spare ribs landjaeger meatloaf.
+# Chicken biltong boudin porchetta jowl swine burgdoggen cow kevin ground round landjaeger ham.
+# Tongue buffalo cow filet mignon boudin sirloin pancetta pork belly beef ribs. Cow landjaeger.
+	`)
+	require.NoError(t, err)
+}
+
+func TestParseCommentsErrMissingType(t *testing.T) {
+	reset()
+	_, err := Parse(`
+		# The definition below should trigger an error
+		# because we commented out its type.
+		node: # bool .
+	`)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Missing Type")
+}
+
+func TestParseTypeComments(t *testing.T) {
+	reset()
+	_, err := Parse(`
+		# User is a service user
+		type User {
+			# TODO: add more fields
+			Name: string # e.g., srfrog
+									 # expanded comment
+									 # embedded # comments # here
+		}
+		# /User
+	`)
+	require.NoError(t, err)
 }
 
 var ps *badger.DB

--- a/schema/state.go
+++ b/schema/state.go
@@ -53,6 +53,8 @@ Loop:
 			l.Emit(itemNewLine)
 		case r == '.':
 			l.Emit(itemDot)
+		case r == '#':
+			return lexComment
 		case r == ',':
 			l.Emit(itemComma)
 		case r == '<':
@@ -100,6 +102,25 @@ func lexWord(l *lex.Lexer) lex.StateFn {
 		}
 		l.Backup()
 		l.Emit(itemText)
+		break
+	}
+	return lexText
+}
+
+// lexComment lexes a comment text.
+func lexComment(l *lex.Lexer) lex.StateFn {
+	for {
+		r := l.Next()
+		if r == lex.EOF {
+			l.Ignore()
+			l.Emit(lex.ItemEOF)
+			break
+		}
+		if !lex.IsEndOfLine(r) {
+			continue
+		}
+		l.Ignore()
+		l.Emit(itemNewLine)
 		break
 	}
 	return lexText

--- a/schema/state.go
+++ b/schema/state.go
@@ -54,7 +54,7 @@ Loop:
 		case r == '.':
 			l.Emit(itemDot)
 		case r == '#':
-			return lexComment
+			return lexTextComment
 		case r == ',':
 			l.Emit(itemComma)
 		case r == '<':
@@ -107,8 +107,8 @@ func lexWord(l *lex.Lexer) lex.StateFn {
 	return lexText
 }
 
-// lexComment lexes a comment text.
-func lexComment(l *lex.Lexer) lex.StateFn {
+// lexTextComment lexes a comment text inside a schema.
+func lexTextComment(l *lex.Lexer) lex.StateFn {
 	for {
 		r := l.Next()
 		if r == lex.EOF {


### PR DESCRIPTION
This PR adds support for comments in schemas. Comments begin with `#` and end with new line or when EOF is reached. A schema with only comments is treated as a no-op.

Example:
```
#
# This is a comment
#
user: bool .
user.name: string @index(exact) . # this should be unique
user.email: string @index(exact) . # this should be unique and lower-cased
user.password: password .
user.code: string . # for password recovery (can be null)
node: bool .
node.hashid: string @index(exact) . # @username/hashid
node.owner: uid @reverse . # (can be null)
node.parent: uid . # [uid] (use facet)
node.xdata: string . # store custom json data
#
# End of test
#
```

Example with type system:
```
# User is a service user
type User {
   # TODO: add more fields
   Name: string # e.g., srfrog
                # expanded comment
                # embedded # comments # here
}
# /User
```

Closes #3130

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3133)
<!-- Reviewable:end -->
