### PR TITLE
adding back the go runtime metrics about CPU and memory

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -26,9 +26,10 @@ import (
 	"go.opencensus.io/trace"
 
 	"contrib.go.opencensus.io/exporter/jaeger"
-	"contrib.go.opencensus.io/exporter/prometheus"
+	oc_prom "contrib.go.opencensus.io/exporter/prometheus"
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -230,7 +231,8 @@ func init() {
 
 	CheckfNoTrace(view.Register(allViews...))
 
-	pe, err := prometheus.NewExporter(prometheus.Options{
+	pe, err := oc_prom.NewExporter(oc_prom.Options{
+		Registry:  prometheus.DefaultRegisterer.(*prometheus.Registry),
 		Namespace: "dgraph",
 		OnError:   func(err error) { glog.Errorf("%v", err) },
 	})

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -61,8 +61,6 @@ var (
 	PendingProposals = stats.Int64("pending_proposals_total",
 		"Number of pending proposals", stats.UnitDimensionless)
 	// NumGoRoutines records the current number of goroutines being executed by Dgraph.
-	NumGoRoutines = stats.Int64("goroutines_total",
-		"Number of goroutines", stats.UnitDimensionless)
 	// MemoryInUse records the current amount of used memory by Dgraph.
 	MemoryInUse = stats.Int64("memory_inuse_bytes",
 		"Amount of memory in use", stats.UnitBytes)
@@ -161,13 +159,6 @@ var (
 			Name:        PendingProposals.Name(),
 			Measure:     PendingProposals,
 			Description: PendingProposals.Description(),
-			Aggregation: view.LastValue(),
-			TagKeys:     allTagKeys,
-		},
-		{
-			Name:        NumGoRoutines.Name(),
-			Measure:     NumGoRoutines,
-			Description: NumGoRoutines.Description(),
 			Aggregation: view.LastValue(),
 			TagKeys:     allTagKeys,
 		},


### PR DESCRIPTION
fixes #3717 

Verified this change by checking the localhost:8180/debug/prometheus_metrics page, and confirmed that the following metrics are showing up
go_goroutines
go_threads
go_memstats_heap_alloc_bytes
dgraph_memory_inuse_bytes
go_memstats_heap_idle_bytes
...

Also removing our own NumGoRoutines metric, since it's already covered by prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3745)
<!-- Reviewable:end -->
