### PR TITLE
Fix bug in debug parameter in HTTP API (Fixes #3622)

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -122,12 +122,12 @@ func processToFastJSON(q string) string {
 }
 
 func runGraphqlQuery(q string) (string, error) {
-	output, _, err := queryWithTs(q, "application/graphql+-", 0)
+	output, _, err := queryWithTs(q, "application/graphql+-", "", 0)
 	return string(output), err
 }
 
 func runJSONQuery(q string) (string, error) {
-	output, _, err := queryWithTs(q, "application/json", 0)
+	output, _, err := queryWithTs(q, "application/json", "", 0)
 	return string(output), err
 }
 

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -73,7 +73,7 @@ upsert {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -98,7 +98,7 @@ upsert {
 	require.True(t, contains(preds, "name"))
 
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -135,7 +135,7 @@ func TestUpsertExample0JSON(t *testing.T) {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -156,7 +156,7 @@ func TestUpsertExample0JSON(t *testing.T) {
 	require.True(t, contains(preds, "name"))
 
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -369,7 +369,7 @@ upsert {
     oldest
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user3")
 	require.Contains(t, res, "56")
@@ -399,7 +399,7 @@ upsert {
     age
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user1")
 }
@@ -454,7 +454,7 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user2")
 
@@ -487,7 +487,7 @@ upsert {
     }
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user2")
 }
@@ -535,7 +535,7 @@ friend: uid @reverse .`))
     oldest
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user3")
 	require.Contains(t, res, "56")
@@ -562,7 +562,7 @@ friend: uid @reverse .`))
     age
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user1")
 }
@@ -610,7 +610,7 @@ friend: uid @reverse .`))
     }
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user2")
 
@@ -636,7 +636,7 @@ friend: uid @reverse .`))
     }
   }
 }`
-	res, _, err = queryWithTs(q3, "application/graphql+-", 0)
+	res, _, err = queryWithTs(q3, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user2")
 }
@@ -670,7 +670,7 @@ upsert {
     name
   }
 }`
-	res, _, err := queryWithTs(q, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user1")
 	require.Contains(t, res, "user2")
@@ -746,7 +746,7 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(q, "application/graphql+-", 0)
+	res, _, err := queryWithTs(q, "application/graphql+-", "", 0)
 	require.NoError(t, err)
 	expected := `
 {

--- a/query/query.go
+++ b/query/query.go
@@ -931,7 +931,7 @@ func isDebug(ctx context.Context) bool {
 	// gRPC client passes information about debug as metadata.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// md is a map[string][]string
-		if len(md["debug"]) != 0 {
+		if len(md["debug"]) > 0 {
 			// We ignore the error here, because in error case,
 			// debug would be false which is what we want.
 			debug, _ = strconv.ParseBool(md["debug"][0])

--- a/query/query.go
+++ b/query/query.go
@@ -932,9 +932,9 @@ func isDebug(ctx context.Context) bool {
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// md is a map[string][]string
 		if len(md["debug"]) != 0 {
-			// We ignore the error here.
-			d, _ := strconv.ParseBool(md["debug"][0])
-			debug = debug || d
+			// We ignore the error here, because in error case,
+			// debug would be false which is what we want.
+			debug, _ = strconv.ParseBool(md["debug"][0])
 		}
 	}
 

--- a/query/query.go
+++ b/query/query.go
@@ -926,22 +926,21 @@ const (
 )
 
 func isDebug(ctx context.Context) bool {
+	var debug bool
+
 	// gRPC client passes information about debug as metadata.
 	if md, ok := metadata.FromIncomingContext(ctx); ok {
 		// md is a map[string][]string
-		if len(md["debug"]) == 0 {
-			return false
+		if len(md["debug"]) != 0 {
+			// We ignore the error here.
+			d, _ := strconv.ParseBool(md["debug"][0])
+			debug = debug || d
 		}
-
-		// We ignore the error here, because debug would be false in
-		// case of an error which is what we would return.
-		debug, _ := strconv.ParseBool(md["debug"][0])
-		return debug
 	}
 
 	// HTTP passes information about debug as query parameter which is attached to context.
-	debug, ok := ctx.Value(DebugKey).(bool)
-	return ok && debug
+	d, _ := ctx.Value(DebugKey).(bool)
+	return debug || d
 }
 
 func (sg *SubGraph) populate(uids []uint64) error {


### PR DESCRIPTION
The logic is incorrectly modified in the `isDebug` function of the PR https://github.com/dgraph-io/dgraph/pull/3605. This PR changes back the logic to use the following -
  * If context has debug set, we set `debug = true`
  * If debug parameter is specified in metadata, we set `debug = true`
  * If both, we set it to true
  * If not set in either of the two, debug is false.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3626)
<!-- Reviewable:end -->
