### PR TITLE
Initial GraphQL setup

### DIFF
--- a/dgraph/cmd/graphql/handler.go
+++ b/dgraph/cmd/graphql/handler.go
@@ -20,57 +20,146 @@ import (
 	"encoding/json"
 	"github.com/dgraph-io/dgo"
 	"github.com/vektah/gqlparser/ast"
+	"github.com/vektah/gqlparser/parser"
+	"github.com/vektah/gqlparser/validator"
+	"mime"
 	"net/http"
 )
 
-// Spec https://facebook.github.io/graphql/
+// GraphQL spec:
+// https://graphql.github.io/graphql-spec/June2018
 //
-// Serves Get and Post
+//
+// GraphQL servers should serve both GET and POST
 // https://graphql.org/learn/serving-over-http/
 //
-// Get:
+// GET should be like
 // http://myapi/graphql?query={me{name}}
 //
-// Post:
-// Should have a json content body like
+// POST should have a json content body like
 // {
 //   "query": "...",
 //   "operationName": "...",
 //   "variables": { "myVariable": "someValue", ... }
 // }
 //
-// result should be json like
+// GraphQL servers should return 200 (even on errors),
+// and result body should be json:
 // {
-//   "data": { ... },
-//   "errors": [ ... ]
+//   "data": { "query_name" : { ... } },
+//   "errors": [ { "message" : ..., ...} ... ]
 // }
 //
+// Key points about the response (https://graphql.github.io/graphql-spec/June2018/#sec-Response)
 //
-// Note the case for multiples in a single operation
+// - If an error was encountered before execution begins,
+//   the data entry should not be present in the result.
 //
-// {
-//   q1(...) {...}
-//   q2(...) {...}
-// }
+// - If an error was encountered during the execution that
+//   prevented a valid response, the data entry in the response should be null.
 //
-// should result in
-// {
-//   "data": {
-//     "q1": {...},
-//     "q2": {...}
-//   }
-//   "errors": [ ... ]
-// }
+// - If no errors were encountered during the requested operation,
+//   the errors entry should not be present in the result.
+//
+// - There's rules around how errors work when there's ! fields in the schema
+//   https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability
+//
+// - The "message" in an error is required, the rest is up to the implementation
+//
+// - The "data" works just like a Dgraph query
+//
 
 type graphqlHandler struct {
 	dgraphClient *dgo.Dgraph
 	schema       *ast.Schema
 }
 
+type graphqlRequest struct {
+	Query         string                 `json:"query"`
+	OperationName string                 `json:"operationName"`
+	Variables     map[string]interface{} `json:"variables"`
+}
+
 func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	b, err := json.Marshal(ErrorResponse("Not yet implemented"))
-	if err != nil {
-		panic(err)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	var gqlReq graphqlRequest
+
+	switch r.Method {
+	case http.MethodGet:
+		// fill gqlReq in
+	case http.MethodPost:
+		mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			// error response - no data
+			return
+		}
+
+		switch mediaType {
+		case "application/json":
+			if err = json.NewDecoder(r.Body).Decode(&gqlReq); err != nil {
+				// error response - no data
+				return
+			}
+		default:
+			// nothing else is valid?
+			//
+			// error response - no data
+			return
+		}
+	default:
+		// error response - no data
+		return
 	}
-	w.Write(b)
+
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: gqlReq.Query})
+	if gqlErr != nil {
+		// error response - no data
+		return
+	}
+
+	listErr := validator.Validate(gh.schema, doc)
+	if len(listErr) != 0 {
+		// error response - no data
+		return
+	}
+
+	op := doc.Operations.ForName(gqlReq.OperationName)
+	if op == nil {
+		// error response - no data
+		return
+	}
+
+	// actually need the output vars here because there's been some type magic
+	// done on them in the validator
+	_, err := validator.VariableValues(gh.schema, op, gqlReq.Variables)
+	if err != nil {
+		// error response - no data
+		return
+	}
+
+	switch op.Operation {
+	case ast.Query:
+		resp := &GraphQLResponse{
+			Data: []byte(`{ "lifeQuery": [ { "meaning" : 42 } ] }`),
+		}
+
+		b, err := json.Marshal(resp)
+		if err != nil {
+			// error response - "data": null
+			return
+		}
+		w.Write(b)
+	case ast.Mutation:
+		b, err := json.Marshal(ErrorResponse("Not yet implemented"))
+		if err != nil {
+			// error response - "data": null
+			return
+		}
+		w.Write(b)
+	default:
+		// error response - no data
+		return
+	}
 }

--- a/dgraph/cmd/graphql/handler.go
+++ b/dgraph/cmd/graphql/handler.go
@@ -18,12 +18,13 @@ package graphql
 
 import (
 	"encoding/json"
+	"mime"
+	"net/http"
+
 	"github.com/dgraph-io/dgo"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/parser"
 	"github.com/vektah/gqlparser/validator"
-	"mime"
-	"net/http"
 )
 
 // GraphQL spec:

--- a/dgraph/cmd/graphql/handler.go
+++ b/dgraph/cmd/graphql/handler.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"encoding/json"
+	"github.com/dgraph-io/dgo"
+	"github.com/vektah/gqlparser/ast"
+	"net/http"
+)
+
+// Spec https://facebook.github.io/graphql/
+//
+// Serves Get and Post
+// https://graphql.org/learn/serving-over-http/
+//
+// Get:
+// http://myapi/graphql?query={me{name}}
+//
+// Post:
+// Should have a json content body like
+// {
+//   "query": "...",
+//   "operationName": "...",
+//   "variables": { "myVariable": "someValue", ... }
+// }
+//
+// result should be json like
+// {
+//   "data": { ... },
+//   "errors": [ ... ]
+// }
+//
+//
+// Note the case for multiples in a single operation
+//
+// {
+//   q1(...) {...}
+//   q2(...) {...}
+// }
+//
+// should result in
+// {
+//   "data": {
+//     "q1": {...},
+//     "q2": {...}
+//   }
+//   "errors": [ ... ]
+// }
+
+type graphqlHandler struct {
+	dgraphClient *dgo.Dgraph
+	schema       *ast.Schema
+}
+
+func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	b, err := json.Marshal(ErrorResponse("Not yet implemented"))
+	if err != nil {
+		panic(err)
+	}
+	w.Write(b)
+}

--- a/dgraph/cmd/graphql/handler.go
+++ b/dgraph/cmd/graphql/handler.go
@@ -81,6 +81,9 @@ type graphqlRequest struct {
 	Variables     map[string]interface{} `json:"variables"`
 }
 
+// ServeHTTP handles GraphQL queries and mutations that get translated
+// like GraphQL->Dgraph->GraphQL.  It writes a valid GraphQL json response
+// to w.
 func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -156,7 +159,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// nothing to do, just log?
 		}
 	case ast.Mutation:
-		b, err := json.Marshal(ErrorResponse("Not yet implemented"))
+		b, err := json.Marshal(errorResponse("Not yet implemented"))
 		if err != nil {
 			// error response - "data": null
 			return

--- a/dgraph/cmd/graphql/handler.go
+++ b/dgraph/cmd/graphql/handler.go
@@ -141,7 +141,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	switch op.Operation {
 	case ast.Query:
-		resp := &GraphQLResponse{
+		resp := &graphQLResponse{
 			Data: []byte(`{ "lifeQuery": [ { "meaning" : 42 } ] }`),
 		}
 
@@ -150,14 +150,20 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// error response - "data": null
 			return
 		}
-		w.Write(b)
+		_, err = w.Write(b)
+		if err != nil {
+			// nothing to do, just log?
+		}
 	case ast.Mutation:
 		b, err := json.Marshal(ErrorResponse("Not yet implemented"))
 		if err != nil {
 			// error response - "data": null
 			return
 		}
-		w.Write(b)
+		_, err = w.Write(b)
+		if err != nil {
+			// nothing to do, just log?
+		}
 	default:
 		// error response - no data
 		return

--- a/dgraph/cmd/graphql/response.go
+++ b/dgraph/cmd/graphql/response.go
@@ -23,24 +23,17 @@ import (
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
-// FIXME:
-// based on https://github.com/99designs/gqlgen/blob/1617ff28daba04a67413ba9696c7650e718aa080/graphql/response.go#L14
-//
 // complete error format yet to be decided.
 // GraphQL spec on errors is here https://graphql.github.io/graphql-spec/June2018/#sec-Errors
 //
 
-// Errors are intentionally serialized first based on the advice in
-// https://github.com/facebook/graphql/commit/7b40390d48680b15cb93e02d46ac5eb249689876#diff-757cea6edf0288677a9eea4cfc801d87R107
-// and https://github.com/facebook/graphql/pull/384
-
-type Response struct {
+type GraphQLResponse struct {
 	Errors gqlerror.List   `json:"errors,omitempty"`
 	Data   json.RawMessage `json:"data"`
 }
 
-func ErrorResponse(messagef string, args ...interface{}) *Response {
-	return &Response{
+func ErrorResponse(messagef string, args ...interface{}) *GraphQLResponse {
+	return &GraphQLResponse{
 		Errors: gqlerror.List{{Message: fmt.Sprintf(messagef, args...)}},
 	}
 }

--- a/dgraph/cmd/graphql/response.go
+++ b/dgraph/cmd/graphql/response.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/vektah/gqlparser/gqlerror"
+)
+
+// FIXME:
+// based on https://github.com/99designs/gqlgen/blob/1617ff28daba04a67413ba9696c7650e718aa080/graphql/response.go#L14
+//
+// complete error format yet to be decided.
+// GraphQL spec on errors is here https://graphql.github.io/graphql-spec/June2018/#sec-Errors
+//
+
+// Errors are intentionally serialized first based on the advice in
+// https://github.com/facebook/graphql/commit/7b40390d48680b15cb93e02d46ac5eb249689876#diff-757cea6edf0288677a9eea4cfc801d87R107
+// and https://github.com/facebook/graphql/pull/384
+
+type Response struct {
+	Errors gqlerror.List   `json:"errors,omitempty"`
+	Data   json.RawMessage `json:"data"`
+}
+
+func ErrorResponse(messagef string, args ...interface{}) *Response {
+	return &Response{
+		Errors: gqlerror.List{{Message: fmt.Sprintf(messagef, args...)}},
+	}
+}

--- a/dgraph/cmd/graphql/response.go
+++ b/dgraph/cmd/graphql/response.go
@@ -27,13 +27,13 @@ import (
 // GraphQL spec on errors is here https://graphql.github.io/graphql-spec/June2018/#sec-Errors
 //
 
-type GraphQLResponse struct {
+type graphQLResponse struct {
 	Errors gqlerror.List   `json:"errors,omitempty"`
 	Data   json.RawMessage `json:"data"`
 }
 
-func ErrorResponse(messagef string, args ...interface{}) *GraphQLResponse {
-	return &GraphQLResponse{
+func ErrorResponse(messagef string, args ...interface{}) *graphQLResponse {
+	return &graphQLResponse{
 		Errors: gqlerror.List{{Message: fmt.Sprintf(messagef, args...)}},
 	}
 }

--- a/dgraph/cmd/graphql/response.go
+++ b/dgraph/cmd/graphql/response.go
@@ -32,7 +32,7 @@ type graphQLResponse struct {
 	Data   json.RawMessage `json:"data"`
 }
 
-func ErrorResponse(messagef string, args ...interface{}) *graphQLResponse {
+func errorResponse(messagef string, args ...interface{}) *graphQLResponse {
 	return &graphQLResponse{
 		Errors: gqlerror.List{{Message: fmt.Sprintf(messagef, args...)}},
 	}

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	schemaFile     string
+	alpha          string
+	useCompression bool
+}
+
+var opt options
+
+var GraphQL x.SubCommand
+
+func init() {
+	GraphQL.Cmd = &cobra.Command{
+		Use:   "graphql",
+		Short: "Run the Dgraph GraphQL tool",
+		Run: func(cmd *cobra.Command, args []string) {
+			defer x.StartProfile(GraphQL.Conf).Stop()
+			run()
+		},
+	}
+
+	GraphQL.EnvPrefix = "DGRAPH_GRAPHQL"
+
+	flags := GraphQL.Cmd.Flags()
+	flags.StringP("alpha", "a", "127.0.0.1:9080",
+		"Comma-separated list of Dgraph alpha gRPC server addresses")
+	flags.BoolP("use_compression", "C", false,
+		"Enable compression on connection to alpha server")
+	flags.StringP("schema", "s", "schema.graphql",
+		"Location of GraphQL schema file")
+
+	cmdInit := &cobra.Command{
+		Use:   "init",
+		Short: "Initializes Dgraph for a GraphQL schema",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer x.StartProfile(GraphQL.Conf).Stop()
+			if err := initDgraph(); err != nil {
+				os.Exit(1)
+			}
+		},
+	}
+	cmdInit.Flags().AddFlag(GraphQL.Cmd.Flag("alpha"))
+	cmdInit.Flags().AddFlag(GraphQL.Cmd.Flag("schema"))
+	GraphQL.Cmd.AddCommand(cmdInit)
+
+	// TLS configuration
+	x.RegisterClientTLSFlags(flags)
+}
+
+func run() {
+	x.PrintVersion()
+	opt = options{
+		schemaFile:     GraphQL.Conf.GetString("schema"),
+		alpha:          GraphQL.Conf.GetString("alpha"),
+		useCompression: GraphQL.Conf.GetBool("use_compression"),
+	}
+
+	fmt.Printf("Bringing up GraphQL API\n")
+	fmt.Printf("...Go make a cup of tea while I implement this\n")
+}
+
+func initDgraph() error {
+	x.PrintVersion()
+	opt = options{
+		schemaFile: GraphQL.Conf.GetString("schema"),
+		alpha:      GraphQL.Conf.GetString("alpha"),
+	}
+
+	fmt.Printf("\nProcessing schema file %q\n", opt.schemaFile)
+	fmt.Printf("Loading into Dgraph at %q\n", opt.alpha)
+
+	fmt.Printf("...Go make a cup of tea while I implement this\n")
+
+	return nil
+}

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"github.com/golang/glog"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -130,10 +131,20 @@ func run() {
 		x.Checkf(gqlErr, "Error parsing GraphQL schema")
 	}
 
-	_, gqlErr = validator.ValidateSchemaDocument(doc)
+	schema, gqlErr := validator.ValidateSchemaDocument(doc)
 	if gqlErr != nil {
 		x.Checkf(gqlErr, "Error validating GraphQL schema")
 	}
+
+	handler := &graphqlHandler{
+		dgraphClient: dgraphClient,
+		schema:       schema,
+	}
+
+	http.Handle("/graphql", handler)
+
+	// the ports and urls etc that the endpoint serves should be input options
+	glog.Fatal(http.ListenAndServe(":8765", nil))
 }
 
 func initDgraph() error {

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -78,8 +78,6 @@ func init() {
 	flags := GraphQL.Cmd.Flags()
 	flags.StringP("alpha", "a", "127.0.0.1:9080",
 		"Comma-separated list of Dgraph alpha gRPC server addresses")
-	flags.BoolP("use_compression", "C", false,
-		"Enable compression on connection to alpha server")
 	flags.StringP("schema", "s", "schema.graphql",
 		"Location of GraphQL schema file")
 
@@ -106,9 +104,8 @@ func init() {
 func run() error {
 	x.PrintVersion()
 	opt = options{
-		schemaFile:     GraphQL.Conf.GetString("schema"),
-		alpha:          GraphQL.Conf.GetString("alpha"),
-		useCompression: GraphQL.Conf.GetBool("use_compression"),
+		schemaFile: GraphQL.Conf.GetString("schema"),
+		alpha:      GraphQL.Conf.GetString("alpha"),
 	}
 
 	glog.Infof("Bringing up GraphQL API for Dgraph at %s\n", opt.alpha)

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/golang/glog"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/golang/glog"
 
 	"github.com/spf13/cobra"
 

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/conv"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/counter"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/debug"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/live"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/version"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/zero"
@@ -72,7 +73,7 @@ var rootConf = viper.New()
 // subcommands initially contains all default sub-commands.
 var subcommands = []*x.SubCommand{
 	&bulk.Bulk, &cert.Cert, &conv.Conv, &live.Live, &alpha.Alpha, &zero.Zero, &version.Version,
-	&debug.Debug, &counter.Increment, &migrate.Migrate,
+	&debug.Debug, &counter.Increment, &migrate.Migrate, &graphql.GraphQL,
 }
 
 func initCmds() {


### PR DESCRIPTION
This PR adds a basic pipeline around GraphQL.  It introduces new commands around `dgraph graphql ...`.  Really early days - just setting up some basic workings to get something to build around.

Basic idea is that you'd do:

1)  `dgraph graphql init --schema myschema.graphql --alpha 127.0.0.1:9080`

and it will translate the GraphQL schema in `myschema.graphql` into a Dgraph schema and alter the schema at the given alpha and get that Dgraph instance ready to serve a GraphQL API.

2 ) `dgraph graphql --alpha 127.0.0.1:9080`

that brings a up a HTTP GraphQL API serving the schema from (1).

Thus far, it does parts of (1) and very little of (2).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3483)
<!-- Reviewable:end -->
