### PR TITLE
Increase Alpha trace logs.

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -517,7 +517,7 @@ func run() {
 	}
 	otrace.ApplyConfig(otrace.Config{
 		DefaultSampler:             otrace.ProbabilitySampler(x.WorkerConfig.Tracing),
-		MaxAnnotationEventsPerSpan: 64,
+		MaxAnnotationEventsPerSpan: 256,
 	})
 
 	// Posting will initialize index which requires schema. Hence, initialize


### PR DESCRIPTION
This change bumps up the number of logs per span to capture all the events from Server.Query instead of getting truncated logs in the trace data of up to 64 of the latest annotations.

When I load the 21-million movie data set and run a query to get all the movies directed by Steven Spielberg, Jaeger shows 232 logs for the query. With this change, the logs would be truncated if there are more than 256 annotations in a single span, leaving us to the same problem of possibly losing valuable info for a query trace.

```
{
  director(func: allofterms(name@en, "steven spielberg")) {
    name@en
    director.film {
      name@en
      initial_release_date
      country {
        name@en
      }
      starring {
        performance.actor {
          name@en
        }
        performance.character {
          name@en
        }
      }
      genre {
        name@en
      }
    }
  }
}
```

![image](https://user-images.githubusercontent.com/2251820/61339794-4996f700-a7f4-11e9-8c55-46c809e328b1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3679)
<!-- Reviewable:end -->
