### PR TITLE
[release/v1.0] Include line and column numbers in lexer errors.

### DIFF
--- a/gql/parser_mutation.go
+++ b/gql/parser_mutation.go
@@ -25,7 +25,7 @@ import (
 )
 
 func ParseMutation(mutation string) (*api.Mutation, error) {
-	lexer := lex.Lexer{Input: mutation}
+	lexer := lex.NewLexer(mutation)
 	lexer.Run(lexInsideMutation)
 	it := lexer.NewIterator()
 	var mu api.Mutation
@@ -46,10 +46,6 @@ func ParseMutation(mutation string) (*api.Mutation, error) {
 		if item.Typ == itemRightCurl {
 			// mutations must be enclosed in a single block.
 			if it.Next() && it.Item().Typ != lex.ItemEOF {
-				if it.Item().Typ == lex.ItemError {
-					return nil, x.Errorf("Unexpected error after end of block: %s",
-						it.Item().String())
-				}
 				return nil, x.Errorf("Unexpected %s after the end of the block.", it.Item().Val)
 			}
 			return &mu, nil

--- a/gql/parser_mutation.go
+++ b/gql/parser_mutation.go
@@ -35,7 +35,7 @@ func ParseMutation(mutation string) (*api.Mutation, error) {
 	}
 	item := it.Item()
 	if item.Typ != itemLeftCurl {
-		return nil, x.Errorf("Expected { at the start of block. Got: [%s]", item.Val)
+		return nil, it.Errorf("Expected { at the start of block. Got: [%s]", item.Val)
 	}
 
 	for it.Next() {
@@ -46,7 +46,7 @@ func ParseMutation(mutation string) (*api.Mutation, error) {
 		if item.Typ == itemRightCurl {
 			// mutations must be enclosed in a single block.
 			if it.Next() && it.Item().Typ != lex.ItemEOF {
-				return nil, x.Errorf("Unexpected %s after the end of the block.", it.Item().Val)
+				return nil, it.Errorf("Unexpected %s after the end of the block.", it.Item().Val)
 			}
 			return &mu, nil
 		}
@@ -69,29 +69,29 @@ func parseMutationOp(it *lex.ItemIterator, op string, mu *api.Mutation) error {
 		}
 		if item.Typ == itemLeftCurl {
 			if parse {
-				return x.Errorf("Too many left curls in set mutation.")
+				return it.Errorf("Too many left curls in set mutation.")
 			}
 			parse = true
 		}
 		if item.Typ == itemMutationContent {
 			if !parse {
-				return x.Errorf("Mutation syntax invalid.")
+				return it.Errorf("Mutation syntax invalid.")
 			}
 			if op == "set" {
 				mu.SetNquads = []byte(item.Val)
 			} else if op == "delete" {
 				mu.DelNquads = []byte(item.Val)
 			} else if op == "schema" {
-				return x.Errorf("Altering schema not supported through http client.")
+				return it.Errorf("Altering schema not supported through http client.")
 			} else if op == "dropall" {
-				return x.Errorf("Dropall not supported through http client.")
+				return it.Errorf("Dropall not supported through http client.")
 			} else {
-				return x.Errorf("Invalid mutation operation.")
+				return it.Errorf("Invalid mutation operation.")
 			}
 		}
 		if item.Typ == itemRightCurl {
 			return nil
 		}
 	}
-	return x.Errorf("Invalid mutation formatting.")
+	return it.Errorf("Invalid mutation formatting.")
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1612,7 +1612,7 @@ func TestParseMutationError(t *testing.T) {
 	`
 	_, err := ParseMutation(query)
 	require.Error(t, err)
-	require.Equal(t, `Expected { at the start of block. Got: [mutation]`, err.Error())
+	require.Contains(t, err.Error(), `Expected { at the start of block. Got: [mutation]`)
 }
 
 func TestParseMutationError2(t *testing.T) {
@@ -1627,7 +1627,7 @@ func TestParseMutationError2(t *testing.T) {
 	`
 	_, err := ParseMutation(query)
 	require.Error(t, err)
-	require.Equal(t, `Expected { at the start of block. Got: [set]`, err.Error())
+	require.Contains(t, err.Error(), `Expected { at the start of block. Got: [set]`)
 }
 
 func TestParseMutationAndQueryWithComments(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1229,7 +1229,8 @@ func TestParseIdListError(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unexpected character [ while parsing request")
+	require.Contains(t, err.Error(),
+		"Unrecognized character in lexText: U+005D ']'")
 }
 
 func TestParseIdListError2(t *testing.T) {
@@ -1241,7 +1242,8 @@ func TestParseIdListError2(t *testing.T) {
 	}`
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unexpected character [ while parsing request.")
+	require.Contains(t, err.Error(),
+		"Unexpected character [ while parsing request.")
 }
 
 func TestParseFirst(t *testing.T) {
@@ -1855,8 +1857,7 @@ func TestParseVariablesError1(t *testing.T) {
 	`
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Variable $")
-	require.Contains(t, err.Error(), "should be initialised")
+	require.Contains(t, err.Error(), "Unrecognized character in lexText: U+0034 '4'")
 }
 
 func TestParseFilter_root(t *testing.T) {
@@ -2162,8 +2163,8 @@ func TestParseFilter_unbalancedbrac(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Unexpected item while parsing @filter")
-	require.Contains(t, err.Error(), "'{'")
+	require.Contains(t, err.Error(),
+		"Unrecognized character inside a func: U+007B '{'")
 }
 
 func TestParseFilter_Geo1(t *testing.T) {
@@ -2405,7 +2406,8 @@ func TestParseCountError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Multiple predicates not allowed in single count")
+	require.Contains(t, err.Error(),
+		"Unrecognized character inside a func: U+007D '}'")
 }
 
 func TestParseCountError2(t *testing.T) {
@@ -2419,7 +2421,8 @@ func TestParseCountError2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Predicate name cannot be empty")
+	require.Contains(t, err.Error(),
+		"Unrecognized character inside a func: U+007D '}'")
 }
 
 func TestParseCheckPwd(t *testing.T) {
@@ -2620,7 +2623,8 @@ func TestLangsInvalid4(t *testing.T) {
 
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected directive or language list")
+	require.Contains(t, err.Error(),
+		"Unrecognized character in lexDirective: U+000A")
 }
 
 func TestLangsInvalid5(t *testing.T) {
@@ -2634,7 +2638,8 @@ func TestLangsInvalid5(t *testing.T) {
 
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected directive or language list")
+	require.Contains(t, err.Error(),
+		"Unrecognized character in lexDirective: U+003C '<'")
 }
 
 func TestLangsInvalid6(t *testing.T) {
@@ -2720,8 +2725,8 @@ func TestLangsFilter_error2(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected arg after func [alloftext]")
-	require.Contains(t, err.Error(), "','")
+	require.Contains(t, err.Error(),
+		"Unrecognized character in lexDirective: U+002C ','")
 }
 
 func TestLangsFunction(t *testing.T) {
@@ -2940,7 +2945,8 @@ func TestParseFacetsError1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected ( after func name [facet1]")
+	require.Contains(t, err.Error(),
+		"Consecutive commas not allowed.")
 }
 
 func TestParseFacetsVarError(t *testing.T) {
@@ -3259,7 +3265,8 @@ func TestParseFacetsFail1(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected ( after func name [key1]")
+	require.Contains(t, err.Error(),
+		"Consecutive commas not allowed.")
 }
 
 func TestParseRepeatArgsError1(t *testing.T) {
@@ -3575,8 +3582,8 @@ func TestParseRegexp6(t *testing.T) {
 `
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected arg after func [regexp]")
-	require.Contains(t, err.Error(), "Unclosed regexp")
+	require.Contains(t, err.Error(),
+		"Unclosed regexp")
 }
 
 func TestMain(m *testing.M) {
@@ -3669,7 +3676,7 @@ func TestDotsEOF(t *testing.T) {
 			..`
 	_, err := Parse(Request{Str: query})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected 3 periods")
+	require.Contains(t, err.Error(), "Unclosed action")
 }
 
 func TestMathWithoutVarAlias(t *testing.T) {
@@ -4318,7 +4325,7 @@ func TestParseMutationTooManyBlocks(t *testing.T) {
 			errStr: "Unexpected { after the end of the block.",
 		},
 		{m: `{set { _:a1 <reg> "a1 content" . }} something`,
-			errStr: "Unexpected error after end of block:",
+			errStr: "Invalid operation type: something after the end of the block",
 		},
 		{m: `
 			# comments are ok
@@ -4420,4 +4427,21 @@ func TestParseGraphQLVarPaginationRootMultiple(t *testing.T) {
 	require.Equal(t, args["offset"], "5")
 	require.Equal(t, args["after"], "0x123")
 	require.Equal(t, gq.Query[0].Order[0].Attr, "name")
+}
+
+func TestLineAndColumnNumberInErrorOutput(t *testing.T) {
+	q := `
+	query {
+		me(func: uid(0x0a)) {
+			friends @filter(alloftext(descr@, "something")) {
+				name
+			}
+			gender,age
+			hometown
+		}
+	}`
+	_, err := Parse(Request{Str: q})
+	require.Error(t, err)
+	require.Contains(t, err.Error(),
+		"line 4 column 35: Unrecognized character in lexDirective: U+002C ','")
 }

--- a/gql/state.go
+++ b/gql/state.go
@@ -81,7 +81,7 @@ func lexInsideMutation(l *lex.Lexer) lex.StateFn {
 			if l.Depth >= 2 {
 				return lexTextMutation
 			}
-		case isSpace(r) || isEndOfLine(r):
+		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
 		case isNameBegin(r):
 			return lexNameMutation
@@ -116,7 +116,7 @@ func lexInsideSchema(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemLeftSquare)
 		case r == rightSquare:
 			l.Emit(itemRightSquare)
-		case isSpace(r) || isEndOfLine(r):
+		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
 		case isNameBegin(r):
 			return lexArgName
@@ -188,7 +188,7 @@ func lexFuncOrArg(l *lex.Lexer) lex.StateFn {
 			}
 		case r == lex.EOF:
 			return l.Errorf("Unclosed Brackets")
-		case isSpace(r) || isEndOfLine(r):
+		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
 		case r == comma:
 			if empty {
@@ -224,7 +224,7 @@ func lexFuncOrArg(l *lex.Lexer) lex.StateFn {
 		case r == '.':
 			l.Emit(itemPeriod)
 		default:
-			return l.Errorf("Unrecognized character in inside a func: %#U", r)
+			return l.Errorf("Unrecognized character inside a func: %#U", r)
 		}
 	}
 }
@@ -251,7 +251,7 @@ Loop:
 			l.Emit(itemLeftRound)
 			l.ArgDepth++
 			return lexQuery
-		case isSpace(r) || isEndOfLine(r):
+		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
 		case isNameBegin(r):
 			l.Backup()
@@ -283,7 +283,7 @@ func lexQuery(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemLeftCurl)
 		case r == lex.EOF:
 			return l.Errorf("Unclosed action")
-		case isSpace(r) || isEndOfLine(r):
+		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
 		case r == comma:
 			l.Emit(itemComma)
@@ -315,21 +315,6 @@ func lexQuery(l *lex.Lexer) lex.StateFn {
 func lexIRIRef(l *lex.Lexer) lex.StateFn {
 	if err := lex.IRIRef(l, itemName); err != nil {
 		return l.Errorf(err.Error())
-	}
-	return l.Mode
-}
-
-// lexFilterFuncName expects input to look like equal("...", "...").
-func lexFilterFuncName(l *lex.Lexer) lex.StateFn {
-	for {
-		// The caller already checked isNameBegin, and absorbed one rune.
-		r := l.Next()
-		if isNameSuffix(r) {
-			continue
-		}
-		l.Backup()
-		l.Emit(itemName)
-		break
 	}
 	return l.Mode
 }
@@ -377,7 +362,7 @@ func lexName(l *lex.Lexer) lex.StateFn {
 func lexComment(l *lex.Lexer) lex.StateFn {
 	for {
 		r := l.Next()
-		if isEndOfLine(r) {
+		if lex.IsEndOfLine(r) {
 			l.Ignore()
 			return l.Mode
 		}
@@ -516,11 +501,6 @@ func isDollar(r rune) bool {
 // isSpace returns true if the rune is a tab or space.
 func isSpace(r rune) bool {
 	return r == '\u0009' || r == '\u0020'
-}
-
-// isEndOfLine returns true if the rune is a Linefeed or a Carriage return.
-func isEndOfLine(r rune) bool {
-	return r == '\u000A' || r == '\u000D'
 }
 
 // isEndLiteral returns true if rune is quotation mark.

--- a/rdf/parse.go
+++ b/rdf/parse.go
@@ -54,11 +54,11 @@ func sane(s string) bool {
 // Parse parses a mutation string and returns the NQuad representation for it.
 func Parse(line string) (api.NQuad, error) {
 	var rnq api.NQuad
-	l := lex.Lexer{
-		Input: line,
-	}
+	l := lex.NewLexer(line)
 	l.Run(lexText)
-
+	if err := l.ValidateResult(); err != nil {
+		return rnq, err
+	}
 	it := l.NewIterator()
 	var oval string
 	var seenOval bool
@@ -143,10 +143,6 @@ L:
 			if rnq.ObjectValue, err = types.ObjectValue(t, p.Value); err != nil {
 				return rnq, err
 			}
-
-		case lex.ItemError:
-			return rnq, x.Errorf(item.Val)
-
 		case itemComment:
 			isCommentLine = true
 			vend = true

--- a/rdf/state.go
+++ b/rdf/state.go
@@ -419,7 +419,7 @@ func lexComment(l *lex.Lexer) lex.StateFn {
 	l.Backup()
 	for {
 		r := l.Next()
-		if isEndOfLine(r) || r == lex.EOF {
+		if lex.IsEndOfLine(r) || r == lex.EOF {
 			break
 		}
 	}
@@ -479,11 +479,6 @@ func isClosingBracket(r rune) bool {
 // isSpace returns true if the rune is a tab or space.
 func isSpace(r rune) bool {
 	return r == '\u0009' || r == '\u0020'
-}
-
-// isEndOfLine returns true if the rune is a Linefeed or a Carriage return.
-func isEndOfLine(r rune) bool {
-	return r == '\u000A' || r == '\u000D'
 }
 
 func isEndLiteral(r rune) bool {

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -302,8 +302,11 @@ func resolveTokenizers(updates []*pb.SchemaUpdate) error {
 // Parse parses a schema string and returns the schema representation for it.
 func Parse(s string) ([]*pb.SchemaUpdate, error) {
 	var schemas []*pb.SchemaUpdate
-	l := lex.Lexer{Input: s}
+	l := lex.NewLexer(s)
 	l.Run(lexText)
+	if err := l.ValidateResult(); err != nil {
+		return nil, err
+	}
 	it := l.NewIterator()
 	for it.Next() {
 		item := it.Item()
@@ -320,10 +323,6 @@ func Parse(s string) ([]*pb.SchemaUpdate, error) {
 				return nil, err
 			}
 			schemas = append(schemas, schema)
-
-		case lex.ItemError:
-			return nil, x.Errorf(item.Val)
-
 		case itemNewLine:
 			// pass empty line
 

--- a/schema/state.go
+++ b/schema/state.go
@@ -48,7 +48,7 @@ Loop:
 			return lexWord
 		case isSpace(r):
 			l.Ignore()
-		case isEndOfLine(r):
+		case lex.IsEndOfLine(r):
 			l.Emit(itemNewLine)
 		case r == '.':
 			l.Emit(itemDot)
@@ -130,9 +130,4 @@ func isNameSuffix(r rune) bool {
 // isSpace returns true if the rune is a tab or space.
 func isSpace(r rune) bool {
 	return r == '\u0009' || r == '\u0020'
-}
-
-// isEndOfLine returns true if the rune is a Linefeed or a Carriage return.
-func isEndOfLine(r rune) bool {
-	return r == '\n' || r == '\u000D'
 }


### PR DESCRIPTION
This PR cherry-picks 21291019ef09adf0fa242865c1512b359149c318 to support line
and column numbers in lexer errors. It also changes parse_mutation.go to use them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3772)
<!-- Reviewable:end -->
