### PR TITLE
Fix bug for debug parameter in /query HTTP API

### DIFF
--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -54,30 +54,34 @@ type params struct {
 	Variables map[string]string `json:"variables"`
 }
 
-func queryWithGz(q, t string, gzReq bool, gzResp bool, timeout string) (
+func queryWithGz(queryText, contentType, debug, timeout string, gzReq, gzResp bool) (
 	string, *http.Response, error) {
 
-	url := addr + "/query"
-	if timeout != "" {
-		url = url + fmt.Sprintf("?timeout=%v", timeout)
+	params := make([]string, 0, 2)
+	if debug != "" {
+		params = append(params, "debug="+debug)
 	}
+	if timeout != "" {
+		params = append(params, fmt.Sprintf("timeout=%v", timeout))
+	}
+	url := addr + "/query?" + strings.Join(params, "&")
 
 	var buf *bytes.Buffer
 	if gzReq {
 		var b bytes.Buffer
 		gz := gzip.NewWriter(&b)
-		gz.Write([]byte(q))
+		gz.Write([]byte(queryText))
 		gz.Close()
 		buf = &b
 	} else {
-		buf = bytes.NewBufferString(q)
+		buf = bytes.NewBufferString(queryText)
 	}
 
 	req, err := http.NewRequest("POST", url, buf)
 	if err != nil {
 		return "", nil, err
 	}
-	req.Header.Add("Content-Type", t)
+	req.Header.Add("Content-Type", contentType)
 
 	if gzReq {
 		req.Header.Set("Content-Encoding", "gzip")
@@ -131,13 +135,13 @@ func queryWithGz(q, t string, gzReq bool, gzResp bool, timeout string) (
 	return string(output), resp, err
 }
 
-func queryWithTs(q, t string, ts uint64) (string, uint64, error) {
+func queryWithTs(q, ct string, ts uint64) (string, uint64, error) {
 	url := addr + "/query"
 	if ts != 0 {
 		url += "?startTs=" + strconv.FormatUint(ts, 10)
 	}
 
-	_, body, err := runWithRetries("POST", t, url, q)
+	_, body, err := runWithRetries("POST", ct, url, q)
 	if err != nil {
 		return "", 0, err
 	}
@@ -158,17 +162,17 @@ func queryWithTs(q, t string, ts uint64) (string, uint64, error) {
 func mutationWithTs(m, t string, isJson bool, commitNow bool, ignoreIndexConflict bool,
 	ts uint64) ([]string, []string, uint64, error) {
 
-	queryParams := make([]string, 0)
+	params := make([]string, 2)
 	if ts != 0 {
-		queryParams = append(queryParams, "startTs="+strconv.FormatUint(ts, 10))
+		params = append(params, "startTs="+strconv.FormatUint(ts, 10))
 	}
 	var keys []string
 	var preds []string
 	if commitNow {
-		queryParams = append(queryParams, "commitNow=true")
+		params = append(params, "commitNow=true")
 	}
 
-	url := addr + "/mutate?" + strings.Join(queryParams, "&")
+	url := addr + "/mutate?" + strings.Join(params, "&")
 	_, body, err := runWithRetries("POST", t, url, m)
 	if err != nil {
 		return keys, preds, 0, err
@@ -507,39 +511,39 @@ func TestHttpCompressionSupport(t *testing.T) {
 	err := runMutation(m1)
 	require.NoError(t, err)
 
-	data, resp, err := queryWithGz(q1, "application/graphql+-", false, false, "")
+	data, resp, err := queryWithGz(q1, "application/graphql+-", "false", "", false, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", false, true, "")
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", false, true)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", true, false, "")
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", true, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", true, true, "")
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", true, true)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
 	// query with timeout
-	data, resp, err = queryWithGz(q1, "application/graphql+-", false, false, "1ms")
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "1ms", false, false)
 	require.EqualError(t, err, ": context deadline exceeded")
 	require.Equal(t, "", data)
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", false, false, "1s")
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "1s", false, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
 	d1, err := json.Marshal(params{Query: q1})
 	require.NoError(t, err)
-	data, resp, err = queryWithGz(string(d1), "application/json", false, false, "1s")
+	data, resp, err = queryWithGz(string(d1), "application/json", "", "1s", false, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
@@ -551,10 +555,98 @@ func TestHttpCompressionSupport(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	data, resp, err = queryWithGz(string(d2), "application/json", false, false, "1s")
+	data, resp, err = queryWithGz(string(d2), "application/json", "", "1s", false, false)
 	require.NoError(t, err)
-	fmt.Println(data)
 	require.Equal(t, `{"data":{"names":[{"name":"Alice"}]}}`, data)
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+}
+
+func TestDebugSupport(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`name: string @index(term) .`))
+
+	m1 := `
+	{
+	  set {
+		_:a <name> "Alice" .
+		_:b <name> "Bob" .
+		_:c <name> "Charlie" .
+		_:d <name> "David" .
+		_:e <name> "Emily" .
+		_:f <name> "Frank" .
+		_:g <name> "Gloria" .
+	  }
+	}
+	`
+	err := runMutation(m1)
+	require.NoError(t, err)
+
+	q1 := `
+	{
+	  users(func: has(name), orderasc: name) {
+	    name
+	  }
+	}
+	`
+
+	requireEqual := func(t *testing.T, data string) {
+		var r struct {
+			Data struct {
+				Users []struct {
+					Name string `json:"name"`
+					UID  string `json:"uid"`
+				} `json:"users"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			require.NoError(t, err)
+		}
+
+		exp := []string{"Alice", "Bob", "Charlie", "David", "Emily", "Frank", "Gloria"}
+		actual := make([]string, 0, len(exp))
+		for _, u := range r.Data.Users {
+			actual = append(actual, u.Name)
+			require.NotEmpty(t, u.UID, "uid should be nonempty in debug mode")
+		}
+		sort.Strings(actual)
+		require.Equal(t, exp, actual)
+	}
+
+	data, resp, err := queryWithGz(q1, "application/graphql+-", "true", "", false, false)
+	require.NoError(t, err)
+	requireEqual(t, data)
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", false, true)
+	require.NoError(t, err)
+	requireEqual(t, data)
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", true, false)
+	require.NoError(t, err)
+	requireEqual(t, data)
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", true, true)
+	require.NoError(t, err)
+	requireEqual(t, data)
+	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
+
+	// query with timeout
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "1ms", false, false)
+	require.EqualError(t, err, ": context deadline exceeded")
+	require.Equal(t, "", data)
+
+	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "1s", false, false)
+	require.NoError(t, err)
+	requireEqual(t, data)
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+
+	d1, err := json.Marshal(params{Query: q1})
+	require.NoError(t, err)
+	data, resp, err = queryWithGz(string(d1), "application/json", "true", "1s", false, false)
+	require.NoError(t, err)
+	requireEqual(t, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -926,14 +926,15 @@ const (
 )
 
 func isDebug(ctx context.Context) bool {
-	var debug bool
 	// gRPC client passes information about debug as metadata.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// md is a map[string][]string
-		debug = len(md["debug"]) > 0 && md["debug"][0] == "true"
+		return len(md["debug"]) > 0 && md["debug"][0] == "true"
 	}
+
 	// HTTP passes information about debug as query parameter which is attached to context.
-	return debug || ctx.Value(DebugKey) == "true"
+	debug, ok := ctx.Value(DebugKey).(bool)
+	return ok && debug
 }
 
 func (sg *SubGraph) populate(uids []uint64) error {

--- a/query/query.go
+++ b/query/query.go
@@ -929,7 +929,14 @@ func isDebug(ctx context.Context) bool {
 	// gRPC client passes information about debug as metadata.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// md is a map[string][]string
-		return len(md["debug"]) > 0 && md["debug"][0] == "true"
+		if len(md["debug"]) == 0 {
+			return false
+		}
+
+		// We ignore the error here, because debug would be false in
+		// case of an error which is what we would return.
+		debug, _ := strconv.ParseBool(md["debug"][0])
+		return debug
 	}
 
 	// HTTP passes information about debug as query parameter which is attached to context.


### PR DESCRIPTION
For HTTP `/query` API, `debug` parameter doesn't seem to work. This PR fixes this issue.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3605)
<!-- Reviewable:end -->
