### PR TITLE
Revert "Add throttle for readMapOutput."

### DIFF
--- a/dgraph/cmd/bulk/shuffle.go
+++ b/dgraph/cmd/bulk/shuffle.go
@@ -43,7 +43,6 @@ func (s *shuffler) run() {
 	x.AssertTrue(len(s.opt.shardOutputDirs) == s.opt.ReduceShards)
 
 	thr := x.NewThrottle(s.opt.NumShufflers)
-	readMapThr := x.NewThrottle(1000)
 	for i := 0; i < s.opt.ReduceShards; i++ {
 		thr.Start()
 		go func(shardId int, db *badger.DB) {
@@ -51,12 +50,8 @@ func (s *shuffler) run() {
 			shuffleInputChs := make([]chan *pb.MapEntry, len(mapFiles))
 			for i, mapFile := range mapFiles {
 				shuffleInputChs[i] = make(chan *pb.MapEntry, 1000)
-				readMapThr.Start()
-				go readMapOutput(mapFile, shuffleInputChs[i], readMapThr)
+				go readMapOutput(mapFile, shuffleInputChs[i])
 			}
-
-			// All map files must be opened before shufflePostings starts.
-			readMapThr.Wait()
 
 			ci := &countIndexer{state: s.state, db: db}
 			s.shufflePostings(shuffleInputChs, ci)
@@ -80,9 +75,7 @@ func (s *shuffler) createBadger(i int) *badger.DB {
 	return db
 }
 
-func readMapOutput(filename string, mapEntryCh chan<- *pb.MapEntry, thr *x.Throttle) {
-	defer thr.Done()
-
+func readMapOutput(filename string, mapEntryCh chan<- *pb.MapEntry) {
 	fd, err := os.Open(filename)
 	x.Check(err)
 	defer fd.Close()


### PR DESCRIPTION
This reverts commit 491862602ed80fb8476e2ef529f75531e6ab4341.

External contribution appears to have broken the bulk loader. Didn't spend much time looking into why, just reverting it for now

Before the change:

```
REDUCE 01s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 02s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 03s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 04s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 05s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 06s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
REDUCE 07s edge_count:0.000 edge_speed:0.000/sec plist_count:0.000 plist_speed:0.000/sec
...
```

After the change:

```
REDUCE 01s edge_count:574.1k edge_speed:574.1k/sec plist_count:516.8k plist_speed:516.8k/sec
REDUCE 02s edge_count:1.074M edge_speed:1.074M/sec plist_count:977.8k plist_speed:977.7k/sec
badger 2019/04/12 13:46:52 DEBUG: Storing value log head: {Fid:1 Len:45 Offset:681127}
REDUCE 03s edge_count:1.526M edge_speed:763.0k/sec plist_count:1.401M plist_speed:700.6k/sec
REDUCE 04s edge_count:2.026M edge_speed:675.3k/sec plist_count:1.876M plist_speed:625.1k/sec
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3288)
<!-- Reviewable:end -->
