### PR TITLE
Fix all tests and docker-compose files to use proper zero port offset.

### DIFF
--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     container_name: bank-dg0.1
     working_dir: /data/dg0.1
     ports:
-      - 5080:5080
-      - 6080:6080
+      - 5180:5180
+      - 6180:6180
     labels:
       cluster: test
     volumes:
@@ -15,7 +15,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero -o 0 --my=zero1:5080 --replicas 1 --idx 1 --logtostderr
+    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --replicas 1 --idx 1 --logtostderr
 
   zero2:
     image: dgraph/dgraph:latest
@@ -23,8 +23,8 @@ services:
     depends_on:
       - zero1
     ports:
-      - 5082:5082
-      - 6082:6082
+      - 5182:5182
+      - 6182:6182
     labels:
       cluster: test
     volumes:
@@ -32,7 +32,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero -o 2 --my=zero2:5082 --replicas 1 --idx 2 --logtostderr --peer=zero1:5080
+    command: /gobin/dgraph zero -o 102 --my=zero2:5182 --replicas 1 --idx 2 --logtostderr --peer=zero1:5180
 
   zero3:
     image: dgraph/dgraph:latest
@@ -40,8 +40,8 @@ services:
     depends_on:
       - zero2
     ports:
-      - 5083:5083
-      - 6083:6083
+      - 5183:5183
+      - 6183:6183
     labels:
       cluster: test
     volumes:
@@ -49,7 +49,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero -o 3 --my=zero3:5083 --replicas 1 --idx 3 --logtostderr --peer=zero1:5080
+    command: /gobin/dgraph zero -o 103 --my=zero3:5183 --replicas 1 --idx 3 --logtostderr --peer=zero1:5180
 
   dg1:
     image: dgraph/dgraph:latest
@@ -65,7 +65,7 @@ services:
       - 9180:9180
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 --logtostderr --mutations=disallow
+    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 --logtostderr --mutations=disallow
 
   dg2:
     image: dgraph/dgraph:latest
@@ -83,7 +83,7 @@ services:
       - 9182:9182
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5080 -o 102 --logtostderr --mutations=strict
+    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 --logtostderr --mutations=strict
 
   dg3:
     image: dgraph/dgraph:latest
@@ -101,4 +101,4 @@ services:
       - 9183:9183
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 --logtostderr --mutations=strict
+    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 --logtostderr --mutations=strict

--- a/ee/backup/docker-compose.yml
+++ b/ee/backup/docker-compose.yml
@@ -12,9 +12,9 @@ services:
     labels:
       cluster: test
     ports:
-      - 5080:5080
-      - 6080:6080
-    command: /gobin/dgraph --cwd=/data/dg0.1 zero --my=zero1:5080 --bindall --logtostderr -v=0
+      - 5180:5180
+      - 6180:6180
+    command: /gobin/dgraph --cwd=/data/dg0.1 zero -o 100 --my=zero1:5180 --bindall --logtostderr -v=0
     user: ${UID:-0}
     volumes:
       - type: bind
@@ -44,7 +44,7 @@ services:
     ports:
       - 8180:8180
       - 9180:9180
-    command: /gobin/dgraph alpha --cwd=/data/dg1 --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    command: /gobin/dgraph alpha --cwd=/data/dg1 --my=dg1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 
   dg2:
     image: dgraph/dgraph:latest
@@ -67,7 +67,7 @@ services:
     ports:
       - 8182:8182
       - 9182:9182
-    command: /gobin/dgraph alpha --cwd=/data/dg2 --my=dg2:7182 --lru_mb=1024 --zero=zero1:5080 -o 102 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    command: /gobin/dgraph alpha --cwd=/data/dg2 --my=dg2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 
   dg3:
     image: dgraph/dgraph:latest
@@ -90,7 +90,7 @@ services:
     ports:
       - 8183:8183
       - 9183:9183
-    command: /gobin/dgraph alpha --cwd=/data/dg3 --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    command: /gobin/dgraph alpha --cwd=/data/dg3 --my=dg3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 -v=0 --enterprise_features --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
 
   minio1:
     image: minio/minio:latest

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5080 --logtostderr -v=2 --jaeger.collector=http://ocagent:14268
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --jaeger.collector=http://ocagent:14268
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1
@@ -22,14 +22,14 @@ services:
     labels:
       cluster: test
     ports:
-    - 5080:5080
-    - 6080:6080
+    - 5180:5180
+    - 6180:6180
     volumes:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --idx=1 --my=zero1:5080 --replicas=3 --logtostderr --jaeger.collector=http://ocagent:14268 -v=2 --bindall
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=3 --logtostderr --jaeger.collector=http://ocagent:14268 -v=2 --bindall
   ocagent:
     image: omnition/opencensus-agent:0.1.6
     container_name: ocagent

--- a/systest/21million/docker-compose.yml
+++ b/systest/21million/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     container_name: zero1
     working_dir: /data/zero1
     ports:
-      - 5080:5080
-      - 6080:6080
+      - 5180:5180
+      - 6180:6180
     labels:
       cluster: test
     volumes:
@@ -16,7 +16,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr --bindall
+    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   alpha1:
     image: dgraph/dgraph:latest
@@ -36,7 +36,7 @@ services:
     labels:
       cluster: test
     command: >
-      /gobin/dgraph alpha --my=alpha1:7180 --zero=zero1:5080 -o 100 --logtostderr
+      /gobin/dgraph alpha --my=alpha1:7180 --zero=zero1:5180 -o 100 --logtostderr
                           --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --lru_mb=1024
 
 volumes:

--- a/systest/bulk_live_fixture_test.go
+++ b/systest/bulk_live_fixture_test.go
@@ -93,13 +93,15 @@ func (s *suite) setup(schemaFile, rdfFile string) {
 	bulkCmd := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"), "bulk",
 		"-f", rdfFile,
 		"-s", schemaFile,
-		"--http", ":"+strconv.Itoa(freePort(0)),
+		"--http", "localhost:"+strconv.Itoa(freePort(0)),
 		"-j=1",
 		"-x=true",
+		"-z", z.SockAddrZero,
 	)
 	bulkCmd.Dir = bulkDir
-	if err := bulkCmd.Run(); err != nil {
+	if out, err := bulkCmd.Output(); err != nil {
 		s.cleanup()
+		s.t.Logf("%s", out)
 		s.t.Fatalf("Bulkloader didn't run: %v\n", err)
 	}
 
@@ -112,10 +114,12 @@ func (s *suite) setup(schemaFile, rdfFile string) {
 		"--files", rdfFile,
 		"--schema", schemaFile,
 		"--alpha", z.SockAddr,
+		"--zero", z.SockAddrZero,
 	)
 	liveCmd.Dir = liveDir
-	if err := liveCmd.Run(); err != nil {
+	if out, err := liveCmd.Output(); err != nil {
 		s.cleanup()
+		s.t.Logf("%s", out)
 		s.t.Fatalf("Live Loader didn't run: %v\n", err)
 	}
 }

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     container_name: bank-dg0.1
     working_dir: /data/dg0.1
     ports:
-      - 5080:5080
-      - 6080:6080
+      - 5180:5180
+      - 6180:6180
     labels:
       cluster: test
     volumes:
@@ -15,7 +15,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --bindall --logtostderr
+    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --bindall --logtostderr
 
   dg1:
     image: dgraph/dgraph:latest
@@ -31,7 +31,7 @@ services:
       - 9180:9180
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 --logtostderr
+    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 --logtostderr
 
   dg2:
     image: dgraph/dgraph:latest
@@ -49,7 +49,7 @@ services:
       - 9182:9182
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5080 -o 102 --logtostderr
+    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 --logtostderr
 
   dg3:
     image: dgraph/dgraph:latest
@@ -67,4 +67,4 @@ services:
       - 9183:9183
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 --logtostderr
+    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 --logtostderr

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     container_name: bank-dg0.1
     working_dir: /data/dg0.1
     ports:
-      - 5080:5080
-      - 6080:6080
+      - 5180:5180
+      - 6180:6180
     labels:
       cluster: test
     volumes:
@@ -16,7 +16,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr --bindall
+    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   dg1:
     image: dgraph/dgraph:latest
@@ -36,7 +36,7 @@ services:
     labels:
       cluster: test
     command: >
-      /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5080 -o 100 --logtostderr
+      /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5180 -o 100 --logtostderr
                           --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --lru_mb=1024
 
 volumes:

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       source: $GOPATH/src/github.com/dgraph-io/dgraph/tlstest/tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5080 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth VERIFYIFGIVEN --enterprise_features --acl_secret_file /dgraph-acl/hmac-secret
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth VERIFYIFGIVEN --enterprise_features --acl_secret_file /dgraph-acl/hmac-secret
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1
@@ -30,13 +30,13 @@ services:
     labels:
       cluster: test
     ports:
-    - 5080:5080
-    - 6080:6080
+    - 5180:5180
+    - 6180:6180
     volumes:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --idx=1 --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       source: $GOPATH/src/github.com/dgraph-io/dgraph/tlstest/tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5080 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUEST
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUEST
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1
@@ -26,13 +26,13 @@ services:
     labels:
       cluster: test
     ports:
-    - 5080:5080
-    - 6080:6080
+    - 5180:5180
+    - 6180:6180
     volumes:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --idx=1 --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       source: $GOPATH/src/github.com/dgraph-io/dgraph/tlstest/tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5080 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUIREANDVERIFY
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUIREANDVERIFY
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1
@@ -26,13 +26,13 @@ services:
     labels:
       cluster: test
     ports:
-    - 5080:5080
-    - 6080:6080
+    - 5180:5180
+    - 6180:6180
     volumes:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --idx=1 --my=zero1:5080 --replicas=3 --logtostderr
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=3 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       source: $GOPATH/src/github.com/dgraph-io/dgraph/tlstest/tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5080 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth VERIFYIFGIVEN
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth VERIFYIFGIVEN
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1
@@ -26,13 +26,13 @@ services:
     labels:
       cluster: test
     ports:
-    - 5080:5080
-    - 6080:6080
+    - 5180:5180
+    - 6180:6180
     volumes:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --idx=1 --my=zero1:5080 --replicas=3 --logtostderr
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=3 --logtostderr
       -v=2 --bindall
 volumes: {}


### PR DESCRIPTION
Zero should run with an offset of 100 in all the tests. This change
fixes the docker-compose files that were not following the convention.
Running test.sh with the -c flag should work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3440)
<!-- Reviewable:end -->
