### PR TITLE
release.sh: Bump Go version for release builds to 1.12.7.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -18,7 +18,7 @@ mkdir $GOPATH
 PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
-GOVERSION="1.12.5"
+GOVERSION="1.12.7"
 
 TAG=$1
 # The Docker tag should not contain a slash e.g. feature/issue1234

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -107,6 +107,7 @@ pushd $basedir/ratel
   source ~/.nvm/nvm.sh
   nvm install --lts
   ./scripts/build.prod.sh
+  ./scripts/test.sh
 popd
 
 # Build Windows.


### PR DESCRIPTION
* Bump Go version for release builds to go1.12.7.

* Run Ratel's e2e tests during release script. The tests used to run in ./scripts/build.prod.sh, but now we run Ratel e2e tests seperately with ./scripts/test.sh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3780)
<!-- Reviewable:end -->
