### PR TITLE
Try another explaination of transactions

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -42,7 +42,7 @@ changes it makes - changes from concurrent transactions aren't visible.
 
 On commit, Dgraph will abort a transaction rather than commit when a
 conflicting, concurrently running transaction has already been committed.  Two
-transactions conflict when both: 
+transactions conflict when both transactions: 
 
 - write data to the same key in an index, or
 - write to the same edge of the same node.  

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -38,7 +38,7 @@ Dgraph as a single unit: that is, on commit, either all the changes are accepted
 by Dgraph or none are. 
 
 A transaction always sees the database state at the moment it began, plus any 
-changes it makes - changes from concurrent transactions aren't visible.
+changes it makes --- changes from concurrent transactions aren't visible.
 
 On commit, Dgraph will abort a transaction, rather than committing changes, when
 a conflicting, concurrently running transaction has already been committed.  Two
@@ -46,7 +46,7 @@ transactions conflict when both transactions:
 
 - write values to the same scalar predicate of the same node (e.g both
   attempting to set a particular node's `address` predicate); or
-- write to a singluar `uid` predicate of the same node (changes to `[uid]` predicates can be concurrently written); or
+- write to a singular `uid` predicate of the same node (changes to `[uid]` predicates can be concurrently written); or
 - write a value that conflicts on an index for a predicate with `@upsert` set in the schema (see [upserts]({{< relref "howto/index.md#upserts">}})).
 
 When a transaction is aborted, all its changes are discarded.  Transactions can be manually aborted.

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -40,15 +40,16 @@ by Dgraph or none are.
 A transaction always sees the database state at the moment it began, plus any 
 changes it makes - changes from concurrent transactions aren't visible.
 
-On commit, Dgraph will abort a transaction rather than commit when a
-conflicting, concurrently running transaction has already been committed.  Two
+On commit, Dgraph will abort a transaction, rather than committing changes, when
+a conflicting, concurrently running transaction has already been committed.  Two
 transactions conflict when both transactions: 
 
-- write data to the same key in an index, or
-- write to the same edge of the same node.  
+- write values to the same scalar predicate of the same node (e.g both
+  attempting to set a particular node's `address` predicate); or
+- write to a singluar `uid` predicate of the same node (changes to `[uid]` predicates can be concurrently written); or
+- write a value that conflicts on an index for a predicate with `@upsert` set in the schema (see [upserts]({{< relref "howto/index.md#upserts">}})).
 
-When a transaction is aborted, all its changes are discarded.  Transactions can
-also be manually aborted.
+When a transaction is aborted, all its changes are discarded.  Transactions can be manually aborted.
 
 ## Go
 

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -32,12 +32,23 @@ fashion, resulting in an initially semi random predicate distribution.
 
 ### Transactions
 
-Clients perform mutations and queries on Dgraph using transactions. A
-transaction is a unit of work to be performed by Dgraph. A transaction commit
-has all-or-nothing semantics: either all the changes are accepted by Dgraph or
-none are. A transaction can be aborted when a concurrently running transaction
-was committed and mutated the same data. Transactions can also be manually
-aborted, in which case all the changes will be discarded.
+Dgraph clients perform mutations and queries using transactions. A
+transaction bounds a sequence of queries and mutations that are committed by
+Dgraph as a single unit: that is, on commit, either all the changes are accepted
+by Dgraph or none are. 
+
+A transaction always sees the database state at the moment it began, plus any 
+changes it makes - changes from concurrent transactions aren't visible.
+
+On commit, Dgraph will abort a transaction rather than commit when a
+conflicting, concurrently running transaction has already been committed.  Two
+transactions conflict when both: 
+
+- write data to the same key in an index, or
+- write to the same edge of the same node.  
+
+When a transaction is aborted, all its changes are discarded.  Transactions can
+also be manually aborted.
 
 ## Go
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2226,11 +2226,11 @@ Query:
 
 ### Upsert directive
 
-Predicates can specify the `@upsert` directive in the schema if you want to do
-upsert operations against it. If the `@upsert` directive is specified then the
-index key for the predicate would be checked for conflict while committing a
-transaction. The `@upsert` directive helps enforce uniqueness constraints when
-running concurrent upserts.
+To use [upsert operations]({{< relref "howto/index.md#upserts">}}) on a
+predicate, specify the `@upsert` directive in the schema. When committing
+transactions involving predicates with the `@upsert` directive, Dgraph checks
+index keys for conflicts, helping to enforce uniqueness constraints when running
+concurrent upserts.
 
 This is how you specify the upsert directive for a predicate.
 ```


### PR DESCRIPTION
@martinmr @danielmai  I saw this https://github.com/dgraph-io/dgraph/pull/3423 and didn't think it explained what a transaction was ☹️   In particular:

- I didn't like "a unit of work"
- "A transaction can be aborted" ... really should mean 'will be'
- what does "same data" mean? doesn't help a user work out why their transactions are conflicting

So, I tried to rewrite it.  Feel free to let me know if I've made it worse.

**Also**: writing this made me realise that I don't really understand the conditions under which two transactions conflict, nor do I really understand exactly what `upsert` means in a Dgraph schema.  So is what I've written right?  Does it really work like that - e.g. if I've got a day index; does that mean every concurrent write on that index will conflict?  I had assumed before that `upsert` in the schema would control those kinds of conflicts and otherwise I'd only get conflicts if I tried to write same edges ... but then is that even a thing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3427)
<!-- Reviewable:end -->
