### PR TITLE
Add timestamps during bulk/live load

### DIFF
--- a/dgraph/cmd/bulk/progress.go
+++ b/dgraph/cmd/bulk/progress.go
@@ -82,7 +82,10 @@ func (p *progress) reportOnce() {
 		rdfCount := atomic.LoadInt64(&p.nquadCount)
 		errCount := atomic.LoadInt64(&p.errCount)
 		elapsed := time.Since(p.start)
-		fmt.Printf("MAP %s nquad_count:%s err_count:%s nquad_speed:%s/sec edge_count:%s edge_speed:%s/sec\n",
+		timestamp := time.Now().Format("15:04:05")
+		fmt.Printf("[%s] MAP %s nquad_count:%s err_count:%s nquad_speed:%s/sec "+
+			"edge_count:%s edge_speed:%s/sec\n",
+			timestamp,
 			x.FixedDuration(elapsed),
 			niceFloat(float64(rdfCount)),
 			niceFloat(float64(errCount)),
@@ -93,6 +96,7 @@ func (p *progress) reportOnce() {
 	case reducePhase:
 		now := time.Now()
 		elapsed := time.Since(p.startReduce)
+		timestamp := time.Now().Format("15:04:05")
 		if p.startReduce.IsZero() {
 			p.startReduce = time.Now()
 			elapsed = time.Second
@@ -101,10 +105,11 @@ func (p *progress) reportOnce() {
 		reduceEdgeCount := atomic.LoadInt64(&p.reduceEdgeCount)
 		pct := ""
 		if mapEdgeCount != 0 {
-			pct = fmt.Sprintf("[%.2f%%] ", 100*float64(reduceEdgeCount)/float64(mapEdgeCount))
+			pct = fmt.Sprintf("%.2f%% ", 100*float64(reduceEdgeCount)/float64(mapEdgeCount))
 		}
-		fmt.Printf("REDUCE %s %sedge_count:%s edge_speed:%s/sec "+
+		fmt.Printf("[%s] REDUCE %s %sedge_count:%s edge_speed:%s/sec "+
 			"plist_count:%s plist_speed:%s/sec\n",
+			timestamp,
 			x.FixedDuration(now.Sub(p.start)),
 			pct,
 			niceFloat(float64(reduceEdgeCount)),

--- a/dgraph/cmd/bulk/progress.go
+++ b/dgraph/cmd/bulk/progress.go
@@ -76,13 +76,13 @@ func (p *progress) report() {
 
 func (p *progress) reportOnce() {
 	mapEdgeCount := atomic.LoadInt64(&p.mapEdgeCount)
+	timestamp := time.Now().Format("15:04:05Z0700")
 	switch phase(atomic.LoadInt32((*int32)(&p.phase))) {
 	case nothing:
 	case mapPhase:
 		rdfCount := atomic.LoadInt64(&p.nquadCount)
 		errCount := atomic.LoadInt64(&p.errCount)
 		elapsed := time.Since(p.start)
-		timestamp := time.Now().Format("15:04:05")
 		fmt.Printf("[%s] MAP %s nquad_count:%s err_count:%s nquad_speed:%s/sec "+
 			"edge_count:%s edge_speed:%s/sec\n",
 			timestamp,
@@ -96,7 +96,6 @@ func (p *progress) reportOnce() {
 	case reducePhase:
 		now := time.Now()
 		elapsed := time.Since(p.startReduce)
-		timestamp := time.Now().Format("15:04:05")
 		if p.startReduce.IsZero() {
 			p.startReduce = time.Now()
 			elapsed = time.Second

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -197,7 +197,7 @@ func (l *loader) printCounters() {
 		counter := l.Counter()
 		rate := float64(counter.Nquads-last.Nquads) / period.Seconds()
 		elapsed := time.Since(start).Round(time.Second)
-		timestamp := time.Now().Format("15:04:05")
+		timestamp := time.Now().Format("15:04:05Z0700")
 		fmt.Printf("[%s] Elapsed: %s Txns: %d N-Quads: %d N-Quads/s [last 5s]: %5.0f Aborts: %d\n",
 			timestamp, x.FixedDuration(elapsed), counter.TxnsDone, counter.Nquads, rate, counter.Aborts)
 		last = counter

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -197,8 +197,9 @@ func (l *loader) printCounters() {
 		counter := l.Counter()
 		rate := float64(counter.Nquads-last.Nquads) / period.Seconds()
 		elapsed := time.Since(start).Round(time.Second)
-		fmt.Printf("[%6s] Txns: %d N-Quads: %d N-Quads/s [last 5s]: %5.0f Aborts: %d\n",
-			elapsed, counter.TxnsDone, counter.Nquads, rate, counter.Aborts)
+		timestamp := time.Now().Format("15:04:05")
+		fmt.Printf("[%s] Elapsed: %s Txns: %d N-Quads: %d N-Quads/s [last 5s]: %5.0f Aborts: %d\n",
+			timestamp, x.FixedDuration(elapsed), counter.TxnsDone, counter.Nquads, rate, counter.Aborts)
 		last = counter
 	}
 }


### PR DESCRIPTION
Add timestamps to make it easer to correlate load logs with server logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3287)
<!-- Reviewable:end -->
