### PR TITLE
Memory optimizations for bulk loader

### DIFF
--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -64,7 +64,7 @@ const (
 func NewChunker(inputFormat InputFormat) Chunker {
 	switch inputFormat {
 	case RdfFormat:
-		return &rdfChunker{lexer: lex.NewLexer("")}
+		return &rdfChunker{lexer: &lex.Lexer{}}
 	case JsonFormat:
 		return &jsonChunker{}
 	default:

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -117,7 +117,7 @@ func (c *rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 }
 
 // Parse is not thread-safe. Only call it serially, because it reuses lexer object.
-func (r *rdfChunker) Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error) {
+func (c *rdfChunker) Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error) {
 	if chunkBuf.Len() == 0 {
 		return nil, io.EOF
 	}

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -45,7 +45,10 @@ type Chunker interface {
 	Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error)
 }
 
-type rdfChunker struct{ lexer *lex.Lexer }
+type rdfChunker struct {
+	lexer *lex.Lexer
+}
+
 type jsonChunker struct{}
 
 // InputFormat represents the multiple formats supported by Chunker.
@@ -73,7 +76,7 @@ func NewChunker(inputFormat InputFormat) Chunker {
 }
 
 // RDF files don't require any special processing at the beginning of the file.
-func (rdfChunker) Begin(r *bufio.Reader) error {
+func (c *rdfChunker) Begin(r *bufio.Reader) error {
 	return nil
 }
 
@@ -81,7 +84,7 @@ func (rdfChunker) Begin(r *bufio.Reader) error {
 // 1) the EOF is reached
 // 2) 1e5 lines have been read
 // 3) some unexpected error happened
-func (rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
+func (c *rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	batch := new(bytes.Buffer)
 	batch.Grow(1 << 20)
 	for lineCount := 0; lineCount < 1e5; lineCount++ {
@@ -126,7 +129,7 @@ func (r *rdfChunker) Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error) {
 			x.Check(err)
 		}
 
-		nq, err := rdf.Parse(str, r.lexer)
+		nq, err := rdf.Parse(str, c.lexer)
 		if err == rdf.ErrEmpty {
 			continue // blank line or comment
 		} else if err != nil {
@@ -139,7 +142,7 @@ func (r *rdfChunker) Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error) {
 }
 
 // RDF files don't require any special processing at the end of the file.
-func (rdfChunker) End(r *bufio.Reader) error {
+func (c *rdfChunker) End(r *bufio.Reader) error {
 	return nil
 }
 

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -113,6 +113,7 @@ func (rdfChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	return batch, nil
 }
 
+// Parse is not thread-safe. Only call it serially, because it reuses lexer object.
 func (r *rdfChunker) Parse(chunkBuf *bytes.Buffer) ([]*api.NQuad, error) {
 	if chunkBuf.Len() == 0 {
 		return nil, io.EOF

--- a/chunker/rdf/parse.go
+++ b/chunker/rdf/parse.go
@@ -19,7 +19,6 @@ package rdf
 import (
 	"strconv"
 	"strings"
-	"sync"
 	"unicode"
 
 	"github.com/dgraph-io/dgo/protos/api"
@@ -52,23 +51,15 @@ func sane(s string) bool {
 	return false
 }
 
-var pool = &sync.Pool{
-	New: func() interface{} { return &lex.Lexer{} },
-}
-
 // Parse parses a mutation string and returns the N-Quad representation for it.
-func Parse(line string) (api.NQuad, error) {
+func Parse(line string, l *lex.Lexer) (api.NQuad, error) {
 	var rnq api.NQuad
 	line = strings.TrimSpace(line)
 	if len(line) == 0 {
 		return rnq, ErrEmpty
 	}
 
-	l := pool.Get().(*lex.Lexer)
-	defer pool.Put(l)
 	l.Reset(line)
-
-	// l := lex.NewLexer(line)
 	l.Run(lexText)
 	if err := l.ValidateResult(); err != nil {
 		return rnq, err

--- a/chunker/rdf/parse_test.go
+++ b/chunker/rdf/parse_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/dgo/protos/api"
+	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -971,9 +972,11 @@ var testNQuads = []struct {
 }
 
 func TestLex(t *testing.T) {
+	l := &lex.Lexer{}
 	for _, test := range testNQuads {
 		t.Logf("Testing %v", test.input)
-		rnq, err := Parse(test.input)
+		l.Reset(test.input)
+		rnq, err := Parse(test.input, l)
 		if test.expectedErr && test.shouldIgnore {
 			require.Equal(t, ErrEmpty, err, "Catch an ignorable case: %v",
 				err.Error())

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -906,9 +906,9 @@ func isAlterAllowed(ctx context.Context) error {
 
 func parseNQuads(b []byte) ([]*api.NQuad, error) {
 	var nqs []*api.NQuad
-	l := lex.NewLexer("")
+	var l lex.Lexer
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
-		nq, err := rdf.Parse(string(line), l)
+		nq, err := rdf.Parse(string(line), &l)
 		if err == rdf.ErrEmpty {
 			continue
 		}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -35,6 +35,7 @@ import (
 	nqjson "github.com/dgraph-io/dgraph/chunker/json"
 	"github.com/dgraph-io/dgraph/chunker/rdf"
 	"github.com/dgraph-io/dgraph/gql"
+	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/query"
@@ -905,8 +906,9 @@ func isAlterAllowed(ctx context.Context) error {
 
 func parseNQuads(b []byte) ([]*api.NQuad, error) {
 	var nqs []*api.NQuad
+	l := lex.NewLexer("")
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
-		nq, err := rdf.Parse(string(line))
+		nq, err := rdf.Parse(string(line), l)
 		if err == rdf.ErrEmpty {
 			continue
 		}

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -500,7 +500,8 @@ func ParseWithNeedVars(r Request, needVars []string) (res Result, rerr error) {
 	query := r.Str
 	vmap := convertToVarMap(r.Variables)
 
-	lexer := lex.NewLexer(query)
+	var lexer lex.Lexer
+	lexer.Reset(query)
 	lexer.Run(lexTopLevel)
 	if err := lexer.ValidateResult(); err != nil {
 		return res, err

--- a/gql/parser_mutation.go
+++ b/gql/parser_mutation.go
@@ -24,7 +24,8 @@ import (
 // ParseMutation parses a block into a mutation. Returns an object with a mutation or
 // an upsert block with mutation, otherwise returns nil with an error.
 func ParseMutation(mutation string) (mu *api.Mutation, err error) {
-	lexer := lex.NewLexer(mutation)
+	var lexer lex.Lexer
+	lexer.Reset(mutation)
 	lexer.Run(lexIdentifyBlock)
 	if err := lexer.ValidateResult(); err != nil {
 		return nil, err

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -22,6 +22,8 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/lex"
+
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/chunker/rdf"
 	"github.com/stretchr/testify/require"
@@ -4438,9 +4440,10 @@ func TestParseLangTagAfterStringInFilter(t *testing.T) {
 }
 
 func parseNquads(b []byte) ([]*api.NQuad, error) {
+	l := lex.NewLexer("")
 	var nqs []*api.NQuad
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
-		nq, err := rdf.Parse(string(line))
+		nq, err := rdf.Parse(string(line), l)
 		if err == rdf.ErrEmpty {
 			continue
 		}

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -22,10 +22,9 @@ import (
 	"runtime/debug"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/lex"
-
 	"github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/chunker/rdf"
+	"github.com/dgraph-io/dgraph/lex"
 	"github.com/stretchr/testify/require"
 )
 

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4439,10 +4439,10 @@ func TestParseLangTagAfterStringInFilter(t *testing.T) {
 }
 
 func parseNquads(b []byte) ([]*api.NQuad, error) {
-	l := lex.NewLexer("")
+	var lexer lex.Lexer
 	var nqs []*api.NQuad
 	for _, line := range bytes.Split(b, []byte{'\n'}) {
-		nq, err := rdf.Parse(string(line), l)
+		nq, err := rdf.Parse(string(line), &lexer)
 		if err == rdf.ErrEmpty {
 			continue
 		}

--- a/gql/state_test.go
+++ b/gql/state_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dgraph-io/dgraph/lex"
 )
 
-func TestNewLexer(t *testing.T) {
+func TestResetLexer(t *testing.T) {
 	input := `
 	query {
 		me(_xid_: rick, id:10 ) {
@@ -36,9 +36,8 @@ func TestNewLexer(t *testing.T) {
 			}
 		}
 	}`
-	l := lex.Lexer{
-		Input: input,
-	}
+	l := &lex.Lexer{}
+	l.Reset(input)
 	l.Run(lexQuery)
 
 	it := l.NewIterator()
@@ -49,7 +48,7 @@ func TestNewLexer(t *testing.T) {
 	}
 }
 
-func TestNewLexerMutation(t *testing.T) {
+func TestNewResetMutation(t *testing.T) {
 	input := `
 	mutation {
 		set {
@@ -66,9 +65,8 @@ func TestNewLexerMutation(t *testing.T) {
 			_city
 		}
 	}`
-	l := lex.Lexer{
-		Input: input,
-	}
+	l := &lex.Lexer{}
+	l.Reset(input)
 	l.Run(lexTopLevel)
 	it := l.NewIterator()
 	for it.Next() {

--- a/gql/state_test.go
+++ b/gql/state_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dgraph-io/dgraph/lex"
 )
 
-func TestResetLexer(t *testing.T) {
+func TestQueryLexing(t *testing.T) {
 	input := `
 	query {
 		me(_xid_: rick, id:10 ) {
@@ -48,7 +48,7 @@ func TestResetLexer(t *testing.T) {
 	}
 }
 
-func TestNewResetMutation(t *testing.T) {
+func TestMutationLexing(t *testing.T) {
 	input := `
 	mutation {
 		set {

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -187,6 +187,13 @@ func NewLexer(input string) *Lexer {
 	}
 }
 
+func (l *Lexer) Reset(input string) {
+	item := l.items // Pick the slice so we can reuse it.
+	*l = Lexer{}
+	l.Input = input
+	l.items = item[:0]
+}
+
 // ValidateResult verifies whether the entire input can be lexed without errors.
 func (l *Lexer) ValidateResult() error {
 	it := l.NewIterator()
@@ -227,12 +234,13 @@ func (l *Lexer) Emit(t ItemType) {
 		// Let ItemEOF go through.
 		return
 	}
-	l.items = append(l.items, Item{
+	item := Item{
 		Typ:    t,
 		Val:    l.Input[l.Start:l.Pos],
 		line:   l.Line,
 		column: l.Column,
-	})
+	}
+	l.items = append(l.items, item)
 	l.moveStartToPos()
 }
 

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -178,21 +178,13 @@ type Lexer struct {
 	Column     int     // the current column number corresponding to Start
 }
 
-// NewLexer returns a new Lexer instance based on the given input.
-func NewLexer(input string) *Lexer {
-	return &Lexer{
-		Input:  input,
-		Line:   1,
-		Column: 0,
-	}
-}
-
 // Reset resets Lexer fields. It reuses already allocated buffers.
 func (l *Lexer) Reset(input string) {
 	item := l.items // Pick the slice so we can reuse it.
 	*l = Lexer{}
 	l.Input = input
 	l.items = item[:0]
+	l.Line = 1
 }
 
 // ValidateResult verifies whether the entire input can be lexed without errors.

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -187,6 +187,7 @@ func NewLexer(input string) *Lexer {
 	}
 }
 
+// Reset resets Lexer fields. It reuses already allocated buffers.
 func (l *Lexer) Reset(input string) {
 	item := l.items // Pick the slice so we can reuse it.
 	*l = Lexer{}

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -180,10 +180,14 @@ type Lexer struct {
 
 // Reset resets Lexer fields. It reuses already allocated buffers.
 func (l *Lexer) Reset(input string) {
-	item := l.items // Pick the slice so we can reuse it.
+	// Pick the slices so we can reuse it.
+	item := l.items
+	widthStack := l.widthStack
+
 	*l = Lexer{}
 	l.Input = input
 	l.items = item[:0]
+	l.widthStack = widthStack[:0]
 	l.Line = 1
 }
 

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -427,7 +427,8 @@ func isTypeDeclaration(item lex.Item, it *lex.ItemIterator) bool {
 func Parse(s string) (*ParsedSchema, error) {
 	var result ParsedSchema
 
-	l := lex.NewLexer(s)
+	var l lex.Lexer
+	l.Reset(s)
 	l.Run(lexText)
 	if err := l.ValidateResult(); err != nil {
 		return nil, err

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -30,8 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/lex"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
@@ -45,6 +43,7 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 
 	"github.com/dgraph-io/dgraph/chunker/rdf"
+	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 )

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -95,7 +95,7 @@ func populateGraphExport(t *testing.T) {
 		"6": 6,
 	}
 
-	l := lex.NewLexer("")
+	l := &lex.Lexer{}
 	for _, edge := range rdfEdges {
 		nq, err := rdf.Parse(edge, l)
 		require.NoError(t, err)
@@ -218,7 +218,7 @@ func TestExportRdf(t *testing.T) {
 	scanner := bufio.NewScanner(r)
 	count := 0
 
-	l := lex.NewLexer("")
+	l := &lex.Lexer{}
 	for scanner.Scan() {
 		nq, err := rdf.Parse(scanner.Text(), l)
 		require.NoError(t, err)

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -30,6 +30,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/lex"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 
@@ -94,8 +96,9 @@ func populateGraphExport(t *testing.T) {
 		"6": 6,
 	}
 
+	l := lex.NewLexer("")
 	for _, edge := range rdfEdges {
-		nq, err := rdf.Parse(edge)
+		nq, err := rdf.Parse(edge, l)
 		require.NoError(t, err)
 		rnq := gql.NQuad{NQuad: &nq}
 		err = facets.SortAndValidate(rnq.Facets)
@@ -215,8 +218,10 @@ func TestExportRdf(t *testing.T) {
 
 	scanner := bufio.NewScanner(r)
 	count := 0
+
+	l := lex.NewLexer("")
 	for scanner.Scan() {
-		nq, err := rdf.Parse(scanner.Text())
+		nq, err := rdf.Parse(scanner.Text(), l)
 		require.NoError(t, err)
 		require.Contains(t, []string{"0x1", "0x2", "0x3", "0x4", "0x5", "0x6"}, nq.Subject)
 		if nq.ObjectValue != nil {


### PR DESCRIPTION
* Resue lexer for parsing RDFs.

Has a huge impact on objects and memory allocated.

Master:
```
Type: alloc_space
Time: Aug 6, 2019 at 4:56pm (PDT)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 43.41GB, 80.47% of 53.95GB total
Dropped 115 nodes (cum <= 0.27GB)
Showing top 10 nodes out of 55
      flat  flat%   sum%        cum   cum%
   13.61GB 25.23% 25.23%    13.61GB 25.23%  github.com/dgraph-io/dgraph/lex.(*Lexer).Emit
    6.23GB 11.55% 36.77%    14.27GB 26.45%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addIndexMapEntries
    4.43GB  8.22% 44.99%     4.43GB  8.22%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.newMapper.func1
    3.56GB  6.59% 51.58%    24.72GB 45.82%  github.com/dgraph-io/dgraph/chunker.rdfChunker.Parse
       3GB  5.55% 57.14%        3GB  5.55%  github.com/dgraph-io/dgraph/posting.NewPosting
    2.96GB  5.49% 62.63%     2.96GB  5.49%  bytes.makeSlice
    2.83GB  5.24% 67.87%     2.83GB  5.24%  github.com/dgraph-io/dgraph/gql.NQuad.createEdgePrototype
    2.63GB  4.88% 72.74%     2.63GB  4.88%  github.com/dgraph-io/dgraph/lex.NewLexer
    2.53GB  4.69% 77.44%     6.97GB 12.92%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addMapEntry
    1.64GB  3.03% 80.47%     1.64GB  3.03%  strings.makeCutsetFunc
```

```
Type: alloc_space
Time: Aug 6, 2019 at 4:58pm (PDT)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 27.22GB, 80.03% of 34.01GB total
Dropped 146 nodes (cum <= 0.17GB)
Showing top 10 nodes out of 53
      flat  flat%   sum%        cum   cum%
    4.71GB 13.85% 13.85%    10.88GB 32.00%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addIndexMapEntries
    3.74GB 10.99% 24.84%     3.74GB 10.99%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.newMapper.func1
    3.61GB 10.62% 35.45%     8.48GB 24.93%  github.com/dgraph-io/dgraph/chunker.(*rdfChunker).Parse
    2.97GB  8.73% 44.18%     2.97GB  8.73%  bytes.makeSlice
    2.94GB  8.64% 52.82%     2.94GB  8.64%  github.com/dgraph-io/dgraph/posting.NewPosting
    2.74GB  8.06% 60.89%     2.74GB  8.06%  github.com/dgraph-io/dgraph/gql.NQuad.createEdgePrototype
    2.11GB  6.19% 67.08%     5.85GB 17.20%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addMapEntry
    1.59GB  4.66% 71.74%     1.59GB  4.66%  strings.makeCutsetFunc
    1.41GB  4.15% 75.89%     1.41GB  4.15%  github.com/dgraph-io/dgraph/lex.(*Lexer).pushWidth
    1.41GB  4.14% 80.03%     1.41GB  4.14%  strconv.syntaxError
```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3762)
<!-- Reviewable:end -->
