### PR TITLE
Fix a StartTs Mismatch bug 

### DIFF
--- a/dgraph/cmd/counter/increment_test.go
+++ b/dgraph/cmd/counter/increment_test.go
@@ -218,3 +218,17 @@ func TestBestEffortOnly(t *testing.T) {
 	}
 	t.Logf("Best-Effort only reads with multiple preds OK.")
 }
+
+func TestBestEffortTs(t *testing.T) {
+	dg := setup(t)
+	pred := "counter.val"
+	incrementInLoop(t, dg, 1)
+	readBestEffort(t, dg, pred, 1)
+	txn := dg.NewReadOnlyTxn().BestEffort()
+	_, err := queryCounter(txn, pred)
+	require.NoError(t, err)
+
+	incrementInLoop(t, dg, 1)        // Increment the MaxAssigned ts at Alpha.
+	_, err = queryCounter(txn, pred) // The timestamp here shouldn't change.
+	require.NoError(t, err)
+}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -593,7 +593,9 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Respo
 		if !req.ReadOnly {
 			return resp, x.Errorf("A best effort query must be read-only.")
 		}
-		req.StartTs = posting.Oracle().MaxAssigned()
+		if req.StartTs == 0 {
+			req.StartTs = posting.Oracle().MaxAssigned()
+		}
 		queryRequest.Cache = worker.NoTxnCache
 	}
 	if req.StartTs == 0 {


### PR DESCRIPTION
It happens when running multiple best effort queries using the same txn. Reuse the same timestamp instead of allocating a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3187)
<!-- Reviewable:end -->
