### PR TITLE
Run bulk loader existence check on individual files

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -134,10 +134,16 @@ func run() {
 	if opt.DataFiles == "" {
 		fmt.Fprint(os.Stderr, "RDF or JSON file(s) location must be specified.\n")
 		os.Exit(1)
-	} else if _, err := os.Stat(opt.DataFiles); err != nil && os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Data path(%v) does not exist.\n", opt.DataFiles)
-		os.Exit(1)
+	} else {
+		fileList := strings.Split(opt.DataFiles, ",")
+		for _, file := range fileList {
+			if _, err := os.Stat(file); err != nil && os.IsNotExist(err) {
+				fmt.Fprintf(os.Stderr, "Data path(%v) does not exist.\n", file)
+				os.Exit(1)
+			}
+		}
 	}
+
 	if opt.ReduceShards > opt.MapShards {
 		fmt.Fprintf(os.Stderr, "Invalid flags: reduce_shards(%d) should be <= map_shards(%d)\n",
 			opt.ReduceShards, opt.MapShards)


### PR DESCRIPTION
When multiple files are provided to the bulk loader, e.g. dgraph bulk -f a.rdf.gz,b.rdf.gz
we should check whether each individual file exists, instead of checking existence for the whole argument "a.rdf.gz,b.rdf.gz"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3681)
<!-- Reviewable:end -->
