### PR TITLE
Workaround for issue #3642.

### DIFF
--- a/query/groupby.go
+++ b/query/groupby.go
@@ -221,7 +221,12 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 				if algo.IndexOf(ul, srcUid) < 0 {
 					continue
 				}
+
 				ul := child.uidMatrix[i]
+				// Workaround for issue #3642.
+				if ul == nil  {
+					continue
+				}
 				for _, uid := range ul.Uids {
 					dedupMap.addValue(attr, types.Val{Tid: types.UidID, Value: uid}, srcUid)
 				}

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -223,11 +223,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 				}
 
 				ul := child.uidMatrix[i]
-				// Workaround for issue #3642.
-				if ul == nil {
-					continue
-				}
-				for _, uid := range ul.Uids {
+				for _, uid := range ul.GetUids() {
 					dedupMap.addValue(attr, types.Val{Tid: types.UidID, Value: uid}, srcUid)
 				}
 			}

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -224,7 +224,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 
 				ul := child.uidMatrix[i]
 				// Workaround for issue #3642.
-				if ul == nil  {
+				if ul == nil {
 					continue
 				}
 				for _, uid := range ul.Uids {


### PR DESCRIPTION
For some reason, there are nil values stored in the uidMatrix, which
results in a segmentation fault when trying to access the Uids field.
The root cause of this issue is still unclear but this change adds an
additional check to prevent the segmentation fault.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3670)
<!-- Reviewable:end -->
