### PR TITLE
Continue instead of breaking while trying to find tablet to move in Zero

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -64,7 +64,7 @@ func (s *Server) rebalanceTablets() {
 	for range ticker.C {
 		predicate, srcGroup, dstGroup := s.chooseTablet()
 		if len(predicate) == 0 {
-			break
+			continue
 		}
 		if err := s.movePredicate(predicate, srcGroup, dstGroup); err != nil {
 			glog.Errorln(err)


### PR DESCRIPTION
We should be continuing inside the loop in `rebalanceTablets` as its possible for Zero to not have received information about tablets the first time it runs or in various other cases when there is nothing to move.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3733)
<!-- Reviewable:end -->
