### PR TITLE
Correctness Fix: Block before proposing mutations and improve conflict key generation

### DIFF
--- a/contrib/integration/testtxn/main_test.go
+++ b/contrib/integration/testtxn/main_test.go
@@ -772,9 +772,9 @@ func TestCountIndexSerialTxns(t *testing.T) {
 	txn0 := dg.NewTxn()
 	mu := api.Mutation{SetNquads: []byte("<0x100> <answer> <0x200> .")}
 	_, err := txn0.Mutate(ctxb, &mu)
-	x.Check(err)
+	require.NoError(t, err)
 	err = txn0.Commit(ctxb)
-	x.Check(err)
+	require.NoError(t, err)
 
 	// Expected edge count of 0x1: 2
 	// This should NOT appear in the query result
@@ -782,22 +782,22 @@ func TestCountIndexSerialTxns(t *testing.T) {
 	txn1 := dg.NewTxn()
 	mu = api.Mutation{SetNquads: []byte("<0x1> <answer> <0x2> .")}
 	_, err = txn1.Mutate(ctxb, &mu)
-	x.Check(err)
+	require.NoError(t, err)
 	err = txn1.Commit(ctxb)
-	x.Check(err)
+	require.NoError(t, err)
 
 	txn2 := dg.NewTxn()
 	mu = api.Mutation{SetNquads: []byte("<0x1> <answer> <0x3> .")}
 	_, err = txn2.Mutate(ctxb, &mu)
-	x.Check(err)
+	require.NoError(t, err)
 	err = txn2.Commit(ctxb)
-	x.Check(err)
+	require.NoError(t, err)
 
 	// Verify query
 	txn := dg.NewReadOnlyTxn()
 	vars := map[string]string{"$num": "1"}
 	resp, err := txn.QueryWithVars(ctxb, countQuery, vars)
-	x.Check(err)
+	require.NoError(t, err)
 	js := string(resp.GetJson())
 	require.JSONEq(t,
 		`{"me": [{"count(answer)": 1, "uid": "0x100"}]}`,
@@ -805,7 +805,7 @@ func TestCountIndexSerialTxns(t *testing.T) {
 	txn = dg.NewReadOnlyTxn()
 	vars = map[string]string{"$num": "2"}
 	resp, err = txn.QueryWithVars(ctxb, countQuery, vars)
-	x.Check(err)
+	require.NoError(t, err)
 	js = string(resp.GetJson())
 	require.JSONEq(t,
 		`{"me": [{"count(answer)": 2, "uid": "0x1"}]}`,

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -313,7 +313,7 @@ func TestTransactionBasic(t *testing.T) {
 	keys, preds, mts, err := mutationWithTs(m1, "application/rdf", false, false, true, ts)
 	require.NoError(t, err)
 	require.Equal(t, mts, ts)
-	require.Equal(t, 3, len(keys))
+	require.Equal(t, 4, len(keys))
 	require.Equal(t, 2, len(preds))
 	var parsedPreds []string
 	for _, pred := range preds {
@@ -367,7 +367,7 @@ func TestTransactionBasicNoPreds(t *testing.T) {
 	keys, _, mts, err := mutationWithTs(m1, "application/rdf", false, false, true, ts)
 	require.NoError(t, err)
 	require.Equal(t, mts, ts)
-	require.Equal(t, 3, len(keys))
+	require.Equal(t, 4, len(keys))
 
 	data, _, err := queryWithTs(q1, "application/graphql+-", 0)
 	require.NoError(t, err)
@@ -413,7 +413,7 @@ func TestTransactionBasicOldCommitFormat(t *testing.T) {
 	keys, _, mts, err := mutationWithTs(m1, "application/rdf", false, false, true, ts)
 	require.NoError(t, err)
 	require.Equal(t, mts, ts)
-	require.Equal(t, 3, len(keys))
+	require.Equal(t, 4, len(keys))
 
 	data, _, err := queryWithTs(q1, "application/graphql+-", 0)
 	require.NoError(t, err)

--- a/posting/index.go
+++ b/posting/index.go
@@ -265,7 +265,6 @@ func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count 
 	if err = plist.addMutation(ctx, txn, t); err != nil {
 		return err
 	}
-
 	ostats.Record(ctx, x.NumEdges.M(1))
 	return nil
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -266,7 +266,6 @@ func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count 
 		return err
 	}
 
-	txn.addConflictKey(fmt.Sprintf("cntIdx|%s|%d", t.Attr, t.ValueId))
 	ostats.Record(ctx, x.NumEdges.M(1))
 	return nil
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -25,7 +25,6 @@ import (
 	"sort"
 
 	"github.com/dgryski/go-farm"
-	"github.com/golang/glog"
 
 	bpb "github.com/dgraph-io/badger/pb"
 	"github.com/dgraph-io/dgo/protos/api"
@@ -405,11 +404,21 @@ func (l *List) addMutationInternal(ctx context.Context, txn *Txn, t *pb.Directed
 		return fmt.Sprintf("%s|%d", key, uid)
 	}
 
+	mpost := NewPosting(t)
+	mpost.StartTs = txn.StartTs
+	if mpost.PostingType != pb.Posting_REF {
+		t.ValueId = fingerprintEdge(t)
+		mpost.Uid = t.ValueId
+	}
+	l.updateMutationLayer(mpost)
+
 	// We ensure that commit marks are applied to posting lists in the right
 	// order. We can do so by proposing them in the same order as received by the Oracle delta
 	// stream from Zero, instead of in goroutines.
 	var conflictKey string
-	if schema.State().HasUpsert(t.Attr) {
+	pk := x.Parse(l.key)
+	switch {
+	case schema.State().HasUpsert(t.Attr):
 		// Consider checking to see if a email id is unique. A user adds:
 		// <uid> <email> "email@email.org", and there's a string equal tokenizer
 		// and upsert directive on the schema.
@@ -419,30 +428,34 @@ func (l *List) addMutationInternal(ctx context.Context, txn *Txn, t *pb.Directed
 		// that two users don't set the same email id.
 		conflictKey = getKey(l.key, 0)
 
-	} else if x.Parse(l.key).IsData() {
-		// Unless upsert is specified, we don't check for index conflicts, only
-		// data conflicts.
-		// If the data is of type UID, then we use SPO for conflict detection.
-		// Otherwise, we use SP (for string, date, int, etc.).
-		typ, err := schema.State().TypeOf(t.Attr)
-		if err != nil {
-			glog.V(2).Infof("Unable to find type of attr: %s. Err: %v", t.Attr, err)
-			// Don't check for conflict.
-		} else if typ == types.UidID {
-			conflictKey = getKey(l.key, t.ValueId)
-		} else {
-			conflictKey = getKey(l.key, 0)
-		}
-	}
+	case pk.IsData() && schema.State().IsList(t.Attr):
+		// Data keys, irrespective of whether they are UID or values, should be judged based on
+		// whether they are lists or not. For UID, t.ValueId = UID. For value, t.ValueId =
+		// fingerprint(value) or could be fingerprint(lang) or something else.
+		//
+		// For singular uid predicate, like partner: uid // no list.
+		// a -> b
+		// a -> c
+		// Run concurrently, only one of them should succeed.
+		// But for friend: [uid], both should succeed.
+		//
+		// Similarly, name: string
+		// a -> "x"
+		// a -> "y"
+		// This should definitely have a conflict.
+		// But, if name: [string], then they can both succeed.
+		conflictKey = getKey(l.key, t.ValueId)
 
-	mpost := NewPosting(t)
-	mpost.StartTs = txn.StartTs
-	if mpost.PostingType != pb.Posting_REF {
-		t.ValueId = fingerprintEdge(t)
-		mpost.Uid = t.ValueId
-	}
+	case pk.IsData(): // NOT a list. This case must happen after the above case.
+		conflictKey = getKey(l.key, 0)
 
-	l.updateMutationLayer(mpost)
+	case pk.IsIndex() || pk.IsCount():
+		// Index keys are by default of type [uid].
+		conflictKey = getKey(l.key, t.ValueId)
+
+	default:
+		// Don't assign a conflictKey.
+	}
 	txn.addConflictKey(conflictKey)
 	return nil
 }

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -201,7 +201,15 @@ func (g *groupi) upsertSchema(schema *pb.SchemaUpdate) {
 	// Propose schema mutation.
 	var m pb.Mutations
 	// schema for a reserved predicate is not changed once set.
-	m.StartTs = 1
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ts, err := Timestamps(ctx, &pb.Num{Val: 1})
+	cancel()
+	if err != nil {
+		glog.Errorf("error while requesting timestamp for schema %v: %v", schema, err)
+		return
+	}
+
+	m.StartTs = ts.StartId
 	m.Schema = append(m.Schema, schema)
 
 	// This would propose the schema mutation and make sure some node serves this predicate

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -595,6 +595,15 @@ func (w *grpcWorker) proposeAndWait(ctx context.Context, txnCtx *api.TxnContext,
 		}
 	}
 
+	// We should wait to ensure that we have seen all the updates until the StartTs of this mutation
+	// transaction. Otherwise, when we read the posting list value for calculating the indices, we
+	// might be wrong because we might be missing out a commit which has updated the value. This
+	// wait here ensures that the proposal would only be registered after seeing txn status of all
+	// pending transactions. Thus, the ordering would be correct.
+	if err := posting.Oracle().WaitForTs(ctx, m.StartTs); err != nil {
+		return err
+	}
+
 	node := groups().Node
 	err := node.proposeAndWait(ctx, &pb.Proposal{Mutations: m})
 	fillTxnContext(txnCtx, m.StartTs)


### PR DESCRIPTION
This PR fixes two things:

- Before proposing mutations, Dgraph didn't block to ensure that it has seen all the committed transaction updates. So, the index calculation had side-effects as shown by count index tests, where a previous update hasn't been registered yet and a new one is made, which caused incorrect count to be generated, hence causing the count index to be wrong.

This PR fixes that by ensuring that Dgraph waits for the Alpha involved to have reached StartTs. Only then would it propose a new update. This ensures that all the updates are in correct order.

- Conflict Keys: Previously, Dgraph was generating conflict keys based on (S, P) for all list values, and (S, P, O) for all uids. This PR changes that by using (S, P) for singular predicates, without considering whether they are uid or value; and using (S, P, O) for list uids/values. This PR also adds conflict keys for indices, treating them as list of uids.

- Based on tests by @danielmai , this PR does not have any impact on the live loader throughput.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3565)
<!-- Reviewable:end -->
