### PR TITLE
Put data before extensions in JSON response.

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -199,11 +199,9 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	out.WriteRune('{')
-	writeEntry("extensions", js)
-	out.WriteRune(',')
-
-	// User can either ask for schema or have a query.
 	writeEntry("data", resp.Json)
+	out.WriteRune(',')
+	writeEntry("extensions", js)
 	out.WriteRune('}')
 
 	writeResponse(w, r, out.Bytes())


### PR DESCRIPTION
Put the query results first in the response, since that's what the user is really asking for, instead of the  metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3194)
<!-- Reviewable:end -->
