### PR TITLE
Fix Raft heartbeat rate for Zero.

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -598,7 +598,7 @@ func (n *node) trySnapshot(skip uint64) {
 
 func (n *node) Run() {
 	var leader bool
-	ticker := time.NewTicker(20 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
 	// snapshot can cause select loop to block while deleting entries, so run


### PR DESCRIPTION
In #3708 (4b41d9c907f3cef4ab83bbbdc1f9ba86f354134d) we bumped up the Raft
heartbeat rate to 100ms ticks. This change also updates the heartbeat ticker for
Zero too. Otherwise, Zero's election ticker would happen every 400ms instead of
every 2s as intended since raft.Config.ElectionTick is set to 20.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3753)
<!-- Reviewable:end -->
