### PR TITLE
Clarify that support for certain geo types refers only to indexing.

### DIFF
--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -474,9 +474,10 @@ _:blank-0 <rating> "è buono"@it .
 
 ### Geolocation support
 
-Support for geo-location data is available in JSON. Geo-location data is entered
+Support for geolocation data is available in JSON. Geo-location data is entered
 as a JSON object with keys "type" and "coordinates". Keep in mind we only
-support the Point, Polygon, and MultiPolygon types. Below is an example:
+support indexing on the Point, Polygon, and MultiPolygon types, but we can store
+other types of geolocation data. Below is an example:
 
 ```
 {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -740,7 +740,7 @@ Query Example: First five directors and all their movies that have a release dat
 
 ### Geolocation
 
-{{% notice "note" %}} As of now we only support indexing Point, Polygon and MultiPolygon [geometry types](https://github.com/twpayne/go-geom#geometry-types).{{% /notice %}}
+{{% notice "note" %}} As of now we only support indexing Point, Polygon and MultiPolygon [geometry types](https://github.com/twpayne/go-geom#geometry-types). However, Dgraph can store other types of gelocation data. {{% /notice %}}
 
 Note that for geo queries, any polygon with holes is replace with the outer loop, ignoring holes.  Also, as for version 0.7.7 polygon containment checks are approximate.
 


### PR DESCRIPTION
Dgraph is able to store any kind of valid geodata, but will only index
Point, Polygon, and MultiPolygon data.

Fixes #3675

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3676)
<!-- Reviewable:end -->
