### PR TITLE
Don't read posting lists from disk when mutating indices.

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -113,7 +113,7 @@ func (txn *Txn) addIndexMutation(ctx context.Context, edge *pb.DirectedEdge,
 	token string) error {
 	key := x.IndexKey(edge.Attr, token)
 
-	plist, err := txn.Get(key)
+	plist, err := txn.GetFromDelta(key)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 
 func (txn *Txn) addReverseMutation(ctx context.Context, t *pb.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
-	plist, err := txn.Get(key)
+	plist, err := txn.GetFromDelta(key)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (l *List) handleDeleteAll(ctx context.Context, edge *pb.DirectedEdge,
 func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count uint32,
 	reverse bool) error {
 	key := x.CountKey(t.Attr, count, reverse)
-	plist, err := txn.Get(key)
+	plist, err := txn.GetFromDelta(key)
 	if err != nil {
 		return err
 	}
@@ -937,7 +937,7 @@ func rebuildListType(ctx context.Context, rb *IndexRebuild) error {
 
 		// Ensure that list is in the cache run by txn. Otherwise, nothing would
 		// get updated.
-		txn.cache.Set(string(pl.key), pl)
+		pl = txn.cache.Set(string(pl.key), pl)
 		if err := pl.addMutation(ctx, txn, t); err != nil {
 			return err
 		}

--- a/posting/index.go
+++ b/posting/index.go
@@ -486,7 +486,7 @@ type rebuild struct {
 
 	// The posting list passed here is the on disk version. It is not coming
 	// from the LRU cache.
-	fn func(uid uint64, pl *List, txn *Txn) error
+	fn func(uid uint64, itr *badger.Iterator, txn *Txn) error
 }
 
 func (r *rebuild) Run(ctx context.Context) error {
@@ -513,13 +513,7 @@ func (r *rebuild) Run(ctx context.Context) error {
 			return nil, errors.Errorf("could not parse key %s", hex.Dump(key))
 		}
 
-		item := itr.Item()
-		keyCopy := item.KeyCopy(nil)
-		l, err := ReadPostingList(keyCopy, itr)
-		if err != nil {
-			return nil, err
-		}
-		if err := r.fn(pk.Uid, l, txn); err != nil {
+		if err := r.fn(pk.Uid, itr, txn); err != nil {
 			return nil, err
 		}
 
@@ -703,7 +697,12 @@ func rebuildIndex(ctx context.Context, rb *IndexRebuild) error {
 
 	pk := x.ParsedKey{Attr: rb.Attr}
 	builder := rebuild{prefix: pk.DataPrefix(), startTs: rb.StartTs}
-	builder.fn = func(uid uint64, pl *List, txn *Txn) error {
+	builder.fn = func(uid uint64, itr *badger.Iterator, txn *Txn) error {
+		pl, err := getPostingList(itr, txn)
+		if err != nil {
+			return err
+		}
+
 		edge := pb.DirectedEdge{Attr: rb.Attr, Entity: uid}
 		return pl.Iterate(txn.StartTs, 0, func(p *pb.Posting) error {
 			// Add index entries based on p.
@@ -775,7 +774,12 @@ func rebuildCountIndex(ctx context.Context, rb *IndexRebuild) error {
 
 	glog.Infof("Rebuilding count index for %s", rb.Attr)
 	var reverse bool
-	fn := func(uid uint64, pl *List, txn *Txn) error {
+	fn := func(uid uint64, itr *badger.Iterator, txn *Txn) error {
+		pl, err := getPostingList(itr, txn)
+		if err != nil {
+			return err
+		}
+
 		t := &pb.DirectedEdge{
 			ValueId: uid,
 			Attr:    rb.Attr,
@@ -860,7 +864,12 @@ func rebuildReverseEdges(ctx context.Context, rb *IndexRebuild) error {
 	glog.Infof("Rebuilding reverse index for %s", rb.Attr)
 	pk := x.ParsedKey{Attr: rb.Attr}
 	builder := rebuild{prefix: pk.DataPrefix(), startTs: rb.StartTs}
-	builder.fn = func(uid uint64, pl *List, txn *Txn) error {
+	builder.fn = func(uid uint64, itr *badger.Iterator, txn *Txn) error {
+		pl, err := getPostingList(itr, txn)
+		if err != nil {
+			return err
+		}
+
 		edge := pb.DirectedEdge{Attr: rb.Attr, Entity: uid}
 		return pl.Iterate(txn.StartTs, 0, func(pp *pb.Posting) error {
 			puid := pp.Uid
@@ -912,9 +921,14 @@ func rebuildListType(ctx context.Context, rb *IndexRebuild) error {
 
 	pk := x.ParsedKey{Attr: rb.Attr}
 	builder := rebuild{prefix: pk.DataPrefix(), startTs: rb.StartTs}
-	builder.fn = func(uid uint64, pl *List, txn *Txn) error {
+	builder.fn = func(uid uint64, itr *badger.Iterator, txn *Txn) error {
+		pl, err := getPostingList(itr, txn)
+		if err != nil {
+			return err
+		}
+
 		var mpost *pb.Posting
-		err := pl.Iterate(txn.StartTs, 0, func(p *pb.Posting) error {
+		err = pl.Iterate(txn.StartTs, 0, func(p *pb.Posting) error {
 			// We only want to modify the untagged value. There could be other values with a
 			// lang tag.
 			if p.Uid == math.MaxUint64 {
@@ -953,6 +967,27 @@ func rebuildListType(ctx context.Context, rb *IndexRebuild) error {
 		return pl.addMutation(ctx, txn, newEdge)
 	}
 	return builder.Run(ctx)
+}
+
+func getPostingList(itr *badger.Iterator, txn *Txn) (*List, error) {
+	item := itr.Item()
+	keyCopy := item.KeyCopy(nil)
+	keyString := string(keyCopy)
+	pl, err := txn.cache.Get(keyCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	if pl != nil {
+		return pl, nil
+	}
+
+	pl, err = ReadPostingList(keyCopy, itr)
+	if err != nil {
+		return nil, err
+	}
+	pl = txn.cache.Set(keyString, pl)
+	return pl, nil
 }
 
 // DeleteAll deletes all entries in the posting list.

--- a/posting/index.go
+++ b/posting/index.go
@@ -113,7 +113,7 @@ func (txn *Txn) addIndexMutation(ctx context.Context, edge *pb.DirectedEdge,
 	token string) error {
 	key := x.IndexKey(edge.Attr, token)
 
-	plist, err := txn.GetFromDelta(key)
+	plist, err := txn.cache.GetFromDelta(key)
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 
 func (txn *Txn) addReverseMutation(ctx context.Context, t *pb.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
-	plist, err := txn.GetFromDelta(key)
+	plist, err := txn.cache.GetFromDelta(key)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func (l *List) handleDeleteAll(ctx context.Context, edge *pb.DirectedEdge,
 func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count uint32,
 	reverse bool) error {
 	key := x.CountKey(t.Attr, count, reverse)
-	plist, err := txn.GetFromDelta(key)
+	plist, err := txn.cache.GetFromDelta(key)
 	if err != nil {
 		return err
 	}

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -77,13 +77,6 @@ func (txn *Txn) Get(key []byte) (*List, error) {
 	return txn.cache.Get(key)
 }
 
-// GetFromDelta retrieves the posting list for the given list from the local cache.
-// If there's a cache miss, the posting list stored on disk will not be read.
-// See documentation for LocalCache.GetFromDelta for more info.
-func (txn *Txn) GetFromDelta(key []byte) (*List, error) {
-	return txn.cache.GetFromDelta(key)
-}
-
 // Update calls UpdateDeltasAndDiscardLists on the local cache.
 func (txn *Txn) Update() {
 	txn.cache.UpdateDeltasAndDiscardLists()

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -77,6 +77,13 @@ func (txn *Txn) Get(key []byte) (*List, error) {
 	return txn.cache.Get(key)
 }
 
+// GetFromDelta retrieves the posting list for the given list from the local cache.
+// If there's a cache miss, the posting list stored on disk will not be read.
+// See documentation for LocalCache.GetFromDelta for more info.
+func (txn *Txn) GetFromDelta(key []byte) (*List, error) {
+	return txn.cache.GetFromDelta(key)
+}
+
 // Update calls UpdateDeltasAndDiscardLists on the local cache.
 func (txn *Txn) Update() {
 	txn.cache.UpdateDeltasAndDiscardLists()


### PR DESCRIPTION
Adding index mutations can be performed without reading the posting
lists in disk. This change modifies the indexing process to avoid
reading any list from disk. It should result in performance
improvements, specially when trying to modify big index posting lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3695)
<!-- Reviewable:end -->
