### PR TITLE
Fix crash when trying to use shortest path with a password predicate.

### DIFF
--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -482,7 +482,6 @@ func TestTwoShortestPathMinWeight(t *testing.T) {
 }
 
 func TestShortestPath(t *testing.T) {
-
 	query := `
 		{
 			A as shortest(from:0x01, to:31) {
@@ -515,6 +514,25 @@ func TestShortestPathRev(t *testing.T) {
 	require.JSONEq(t,
 		`{"data": {"_path_":[{"uid":"0x17","_weight_":1, "friend":{"uid":"0x1"}}],"me":[{"name":"Rick Grimes"},{"name":"Michonne"}]}}`,
 		js)
+}
+
+// Regression test for https://github.com/dgraph-io/dgraph/issues/3657.
+func TestShortestPathPassword(t *testing.T) {
+	query := `
+		{
+			A as shortest(from:0x01, to:31) {
+				password
+				friend
+			}
+
+			me(func: uid( A)) {
+				name
+			}
+		}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"_path_":[{"uid":"0x1", "_weight_": 1, "friend":{"uid":"0x1f"}}],
+			"me":[{"name":"Michonne"},{"name":"Andrea"}]}}`, js)
 }
 
 func TestFacetVarRetrieval(t *testing.T) {

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -185,7 +185,7 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 				for mIdx, fromUID := range subgraph.SrcUIDs.Uids {
 					// This can happen when trying to go traverse a predicate of type password
 					// for example.
-					if len(subgraph.uidMatrix) < mIdx+1 {
+					if mIdx >= len(subgraph.uidMatrix) {
 						continue
 					}
 

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -183,6 +183,12 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 
 				// Send the destuids in res chan.
 				for mIdx, fromUID := range subgraph.SrcUIDs.Uids {
+					// This can happen when trying to go traverse a predicate of type password
+					// for example.
+					if len(subgraph.uidMatrix) < mIdx+1 {
+						continue
+					}
+
 					for lIdx, toUID := range subgraph.uidMatrix[mIdx].Uids {
 						if adjacencyMap[fromUID] == nil {
 							adjacencyMap[fromUID] = make(map[uint64]mapItem)


### PR DESCRIPTION
The crash happens because querying this predicate does not populate the
uid matrix, resulting in an out-of-index error. This fix just checks the
size of the uid matrix before trying to access it.

Fixes #3657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3662)
<!-- Reviewable:end -->
