### PR TITLE
Fix panic in fillVars

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -220,13 +220,13 @@ type SchoolInfo {
 	abbr: string
 	school: [uid]
 	district: [uid]
-	state: [uid]	
+	state: [uid]
 	county: [uid]
 }
 
 type User {
 	name: string
-	password: password	
+	password: password
 }
 
 type Node {
@@ -271,6 +271,7 @@ year                           : int .
 previous_model                 : uid @reverse .
 created_at                     : datetime @index(hour) .
 updated_at                     : datetime @index(year) .
+number                         : int @index(int) .
 `
 
 func populateCluster() {

--- a/query/query.go
+++ b/query/query.go
@@ -343,6 +343,11 @@ func aggWithVarFieldName(pc *SubGraph) string {
 	return fieldName
 }
 
+func emptyIneqFnWithVar(sg *SubGraph) bool {
+	return sg.SrcFunc != nil && isInequalityFn(sg.SrcFunc.Name) && len(sg.SrcFunc.Args) == 0 &&
+		len(sg.Params.NeedsVar) > 0
+}
+
 func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
 	sv, ok := pc.Params.uidToVal[uid]
 	if !ok || sv.Value == nil {
@@ -2671,8 +2676,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			// 1. It just does aggregation and math functions which is when sg.Params.IsEmpty is true.
 			// 2. Its has an inequality fn at root without any args which can happen when it uses
 			// value variables for args which don't expand to any value.
-			if sg.Params.IsEmpty ||
-				sg.SrcFunc != nil && isInequalityFn(sg.SrcFunc.Name) && len(sg.SrcFunc.Args) == 0 {
+			if sg.Params.IsEmpty || emptyIneqFnWithVar(sg) {
 				errChan <- nil
 				continue
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -344,9 +344,6 @@ func aggWithVarFieldName(pc *SubGraph) string {
 }
 
 func addInternalNode(pc *SubGraph, uid uint64, dst outputNode) error {
-	if len(pc.Params.uidToVal) == 0 {
-		return nil
-	}
 	sv, ok := pc.Params.uidToVal[uid]
 	if !ok || sv.Value == nil {
 		return nil
@@ -1709,21 +1706,6 @@ func (sg *SubGraph) fillVars(mp map[string]varValue) error {
 				return errors.Errorf("Wrong variable type encountered for var(%v) %v.", v.Name, v.Typ)
 
 			default:
-				// This var does not match any uids or vals but we are still trying to access it.
-				if v.Typ == gql.ValueVar {
-					// * * * * * * * * * * * * * * * * * * *
-					// Default value vars
-					// * * * * * * * * * * * * * * * * * * *
-					//
-					// Provide a default value for valueVarAggregation() to eval val().
-					// This is a noop for aggregation funcs that would fail.
-					// The zero aggs won't show because there are no uids matched.
-					//
-					// NOTE: If you need to make type assertions that might involve
-					// default value vars, use `Safe()` func and not val.Value directly.
-					mp[v.Name].Vals[0] = types.Val{}
-					sg.Params.uidToVal = mp[v.Name].Vals
-				}
 			}
 		}
 	}
@@ -1749,7 +1731,9 @@ func (sg *SubGraph) replaceVarInFunc() error {
 			continue
 		}
 		if len(sg.Params.uidToVal) == 0 {
-			return errors.Errorf("No value found for value variable %q", arg.Value)
+			// This means that the variable didn't have any values and hence there is nothing to add
+			// to args. Setting isEmpty to true would mean that they query is not processed.
+			break
 		}
 		// We don't care about uids, just take all the values and put as args.
 		// There would be only one value var per subgraph as per current assumptions.
@@ -2683,8 +2667,12 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			hasExecuted[idx] = true
 			numQueriesDone++
 			idxList = append(idxList, idx)
-			// Doesn't need to be executed as it just does aggregation and math functions.
-			if sg.Params.IsEmpty {
+			// A query doesn't need to be executed if
+			// 1. It just does aggregation and math functions which is when sg.Params.IsEmpty is true.
+			// 2. Its has an inequality fn at root without any args which can happen when it uses
+			// value variables for args which don't expand to any value.
+			if sg.Params.IsEmpty ||
+				sg.SrcFunc != nil && isInequalityFn(sg.SrcFunc.Name) && len(sg.SrcFunc.Args) == 0 {
 				errChan <- nil
 				continue
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -2401,9 +2401,9 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 }
 
 func (sg *SubGraph) sortAndPaginateUsingVar(ctx context.Context) error {
-	// nil has a different from an initialized map of zero length here. If the variable didn't return
-	// any values then uidToVal would be an empty with zero length. If the variable was used before
-	// definition, the uidToVal would be nil.
+	// nil has a different meaning from an initialized map of zero length here. If the variable
+	// didn't return any values then uidToVal would be an empty with zero length. If the variable
+	// was used before definition, uidToVal would be nil.
 	if sg.Params.uidToVal == nil {
 		return errors.Errorf("Variable: [%s] used before definition.", sg.Params.Order[0].Attr)
 	}

--- a/query/query.go
+++ b/query/query.go
@@ -1740,7 +1740,7 @@ func (sg *SubGraph) replaceVarInFunc() error {
 		}
 		if len(sg.Params.uidToVal) == 0 {
 			// This means that the variable didn't have any values and hence there is nothing to add
-			// to args. Setting isEmpty to true would mean that they query is not processed.
+			// to args.
 			break
 		}
 		// We don't care about uids, just take all the values and put as args.

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1809,7 +1809,7 @@ func TestNonFlattenedResponse(t *testing.T) {
 		me(func: eq(name@en, "Baz Luhrmann")) {
 			uid
 			director.film {
-				name@en	
+				name@en
 			}
 		}
 	}`

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1241,6 +1241,60 @@ func TestAggregateRootError(t *testing.T) {
 	require.Contains(t, err.Error(), "Only aggregated variables allowed within empty block.")
 }
 
+func TestAggregateEmpty1(t *testing.T) {
+	query := `
+	{
+		var(func: has(number)) {
+			number as number
+		}
+		var() {
+			highest as max(val(number))
+		}
+
+		all(func: eq(number, val(highest))) {
+			uid
+			number
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"all":[]}}`, js)
+}
+
+func TestAggregateEmpty2(t *testing.T) {
+	query := `
+		{
+			var(func: has(number))
+			{
+				highest_number as number
+			}
+			all(func: eq(number, val(highest_number)))
+			{
+				uid
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"all":[]}}`, js)
+}
+
+func TestAggregateEmpty3(t *testing.T) {
+	query := `
+		{
+			var(func: has(number))
+			{
+				highest_number as number
+			}
+			all(func: ge(number, val(highest_number)))
+			{
+				uid
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"all":[]}}`, js)
+}
+
 func TestFilterLang(t *testing.T) {
 	// This tests the fix for #1334. While getting uids for filter, we fetch data keys when number
 	// of uids is less than number of tokens. Lang tag was not passed correctly while fetching these


### PR DESCRIPTION
This fixes #3470.  Test cases have been added to verify the fix. The default case in fillVars seemed hacky because it was assigning a value corresponding to uid `0` in `uidToVal`, that has been removed. The code in the query package needs more work to clarify what the invariants are but that would be part of another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3505)
<!-- Reviewable:end -->
