### PR TITLE
[release/v1.0] Fix bug when exporting a predicate name to the schema.

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -156,13 +156,9 @@ func toRDF(pl *posting.List, prefix string, readTs uint64) (*bpb.KVList, error) 
 func toSchema(attr string, update pb.SchemaUpdate) (*bpb.KVList, error) {
 	// bytes.Buffer never returns error for any of the writes. So, we don't need to check them.
 	var buf bytes.Buffer
-	if strings.ContainsRune(attr, ':') {
-		buf.WriteRune('<')
-		buf.WriteString(attr)
-		buf.WriteRune('>')
-	} else {
-		buf.WriteString(attr)
-	}
+	buf.WriteRune('<')
+	buf.WriteString(attr)
+	buf.WriteRune('>')
 	buf.WriteByte(':')
 	if update.List {
 		buf.WriteRune('[')

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -262,7 +262,7 @@ func TestToSchema(t *testing.T) {
 					Lang:      true,
 				},
 			},
-			expected: "Alice:string @reverse @count @lang @upsert . \n",
+			expected: "<Alice>:string @reverse @count @lang @upsert . \n",
 		},
 		{
 			skv: &skv{


### PR DESCRIPTION
This change is fixing #3699 for the 1.0 branch. The logic in this branch
was slightly different. In this case, the brackets are only added if
there's a colon in the predicate name. This logic is also buggy as it
doesn't handle predicate names consisting of only numbers.

The fix is to add the brackets for every predicate name for consistency
and simplicity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3701)
<!-- Reviewable:end -->
