### PR TITLE
Allow truncating raft logs via debug tool

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -90,7 +90,7 @@ func init() {
 
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
-		"Remove data from Raft entries up until this index.")
+		"Remove data from Raft entries until but not including this index.")
 }
 
 func toInt(o *pb.Posting) int {

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -89,7 +89,8 @@ func init() {
 		"Show a histogram of the key and value sizes.")
 
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
-	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0, "Remove data from Raft entries up until this index.")
+	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
+		"Remove data from Raft entries up until this index.")
 }
 
 func toInt(o *pb.Posting) int {


### PR DESCRIPTION
This PR would add a flag in debug tool, which would allow dropping data from Raft log entries of type EntryNormal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3345)
<!-- Reviewable:end -->
