### PR TITLE
[bulk loader] add parallelism control for read map output

### DIFF
--- a/dgraph/cmd/bulk/shuffle.go
+++ b/dgraph/cmd/bulk/shuffle.go
@@ -43,7 +43,7 @@ func (s *shuffler) run() {
 	x.AssertTrue(len(s.opt.shardOutputDirs) == s.opt.ReduceShards)
 
 	thr := x.NewThrottle(s.opt.NumShufflers)
-	readMapThr := x.NewThrottle(s.opt.NumGoroutines)
+	readMapThr := x.NewThrottle(1000)
 	for i := 0; i < s.opt.ReduceShards; i++ {
 		thr.Start()
 		go func(shardId int, db *badger.DB) {


### PR DESCRIPTION
### Motivation
Fix thread exhaustion at bulk loader shuffle stage while generated map files > 10000 by bulk loader map stage. The following is the error log:
```
MAP 03h34m24s nquad_count:6.586G err_count:0.000 nquad_speed:511.9k/sec edge_count:13.17G edge_speed:1.024M/sec
Shard tmp/shards/000 -> Reduce tmp/shards/shard_0/000
REDUCE 03h34m25s [0.00%] edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
badger 2019/04/05 04:12:27 INFO: All 0 tables opened in 0s
REDUCE 03h34m26s [0.00%] edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
runtime: program exceeds 10000-thread limit
fatal error: thread exhaustion
```
A Go program creates a new thread only when a goroutine is ready to run but all the existing threads are blocked in system calls, cgo calls, or are locked to other goroutines due to use of runtime.LockOSThread.

Too much map files read will cause a lot of goroutines doing blocking calls and the initial setting is 10,000 threads for number of operating system threads that the Go program can use. https://golang.org/pkg/runtime/debug/#SetMaxThreads

To reproduce this problem, can specify a smaller map output file size by `--mapoutput_mb=1` and ensure the data size > 10000MB.

Of course, can specify a bigger map output file size like 1024mb to avoid too much map file generated, but this is not an elegant solution, too much memory will used and can not match too big data load.

So i prefer to add `Throttle` to limit the parallelism of read map output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3276)
<!-- Reviewable:end -->
