### PR TITLE
systest: Fix relative path in test-21million.sh.

### DIFF
--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -88,7 +88,7 @@ if [[ $LOADER != none ]]; then
     trap "rm -f $VERSION_FILE" EXIT
     curl -LSs --head $SCHEMA_URL | awk 'toupper($0)~/^ETAG:/ {print "Schema:"$2}' >> $VERSION_FILE
     curl -LSs --head $DATA_URL | awk 'toupper($0)~/^ETAG:/ {print "Data:"$2}' >> $VERSION_FILE
-    diff -bi $VERSION_FILE queries/data-version || true
+    diff -bi $VERSION_FILE $QUERY_DIR/data-version || true
 fi
 
 Info "entering directory $SRCDIR"


### PR DESCRIPTION
Use the $QUERY_DIR absolute path instead of the relative path for the queries
directory so that the test script can be run as

    ./systest/21million/test-21million.sh

instead of

    cd ./systest/21million
    ./test-21million.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3715)
<!-- Reviewable:end -->
