### PR TITLE
Return GraphQL compliant errors

### DIFF
--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -38,15 +38,10 @@ import (
 	"github.com/dgraph-io/dgraph/z"
 )
 
-type respError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
-}
-
 type res struct {
 	Data       json.RawMessage   `json:"data"`
 	Extensions *query.Extensions `json:"extensions,omitempty"`
-	Errors     []respError       `json:"errors,omitempty"`
+	Errors     []x.GqlError      `json:"errors,omitempty"`
 }
 
 type params struct {
@@ -466,7 +461,7 @@ func TestAlterAllFieldsShouldBeSet(t *testing.T) {
 	var qr x.QueryResWithData
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &qr))
 	require.Len(t, qr.Errors, 1)
-	require.Equal(t, qr.Errors[0].Code, "Error")
+	require.Equal(t, qr.Errors[0].Extensions["code"], "Error")
 }
 
 func TestHttpCompressionSupport(t *testing.T) {


### PR DESCRIPTION
Add GraphQL spec compliant errors to x package.  That means alpha http endpoint should return GraphQL compliant errors.

Change from current structure is where `code` sits.  With this PR it moves to `extensions`.  Should we call this **breaking** and move into 1.1 release?

This changes means Alpha and GraphQL layer can use the same sorts of errors and responses and moves Dgraph closer to GraphQL compliant.

Maybe we should consider using GQL Locations structure for reporting locations of Dgraph query parsing errors as well?


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3728)
<!-- Reviewable:end -->
