### PR TITLE
Unset GOBIN before running release script.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -11,6 +11,7 @@ RED='\033[91;1m'
 RESET='\033[0m'
 
 # Don't use standard GOPATH. Create a new one.
+unset GOBIN
 GOPATH="/tmp/go"
 rm -Rf $GOPATH
 mkdir $GOPATH


### PR DESCRIPTION
I had an issue since GOBIN and GOPATH were both set in my environment to
simply setting GOPATH caused the binaries to be built in the default
GOBIN. Unsetting GOBIN should prevent this situation from happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3785)
<!-- Reviewable:end -->
