### PR TITLE
Reduce test time

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -15,8 +15,8 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   make install
-  docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
-  docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
+  docker-compose -p dgraph -f $compose_file down --remove-orphans
+  docker-compose -p dgraph -f $compose_file up --force-recreate --detach || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6080 || exit 1
@@ -27,9 +27,6 @@ function restartCluster {
 function stopCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph >/dev/null
-  docker ps --filter label="cluster=test" --format "{{.Names}}" \
-  | xargs -r docker stop | sed 's/^/Stopped /'
-  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
-  | xargs -r docker rm | sed 's/^/Removed /'
+  docker-compose -p dgraph down --remove-orphans
   popd >/dev/null
 }

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -15,7 +15,8 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   make install
-  docker-compose -p dgraph -f $compose_file up --remove-orphans --force-recreate --detach || exit 1
+  docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
+  docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6080 || exit 1
@@ -26,10 +27,9 @@ function restartCluster {
 function stopCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph >/dev/null
-#  docker ps --filter label="cluster=test" --format "{{.Names}}" \
-#  | xargs -r docker stop | sed 's/^/Stopped /'
-#  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
-#  | xargs -r docker rm | sed 's/^/Removed /'
-  docker-compose -p dgraph down --remove-orphans
+  docker ps --filter label="cluster=test" --format "{{.Names}}" \
+  | xargs -r docker stop | sed 's/^/Stopped /'
+  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
+  | xargs -r docker rm | sed 's/^/Removed /'
   popd >/dev/null
 }

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -15,8 +15,8 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   make install
-  docker-compose -p dgraph -f $compose_file down --remove-orphans
-  docker-compose -p dgraph -f $compose_file up --force-recreate --detach || exit 1
+  docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
+  docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6080 || exit 1
@@ -27,6 +27,9 @@ function restartCluster {
 function stopCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph >/dev/null
-  docker-compose -p dgraph down --remove-orphans
+  docker ps --filter label="cluster=test" --format "{{.Names}}" \
+  | xargs -r docker stop | sed 's/^/Stopped /'
+  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
+  | xargs -r docker rm | sed 's/^/Removed /'
   popd >/dev/null
 }

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -15,8 +15,7 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   make install
-  docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
-  docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
+  docker-compose -p dgraph -f $compose_file up --remove-orphans --force-recreate --detach || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6080 || exit 1
@@ -27,9 +26,10 @@ function restartCluster {
 function stopCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph >/dev/null
-  docker ps --filter label="cluster=test" --format "{{.Names}}" \
-  | xargs -r docker stop | sed 's/^/Stopped /'
-  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
-  | xargs -r docker rm | sed 's/^/Removed /'
+#  docker ps --filter label="cluster=test" --format "{{.Names}}" \
+#  | xargs -r docker stop | sed 's/^/Stopped /'
+#  docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
+#  | xargs -r docker rm | sed 's/^/Removed /'
+  docker-compose -p dgraph down --remove-orphans
   popd >/dev/null
 }

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -28,6 +28,10 @@ import (
 const loginEndpoint = "http://localhost:8180/login"
 
 func TestCurlAuthorization(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	glog.Infof("testing with port 9180")
 	dg := z.DgraphClientWithGroot(":9180")
 	createAccountAndData(t, dg)

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -29,7 +29,7 @@ const loginEndpoint = "http://localhost:8180/login"
 
 func TestCurlAuthorization(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("skipping because -short=true")
 	}
 
 	glog.Infof("testing with port 9180")

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -103,7 +103,7 @@ func TestReservedPredicates(t *testing.T) {
 
 func TestAuthorization(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("skipping because -short=true")
 	}
 
 	glog.Infof("testing with port 9180")
@@ -332,7 +332,7 @@ func createGroupAndAcls(t *testing.T, group string, addUserToGroup bool) {
 
 func TestPredicateRegex(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("skipping because -short=true")
 	}
 
 	glog.Infof("testing with port 9180")

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -102,6 +102,10 @@ func TestReservedPredicates(t *testing.T) {
 }
 
 func TestAuthorization(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	glog.Infof("testing with port 9180")
 	dg1 := z.DgraphClientWithGroot(":9180")
 	testAuthorization(t, dg1)
@@ -352,6 +356,10 @@ func TestPasswordReset(t *testing.T) {
 }
 
 func TestPredicateRegex(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	glog.Infof("testing with port 9180")
 	dg := z.DgraphClientWithGroot(":9180")
 	createAccountAndData(t, dg)

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ readonly DGRAPH_ROOT=${GOPATH:-$HOME}/src/github.com/dgraph-io/dgraph
 source $DGRAPH_ROOT/contrib/scripts/functions.sh
 
 PATH+=:$DGRAPH_ROOT/contrib/scripts/
-GO_TEST_OPTS=( "-short=true" )
+GO_TEST_OPTS=( )
 TEST_FAILED=0
 TEST_SET="unit"
 BUILD_TAGS=
@@ -35,7 +35,6 @@ notes:
 
     Tests are always run with -short=true."
 }
-
 
 function Info {
     echo -e "\e[1;36mINFO: $*\e[0m"
@@ -141,6 +140,7 @@ if [[ $# -eq 0 ]]; then
     go list ./... > $MATCHING_TESTS
     if [[ $TEST_SET == unit ]]; then
         Info "Running only unit tests"
+        GO_TEST_OPTS+=( "-short=true" )
     fi
 elif [[ $# -eq 1 ]]; then
     REGEX=${1%/}
@@ -155,6 +155,9 @@ fi
 # assemble list of tests before executing any
 FindCustomClusterTests
 FindDefaultClusterTests
+
+# abort all tests on Ctrl-C, not just the current one
+trap "echo >&2 SIGINT ; exit 2" SIGINT
 
 START_TIME=$(date +%s)
 

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -62,6 +62,10 @@ func TestXidmap(t *testing.T) {
 }
 
 func TestXidmapMemory(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	var loop uint32
 	bToMb := func(b uint64) uint64 {
 		return b / 1024 / 1024

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -63,7 +63,7 @@ func TestXidmap(t *testing.T) {
 
 func TestXidmapMemory(t *testing.T) {
 	if testing.Short() {
-		t.Skip()
+		t.Skip("skipping because -short=true")
 	}
 
 	var loop uint32


### PR DESCRIPTION
Reduce the time the default test.sh invocation takes (from 14 to 4 minutes on my home machine).

Change summary:

* Skip ACL tests with long sleeps when running quick test.
* Skip long-running TestXidmapMemory test when running quick test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3134)
<!-- Reviewable:end -->
