### PR TITLE
Properly escape strings during export.

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -20,11 +20,11 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"time"
 	"unicode"
@@ -131,6 +131,18 @@ func facetToString(fct *api.Facet) (string, error) {
 	return v2.Value.(string), nil
 }
 
+// jsonString converts a string into a valid JSON string.
+func jsonString(str string) string {
+	byt, err := json.Marshal(str)
+	if err != nil {
+		// All valid stings should be able to be escaped to a JSON string so
+		// it's safe to panic here. Marshal has to return an error because it
+		// accepts an interface.
+		panic("Could not marshal string to JSON string")
+	}
+	return string(byt)
+}
+
 func (e *exporter) toJSON() (*bpb.KVList, error) {
 	bp := new(bytes.Buffer)
 
@@ -173,7 +185,7 @@ func (e *exporter) toJSON() (*bpb.KVList, error) {
 			}
 
 			if !val.Tid.IsNumber() {
-				str = strconv.Quote(str)
+				str = jsonString(str)
 			}
 
 			fmt.Fprint(bp, str)
@@ -195,7 +207,7 @@ func (e *exporter) toJSON() (*bpb.KVList, error) {
 			}
 
 			if !tid.IsNumber() {
-				str = strconv.Quote(str)
+				str = jsonString(str)
 			}
 
 			fmt.Fprint(bp, str)
@@ -227,7 +239,7 @@ func (e *exporter) toRDF() (*bpb.KVList, error) {
 				glog.Errorf("Ignoring error: %+v\n", err)
 				return nil
 			}
-			fmt.Fprintf(bp, "%q", str)
+			fmt.Fprintf(bp, "%s", jsonString(str))
 
 			tid := types.TypeID(p.ValType)
 			if p.PostingType == pb.Posting_VALUE_LANG {
@@ -262,7 +274,7 @@ func (e *exporter) toRDF() (*bpb.KVList, error) {
 				}
 
 				if tid == types.StringID {
-					str = strconv.Quote(str)
+					str = jsonString(str)
 				}
 				fmt.Fprint(bp, str)
 			}

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -57,6 +57,7 @@ func populateGraphExport(t *testing.T) {
 		`<3> <name> "First Line\nSecondLine" .`,
 		"<1> <friend_not_served> <5> <author0> .",
 		`<5> <name> "" .`,
+		`<6> <name> "Ding!\u0007Ding!\u0007Ding!\u0007" .`,
 	}
 	idMap := map[string]uint64{
 		"1": 1,
@@ -64,6 +65,7 @@ func populateGraphExport(t *testing.T) {
 		"3": 3,
 		"4": 4,
 		"5": 5,
+		"6": 6,
 	}
 
 	for _, edge := range rdfEdges {
@@ -186,7 +188,7 @@ func TestExportRdf(t *testing.T) {
 	for scanner.Scan() {
 		nq, err := rdf.Parse(scanner.Text())
 		require.NoError(t, err)
-		require.Contains(t, []string{"0x1", "0x2", "0x3", "0x4", "0x5"}, nq.Subject)
+		require.Contains(t, []string{"0x1", "0x2", "0x3", "0x4", "0x5", "0x6"}, nq.Subject)
 		if nq.ObjectValue != nil {
 			switch nq.Subject {
 			case "0x1", "0x2":
@@ -198,6 +200,8 @@ func TestExportRdf(t *testing.T) {
 			case "0x4":
 			case "0x5":
 				require.Equal(t, `<0x5> <name> "" .`, scanner.Text())
+			case "0x6":
+				require.Equal(t, `<0x6> <name> "Ding!\u0007Ding!\u0007Ding!\u0007" .`, scanner.Text())
 			default:
 				t.Errorf("Unexpected subject: %v", nq.Subject)
 			}
@@ -240,7 +244,7 @@ func TestExportRdf(t *testing.T) {
 	}
 	require.NoError(t, scanner.Err())
 	// This order will be preserved due to file naming.
-	require.Equal(t, 8, count)
+	require.Equal(t, 9, count)
 
 	checkExportSchema(t, schemaFileList)
 }
@@ -276,6 +280,7 @@ func TestExportJson(t *testing.T) {
   {"uid":"0x2","name@en":"pho\ton"},
   {"uid":"0x3","name":"First Line\nSecondLine"},
   {"uid":"0x5","name":""},
+  {"uid":"0x6","name":"Ding!\u0007Ding!\u0007Ding!\u0007"},
   {"uid":"0x1","friend":[{"uid":"0x5"}]},
   {"uid":"0x2","friend":[{"uid":"0x5"}]},
   {"uid":"0x3","friend":[{"uid":"0x5"}]},

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -133,7 +133,7 @@ func initTest(t *testing.T, schemaStr string) {
 }
 
 func initClusterTest(t *testing.T, schemaStr string) *dgo.Dgraph {
-	dg := z.DgraphClientWithGroot(z.SockAddr)
+	dg := z.DgraphClient(z.SockAddr)
 	z.DropAll(t, dg)
 
 	err := dg.Alter(context.Background(), &api.Operation{Schema: schemaStr})


### PR DESCRIPTION
Currently some characters (e.g "\a") are not being properly escaped.
This change uses json.Marshal to properly escape them.

Also make export_test.go work again (it was attempting to login but
the worker package is not using ACLs).

Fixes #3383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3424)
<!-- Reviewable:end -->
