### PR TITLE
Update compose tool Makefile to install Dgraph binary too.

### DIFF
--- a/compose/Makefile
+++ b/compose/Makefile
@@ -16,10 +16,13 @@
 
 BIN           = compose
 BUILD_FLAGS  ?= "-N -l"
-GOPATH       ?= $(shell go env GOPATH)
 
 .PHONY: all
-all: $(BIN)
+all: install_dgraph $(BIN)
+
+.PHONY: install_dgraph
+install_dgraph:
+	$(MAKE) -C .. install
 
 $(BIN): compose.go
 	go build -gcflags=$(BUILD_FLAGS) -o $(BIN)


### PR DESCRIPTION
Running `make` in the compose directory installs Dgraph to `$GOPATH/bin/dgraph` and builds the compose tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3533)
<!-- Reviewable:end -->
