### PR TITLE
adding the draining mode

### DIFF
--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -46,6 +46,27 @@ func handlerInit(w http.ResponseWriter, r *http.Request, method string) bool {
 	return true
 }
 
+func drainingHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPut:
+		fallthrough
+	case http.MethodPost:
+		enableStr := r.URL.Query().Get("enable")
+
+		enable, err := strconv.ParseBool(enableStr)
+		if err != nil {
+			x.SetStatus(w, x.ErrorInvalidRequest,
+				"Found invalid value for the enable parameter")
+		}
+
+		x.UpdateDrainingMode(enable)
+		x.Check2(w.Write([]byte(fmt.Sprintf(`{"code": "Success",`+
+			`"message": "draining mode has been set to %v"}`, enable))))
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}
+}
+
 func shutDownHandler(w http.ResponseWriter, r *http.Request) {
 	if !handlerInit(w, r, http.MethodGet) {
 		return

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -440,13 +440,11 @@ func handleCommitOrAbort(startTs uint64, reqText []byte, abort bool) (map[string
 	}
 
 	var reqMap map[string][]string
-	if err := json.Unmarshal(reqText, &reqMap); err != nil && !useList {
-		return nil, err
-	}
+	err := json.Unmarshal(reqText, &reqMap)
 
 	if useList {
 		tc.Keys = reqList
-	} else {
+	} else if err != nil {
 		tc.Keys = reqMap["keys"]
 		tc.Preds = reqMap["preds"]
 	}

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -275,6 +275,7 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
 	if err := x.HealthCheck(); err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 
@@ -388,6 +389,7 @@ func setupServer() {
 	http.HandleFunc("/debug/store", storeStatsHandler)
 
 	http.HandleFunc("/admin/shutdown", shutDownHandler)
+	http.HandleFunc("/admin/draining", drainingHandler)
 	http.HandleFunc("/admin/export", exportHandler)
 	http.HandleFunc("/admin/config/lru_mb", memoryLimitHandler)
 

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -32,6 +32,9 @@ import (
 // since ACL is only supported in the enterprise version.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
+	if err := x.HealthCheck(); err != nil {
+		return nil, err
+	}
 
 	glog.Warningf("Login failed: %s", x.ErrNotSupported)
 	return &api.Response{}, x.ErrNotSupported

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -40,6 +40,10 @@ import (
 // Login handles login requests from clients.
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
+	if err := x.HealthCheck(); err != nil {
+		return nil, err
+	}
+
 	ctx, span := otrace.StartSpan(ctx, "server.Login")
 	defer span.End()
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -848,8 +848,8 @@ func (s *Server) CommitOrAbort(ctx context.Context, tc *api.TxnContext) (*api.Tx
 	if err == y.ErrAborted {
 		tctx.Aborted = true
 		if tc.Aborted {
-			// if the intention is to abort the transaction,
-			// then we should treat the y.ErrAborted not as an error
+			// If the intention is to abort the transaction,
+			// then we should treat the y.ErrAborted not as an error.
 			return tctx, nil
 		}
 		return tctx, status.Errorf(codes.Aborted, err.Error())

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -847,6 +847,11 @@ func (s *Server) CommitOrAbort(ctx context.Context, tc *api.TxnContext) (*api.Tx
 	commitTs, err := worker.CommitOverNetwork(ctx, tc)
 	if err == y.ErrAborted {
 		tctx.Aborted = true
+		if tc.Aborted {
+			// if the intention is to abort the transaction,
+			// then we should treat the y.ErrAborted not as an error
+			return tctx, nil
+		}
 		return tctx, status.Errorf(codes.Aborted, err.Error())
 	}
 	tctx.StartTs = tc.StartTs

--- a/x/health.go
+++ b/x/health.go
@@ -23,13 +23,26 @@ import (
 )
 
 var (
-	healthCheck uint32
-	errHealth   = errors.New("Please retry again, server is not ready to accept requests")
+	// the drainingMode variable should be accessed through the atomic.Store and atomic.Load
+	// functions. The value 0 means the draining-mode is disabled, and the value 1 means the
+	// mode is enabled
+	drainingMode uint32
+
+	healthCheck     uint32
+	errHealth       = errors.New("Please retry again, server is not ready to accept requests")
+	errDrainingMode = errors.New("the server is in draining mode, " +
+		"and client requests will only be allowed after exiting the mode " +
+		" by sending a POST request to /admin/draining?enable=false")
 )
 
 // UpdateHealthStatus updates the server's health status so it can start accepting requests.
 func UpdateHealthStatus(ok bool) {
 	setStatus(&healthCheck, ok)
+}
+
+// UpdateDrainingMode updates the server's draining mode
+func UpdateDrainingMode(enable bool) {
+	setStatus(&drainingMode, enable)
 }
 
 // HealthCheck returns whether the server is ready to accept requests or not
@@ -38,6 +51,9 @@ func UpdateHealthStatus(ok bool) {
 func HealthCheck() error {
 	if atomic.LoadUint32(&healthCheck) == 0 {
 		return errHealth
+	}
+	if atomic.LoadUint32(&drainingMode) == 1 {
+		return errDrainingMode
 	}
 	return nil
 }


### PR DESCRIPTION
The draining mode is used to disable all requests from the user, which can be useful during online restore or point-in-time-recovery.

Besides, this PR also refactored the implementation of the http /commit endpoint to call the Server.CommitOrAbort method, which already has the health check logic built in.