### PR TITLE
Compose tool: Use badger backend with Jaeger.

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -231,10 +231,15 @@ func getJaeger() Service {
 		ContainerName: "jaeger",
 		WorkingDir:    "/working/jaeger",
 		Ports: []string{
+			toExposedPort(14268),
 			toExposedPort(16686),
 		},
-		Environment: []string{"COLLECTOR_ZIPKIN_HTTP_PORT=9411"},
-		Command:     "--memory.max-traces=1000000",
+		Environment: []string{
+			"SPAN_STORAGE_TYPE=badger",
+		},
+		Command: "--badger.ephemeral=false" +
+			" --badger.directory-key /working/jaeger/keys" +
+			" --badger.directory-value /working/jaeger/values",
 	}
 	return svc
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -238,8 +238,8 @@ func getJaeger() Service {
 			"SPAN_STORAGE_TYPE=badger",
 		},
 		Command: "--badger.ephemeral=false" +
-			" --badger.directory-key /working/jaeger/keys" +
-			" --badger.directory-value /working/jaeger/values",
+			" --badger.directory-key /working/jaeger" +
+			" --badger.directory-value /working/jaeger",
 	}
 	return svc
 }


### PR DESCRIPTION
Badger backend is now supported in Jaeger as an alternative for the in-memory store in the all-in-one binary.

Jaeger's badger backend can be configured to store traces in-memory (--badger.ephemeral) or on disk. This change configures Jaeger to store traces on disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3386)
<!-- Reviewable:end -->
