### PR TITLE
Handle non-list UIDs predicates in bulk loader.

### DIFF
--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -79,6 +79,16 @@ func (s *schemaStore) getSchema(pred string) *pb.SchemaUpdate {
 	return s.schemaMap[pred]
 }
 
+func (s *schemaStore) setSchemaAsList(pred string) {
+	s.Lock()
+	defer s.Unlock()
+	schema, ok := s.schemaMap[pred]
+	if !ok {
+		return
+	}
+	schema.List = true
+}
+
 func (s *schemaStore) validateType(de *pb.DirectedEdge, objectIsUID bool) {
 	if objectIsUID {
 		de.ValueType = pb.Posting_UID

--- a/systest/bulk_live_cases_test.go
+++ b/systest/bulk_live_cases_test.go
@@ -284,6 +284,165 @@ func TestLoadTypes(t *testing.T) {
 		`{"types":[{"name":"Person", "fields":[{"name":"name", "type":"string"}]}]}`))
 }
 
+// This test is similar to TestCount but the friend predicate is not a list. The bulk loader
+// should detect this and force it to be a list to avoid any data loss. This test only runs
+// in the bulk loader.
+func TestBulkSingleUid(t *testing.T) {
+	s := newBulkOnlySuite(t, `
+		name: string @index(exact) .
+		friend: uid @count @reverse .
+	`, `
+		_:alice <friend> _:bob   .
+		_:alice <friend> _:carol .
+		_:alice <friend> _:dave  .
+
+		_:bob   <friend> _:carol .
+
+		_:carol <friend> _:bob   .
+		_:carol <friend> _:dave  .
+
+		_:erin  <friend> _:bob   .
+		_:erin  <friend> _:carol .
+
+		_:frank <friend> _:carol .
+		_:frank <friend> _:dave  .
+		_:frank <friend> _:erin  .
+
+		_:grace <friend> _:alice .
+		_:grace <friend> _:bob   .
+		_:grace <friend> _:carol .
+		_:grace <friend> _:dave  .
+		_:grace <friend> _:erin  .
+		_:grace <friend> _:frank .
+
+		_:alice <name> "Alice" .
+		_:bob   <name> "Bob" .
+		_:carol <name> "Carol" .
+		_:erin  <name> "Erin" .
+		_:frank <name> "Frank" .
+		_:grace <name> "Grace" .
+	`)
+	defer s.cleanup()
+
+	// Ensures that the index keys are written to disk after commit.
+	time.Sleep(time.Second)
+	t.Run("All queries", s.testCase(`
+	{
+		alice_friend_count(func: eq(name, "Alice")) {
+			count(friend),
+		},
+		bob_friend_count(func: eq(name, "Bob")) {
+			count(friend),
+		},
+		carol_friend_count(func: eq(name, "Carol")) {
+			count(friend),
+		},
+		erin_friend_count(func: eq(name, "Erin")) {
+			count(friend),
+		},
+		frank_friend_count(func: eq(name, "Frank")) {
+			count(friend),
+		},
+		grace_friend_count(func: eq(name, "Grace")) {
+			count(friend),
+		},
+
+		has_1_friend(func: has(friend)) @filter(eq(count(friend), 1)) {
+			name
+		},
+		has_2_friends(func: has(friend)) @filter(eq(count(friend), 2)) {
+			name
+		},
+		has_3_friends(func: has(friend)) @filter(eq(count(friend), 3)) {
+			name
+		},
+		has_4_friends(func: has(friend)) @filter(eq(count(friend), 4)) {
+			name
+		},
+		has_5_friends(func: has(friend)) @filter(eq(count(friend), 5)) {
+			name
+		},
+		has_6_friends(func: has(friend)) @filter(eq(count(friend), 6)) {
+			name
+		},
+
+		has_1_rev_friend(func: has(friend)) @filter(eq(count(~friend), 1)) {
+			name
+		},
+		has_2_rev_friends(func: has(friend)) @filter(eq(count(~friend), 2)) {
+			name
+		},
+		has_3_rev_friends(func: has(friend)) @filter(eq(count(~friend), 3)) {
+			name
+		},
+		has_4_rev_friends(func: has(friend)) @filter(eq(count(~friend), 4)) {
+			name
+		},
+		has_5_rev_friends(func: has(friend)) @filter(eq(count(~friend), 5)) {
+			name
+		},
+		has_6_rev_friends(func: has(friend)) @filter(eq(count(~friend), 6)) {
+			name
+		},
+	}
+	`, `
+	{
+		"alice_friend_count": [
+			{ "count(friend)": 3 }
+		],
+		"bob_friend_count": [
+			{ "count(friend)": 1 }
+		],
+		"carol_friend_count": [
+			{ "count(friend)": 2 }
+		],
+		"erin_friend_count": [
+			{ "count(friend)": 2 }
+		],
+		"frank_friend_count": [
+			{ "count(friend)": 3 }
+		],
+		"grace_friend_count": [
+			{ "count(friend)": 6 }
+		],
+
+		"has_1_friend": [
+			{ "name": "Bob" }
+		],
+		"has_2_friends": [
+			{ "name": "Carol" },
+			{ "name": "Erin" }
+		],
+		"has_3_friends": [
+			{ "name": "Alice" },
+			{ "name": "Frank" }
+		],
+		"has_4_friends": [],
+		"has_5_friends": [],
+		"has_6_friends": [
+			{ "name": "Grace" }
+		],
+
+		"has_1_rev_friend": [
+			{ "name": "Alice" },
+			{ "name": "Frank" }
+		],
+		"has_2_rev_friends": [
+			{ "name": "Erin" }
+		],
+		"has_3_rev_friends": [
+		],
+		"has_4_rev_friends": [
+			{ "name": "Bob" }
+		],
+		"has_5_rev_friends": [
+			{ "name": "Carol" }
+		],
+		"has_6_rev_friends": []
+	}
+	`))
+}
+
 // TODO: Fix this later.
 func DONOTRUNTestGoldenData(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
If more than one uid is found in the list for a non-list predicate,
print a warning and force the predicate to be a list to avoid data-loss.
The user is responsible for fixing the situation once Dgraph is up and
running.

Fixes #3656
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3659)
<!-- Reviewable:end -->
