### PR TITLE
[Cherry-pick into 1.0 branch] Return error instead of asserting in handleCompareFunction.

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -976,8 +976,10 @@ func (qs *queryState) handleRegexFunction(ctx context.Context, arg funcArgs) err
 func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) error {
 	attr := arg.q.Attr
 	tokenizer, err := pickTokenizer(attr, arg.srcFn.fname)
-	// We should already have checked this in getInequalityTokens.
-	x.Check(err)
+	if err != nil {
+		return err
+	}
+
 	// Only if the tokenizer that we used IsLossy, then we need to fetch
 	// and compare the actual values.
 	if tokenizer.IsLossy() {


### PR DESCRIPTION
The assumption is not actually true since a DropAll can happen after the
first index check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3665)
<!-- Reviewable:end -->
