### PR TITLE
Fix dir cleanup in backup test.

### DIFF
--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -265,7 +265,8 @@ func dirCleanup() {
 	x.Check(os.RemoveAll(restoreDir))
 	x.Check(os.RemoveAll(localBackupDir))
 
-	cmd := []string{"rm", "-rf", "/data/backups/dgraph.*"}
+
+	cmd := []string{"bash", "-c", "rm -rf /data/backups/dgraph.*"}
 	x.Check(z.DockerExec(alphaContainers[0], cmd...))
 }
 


### PR DESCRIPTION
Commands with arguments to docker exec are supposed to be passed using
the format "dgraph exec <container> bash -c <command>". This change
fixes this for the dir cleanup in the backup tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3524)
<!-- Reviewable:end -->
