### PR TITLE
Do not retrieve facets when max recurse depth has been reached.

### DIFF
--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -840,7 +840,13 @@ func TestRecurseFacetOrder(t *testing.T) {
 	}
   `
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"friend":[{"uid":"0x19","name":"Daryl Dixon","friend|since":"2007-05-02T15:04:05Z"},{"friend":[{"friend|since":"2006-01-02T15:04:05Z"}],"uid":"0x17","name":"Rick Grimes","friend|since":"2006-01-02T15:04:05Z"},{"uid":"0x1f","name":"Andrea","friend|since":"2006-01-02T15:04:05Z"},{"uid":"0x65","friend|since":"2005-05-02T15:04:05Z"},{"uid":"0x18","name":"Glenn Rhee","friend|since":"2004-05-02T15:04:05Z"}],"uid":"0x1","name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"friend":[
+			{"uid":"0x19","name":"Daryl Dixon","friend|since":"2007-05-02T15:04:05Z"},
+			{"uid":"0x17","name":"Rick Grimes","friend|since":"2006-01-02T15:04:05Z"},
+			{"uid":"0x1f","name":"Andrea","friend|since":"2006-01-02T15:04:05Z"},
+			{"uid":"0x65","friend|since":"2005-05-02T15:04:05Z"},
+			{"uid":"0x18","name":"Glenn Rhee","friend|since":"2004-05-02T15:04:05Z"}],
+		"uid":"0x1","name":"Michonne"}]}}`, js)
 
 	query = `
     {
@@ -852,7 +858,13 @@ func TestRecurseFacetOrder(t *testing.T) {
 	}
   `
 	js = processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"friend":[{"uid":"0x18","name":"Glenn Rhee","friend|since":"2004-05-02T15:04:05Z"},{"uid":"0x65","friend|since":"2005-05-02T15:04:05Z"},{"friend":[{"friend|since":"2006-01-02T15:04:05Z"}],"uid":"0x17","name":"Rick Grimes","friend|since":"2006-01-02T15:04:05Z"},{"uid":"0x1f","name":"Andrea","friend|since":"2006-01-02T15:04:05Z"},{"uid":"0x19","name":"Daryl Dixon","friend|since":"2007-05-02T15:04:05Z"}],"uid":"0x1","name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"friend":[
+			{"uid":"0x18","name":"Glenn Rhee","friend|since":"2004-05-02T15:04:05Z"},
+			{"uid":"0x65","friend|since":"2005-05-02T15:04:05Z"},
+			{"uid":"0x17","name":"Rick Grimes","friend|since":"2006-01-02T15:04:05Z"},
+			{"uid":"0x1f","name":"Andrea","friend|since":"2006-01-02T15:04:05Z"},
+			{"uid":"0x19","name":"Daryl Dixon","friend|since":"2007-05-02T15:04:05Z"}],
+		"uid":"0x1","name":"Michonne"}]}}`, js)
 }
 
 func TestFacetsAlias(t *testing.T) {

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -68,6 +68,16 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 		}
 		depth++
 
+		// When the maximum depth has been reached, avoid retrieving any facets as
+		// the nodes at the other end of the edge will not be a part of this query.
+		// Otherwise, the facets will be included in the query without any other
+		// information about the node, which is quite counter-intuitive.
+		if depth == maxDepth {
+			for _, sg := range exec {
+				sg.Params.Facet = nil
+			}
+		}
+
 		rrch := make(chan error, len(exec))
 		for _, sg := range exec {
 			go ProcessGraph(ctx, sg, dummy, rrch)


### PR DESCRIPTION
Currently, recurse will retrive the facets at max depth, which results
in the facets being present in the results while the node on the other
side of the edge is absent from the result. This change modifies the
logic so that facets are only included if the node to which the edge
connects is included in the results as well.

Fixes #3163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3190)
<!-- Reviewable:end -->
