### PR TITLE
Remove goimports from list of golangci checks.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,6 @@ linters:
     - ineffassign
     - gas
     - gofmt
-    - goimports
     - golint
     - gosimple
     - govet


### PR DESCRIPTION
gofmt already covers this use case. Also, sometimes the output of gofmt
is incompatible with goimports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3433)
<!-- Reviewable:end -->
