### PR TITLE
Add CORS headers to Access-Control-Allow-Headers

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -159,7 +159,8 @@ func AddCorsHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
 	w.Header().Set("Access-Control-Allow-Headers", "X-Dgraph-AccessToken, "+
-		"Content-Type, Content-Length, Accept-Encoding, Cache-Control")
+		"Content-Type, Content-Length, Accept-Encoding, Cache-Control, "+
+		"X-CSRF-Token, X-Auth-Token, X-Requested-With")
 	w.Header().Set("Access-Control-Allow-Credentials", "true")
 	w.Header().Set("Connection", "close")
 }


### PR DESCRIPTION
Following headers are added -
   * X-CSRF-Token
   * X-Auth-Token
   * X-Requested-With

- Initially added by @manishrjain  in this commit https://github.com/dgraph-io/dgraph/commit/09f1d0c4aef3e3220d4b7f94c64d33ae5566e6e5
- And then removed in the PR https://github.com/dgraph-io/dgraph/pull/3624 after an issue is raised by @paulftw here https://github.com/dgraph-io/dgraph/issues/3623
- Adding back again on @manishrjain suggestion


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3637)
<!-- Reviewable:end -->
