### PR TITLE
If HttpLogin function response contains error messages, return it directly

### DIFF
--- a/z/client.go
+++ b/z/client.go
@@ -213,6 +213,12 @@ func HttpLogin(params *LoginParams) (string, string, error) {
 
 	var outputJson map[string]map[string]string
 	if err := json.Unmarshal(respBody, &outputJson); err != nil {
+		var errOutputJson map[string]interface{}
+		if err := json.Unmarshal(respBody, &errOutputJson); err == nil {
+			if _, ok := errOutputJson["errors"]; ok {
+				return "", "", fmt.Errorf("response error: %v", string(respBody))
+			}
+		}
 		return "", "", fmt.Errorf("unable to unmarshal the output to get JWTs: %v", err)
 	}
 


### PR DESCRIPTION
If HttpLogin function response contains error messages，should print the error message from the alpha server , but now it  print a unmarshall error. Not friendly enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3275)
<!-- Reviewable:end -->
