### PR TITLE
Access groupi.gid atomically 

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -527,7 +527,6 @@ func run() {
 	sdCh := make(chan os.Signal, 3)
 	shutdownCh = make(chan struct{})
 
-	var numShutDownSig int
 	defer func() {
 		signal.Stop(sdCh)
 		close(sdCh)
@@ -535,6 +534,7 @@ func run() {
 	// sigint : Ctrl-C, sigterm : kill command.
 	signal.Notify(sdCh, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
+		var numShutDownSig int
 		for {
 			select {
 			case _, ok := <-sdCh:
@@ -555,7 +555,6 @@ func run() {
 			}
 		}
 	}()
-	_ = numShutDownSig
 
 	// Setup external communication.
 	aclCloser := y.NewCloser(1)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -545,7 +545,7 @@ func (n *node) commitOrAbort(pkey string, delta *pb.OracleDelta) error {
 	}
 
 	g := groups()
-	atomic.StoreUint64(&g.deltaChecksum, delta.GroupChecksums[g.gid])
+	atomic.StoreUint64(&g.deltaChecksum, delta.GroupChecksums[g.groupId()])
 
 	// Now advance Oracle(), so we can service waiting reads.
 	posting.Oracle().ProcessDelta(delta)

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -289,8 +289,6 @@ func (g *groupi) applyState(state *pb.MembershipState) {
 }
 
 func (g *groupi) ServesGroup(gid uint32) bool {
-	// No need to acquire the lock on g because gid is always
-	// accessed atomically via groupId() function
 	return g.groupId() == gid
 }
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -259,8 +259,8 @@ func (g *groupi) applyState(state *pb.MembershipState) {
 		for _, tablet := range group.Tablets {
 			g.tablets[tablet.Predicate] = tablet
 		}
-		if gid == g.gid {
-			glog.V(3).Infof("group %d checksum: %d", g.gid, group.Checksum)
+		if gid == g.groupId() {
+			glog.V(3).Infof("group %d checksum: %d", g.groupId(), group.Checksum)
 			atomic.StoreUint64(&g.membershipChecksum, group.Checksum)
 		}
 	}
@@ -289,9 +289,9 @@ func (g *groupi) applyState(state *pb.MembershipState) {
 }
 
 func (g *groupi) ServesGroup(gid uint32) bool {
-	g.RLock()
-	defer g.RUnlock()
-	return g.gid == gid
+	// No need to acquire the lock on g because gid is always
+	// accessed atomically via groupId() function
+	return g.groupId() == gid
 }
 
 func (g *groupi) ChecksumsMatch(ctx context.Context) error {
@@ -307,7 +307,7 @@ func (g *groupi) ChecksumsMatch(ctx context.Context) error {
 				return nil
 			}
 		case <-ctx.Done():
-			return fmt.Errorf("Group checksum mismatch for id: %d", g.gid)
+			return fmt.Errorf("Group checksum mismatch for id: %d", g.groupId())
 		}
 	}
 }

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -170,10 +170,10 @@ func (w *grpcWorker) MovePredicate(ctx context.Context,
 	if !n.AmLeader() {
 		return &emptyPayload, errNotLeader
 	}
-	if groups().gid != in.SourceGid {
+	if groups().groupId() != in.SourceGid {
 		return &emptyPayload,
 			x.Errorf("Group id doesn't match, received request for %d, my gid: %d",
-				in.SourceGid, groups().gid)
+				in.SourceGid, groups().groupId())
 	}
 	if len(in.Predicate) == 0 {
 		return &emptyPayload, errEmptyPredicate


### PR DESCRIPTION
We were accessing groupi.gid without synchronization. This commit ensures that groupi.gid is always accessed atomically. Fixes #3343 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3402)
<!-- Reviewable:end -->
