### PR TITLE
Refactor: avoid double parsing of mutation string in ACL

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dgraph-io/badger/y"
 	"github.com/dgraph-io/dgo/protos/api"
+	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 )
@@ -48,7 +49,7 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	return nil
 }
 
-func authorizeMutation(ctx context.Context, mu *api.Mutation) error {
+func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	return nil
 }
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -418,15 +418,28 @@ func annotateStartTs(span *otrace.Span, ts uint64) {
 	span.Annotate([]otrace.Attribute{otrace.Int64Attribute("startTs", int64(ts))}, "")
 }
 
-func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (resp *api.Assigned, err error) {
-	if err := authorizeMutation(ctx, mu); err != nil {
-		return nil, err
-	}
-
-	return s.doMutate(ctx, mu)
+func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (*api.Assigned, error) {
+	return s.doMutate(ctx, mu, true)
 }
 
-func (s *Server) doMutate(ctx context.Context, mu *api.Mutation) (resp *api.Assigned, rerr error) {
+func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool) (
+	resp *api.Assigned, rerr error) {
+
+	var l query.Latency
+	l.Start = time.Now()
+	gmu, err := parseMutationObject(mu)
+	if err != nil {
+		return resp, err
+	}
+	parseEnd := time.Now()
+	l.Parsing = parseEnd.Sub(l.Start)
+
+	if authorize {
+		if err := authorizeMutation(ctx, gmu); err != nil {
+			return nil, err
+		}
+	}
+
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -472,16 +485,6 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation) (resp *api.Assi
 		span.Annotate(nil, "Empty mutation")
 		return resp, fmt.Errorf("Empty mutation")
 	}
-
-	var l query.Latency
-	l.Start = time.Now()
-	gmu, err := parseMutationObject(mu)
-	if err != nil {
-		return resp, err
-	}
-
-	parseEnd := time.Now()
-	l.Parsing = parseEnd.Sub(l.Start)
 
 	defer func() {
 		l.Processing = time.Since(parseEnd)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3494)
<!-- Reviewable:end -->
