### PR TITLE
fix race condition in the test-21million.sh

### DIFF
--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -122,6 +122,9 @@ DockerCompose up -d --force-recreate alpha1
 
 Info "waiting for alpha to be ready"
 DockerCompose logs -f alpha1 | grep -q -m1 "Server is ready"
+# after the server prints the log "Server is ready", it may be still loading data from badger
+Info "sleeping for 10 seconds for the server to be ready"
+sleep 10
 
 if [[ $LOADER == live ]]; then
     Info "live loading data set"


### PR DESCRIPTION
In the test-21million.sh, after bulk loading finishes and starting alpha, it waits for the log message "Server is ready" from alpha, and then starts running queries to validate the result.

However, the alpha logs [alpha_logs.txt](https://github.com/dgraph-io/dgraph/files/3428358/alpha_logs.txt) show that after the log entry "Server is ready", the alpha server is still loading data from badger, and thus can give empty response to the queries. This is a race condition, and makes the test script flaky.

This PR tries to mitigate the problem by introducing an extra 10s delay after seeing the log message.
While this does not completely eliminate the root cause, it helps making the test pass on my local machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3719)
<!-- Reviewable:end -->
