### PR TITLE
In backup tests, check the number of manifests equals number of dirs.

### DIFF
--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -219,14 +219,21 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs()
+
 	files := x.WalkPathFunc(copyBackupDir, func(path string, isdir bool) bool {
 		return !isdir && strings.HasSuffix(path, ".backup")
 	})
-	require.True(t, len(files) == numExpectedFiles)
+	require.Equal(t, numExpectedFiles, len(files))
+
 	dirs := x.WalkPathFunc(copyBackupDir, func(path string, isdir bool) bool {
 		return isdir && strings.HasPrefix(path, "data/backups_copy/dgraph.")
 	})
-	require.True(t, len(dirs) == numExpectedDirs)
+	require.Equal(t, numExpectedDirs, len(dirs))
+
+	manifests := x.WalkPathFunc(copyBackupDir, func(path string, isdir bool) bool {
+		return !isdir && strings.Contains(path, "manifest.json")
+	})
+	require.Equal(t, numExpectedDirs, len(manifests))
 
 	return dirs
 }

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -225,14 +225,21 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs(t)
+
 	files := x.WalkPathFunc(backupDir, func(path string, isdir bool) bool {
 		return !isdir && strings.HasSuffix(path, ".backup")
 	})
-	require.True(t, len(files) == numExpectedFiles)
+	require.Equal(t, numExpectedFiles, len(files))
+
 	dirs := x.WalkPathFunc(backupDir, func(path string, isdir bool) bool {
 		return isdir && strings.HasPrefix(path, "data/backups/dgraph.")
 	})
-	require.True(t, len(dirs) == numExpectedDirs)
+	require.Equal(t, numExpectedDirs, len(dirs))
+
+	manifests := x.WalkPathFunc(backupDir, func(path string, isdir bool) bool {
+		return !isdir && strings.Contains(path, "manifest.json")
+	})
+	require.Equal(t, numExpectedDirs, len(manifests))
 
 	return dirs
 }


### PR DESCRIPTION
The filesystem backup tests are a bit flaky in TeamCity. As a first
step, this change adds verification that the number of manifests equals
the number of expected backup directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3706)
<!-- Reviewable:end -->
