### PR TITLE
Fix bug introduced by #3234.

### DIFF
--- a/chunker/json/parse.go
+++ b/chunker/json/parse.go
@@ -254,9 +254,9 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 			continue
 		}
 
-		if op == DeleteNquads {
-			// This corresponds to edge deletion.
-			if v == nil {
+		if v == nil {
+			if op == DeleteNquads {
+				// This corresponds to edge deletion.
 				nq := &api.NQuad{
 					Subject:     mr.uid,
 					Predicate:   pred,
@@ -269,6 +269,9 @@ func mapToNquads(m map[string]interface{}, idx *int, op int, parentPred string) 
 				mr.nquads = append(mr.nquads, nq)
 				continue
 			}
+
+			// If op is SetNquads, ignore this triplet and continue.
+			continue
 		}
 
 		prefix := pred + query.FacetDelimeter

--- a/chunker/json/parse_test.go
+++ b/chunker/json/parse_test.go
@@ -435,3 +435,11 @@ func TestNquadsFromJsonDeleteStarLang(t *testing.T) {
 	}
 	require.Equal(t, expected, nq[0])
 }
+
+func TestSetNquadNilValue(t *testing.T) {
+	json := `{"uid":1000,"name": null}`
+
+	nq, err := Parse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(nq))
+}


### PR DESCRIPTION
I deleted some duplicate logic but I missed a continue statement and as
a result set nquads with a nil value started causing a panic. This
change fixes the bug and introduces a regression test.

Fixes #3255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3258)
<!-- Reviewable:end -->
