### PR TITLE
Enable race detector for test.sh builds.

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -17,7 +17,7 @@ function restartCluster {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     (env GOOS=linux GOARCH=amd64 go build) && mv -f dgraph $GOPATH/bin/dgraph
   else
-    make install
+    make BUILD_RACE=Y install
   fi
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
   docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -38,9 +38,14 @@ ifneq ($(strip $(BUILD_TAGS)),)
 	endif
 endif
 
-# add the gcflags to disable compiler optimizations, which will help debugging with dlv
+# Build with compiler optimizations disabled, which will help debugging with dlv.
 ifneq ($(strip $(BUILD_DEBUG)),)
 	BUILD_FLAGS += -gcflags="all=-N -l"
+endif
+
+# Build with race detector enabled.
+ifneq ($(strip $(BUILD_RACE)),)
+	BUILD_FLAGS += -race
 endif
 
 .PHONY: all $(BIN)


### PR DESCRIPTION
This PR adds another switch to the dgraph/Makefile to enable the Go race detector. Example usage: `make BUILD_RACE=Y install`.

functions.sh now builds Dgraph with the race detector enabled for any test.sh tests (this includes CI).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3450)
<!-- Reviewable:end -->
