### PR TITLE
Fix how enconding_ns is calculated.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -787,6 +787,8 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Respo
 	if er, err = queryRequest.Process(ctx); err != nil {
 		return resp, errors.Wrap(err, "")
 	}
+	l.Transport = time.Since(l.Start) - l.Parsing - l.Processing
+
 	var js []byte
 	if len(er.SchemaNode) > 0 || len(er.Types) > 0 {
 		sort.Slice(er.SchemaNode, func(i, j int) bool {
@@ -813,6 +815,8 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request) (resp *api.Respo
 	resp.Json = js
 	span.Annotatef(nil, "Response = %s", js)
 
+	// TODO(martinmr): Include Transport as part of the latency. Need to do this separately
+	// since it involves modifying the API protos.
 	gl := &api.Latency{
 		ParsingNs:    uint64(l.Parsing.Nanoseconds()),
 		ProcessingNs: uint64(l.Processing.Nanoseconds()),

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -495,7 +495,7 @@ type Extensions struct {
 
 func (sg *SubGraph) toFastJSON(l *Latency) ([]byte, error) {
 	defer func() {
-		l.Json = time.Since(l.Start) - l.Parsing - l.Processing
+		l.Json = time.Since(l.Start) - l.Parsing - l.Processing - l.Transport
 	}()
 
 	var seedNode *fastJsonNode

--- a/query/query.go
+++ b/query/query.go
@@ -107,6 +107,7 @@ type Latency struct {
 	Start      time.Time     `json:"-"`
 	Parsing    time.Duration `json:"query_parsing"`
 	Processing time.Duration `json:"processing"`
+	Transport  time.Duration `json:"transport"`
 	Json       time.Duration `json:"json_conversion"`
 }
 


### PR DESCRIPTION
Currently, the time taken to receive the query response is included as
part of the encoding time. This PR fixes that calculation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3692)
<!-- Reviewable:end -->
