### PR TITLE
Use sync.Pool for posting lists in getInternal and getNew.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -412,6 +412,7 @@ func (l *List) Release() {
 		for _, p := range list.GetPostings() {
 			postingPool.Put(p)
 		}
+		list.Reset()
 		postingListPool.Put(list)
 	}
 	fromList(l.plist)

--- a/posting/list.go
+++ b/posting/list.go
@@ -401,11 +401,18 @@ var postingPool = &sync.Pool{
 	},
 }
 
+var postingListPool = &sync.Pool{
+	New: func() interface{} {
+		return &pb.PostingList{}
+	},
+}
+
 func (l *List) Release() {
 	fromList := func(list *pb.PostingList) {
 		for _, p := range list.GetPostings() {
 			postingPool.Put(p)
 		}
+		postingListPool.Put(list)
 	}
 	fromList(l.plist)
 	for _, plist := range l.mutationMap {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -241,7 +241,7 @@ func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) 
 		pl = &List{
 			key:         key,
 			mutationMap: make(map[uint64]*pb.PostingList),
-			plist:       new(pb.PostingList),
+			plist:       postingListPool.Get().(*pb.PostingList),
 		}
 	}
 

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -144,7 +144,7 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 	l := new(List)
 	l.key = key
 	l.mutationMap = make(map[uint64]*pb.PostingList)
-	l.plist = new(pb.PostingList)
+	l.plist = postingListPool.Get().(*pb.PostingList)
 
 	// Iterates from highest Ts to lowest Ts
 	for it.Valid() {
@@ -172,7 +172,7 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 			return l, nil
 		case BitDeltaPosting:
 			err := item.Value(func(val []byte) error {
-				pl := &pb.PostingList{}
+				pl := postingListPool.Get().(*pb.PostingList)
 				x.Check(pl.Unmarshal(val))
 				pl.CommitTs = item.Version()
 				for _, mpost := range pl.Postings {


### PR DESCRIPTION
Before:

```
ROUTINE ======================== github.com/dgraph-io/dgraph/posting.(*LocalCache).getInternal in /home/martinmr/go/src/github.com/dgraph-io/dgraph/posting/lists.go
    6.49GB    15.49GB (flat, cum) 11.68% of Total
         .          .    223:
         .          .    224:func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) {
         .          .    225:   if lc == nil {
         .          .    226:           return getNew(key, pstore)
         .          .    227:   }
    1.13GB     1.13GB    228:   skey := string(key)
         .          .    229:   if pl := lc.getNoStore(skey); pl != nil {
         .          .    230:           return pl, nil
         .          .    231:   }
         .          .    232:
         .          .    233:   var pl *List
         .          .    234:   if readFromDisk {
         .          .    235:           var err error
         .     6.52GB    236:           pl, err = getNew(key, pstore)
         .          .    237:           if err != nil {
         .          .    238:                   return nil, err
         .          .    239:           }
         .          .    240:   } else {
         .          .    241:           pl = &List{
         .          .    242:                   key:         key,
    1.02GB     1.02GB    243:                   mutationMap: make(map[uint64]*pb.PostingList),
    4.34GB     4.34GB    244:                   plist:       new(pb.PostingList),
         .          .    245:           }
         .          .    246:   }
         .          .    247:
         .          .    248:   // If we just brought this posting list into memory and we already have a delta for it, let's
         .          .    249:   // apply it before returning the list.
         .          .    250:   lc.RLock()
         .          .    251:   if delta, ok := lc.deltas[skey]; ok && len(delta) > 0 {
         .          .    252:           pl.setMutation(lc.startTs, delta)
         .          .    253:   }
         .          .    254:   lc.RUnlock()
         .     2.48GB    255:   return lc.SetIfAbsent(skey, pl), nil
         .          .    256:}
         .          .    257:
         .          .    258:// Get retrieves the cached version of the list associated with the given key.
         .          .    259:func (lc *LocalCache) Get(key []byte) (*List, error) {
         .          .    260:   return lc.getInternal(key, true)
```

After:
```
ROUTINE ======================== github.com/dgraph-io/dgraph/posting.(*LocalCache).getInternal in /home/martinmr/go/src/github.com/dgraph-io/dgraph/posting/lists.go
    3.23GB     9.65GB (flat, cum) 11.14% of Total
         .          .    223:
         .          .    224:func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) {
         .          .    225:   if lc == nil {
         .          .    226:           return getNew(key, pstore)
         .          .    227:   }
  851.02MB   851.02MB    228:   skey := string(key)
         .          .    229:   if pl := lc.getNoStore(skey); pl != nil {
         .          .    230:           return pl, nil
         .          .    231:   }
         .          .    232:
         .          .    233:   var pl *List
         .          .    234:   if readFromDisk {
         .          .    235:           var err error
         .     4.50GB    236:           pl, err = getNew(key, pstore)
         .          .    237:           if err != nil {
         .          .    238:                   return nil, err
         .          .    239:           }
         .          .    240:   } else {
         .          .    241:           pl = &List{
         .          .    242:                   key:         key,
  859.04MB   859.04MB    243:                   mutationMap: make(map[uint64]*pb.PostingList),
    1.56GB     1.60GB    244:                   plist: postingListPool.Get().(*pb.PostingList),
         .          .    245:           }
         .          .    246:   }
         .          .    247:
         .          .    248:   // If we just brought this posting list into memory and we already have a delta for it, let's
         .          .    249:   // apply it before returning the list.
         .          .    250:   lc.RLock()
         .          .    251:   if delta, ok := lc.deltas[skey]; ok && len(delta) > 0 {
         .          .    252:           pl.setMutation(lc.startTs, delta)
         .          .    253:   }
         .          .    254:   lc.RUnlock()
         .     1.88GB    255:   return lc.SetIfAbsent(skey, pl), nil
         .          .    256:}
         .          .    257:
         .          .    258:// Get retrieves the cached version of the list associated with the given key.
         .          .    259:func (lc *LocalCache) Get(key []byte) (*List, error) {
         .          .    260:   return lc.getInternal(key, true)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3773)
<!-- Reviewable:end -->
