### PR TITLE
Fix error when exporting a predicate to the schema.

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -27,7 +27,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"

--- a/worker/export.go
+++ b/worker/export.go
@@ -88,20 +88,6 @@ var rdfTypeMap = map[types.TypeID]string{
 	types.PasswordID: "xs:password",
 }
 
-// Having '<' and '>' around all predicates makes the exported schema harder
-// for humans to look at, so only put them on predicates containing "exotic"
-// characters (i.e. ones not in this list).
-var predNonSpecialChars = unicode.RangeTable{
-	R16: []unicode.Range16{
-		// Ranges must be in order.
-		{'.', '.', 1},
-		{'0', '9', 1},
-		{'A', 'Z', 1},
-		{'_', '_', 1},
-		{'a', 'z', 1},
-	},
-}
-
 // UIDs like 0x1 look weird but 64-bit ones like 0x0000000000000001 are too long.
 var uidFmtStrRdf = "<0x%x>"
 var uidFmtStrJson = "\"0x%x\""
@@ -293,16 +279,9 @@ func (e *exporter) toRDF() (*bpb.KVList, error) {
 func toSchema(attr string, update pb.SchemaUpdate) (*bpb.KVList, error) {
 	// bytes.Buffer never returns error for any of the writes. So, we don't need to check them.
 	var buf bytes.Buffer
-	isSpecial := func(r rune) bool {
-		return !(unicode.In(r, &predNonSpecialChars))
-	}
-	if strings.IndexFunc(attr, isSpecial) >= 0 {
-		buf.WriteRune('<')
-		buf.WriteString(attr)
-		buf.WriteRune('>')
-	} else {
-		buf.WriteString(attr)
-	}
+	buf.WriteRune('<')
+	buf.WriteString(attr)
+	buf.WriteRune('>')
 	buf.WriteByte(':')
 	if update.List {
 		buf.WriteRune('[')

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -370,7 +370,7 @@ func TestToSchema(t *testing.T) {
 					Lang:      true,
 				},
 			},
-			expected: "Alice:string @reverse @count @lang @upsert . \n",
+			expected: "<Alice>:string @reverse @count @lang @upsert . \n",
 		},
 		{
 			skv: &skv{
@@ -445,7 +445,7 @@ func TestToSchema(t *testing.T) {
 					Lang:      true,
 				},
 			},
-			expected: "data_base:string @lang . \n",
+			expected: "<data_base>:string @lang . \n",
 		},
 		{
 			skv: &skv{
@@ -460,7 +460,7 @@ func TestToSchema(t *testing.T) {
 					Lang:      true,
 				},
 			},
-			expected: "data.base:string @lang . \n",
+			expected: "<data.base>:string @lang . \n",
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
The current logic only adds the '<' and '>' characters around the
predicate list if it has something other than numbers and letters.
However, this logic is faulty since a predicate consisting of only
numbers needs to have the surrounding brackets to be properly parsed.

This change removes that logic and adds the surrounding brackets to all
predicates for simplicity and correctness.

Fixes #3699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3700)
<!-- Reviewable:end -->
