### PR TITLE
Small script to benchmark live and bulk loader.

### DIFF
--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -1,0 +1,43 @@
+# Docker compose file for use with test-21million.sh.
+#
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: bank-dg0.1
+    working_dir: /data/dg0.1
+    ports:
+      - 5080:5080
+      - 6080:6080
+    labels:
+      cluster: test
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr --bindall
+
+  dg1:
+    image: dgraph/dgraph:latest
+    container_name: bank-dg1
+    working_dir: /data/dg1
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: volume
+        source: data
+        target: /data/dg1
+    ports:
+      - 8180:8180
+      - 9180:9180
+    labels:
+      cluster: test
+    command: >
+      /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5080 -o 100 --logtostderr
+                          --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --lru_mb=1024
+
+volumes:
+  data:

--- a/systest/loader-benchmark/loader-benchmark.sh
+++ b/systest/loader-benchmark/loader-benchmark.sh
@@ -4,7 +4,7 @@ readonly ME=${0##*/}
 readonly SRCDIR=$(dirname $0)
 
 BENCHMARKS_REPO="https://github.com/dgraph-io/benchmarks"
-BENCHMARK_SIZE=${BENCHMARK_SIZE:=small}
+BENCHMARK_SIZE=${BENCHMARK_SIZE:=big}
 SCHEMA_URL="$BENCHMARKS_REPO/blob/master/data/21million-noindex.schema?raw=true"
 DGRAPH_LOADER=${DGRAPH_LOADER:=bulk}
 

--- a/systest/loader-benchmark/loader-benchmark.sh
+++ b/systest/loader-benchmark/loader-benchmark.sh
@@ -1,0 +1,78 @@
+#!/bin/bash -e
+
+readonly ME=${0##*/}
+readonly SRCDIR=$(dirname $0)
+
+BENCHMARKS_REPO="https://github.com/dgraph-io/benchmarks"
+BENCHMARK_SIZE=${BENCHMARK_SIZE:=small}
+SCHEMA_URL="$BENCHMARKS_REPO/blob/master/data/21million.schema?raw=true"
+
+DGRAPH_LOADER=${DGRAPH_LOADER:=bulk}
+DGRAPH_RELOAD=${DGRAPH_RELOAD:=yes}
+DGRAPH_LOAD_ONLY=${DGRAPH_LOAD_ONLY:=}
+
+function Info {
+    echo -e "INFO: $*"
+}
+
+function DockerCompose {
+    docker-compose -p dgraph "$@"
+}
+
+if [[ $BENCHMARK_SIZE != small && $BENCHMARK_SIZE != big ]]; then
+    echo >&2 "$ME: loader must be 'small' or 'big'  -- $BENCHMARK_SIZE"
+    exit 1
+fi
+
+if [[ $BENCHMARK_SIZE == small ]]; then
+    DATA_URL="$BENCHMARKS_REPO/blob/master/data/1million.rdf.gz?raw=true"
+else
+    DATA_URL="$BENCHMARKS_REPO/blob/master/data/21million.rdf.gz?raw=true"
+fi
+
+if [[ $DGRAPH_LOADER != bulk && $DGRAPH_LOADER != live ]]; then
+    echo >&2 "$ME: loader must be 'bulk' or 'live' -- $DGRAPH_LOADER"
+    exit 1
+fi
+
+if [[ ${DGRAPH_RELOAD,,} != yes ]]; then
+    unset DGRAPH_RELOAD
+fi
+
+Info "entering directory $SRCDIR"
+cd $SRCDIR
+
+if [[ $DGRAPH_RELOAD ]]; then
+    Info "removing old data (if any)"
+    DockerCompose down -v
+else
+    Info "using previously loaded data"
+fi
+
+Info "bringing up zero container"
+DockerCompose up -d zero1
+
+Info "waiting for zero to become leader"
+DockerCompose logs -f zero1 | grep -q -m1 "I've become the leader"
+
+if [[ $DGRAPH_RELOAD && $DGRAPH_LOADER == bulk ]]; then
+    Info "bulk loading 21million data set"
+    DockerCompose run --rm dg1 \
+        bash -s <<EOF
+            /gobin/dgraph bulk --schema=<(curl -LSs $SCHEMA_URL) --files=<(curl -LSs $DATA_URL) \
+                               --format=rdf --zero=zero1:5080 --out=/data/dg1/bulk
+            mv /data/dg1/bulk/0/p /data/dg1
+EOF
+fi
+
+Info "bringing up alpha container"
+DockerCompose up -d dg1
+
+Info "waiting for alpha to be ready"
+DockerCompose logs -f dg1 | grep -q -m1 "Server is ready"
+
+if [[ $DGRAPH_RELOAD && $DGRAPH_LOADER == live ]]; then
+    Info "live loading 21million data set"
+    dgraph live --schema=<(curl -LSs $SCHEMA_URL) --files=<(curl -LSs $DATA_URL) \
+                --format=rdf --zero=:5080 --dgraph=:9180 --logtostderr
+fi

--- a/systest/loader-benchmark/loader-benchmark.sh
+++ b/systest/loader-benchmark/loader-benchmark.sh
@@ -5,7 +5,7 @@ readonly SRCDIR=$(dirname $0)
 
 BENCHMARKS_REPO="https://github.com/dgraph-io/benchmarks"
 BENCHMARK_SIZE=${BENCHMARK_SIZE:=small}
-SCHEMA_URL="$BENCHMARKS_REPO/blob/master/data/21million.schema?raw=true"
+SCHEMA_URL="$BENCHMARKS_REPO/blob/master/data/21million-noindex.schema?raw=true"
 DGRAPH_LOADER=${DGRAPH_LOADER:=bulk}
 
 function Info {


### PR DESCRIPTION
Mostly based on the 21million test script, this script allows running
the live and bulk loader on two datasets (1 million and 21 million
triples respectively).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3270)
<!-- Reviewable:end -->
