### PR TITLE
Skip afterUid after decoder seek

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -44,7 +44,7 @@ func IntersectCompressedWith(pack *pb.UidPack, afterUID uint64, v, o *pb.List) {
 		return
 	}
 	dec := codec.Decoder{Pack: pack}
-	dec.Seek(afterUID)
+	dec.Seek(afterUID, codec.SeekStart)
 	n := dec.ApproxLen()
 	m := len(v.Uids)
 
@@ -118,7 +118,7 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	}
 
 	for _, u := range q {
-		uids := dec.Seek(u)
+		uids := dec.Seek(u, codec.SeekStart)
 		if len(uids) == 0 {
 			return
 		}

--- a/codec/benchmark/benchmark.go
+++ b/codec/benchmark/benchmark.go
@@ -144,7 +144,7 @@ func benchmarkUnpack(trials int, chunks *chunks) int {
 		start := time.Now()
 		for _, p := range packed {
 			dec := codec.Decoder{Pack: p}
-			for uids := dec.Seek(0); len(uids) > 0; uids = dec.Next() {
+			for uids := dec.Seek(0, 0); len(uids) > 0; uids = dec.Next() {
 			}
 		}
 		times[i] = int(time.Since(start).Nanoseconds())

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -29,8 +29,10 @@ import (
 type seekPos int
 
 const (
-	SeekStart   seekPos = iota // seek relative to the origin of the list (inclusive)
-	SeekCurrent                // seek relative to the current offset
+	// SeekStart is used with Seek() to search relative to the Uid, returning it in the results.
+	SeekStart seekPos = iota
+	// SeekCurrent to Seek() a Uid using it as offset, not as part of the results.
+	SeekCurrent
 )
 
 type Encoder struct {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	SeekStart   = 0 // seek relative to the origin of the file
+	SeekStart   = 0 // seek relative to the origin of the list (inclusive)
 	SeekCurrent = 1 // seek relative to the current offset
-	// SeekEnd     = 2 // seek relative to the end
+	SeekEnd     = 2 // seek relative to the end
 )
 
 type Encoder struct {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -29,7 +29,6 @@ import (
 const (
 	SeekStart   = 0 // seek relative to the origin of the list (inclusive)
 	SeekCurrent = 1 // seek relative to the current offset
-	SeekEnd     = 2 // seek relative to the end
 )
 
 type Encoder struct {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -115,6 +115,12 @@ func (d *Decoder) ApproxLen() int {
 
 type searchFunc func(int) bool
 
+// Seek will search for uid in a packed block using the specified whence position.
+// The value of whence must be one of the predefined values SeekStart or SeekCurrent.
+// SeekStart searches uid and includes it as part of the results.
+// SeekCurrent searches uid but only as offset, it won't be included with results.
+//
+// Returns a slice of all uids whence the position, or an empty slice if none found.
 func (d *Decoder) Seek(uid uint64, whence seekPos) []uint64 {
 	if d.Pack == nil {
 		return []uint64{}

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/binary"
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -79,6 +80,7 @@ func TestSeek(t *testing.T) {
 	tests := []struct {
 		in, out uint64
 		whence  int
+		empty   bool
 	}{
 		{in: 0, out: 0, whence: SeekStart},
 		{in: 0, out: 0, whence: SeekCurrent},
@@ -92,11 +94,19 @@ func TestSeek(t *testing.T) {
 		{in: 1101, out: 1110, whence: SeekCurrent},
 		{in: 10000, out: 10000, whence: SeekStart},
 		{in: 9999, out: 10000, whence: SeekCurrent},
+		{in: uint64(N), empty: true, whence: SeekStart},
+		{in: uint64(N), empty: true, whence: SeekCurrent},
+		{in: math.MaxUint64, empty: true, whence: SeekStart},
+		{in: math.MaxUint64, empty: true, whence: SeekCurrent},
 	}
 
 	for _, tc := range tests {
 		uids := dec.Seek(tc.in, tc.whence)
-		require.Equal(t, tc.out, uids[0])
+		if tc.empty {
+			require.Empty(t, uids)
+		} else {
+			require.Equal(t, tc.out, uids[0])
+		}
 	}
 }
 

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -82,12 +82,14 @@ func TestSeek(t *testing.T) {
 	}{
 		{in: 0, out: 0, whence: SeekStart},
 		{in: 0, out: 0, whence: SeekCurrent},
+		{in: 100, out: 100, whence: SeekStart},
+		{in: 100, out: 110, whence: SeekCurrent},
 		{in: 1000, out: 1000, whence: SeekStart},
 		{in: 1000, out: 1010, whence: SeekCurrent},
-		{in: 99, out: 100, whence: SeekStart},
-		{in: 99, out: 100, whence: SeekCurrent},
-		{in: 101, out: 110, whence: SeekStart},
-		{in: 101, out: 110, whence: SeekCurrent},
+		{in: 1999, out: 2000, whence: SeekStart},
+		{in: 1999, out: 2000, whence: SeekCurrent},
+		{in: 1101, out: 1110, whence: SeekStart},
+		{in: 1101, out: 1110, whence: SeekCurrent},
 		{in: 10000, out: 10000, whence: SeekStart},
 		{in: 9999, out: 10000, whence: SeekCurrent},
 	}

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -79,7 +79,7 @@ func TestSeek(t *testing.T) {
 
 	tests := []struct {
 		in, out uint64
-		whence  int
+		whence  seekPos
 		empty   bool
 	}{
 		{in: 0, out: 0, whence: SeekStart},

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -88,6 +88,8 @@ func TestSeek(t *testing.T) {
 		{in: 99, out: 100, whence: SeekCurrent},
 		{in: 101, out: 110, whence: SeekStart},
 		{in: 101, out: 110, whence: SeekCurrent},
+		{in: 10000, out: 10000, whence: SeekStart},
+		{in: 9999, out: 10000, whence: SeekCurrent},
 	}
 
 	for _, tc := range tests {

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -376,7 +376,7 @@ func history(lookup []byte, itr *badger.Iterator) {
 			fmt.Fprintf(&buf, " Num uids = %d. Size = %d\n",
 				codec.ExactLen(plist.Pack), plist.Pack.Size())
 			dec := codec.Decoder{Pack: plist.Pack}
-			for uids := dec.Seek(0); len(uids) > 0; uids = dec.Next() {
+			for uids := dec.Seek(0, codec.SeekStart); len(uids) > 0; uids = dec.Next() {
 				for _, uid := range uids {
 					fmt.Fprintf(&buf, " Uid = %d\n", uid)
 				}

--- a/posting/list.go
+++ b/posting/list.go
@@ -103,7 +103,7 @@ func (it *PIterator) Init(pl *pb.PostingList, afterUid uint64) {
 	it.uidx = 0
 
 	// The decoder Seek includes afterUid in uids, we must skip it to iterate correctly.
-	if len(it.uids) > 0 && it.uids[0] == afterUid {
+	if it.Valid() && it.uids[0] == afterUid {
 		it.uidx++
 	}
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -99,13 +99,9 @@ func (it *PIterator) Init(pl *pb.PostingList, afterUid uint64) {
 	it.uidPosting = &pb.Posting{}
 
 	it.dec = &codec.Decoder{Pack: pl.Pack}
-	it.uids = it.dec.Seek(afterUid)
+	// codec.SeekCurrent makes sure we skip returning afterUid during seek.
+	it.uids = it.dec.Seek(afterUid, codec.SeekCurrent)
 	it.uidx = 0
-
-	// The decoder Seek includes afterUid in uids, we must skip it to iterate correctly.
-	if it.Valid() && it.uids[0] == afterUid {
-		it.uidx++
-	}
 
 	it.plen = len(pl.Postings)
 	it.pidx = sort.Search(it.plen, func(idx int) bool {

--- a/query/query.go
+++ b/query/query.go
@@ -828,7 +828,7 @@ func (args *params) fill(gq *gql.GraphQuery) error {
 		if err != nil {
 			return err
 		}
-		args.AfterUID = uint64(after)
+		args.AfterUID = after
 	}
 
 	if args.Alias == "shortest" {

--- a/worker/task.go
+++ b/worker/task.go
@@ -807,7 +807,7 @@ func (qs *queryState) helpProcessTask(
 
 	opts := posting.ListOptions{
 		ReadTs:   q.ReadTs,
-		AfterUID: uint64(q.AfterUid),
+		AfterUID: q.AfterUid,
 	}
 	// If we have srcFunc and Uids, it means its a filter. So we intersect.
 	if srcFn.fnType != NotAFunction && q.UidList != nil && len(q.UidList.Uids) > 0 {


### PR DESCRIPTION
When using pagination, both at root and children, the pagination results include the uid specified in `after` clause. This change fixes the posting list iterator by skipping the `afterUid` from the unpacked uid list, to yield the correct result.

Closes #3109

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3149)
<!-- Reviewable:end -->
