### PR TITLE
Revert "Point the product roadmap link to the 2019 issue"

### DIFF
--- a/wiki/content/faq/index.md
+++ b/wiki/content/faq/index.md
@@ -61,7 +61,7 @@ Dgraph will aim to support [Gremlin](https://github.com/tinkerpop/gremlin/wiki) 
 If there is a demand for it, Dgraph could support [Cypher](https://neo4j.com/developer/cypher-query-language/). It would most likely be after v1.0.
 
 ### Can Dgraph support X?
-Please see Dgraph [product roadmap](https://github.com/dgraph-io/dgraph/issues/2894) of what we're planning to support. If `request X` is not part of it, please feel free to start a discussion at [discuss.dgraph.io](https://discuss.dgraph.io), or file a [Github Issue](https://github.com/dgraph-io/dgraph/issues).
+Please see Dgraph [product roadmap](https://github.com/dgraph-io/dgraph/issues/1) of what we're planning to support for v1.0. If `request X` is not part of it, please feel free to start a discussion at [discuss.dgraph.io](https://discuss.dgraph.io), or file a [Github Issue](https://github.com/dgraph-io/dgraph/issues).
 
 ## Long Term Plans
 


### PR DESCRIPTION
Reverts dgraph-io/dgraph#3644

I didn't noticed the base of this PR was branch release/v1.0.15. It should be master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3646)
<!-- Reviewable:end -->
