### PR TITLE
Add support for ECDSA in dgraph cert

### DIFF
--- a/dgraph/cmd/cert/cert.go
+++ b/dgraph/cmd/cert/cert.go
@@ -119,7 +119,7 @@ func (c *certConfig) generatePair(keyFile, certFile string) error {
 		return err
 	}
 
-	f, err := safeCreate(certFile, c.force, 0666)
+	fp, err := safeCreate(certFile, c.force, 0666)
 	if err != nil {
 		// check the existing cert.
 		if os.IsExist(err) {
@@ -127,9 +127,9 @@ func (c *certConfig) generatePair(keyFile, certFile string) error {
 		}
 		return err
 	}
-	defer f.Close()
+	defer fp.Close()
 
-	err = pem.Encode(f, &pem.Block{
+	err = pem.Encode(fp, &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: der,
 	})

--- a/dgraph/cmd/cert/cert.go
+++ b/dgraph/cmd/cert/cert.go
@@ -45,6 +45,7 @@ type certConfig struct {
 	force   bool
 	hosts   []string
 	client  string
+	curve   string
 }
 
 // generatePair makes a new key/cert pair from a request. This function
@@ -52,10 +53,11 @@ type certConfig struct {
 // It will generate two files, a key and cert, upon success.
 // Returns nil on success, or an error otherwise.
 func (c *certConfig) generatePair(keyFile, certFile string) error {
-	key, err := makeKey(keyFile, c.keySize, c.force)
+	priv, err := makeKey(keyFile, c)
 	if err != nil {
 		return err
 	}
+	key := priv.(crypto.Signer)
 
 	sn, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt64))
 	if err != nil {

--- a/dgraph/cmd/cert/create.go
+++ b/dgraph/cmd/cert/create.go
@@ -17,6 +17,9 @@
 package cert
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -27,6 +30,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (
@@ -42,39 +47,62 @@ const (
 	keySizeTooLarge = 4096
 )
 
-// makeKey generates an RSA private key of bitSize length, storing it in the
-// file fn. If force is true, the file is replaced.
-// Returns the RSA private key, or error otherwise.
-func makeKey(fn string, bitSize int, force bool) (*rsa.PrivateKey, error) {
-	f, err := safeCreate(fn, force, 0600)
+// makeKey generates an RSA or ECDSA private key using the configuration in 'c'.
+// The new private key is stored in the path at 'keyFile'.
+// If force is true, any existing file at the path is replaced.
+// For RSA, the configuration keySize is used for length.
+// For ECDSA, the configuration elliptical curve is used.
+// Returns the RSA or ECDSA private key, or error otherwise.
+func makeKey(keyFile string, c *certConfig) (crypto.PrivateKey, error) {
+	f, err := safeCreate(keyFile, c.force, 0600)
 	if err != nil {
 		// reuse the existing key, if possible.
 		if os.IsExist(err) {
-			return readKey(fn)
+			return readKey(keyFile)
 		}
 		return nil, err
 	}
 	defer f.Close()
 
-	key, err := rsa.GenerateKey(rand.Reader, bitSize)
+	var key crypto.PrivateKey
+	switch c.curve {
+	case "":
+		key, err = rsa.GenerateKey(rand.Reader, c.keySize)
+	case "P224":
+		key, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case "P256":
+		key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case "P384":
+		key, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case "P521":
+		key, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	err = pem.Encode(f, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
-	if err != nil {
-		return nil, err
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		b, err := x509.MarshalECPrivateKey(k)
+		if err != nil {
+			return nil, err
+		}
+		return key, pem.Encode(f, &pem.Block{
+			Type:  "EC PRIVATE KEY",
+			Bytes: b,
+		})
+	case *rsa.PrivateKey:
+		return key, pem.Encode(f, &pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: x509.MarshalPKCS1PrivateKey(k),
+		})
 	}
-
-	return key, nil
+	return nil, x.Errorf("Unsupported key type: %T", key)
 }
 
 // readKey tries to read and decode the contents of a private key at fn.
 // Returns the RSA private key, or error otherwise.
-func readKey(fn string) (*rsa.PrivateKey, error) {
+func readKey(fn string) (crypto.PrivateKey, error) {
 	b, err := ioutil.ReadFile(fn)
 	if err != nil {
 		return nil, err
@@ -84,11 +112,12 @@ func readKey(fn string) (*rsa.PrivateKey, error) {
 	switch {
 	case block == nil:
 		return nil, fmt.Errorf("Failed to read key block")
-	case block.Type != "RSA PRIVATE KEY":
-		return nil, fmt.Errorf("Unknown PEM type: %s", block.Type)
+	case block.Type == "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case block.Type == "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
 	}
-
-	return x509.ParsePKCS1PrivateKey(block.Bytes)
+	return nil, fmt.Errorf("Unknown PEM type: %s", block.Type)
 }
 
 // readCert tries to read and decode the contents of an RSA-signed cert at fn.
@@ -129,6 +158,7 @@ func createCAPair(opt options) error {
 		until:   defaultCADays,
 		keySize: opt.keySize,
 		force:   opt.force,
+		curve:   opt.curve,
 	}
 	if err := cc.generatePair(opt.caKey, opt.caCert); err != nil {
 		return err
@@ -152,6 +182,7 @@ func createNodePair(opt options) error {
 		keySize: opt.keySize,
 		force:   opt.force,
 		hosts:   opt.nodes,
+		curve:   opt.curve,
 	}
 
 	var err error
@@ -159,9 +190,12 @@ func createNodePair(opt options) error {
 	if err != nil {
 		return err
 	}
-	cc.signer, err = readKey(opt.caKey)
-	if err != nil {
-		return err
+	{
+		priv, err := readKey(opt.caKey)
+		if err != nil {
+			return err
+		}
+		cc.signer = priv.(crypto.Signer)
 	}
 
 	certFile := filepath.Join(opt.dir, defaultNodeCert)
@@ -188,6 +222,7 @@ func createClientPair(opt options) error {
 		keySize: opt.keySize,
 		force:   opt.force,
 		client:  opt.client,
+		curve:   opt.curve,
 	}
 
 	var err error
@@ -195,9 +230,12 @@ func createClientPair(opt options) error {
 	if err != nil {
 		return err
 	}
-	cc.signer, err = readKey(opt.caKey)
-	if err != nil {
-		return err
+	{
+		priv, err := readKey(opt.caKey)
+		if err != nil {
+			return err
+		}
+		cc.signer = priv.(crypto.Signer)
 	}
 
 	certFile := filepath.Join(opt.dir, fmt.Sprint("client.", opt.client, ".crt"))
@@ -227,6 +265,14 @@ func createCerts(opt options) error {
 		return errors.New("Key size value is too large (x > 4096)")
 	case opt.keySize%2 != 0:
 		return errors.New("Key size value must be a factor of 2")
+	}
+
+	if opt.curve != "" {
+		switch opt.curve {
+		case "P224", "P256", "P384", "P521":
+		default:
+			return errors.New(`Elliptic curve value must be one of: "P224", "P256", "P384", "P521"`)
+		}
 	}
 
 	// no path then save it in certsDir.

--- a/dgraph/cmd/cert/info.go
+++ b/dgraph/cmd/cert/info.go
@@ -39,7 +39,7 @@ type certInfo struct {
 	serialNumber string
 	verifiedCA   string
 	digest       string
-	encType      string
+	algo         string
 	expireDate   time.Time
 	hosts        []string
 	fileMode     string
@@ -129,11 +129,11 @@ func getFileInfo(file string) *certInfo {
 		}
 		switch k := key.(type) {
 		case *ecdsa.PrivateKey:
-			info.encType = fmt.Sprintf("ECDSA %s (FIPS-3)", k.PublicKey.Curve.Params().Name)
+			info.algo = fmt.Sprintf("ECDSA %s (FIPS-3)", k.PublicKey.Curve.Params().Name)
 			info.digest = getHexDigest(elliptic.Marshal(k.PublicKey.Curve,
 				k.PublicKey.X, k.PublicKey.Y))
 		case *rsa.PrivateKey:
-			info.encType = fmt.Sprintf("RSA %d bits (PKCS#1)", k.PublicKey.N.BitLen())
+			info.algo = fmt.Sprintf("RSA %d bits (PKCS#1)", k.PublicKey.N.BitLen())
 			info.digest = getHexDigest(k.PublicKey.N.Bytes())
 		}
 

--- a/dgraph/cmd/cert/info.go
+++ b/dgraph/cmd/cert/info.go
@@ -39,6 +39,7 @@ type certInfo struct {
 	serialNumber string
 	verifiedCA   string
 	digest       string
+	encType      string
 	expireDate   time.Time
 	hosts        []string
 	fileMode     string
@@ -86,7 +87,7 @@ func getFileInfo(file string) *certInfo {
 		case *ecdsa.PublicKey:
 			info.digest = getHexDigest(elliptic.Marshal(key.Curve, key.X, key.Y))
 		default:
-			info.digest = "Invalid RSA public key"
+			info.digest = "Invalid public key"
 		}
 
 		if file != defaultCACert {
@@ -128,9 +129,11 @@ func getFileInfo(file string) *certInfo {
 		}
 		switch k := key.(type) {
 		case *ecdsa.PrivateKey:
+			info.encType = fmt.Sprintf("ECDSA %s (FIPS-3)", k.PublicKey.Curve.Params().Name)
 			info.digest = getHexDigest(elliptic.Marshal(k.PublicKey.Curve,
 				k.PublicKey.X, k.PublicKey.Y))
 		case *rsa.PrivateKey:
+			info.encType = fmt.Sprintf("RSA %d bits (PKCS#1)", k.PublicKey.N.BitLen())
 			info.digest = getHexDigest(k.PublicKey.N.Bytes())
 		}
 

--- a/dgraph/cmd/cert/info.go
+++ b/dgraph/cmd/cert/info.go
@@ -80,10 +80,14 @@ func getFileInfo(file string) *certInfo {
 			return &info
 		}
 
-		if key, ok := cert.PublicKey.(*rsa.PublicKey); ok {
+		switch key := cert.PublicKey.(type) {
+		case *rsa.PublicKey:
 			h := md5.Sum(key.N.Bytes())
 			info.md5sum = fmt.Sprintf("%X", h[:])
-		} else {
+		case *ecdsa.PublicKey:
+			h := md5.Sum(elliptic.Marshal(key.Curve, key.X, key.Y))
+			info.md5sum = fmt.Sprintf("%X", h[:])
+		default:
 			info.md5sum = "Invalid RSA public key"
 		}
 

--- a/dgraph/cmd/cert/run.go
+++ b/dgraph/cmd/cert/run.go
@@ -50,7 +50,7 @@ func init() {
 	flag.StringP("dir", "d", defaultDir, "directory containing TLS certs and keys")
 	flag.StringP("ca-key", "k", defaultCAKey, "path to the CA private key")
 	flag.IntP("keysize", "r", defaultKeySize, "RSA key bit size for creating new keys")
-	flag.StringP("curve", "e", "",
+	flag.StringP("elliptic-curve", "e", "",
 		`ECDSA curve for private key. Values are: "P224", "P256", "P384", "P521".`)
 	flag.Int("duration", defaultDays, "duration of cert validity in days")
 	flag.StringSliceP("nodes", "n", nil, "creates cert/key pair for nodes")
@@ -80,7 +80,7 @@ func run() {
 		nodes:   Cert.Conf.GetStringSlice("nodes"),
 		force:   Cert.Conf.GetBool("force"),
 		verify:  Cert.Conf.GetBool("verify"),
-		curve:   Cert.Conf.GetString("curve"),
+		curve:   Cert.Conf.GetString("elliptic-curve"),
 	}
 
 	x.Check(createCerts(opt))

--- a/dgraph/cmd/cert/run.go
+++ b/dgraph/cmd/cert/run.go
@@ -27,10 +27,10 @@ import (
 var Cert x.SubCommand
 
 type options struct {
-	dir, caKey, caCert, client string
-	force, verify              bool
-	keySize, days              int
-	nodes                      []string
+	dir, caKey, caCert, client, curve string
+	force, verify                     bool
+	keySize, days                     int
+	nodes                             []string
 }
 
 var opt options
@@ -49,7 +49,9 @@ func init() {
 	flag := Cert.Cmd.Flags()
 	flag.StringP("dir", "d", defaultDir, "directory containing TLS certs and keys")
 	flag.StringP("ca-key", "k", defaultCAKey, "path to the CA private key")
-	flag.Int("keysize", defaultKeySize, "RSA key bit size for creating new keys")
+	flag.IntP("keysize", "r", defaultKeySize, "RSA key bit size for creating new keys")
+	flag.StringP("curve", "e", "",
+		`ECDSA curve for private key. Values are: "P224", "P256", "P384", "P521".`)
 	flag.Int("duration", defaultDays, "duration of cert validity in days")
 	flag.StringSliceP("nodes", "n", nil, "creates cert/key pair for nodes")
 	flag.StringP("client", "c", "", "create cert/key pair for a client name")
@@ -78,6 +80,7 @@ func run() {
 		nodes:   Cert.Conf.GetStringSlice("nodes"),
 		force:   Cert.Conf.GetBool("force"),
 		verify:  Cert.Conf.GetBool("verify"),
+		curve:   Cert.Conf.GetString("curve"),
 	}
 
 	x.Check(createCerts(opt))

--- a/dgraph/cmd/cert/run.go
+++ b/dgraph/cmd/cert/run.go
@@ -138,8 +138,8 @@ func listCerts() error {
 		if f.hosts != nil {
 			fmt.Printf("%14s: %s\n", "Hosts", strings.Join(f.hosts, ", "))
 		}
-		if f.encType != "" {
-			fmt.Printf("%14s: %s\n", "Encryption", f.encType)
+		if f.algo != "" {
+			fmt.Printf("%14s: %s\n", "Algorithm", f.algo)
 		}
 		fmt.Printf("%14s: %s\n\n", "SHA-256 Digest", f.digest)
 	}

--- a/dgraph/cmd/cert/run.go
+++ b/dgraph/cmd/cert/run.go
@@ -40,9 +40,9 @@ func init() {
 		Use:   "cert",
 		Short: "Dgraph TLS certificate management",
 		Args:  cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			defer x.StartProfile(Cert.Conf).Stop()
-			run()
+			return run()
 		},
 	}
 
@@ -70,7 +70,7 @@ func init() {
 	Cert.Cmd.AddCommand(cmdList)
 }
 
-func run() {
+func run() error {
 	opt = options{
 		dir:     Cert.Conf.GetString("dir"),
 		caKey:   Cert.Conf.GetString("ca-key"),
@@ -83,7 +83,7 @@ func run() {
 		curve:   Cert.Conf.GetString("elliptic-curve"),
 	}
 
-	x.Check(createCerts(opt))
+	return createCerts(opt)
 }
 
 // listCerts handles the subcommand of "dgraph cert ls".
@@ -137,6 +137,9 @@ func listCerts() error {
 		}
 		if f.hosts != nil {
 			fmt.Printf("%14s: %s\n", "Hosts", strings.Join(f.hosts, ", "))
+		}
+		if f.encType != "" {
+			fmt.Printf("%14s: %s\n", "Encryption", f.encType)
 		}
 		fmt.Printf("%14s: %s\n\n", "SHA-256 Digest", f.digest)
 	}


### PR DESCRIPTION
This PR adds support for Weierstrass curves to create private and public keys in Dgraph TLS certificates, `dgraph cert` command.

Summary of changes:
- Modify `makeKey()` and `readKey()` to use crypto.PrivateKey and support any type that implements it.
- Add new flag for ECDSA curves `--elliptic-curve` and `-e`
- Detection code when reading `.key` files to know which type it is (RSA or ECDSA).
- Add new flag for RSA bit length `-r`
- Add 'Algorithm' to indicate the key type in `dgraph cert ls`

Reference #2642

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3269)
<!-- Reviewable:end -->
