### PR TITLE
Replace xgo in release.sh.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -72,7 +72,7 @@ popd
 
 pushd $basedir/dgraph
   git pull
-  git checkout -b /$TAG $TAG
+  git checkout $TAG
   # HEAD here points to whatever is checked out.
   lastCommitSHA1=$(git rev-parse --short HEAD)
   gitBranch=$(git rev-parse --abbrev-ref HEAD)

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -6,6 +6,10 @@
 # binaries and prepare them such that any human or script can then pick these up
 # and use them as they deem fit.
 
+# Output colors
+RED='\033[91;1m'
+RESET='\033[0m'
+
 # Don't use standard GOPATH. Create a new one.
 GOPATH="/tmp/go"
 rm -Rf $GOPATH
@@ -13,7 +17,7 @@ mkdir $GOPATH
 # Necessary to pick up Gobin binaries like protoc-gen-gofast
 PATH="$GOPATH/bin:$PATH"
 
-# TODO(dmai): check Go version for release builds.
+# The Go version used for release builds must match this version.
 GOVERSION="1.12.5"
 
 TAG=$1
@@ -49,6 +53,10 @@ commitTime="github.com/dgraph-io/dgraph/x.lastCommitTime"
 
 echo "Using Go version"
 go version
+if [[ ! "$(go version)" =~ $GOVERSION ]]; then
+   echo -e "${RED}Go version is NOT expected. Should be $GOVERSION.${RESET}"
+   exit 1
+fi
 
 go get -u github.com/jteeuwen/go-bindata/...
 go get -d -u golang.org/x/net/context

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -119,7 +119,7 @@ popd
 
 pushd $basedir/badger/badger
   env GOOS=windows GOARCH=amd64 go build -o badger-windows-amd64.exe -v .
-  mv badger-windows-amd64.exe $TMP/windows/badger
+  mv badger-windows-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -81,13 +81,13 @@ pushd $basedir/dgraph
 popd
 
 # Regenerate protos. Should not be different from what's checked in.
-# pushd $basedir/dgraph/protos
-#   make regenerate
-#   if [[ "$(git status --porcelain)" ]]; then
-#       echo >&2 "Generated protos different in release."
-#       exit 1
-#   fi
-# popd
+pushd $basedir/dgraph/protos
+  make regenerate
+  if [[ "$(git status --porcelain)" ]]; then
+      echo >&2 "Generated protos different in release."
+      exit 1
+  fi
+popd
 
 # Clone ratel repo.
 pushd $basedir
@@ -103,8 +103,8 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-	env GOOS=windows GOARCH=amd64 go build -o dgraph-windows-amd64.exe -ldflags \
-  "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+  env GOOS=windows GOARCH=amd64 go build -o dgraph-windows-amd64.exe -ldflags \
+      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-amd64.exe $TMP/windows/dgraph.exe
 popd
@@ -115,14 +115,14 @@ pushd $basedir/badger/badger
 popd
 
 pushd $basedir/ratel
-         env GOOS=windows GOARCH=amd64 go build -o ratel-windows-amd64.exe -v -ldflags "-X $ratel_release=$release_version" .
-	mv ratel-windows-amd64.exe $TMP/windows/dgraph-ratel.exe
+  env GOOS=windows GOARCH=amd64 go build -o ratel-windows-amd64.exe -v -ldflags "-X $ratel_release=$release_version" .
+  mv ratel-windows-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
   env GOOS=darwin GOARCH=amd64 go build -o dgraph-darwin-amd64 -ldflags \
-  "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-amd64 $TMP/darwin/dgraph
 popd
@@ -139,8 +139,8 @@ popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-        env GOOS=linux GOARCH=amd64 go build -o dgraph-linux-amd64 -ldflags \
-  "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+  env GOOS=linux GOARCH=amd64 go build -o dgraph-linux-amd64 -ldflags \
+      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
   mv dgraph-linux-amd64 $TMP/linux/dgraph
@@ -154,7 +154,7 @@ popd
 
 pushd $basedir/ratel
   env GOOS=linux GOARCH=amd64 go build -o ratel-linux-amd64 -v -ldflags "-X $ratel_release=$release_version" .
-	mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
+  mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd
 
 createSum () {

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -111,43 +111,50 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  env GOOS=windows GOARCH=amd64 go build -o dgraph-windows-amd64.exe -ldflags \
+  env GOOS=windows GOARCH=amd64 go get -v -d .
+  env GOOS=windows GOARCH=amd64 go build -v -o dgraph-windows-amd64.exe -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=windows GOARCH=amd64 go build -o badger-windows-amd64.exe -v .
+  env GOOS=windows GOARCH=amd64 go get -v -d .
+  env GOOS=windows GOARCH=amd64 go build -v -o badger-windows-amd64.exe .
   mv badger-windows-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  env GOOS=windows GOARCH=amd64 go build -o ratel-windows-amd64.exe -v -ldflags "-X $ratel_release=$release_version" .
+  env GOOS=windows GOARCH=amd64 go get -v -d .
+  env GOOS=windows GOARCH=amd64 go build -v -o ratel-windows-amd64.exe -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  env GOOS=darwin GOARCH=amd64 go build -o dgraph-darwin-amd64 -ldflags \
+  env GOOS=darwin GOARCH=amd64 go get -v -d .
+  env GOOS=darwin GOARCH=amd64 go build -v -o dgraph-darwin-amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-amd64 $TMP/darwin/dgraph
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=darwin GOARCH=amd64 go build -o badger-darwin-amd64 -v .
+  env GOOS=darwin GOARCH=amd64 go get -v -d .
+  env GOOS=darwin GOARCH=amd64 go build -v -o badger-darwin-amd64 .
   mv badger-darwin-amd64 $TMP/darwin/badger
 popd
 
 pushd $basedir/ratel
-  env GOOS=darwin GOARCH=amd64 go build -o ratel-darwin-amd64 -v -ldflags "-X $ratel_release=$release_version" .
+  env GOOS=darwin GOARCH=amd64 go get -v -d .
+  env GOOS=darwin GOARCH=amd64 go build -v -o ratel-darwin-amd64 -v -ldflags "-X $ratel_release=$release_version" .
   mv ratel-darwin-amd64 $TMP/darwin/dgraph-ratel
 popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-  env GOOS=linux GOARCH=amd64 go build -o dgraph-linux-amd64 -ldflags \
+  env GOOS=linux GOARCH=amd64 go get -v -d .
+  env GOOS=linux GOARCH=amd64 go build -v -o dgraph-linux-amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
@@ -155,13 +162,15 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=linux GOARCH=amd64 go build -o badger-linux-amd64 -v .
+  env GOOS=linux GOARCH=amd64 go get -v -d .
+  env GOOS=linux GOARCH=amd64 go build -v -o badger-linux-amd64 .
   strip -x badger-linux-amd64
   mv badger-linux-amd64 $TMP/linux/badger
 popd
 
 pushd $basedir/ratel
-  env GOOS=linux GOARCH=amd64 go build -o ratel-linux-amd64 -v -ldflags "-X $ratel_release=$release_version" .
+  env GOOS=linux GOARCH=amd64 go get -v -d .
+  env GOOS=linux GOARCH=amd64 go build -v -o ratel-linux-amd64 -ldflags "-X $ratel_release=$release_version" .
   strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -162,6 +162,7 @@ popd
 
 pushd $basedir/ratel
   env GOOS=linux GOARCH=amd64 go build -o ratel-linux-amd64 -v -ldflags "-X $ratel_release=$release_version" .
+  strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd
 


### PR DESCRIPTION
xgo does not always keep up to date with the latest Go release version. For instance, now we want to build with go1.12.5, but xgo hasn't been updated with 1.12.5 yet. To give us more control on which Go version used to build release binaries, this PR replaces xgo with `go`'s own cross-compilation. This means we can use any version of Go for releases.

One of the nice points of using xgo was for supporting Cgo builds. Since we don't depend on Cgo, not using xgo is OK. This change uses the currently installed version of Go for release builds and adds a check to make sure the installed Go version matches [$GOVERSION](https://github.com/dgraph-io/dgraph/compare/danielmai/release-no-xgo?expand=1#diff-57e4ffb93c3aeba63168f47981b9f946R21) (currently 1.12.5).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3487)
<!-- Reviewable:end -->
