### PR TITLE
Empty datetime will fail when returning results

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -159,7 +159,12 @@ func valToBytes(v types.Val) ([]byte, error) {
 		}
 		return []byte("false"), nil
 	case types.DateTimeID:
-		return v.Value.(time.Time).MarshalJSON()
+		// Return empty string instead of zero-time value string - issue#3166
+		t := v.Value.(time.Time)
+		if t.IsZero() {
+			return []byte(`""`), nil
+		}
+		return t.MarshalJSON()
 	case types.GeoID:
 		return geojson.Marshal(v.Value.(geom.T))
 	case types.UidID:

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -79,12 +79,8 @@ func Convert(from Val, toID TypeID) (Val, error) {
 				return to, x.Errorf("Invalid value for bool %v", data[0])
 			case DateTimeID:
 				var t time.Time
-				// Only try to convert binary data with length > 0. If the value is null,
-				// convert to zero-time value.
-				if len(data) != 0 {
-					if err := t.UnmarshalBinary(data); err != nil {
-						return to, err
-					}
+				if err := t.UnmarshalBinary(data); err != nil {
+					return to, err
 				}
 				*res = t
 			case GeoID:
@@ -106,46 +102,34 @@ func Convert(from Val, toID TypeID) (Val, error) {
 			case BinaryID:
 				*res = []byte(vc)
 			case IntID:
-				*res = int64(0)
-				if vc != "" {
-					val, err := strconv.ParseInt(vc, 10, 64)
-					if err != nil {
-						return to, err
-					}
-					*res = val
+				val, err := strconv.ParseInt(vc, 10, 64)
+				if err != nil {
+					return to, err
 				}
+				*res = val
 			case FloatID:
-				*res = float64(0)
-				if vc != "" {
-					val, err := strconv.ParseFloat(vc, 64)
-					if err != nil {
-						return to, err
-					}
-					if math.IsNaN(val) {
-						return to, fmt.Errorf("Got invalid value: NaN")
-					}
-					*res = val
+				val, err := strconv.ParseFloat(vc, 64)
+				if err != nil {
+					return to, err
 				}
+				if math.IsNaN(val) {
+					return to, fmt.Errorf("Got invalid value: NaN")
+				}
+				*res = val
 			case StringID, DefaultID:
 				*res = vc
 			case BoolID:
-				*res = false
-				if vc != "" {
-					val, err := strconv.ParseBool(vc)
-					if err != nil {
-						return to, err
-					}
-					*res = val
+				val, err := strconv.ParseBool(vc)
+				if err != nil {
+					return to, err
 				}
+				*res = val
 			case DateTimeID:
-				*res = time.Time{}
-				if vc != "" {
-					t, err := ParseTime(vc)
-					if err != nil {
-						return to, err
-					}
-					*res = t
+				t, err := ParseTime(vc)
+				if err != nil {
+					return to, err
 				}
+				*res = t
 			case GeoID:
 				var g geom.T
 				text := bytes.Replace([]byte(vc), []byte("'"), []byte("\""), -1)
@@ -184,10 +168,7 @@ func Convert(from Val, toID TypeID) (Val, error) {
 			case StringID, DefaultID:
 				*res = strconv.FormatInt(vc, 10)
 			case DateTimeID:
-				*res = time.Time{}
-				if vc != 0 {
-					*res = time.Unix(vc, 0).UTC()
-				}
+				*res = time.Unix(vc, 0).UTC()
 			default:
 				return to, cantConvert(fromID, toID)
 			}
@@ -217,13 +198,10 @@ func Convert(from Val, toID TypeID) (Val, error) {
 			case StringID, DefaultID:
 				*res = strconv.FormatFloat(vc, 'G', -1, 64)
 			case DateTimeID:
-				*res = time.Time{}
-				if vc != 0 {
-					secs := int64(vc)
-					fracSecs := vc - float64(secs)
-					nsecs := int64(fracSecs * nanoSecondsInSec)
-					*res = time.Unix(secs, nsecs).UTC()
-				}
+				secs := int64(vc)
+				fracSecs := vc - float64(secs)
+				nsecs := int64(fracSecs * nanoSecondsInSec)
+				*res = time.Unix(secs, nsecs).UTC()
 			default:
 				return to, cantConvert(fromID, toID)
 			}
@@ -263,48 +241,28 @@ func Convert(from Val, toID TypeID) (Val, error) {
 	case DateTimeID:
 		{
 			var t time.Time
-			// When we use Convert(BinaryID, DateTimeID) to store values if the value is empty,
-			// the conversion yields a zero time value. Here we check if that's the case and skip
-			// marshaling and return the ztv. Then we can handle it better if we need to return it
-			// in a result.
-			if len(data) == 15 {
-				if err := t.UnmarshalBinary(data); err != nil {
-					return to, err
-				}
+			if err := t.UnmarshalBinary(data); err != nil {
+				return to, err
 			}
-			// NOTE: when converting datetime values to anything else, we must
-			// check for zero-time value and return the zero value of the new type.
 			switch toID {
 			case DateTimeID:
 				*res = t
 			case BinaryID:
-				*res = []byte("")
-				if !t.IsZero() {
-					r, err := t.MarshalBinary()
-					if err != nil {
-						return to, err
-					}
-					*res = r
+				r, err := t.MarshalBinary()
+				if err != nil {
+					return to, err
 				}
+				*res = r
 			case StringID, DefaultID:
-				*res = ""
-				if !t.IsZero() {
-					val, err := t.MarshalText()
-					if err != nil {
-						return to, err
-					}
-					*res = string(val)
+				val, err := t.MarshalText()
+				if err != nil {
+					return to, err
 				}
+				*res = string(val)
 			case IntID:
-				*res = int64(0)
-				if !t.IsZero() {
-					*res = t.Unix()
-				}
+				*res = t.Unix()
 			case FloatID:
-				*res = float64(0)
-				if !t.IsZero() {
-					*res = float64(t.UnixNano()) / float64(nanoSecondsInSec)
-				}
+				*res = float64(t.UnixNano()) / float64(nanoSecondsInSec)
 			default:
 				return to, cantConvert(fromID, toID)
 			}
@@ -432,23 +390,17 @@ func Marshal(from Val, to *Val) error {
 		vc := val.(time.Time)
 		switch toID {
 		case StringID, DefaultID:
-			*res = ""
-			if !vc.IsZero() {
-				val, err := vc.MarshalText()
-				if err != nil {
-					return err
-				}
-				*res = string(val)
+			val, err := vc.MarshalText()
+			if err != nil {
+				return err
 			}
+			*res = string(val)
 		case BinaryID:
-			*res = []byte("")
-			if !vc.IsZero() {
-				r, err := vc.MarshalBinary()
-				if err != nil {
-					return err
-				}
-				*res = r
+			r, err := vc.MarshalBinary()
+			if err != nil {
+				return err
 			}
+			*res = r
 		default:
 			return cantConvert(fromID, toID)
 		}

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -36,10 +36,17 @@ import (
 
 // Convert converts the value to given scalar type.
 func Convert(from Val, toID TypeID) (Val, error) {
-	to := ValueForType(toID)
+	var to Val
+
+	// sanity: we expect a value
+	data, ok := from.Value.([]byte)
+	if !ok {
+		return to, x.Errorf("Invalid data to convert to %s", toID.Name())
+	}
+	to = ValueForType(toID)
 	fromID := from.Tid
-	data := from.Value.([]byte)
 	res := &to.Value
+
 	// Convert from-type to to-type and store in the result interface.
 	switch fromID {
 	case BinaryID:

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -252,7 +252,10 @@ func Convert(from Val, toID TypeID) (Val, error) {
 	case DateTimeID:
 		{
 			var t time.Time
-			// We must inverse the binary->datetime for zero-time values.
+			// When we use Convert(BinaryID, DateTimeID) to store values if the value is empty,
+			// the conversion yields a zero time value. Here we check if that's the case and skip
+			// marshaling and return the ztv. Then we can handle it better if we need to return it
+			// in a result.
 			if !bytes.Equal(data, []byte("")) {
 				if err := t.UnmarshalBinary(data); err != nil {
 					return to, err

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -252,8 +252,11 @@ func Convert(from Val, toID TypeID) (Val, error) {
 	case DateTimeID:
 		{
 			var t time.Time
-			if err := t.UnmarshalBinary(data); err != nil {
-				return to, err
+			// We must inverse the binary->datetime for zero-time values.
+			if !bytes.Equal(data, []byte("")) {
+				if err := t.UnmarshalBinary(data); err != nil {
+					return to, err
+				}
 			}
 			// NOTE: when converting datetime values to anything else, we must
 			// check for zero-time value and return the zero value of the new type.

--- a/types/conversion_test.go
+++ b/types/conversion_test.go
@@ -84,6 +84,10 @@ func TestConversionEdgeCases(t *testing.T) {
 		in, out Val
 		failure string
 	}{
+		{in: Val{Tid: BinaryID, Value: nil},
+			out:     Val{Tid: BinaryID, Value: nil},
+			failure: "Invalid data to convert to binary"},
+
 		// From BinaryID to X
 		{in: Val{Tid: BinaryID, Value: []byte{}},
 			out:     Val{Tid: IntID, Value: int64(0)},

--- a/types/conversion_test.go
+++ b/types/conversion_test.go
@@ -79,6 +79,36 @@ func TestSameConversionDateTime(t *testing.T) {
 	}
 }
 
+func TestConversionEmpty(t *testing.T) {
+	tests := []struct {
+		in, out Val
+	}{
+		{in: Val{Tid: BinaryID, Value: []byte{}},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+		{in: Val{Tid: BinaryID, Value: bs("")},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
+			out: Val{Tid: BinaryID, Value: []byte{}}},
+		{in: Val{Tid: StringID, Value: bs("")},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
+			out: Val{Tid: StringID, Value: ""}},
+		{in: Val{Tid: DefaultID, Value: bs("")},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
+			out: Val{Tid: DefaultID, Value: ""}},
+		{in: Val{Tid: DateTimeID, Value: bs("")},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+		{in: Val{Tid: DateTimeID, Value: []byte{}},
+			out: Val{Tid: DateTimeID, Value: time.Time{}}},
+	}
+	for _, tc := range tests {
+		out, err := Convert(tc.in, tc.out.Tid)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.out, out)
+	}
+}
+
 func TestConvertToDefault(t *testing.T) {
 	tests := []struct {
 		in  Val

--- a/types/conversion_test.go
+++ b/types/conversion_test.go
@@ -84,8 +84,8 @@ func TestConversionEdgeCases(t *testing.T) {
 		in, out Val
 		failure string
 	}{
-		{in: Val{Tid: BinaryID, Value: nil},
-			out:     Val{Tid: BinaryID, Value: nil},
+		{in: Val{Tid: BinaryID},
+			out:     Val{Tid: BinaryID},
 			failure: "Invalid data to convert to binary"},
 
 		// From BinaryID to X
@@ -169,7 +169,8 @@ func TestConversionEdgeCases(t *testing.T) {
 			out:     Val{Tid: FloatID, Value: float64(0)},
 			failure: "Time.UnmarshalBinary: no data"},
 		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
-			out: Val{Tid: FloatID, Value: float64(time.Time{}.UnixNano()) / float64(nanoSecondsInSec)}},
+			out: Val{Tid: FloatID,
+				Value: float64(time.Time{}.UnixNano()) / float64(nanoSecondsInSec)}},
 	}
 	for _, tc := range tests {
 		t.Logf("%s to %s != %v", tc.in.Tid.Name(), tc.out.Tid.Name(), tc.out.Value)


### PR DESCRIPTION
Datetime predicates with empty values are stored internally as [zero-time values](https://golang.org/pkg/time/#Time.IsZero) (ZVT). But when returning the results of a query, the ZTV is converted to a binary value and converted again to datetime (to preTraverse results). This led to marshaling empty string to datetime which failed. This change adds detection of ZTV when returning results to avoid the marshaling failure.

Closes #3166

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3169)
<!-- Reviewable:end -->
