### PR TITLE
test.sh: add oss test flag

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -15,7 +15,7 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    xgo --targets=linux/amd64 . && mv -f dgraph-linux-amd64 $GOPATH/bin/dgraph
+    (env GOOS=linux GOARCH=amd64 go build) && mv -f dgraph $GOPATH/bin/dgraph
   else
     make install
   fi

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -14,7 +14,11 @@ function restartCluster {
   basedir=$GOPATH/src/github.com/dgraph-io/dgraph
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
-  make install
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    xgo --targets=linux/amd64 . && mv -f dgraph-linux-amd64 $GOPATH/bin/dgraph
+  else
+    make install
+  fi
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
   docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
   popd >/dev/null

--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,7 @@ options:
     -u --unit       run unit tests only
     -c --cluster    run unit tests and custom cluster test
     -f --full       run all tests
+       --oss        run tests with 'oss' tagging
     -v --verbose    run tests in verbose mode
     -n --no-cache   re-run test even if previous result is in cache
 
@@ -121,7 +122,7 @@ function RunCustomClusterTests {
 # MAIN
 #
 
-ARGS=$(/usr/bin/getopt -n$ME -o"hucfvn" -l"help,unit,cluster,full,verbose,no-cache" -- "$@") \
+ARGS=$(getopt -n$ME -o"hucfvn" -l"help,unit,cluster,full,oss,verbose,no-cache" -- "$@") \
     || exit 1
 eval set -- "$ARGS"
 while true; do
@@ -132,6 +133,7 @@ while true; do
         -f|--full)      TEST_SET="unit:cluster:full"  ;;
         -v|--verbose)   GO_TEST_OPTS+=( "-v" )        ;;
         -n|--no-cache)  GO_TEST_OPTS+=( "-count=1" )  ;;
+        --oss)          GO_TEST_OPTS+=( "-tags=oss" )  ;;
         --)             shift; break                  ;;
     esac
     shift

--- a/test.sh
+++ b/test.sh
@@ -14,6 +14,12 @@
 #   PATH="/usr/local/opt/curl/bin:$PATH"
 #   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 #   PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+#
+# xgo cross-compiler (to build binary for Docker):
+#   go get github.com/karalabe/xgo
+#
+# Keep in mind that the test build will overwrite the "dgraph"
+# binary in your $GOPATH/bin with the Linux-ELF binary for Docker.
 
 readonly ME=${0##*/}
 readonly DGRAPH_ROOT=${GOPATH:-$HOME}/src/github.com/dgraph-io/dgraph

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,19 @@
 #
 # usage: test.sh [pkg_regex]
 
+# Notes for testing under macOS (Sierra and up)
+# Required Homebrew (https://brew.sh/) packages:
+#   - curl
+#   - coreutils
+#   - gnu-getop
+#   - findutils
+#
+# Your $PATH must have all required packages in .bashrc:
+#   PATH="/usr/local/opt/gnu-getopt/bin:$PATH"
+#   PATH="/usr/local/opt/curl/bin:$PATH"
+#   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+#   PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+
 readonly ME=${0##*/}
 readonly DGRAPH_ROOT=${GOPATH:-$HOME}/src/github.com/dgraph-io/dgraph
 

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,7 @@
 
 # Notes for testing under macOS (Sierra and up)
 # Required Homebrew (https://brew.sh/) packages:
+#   - bash
 #   - curl
 #   - coreutils
 #   - gnu-getop
@@ -14,9 +15,10 @@
 #   PATH="/usr/local/opt/curl/bin:$PATH"
 #   PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 #   PATH="/usr/local/opt/findutils/libexec/gnubin:$PATH"
+#   export PATH
 #
-# xgo cross-compiler (to build binary for Docker):
-#   go get github.com/karalabe/xgo
+# After brew packages and PATHs are set, run tests with:
+#   /usr/local/bin/bash test.sh
 #
 # Keep in mind that the test build will overwrite the "dgraph"
 # binary in your $GOPATH/bin with the Linux-ELF binary for Docker.


### PR DESCRIPTION
This PR adds a new `--oss` flag to `test.sh` to test using OSS tagging. Also, minor tweaks to let `test.sh` run in macOS. Running tests in macOS requires installing [Homebrew](https://brew.sh/) 🍺  packages.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3196)
<!-- Reviewable:end -->
