### PR TITLE
Fix panic in query.go

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -159,13 +159,10 @@ func ProcessTaskOverNetwork(ctx context.Context, q *pb.Query) (*pb.Result, error
 		func(ctx context.Context, c pb.WorkerClient) (interface{}, error) {
 			return c.ServeTask(ctx, q)
 		})
-
-	if err != nil && strings.Contains(err.Error(), ErrUnservedTabletMessage) {
-		return &emptyResult, errUnservedTablet
-	}
 	if err != nil {
 		return &emptyResult, err
 	}
+
 	reply := result.(*pb.Result)
 	if span != nil {
 		span.Annotatef(nil, "Reply from server. len: %v gid: %v Attr: %v",

--- a/worker/task.go
+++ b/worker/task.go
@@ -160,11 +160,11 @@ func ProcessTaskOverNetwork(ctx context.Context, q *pb.Query) (*pb.Result, error
 			return c.ServeTask(ctx, q)
 		})
 
-	if err == errUnservedTablet {
+	if err != nil && strings.Contains(err.Error(), ErrUnservedTabletMessage) {
 		return &emptyResult, errUnservedTablet
 	}
 	if err != nil {
-		return nil, err
+		return &emptyResult, err
 	}
 	reply := result.(*pb.Result)
 	if span != nil {


### PR DESCRIPTION
ProcessTaskOverNetwork now always returns a valid pointer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3318)
<!-- Reviewable:end -->
