### PR TITLE
Take snapshots less frequently

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -107,8 +107,8 @@ they form a Raft group and provide synchronous replication.
 			" lower this number, the more frequent snapshot creation would be."+
 			" Also determines how often Rollups would happen.")
 	flag.String("abort_older_than", "5m",
-		"Abort any pending transactions older than this duration. The liveness of transaction"+
-			" is determined based on the last mutation ran by the transaction.")
+		"Abort any pending transactions older than this duration. The liveness of a"+
+			" transaction is determined by its last mutation.")
 
 	// OpenCensus flags.
 	flag.Float64("trace", 1.0, "The ratio of queries to trace.")

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -497,6 +497,9 @@ func printKeys(db *badger.DB) {
 
 		// Don't use a switch case here. Because multiple of these can be true. In particular,
 		// IsSchema can be true alongside IsData.
+		if pk.IsRaft() {
+			buf.WriteString("{r}")
+		}
 		if pk.IsData() {
 			buf.WriteString("{d}")
 		}

--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -106,7 +106,7 @@ func printRaft(db *badger.DB, store *raftwal.DiskStorage) {
 
 	pending := make(map[uint64]bool)
 	for startIdx < lastIdx-1 {
-		entries, err := store.Entries(startIdx, lastIdx, 64<<20 /* 64 MB Max Size */)
+		entries, err := store.Entries(startIdx, lastIdx+1, 64<<20 /* 64 MB Max Size */)
 		if err != nil {
 			fmt.Printf("Got error while retrieving entries: %v\n", err)
 			return

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -673,6 +673,9 @@ func (n *node) findRaftProgress() (uint64, error) {
 	var applied uint64
 	err := pstore.View(func(txn *badger.Txn) error {
 		item, err := txn.Get(x.RaftKey())
+		if err == badger.ErrKeyNotFound {
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -700,8 +700,6 @@ func (n *node) updateRaftProgress() error {
 		return err
 	}
 	if snap == nil {
-		glog.V(1).Infof("No new Raft progress calculated. Done until: %d",
-			n.Applied.DoneUntil())
 		return nil
 	}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -695,7 +695,7 @@ func (n *node) updateRaftProgress() error {
 	// Both leader and followers can independently update their Raft progress. We don't store
 	// this in Raft WAL. Instead, this is used to just skip over log records that this Alpha
 	// has already applied, to speed up things on a restart.
-	snap, err := n.calculateSnapshot(10)
+	snap, err := n.calculateSnapshot(10) // 10 is a randomly chosen small number.
 	if err != nil {
 		return err
 	}

--- a/x/config.go
+++ b/x/config.go
@@ -16,7 +16,10 @@
 
 package x
 
-import "net"
+import (
+	"net"
+	"time"
+)
 
 type Options struct {
 	DebugMode      bool
@@ -43,6 +46,8 @@ type WorkerOptions struct {
 	MaxRetries          int
 	StrictMutations     bool
 	AclEnabled          bool
+	AbortOlderThan      time.Duration
+	SnapshotAfter       int
 }
 
 var WorkerConfig WorkerOptions

--- a/x/keys.go
+++ b/x/keys.go
@@ -144,6 +144,10 @@ type ParsedKey struct {
 	bytePrefix byte
 }
 
+func (p ParsedKey) IsRaft() bool {
+	return p.bytePrefix == byteRaft
+}
+
 func (p ParsedKey) IsData() bool {
 	return p.bytePrefix == DefaultPrefix && p.byteType == ByteData
 }
@@ -303,6 +307,10 @@ func Parse(key []byte) *ParsedKey {
 	p := &ParsedKey{}
 
 	p.bytePrefix = key[0]
+	if p.bytePrefix == byteRaft {
+		return p
+	}
+
 	sz := int(binary.BigEndian.Uint16(key[1:3]))
 	k := key[3:]
 

--- a/x/keys.go
+++ b/x/keys.go
@@ -36,6 +36,7 @@ const (
 	DefaultPrefix = byte(0x00)
 	byteSchema    = byte(0x01)
 	byteType      = byte(0x02)
+	byteRaft      = byte(0xff)
 )
 
 func writeAttr(buf []byte, attr string) []byte {
@@ -46,6 +47,13 @@ func writeAttr(buf []byte, attr string) []byte {
 	AssertTrue(len(attr) == copy(rest, attr))
 
 	return rest[len(attr):]
+}
+
+func RaftKey() []byte {
+	buf := make([]byte, 5)
+	buf[0] = byteRaft
+	AssertTrue(4 == copy(buf[1:5], []byte("raft")))
+	return buf
 }
 
 // SchemaKey returns schema key for given attribute. Schema keys are stored


### PR DESCRIPTION
Taking snapshots frequently causes a straggler follower to have a hard time getting a new snapshot streamed. If the latter takes more time than the former, then the straggler would never catch up.

So, instead of taking snapshots frequently, this PR adds a mechanism to track the progress of Raft in the p directory. This way, a restarted Alpha does not need to replay all the Raft logs, only the ones which it hasn't applied yet.

This PR adds two new flags:
1. The duration after which we'd abort a txn.
2. The number of Raft logs after which a snapshot would be taken.

This PR also removes a strange lastCommitTs logic, which was only spitting out an log error, without doing anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3367)
<!-- Reviewable:end -->
