### PR TITLE
Update live loader flag help text.

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -87,7 +87,8 @@ func init() {
 	flag.StringP("files", "f", "", "Location of *.rdf(.gz) or *.json(.gz) file(s) to load")
 	flag.StringP("schema", "s", "", "Location of schema file")
 	flag.String("format", "", "Specify file format (rdf or json) instead of getting it from filename")
-	flag.StringP("dgraph", "d", "127.0.0.1:9080", "Comma-separated list of Dgraph alpha gRPC server addresses")
+	flag.StringP("dgraph", "d", "127.0.0.1:9080",
+		"Comma-separated list of Dgraph alpha gRPC server addresses")
 	flag.StringP("zero", "z", "127.0.0.1:5080", "Dgraph zero gRPC server address")
 	flag.IntP("conc", "c", 10,
 		"Number of concurrent requests to make to Dgraph")

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -87,7 +87,7 @@ func init() {
 	flag.StringP("files", "f", "", "Location of *.rdf(.gz) or *.json(.gz) file(s) to load")
 	flag.StringP("schema", "s", "", "Location of schema file")
 	flag.String("format", "", "Specify file format (rdf or json) instead of getting it from filename")
-	flag.StringP("dgraph", "d", "127.0.0.1:9080", "Dgraph alpha gRPC server address")
+	flag.StringP("dgraph", "d", "127.0.0.1:9080", "Comma-separated list of Dgraph alpha gRPC server addresses")
 	flag.StringP("zero", "z", "127.0.0.1:5080", "Dgraph zero gRPC server address")
 	flag.IntP("conc", "c", 10,
 		"Number of concurrent requests to make to Dgraph")


### PR DESCRIPTION
The live loader can already take in multiple Dgraph Alpha addresses to
distribute the load across the cluster during loading. The flag help text makes
this option clearer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3278)
<!-- Reviewable:end -->
