### PR TITLE
Replace all occurences of NQuad with N-Quad - the way w3.org spells it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,7 +301,7 @@ are now exposed via flags named with `--badger.` prefix.
 ### Fixed
 
 * Fix bug where predicate with string type sometimes appeared as `_:uidffffffffffffffff` in exports.
-* Validate facet value should be according to the facet type supplied when mutating using NQuads ([#2074](https://github.com/dgraph-io/dgraph/issues/2074)).
+* Validate facet value should be according to the facet type supplied when mutating using N-Quads ([#2074](https://github.com/dgraph-io/dgraph/issues/2074)).
 * Use `time.Equal` function for comparing predicates with `datetime`([#2219](https://github.com/dgraph-io/dgraph/issues/2219)).
 * Skip `BitEmptyPosting` for `has` queries.
 * Return error from query if we don't serve the group for the attribute instead of crashing ([#2227](https://github.com/dgraph-io/dgraph/issues/2227)).
@@ -575,7 +575,7 @@ Examples for [Go client](https://godoc.org/github.com/dgraph-io/dgraph/client#ex
 #### Mutations
 
 * Mutations can only be done via `Mutate` Grpc endpoint or via [`/mutate` HTTP handler](https://docs.dgraph.io/clients/#transactions).
-* `Mutate` Grpc endpoint can be used to set/ delete JSON, or set/ delete a list of NQuads and set/ delete raw RDF strings.
+* `Mutate` Grpc endpoint can be used to set/ delete JSON, or set/ delete a list of N-Quads and set/ delete raw RDF strings.
 * Mutation blocks don't require the mutation keyword anymore. Here is an example of the new syntax.
 ```
 {

--- a/chunker/rdf/parse.go
+++ b/chunker/rdf/parse.go
@@ -51,7 +51,7 @@ func sane(s string) bool {
 	return false
 }
 
-// Parse parses a mutation string and returns the NQuad representation for it.
+// Parse parses a mutation string and returns the N-Quad representation for it.
 func Parse(line string) (api.NQuad, error) {
 	var rnq api.NQuad
 	l := lex.NewLexer(line)
@@ -152,7 +152,7 @@ L:
 			if !it.Next() {
 				return rnq, x.Errorf("Invalid end of input. Input: [%s]", line)
 			}
-			// RDF spec says NQuad's should be terminated with a newline. Since we break the input
+			// RDF spec says N-Quads should be terminated with a newline. Since we break the input
 			// by newline already. We should get EOF or # after dot(.)
 			item = it.Item()
 			if !(item.Typ == lex.ItemEOF || item.Typ == itemComment) {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -240,7 +240,7 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 			mu.DeleteJson = delJSON.bs
 		}
 	} else {
-		// Parse NQuads.
+		// Parse N-Quads.
 		mu, err = gql.ParseMutation(string(m))
 		if err != nil {
 			x.SetStatus(w, x.ErrorInvalidRequest, err.Error())

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -849,7 +849,7 @@ func validateKey(key string) error {
 	return nil
 }
 
-// validateKeys checks predicate and facet keys in Nquad for syntax errors.
+// validateKeys checks predicate and facet keys in N-Quad for syntax errors.
 func validateKeys(nq *api.NQuad) error {
 	if err := validateKey(nq.Predicate); err != nil {
 		return x.Errorf("predicate %q %s", nq.Predicate, err)

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -514,7 +514,7 @@ func ObjectValue(id TypeID, value interface{}) (*api.Value, error) {
 			return def, x.Errorf("Expected value of type []byte. Got : %v", value)
 		}
 		return &api.Value{Val: &api.Value_BytesVal{BytesVal: v}}, nil
-	// Geo and datetime are stored in binary format in the NQuad, so lets
+	// Geo and datetime are stored in binary format in the N-Quad, so lets
 	// convert them here.
 	case GeoID:
 		b, err := toBinary(id, value)

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1427,13 +1427,13 @@ There are two different tools that can be used for fast data loading:
 - `dgraph live` runs the Dgraph Live Loader
 - `dgraph bulk` runs the Dgraph Bulk Loader
 
-{{% notice "note" %}} Both tools only accept [RDF NQuad/Triple
+{{% notice "note" %}} Both tools only accept [RDF N-Quad/Triple
 data](https://www.w3.org/TR/n-quads/) in plain or gzipped format. Data
 in other formats must be converted.{{% /notice %}}
 
 ### Live Loader
 
-Dgraph Live Loader (run with `dgraph live`) is a small helper program which reads RDF NQuads from a gzipped file, batches them up, creates mutations (using the go client) and shoots off to Dgraph.
+Dgraph Live Loader (run with `dgraph live`) is a small helper program which reads RDF N-Quads from a gzipped file, batches them up, creates mutations (using the go client) and shoots off to Dgraph.
 
 Dgraph Live Loader correctly handles assigning unique IDs to blank nodes across multiple files, and can optionally persist them to disk to save memory, in case the loader was re-run.
 

--- a/wiki/content/design-concepts/index.md
+++ b/wiki/content/design-concepts/index.md
@@ -70,7 +70,7 @@ visible to all future readers, irrespective of client boundaries.
 
 ### Edges
 
-Typical data format is RDF [NQuad](https://www.w3.org/TR/n-quads/) which is:
+Typical data format is RDF [N-Quad](https://www.w3.org/TR/n-quads/) which is:
 
 * `Subject, Predicate, Object, Label`, aka
 * `Entity, Attribute, Other Entity / Value, Label`
@@ -82,7 +82,7 @@ i.e. from `Subject -> Object`. This is the direction that the queries would be r
 queries in that direction, they would need to define the [reverse edge](/query-language#reverse-edges)
 as part of the schema.{{% /notice %}}
 
-Internally, the RDF NQuad gets parsed into this format.
+Internally, the RDF N-Quad gets parsed into this format.
 
 ```
 type DirectedEdge struct {

--- a/x/values.go
+++ b/x/values.go
@@ -18,7 +18,7 @@ package x
 
 type ValueTypeInfo int32
 
-// Type of a data inside DirectedEdge, Posting or NQuad
+// Type of a data inside DirectedEdge, Posting or N-Quad
 const (
 	ValueUnknown ValueTypeInfo = iota // unknown type of value
 	ValueEmpty                        // no UID and no value
@@ -28,7 +28,7 @@ const (
 	ValueMulti
 )
 
-// Helper function, to decide value type of DirectedEdge/Posting/NQuad
+// Helper function, to decide value type of DirectedEdge/Posting/N-Quad
 func ValueType(hasValue, hasLang, hasSpecialId bool) ValueTypeInfo {
 	switch {
 	case hasValue && hasLang:


### PR DESCRIPTION
I've noticed we mix N-Quads and NQuads in docs and in source code comments. 
Some files even had both versions.

N-Quad is preferred because that's what [the standard](https://www.w3.org/TR/n-quads/) is using. And our docs link to that standard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3144)
<!-- Reviewable:end -->
