### PR TITLE
Adding the feature to allow an alpha go into lame duck mode

### DIFF
--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"strconv"
-	"sync/atomic"
 
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/posting"
@@ -60,13 +59,7 @@ func drainingHandler(w http.ResponseWriter, r *http.Request) {
 				"Found invalid value for the enable parameter")
 		}
 
-		var ldMode int32
-		if enable {
-			ldMode = 1
-		} else {
-			ldMode = 0
-		}
-		atomic.StoreInt32(&edgraph.State.DrainingMode, ldMode)
+		x.UpdateDrainingMode(enable)
 		x.Check2(w.Write([]byte(fmt.Sprintf(`{"code": "Success",`+
 			`"message": "draining mode has been set to %v"}`, enable))))
 	default:

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -388,6 +388,7 @@ func setupServer() {
 	http.HandleFunc("/debug/store", storeStatsHandler)
 
 	http.HandleFunc("/admin/shutdown", shutDownHandler)
+	http.HandleFunc("/admin/lame", lameHandler)
 	http.HandleFunc("/admin/export", exportHandler)
 	http.HandleFunc("/admin/config/lru_mb", memoryLimitHandler)
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -30,7 +30,6 @@ import (
 	"os/signal"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -276,6 +275,7 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
 	if err := x.HealthCheck(); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 
@@ -283,12 +283,12 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 		Version      string        `json:"version"`
 		Instance     string        `json:"instance"`
 		Uptime       time.Duration `json:"uptime"`
-		DrainingMode bool          `json:drainingMode`
+		DrainingMode bool          `json:"drainingMode"`
 	}{
 		Version:      x.Version(),
 		Instance:     "alpha",
 		Uptime:       time.Since(beginTime),
-		DrainingMode: atomic.LoadInt32(&edgraph.State.DrainingMode) == 1,
+		DrainingMode: x.DrainingMode(),
 	}
 	data, _ := json.Marshal(info)
 

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -32,7 +32,7 @@ import (
 // since ACL is only supported in the enterprise version.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
-	if err := checkLDMode(); err != nil {
+	if err := checkDrainingMode(); err != nil {
 		return nil, err
 	}
 

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -32,6 +32,9 @@ import (
 // since ACL is only supported in the enterprise version.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
 
 	glog.Warningf("Login failed: %s", x.ErrNotSupported)
 	return &api.Response{}, x.ErrNotSupported

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -40,6 +40,10 @@ import (
 // Login handles login requests from clients.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
+
 	ctx, span := otrace.StartSpan(ctx, "server.Login")
 	defer span.End()
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -40,7 +40,7 @@ import (
 // Login handles login requests from clients.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
-	if err := checkLDMode(); err != nil {
+	if err := checkDrainingMode(); err != nil {
 		return nil, err
 	}
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -73,6 +74,11 @@ type ServerState struct {
 	mandatoryVlogTicker *time.Ticker // runs every 10m, we always run vlog GC.
 
 	needTs chan tsReq
+
+	// the LameDuckMode variable should be accessed through the atomic.Store and atomic.Load
+	// functions. The value 0 means the lame-duck-mode is disabled, and the value 1 means the
+	// mode is enabled
+	LameDuckMode int32
 }
 
 // State is the instance of ServerState used by the current server.
@@ -274,8 +280,24 @@ func (s *ServerState) getTimestamp(readOnly bool) uint64 {
 	return <-tr.ch
 }
 
+// checkLDMode checks if the State.LameDuckMode is enabled
+// if so, it will return an error indicating that any request from the client
+// should be denied
+func checkLDMode() error {
+	ldMode := atomic.LoadInt32(&State.LameDuckMode)
+	if ldMode == 1 {
+		return fmt.Errorf("the server is in lame duck mode, " +
+			"and hence client requests are not allowed")
+	}
+	return nil
+}
+
 // Alter handles requests to change the schema or remove parts or all of the data.
 func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
+
 	ctx, span := otrace.StartSpan(ctx, "Server.Alter")
 	defer span.End()
 	span.Annotatef(nil, "Alter operation: %+v", op)
@@ -421,6 +443,9 @@ func annotateStartTs(span *otrace.Span, ts uint64) {
 
 // Mutate handles requests to perform mutations.
 func (s *Server) Mutate(ctx context.Context, mu *api.Mutation) (*api.Assigned, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
 	return s.doMutate(ctx, mu, true)
 }
 
@@ -686,6 +711,9 @@ func updateMutations(gmu *gql.Mutation, varToUID map[string]string) {
 
 // Query handles queries and returns the data.
 func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
 	if err := authorizeQuery(ctx, req); err != nil {
 		return nil, err
 	}
@@ -825,6 +853,9 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Respo
 
 // CommitOrAbort commits or aborts a transaction.
 func (s *Server) CommitOrAbort(ctx context.Context, tc *api.TxnContext) (*api.TxnContext, error) {
+	if err := checkLDMode(); err != nil {
+		return nil, err
+	}
 	ctx, span := otrace.StartSpan(ctx, "Server.CommitOrAbort")
 	defer span.End()
 

--- a/x/health.go
+++ b/x/health.go
@@ -23,13 +23,30 @@ import (
 )
 
 var (
-	healthCheck uint32
-	errHealth   = errors.New("Please retry again, server is not ready to accept requests")
+	// the drainingMode variable should be accessed through the atomic.Store and atomic.Load
+	// functions. The value 0 means the draining-mode is disabled, and the value 1 means the
+	// mode is enabled
+	drainingMode uint32
+
+	healthCheck     uint32
+	errHealth       = errors.New("Please retry again, server is not ready to accept requests")
+	ErrDrainingMode = errors.New("the server is in draining mode, " +
+		"and client requests will only be allowed after exiting the mode " +
+		" by sending a POST request to /admin/draining?enable=false")
 )
 
 // UpdateHealthStatus updates the server's health status so it can start accepting requests.
 func UpdateHealthStatus(ok bool) {
 	setStatus(&healthCheck, ok)
+}
+
+// UpdateDrainingMode updates the server's draining mode
+func UpdateDrainingMode(enable bool) {
+	setStatus(&drainingMode, enable)
+}
+
+func DrainingMode() bool {
+	return atomic.LoadUint32(&drainingMode) == 1
 }
 
 // HealthCheck returns whether the server is ready to accept requests or not
@@ -38,6 +55,9 @@ func UpdateHealthStatus(ok bool) {
 func HealthCheck() error {
 	if atomic.LoadUint32(&healthCheck) == 0 {
 		return errHealth
+	}
+	if DrainingMode() {
+		return ErrDrainingMode
 	}
 	return nil
 }


### PR DESCRIPTION
In the lame duck mode, the alpha server will reject all requests from the client.
This feature will be useful during a restore operation, or a point-in-time-recovery while the cluster is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3666)
<!-- Reviewable:end -->
