### PR TITLE
live loading from stdin

### DIFF
--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -69,6 +69,10 @@ func (rdfChunker) Begin(r *bufio.Reader) error {
 	return nil
 }
 
+// Chunk reads the input line by line until one of the following 3 conditions happens
+// 1) the EOF is reached
+// 2) 1e5 lines have been read
+// 3) some unexpected error happened
 func (rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	batch := new(bytes.Buffer)
 	batch.Grow(1 << 20)
@@ -273,7 +277,14 @@ func slurpQuoted(r *bufio.Reader, out *bytes.Buffer) error {
 // and decompressed automatically even without the gz extension. The caller is responsible for
 // calling the returned cleanup function when done with the reader.
 func FileReader(file string) (rd *bufio.Reader, cleanup func()) {
-	f, err := os.Open(file)
+	var f *os.File
+	var err error
+	if file == "-" {
+		f = os.Stdin
+	} else {
+		f, err = os.Open(file)
+	}
+
 	x.Check(err)
 
 	cleanup = func() { f.Close() }

--- a/x/file.go
+++ b/x/file.go
@@ -79,7 +79,10 @@ func FindDataFiles(str string, ext []string) []string {
 	}
 
 	list := strings.Split(str, ",")
-	if len(list) == 1 {
+	if len(list) == 1 && list[0] != "-" {
+		// make sure the file or directory exists,
+		// and recursively search for files if it's a directory
+
 		fi, err := os.Stat(str)
 		if os.IsNotExist(err) {
 			glog.Errorf("File or directory does not exist: %s", str)


### PR DESCRIPTION
Adding the support of live loader reading from standard input
Refactored the code around chunk processing, mainly because the checking of 
   if err == io.EOF
is supposed to be checking the err returned by the ck.Chunk function, however in the current code, the err variable can be overwriten by the ck.Parse function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3266)
<!-- Reviewable:end -->
