### PR TITLE
Fix the calculation

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -686,7 +686,7 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 					if first, err := n.Store.FirstIndex(); err == nil {
 						// Save some cycles by only calculating snapshot if the checkpoint has gone
 						// quite a bit further than the first index.
-						calculate = chk-first >= uint64(x.WorkerConfig.SnapshotAfter)
+						calculate = chk >= first+uint64(x.WorkerConfig.SnapshotAfter)
 					}
 				}
 				// We keep track of the applied index in the p directory. Even if we don't take


### PR DESCRIPTION
Right after a rollup, the first index may become 1 larger than the checkpoint index, e.g. first index is 211 and the checkpoint index(chk) is 210. Since the variables chk and first are of type *uint64*, the expression chk - first will result in the value math.MaxUint64 (integer underflow), which is then used to compare with SnapshotAfter, and generate the wrong result. 

This PR avoids the integer underflow in such cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3598)
<!-- Reviewable:end -->
