### PR TITLE
Use initial schema during bulk load.

### DIFF
--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dgraph-io/badger"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/schema"
 	wk "github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -45,6 +46,15 @@ func newSchemaStore(initial []*pb.SchemaUpdate, opt options, state *state) *sche
 		},
 		state: state,
 	}
+
+	// Load all initial predicates. Some predicates that might not be used when
+	// the alpha is started (e.g ACL predicates) might be included but it's
+	// better to include them in case the input data contains triples with these
+	// predicates.
+	for _, update := range schema.CompleteInitialSchema() {
+		s.m[update.Predicate] = update
+	}
+
 	if opt.StoreXids {
 		s.m["xid"] = &pb.SchemaUpdate{
 			ValueType: pb.Posting_STRING,


### PR DESCRIPTION
Use the initial schema during bulk load, otherwise data might not be
loaded correctly for those predicates.

In particular, I observed that when loading the 21million dataset with
dgraph.type triples added to it, queries would not respond and would
eventually timeout. I figured this was because the index for that
predicate was not built during the bulkload. I reloaded the dataset with
my changes included and queries respond immediately.

Fixes #3329 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3333)
<!-- Reviewable:end -->
