### PR TITLE
Fix Bug in IntersectCompressedWithLinJump

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -81,6 +81,10 @@ func IntersectCompressedWithLinJump(dec *codec.Decoder, v []uint64, o *[]uint64)
 			break
 		}
 		_, off := IntersectWithLin(u, v[k:], o)
+		if off == 0 {
+			off = 1 // If v[k] isn't in u more forward
+		}
+
 		k += off
 	}
 }

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -82,7 +82,7 @@ func IntersectCompressedWithLinJump(dec *codec.Decoder, v []uint64, o *[]uint64)
 		}
 		_, off := IntersectWithLin(u, v[k:], o)
 		if off == 0 {
-			off = 1 // If v[k] isn't in u more forward
+			off = 1 // If v[k] isn't in u, move forward.
 		}
 
 		k += off

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -414,65 +414,55 @@ func skipDuplicate(in []uint64, idx int) int {
 	return i
 }
 
-func TestIntersectCompressedWithLinJump(t *testing.T) {
-	NUM1 := []int{0, 1, 3, 11, 100}
-	NUM2 := []int{0, 1, 3, 11, 100}
+func sortUint64(nums []uint64) {
+	sort.Slice(nums, func(i, j int) bool { return nums[i] < nums[j] })
+}
 
+func fillNums(N1, N2 int) ([]uint64, []uint64, []uint64) {
 	rand.Seed(time.Now().UnixNano())
 
-	for _, N1 := range NUM1 {
-		for _, N2 := range NUM2 {
-			// Elements of common array will be in encoded block as well as v
-			common := make([]uint64, N1)
-			r := make([]uint64, N2)
-			v := make([]uint64, N1+N2)
+	commonNums := make([]uint64, N1)
+	blockNums := make([]uint64, N1+N2)
+	otherNums := make([]uint64, N1+N2)
 
-			for i := 0; i < N1; i++ {
-				common[i] = rand.Uint64()
-			}
+	for i := 0; i < N1; i++ {
+		val := rand.Uint64()
+		commonNums[i] = val
+		blockNums[i] = val
+		otherNums[i] = val
+	}
 
-			for i := 0; i < N2; i++ {
-				r[i] = rand.Uint64()
-			}
+	for i := N1; i < N1+N2; i++ {
+		blockNums[i] = rand.Uint64()
+		otherNums[i] = rand.Uint64()
+	}
 
-			blkNums := make([]uint64, N1+N2)
-			for i, v := range common {
-				blkNums[i] = v
-			}
+	sortUint64(commonNums)
+	sortUint64(blockNums)
+	sortUint64(otherNums)
 
-			for i, v := range r {
-				blkNums[N1+i] = v
-			}
+	return commonNums, blockNums, otherNums
+}
 
-			sort.Slice(blkNums, func(i, j int) bool { return blkNums[i] < blkNums[j] })
+func TestIntersectCompressedWithLinJump(t *testing.T) {
+	lengths := []int{0, 1, 3, 11, 100}
+
+	for _, N1 := range lengths {
+		for _, N2 := range lengths {
+			// Intersection of blockNums and otherNums is commonNums.
+			commonNums, blockNums, otherNums := fillNums(N1, N2)
 
 			enc := codec.Encoder{BlockSize: 10}
-			for _, num := range blkNums {
+			for _, num := range blockNums {
 				enc.Add(num)
 			}
 
 			pack := enc.Done()
 			dec := codec.Decoder{Pack: pack}
 
-			for i := 0; i < N2; i++ {
-				r[i] = rand.Uint64()
-			}
-
-			for i, t := range common {
-				v[i] = t
-			}
-
-			for i, t := range r {
-				v[N1+i] = t
-			}
-
-			sort.Slice(v, func(i, j int) bool { return v[i] < v[j] })
-
-			o := make([]uint64, 0)
-			IntersectCompressedWithLinJump(&dec, v, &o)
-
-			sort.Slice(common, func(i, j int) bool { return common[i] < common[j] })
-			require.Equal(t, common, o)
+			actual := make([]uint64, 0)
+			IntersectCompressedWithLinJump(&dec, otherNums, &actual)
+			require.Equal(t, commonNums, actual)
 		}
 	}
 }

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -190,19 +190,14 @@ func (d *Decoder) Uids() []uint64 {
 }
 
 func (d *Decoder) LinearSeek(seek uint64) []uint64 {
-	prev := d.blockIdx
 	for {
 		v := d.PeekNextBase()
-		if seek <= v {
+		if seek < v {
 			break
 		}
 		d.blockIdx++
 	}
-	if d.blockIdx == prev {
-		// The seek id is <= base of next block. But, we have already searched this
-		// block. So, let's move to the next block anyway.
-		return d.Next()
-	}
+
 	return d.unpackBlock()
 }
 

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -189,6 +189,9 @@ func (d *Decoder) Uids() []uint64 {
 	return d.uids
 }
 
+// LinearSeek returns uids of the last block whose base is less than seek.
+// If there are no such blocks i.e. seek < base of first block, it returns uids of first
+// block. LinearSeek is used to get closest uids which are >= seek.
 func (d *Decoder) LinearSeek(seek uint64) []uint64 {
 	for {
 		v := d.PeekNextBase()

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -110,7 +110,7 @@ func TestSeek(t *testing.T) {
 	}
 }
 
-func TestLinearSeek1(t *testing.T) {
+func TestLinearSeek(t *testing.T) {
 	N := 10001
 	enc := Encoder{BlockSize: 10}
 	for i := 0; i < N; i += 10 {
@@ -119,105 +119,22 @@ func TestLinearSeek1(t *testing.T) {
 	pack := enc.Done()
 	dec := Decoder{Pack: pack}
 
-	var found bool
-	for i := 0; i < N; i += 10 {
-		found = false
+	for i := 0; i < 2*N; i += 10 {
 		uids := dec.LinearSeek(uint64(i))
 
-		for _, uid := range uids {
-			if uid == uint64(i) {
-				found = true
-				break
-			}
+		if i < N {
+			require.Contains(t, uids, uint64(i))
+		} else {
+			require.NotContains(t, uids, uint64(i))
 		}
-
-		require.Equal(t, found, true)
 	}
 
+	//blockIdx points to last block.
 	for i := 0; i < 9990; i += 10 {
-		found = false
 		uids := dec.LinearSeek(uint64(i))
 
-		for _, uid := range uids {
-			if uid == uint64(i) {
-				found = true
-				break
-			}
-		}
-		// blockIdx has increased, so LinearSeek shouldn't
-		// be able to find smaller numbers.
-		require.Equal(t, found, false)
+		require.NotContains(t, uids, uint64(i))
 	}
-}
-
-func TestLinearSeek2(t *testing.T) {
-	N := 15
-	enc := Encoder{BlockSize: 10}
-	for i := 0; i < N; i++ {
-		enc.Add(uint64(i))
-	}
-	pack := enc.Done()
-	dec := Decoder{Pack: pack}
-
-	var found bool
-	uids := dec.LinearSeek(uint64(0))
-	for _, uid := range uids {
-		if uid == uint64(0) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, true)
-
-	found = false
-	uids = dec.LinearSeek(uint64(11))
-	for _, uid := range uids {
-		if uid == uint64(11) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, true)
-
-	found = false
-	uids = dec.LinearSeek(uint64(14))
-	for _, uid := range uids {
-		if uid == uint64(14) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, true)
-
-	found = false
-	uids = dec.LinearSeek(uint64(15))
-	for _, uid := range uids {
-		if uid == uint64(15) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, false)
-
-	found = false
-	uids = dec.LinearSeek(uint64(1))
-	for _, uid := range uids {
-		if uid == uint64(1) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, false)
-
-	found = false
-	uids = dec.LinearSeek(uint64(0))
-	for _, uid := range uids {
-		if uid == uint64(0) {
-			found = true
-			break
-		}
-	}
-	require.Equal(t, found, false)
 }
 
 func TestDecoder(t *testing.T) {

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -110,6 +110,116 @@ func TestSeek(t *testing.T) {
 	}
 }
 
+func TestLinearSeek1(t *testing.T) {
+	N := 10001
+	enc := Encoder{BlockSize: 10}
+	for i := 0; i < N; i += 10 {
+		enc.Add(uint64(i))
+	}
+	pack := enc.Done()
+	dec := Decoder{Pack: pack}
+
+	var found bool
+	for i := 0; i < N; i += 10 {
+		found = false
+		uids := dec.LinearSeek(uint64(i))
+
+		for _, uid := range uids {
+			if uid == uint64(i) {
+				found = true
+				break
+			}
+		}
+
+		require.Equal(t, found, true)
+	}
+
+	for i := 0; i < 9990; i += 10 {
+		found = false
+		uids := dec.LinearSeek(uint64(i))
+
+		for _, uid := range uids {
+			if uid == uint64(i) {
+				found = true
+				break
+			}
+		}
+		// blockIdx has increased, so LinearSeek shouldn't
+		// be able to find smaller numbers.
+		require.Equal(t, found, false)
+	}
+}
+
+func TestLinearSeek2(t *testing.T) {
+	N := 15
+	enc := Encoder{BlockSize: 10}
+	for i := 0; i < N; i++ {
+		enc.Add(uint64(i))
+	}
+	pack := enc.Done()
+	dec := Decoder{Pack: pack}
+
+	var found bool
+	uids := dec.LinearSeek(uint64(0))
+	for _, uid := range uids {
+		if uid == uint64(0) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, true)
+
+	found = false
+	uids = dec.LinearSeek(uint64(11))
+	for _, uid := range uids {
+		if uid == uint64(11) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, true)
+
+	found = false
+	uids = dec.LinearSeek(uint64(14))
+	for _, uid := range uids {
+		if uid == uint64(14) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, true)
+
+	found = false
+	uids = dec.LinearSeek(uint64(15))
+	for _, uid := range uids {
+		if uid == uint64(15) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, false)
+
+	found = false
+	uids = dec.LinearSeek(uint64(1))
+	for _, uid := range uids {
+		if uid == uint64(1) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, false)
+
+	found = false
+	uids = dec.LinearSeek(uint64(0))
+	for _, uid := range uids {
+		if uid == uint64(0) {
+			found = true
+			break
+		}
+	}
+	require.Equal(t, found, false)
+}
+
 func TestDecoder(t *testing.T) {
 	N := 10001
 	var expected []uint64


### PR DESCRIPTION
IntersectCompressedWithLinJump function was failing test(issue #3553)
with data mismatch because LinearSeek wasn't behaving properly.
LinearSeek(n) had an expectation that the block with current blockIdx has
already been searched for, but it wasn't being used that way in
IntersectCompressedWithLinJump function. Also LinearSeek was returning
uids of current block, even if next block's base is equal to n.

Now function LinearSeek(n) returns uids of the last block whose base
is less than n. IntersectCompressedWithLinJump stores intersection of
uids in encoded block with an arrary into another array. Fixes #3553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3555)
<!-- Reviewable:end -->
