### PR TITLE
Ensure reserved predicates cannot be moved.

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -155,6 +155,9 @@ func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
 
 	groupId, ok := intFromQueryParam(w, r, "group")
 	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		x.SetStatus(w, x.ErrorInvalidRequest, fmt.Sprintf(
+			"Query parameter 'group' should contain a valid integer."))
 		return
 	}
 	dstGroup := uint32(groupId)


### PR DESCRIPTION
This change ensures reserved predicates cannot be moved, either by calls
to the /movePred endpoint or during rebalancing of predicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3137)
<!-- Reviewable:end -->
