### PR TITLE
Don't read data posting lists in certain cases

### DIFF
--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -77,6 +77,10 @@ func (txn *Txn) Get(key []byte) (*List, error) {
 	return txn.cache.Get(key)
 }
 
+func (txn *Txn) GetFromDelta(key []byte) (*List, error) {
+	return txn.cache.GetFromDelta(key)
+}
+
 // Update calls UpdateDeltasAndDiscardLists on the local cache.
 func (txn *Txn) Update() {
 	txn.cache.UpdateDeltasAndDiscardLists()

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -77,6 +77,7 @@ func (txn *Txn) Get(key []byte) (*List, error) {
 	return txn.cache.Get(key)
 }
 
+// GetFromDelta retrieves the posting list from delta cache, not from Badger.
 func (txn *Txn) GetFromDelta(key []byte) (*List, error) {
 	return txn.cache.GetFromDelta(key)
 }

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -90,8 +90,8 @@ func runMutation(ctx context.Context, edge *pb.DirectedEdge, txn *posting.Txn) e
 	case su.GetValueType() == pb.Posting_UID && !su.GetList():
 		// Single UID, not a list.
 		fn = txn.Get
-	case edge.Op == pb.DirectedEdge_DEL && string(edge.Value) == x.Star:
-		// Delete all. To keep things simple, don't worry about whether indexed or not.
+	case edge.Op == pb.DirectedEdge_DEL:
+		// Covers various delete cases to keep things simple.
 		fn = txn.Get
 	default:
 		// Reverse index doesn't need the posting list to be read. We already covered count index,

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -77,32 +77,32 @@ func runMutation(ctx context.Context, edge *pb.DirectedEdge, txn *posting.Txn) e
 
 	key := x.DataKey(edge.Attr, edge.Entity)
 	// The following is a performance optimization which allows us to not read a posting list from
-	// disk. We calculate this based on how AddMutationWithIndex works. General idea is that if
-	// we're not using the read posting list, we don't need to retrieve it. We need posting list if
-	// we're doing indexing or count index or enforcing single UID, etc. In other cases, we can just
-	// create a posting list facade in memory and use it to store the delta in Badger. Later, Rollup
-	// operation would consolidate all these deltas into a posting list.
-	var fn func(key []byte) (*posting.List, error)
+	// disk. We calculate this based on how AddMutationWithIndex works. The general idea is that if
+	// we're not using the read posting list, we don't need to retrieve it. We need the posting list
+	// if we're doing indexing or count index or enforcing single UID, etc. In other cases, we can
+	// just create a posting list facade in memory and use it to store the delta in Badger. Later,
+	// the rollup operation would consolidate all these deltas into a posting list.
+	var getFn func(key []byte) (*posting.List, error)
 	switch {
 	case len(su.GetTokenizer()) > 0 || su.GetCount():
 		// Any index or count index.
-		fn = txn.Get
+		getFn = txn.Get
 	case su.GetValueType() == pb.Posting_UID && !su.GetList():
 		// Single UID, not a list.
-		fn = txn.Get
+		getFn = txn.Get
 	case edge.Op == pb.DirectedEdge_DEL:
 		// Covers various delete cases to keep things simple.
-		fn = txn.Get
+		getFn = txn.Get
 	default:
 		// Reverse index doesn't need the posting list to be read. We already covered count index,
 		// single uid and delete all above.
-		// Values, whether single or list, don't need to read.
-		// Uid list doesn't need to read.
-		fn = txn.GetFromDelta
+		// Values, whether single or list, don't need to be read.
+		// Uid list doesn't need to be read.
+		getFn = txn.GetFromDelta
 	}
 
 	t := time.Now()
-	plist, err := fn(key)
+	plist, err := getFn(key)
 	if dur := time.Since(t); dur > time.Millisecond {
 		if span := otrace.FromContext(ctx); span != nil {
 			span.Annotatef([]otrace.Attribute{otrace.BoolAttribute("slow-get", true)},


### PR DESCRIPTION
To further #3695 , only read posting lists in certain cases. For e.g., when they are indexed, or when there's a delete operation or when it's a single UID predicate, etc. For the rest, don't read them. This further improves the performance of live data loading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3713)
<!-- Reviewable:end -->
