### PR TITLE
When calculating a snapshot, retrieve entries in batches.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1248,18 +1248,16 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	// cases where the raft log is too big to fit into memory. Instead of retrieving
 	// all entries at once, retrieve it in batches of 64MB.
 	var lastEntry raftpb.Entry
-	var batchSize uint64
 	var foundEntries bool
-	batchSize = 64 * (1 << 20)
 	batchFirst := first
-	for batchFirst < last+1 {
-		entries, err := n.Store.Entries(batchFirst, last+1, batchSize)
+	for batchFirst <= last {
+		entries, err := n.Store.Entries(batchFirst, last+1, 64<<20)
 		if err != nil {
 			span.Annotatef(nil, "Error: %v", err)
 			return nil, err
 		}
 
-		// Exit early from the loop If no entries were found.
+		// Exit early from the loop if no entries were found.
 		if len(entries) == 0 {
 			break
 		}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1249,8 +1249,7 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	// all entries at once, retrieve it in batches of 64MB.
 	var lastEntry raftpb.Entry
 	var foundEntries bool
-	batchFirst := first
-	for batchFirst <= last {
+	for batchFirst := first; batchFirst <= last; {
 		entries, err := n.Store.Entries(batchFirst, last+1, 64<<20)
 		if err != nil {
 			span.Annotatef(nil, "Error: %v", err)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1225,15 +1225,10 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	}
 	span.Annotatef(nil, "Found Raft entries: %d", last-first)
 
-	entries, err := n.Store.Entries(first, last+1, math.MaxUint64)
-	if err != nil {
-		span.Annotatef(nil, "Error: %v", err)
-		return nil, err
-	}
-
 	if num := posting.Oracle().NumPendingTxns(); num > 0 {
 		glog.V(2).Infof("Num pending txns: %d", num)
 	}
+
 	// We can't rely upon the Raft entries to determine the minPendingStart,
 	// because there are many cases during mutations where we don't commit or
 	// abort the transaction. This might happen due to an early error thrown.
@@ -1248,27 +1243,57 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	minPendingStart := posting.Oracle().MinPendingStartTs()
 	maxCommitTs := snap.ReadTs
 	var snapshotIdx uint64
-	for _, entry := range entries {
-		if entry.Type != raftpb.EntryNormal {
-			continue
-		}
-		var proposal pb.Proposal
-		if err := proposal.Unmarshal(entry.Data); err != nil {
+
+	// Trying to retrieve all entries at once might cause out-of-memory issues in
+	// cases where the raft log is too big to fit into memory. Instead of retrieving
+	// all entries at once, retrieve it in batches of 64MB.
+	var lastEntry raftpb.Entry
+	var batchSize uint64
+	var foundEntries bool
+	batchSize = 64 * (1 << 20)
+	batchFirst := first
+	for batchFirst < last+1 {
+		entries, err := n.Store.Entries(batchFirst, last+1, batchSize)
+		if err != nil {
 			span.Annotatef(nil, "Error: %v", err)
 			return nil, err
 		}
-		if proposal.Mutations != nil {
-			start := proposal.Mutations.StartTs
-			if start >= minPendingStart && snapshotIdx == 0 {
-				snapshotIdx = entry.Index - 1
-			}
+
+		// Exit early from the loop If no entries were found.
+		if len(entries) == 0 {
+			break
 		}
-		if proposal.Delta != nil {
-			for _, txn := range proposal.Delta.GetTxns() {
-				maxCommitTs = x.Max(maxCommitTs, txn.CommitTs)
+
+		// Store the last entry (as it might be needed outside the loop) and set the
+		// start of the new batch at the entry following it. Also set foundEntries to
+		// true to indicate to the code outside the loop that entries were retrieved.
+		foundEntries = true
+		lastEntry = entries[len(entries)-1]
+		batchFirst = lastEntry.Index + 1
+
+		for _, entry := range entries {
+			if entry.Type != raftpb.EntryNormal {
+				continue
+			}
+			var proposal pb.Proposal
+			if err := proposal.Unmarshal(entry.Data); err != nil {
+				span.Annotatef(nil, "Error: %v", err)
+				return nil, err
+			}
+			if proposal.Mutations != nil {
+				start := proposal.Mutations.StartTs
+				if start >= minPendingStart && snapshotIdx == 0 {
+					snapshotIdx = entry.Index - 1
+				}
+			}
+			if proposal.Delta != nil {
+				for _, txn := range proposal.Delta.GetTxns() {
+					maxCommitTs = x.Max(maxCommitTs, txn.CommitTs)
+				}
 			}
 		}
 	}
+
 	if maxCommitTs == 0 {
 		span.Annotate(nil, "maxCommitTs is zero")
 		return nil, nil
@@ -1276,8 +1301,8 @@ func (n *node) calculateSnapshot(discardN int) (*pb.Snapshot, error) {
 	if snapshotIdx <= 0 {
 		// It is possible that there are no pending transactions. In that case,
 		// snapshotIdx would be zero.
-		if len(entries) > 0 {
-			snapshotIdx = entries[len(entries)-1].Index
+		if foundEntries {
+			snapshotIdx = lastEntry.Index
 		}
 		span.Annotatef(nil, "snapshotIdx is zero. Using last entry's index: %d", snapshotIdx)
 	}


### PR DESCRIPTION
Calculating a snapshot can lead to an OOM issue since the entries might
not be able to fit into memory. This PR changes to logic to instead
retrieve the entries in batches of 64MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3409)
<!-- Reviewable:end -->
