### PR TITLE
Fix bug for queries with @recurse and expand(_all_).

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -468,6 +468,7 @@ func populateCluster() {
 		<36> <abbr> "CA" .
 
 		<1> <password> "123456" .
+		<32> <password> "123456" .
 		<23> <pass> "654321" .
 
 		<23> <shadow_deep> "4" .

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -94,6 +94,11 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 		}
 
 		for _, sg := range exec {
+			// sg.uidMatrix can be empty. Continue if that is the case.
+			if len(sg.uidMatrix) == 0 {
+				continue
+			}
+
 			if sg.UnknownAttr {
 				continue
 			}


### PR DESCRIPTION
Currently this type of queries might result in an unrecoverable error
in the alpha. This happens for example, while trying to expand on a node
of type PASSWORD.

The reason is that handleValuePostings and handleUidPostings sometimes
successfully return early without setting the UidMatrix field.

This change adds a fix and modifies the existing test to trigger this
case. I have verified that the test crashes the alpha when the fix is
absent.

Fixes #3161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3179)
<!-- Reviewable:end -->
