### PR TITLE
[Upsert #3] Add support for parsing functions in RDF (#3412)

### DIFF
--- a/chunker/rdf/parse_test.go
+++ b/chunker/rdf/parse_test.go
@@ -895,6 +895,79 @@ var testNQuads = []struct {
 		input:       `<alice> <age> "13"^^<xs:double> (salary=NaN) .`,
 		expectedErr: true,
 	},
+	{
+		input: `uid(v) <lives> "\x02 wonderland" .`,
+		nq: api.NQuad{
+			Subject:     "uid(v)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "\x02 wonderland"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  v  ) <lives> "vrinadavan" .`,
+		nq: api.NQuad{
+			Subject:     "uid(v)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "vrinadavan"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> "vrinadavan" .`,
+		nq: api.NQuad{
+			Subject:     "uid(val)",
+			Predicate:   "lives",
+			ObjectValue: &api.Value{Val: &api.Value_DefaultVal{DefaultVal: "vrinadavan"}},
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> uid(g) .`,
+		nq: api.NQuad{
+			Subject:   "uid(val)",
+			Predicate: "lives",
+			ObjectId:  "uid(g)",
+		},
+		expectedErr: false,
+	},
+	{
+		input: `uid  (  val  ) <lives> uid ( g )  .`,
+		nq: api.NQuad{
+			Subject:   "uid(val)",
+			Predicate: "lives",
+			ObjectId:  "uid(g)",
+		},
+		expectedErr: false,
+	},
+	{
+		input:       `uid  (  val   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid   val )   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `ui(uid)   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid())   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid()   <lives> uid ( g )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid(a)   <lives> uid (  )  .`,
+		expectedErr: true,
+	},
+	{
+		input:       `uid(a)   lives> uid (  )  .`,
+		expectedErr: true,
+	},
 }
 
 func TestLex(t *testing.T) {

--- a/chunker/rdf/state.go
+++ b/chunker/rdf/state.go
@@ -26,23 +26,24 @@ import (
 
 // The constants represent different types of lexed Items possible for an rdf N-Quad.
 const (
-	itemText       lex.ItemType = 5 + iota // plain text
-	itemSubject                            // subject, 6
-	itemPredicate                          // predicate, 7
-	itemObject                             // object, 8
-	itemLabel                              // label, 9
-	itemLiteral                            // literal, 10
-	itemLanguage                           // language, 11
-	itemObjectType                         // object type, 12
-	itemValidEnd                           // end with dot, 13
-	itemComment                            // comment, 14
-	itemComma                              // comma, 15
-	itemEqual                              // equal, 16
-	itemLeftRound                          // '(', 17
-	itemRightRound                         // ')', 18
-	itemStar                               // *, 19
-	itemVarKeyword                         // var, 20
-	itemVarName                            // 21
+	itemText        lex.ItemType = 5 + iota // plain text
+	itemSubject                             // subject, 6
+	itemPredicate                           // predicate, 7
+	itemObject                              // object, 8
+	itemLabel                               // label, 9
+	itemLiteral                             // literal, 10
+	itemLanguage                            // language, 11
+	itemObjectType                          // object type, 12
+	itemValidEnd                            // end with dot, 13
+	itemComment                             // comment, 14
+	itemComma                               // comma, 15
+	itemEqual                               // equal, 16
+	itemLeftRound                           // '(', 17
+	itemRightRound                          // ')', 18
+	itemStar                                // *, 19
+	itemSubjectFunc                         // uid, 20
+	itemObjectFunc                          // uid, 21
+	itemVarName                             // 22
 )
 
 // These constants keep a track of the depth while parsing an rdf N-Quad.
@@ -137,6 +138,7 @@ func lexText(l *lex.Lexer) lex.StateFn {
 				l.Depth = atSubject
 			}
 
+		// TODO(Aman): add support for more functions here.
 		case r == 'u':
 			if l.Depth != atSubject && l.Depth != atObject {
 				return l.Errorf("Unexpected char 'u'")
@@ -422,19 +424,23 @@ func lexComment(l *lex.Lexer) lex.StateFn {
 func lexVariable(l *lex.Lexer) lex.StateFn {
 	var r rune
 
+	// TODO(Aman): add support for more functions here.
 	for _, c := range "uid" {
 		if r = l.Next(); r != c {
 			return l.Errorf("Unexpected char '%c' when parsing var keyword", r)
 		}
 	}
-	l.Emit(itemVarKeyword)
+	if l.Depth == atObject {
+		l.Emit(itemObjectFunc)
+	} else if l.Depth == atSubject {
+		l.Emit(itemSubjectFunc)
+	}
 	l.IgnoreRun(isSpace)
 
 	if r = l.Next(); r != '(' {
 		return l.Errorf("Expected '(' after var keyword, found: '%c'", r)
 	}
 	l.Emit(itemLeftRound)
-
 	l.IgnoreRun(isSpace)
 
 	for {
@@ -447,11 +453,11 @@ func lexVariable(l *lex.Lexer) lex.StateFn {
 			break
 		}
 		if isSpace(r) {
+			l.Backup()
 			break
 		}
 	}
 	l.Emit(itemVarName)
-
 	l.IgnoreRun(isSpace)
 
 	if r = l.Next(); r != ')' {


### PR DESCRIPTION
Following are now possible (useful in upsert API)
  * uid(v) <predicate> "object" .
  * <0x01> <predicate> uid(foo) .

For now, we only support uid function. In future, we can
add support for more functions, starting with `val`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3539)
<!-- Reviewable:end -->
