### PR TITLE
Fix the HTTP Headers in HTTP API (Fixes #3623)

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -158,9 +158,8 @@ func SetHttpStatus(w http.ResponseWriter, code int, msg string) {
 func AddCorsHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers",
-		"Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, X-Auth-Token, "+
-			"Cache-Control, X-Requested-With, X-Dgraph-IgnoreIndexConflict")
+	w.Header().Set("Access-Control-Allow-Headers", "X-Dgraph-AccessToken, "+
+		"Content-Type, Content-Length, Accept-Encoding, Cache-Control")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Connection", "close")
 }


### PR DESCRIPTION
Remove headers from Access-Control-Allow-Headers
   * X-CSRF-Token
   * X-Auth-Token
   * X-Requested-With
   * X-Dgraph-IgnoreIndexConflict

Add headers to Access-Control-Allow-Headers
   * X-Dgraph-AccessToken

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3624)
<!-- Reviewable:end -->
