### PR TITLE
Fixing the flaky test TestNodes

### DIFF
--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -27,8 +27,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -36,7 +34,6 @@ import (
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/z"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 func NodesSetup(t *testing.T, c *dgo.Dgraph) {
@@ -126,44 +123,8 @@ func getError(rc io.ReadCloser) error {
 	return nil
 }
 
-func getClientToGroup(groupId string) (*dgo.Dgraph, error) {
-	state, err := z.GetState()
-	if err != nil {
-		return nil, err
-	}
-
-	group, ok := state.Groups[groupId]
-	if !ok {
-		return nil, fmt.Errorf("group %s does not exist", groupId)
-	}
-
-	if len(group.Members) == 0 {
-		return nil, fmt.Errorf("the group %s has no members", groupId)
-	}
-
-	member := group.Members["1"]
-	parts := strings.Split(member.Addr, ":")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("the member has an invalid address: %v", member.Addr)
-	}
-	// internalPort is used for communication between alpha nodes
-	internalPort, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return nil, fmt.Errorf("unable to parse the port number from %s", parts[1])
-	}
-
-	// externalPort is for handling connections from clients
-	externalPort := internalPort + 2000
-
-	conn, err := grpc.Dial(fmt.Sprintf("localhost:%d", externalPort), grpc.WithInsecure())
-	if err != nil {
-		return nil, err
-	}
-	return dgo.NewDgraphClient(api.NewDgraphClient(conn)), nil
-}
-
 func TestNodes(t *testing.T) {
-	dg, err := getClientToGroup("1")
+	dg, err := z.GetClientToGroup("1")
 	require.NoError(t, err, "error while getting connection to group 1")
 
 	NodesSetup(t, dg)

--- a/z/zero.go
+++ b/z/zero.go
@@ -30,8 +30,8 @@ type StateResponse struct {
 	Groups map[string]struct {
 		Members map[string]struct {
 			Addr       string `json:"addr"`
-			GroupId    int    `json:"groupId"`
-			Id         string `json:"id"`
+			GroupID    int    `json:"groupId"`
+			ID         string `json:"id"`
 			LastUpdate string `json:"lastUpdate"`
 			Leader     bool   `json:"leader"`
 		} `json:"members"`

--- a/z/zero.go
+++ b/z/zero.go
@@ -28,7 +28,13 @@ import (
 // the /state endpoint in zero.
 type StateResponse struct {
 	Groups map[string]struct {
-		Members map[string]interface{} `json:"members"`
+		Members map[string]struct {
+			Addr       string `json:"addr"`
+			GroupId    int    `json:"groupId"`
+			Id         string `json:"id"`
+			LastUpdate string `json:"lastUpdate"`
+			Leader     bool   `json:"leader"`
+		} `json:"members"`
 		Tablets map[string]struct {
 			GroupID   int    `json:"groupId"`
 			Predicate string `json:"predicate"`

--- a/z/zero.go
+++ b/z/zero.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/dgraph-io/dgo"
 	"github.com/dgraph-io/dgo/protos/api"
-	"github.com/dgraph-io/dgraph/z"
 	"google.golang.org/grpc"
 )
 
@@ -79,7 +78,7 @@ func GetState() (*StateResponse, error) {
 }
 
 func GetClientToGroup(groupID string) (*dgo.Dgraph, error) {
-	state, err := z.GetState()
+	state, err := GetState()
 	if err != nil {
 		return nil, err
 	}

--- a/z/zero.go
+++ b/z/zero.go
@@ -78,19 +78,19 @@ func GetState() (*StateResponse, error) {
 	return &st, nil
 }
 
-func GetClientToGroup(groupId string) (*dgo.Dgraph, error) {
+func GetClientToGroup(groupID string) (*dgo.Dgraph, error) {
 	state, err := z.GetState()
 	if err != nil {
 		return nil, err
 	}
 
-	group, ok := state.Groups[groupId]
+	group, ok := state.Groups[groupID]
 	if !ok {
-		return nil, fmt.Errorf("group %s does not exist", groupId)
+		return nil, fmt.Errorf("group %s does not exist", groupID)
 	}
 
 	if len(group.Members) == 0 {
-		return nil, fmt.Errorf("the group %s has no members", groupId)
+		return nil, fmt.Errorf("the group %s has no members", groupID)
 	}
 
 	member := group.Members["1"]


### PR DESCRIPTION
The TestNodes method fails once in a while with the error message:
=== RUN   TestNodes
--- FAIL: TestNodes (100.02s)
        Error Trace:    group_delete_test.go:91
        		group_delete_test.go:196
        Error:		Received unexpected error:
        	rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing dial tcp [::1]:9180: connect: connection refused"

Upon investigation, it turns out that the test is using the docker-compose file with 3 alpha nodes, and it assumes dg1 will be in group 1, dg2 will be in group2 and dg3 will be in group 3. During the test it would remove the nodes in group 2 and group 3, and then use the connection to *dg1* for verifying that a query still works.

However, it is possible that dg1 is actually in group 2 or group 3, instead of group 1. When that happens, dg1 will be shutdown by the remove node request, causing the final query that is still using connection to dg1 to fail. This is demonstrated by the fact that after the test fails, zero has the following state
```
{
    "cid": "0f8374a8-e16b-4500-b91a-7a07b76e361f",
    "counter": "2071",
    "groups": {
        "1": {
            "checksum": "9309113724815971540",
            "members": {
                "1": {
                    "addr": "dg3:7183",
                    "groupId": 1,
                    "id": "1",
                    "lastUpdate": "1559846886",
                    "leader": true
                }
            },
            "tablets": {
                "dgraph.type": {
                    "groupId": 1,
                    "predicate": "dgraph.type"
                },
                "directed_by": {
                    "groupId": 1,
                    "predicate": "directed_by"
                },
                "director.film": {
                    "groupId": 1,
                    "predicate": "director.film"
                },
                "http://www.w3.org/2000/01/rdf-schema#domain": {
                    "groupId": 1,
                    "predicate": "http://www.w3.org/2000/01/rdf-schema#domain"
                },
                "http://www.w3.org/2000/01/rdf-schema#range": {
                    "groupId": 1,
                    "predicate": "http://www.w3.org/2000/01/rdf-schema#range"
                },
                "http://www.w3.org/2002/07/owl#inverseOf": {
                    "groupId": 1,
                    "predicate": "http://www.w3.org/2002/07/owl#inverseOf"
                },
                "initial_release_date": {
                    "groupId": 1,
                    "predicate": "initial_release_date"
                },
                "name": {
                    "groupId": 1,
                    "predicate": "name"
                },
                "type.property.expected_type": {
                    "groupId": 1,
                    "predicate": "type.property.expected_type"
                },
                "type.property.reverse_property": {
                    "groupId": 1,
                    "predicate": "type.property.reverse_property"
                },
                "type.property.schema": {
                    "groupId": 1,
                    "predicate": "type.property.schema"
                }
            }
        }
    },
    "maxLeaseId": "270000",
    "maxRaftId": "3",
    "maxTxnTs": "10000",
    "removed": [
        {
            "addr": "dg1:7180",
            "groupId": 3,
            "id": "3",
            "lastUpdate": "1559846886",
            "leader": true
        },
        {
            "addr": "dg2:7182",
            "groupId": 2,
            "id": "2",
            "lastUpdate": "1559846886",
            "leader": true
        }
    ],
    "zeros": {
        "1": {
            "addr": "zero1:5180",
            "id": "1",
            "leader": true
        }
    }
}
```

So instead of using the connection to dg1, this PR changes the logic so that it asks zero which node is in group 1 (could be dg2 or dg3), and uses that node for queries. Hence it guarantees that the node in group 1 will not be affected by the remove node requests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3530)
<!-- Reviewable:end -->
