### PR TITLE
Fix convoluted buffer writing logic in zero/http.go

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -201,8 +201,8 @@ func (st *state) moveTablet(w http.ResponseWriter, r *http.Request) {
 		x.SetStatus(w, x.Error, err.Error())
 		return
 	}
-	_, err := w.Write([]byte(fmt.Sprintf("Predicate: [%s] moved from group: [%d] to [%d]",
-		tablet, srcGroup, dstGroup)))
+	_, err := fmt.Fprintf(w, "Predicate: [%s] moved from group [%d] to [%d]",
+		tablet, srcGroup, dstGroup)
 	if err != nil {
 		glog.Warningf("Error while writing response: %+v", err)
 	}

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -123,7 +123,7 @@ func (st *state) removeNode(w http.ResponseWriter, r *http.Request) {
 		x.SetStatus(w, x.Error, err.Error())
 		return
 	}
-	_, err := w.Write([]byte(fmt.Sprintf("Removed node with group: %v, idx: %v", groupId, nodeId)))
+	_, err := fmt.Fprintf(w, "Removed node with group: %v, idx: %v", groupId, nodeId)
 	if err != nil {
 		glog.Warningf("Error while writing response: %+v", err)
 	}


### PR DESCRIPTION
Use Fprintf to directly write to a buffer instead of using Write and
Sprintf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3652)
<!-- Reviewable:end -->
