### PR TITLE
Decrease rate of Raft heartbeat messages.

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -89,8 +89,8 @@ func NewNode(rc *pb.RaftContext, store *raftwal.DiskStorage) *Node {
 		Store:  store,
 		Cfg: &raft.Config{
 			ID:                       rc.Id,
-			ElectionTick:             100, // 2s if we call Tick() every 20 ms.
-			HeartbeatTick:            1,   // 20ms if we call Tick() every 20 ms.
+			ElectionTick:             20, // 2s if we call Tick() every 100 ms.
+			HeartbeatTick:            1,  // 100ms if we call Tick() every 100 ms.
 			Storage:                  store,
 			MaxInflightMsgs:          256,
 			MaxSizePerMsg:            256 << 10, // 256 KB should allow more batching.

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -727,7 +727,7 @@ func (n *node) Run() {
 	firstRun := true
 	var leader bool
 	// See also our configuration of HeartbeatTick and ElectionTick.
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
 	done := make(chan struct{})

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -727,6 +727,10 @@ func (n *node) Run() {
 	firstRun := true
 	var leader bool
 	// See also our configuration of HeartbeatTick and ElectionTick.
+	// Before we used to have 20ms ticks, but they would overload the Raft tick channel, causing
+	// "tick missed to fire" logs. Etcd uses 100ms and they haven't seen those issues.
+	// Additionally, using 100ms for ticks does not cause proposals to slow down, because they get
+	// sent out asap and don't rely on ticks. So, setting this to 100ms instead of 20ms is a NOOP.
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -727,7 +727,7 @@ func (n *node) Run() {
 	firstRun := true
 	var leader bool
 	// See also our configuration of HeartbeatTick and ElectionTick.
-	ticker := time.NewTicker(20 * time.Millisecond)
+	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
 	done := make(chan struct{})
@@ -757,6 +757,7 @@ func (n *node) Run() {
 			// start an election process. And that election process would just continue to happen
 			// indefinitely because checkpoints and snapshots are being calculated indefinitely.
 		case <-ticker.C:
+			glog.Infof("Called n.Raft().Tick().\n")
 			n.Raft().Tick()
 
 		case rd := <-n.Raft().Ready():

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -757,7 +757,6 @@ func (n *node) Run() {
 			// start an election process. And that election process would just continue to happen
 			// indefinitely because checkpoints and snapshots are being calculated indefinitely.
 		case <-ticker.C:
-			glog.Infof("Called n.Raft().Tick().\n")
 			n.Raft().Tick()
 
 		case rd := <-n.Raft().Ready():


### PR DESCRIPTION
Setting Raft's HeartbeatTick to 100ms to reduce the number of heartbeats that need to be sent. This changes how often heartbeats are sent but does not affect the time needed for a leader election to occur if the leader is in a network partition (= 100ms * 20 = 2 seconds).

Notes on when leader re-election happens:

- The followers of the group will need to wait for the election tick duration if the leader is (1) in a network partition or (2) forcibly killed (SIGKILL).
- If the leader stops gracefully (SIGTERM) then a follower will receive a timeout message from the leader and immediately start an election, as shown in these logs from Node 0x2 where Node 0x1 was a leader and was stopped with SIGTERM:

```
I0723 01:03:15.444784       1 raft_server.go:233] RaftComm: [0x2] Received msg of type: MsgTimeoutNow from 0x1
I0723 01:03:15.444864       1 log.go:34] 2 [term 8] received MsgTimeoutNow from 1 and starts an election to get leadership.
I0723 01:03:15.444890       1 log.go:34] 2 became candidate at term 9
I0723 01:03:15.444898       1 log.go:34] 2 received MsgVoteResp from 2 at term 9
I0723 01:03:15.444974       1 log.go:34] 2 [logterm: 8, index: 3456] sent MsgVote request to 1 at term 9
I0723 01:03:15.445119       1 log.go:34] 2 [logterm: 8, index: 3456] sent MsgVote request to 3 at term 9
I0723 01:03:15.445199       1 log.go:34] raft.node: 2 lost leader 1 at term 9
I0723 01:03:15.447296       1 node.go:249] RaftComm: [0x2] Sending message of type MsgVote to 0x1
I0723 01:03:15.447372       1 node.go:249] RaftComm: [0x2] Sending message of type MsgVote to 0x3
I0723 01:03:15.450316       1 raft_server.go:233] RaftComm: [0x2] Received msg of type: MsgVoteResp from 0x1
I0723 01:03:15.450365       1 log.go:34] 2 received MsgVoteResp from 1 at term 9
I0723 01:03:15.450390       1 log.go:34] 2 [quorum:2] has received 2 MsgVoteResp votes and 0 vote rejections
I0723 01:03:15.450420       1 log.go:34] 2 became leader at term 9
I0723 01:03:15.450521       1 log.go:34] raft.node: 2 elected leader 2 at term 9
I0723 01:03:15.580813       1 groups.go:808] Leader idx=0x2 of group=1 is connecting to Zero for txn updates
I0723 01:03:15.580854       1 groups.go:817] Got Zero leader: zero1:5180
W0723 01:03:16.445513       1 pool.go:237] Connection lost with alpha1:7180. Error: rpc error: code = Unavailable desc = transport is closing
W0723 01:03:16.480873       1 node.go:415] Unable to send message to peer: 0x1. Error: EOF
I0723 01:03:17.453171       1 raft_server.go:233] RaftComm: [0x2] Received msg of type: MsgVoteResp from 0x3
```

These logs all happen within 1-2ms, but above we see that Node 0x2 starts an election at `I0723 01:03:15.444864` even before the log message that acknowledges that it lost leader 0x1 at `I0723 01:03:15.445199`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3708)
<!-- Reviewable:end -->
