### PR TITLE
Fix bulk loader bug regarding unknown UID predicates.

### DIFF
--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -81,6 +81,9 @@ func (s *schemaStore) validateType(de *pb.DirectedEdge, objectIsUID bool) {
 		sch, ok = s.m[de.Attr]
 		if !ok {
 			sch = &pb.SchemaUpdate{ValueType: de.ValueType}
+			if objectIsUID {
+				sch.List = true
+			}
 			s.m[de.Attr] = sch
 		}
 		s.Unlock()


### PR DESCRIPTION
When a new predicate is created by the bulk loader, it should default to
a list if the object typ is UID.

Fixes #3150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3173)
<!-- Reviewable:end -->
