### PR TITLE
Disable race flag by default for tests.

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -17,7 +17,7 @@ function restartCluster {
   if [[ "$OSTYPE" == "darwin"* ]]; then
     (env GOOS=linux GOARCH=amd64 go build) && mv -f dgraph $GOPATH/bin/dgraph
   else
-    make BUILD_RACE=Y install
+    make install
   fi
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
   docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1


### PR DESCRIPTION
Yesterday we enabled the race detector for tests in #3450. Tests are running about 1.9 times longer overall with the race flag enabled (28 min vs 15 min with `./test.sh -c`). To actually make use of the race detector during tests, we need to check the Alpha/Zeros logs and to only enable the race flag for specific tests. Until then, let's disable the race detector by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3458)
<!-- Reviewable:end -->
