### PR TITLE
Limit num pending proposals in apply channel

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -845,12 +845,15 @@ func (n *node) Run() {
 			}
 			// Send the whole lot to applyCh in one go, instead of sending proposals one by one.
 			if len(proposals) > 0 {
+				// Apply the meter this before adding size to pending size so some crazy big
+				// proposal can be pushed to applyCh. If this do this after adding its size to
+				// pending size, we could block forever in rampMeter.
+				n.rampMeter()
 				var pendingSize int64
 				for _, p := range proposals {
 					pendingSize += int64(p.Size())
 				}
 				atomic.AddInt64(&n.pendingSize, pendingSize)
-				n.rampMeter()
 				n.applyCh <- proposals
 			}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -853,7 +853,9 @@ func (n *node) Run() {
 				for _, p := range proposals {
 					pendingSize += int64(p.Size())
 				}
-				atomic.AddInt64(&n.pendingSize, pendingSize)
+				if sz := atomic.AddInt64(&n.pendingSize, pendingSize); sz > 2*maxPendingSize {
+					glog.Warningf("Inflight proposal size: %d. There would be some throttling.", sz)
+				}
 				n.applyCh <- proposals
 			}
 


### PR DESCRIPTION
Add a ramp meter to avoid pushing too many big proposals to apply channel to prevent OOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3340)
<!-- Reviewable:end -->
