### PR TITLE
Fix panic when deleting a user or group that does not exist

### DIFF
--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -207,6 +207,8 @@ func del(conf *viper.Viper) error {
 }
 
 type AclEntity interface {
+	// the implementation of GetUid must check the case that the entity is nil
+	// and return an empty string accordingly
 	GetUid() string
 }
 
@@ -231,7 +233,7 @@ func userOrGroupDel(conf *viper.Viper, userOrGroupId string,
 	if err != nil {
 		return err
 	}
-	if entity == nil || len(entity.GetUid()) == 0 {
+	if len(entity.GetUid()) == 0 {
 		return fmt.Errorf("unable to delete %q since it does not exist",
 			userOrGroupId)
 	}

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -233,7 +233,7 @@ func userOrGroupDel(conf *viper.Viper, userOrGroupId string,
 	if err != nil {
 		return err
 	}
-	if len(entity.GetUid()) == 0 {
+	if entity == nil || len(entity.GetUid()) == 0 {
 		return fmt.Errorf("unable to delete %q since it does not exist",
 			userOrGroupId)
 	}

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"time"
@@ -220,7 +221,7 @@ func userOrGroupDel(conf *viper.Viper, userOrGroupId string,
 	if err != nil {
 		return err
 	}
-	if entity == nil || len(entity.GetUid()) == 0 {
+	if reflect.ValueOf(entity).IsNil() || len(entity.GetUid()) == 0 {
 		return fmt.Errorf("unable to delete %q since it does not exist",
 			userOrGroupId)
 	}

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -185,23 +185,12 @@ func del(conf *viper.Viper) error {
 		return userOrGroupDel(conf, userId,
 			func(ctx context.Context, txn *dgo.Txn, userId string) (AclEntity, error) {
 				user, err := queryUser(ctx, txn, userId)
-				if user == nil {
-					// here we explicitly check if the concrete type is nil, in order to
-					// return a interface type that has both the type and value being nil.
-					// without this check, we would return an interface with only the value
-					// being nil, and such an interface won't be equal to nil per
-					// https://golang.org/doc/faq#nil_error
-					return nil, err
-				}
 				return user, err
 			})
 	}
 	return userOrGroupDel(conf, groupId,
 		func(ctx context.Context, txn *dgo.Txn, groupId string) (AclEntity, error) {
 			group, err := queryGroup(ctx, txn, groupId)
-			if group == nil {
-				return nil, err
-			}
 			return group, err
 		})
 }
@@ -233,7 +222,7 @@ func userOrGroupDel(conf *viper.Viper, userOrGroupId string,
 	if err != nil {
 		return err
 	}
-	if entity == nil || len(entity.GetUid()) == 0 {
+	if len(entity.GetUid()) == 0 {
 		return fmt.Errorf("unable to delete %q since it does not exist",
 			userOrGroupId)
 	}

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -70,6 +70,9 @@ type User struct {
 }
 
 func (u *User) GetUid() string {
+	if u == nil {
+		return ""
+	}
 	return u.Uid
 }
 
@@ -109,6 +112,9 @@ type Group struct {
 }
 
 func (g *Group) GetUid() string {
+	if g == nil {
+		return ""
+	}
 	return g.Uid
 }
 


### PR DESCRIPTION
When deleting a user or group that does not exist, the return variable of type AclEntity has a type, with a value of nil. In such a case, the variable is treated not being nil per https://golang.org/doc/faq#nil_error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3218)
<!-- Reviewable:end -->
