### PR TITLE
UpsertSpan so successful ACL accesses are sent to Jaeger

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -482,8 +482,7 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	}
 
 	err := doAuthorizeAlter()
-	span := otrace.FromContext(ctx)
-	if span != nil {
+	if span := otrace.FromContext(ctx); span != nil {
 		span.Annotatef(nil, (&AccessEntry{
 			userId:    userId,
 			groups:    groupIds,

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -704,7 +704,8 @@ func authorizeQuery(ctx context.Context, req *api.Request) error {
 	}
 
 	err = doAuthorizeQuery()
-	if span := otrace.FromContext(ctx); span != nil {
+	span := otrace.FromContext(ctx)
+	if span != nil {
 		span.Annotatef(nil, (&AccessEntry{
 			userId:    userId,
 			groups:    groupIds,

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -593,8 +593,7 @@ func authorizeMutation(ctx context.Context, mu *api.Mutation) error {
 	}
 
 	err = doAuthorizeMutation()
-	span := otrace.FromContext(ctx)
-	if span != nil {
+	if span := otrace.FromContext(ctx); span != nil {
 		span.Annotatef(nil, (&AccessEntry{
 			userId:    userId,
 			groups:    groupIds,
@@ -703,8 +702,7 @@ func authorizeQuery(ctx context.Context, req *api.Request) error {
 	}
 
 	err = doAuthorizeQuery()
-	span := otrace.FromContext(ctx)
-	if span != nil {
+	if span := otrace.FromContext(ctx); span != nil {
 		span.Annotatef(nil, (&AccessEntry{
 			userId:    userId,
 			groups:    groupIds,

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -276,7 +276,7 @@ func (s *ServerState) getTimestamp(readOnly bool) uint64 {
 }
 
 func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, error) {
-	ctx, span := otrace.StartSpan(ctx, "Server.Alter")
+	ctx, span := x.UpsertSpanWithMethod(ctx, "Server.Alter")
 	defer span.End()
 	span.Annotatef(nil, "Alter operation: %+v", op)
 
@@ -377,6 +377,7 @@ func annotateStartTs(span *otrace.Span, ts uint64) {
 }
 
 func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (resp *api.Assigned, err error) {
+	ctx, _ = x.UpsertSpanWithMethod(ctx, methodMutate)
 	if err := authorizeMutation(ctx, mu); err != nil {
 		return nil, err
 	}
@@ -390,8 +391,7 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation) (resp *api.Assi
 	}
 	startTime := time.Now()
 
-	ctx, span := otrace.StartSpan(ctx, methodMutate)
-	ctx = x.WithMethod(ctx, methodMutate)
+	ctx, span := x.UpsertSpanWithMethod(ctx, methodMutate)
 	defer func() {
 		span.End()
 		v := x.TagValueStatusOK
@@ -509,6 +509,8 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation) (resp *api.Assi
 }
 
 func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, error) {
+	ctx, _ = x.UpsertSpanWithMethod(ctx, methodQuery)
+
 	if err := authorizeQuery(ctx, req); err != nil {
 		return nil, err
 	}
@@ -521,21 +523,17 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, er
 
 // This method is used to execute the query and return the response to the
 // client as a protocol buffer message.
-func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Response, rerr error) {
+func (s *Server) doQuery(ctx context.Context, req *api.Request) (*api.Response, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
 	startTime := time.Now()
 
+	ctx, span := x.UpsertSpan(ctx, methodQuery)
 	var measurements []ostats.Measurement
-	ctx, span := otrace.StartSpan(ctx, methodQuery)
-	ctx = x.WithMethod(ctx, methodQuery)
 	defer func() {
 		span.End()
 		v := x.TagValueStatusOK
-		if rerr != nil {
-			v = x.TagValueStatusError
-		}
 		ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, v))
 		timeSpentMs := x.SinceMs(startTime)
 		measurements = append(measurements, x.LatencyMs.M(timeSpentMs))
@@ -551,7 +549,7 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Respo
 		measurements = append(measurements, x.PendingQueries.M(-1))
 	}()
 
-	resp = &api.Response{}
+	resp := &api.Response{}
 	if len(req.Query) == 0 {
 		span.Annotate(nil, "Empty query")
 		return resp, fmt.Errorf("Empty query")

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -531,16 +531,20 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (*api.Response, 
 
 	ctx, span := x.UpsertSpanWithMethod(ctx, methodQuery)
 	var measurements []ostats.Measurement
+	var err error
 	defer func() {
 		span.End()
 		v := x.TagValueStatusOK
+		if err != nil {
+			v = x.TagValueStatusError
+		}
 		ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, v))
 		timeSpentMs := x.SinceMs(startTime)
 		measurements = append(measurements, x.LatencyMs.M(timeSpentMs))
 		ostats.Record(ctx, measurements...)
 	}()
 
-	if err := x.HealthCheck(); err != nil {
+	if err = x.HealthCheck(); err != nil {
 		return nil, err
 	}
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -529,7 +529,7 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (*api.Response, 
 	}
 	startTime := time.Now()
 
-	ctx, span := x.UpsertSpan(ctx, methodQuery)
+	ctx, span := x.UpsertSpanWithMethod(ctx, methodQuery)
 	var measurements []ostats.Measurement
 	defer func() {
 		span.End()

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -112,7 +112,7 @@ var errUnableToServe = errors.New("Server overloaded with pending proposals. Ple
 // to be applied(written to WAL) to all the nodes in the group.
 func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr error) {
 	startTime := time.Now()
-	ctx, _ = x.UpsertSpanWithMethod(ctx, "n.proposeAndWait")
+	ctx = x.WithMethod(ctx, "n.proposeAndWait")
 	defer func() {
 		v := x.TagValueStatusOK
 		if perr != nil {

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -112,7 +112,7 @@ var errUnableToServe = errors.New("Server overloaded with pending proposals. Ple
 // to be applied(written to WAL) to all the nodes in the group.
 func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr error) {
 	startTime := time.Now()
-	ctx = x.WithMethod(ctx, "n.proposeAndWait")
+	ctx, _ = x.UpsertSpanWithMethod(ctx, "n.proposeAndWait")
 	defer func() {
 		v := x.TagValueStatusOK
 		if perr != nil {

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -223,7 +223,12 @@ func UpsertSpanWithMethod(ctx context.Context, name string) (context.Context,
 		ctx, span = otrace.StartSpan(ctx, name)
 	}
 
-	ctx, err := tag.New(ctx, tag.Upsert(KeyMethod, name))
-	Check(err)
+	ctx = WithMethod(ctx, name)
 	return ctx, span
+}
+
+func WithMethod(parent context.Context, method string) context.Context {
+	ctx, err := tag.New(parent, tag.Upsert(KeyMethod, method))
+	Check(err)
+	return ctx
 }

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -214,21 +214,15 @@ func SinceMs(startTime time.Time) float64 {
 	return float64(time.Since(startTime)) / 1e6
 }
 
-// UpsertSpan returns the current the span in the context if it exists.
-// Otherwise it create a new span with the given name and returns the new context and span
-func UpsertSpan(ctx context.Context, name string) (context.Context, *otrace.Span) {
-	span := otrace.FromContext(ctx)
-	if span != nil {
-		return ctx, span
-	}
-	return otrace.StartSpan(ctx, name)
-}
-
 // UpsertSpanWithMethod upserts a span using the provide name, and also upserts the name as a tag
 // under the method key
 func UpsertSpanWithMethod(ctx context.Context, name string) (context.Context,
 	*otrace.Span) {
-	ctx, span := UpsertSpan(ctx, name)
+	span := otrace.FromContext(ctx)
+	if span == nil {
+		ctx, span = otrace.StartSpan(ctx, name)
+	}
+
 	ctx, err := tag.New(ctx, tag.Upsert(KeyMethod, name))
 	Check(err)
 	return ctx, span


### PR DESCRIPTION
spans need to be started inside Query, Mutate, and Alter (instead of doQuery, doMutate, doAlter), so the successful ACL accesses are captured by the span and sent to Jaeger

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3217)
<!-- Reviewable:end -->
