### PR TITLE
Populate the StartTs for the commit gRPC call

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -667,6 +667,7 @@ func (s *Server) CommitOrAbort(ctx context.Context, tc *api.TxnContext) (*api.Tx
 		tctx.Aborted = true
 		return tctx, status.Errorf(codes.Aborted, err.Error())
 	}
+	tctx.StartTs = tc.StartTs
 	tctx.CommitTs = commitTs
 	return tctx, err
 }


### PR DESCRIPTION
so that the client can verify the startTs in the response still matches their locally cached startTs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3228)
<!-- Reviewable:end -->
