### PR TITLE
Turn obsolete error into warning

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -340,7 +340,8 @@ func aggWithVarFieldName(pc *SubGraph) string {
 
 func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
 	if len(pc.Params.uidToVal) == 0 {
-		return x.Errorf("Wrong use of var() with %v.", pc.Params.NeedsVar)
+		glog.V(2).Infof("Wrong use of var() with %v.", pc.Params.NeedsVar)
+		return nil
 	}
 	sv, ok := pc.Params.uidToVal[uid]
 	if !ok || sv.Value == nil {

--- a/query/query.go
+++ b/query/query.go
@@ -340,7 +340,6 @@ func aggWithVarFieldName(pc *SubGraph) string {
 
 func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
 	if len(pc.Params.uidToVal) == 0 {
-		glog.V(2).Infof("Wrong use of var() with %v.", pc.Params.NeedsVar)
 		return nil
 	}
 	sv, ok := pc.Params.uidToVal[uid]


### PR DESCRIPTION
The default value logic obsoleted this error. When generating the output graph
we already have all the values necessary. This error was when we needed to match `uidToVal`
to `NeedsVar`.

Closes #3171

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3172)
<!-- Reviewable:end -->
