### PR TITLE
New upsert block

### DIFF
--- a/chunker/rdf/parse.go
+++ b/chunker/rdf/parse.go
@@ -77,17 +77,17 @@ L:
 		case itemSubject:
 			rnq.Subject = strings.Trim(item.Val, " ")
 
-		case itemVarKeyword:
-			it.Next()
-			if item = it.Item(); item.Typ != itemLeftRound {
-				return rnq, errors.Errorf("Expected '(', found: %s", item.Val)
-			}
-			it.Next()
-			if item = it.Item(); item.Typ != itemVarName {
-				return rnq, errors.Errorf("Expected variable name, found: %s", item.Val)
+		case itemSubjectFunc:
+			var err error
+			if rnq.Subject, err = parseFunction(it); err != nil {
+				return rnq, err
 			}
 
-			it.Next() // parse ')'
+		case itemObjectFunc:
+			var err error
+			if rnq.ObjectId, err = parseFunction(it); err != nil {
+				return rnq, err
+			}
 
 		case itemPredicate:
 			// Here we split predicate and lang directive (ex: "name@en"), if needed.
@@ -200,6 +200,34 @@ L:
 	}
 
 	return rnq, nil
+}
+
+// parseFunction parses uid(<var name>) and returns
+// uid(<var name>) after striping whitespace if any
+func parseFunction(it *lex.ItemIterator) (string, error) {
+	item := it.Item()
+	s := item.Val
+
+	it.Next()
+	if item = it.Item(); item.Typ != itemLeftRound {
+		return "", errors.Errorf("Expected '(', found: %s", item.Val)
+	}
+
+	it.Next()
+	if item = it.Item(); item.Typ != itemVarName {
+		return "", errors.Errorf("Expected variable name, found: %s", item.Val)
+	}
+	if strings.TrimSpace(item.Val) == "" {
+		return "", errors.Errorf("Empty variable name in function call")
+	}
+	s += "(" + item.Val + ")"
+
+	it.Next()
+	if item = it.Item(); item.Typ != itemRightRound {
+		return "", errors.Errorf("Expected ')', found: %s", item.Val)
+	}
+
+	return s, nil
 }
 
 func parseFacets(it *lex.ItemIterator, rnq *api.NQuad) error {

--- a/chunker/rdf/parse_test.go
+++ b/chunker/rdf/parse_test.go
@@ -895,6 +895,79 @@ var testNQuads = []struct {
 		input:       `<alice> <age> "13"^^<xs:double> (salary=NaN) .`,
 		expectedErr: true,
 	},
+	{
+		input: `uid(v) <lives> "\x02 wonderland" .`,
+		nq: api.NQuad{
+			Subject:     "uid(v)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "\x02 wonderland"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  v  ) <lives> "vrinadavan" .`,
+		nq: api.NQuad{
+			Subject:     "uid(v)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "vrinadavan"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> "vrinadavan" .`,
+		nq: api.NQuad{
+			Subject:     "uid(val)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "vrinadavan"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> uid(g) .`,
+		nq: api.NQuad{
+			Subject:   "uid(val)",
+			Predicate: "lives",
+			ObjectId:  "uid(g)",
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> uid ( g )  .`,
+		nq: api.NQuad{
+			Subject:   "uid(val)",
+			Predicate: "lives",
+			ObjectId:  "uid(g)",
+		},
+		expectedErr: false,
+	},
+	{
+		input:       `uid  (  val   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid   val )   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `ui(uid)   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid())   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid()   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid(a)   <lives> uid (  )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid(a)   lives> uid (  )  .`,
+		expectedErr: true,
+	},
 }
 
 func TestLex(t *testing.T) {

--- a/chunker/rdf/state.go
+++ b/chunker/rdf/state.go
@@ -26,23 +26,24 @@ import (
 
 // The constants represent different types of lexed Items possible for an rdf N-Quad.
 const (
-	itemText       lex.ItemType = 5 + iota // plain text
-	itemSubject                            // subject, 6
-	itemPredicate                          // predicate, 7
-	itemObject                             // object, 8
-	itemLabel                              // label, 9
-	itemLiteral                            // literal, 10
-	itemLanguage                           // language, 11
-	itemObjectType                         // object type, 12
-	itemValidEnd                           // end with dot, 13
-	itemComment                            // comment, 14
-	itemComma                              // comma, 15
-	itemEqual                              // equal, 16
-	itemLeftRound                          // '(', 17
-	itemRightRound                         // ')', 18
-	itemStar                               // *, 19
-	itemVarKeyword                         // var, 20
-	itemVarName                            // 21
+	itemText        lex.ItemType = 5 + iota // plain text
+	itemSubject                             // subject, 6
+	itemPredicate                           // predicate, 7
+	itemObject                              // object, 8
+	itemLabel                               // label, 9
+	itemLiteral                             // literal, 10
+	itemLanguage                            // language, 11
+	itemObjectType                          // object type, 12
+	itemValidEnd                            // end with dot, 13
+	itemComment                             // comment, 14
+	itemComma                               // comma, 15
+	itemEqual                               // equal, 16
+	itemLeftRound                           // '(', 17
+	itemRightRound                          // ')', 18
+	itemStar                                // *, 19
+	itemSubjectFunc                         // uid, 20
+	itemObjectFunc                          // uid, 21
+	itemVarName                             // 22
 )
 
 // These constants keep a track of the depth while parsing an rdf N-Quad.
@@ -137,6 +138,7 @@ func lexText(l *lex.Lexer) lex.StateFn {
 				l.Depth = atSubject
 			}
 
+		// TODO(Aman): add support for more functions here.
 		case r == 'u':
 			if l.Depth != atSubject && l.Depth != atObject {
 				return l.Errorf("Unexpected char 'u'")
@@ -422,40 +424,39 @@ func lexComment(l *lex.Lexer) lex.StateFn {
 func lexVariable(l *lex.Lexer) lex.StateFn {
 	var r rune
 
+	// TODO(Aman): add support for more functions here.
 	for _, c := range "uid" {
 		if r = l.Next(); r != c {
-			return l.Errorf("Unexpected char '%c' when parsing var keyword", r)
+			return l.Errorf("Unexpected char '%c' when parsing uid keyword", r)
 		}
 	}
-	l.Emit(itemVarKeyword)
+	if l.Depth == atObject {
+		l.Emit(itemObjectFunc)
+	} else if l.Depth == atSubject {
+		l.Emit(itemSubjectFunc)
+	}
 	l.IgnoreRun(isSpace)
 
 	if r = l.Next(); r != '(' {
-		return l.Errorf("Expected '(' after var keyword, found: '%c'", r)
+		return l.Errorf("Expected '(' after uid keyword, found: '%c'", r)
 	}
 	l.Emit(itemLeftRound)
-
 	l.IgnoreRun(isSpace)
 
-	for {
-		r := l.Next()
-		if r == lex.EOF {
-			return l.Errorf("Unexpected end of input while reading variable name.")
-		}
-		if r == ')' {
-			l.Backup()
-			break
-		}
-		if isSpace(r) {
-			break
-		}
+	// TODO(Aman): we support all characters in variable names except space and
+	// right bracket. we should support only limited characters in variable names.
+	// For now, this is fine because variables names must be used once in query
+	// block before they can be used here. And, we throw an error if number of
+	// used variables are different than number of defined variables.
+	acceptVar := func(r rune) bool { return !(isSpace(r) || r == ')') }
+	if _, valid := l.AcceptRun(acceptVar); !valid {
+		return l.Errorf("Unexpected end of input while reading variable name")
 	}
 	l.Emit(itemVarName)
-
 	l.IgnoreRun(isSpace)
 
 	if r = l.Next(); r != ')' {
-		return l.Errorf("Expected ')' while reading var, found: '%c'", r)
+		return l.Errorf("Expected ')' while reading uid func, found: '%c'", r)
 	}
 	l.Emit(itemRightRound)
 	l.Depth++

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -320,6 +320,13 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 		if delJSON, ok := ms["delete"]; ok && delJSON != nil {
 			mu.DeleteJson = delJSON.bs
 		}
+		if queryText, ok := ms["query"]; ok && queryText != nil {
+			mu.Query, err = strconv.Unquote(string(queryText.bs))
+			if err != nil {
+				x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
+				return
+			}
+		}
 
 	case "application/rdf":
 		// Parse N-Quads.

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -18,8 +18,12 @@ package alpha
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/z"
+
+	"github.com/dgraph-io/dgo/y"
 	"github.com/stretchr/testify/require"
 )
 
@@ -155,4 +159,599 @@ func TestUpsertExample0JSON(t *testing.T) {
 	res, _, err = queryWithTs(q1, "application/graphql+-", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
+}
+
+func TestUpsertNoVarErr(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+friend: uid @reverse .`))
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      _:user1 <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      ...fragmentA
+      friend {
+        ...fragmentA
+        age
+      }
+    }
+  }
+
+  fragment fragmentA {
+    uid
+  }
+}`
+	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.Contains(t, err.Error(), "upsert query op has no variables")
+}
+
+func TestUpsertWithFragment(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+friend: uid @reverse .`))
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid(variable) <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      friend {
+        ...fragmentA
+      }
+    }
+  }
+
+  fragment fragmentA {
+    variable as uid
+  }
+}`
+	keys, preds, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+	require.True(t, 0 == len(keys))
+	require.True(t, contains(preds, "age"))
+
+	// Ensure that another run works too
+	keys, preds, _, err = mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+	require.True(t, 0 == len(keys))
+	require.True(t, contains(preds, "age"))
+}
+
+func TestUpsertInvalidErr(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) .
+friend: uid @reverse .`))
+
+	m1 := `
+{
+  set {
+    uid(variable) <age> "45" .
+  }
+}`
+	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.Contains(t, err.Error(), "invalid syntax")
+}
+
+func TestUpsertUndefinedVarErr(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) .
+friend: uid @reverse .`))
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid(42) <age> "45" .
+      uid(variable) <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      friend {
+        ...fragmentA
+      }
+    }
+  }
+
+  fragment fragmentA {
+    variable as uid
+  }
+}`
+	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.Contains(t, err.Error(), "Some variables are used but not defined")
+	require.Contains(t, err.Error(), "Defined:[variable]")
+	require.Contains(t, err.Error(), "Used:[42 variable]")
+}
+
+func TestUpsertUnusedVarErr(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) .
+friend: uid @reverse .`))
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid(var2) <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      var2 as uid
+      friend {
+        ...fragmentA
+      }
+    }
+  }
+
+  fragment fragmentA {
+    var1 as uid
+    name
+  }
+}`
+	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.Contains(t, err.Error(), "Some variables are defined but not used")
+	require.Contains(t, err.Error(), "Defined:[var1 var2]")
+	require.Contains(t, err.Error(), "Used:[var2]")
+}
+
+func TestUpsertExampleNode(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) @lang .
+friend: uid @reverse .`))
+
+	m0 := `
+{
+  set {
+    _:user1 <age> "23" .
+    _:user1 <name@en> "user1" .
+    _:user2 <age> "34" .
+    _:user2 <name@en> "user2" .
+    _:user3 <age> "56" .
+    _:user3 <name@en> "user3" .
+  }
+}`
+	_, _, _, err := mutationWithTs(m0, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid(	u) <oldest> "true" .
+    }
+  }
+
+  query {
+    var(func: has(age)) {
+      a as age
+    }
+
+    oldest(func: uid(a), orderdesc: val(a), first: 1) {
+      u as uid
+      name
+      age
+    }
+  }
+}`
+	_, _, _, err = mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	q1 := `
+{
+  q(func: has(oldest)) {
+    name@en
+    age
+    oldest
+  }
+}`
+	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "user3")
+	require.Contains(t, res, "56")
+	require.Contains(t, res, "true")
+
+	m2 := `
+upsert {
+  mutation {
+    delete {
+      uid (u1) <name> * .
+    }
+  }
+
+  query {
+    user1(func: eq(name@en, "user1")) {
+      u1 as uid
+    }
+  }
+}`
+	_, _, _, err = mutationWithTs(m2, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	q2 := `
+{
+  q(func: eq(name@en, "user1")) {
+    name@en
+    age
+  }
+}`
+	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.NotContains(t, res, "user1")
+}
+
+func TestUpsertExampleEdge(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) @lang .
+friend: uid @reverse .`))
+
+	m0 := `
+{
+  set {
+    _:user1 <age> "23" .
+    _:user1 <name@en> "user1" .
+    _:user2 <age> "34" .
+    _:user2 <name@en> "user2" .
+    _:user3 <age> "56" .
+    _:user3 <name@en> "user3" .
+  }
+}`
+	_, _, _, err := mutationWithTs(m0, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid ( u1 ) <friend> uid ( u2 ) .
+    }
+  }
+
+  query {
+    user1(func: eq(name@en, "user1")) {
+      u1 as uid
+    }
+
+    user2(func: eq(name@en, "user2")) {
+      u2 as uid
+    }
+  }
+}`
+	_, _, _, err = mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	q1 := `
+{
+  q(func: eq(name@en, "user1")) {
+    friend {
+      name@en
+    }
+  }
+}`
+	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "user2")
+
+	m2 := `
+upsert {
+  mutation {
+    delete {
+      uid (u1) <friend> uid ( u2 ) .
+    }
+  }
+
+  query {
+    user1(func: eq(name@en, "user1")) {
+      u1 as uid
+    }
+
+    user2(func: eq(name@en, "user2")) {
+      u2 as uid
+    }
+  }
+}`
+	_, _, _, err = mutationWithTs(m2, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	q2 := `
+{
+  q(func: eq(name@en, "user1")) {
+    friend {
+      name@en
+    }
+  }
+}`
+	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.NotContains(t, res, "user2")
+}
+
+func TestUpsertExampleNodeJSON(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) @lang .
+friend: uid @reverse .`))
+
+	m0 := `
+{
+  set {
+    _:user1 <age> "23" .
+    _:user1 <name@en> "user1" .
+    _:user2 <age> "34" .
+    _:user2 <name@en> "user2" .
+    _:user3 <age> "56" .
+    _:user3 <name@en> "user3" .
+  }
+}`
+	_, _, _, err := mutationWithTs(m0, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	m1 := `
+{
+  "set": [
+    {
+      "uid": "uid(u)",
+      "oldest": "true"
+    }
+  ],
+
+  "query": "{var(func: has(age)) {a as age} oldest(func: uid(a), orderdesc: val(a), first: 1) {u as uid}}"
+}`
+	_, _, _, err = mutationWithTs(m1, "application/json", false, true, true, 0)
+	require.NoError(t, err)
+
+	q1 := `
+{
+  q(func: has(oldest)) {
+    name@en
+    age
+    oldest
+  }
+}`
+	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "user3")
+	require.Contains(t, res, "56")
+	require.Contains(t, res, "true")
+
+	m2 := `
+{
+  "delete": [
+    {
+      "uid": "uid (u1)",
+      "name": null
+    }
+  ],
+
+  "query": "{user1(func: eq(name@en, \"user1\")) {u1 as uid}}"
+}`
+	_, _, _, err = mutationWithTs(m2, "application/json", false, true, true, 0)
+	require.NoError(t, err)
+
+	q2 := `
+{
+  q(func: eq(name@en, "user1")) {
+    name@en
+    age
+  }
+}`
+	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.NotContains(t, res, "user1")
+}
+
+func TestUpsertExampleEdgeJSON(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+age: int @index(int) .
+name: string @index(exact) @lang .
+friend: uid @reverse .`))
+
+	m0 := `
+{
+  set {
+    _:user1 <age> "23" .
+    _:user1 <name@en> "user1" .
+    _:user2 <age> "34" .
+    _:user2 <name@en> "user2" .
+    _:user3 <age> "56" .
+    _:user3 <name@en> "user3" .
+  }
+}`
+	_, _, _, err := mutationWithTs(m0, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	m1 := `
+{
+  "set": [
+      {
+        "uid": "uid(u1)",
+        "friend": "uid  (u2 ) "
+    }
+  ],
+
+  "query": "{user1(func: eq(name@en, \"user1\")) {u1 as uid} user2(func: eq(name@en, \"user2\")) {u2 as uid}}"
+}`
+	_, _, _, err = mutationWithTs(m1, "application/json", false, true, true, 0)
+	require.NoError(t, err)
+
+	q1 := `
+{
+  q(func: eq(name@en, "user1")) {
+    friend {
+      name@en
+    }
+  }
+}`
+	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "user2")
+
+	m3 := `
+{
+  "delete": [
+    {
+      "uid": "uid (u1)",
+      "friend": "uid ( u2 )"
+    }
+  ],
+
+  "query": "{user1(func: eq(name@en, \"user1\")) {u1 as uid} user2(func: eq(name@en, \"user2\")) {u2 as uid}}"
+}`
+	_, _, _, err = mutationWithTs(m3, "application/json", false, true, true, 0)
+	require.NoError(t, err)
+
+	q3 := `
+{
+  q(func: eq(name@en, "user1")) {
+    friend {
+      name@en
+    }
+  }
+}`
+	res, _, err = queryWithTs(q3, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.NotContains(t, res, "user2")
+}
+
+func TestUpsertBlankNodeWithVar(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`name: string @index(exact) @lang .`))
+
+	m := `
+upsert {
+  mutation {
+    set {
+      uid(u) <name> "user1" .
+      _:u <name> "user2" .
+    }
+  }
+
+  query {
+    users(func: eq(name, "user1")) {
+      u as uid
+    }
+  }
+}`
+	_, _, _, err := mutationWithTs(m, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+
+	q := `
+{
+  users(func: has(name)) {
+    uid
+    name
+  }
+}`
+	res, _, err := queryWithTs(q, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "user1")
+	require.Contains(t, res, "user2")
+}
+
+func TestUpsertParallel(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+email: string @index(exact) @upsert .
+name: string @index(exact) @lang .
+friend: uid @reverse .`))
+
+	m := `
+upsert {
+  mutation {
+    set {
+      uid(u1) <email> "user1@dgraph.io" .
+      uid(u1) <name> "user1" .
+      uid(u2) <email> "user2@dgraph.io" .
+      uid(u2) <name> "user2" .
+      uid(u1) <friend> uid(u2) .
+    }
+  }
+
+  query {
+    user1(func: eq(email, "user1@dgraph.io")) {
+      u1 as uid
+    }
+
+    user2(func: eq(email, "user2@dgraph.io")) {
+      u2 as uid
+    }
+  }
+}`
+	doUpsert := func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			err := y.ErrAborted
+			for err != nil && strings.Contains(err.Error(), "Transaction has been aborted. Please retry") {
+				_, _, _, err = mutationWithTs(m, "application/rdf", false, true, true, 0)
+			}
+
+			require.NoError(t, err)
+		}
+	}
+
+	// 10 routines each doing parallel upsert 10 times
+	var wg sync.WaitGroup
+	wg.Add(10)
+	for i := 0; i < 10; i++ {
+		go doUpsert(&wg)
+	}
+	wg.Wait()
+
+	q := `
+{
+  user1(func: eq(email, "user1@dgraph.io")) {
+    name
+    email
+    friend {
+      name
+      email
+    }
+  }
+}`
+	res, _, err := queryWithTs(q, "application/graphql+-", 0)
+	require.NoError(t, err)
+	expected := `
+{
+  "data": {
+    "user1": [
+      {
+        "name": "user1",
+        "email": "user1@dgraph.io",
+        "friend": {
+          "name": "user2",
+          "email": "user2@dgraph.io"
+        }
+      }
+    ]
+  }
+}`
+	z.CompareJSON(t, expected, res)
 }

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// contains checks whether given element is contained
+// in any of the elements of the given list of strings.
+func contains(ps []string, p string) bool {
+	var res bool
+	for _, v := range ps {
+		res = res || strings.Contains(v, p)
+	}
+
+	return res
+}
+
+func TestUpsertExample0(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`email: string @index(exact) .`))
+
+	// Mutation with wrong name
+	m1 := `
+upsert {
+  mutation {
+    set {
+      uid(v) <name> "Wrong" .
+      uid(v) <email> "ashish@dgraph.io" .
+    }
+  }
+
+  query {
+    me(func: eq(email, "ashish@dgraph.io")) {
+      v as uid
+    }
+  }
+}`
+	keys, preds, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+	require.True(t, len(keys) == 0)
+	require.True(t, contains(preds, "email"))
+	require.True(t, contains(preds, "name"))
+
+	// query should return the wrong name
+	q1 := `
+{
+  q(func: has(email)) {
+    uid
+    name
+    email
+  }
+}`
+	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "Wrong")
+
+	// mutation with correct name
+	m2 := `
+upsert {
+  mutation {
+    set {
+      uid(v) <name> "Ashish" .
+    }
+  }
+
+  query {
+    me(func: eq(email, "ashish@dgraph.io")) {
+      v as uid
+    }
+  }
+}`
+	keys, preds, _, err = mutationWithTs(m2, "application/rdf", false, true, true, 0)
+	require.NoError(t, err)
+	require.True(t, len(keys) == 0)
+	require.True(t, contains(preds, "name"))
+
+	// query should return correct name
+	res, _, err = queryWithTs(q1, "application/graphql+-", 0)
+	require.NoError(t, err)
+	require.Contains(t, res, "Ashish")
+}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -524,8 +524,22 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool)
 			return s
 		}
 
+		// Remove the mutations from gmu.Del when no UID was found
+		gmuDel := make([]*api.NQuad, 0, len(gmu.Del))
+		for _, nq := range gmu.Del {
+			nq.Subject = getNewVal(nq.Subject)
+			nq.ObjectId = getNewVal(nq.ObjectId)
+
+			if !strings.HasPrefix(nq.Subject, "_:uid(") &&
+				!strings.HasPrefix(nq.ObjectId, "_:uid(") {
+
+				gmuDel = append(gmuDel, nq)
+			}
+		}
+		gmu.Del = gmuDel
+
 		// update the values in mutation block from the query block.
-		for _, nq := range append(gmu.Set, gmu.Del...) {
+		for _, nq := range gmu.Set {
 			nq.Subject = getNewVal(nq.Subject)
 			nq.ObjectId = getNewVal(nq.ObjectId)
 		}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -501,6 +501,36 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool)
 		}
 	}()
 
+	needVars := findVars(gmu)
+	varToUID, err := doQueryInUpsert(ctx, &l, mu.Query, needVars, mu.StartTs)
+	if err != nil {
+		return resp, err
+	}
+
+	if mu.Query != "" {
+		// does following transformations:
+		//   * uid(v) -> 0x123     -- If v is defined in query block
+		//   * uid(v) -> _:uid(v)  -- Otherwise
+		getNewVal := func(s string) string {
+			if strings.HasPrefix(s, "uid(") {
+				varName := s[4 : len(s)-1]
+				if uid, ok := varToUID[varName]; ok {
+					return uid
+				}
+
+				return "_:" + s
+			}
+
+			return s
+		}
+
+		// update the values in mutation block from the query block.
+		for _, nq := range append(gmu.Set, gmu.Del...) {
+			nq.Subject = getNewVal(nq.Subject)
+			nq.ObjectId = getNewVal(nq.ObjectId)
+		}
+	}
+
 	newUids, err := query.AssignUids(ctx, gmu.Set)
 	if err != nil {
 		return resp, err
@@ -558,6 +588,89 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool)
 	resp.Context.Keys = resp.Context.Keys[:0]
 	resp.Context.CommitTs = cts
 	return resp, nil
+}
+
+// findVars finds all the variables used in mutation block
+func findVars(gmu *gql.Mutation) []string {
+	vars := make(map[string]struct{})
+	updateVars := func(s string) {
+		if strings.HasPrefix(s, "uid(") {
+			varName := s[4 : len(s)-1]
+			vars[varName] = struct{}{}
+		}
+	}
+	for _, nq := range gmu.Set {
+		updateVars(nq.Subject)
+		updateVars(nq.ObjectId)
+	}
+	for _, nq := range gmu.Del {
+		updateVars(nq.Subject)
+		updateVars(nq.ObjectId)
+	}
+
+	varsList := make([]string, 0, len(vars))
+	for v := range vars {
+		varsList = append(varsList, v)
+	}
+	if glog.V(3) {
+		glog.Infof("Variables used in mutation block: %v", varsList)
+	}
+
+	return varsList
+}
+
+// doQueryInUpsert processes a query in the upsert block.
+// TODO(Aman): refactor this function along with doMutate
+func doQueryInUpsert(ctx context.Context, l *query.Latency, queryText string,
+	needVars []string, startTs uint64) (map[string]string, error) {
+
+	varToUID := make(map[string]string)
+	if queryText == "" {
+		return varToUID, nil
+	}
+
+	if startTs == 0 {
+		return nil, errors.Errorf("Transaction timestamp is zero")
+	}
+
+	parsedReq, err := gql.ParseWithNeedVars(gql.Request{
+		Str:       queryText,
+		Variables: make(map[string]string),
+	}, needVars)
+	if err != nil {
+		return nil, err
+	}
+	if err = validateQuery(parsedReq.Query); err != nil {
+		return nil, err
+	}
+
+	qr := query.Request{
+		Latency:  l,
+		GqlQuery: &parsedReq,
+		ReadTs:   startTs,
+	}
+	if err := qr.ProcessQuery(ctx); err != nil {
+		return nil, errors.Wrapf(err, "while processing query: %q", queryText)
+	}
+
+	if len(qr.Vars) <= 0 {
+		return nil, fmt.Errorf("upsert query op has no variables")
+	}
+
+	// TODO(Aman): allow multiple values for each variable.
+	// If a variable doesn't have any UID, we generate one ourselves later.
+	for name, v := range qr.Vars {
+		if v.Uids == nil {
+			continue
+		}
+		if len(v.Uids.Uids) > 1 {
+			return nil, fmt.Errorf("more than one values found for var (%s)", name)
+		} else if len(v.Uids.Uids) == 1 {
+			varToUID[name] = fmt.Sprintf("%d", v.Uids.Uids[0])
+		}
+	}
+
+	return varToUID, nil
 }
 
 // Query handles queries and returns the data.

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -555,6 +555,12 @@ func ParseWithNeedVars(r Request, needVars []string) (res Result, rerr error) {
 		}
 
 		allVars := res.QueryVars
+		// Add the variables that are needed outside the query block.
+		// For example, mutation block in upsert block will be using
+		// variables from the query block that is getting parsed here.
+		if len(needVars) != 0 {
+			allVars = append(allVars, &Vars{Needs: needVars})
+		}
 		if err := checkDependency(allVars); err != nil {
 			return res, err
 		}

--- a/gql/parser_mutation.go
+++ b/gql/parser_mutation.go
@@ -22,15 +22,121 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ParseMutation(mutation string) (*api.Mutation, error) {
+// ParseMutation parses a block into a mutation. Returns an object with a mutation or
+// an upsert block with mutation, otherwise returns nil with an error.
+func ParseMutation(mutation string) (mu *api.Mutation, err error) {
 	lexer := lex.NewLexer(mutation)
-	lexer.Run(lexInsideMutation)
+	lexer.Run(lexIdentifyBlock)
+	if err := lexer.ValidateResult(); err != nil {
+		return nil, err
+	}
+
 	it := lexer.NewIterator()
+	if !it.Next() {
+		return nil, errors.Errorf("Invalid mutation")
+	}
+
+	item := it.Item()
+	switch item.Typ {
+	case itemUpsertBlock:
+		if mu, err = ParseUpsertBlock(it); err != nil {
+			return nil, err
+		}
+	case itemLeftCurl:
+		if mu, err = ParseMutationBlock(it); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.Errorf("Unexpected token: [%s]", item.Val)
+	}
+
+	// mutations must be enclosed in a single block.
+	if it.Next() && it.Item().Typ != lex.ItemEOF {
+		return nil, errors.Errorf("Unexpected %s after the end of the block", it.Item().Val)
+	}
+
+	return mu, nil
+}
+
+// ParseUpsertBlock parses the upsert block
+func ParseUpsertBlock(it *lex.ItemIterator) (*api.Mutation, error) {
+	var mu *api.Mutation
+	var queryText string
+	var queryFound bool
+
+	// ===>upsert<=== {...}
+	if !it.Next() {
+		return nil, errors.Errorf("Unexpected end of upsert block")
+	}
+
+	// upsert ===>{<=== ....}
+	item := it.Item()
+	if item.Typ != itemLeftCurl {
+		return nil, errors.Errorf("Expected { at the start of block. Got: [%s]", item.Val)
+	}
+
+	for it.Next() {
+		item = it.Item()
+		switch {
+		// upsert {... ===>}<===
+		case item.Typ == itemRightCurl:
+			if mu == nil {
+				return nil, errors.Errorf("Empty mutation block")
+			} else if !queryFound {
+				return nil, errors.Errorf("Query op not found in upsert block")
+			} else {
+				mu.Query = queryText
+				return mu, nil
+			}
+
+		// upsert { mutation{...} ===>query<==={...}}
+		case item.Typ == itemUpsertBlockOp && item.Val == "query":
+			if queryFound {
+				return nil, errors.Errorf("Multiple query ops inside upsert block")
+			}
+			queryFound = true
+			if !it.Next() {
+				return nil, errors.Errorf("Unexpected end of upsert block")
+			}
+			item = it.Item()
+			if item.Typ != itemUpsertBlockOpContent {
+				return nil, errors.Errorf("Expecting brace, found '%s'", item.Val)
+			}
+			queryText += item.Val
+
+		// upsert { ===>mutation<=== {...} query{...}}
+		case item.Typ == itemUpsertBlockOp && item.Val == "mutation":
+			if !it.Next() {
+				return nil, errors.Errorf("Unexpected end of upsert block")
+			}
+			var err error
+			if mu, err = ParseMutationBlock(it); err != nil {
+				return nil, err
+			}
+
+		// upsert { mutation{...} ===>fragment<==={...}}
+		case item.Typ == itemUpsertBlockOp && item.Val == "fragment":
+			if !it.Next() {
+				return nil, errors.Errorf("Unexpected end of upsert block")
+			}
+			item = it.Item()
+			if item.Typ != itemUpsertBlockOpContent {
+				return nil, errors.Errorf("Expecting brace, found '%s'", item.Val)
+			}
+			queryText += "fragment" + item.Val
+
+		default:
+			return nil, errors.Errorf("Unexpected token in upsert block [%s]", item.Val)
+		}
+	}
+
+	return nil, errors.Errorf("Invalid upsert block")
+}
+
+// ParseMutationBlock parses the mutation block
+func ParseMutationBlock(it *lex.ItemIterator) (*api.Mutation, error) {
 	var mu api.Mutation
 
-	if !it.Next() {
-		return nil, errors.New("Invalid mutation")
-	}
 	item := it.Item()
 	if item.Typ != itemLeftCurl {
 		return nil, errors.Errorf("Expected { at the start of block. Got: [%s]", item.Val)
@@ -42,10 +148,6 @@ func ParseMutation(mutation string) (*api.Mutation, error) {
 			continue
 		}
 		if item.Typ == itemRightCurl {
-			// mutations must be enclosed in a single block.
-			if it.Next() && it.Item().Typ != lex.ItemEOF {
-				return nil, errors.Errorf("Unexpected %s after the end of the block.", it.Item().Val)
-			}
 			return &mu, nil
 		}
 		if item.Typ == itemMutationOp {
@@ -71,7 +173,7 @@ func parseMutationOp(it *lex.ItemIterator, op string, mu *api.Mutation) error {
 			}
 			parse = true
 		}
-		if item.Typ == itemMutationContent {
+		if item.Typ == itemMutationOpContent {
 			if !parse {
 				return errors.Errorf("Mutation syntax invalid.")
 			}

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1641,7 +1641,7 @@ func TestParseMutationError(t *testing.T) {
 	`
 	_, err := ParseMutation(query)
 	require.Error(t, err)
-	require.Equal(t, `Expected { at the start of block. Got: [mutation]`, err.Error())
+	require.Contains(t, err.Error(), `Invalid block: [mutation]`)
 }
 
 func TestParseMutationError2(t *testing.T) {
@@ -1656,7 +1656,7 @@ func TestParseMutationError2(t *testing.T) {
 	`
 	_, err := ParseMutation(query)
 	require.Error(t, err)
-	require.Equal(t, `Expected { at the start of block. Got: [set]`, err.Error())
+	require.Contains(t, err.Error(), `Invalid block: [set]`)
 }
 
 func TestParseMutationAndQueryWithComments(t *testing.T) {
@@ -4362,10 +4362,10 @@ func TestParseMutationTooManyBlocks(t *testing.T) {
          }{
 		   set { _:b2 <reg> "b2 content" . }
 		 }`,
-			errStr: "Unexpected { after the end of the block.",
+			errStr: "Unrecognized character in lexText",
 		},
 		{m: `{set { _:a1 <reg> "a1 content" . }} something`,
-			errStr: "Invalid operation type: something after the end of the block",
+			errStr: "Invalid operation type: something",
 		},
 		{m: `
           # comments are ok

--- a/gql/state.go
+++ b/gql/state.go
@@ -17,7 +17,9 @@
 // Package gql is responsible for lexing and parsing a GraphQL query/mutation.
 package gql
 
-import "github.com/dgraph-io/dgraph/lex"
+import (
+	"github.com/dgraph-io/dgraph/lex"
+)
 
 const (
 	leftCurl    = '{'
@@ -39,26 +41,151 @@ const (
 
 // Constants representing type of different graphql lexed items.
 const (
-	itemText            lex.ItemType = 5 + iota // plain text
-	itemLeftCurl                                // left curly bracket
-	itemRightCurl                               // right curly bracket
-	itemEqual                                   // equals to symbol
-	itemName                                    // [9] names
-	itemOpType                                  // operation type
-	itemLeftRound                               // left round bracket
-	itemRightRound                              // right round bracket
-	itemColon                                   // Colon
-	itemAt                                      // @
-	itemPeriod                                  // .
-	itemDollar                                  // $
-	itemRegex                                   // /
-	itemMutationOp                              // mutation operation
-	itemMutationContent                         // mutation content
+	itemText                 lex.ItemType = 5 + iota // plain text
+	itemLeftCurl                                     // left curly bracket
+	itemRightCurl                                    // right curly bracket
+	itemEqual                                        // equals to symbol
+	itemName                                         // [9] names
+	itemOpType                                       // operation type
+	itemLeftRound                                    // left round bracket
+	itemRightRound                                   // right round bracket
+	itemColon                                        // Colon
+	itemAt                                           // @
+	itemPeriod                                       // .
+	itemDollar                                       // $
+	itemRegex                                        // /
+	itemMutationOp                                   // mutation operation (set, delete)
+	itemMutationOpContent                            // mutation operation content
+	itemUpsertBlock                                  // mutation upsert block
+	itemUpsertBlockOp                                // upsert block op (query, mutate)
+	itemUpsertBlockOpContent                         // upsert block operations' content
 	itemLeftSquare
 	itemRightSquare
 	itemComma
 	itemMathOp
 )
+
+// lexIdentifyBlock identifies whether it is an upsert block
+// If the block begins with "{" => mutation block
+// Else if the block begins with "upsert" => upsert block
+func lexIdentifyBlock(l *lex.Lexer) lex.StateFn {
+	l.Mode = lexIdentifyBlock
+	for {
+		switch r := l.Next(); {
+		case isSpace(r) || lex.IsEndOfLine(r):
+			l.Ignore()
+		case isNameBegin(r):
+			return lexNameBlock
+		case r == leftCurl:
+			l.Backup()
+			return lexInsideMutation
+		case r == '#':
+			return lexComment
+		case r == lex.EOF:
+			return l.Errorf("Invalid mutation block")
+		default:
+			return l.Errorf("Unexpected character while identifying mutation block: %#U", r)
+		}
+	}
+}
+
+// lexNameBlock lexes the blocks, for now, only upsert block
+func lexNameBlock(l *lex.Lexer) lex.StateFn {
+	for {
+		// The caller already checked isNameBegin, and absorbed one rune.
+		r := l.Next()
+		if isNameSuffix(r) {
+			continue
+		}
+		l.Backup()
+		switch word := l.Input[l.Start:l.Pos]; word {
+		case "upsert":
+			l.Emit(itemUpsertBlock)
+			return lexUpsertBlock
+		default:
+			return l.Errorf("Invalid block: [%s]", word)
+		}
+	}
+}
+
+// lexUpsertBlock lexes the upsert block
+func lexUpsertBlock(l *lex.Lexer) lex.StateFn {
+	l.Mode = lexUpsertBlock
+	for {
+		switch r := l.Next(); {
+		case r == rightCurl:
+			l.BlockDepth--
+			l.Emit(itemRightCurl)
+			if l.BlockDepth == 0 {
+				return lexTopLevel
+			}
+		case r == leftCurl:
+			l.BlockDepth++
+			l.Emit(itemLeftCurl)
+		case isSpace(r) || lex.IsEndOfLine(r):
+			l.Ignore()
+		case isNameBegin(r):
+			return lexNameUpsertOp
+		case r == '#':
+			return lexComment
+		case r == lex.EOF:
+			return l.Errorf("Unclosed upsert block")
+		default:
+			return l.Errorf("Unrecognized character in upsert block: %#U", r)
+		}
+	}
+}
+
+// lexNameUpsertOp parses the operation names inside upsert block
+func lexNameUpsertOp(l *lex.Lexer) lex.StateFn {
+	for {
+		// The caller already checked isNameBegin, and absorbed one rune.
+		r := l.Next()
+		if isNameSuffix(r) {
+			continue
+		}
+		l.Backup()
+		word := l.Input[l.Start:l.Pos]
+		switch word {
+		case "query":
+			l.Emit(itemUpsertBlockOp)
+			return lexBlockContent
+		case "mutation":
+			l.Emit(itemUpsertBlockOp)
+			return lexInsideMutation
+		case "fragment":
+			l.Emit(itemUpsertBlockOp)
+			return lexBlockContent
+		default:
+			return l.Errorf("Invalid operation type: %s", word)
+		}
+	}
+}
+
+// lexBlockContent lexes and absorbs the text inside a block (covered by braces).
+func lexBlockContent(l *lex.Lexer) lex.StateFn {
+	depth := 0
+	for {
+		switch l.Next() {
+		case lex.EOF:
+			return l.Errorf("Unclosed block (matching braces not found)")
+		case quote:
+			if err := l.LexQuotedString(); err != nil {
+				return l.Errorf(err.Error())
+			}
+		case leftCurl:
+			depth++
+		case rightCurl:
+			depth--
+			if depth < 0 {
+				return l.Errorf("Unopened } found")
+			} else if depth == 0 {
+				l.Emit(itemUpsertBlockOpContent)
+				return lexUpsertBlock
+			}
+		}
+	}
+}
 
 func lexInsideMutation(l *lex.Lexer) lex.StateFn {
 	l.Mode = lexInsideMutation
@@ -225,6 +352,13 @@ func lexFuncOrArg(l *lex.Lexer) lex.StateFn {
 }
 
 func lexTopLevel(l *lex.Lexer) lex.StateFn {
+	// TODO(Aman): Find a way to identify different blocks in future. We only have
+	// Upsert block right now. BlockDepth tells us nesting of blocks. Currently, only
+	// the Upsert block has nested mutation/query/fragment blocks.
+	if l.BlockDepth != 0 {
+		return lexUpsertBlock
+	}
+
 	l.Mode = lexTopLevel
 Loop:
 	for {
@@ -395,7 +529,7 @@ func lexTextMutation(l *lex.Lexer) lex.StateFn {
 			continue
 		}
 		l.Backup()
-		l.Emit(itemMutationContent)
+		l.Emit(itemMutationOpContent)
 		break
 	}
 	return lexInsideMutation

--- a/gql/upsert_test.go
+++ b/gql/upsert_test.go
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidBlockErr(t *testing.T) {
+	query := `
+query {
+  me(func: eq(age, 34)) {
+    uid
+    friend {
+      uid
+      age
+    }
+  }
+}`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid block: [query]")
+}
+
+func TestExtraRightCurlErr(t *testing.T) {
+	query := `
+upsert {
+  query {
+    me(func: eq(age, 34)) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+}
+`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Too many right curl")
+}
+
+func TestNoMutationErr(t *testing.T) {
+	query := `
+upsert {
+  query {
+    me(func: eq(age, 34)) {
+      uid
+      friend {
+        uid age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Empty mutation block")
+}
+
+func TestMultipleQueryErr(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+
+  query {
+    me2(func: eq(age, 34)) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Multiple query ops inside upsert block")
+}
+
+func TestEmptyUpsertErr(t *testing.T) {
+	query := `upsert {}`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Empty mutation block")
+}
+
+func TestNoRightCurlErr(t *testing.T) {
+	query := `upsert {`
+	_, err := ParseMutation(query)
+	require.Contains(t, err.Error(), "Unclosed upsert block")
+}
+
+func TestIncompleteBlockErr(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, "{
+`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Unexpected end of input")
+}
+
+func TestMissingQueryErr(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Query op not found in upsert block")
+}
+
+func TestUpsertWithFragment(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      ...fragmentA
+      friend {
+        ...fragmentA
+        age
+      }
+    }
+  }
+
+  fragment fragmentA {
+    uid
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}
+
+func TestUpsertEx1(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, "{")) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}
+
+func TestUpsertWithSpaces(t *testing.T) {
+	query := `
+upsert
+
+{
+  mutation
+
+  {
+    set
+    {
+      "_:user1" <age> "45" .
+
+      # This is a comment
+      "_:user1" <name> "{vishesh" .
+    }}
+
+  query
+
+  {
+    me(func: eq(age, "{")) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}
+
+func TestUpsertWithBlankNode(t *testing.T) {
+	query := `
+upsert {
+  query {
+    me(func: eq(age, 34)) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}
+
+func TestUpsertMutationThenQuery(t *testing.T) {
+	query := `
+upsert {
+  mutation {
+    set {
+      "_:user1" <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}
+
+func TestUpsertWithFilter(t *testing.T) {
+	query := `upsert {
+  mutation {
+    set {
+      uid(a) <age> "45"
+      uid(b) <age> "45" .
+    }
+  }
+
+  query {
+    me(func: eq(age, 34)) @filter(ge(name, "user")) {
+      uid
+      friend {
+        uid
+        age
+      }
+    }
+  }
+}
+`
+	_, err := ParseMutation(query)
+	require.Nil(t, err)
+}

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -163,6 +163,7 @@ type Lexer struct {
 	widthStack []*RuneWidth
 	items      []Item  // channel of scanned items.
 	Depth      int     // nesting of {}
+	BlockDepth int     // nesting of blocks (e.g. mutation block inside upsert block)
 	ArgDepth   int     // nesting of ()
 	Mode       StateFn // Default state to go back to after reading a token.
 	Line       int     // the current line number corresponding to Start
@@ -191,7 +192,7 @@ func (l *Lexer) ValidateResult() error {
 func (l *Lexer) Run(f StateFn) *Lexer {
 	for state := f; state != nil; {
 		// The following statement is useful for debugging.
-		//fmt.Printf("Func: %v\n", runtime.FuncForPC(reflect.ValueOf(state).Pointer()).Name())
+		// fmt.Printf("Func: %v\n", runtime.FuncForPC(reflect.ValueOf(state).Pointer()).Name())
 		state = state(l)
 	}
 	return l

--- a/query/query.go
+++ b/query/query.go
@@ -1491,7 +1491,7 @@ AssignStep:
 
 // Updates the doneVars map by picking up uid/values from the current Subgraph
 func (sg *SubGraph) updateVars(doneVars map[string]varValue, sgPath []*SubGraph) error {
-	// NOTE: although we initialize doneVars (req.vars) in ProcessQuery, this nil check is for
+	// NOTE: although we initialize doneVars (req.Vars) in ProcessQuery, this nil check is for
 	// non-root lookups that happen to other nodes. Don't use len(doneVars) == 0 !
 	if doneVars == nil || (sg.Params.Var == "" && sg.Params.FacetVar == nil) {
 		return nil
@@ -2593,7 +2593,7 @@ type Request struct {
 
 	Subgraphs []*SubGraph
 
-	vars map[string]varValue
+	Vars map[string]varValue
 }
 
 // ProcessQuery processes query part of the request (without mutations).
@@ -2605,7 +2605,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 	defer stop()
 
 	// doneVars stores the processed variables.
-	req.vars = make(map[string]varValue)
+	req.Vars = make(map[string]varValue)
 	loopStart := time.Now()
 	queries := req.GqlQuery.Query
 	for i := 0; i < len(queries); i++ {
@@ -2647,7 +2647,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			}
 			// The variable should be defined in this block or should have already been
 			// populated by some other block, otherwise we are not ready to execute yet.
-			_, ok := req.vars[v]
+			_, ok := req.Vars[v]
 			if !ok && !selfDep {
 				return false
 			}
@@ -2671,7 +2671,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 				continue
 			}
 
-			err = sg.recursiveFillVars(req.vars)
+			err = sg.recursiveFillVars(req.Vars)
 			if err != nil {
 				return err
 			}
@@ -2719,10 +2719,10 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			sg := req.Subgraphs[idx]
 
 			var sgPath []*SubGraph
-			if err := sg.populateVarMap(req.vars, sgPath); err != nil {
+			if err := sg.populateVarMap(req.Vars, sgPath); err != nil {
 				return err
 			}
-			if err := sg.populatePostAggregation(req.vars, []*SubGraph{}, nil); err != nil {
+			if err := sg.populatePostAggregation(req.Vars, []*SubGraph{}, nil); err != nil {
 				return err
 			}
 		}

--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -778,3 +778,152 @@ Mutation with a JSON file:
 ```sh
 curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow=true -d @data.json
 ```
+
+## Upsert Block
+
+The Upsert block allows performing queries and mutations in a single request. The Upsert
+block contains one query block and one mutation block. Variables defined in the
+query block can be used in the mutation block using the `uid` function.
+
+In general, the structure of the Upsert block is as follows:
+
+```
+upsert {
+  query <query block>
+  [fragment <fragment block>]
+  mutation <mutation block>
+}
+```
+
+The Mutation block currently only allows the `uid` function, which allows extracting UIDs
+from variables defined in the query block. There are 3 possible outcomes based on the
+results of executing the query block:
+  * If the variable is empty i.e. has no value, the `uid` function returns a new UID and
+  is treated similar to a blank node.
+  * If the variable stores exactly one UID, the `uid` function returns the uid stored in
+  the variable.
+  * If the variable stores more than one UID, the mutation fails. We plan to support
+  this use case in the future.
+
+### Example
+
+Consider an example with following schema:
+
+```sh
+curl localhost:8080/alter -X POST -d $'
+  name: string @index(term) .
+  email: string @index(exact) @upsert .
+  age: int @index(int) .
+  friend: uid @reverse .
+' | jq
+```
+
+### Insert Use Case
+
+Now, let's say we want to create a new user with `email`, and `name` information.
+We also want to make sure that two users cannot have same email id in the database.
+We can do this using the Upsert block as follows:
+
+```sh
+curl -H "Content-Type: application/rdf" -X POST localhost:8080/mutate?commitNow=true -d  $'
+upsert {
+  query {
+    me(func: eq(email, "user@dgraph.io")) {
+      v as uid
+    }
+  }
+
+  mutation {
+    set {
+      uid(v) <name> "first last" .
+      uid(v) <email> "user@dgraph.io" .
+    }
+  }
+}
+' | jq
+```
+
+Result:
+
+```json
+{
+  "data": {
+    "code": "Success",
+    "message": "Done",
+    "uids": {
+      "uid(v)": "0x2"
+    }
+  },
+  "extensions": {
+    "server_latency": {
+      "parsing_ns": 71033,
+      "processing_ns": 22994018
+    },
+    "txn": {
+      "start_ts": 4,
+      "commit_ts": 5,
+      "preds": [
+        "1-email",
+        "1-name"
+      ]
+    }
+  }
+}
+```
+
+The upsert first checks whether a user with the email `user@dgraph.io` exists. Because
+the database is currently empty, no such user exists. Hence, the variable `v` will be
+empty. In this case, the `uid` function returns a new UID for the variable `v` replacing
+with the new UID value wherever `uid(v)` is used.
+
+### Update Use Case
+
+Now, we want to add the `age` information for the same user having email ID
+`user@dgraph.io`. We can use the Upsert block to do the same as follows:
+
+```sh
+curl -H "Content-Type: application/rdf" -X POST localhost:8080/mutate?commitNow=true -d  $'
+upsert {
+  query {
+    me(func: eq(email, "user@dgraph.io")) {
+      v as uid
+    }
+  }
+
+  mutation {
+    set {
+      uid(v) <age> "28" .
+    }
+  }
+}
+' | jq
+```
+
+Result:
+
+```json
+{
+  "data": {
+    "code": "Success",
+    "message": "Done",
+    "uids": {}
+  },
+  "extensions": {
+    "server_latency": {
+      "parsing_ns": 39017,
+      "processing_ns": 21231954
+    },
+    "txn": {
+      "start_ts": 7,
+      "commit_ts": 8,
+      "preds": [
+        "1-age"
+      ]
+    }
+  }
+}
+```
+
+Here, the query block queries for a user with `email` as `user@dgraph.io`. It stores the
+`uid` of the user in variable `v`. The mutation block then updates the `age` of the
+user. The `uid` function extracts the uid from the variable `v`.


### PR DESCRIPTION
Related to #3197 
Fixes #3059 

Example upsert operation -
```
   upsert {
      query {
        me(func: eq(email, "aman@dgraph.io")) {
          v as uid
        }
      }
      mutation {
          set {
            uid(v) <name> "Aman" .
            uid(v) <email> "aman@dgraph.io" .
          }
      }
    }
```

Probably in the next version -
 * [ ] Add support for multi valued variables
 * [ ] Support for val function
 * [ ] Add support for `@if`
 * [ ] Fuzz tests

Changes in other repos -
 * [x] Add tests in dgo repo https://github.com/dgraph-io/dgo/pull/68
 * [x] Python Client https://github.com/dgraph-io/pydgraph/pull/74
 * [x] Java Client https://github.com/dgraph-io/dgraph4j/pull/88
 * [x] JS Client https://github.com/dgraph-io/dgraph-js/commit/21563532863a01a639b4ddf4848e3de3de77b3e0

Todo 
 * [x] Add lots of tests for RDF and JSON
 * [x] Add documentation (docs.dgraph.io)
 * [x] ~~Add support for tracing~~
 * [x] JSON format for upsert block
 * [x] Add V(3) logging
 * [x] Support for uid function
 * [x] Fragments in upsert block
 * [x] ~~Two query blocks inside upsert block?~~
 * [x] no query block inside upsert block?
 * [x] no mutation block inside upsert block?
 * [x] no variable in query block?
 * [x] support for blank nodes in mutation block?
 * [x] Ensure upsert only generates 1 UID

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3412)
<!-- Reviewable:end -->
