### PR TITLE
Fix for panic in fillGroupedVars

### DIFF
--- a/query/groupby.go
+++ b/query/groupby.go
@@ -295,7 +295,7 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 		if attr == "" {
 			attr = child.Attr
 		}
-		if len(child.DestUIDs.Uids) != 0 {
+		if child.DestUIDs != nil && len(child.DestUIDs.Uids) != 0 {
 			// It's a UID node.
 			for i := 0; i < len(child.uidMatrix); i++ {
 				srcUid := child.SrcUIDs.Uids[i]

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -213,7 +213,7 @@ func (sg *SubGraph) formResult(ul *pb.List) (*groupResults, error) {
 		if attr == "" {
 			attr = child.Attr
 		}
-		if child.DestUIDs != nil && len(child.DestUIDs.Uids) != 0 {
+		if len(child.DestUIDs.GetUids()) > 0 {
 			// It's a UID node.
 			for i := 0; i < len(child.uidMatrix); i++ {
 				srcUid := child.SrcUIDs.Uids[i]
@@ -295,7 +295,7 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 		if attr == "" {
 			attr = child.Attr
 		}
-		if child.DestUIDs != nil && len(child.DestUIDs.Uids) != 0 {
+		if len(child.DestUIDs.GetUids()) > 0 {
 			// It's a UID node.
 			for i := 0; i < len(child.uidMatrix); i++ {
 				srcUid := child.SrcUIDs.Uids[i]

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1325,6 +1325,29 @@ func TestGroupByFriendsMultipleParentsVar(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"uid":"0x18","name":"Glenn Rhee","val(f)":2},{"uid":"0x1","name":"Michonne","val(f)":1},{"uid":"0x17","name":"Rick Grimes","val(f)":1},{"uid":"0x19","name":"Daryl Dixon","val(f)":1},{"uid":"0x1f","name":"Andrea","val(f)":1},{"uid":"0x65","val(f)":1}]}}`, js)
 }
 
+func TestGroupBy_Fix3768(t *testing.T) {
+	query := `
+		{
+			var(func: eq(name, "abcdef")) @ignorereflex {
+				random_nonexistent {
+					f as uid
+				}
+			}
+
+			me(func: uid(f)) @groupby(uid) {
+				a as count(uid)
+			}
+
+			me2(func: uid(f)) {
+				val(a)
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me2": []}}`, js)
+
+}
+
 func TestMultiEmptyBlocks(t *testing.T) {
 
 	query := `

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1325,7 +1325,8 @@ func TestGroupByFriendsMultipleParentsVar(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"uid":"0x18","name":"Glenn Rhee","val(f)":2},{"uid":"0x1","name":"Michonne","val(f)":1},{"uid":"0x17","name":"Rick Grimes","val(f)":1},{"uid":"0x19","name":"Daryl Dixon","val(f)":1},{"uid":"0x1f","name":"Andrea","val(f)":1},{"uid":"0x65","val(f)":1}]}}`, js)
 }
 
-func TestGroupBy_Fix3768(t *testing.T) {
+func TestGroupBy_FixPanicForNilDestUIDs(t *testing.T) {
+	// This a fix for GitHub issue #3768.
 	query := `
 		{
 			var(func: eq(name, "abcdef")) @ignorereflex {


### PR DESCRIPTION
Fixes #3768 

For a uid child,  DestUIDs can be nil if there were no source UIDs. This check was already happening in `formResult` but has been missed in this function. I am working on adding more code comments and trying to reduce the code duplication for the groupby code if possible in another PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3781)
<!-- Reviewable:end -->
