### PR TITLE
Bug Fix: Avoid Dgraph cluster getting stuck in infinite leader election

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -73,7 +73,8 @@ type Node struct {
 	// applied (to PL) -> synced (to BadgerDB).
 	Applied y.WaterMark
 
-	Heartbeats int64
+	heartbeatsOut int64
+	heartbeatsIn  int64
 }
 
 type ToGlog struct {
@@ -158,12 +159,16 @@ func NewNode(rc *pb.RaftContext, store *raftwal.DiskStorage) *Node {
 }
 
 func (n *Node) ReportRaftComms() {
-	ticker := time.NewTicker(10 * time.Second)
+	if !glog.V(3) {
+		return
+	}
+	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		num := atomic.SwapInt64(&n.Heartbeats, 0)
-		glog.V(2).Infof("RaftComm: [%#x] Heartbeats exchanged since last report: %d", n.Id, num)
+		out := atomic.SwapInt64(&n.heartbeatsOut, 0)
+		in := atomic.SwapInt64(&n.heartbeatsIn, 0)
+		glog.Infof("RaftComm: [%#x] Heartbeats out: %d, in: %d", n.Id, out, in)
 	}
 }
 
@@ -245,7 +250,7 @@ func (n *Node) Send(msg raftpb.Message) {
 	if glog.V(2) {
 		switch msg.Type {
 		case raftpb.MsgHeartbeat, raftpb.MsgHeartbeatResp:
-			atomic.AddInt64(&n.Heartbeats, 1)
+			atomic.AddInt64(&n.heartbeatsOut, 1)
 		case raftpb.MsgReadIndex, raftpb.MsgReadIndexResp:
 		case raftpb.MsgApp, raftpb.MsgAppResp:
 		case raftpb.MsgProp:

--- a/conn/raft_server.go
+++ b/conn/raft_server.go
@@ -229,7 +229,7 @@ func (w *RaftServer) RaftMessage(server pb.Raft_RaftMessageServer) error {
 			if glog.V(2) {
 				switch msg.Type {
 				case raftpb.MsgHeartbeat, raftpb.MsgHeartbeatResp:
-					atomic.AddInt64(&n.Heartbeats, 1)
+					atomic.AddInt64(&n.heartbeatsIn, 1)
 				case raftpb.MsgReadIndex, raftpb.MsgReadIndexResp:
 				case raftpb.MsgApp, raftpb.MsgAppResp:
 				case raftpb.MsgProp:

--- a/conn/raft_server.go
+++ b/conn/raft_server.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dgraph-io/dgo/protos/api"
@@ -228,6 +229,7 @@ func (w *RaftServer) RaftMessage(server pb.Raft_RaftMessageServer) error {
 			if glog.V(2) {
 				switch msg.Type {
 				case raftpb.MsgHeartbeat, raftpb.MsgHeartbeatResp:
+					atomic.AddInt64(&n.Heartbeats, 1)
 				case raftpb.MsgReadIndex, raftpb.MsgReadIndexResp:
 				case raftpb.MsgApp, raftpb.MsgAppResp:
 				case raftpb.MsgProp:

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -742,42 +742,45 @@ func (n *node) Run() {
 		slowTicker := time.NewTicker(time.Minute)
 		defer slowTicker.Stop()
 
-		select {
-		case <-slowTicker.C:
-			// Do these operations asynchronously away from the main Run loop to allow heartbeats to
-			// be sent on time. Otherwise, followers would just keep running elections.
+		for {
+			select {
+			case <-slowTicker.C:
+				// Do these operations asynchronously away from the main Run loop to allow heartbeats to
+				// be sent on time. Otherwise, followers would just keep running elections.
 
-			n.elog.Printf("Size of applyCh: %d", len(n.applyCh))
-			if err := n.updateRaftProgress(); err != nil {
-				glog.Errorf("While updating Raft progress: %v", err)
-			}
-
-			if n.AmLeader() {
-				// We keep track of the applied index in the p directory. Even if we don't take
-				// snapshot for a while and let the Raft logs grow and restart, we would not have to
-				// run all the log entries, because we can tell Raft.Config to set Applied to that
-				// index.
-				// This applied index tracking also covers the case when we have a big index
-				// rebuild. The rebuild would be tracked just like others and would not need to be
-				// replayed after a restart, because the Applied config would let us skip right
-				// through it.
-				// We use disk based storage for Raft. So, we're not too concerned about
-				// snapshotting.  We just need to do enough, so that we don't have a huge backlog of
-				// entries to process on a restart.
-				if err := n.proposeSnapshot(x.WorkerConfig.SnapshotAfter); err != nil {
-					x.Errorf("While calculating and proposing snapshot: %v", err)
+				n.elog.Printf("Size of applyCh: %d", len(n.applyCh))
+				if err := n.updateRaftProgress(); err != nil {
+					glog.Errorf("While updating Raft progress: %v", err)
 				}
-				go n.abortOldTransactions()
-			}
 
-		case <-n.closer.HasBeenClosed():
-			glog.Infof("Stopping node.Run")
-			if peerId, has := groups().MyPeer(); has && n.AmLeader() {
-				n.Raft().TransferLeadership(n.ctx, x.WorkerConfig.RaftId, peerId)
-				time.Sleep(time.Second) // Let transfer happen.
+				if n.AmLeader() {
+					// We keep track of the applied index in the p directory. Even if we don't take
+					// snapshot for a while and let the Raft logs grow and restart, we would not have to
+					// run all the log entries, because we can tell Raft.Config to set Applied to that
+					// index.
+					// This applied index tracking also covers the case when we have a big index
+					// rebuild. The rebuild would be tracked just like others and would not need to be
+					// replayed after a restart, because the Applied config would let us skip right
+					// through it.
+					// We use disk based storage for Raft. So, we're not too concerned about
+					// snapshotting.  We just need to do enough, so that we don't have a huge backlog of
+					// entries to process on a restart.
+					if err := n.proposeSnapshot(x.WorkerConfig.SnapshotAfter); err != nil {
+						x.Errorf("While calculating and proposing snapshot: %v", err)
+					}
+					go n.abortOldTransactions()
+				}
+
+			case <-n.closer.HasBeenClosed():
+				glog.Infof("Stopping node.Run")
+				if peerId, has := groups().MyPeer(); has && n.AmLeader() {
+					n.Raft().TransferLeadership(n.ctx, x.WorkerConfig.RaftId, peerId)
+					time.Sleep(time.Second) // Let transfer happen.
+				}
+				n.Raft().Stop()
+				close(done)
+				return
 			}
-			n.Raft().Stop()
-			close(done)
 		}
 	}()
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -752,6 +752,8 @@ func (n *node) Run() {
 		close(done)
 	}()
 
+	go n.ReportRaftComms()
+
 	applied, err := n.findRaftProgress()
 	if err != nil {
 		glog.Errorf("While trying to find raft progress: %v", err)
@@ -802,6 +804,9 @@ func (n *node) Run() {
 				otrace.WithSampler(otrace.ProbabilitySampler(0.001)))
 
 			if rd.SoftState != nil {
+				glog.V(2).Infof("RaftComm: Resetting heartbeats")
+				atomic.StoreInt64(&n.Node.Heartbeats, 0)
+
 				groups().triggerMembershipSync()
 				leader = rd.RaftState == raft.StateLeader
 			}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -804,9 +804,6 @@ func (n *node) Run() {
 				otrace.WithSampler(otrace.ProbabilitySampler(0.001)))
 
 			if rd.SoftState != nil {
-				glog.V(2).Infof("RaftComm: Resetting heartbeats")
-				atomic.StoreInt64(&n.Node.Heartbeats, 0)
-
 				groups().triggerMembershipSync()
 				leader = rd.RaftState == raft.StateLeader
 			}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1231,7 +1231,7 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	}
 
 	if num := posting.Oracle().NumPendingTxns(); num > 0 {
-		glog.Infof("Num pending txns: %d", num)
+		glog.V(2).Infof("Num pending txns: %d", num)
 	}
 	// We can't rely upon the Raft entries to determine the minPendingStart,
 	// because there are many cases during mutations where we don't commit or

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -724,7 +724,7 @@ func (n *node) updateRaftProgress() error {
 	if err := txn.CommitAt(1, nil); err != nil {
 		return err
 	}
-	glog.V(1).Infof("[%#x] Set Raft progress to index: %d.", n.Id, snap.Index)
+	glog.V(2).Infof("[%#x] Set Raft progress to index: %d.", n.Id, snap.Index)
 	return nil
 }
 
@@ -737,47 +737,22 @@ func (n *node) Run() {
 	ticker := time.NewTicker(20 * time.Millisecond)
 	defer ticker.Stop()
 
-	slowTicker := time.NewTicker(30 * time.Second)
-	defer slowTicker.Stop()
-
 	done := make(chan struct{})
 	go func() {
-		<-n.closer.HasBeenClosed()
-		glog.Infof("Stopping node.Run")
-		if peerId, has := groups().MyPeer(); has && n.AmLeader() {
-			n.Raft().TransferLeadership(n.ctx, x.WorkerConfig.RaftId, peerId)
-			time.Sleep(time.Second) // Let transfer happen.
-		}
-		n.Raft().Stop()
-		close(done)
-	}()
+		slowTicker := time.NewTicker(time.Minute)
+		defer slowTicker.Stop()
 
-	go n.ReportRaftComms()
-
-	applied, err := n.findRaftProgress()
-	if err != nil {
-		glog.Errorf("While trying to find raft progress: %v", err)
-	} else {
-		glog.Infof("Found Raft progress in p directory: %d", applied)
-	}
-
-	for {
 		select {
-		case <-done:
-			// We use done channel here instead of closer.HasBeenClosed so that we can transfer
-			// leadership in a goroutine. The push to n.applyCh happens in this loop, so the close
-			// should happen here too. Otherwise, race condition between push and close happens.
-			close(n.applyCh)
-			glog.Infoln("Raft node done.")
-			return
-
 		case <-slowTicker.C:
+			// Do these operations asynchronously away from the main Run loop to allow heartbeats to
+			// be sent on time. Otherwise, followers would just keep running elections.
+
 			n.elog.Printf("Size of applyCh: %d", len(n.applyCh))
 			if err := n.updateRaftProgress(); err != nil {
 				glog.Errorf("While updating Raft progress: %v", err)
 			}
 
-			if leader {
+			if n.AmLeader() {
 				// We keep track of the applied index in the p directory. Even if we don't take
 				// snapshot for a while and let the Raft logs grow and restart, we would not have to
 				// run all the log entries, because we can tell Raft.Config to set Applied to that
@@ -795,11 +770,46 @@ func (n *node) Run() {
 				go n.abortOldTransactions()
 			}
 
+		case <-n.closer.HasBeenClosed():
+			glog.Infof("Stopping node.Run")
+			if peerId, has := groups().MyPeer(); has && n.AmLeader() {
+				n.Raft().TransferLeadership(n.ctx, x.WorkerConfig.RaftId, peerId)
+				time.Sleep(time.Second) // Let transfer happen.
+			}
+			n.Raft().Stop()
+			close(done)
+		}
+	}()
+
+	go n.ReportRaftComms()
+
+	applied, err := n.findRaftProgress()
+	if err != nil {
+		glog.Errorf("While trying to find raft progress: %v", err)
+	} else {
+		glog.Infof("Found Raft progress in p directory: %d", applied)
+	}
+
+	var timer x.Timer
+	for {
+		select {
+		case <-done:
+			// We use done channel here instead of closer.HasBeenClosed so that we can transfer
+			// leadership in a goroutine. The push to n.applyCh happens in this loop, so the close
+			// should happen here too. Otherwise, race condition between push and close happens.
+			close(n.applyCh)
+			glog.Infoln("Raft node done.")
+			return
+
+			// Slow ticker can't be placed here because figuring out checkpoints and snapshots takes
+			// time and if the leader does not send heartbeats out during this time, the followers
+			// start an election process. And that election process would just continue to happen
+			// indefinitely because checkpoints and snapshots are being calculated indefinitely.
 		case <-ticker.C:
 			n.Raft().Tick()
 
 		case rd := <-n.Raft().Ready():
-			start := time.Now()
+			timer.Start()
 			_, span := otrace.StartSpan(n.ctx, "Alpha.RunLoop",
 				otrace.WithSampler(otrace.ProbabilitySampler(0.001)))
 
@@ -877,13 +887,13 @@ func (n *node) Run() {
 
 			// Store the hardstate and entries. Note that these are not CommittedEntries.
 			n.SaveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
-			diskDur := time.Since(start)
 			if span != nil {
 				span.Annotatef(nil, "Saved %d entries. Snapshot, HardState empty? (%v, %v)",
 					len(rd.Entries),
 					raft.IsEmptySnap(rd.Snapshot),
 					raft.IsEmptyHardState(rd.HardState))
 			}
+			timer.Record("disk")
 
 			// Now schedule or apply committed entries.
 			var proposals []*pb.Proposal
@@ -955,8 +965,11 @@ func (n *node) Run() {
 			if span != nil {
 				span.Annotate(nil, "Followed queued messages.")
 			}
+			timer.Record("proposals")
 
 			n.Raft().Advance()
+			timer.Record("advance")
+
 			if firstRun && n.canCampaign {
 				go n.Raft().Campaign(n.ctx)
 				firstRun = false
@@ -966,14 +979,13 @@ func (n *node) Run() {
 				span.End()
 				ostats.RecordWithTags(context.Background(),
 					[]tag.Mutator{tag.Upsert(x.KeyMethod, "alpha.RunLoop")},
-					x.LatencyMs.M(x.SinceMs(start)))
+					x.LatencyMs.M(float64(timer.Total())/1e6))
 			}
-			if time.Since(start) > 100*time.Millisecond {
+			if timer.Total() > 100*time.Millisecond {
 				glog.Warningf(
-					"Raft.Ready took too long to process: %v. Most likely due to slow disk: %v."+
+					"Raft.Ready took too long to process: %s"+
 						" Num entries: %d. MustSync: %v",
-					time.Since(start).Round(time.Millisecond), diskDur.Round(time.Millisecond),
-					len(rd.Entries), rd.MustSync)
+					timer.String(), len(rd.Entries), rd.MustSync)
 			}
 		}
 	}

--- a/x/x.go
+++ b/x/x.go
@@ -379,10 +379,14 @@ func (b *BytesBuffer) TruncateBy(n int) {
 	AssertTrue(b.off >= 0 && b.sz >= 0)
 }
 
+type record struct {
+	Name string
+	Dur  time.Duration
+}
 type Timer struct {
 	start   time.Time
 	last    time.Time
-	records []time.Duration
+	records []record
 }
 
 func (t *Timer) Start() {
@@ -391,18 +395,24 @@ func (t *Timer) Start() {
 	t.records = t.records[:0]
 }
 
-func (t *Timer) Record() {
+func (t *Timer) Record(name string) {
 	now := time.Now()
-	t.records = append(t.records, now.Sub(t.last))
+	t.records = append(t.records, record{
+		Name: name,
+		Dur:  now.Sub(t.last).Round(time.Millisecond),
+	})
 	t.last = now
 }
 
 func (t *Timer) Total() time.Duration {
-	return time.Since(t.start)
+	return time.Since(t.start).Round(time.Millisecond)
 }
 
-func (t *Timer) All() []time.Duration {
-	return t.records
+func (t *Timer) String() string {
+	sort.Slice(t.records, func(i, j int) bool {
+		return t.records[i].Dur > t.records[j].Dur
+	})
+	return fmt.Sprintf("Timer Total: %s. Breakdown: %v", t.Total(), t.records)
 }
 
 // PredicateLang extracts the language from a predicate (or facet) name.


### PR DESCRIPTION
Dgraph Alphas were calculating snapshots and checkpoints in the main Raft loop, which depending upon disk speed caused Ticks to not be done for seconds. This caused the followers to assume that the leader is unavailable, triggering an election. Because the checkpoint and snapshot calculation happens every 30s, the election was happening every 30s as well.

This PR moves both of those outside the main loop into their own goroutine (colocated with the code which shuts down Raft node). Tested successfully with a live cluster which was exhibiting these symptoms.

This PR also tracks how many heartbeats have come in and gone out from each node and prints them out under V(3). Useful for debugging.

The PR improves upon and uses x.Timer to track Raft.Ready components' latencies and report them in both Alphas and Zeros. This fixes the incorrect statement we were making about disk latency being the primary cause of Raft.Ready being slow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3391)
<!-- Reviewable:end -->
