### PR TITLE
Cherry-pick geo docs changes to release/v1.0

### DIFF
--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -344,6 +344,47 @@ to the key `blank-0`. You could specify your own key like
 In this case, the assigned uids map would have a key called `diggy` with the value being the uid
 assigned to it.
 
+### Language support
+
+An important difference between RDF and JSON mutations is in regards to specifying a string value's
+language. In JSON, the language tag is appended to the edge _name_, not the value like in RDF.
+
+For example, the JSON mutation
+```json
+{
+  "food": "taco",
+  "rating@en": "tastes good",
+  "rating@es": "sabe bien",
+  "rating@fr": "c'est bon",
+  "rating@it": "è buono"
+}
+```
+
+is equivalent to the following RDF:
+```
+_:blank-0 <food> "taco" .
+_:blank-0 <rating> "tastes good"@en .
+_:blank-0 <rating> "sabe bien"@es .
+_:blank-0 <rating> "c'est bon"@fr .
+_:blank-0 <rating> "è buono"@it .
+```
+
+### Geolocation support
+
+Support for geo-location data is available in JSON. Geo-location data is entered
+as a JSON object with keys "type" and "coordinates". Keep in mind we only
+support the Point, Polygon, and MultiPolygon types. Below is an example:
+
+```
+{
+  "food": "taco",
+  location: {
+    "type": "Point",
+    "coordinates": [1.0, 2.0]
+  }
+}
+```
+
 ### Referencing existing nodes
 
 If a JSON object contains a field named `"uid"`, then that field is interpreted

--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -371,9 +371,10 @@ _:blank-0 <rating> "è buono"@it .
 
 ### Geolocation support
 
-Support for geo-location data is available in JSON. Geo-location data is entered
+Support for geolocation data is available in JSON. Geo-location data is entered
 as a JSON object with keys "type" and "coordinates". Keep in mind we only
-support the Point, Polygon, and MultiPolygon types. Below is an example:
+support indexing on the Point, Polygon, and MultiPolygon types, but we can store
+other types of geolocation data. Below is an example:
 
 ```
 {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -704,7 +704,7 @@ Query Example: First five directors and all their movies that have a release dat
 
 ### Geolocation
 
-{{% notice "note" %}} As of now we only support indexing Point, Polygon and MultiPolygon [geometry types](https://github.com/twpayne/go-geom#geometry-types).{{% /notice %}}
+{{% notice "note" %}} As of now we only support indexing Point, Polygon and MultiPolygon [geometry types](https://github.com/twpayne/go-geom#geometry-types). However, Dgraph can store other types of gelocation data. {{% /notice %}}
 
 Note that for geo queries, any polygon with holes is replace with the outer loop, ignoring holes.  Also, as for version 0.7.7 polygon containment checks are approximate.
 


### PR DESCRIPTION
I realised there are some changes that were merged into 1.0.16 so that they show up in the docs but not in the release/v1.0 branch. This means the next releases will not include the changes.

There were some docs about language support that were added when I cherry-picked my first commit. I've left them in this PR since the same situation applies to those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3723)
<!-- Reviewable:end -->
