### PR TITLE
release/v1.0: Add prometheus metrics for latest raft applied index and oracle max assigned ts.

### DIFF
--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -220,6 +220,7 @@ func (o *oracle) ProcessDelta(delta *pb.OracleDelta) {
 		delete(o.waiters, startTs)
 	}
 	x.AssertTrue(atomic.CompareAndSwapUint64(&o.maxAssigned, curMax, delta.MaxAssigned))
+	x.MaxAssignedTs.Set(int64(o.MaxAssigned()))
 }
 
 func (o *oracle) ResetTxns() {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -397,6 +397,7 @@ func (n *node) processApplyCh() {
 			n.Proposals.Done(proposal.Key, perr)
 			n.Applied.Done(proposal.Index)
 		}
+		x.WatermarkIndex.Set(int64(n.Applied.DoneUntil()))
 	}
 
 	maxAge := 10 * time.Minute

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -397,7 +397,7 @@ func (n *node) processApplyCh() {
 			n.Proposals.Done(proposal.Key, perr)
 			n.Applied.Done(proposal.Index)
 		}
-		x.WatermarkIndex.Set(int64(n.Applied.DoneUntil()))
+		x.RaftAppliedIndex.Set(int64(n.Applied.DoneUntil()))
 	}
 
 	maxAge := 10 * time.Minute

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -44,6 +44,7 @@ var (
 	AlphaHealth      *expvar.Int
 	MaxPlSize        *expvar.Int
 	MaxPlLength      *expvar.Int
+	WatermarkIndex   *expvar.Int
 
 	PredicateStats *expvar.Map
 	Conf           *expvar.Map
@@ -72,6 +73,7 @@ func init() {
 	Conf = expvar.NewMap("dgraph_config")
 	MaxPlSize = expvar.NewInt("dgraph_max_list_bytes")
 	MaxPlLength = expvar.NewInt("dgraph_max_list_length")
+	WatermarkIndex = expvar.NewInt("dgraph_watermark_done_index")
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -144,6 +146,11 @@ func init() {
 		"dgraph_max_list_length": prometheus.NewDesc(
 			"dgraph_max_list_length",
 			"dgraph_max_list_length",
+			nil, nil,
+		),
+		"dgraph_watermark_done_index": prometheus.NewDesc(
+			"dgraph_watermark_done_index",
+			"dgraph_watermark_done_index",
 			nil, nil,
 		),
 		"dgraph_pending_proposals_total": prometheus.NewDesc(

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -45,6 +45,7 @@ var (
 	MaxPlSize        *expvar.Int
 	MaxPlLength      *expvar.Int
 	RaftAppliedIndex *expvar.Int
+	MaxAssignedTs    *expvar.Int
 
 	PredicateStats *expvar.Map
 	Conf           *expvar.Map
@@ -74,6 +75,7 @@ func init() {
 	MaxPlSize = expvar.NewInt("dgraph_max_list_bytes")
 	MaxPlLength = expvar.NewInt("dgraph_max_list_length")
 	RaftAppliedIndex = expvar.NewInt("dgraph_raft_applied_index")
+	MaxAssignedTs = expvar.NewInt("dgraph_max_assigned_ts")
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -151,6 +153,11 @@ func init() {
 		"dgraph_raft_applied_index": prometheus.NewDesc(
 			"dgraph_raft_applied_index",
 			"dgraph_raft_applied_index",
+			nil, nil,
+		),
+		"dgraph_max_assigned_ts": prometheus.NewDesc(
+			"dgraph_max_assigned_ts",
+			"dgraph_max_assigned_ts",
 			nil, nil,
 		),
 		"dgraph_pending_proposals_total": prometheus.NewDesc(

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -44,7 +44,7 @@ var (
 	AlphaHealth      *expvar.Int
 	MaxPlSize        *expvar.Int
 	MaxPlLength      *expvar.Int
-	WatermarkIndex   *expvar.Int
+	RaftAppliedIndex *expvar.Int
 
 	PredicateStats *expvar.Map
 	Conf           *expvar.Map
@@ -73,7 +73,7 @@ func init() {
 	Conf = expvar.NewMap("dgraph_config")
 	MaxPlSize = expvar.NewInt("dgraph_max_list_bytes")
 	MaxPlLength = expvar.NewInt("dgraph_max_list_length")
-	WatermarkIndex = expvar.NewInt("dgraph_watermark_done_index")
+	RaftAppliedIndex = expvar.NewInt("dgraph_raft_applied_index")
 
 	go func() {
 		ticker := time.NewTicker(5 * time.Second)
@@ -148,9 +148,9 @@ func init() {
 			"dgraph_max_list_length",
 			nil, nil,
 		),
-		"dgraph_watermark_done_index": prometheus.NewDesc(
-			"dgraph_watermark_done_index",
-			"dgraph_watermark_done_index",
+		"dgraph_raft_applied_index": prometheus.NewDesc(
+			"dgraph_raft_applied_index",
+			"dgraph_raft_applied_index",
 			nil, nil,
 		),
 		"dgraph_pending_proposals_total": prometheus.NewDesc(


### PR DESCRIPTION
* Add a new metric `dgraph_raft_applied_index` to capture the latest Raft index that has been applied for Alphas.

    Metric looks like this in `/debug/prometheus_metrics`:

    ```
    dgraph_raft_applied_index 5024
    ```

* Add a new metric `dgraph_max_assigned_ts` to capture the latest max assigned timestamp from Zero. This value is cluster-wide and should be the same across all Alphas.

    Metric looks like this in `/debug/prometheus_metrics`:

    ```
    dgraph_max_assigned_ts 50800
    ```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3336)
<!-- Reviewable:end -->
