### PR TITLE
Migrating the GetDgraphClient logic into package x

### DIFF
--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -89,7 +89,7 @@ func userAdd(conf *viper.Viper, userid string, password string) error {
 
 	if len(password) == 0 {
 		var err error
-		password, err = askUserPassword(userid, "New", 2)
+		password, err = x.AskUserPassword(userid, "New", 2)
 		if err != nil {
 			return err
 		}
@@ -290,7 +290,7 @@ func changePassword(conf *viper.Viper, userId string) error {
 	defer cancel()
 
 	// 2. get the new password
-	newPassword, err := askUserPassword(userId, "New", 2)
+	newPassword, err := x.AskUserPassword(userId, "New", 2)
 	if err != nil {
 		return err
 	}

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -156,7 +156,7 @@ func getClientWithAdminCtx(conf *viper.Viper) (*dgo.Dgraph, x.CloseFunc, error) 
 	dg, closeClient := x.GetDgraphClient(conf, false)
 	err := x.GetPassAndLogin(dg, &x.CredOpt{
 		Conf:        conf,
-		UserId:      x.GrootId,
+		UserID:      x.GrootId,
 		PasswordOpt: gPassword,
 	})
 	if err != nil {

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -154,7 +154,7 @@ type JwtGroup struct {
 // options, and then login using groot id and password
 func getClientWithAdminCtx(conf *viper.Viper) (*dgo.Dgraph, x.CloseFunc, error) {
 	dg, closeClient := x.GetDgraphClient(conf, false)
-	cancel, err := x.GetPassAndLogin(dg, &x.CredOpt{
+	err := x.GetPassAndLogin(dg, &x.CredOpt{
 		Conf:        conf,
 		UserId:      x.GrootId,
 		PasswordOpt: gPassword,
@@ -162,10 +162,7 @@ func getClientWithAdminCtx(conf *viper.Viper) (*dgo.Dgraph, x.CloseFunc, error) 
 	if err != nil {
 		return nil, nil, err
 	}
-	return dg, func() {
-		cancel()
-		closeClient()
-	}, nil
+	return dg, closeClient, nil
 }
 
 func CreateUserNQuads(userId string, password string) []*api.NQuad {

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -156,7 +156,7 @@ func getClientWithAdminCtx(conf *viper.Viper) (*dgo.Dgraph, x.CloseFunc, error) 
 	dg, closeClient := x.GetDgraphClient(conf, false)
 	cancel, err := x.GetPassAndLogin(dg, &x.CredOpt{
 		Conf:        conf,
-		Userid:      x.GrootId,
+		UserId:      x.GrootId,
 		PasswordOpt: gPassword,
 	})
 	if err != nil {

--- a/x/x.go
+++ b/x/x.go
@@ -600,7 +600,7 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 	if login && len(user) > 0 {
 		err = GetPassAndLogin(dg, &CredOpt{
 			Conf:        conf,
-			UserId:      user,
+			UserID:      user,
 			PasswordOpt: "password",
 		})
 		Checkf(err, "While retrieving password and logging in")
@@ -616,7 +616,7 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 
 type CredOpt struct {
 	Conf        *viper.Viper
-	UserId      string
+	UserID      string
 	PasswordOpt string
 }
 
@@ -652,15 +652,15 @@ func GetPassAndLogin(dg *dgo.Dgraph, opt *CredOpt) error {
 	password := opt.Conf.GetString(opt.PasswordOpt)
 	if len(password) == 0 {
 		var err error
-		password, err = AskUserPassword(opt.UserId, "Current", 1)
+		password, err = AskUserPassword(opt.UserID, "Current", 1)
 		if err != nil {
 			return err
 		}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	if err := dg.Login(ctx, opt.UserId, password); err != nil {
-		return fmt.Errorf("unable to login to the %v account:%v", opt.UserId, err)
+	if err := dg.Login(ctx, opt.UserID, password); err != nil {
+		return fmt.Errorf("unable to login to the %v account:%v", opt.UserID, err)
 	}
 	fmt.Println("Login successful.")
 	// update the context so that it has the admin jwt token


### PR DESCRIPTION
The live loader, increment, and acl sub-commands all share similar options when creating the dgraph client, which include
// --alpha specifies a comma separated list of endpoints to connect to
// --tls_cacert, --tls_cert, --tls_key etc specify the TLS configuration of the connection
// --retries specifies how many times we should retry the connection to each endpoint upon failures
// --user and --password specify the credentials we should use to login with the server

This PR refactors the logic of checking those options into a method in package x, and uses that method in the different sub-commands.

A side effect of this PR is adding the user login feature in the live loader before processing data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3600)
<!-- Reviewable:end -->
