### PR TITLE
Refactor Mutate function for processing mutation

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -190,7 +190,7 @@ upsert {
   }
 }`
 	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, true, 0)
-	require.Contains(t, err.Error(), "upsert query op has no variables")
+	require.Contains(t, err.Error(), "upsert query block has no variables")
 }
 
 func TestUpsertWithFragment(t *testing.T) {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -485,7 +485,7 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool)
 	if err != nil {
 		return resp, err
 	}
-	parsingTime += time.Now().Sub(startParsingTime)
+	parsingTime += time.Since(startParsingTime)
 
 	if authorize {
 		if err := authorizeMutation(ctx, gmu); err != nil {
@@ -572,7 +572,7 @@ func (s *Server) doMutate(ctx context.Context, mu *api.Mutation, authorize bool)
 	return resp, nil
 }
 
-// doQueryInUpsert processes the query in upsert block
+// doQueryInUpsert processes the query in upsert block.
 func doQueryInUpsert(ctx context.Context, startTs uint64, gmu *gql.Mutation,
 	queryText string) (time.Duration, error) {
 
@@ -670,7 +670,7 @@ func updateMutations(gmu *gql.Mutation, varToUID map[string]string) {
 		return s
 	}
 
-	// Remove the mutations from gmu.Del when no UID was found
+	// Remove the mutations from gmu.Del when no UID was found.
 	gmuDel := make([]*api.NQuad, 0, len(gmu.Del))
 	for _, nq := range gmu.Del {
 		nq.Subject = getNewVal(nq.Subject)
@@ -684,7 +684,7 @@ func updateMutations(gmu *gql.Mutation, varToUID map[string]string) {
 	}
 	gmu.Del = gmuDel
 
-	// update the values in mutation block from the query block.
+	// Update the values in mutation block from the query block.
 	for _, nq := range gmu.Set {
 		nq.Subject = getNewVal(nq.Subject)
 		nq.ObjectId = getNewVal(nq.ObjectId)


### PR DESCRIPTION
Refactoring ensures the following -
  - The `doMutate` function was complex before doing things in sequence without any particular reasoning. Now we do the context check, health check, mutation allowed check first. Then we do authorization check, process query in case of upsert block and finally process mutation.
  - We are using `mu` (unparsed mutation) sometimes and `gmu` (parsed mutation) sometimes. Now it uses `gmu` once parsing is done.
  - We were passing and returning too many arguments before.
  - we are computing parsing and processing time more accurately now.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3583)
<!-- Reviewable:end -->
