### PR TITLE
[cherry-pick] Add cluster-only and full-only flags to test.sh.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -159,19 +159,22 @@ function RunCustomClusterTests {
 # MAIN
 #
 
-ARGS=$(getopt -n$ME -o"hucfvn" -l"help,unit,cluster,full,oss,verbose,no-cache" -- "$@") \
+ARGS=$(getopt -n$ME -o"hucCfFvn" \
+              -l"help,unit,cluster,cluster-only,full,full-only,oss,verbose,no-cache" -- "$@") \
     || exit 1
 eval set -- "$ARGS"
 while true; do
     case "$1" in
-        -h|--help)      Usage; exit 0                 ;;
-        -u|--unit)      TEST_SET="unit"               ;;
-        -c|--cluster)   TEST_SET="unit:cluster"       ;;
-        -f|--full)      TEST_SET="unit:cluster:full"  ;;
-        -v|--verbose)   GO_TEST_OPTS+=( "-v" )        ;;
-        -n|--no-cache)  GO_TEST_OPTS+=( "-count=1" )  ;;
-           --oss)       GO_TEST_OPTS+=( "-tags=oss" ) ;;
-        --)             shift; break                  ;;
+        -h|--help)         Usage; exit 0                 ;;
+        -u|--unit)         TEST_SET="unit"               ;;
+        -c|--cluster)      TEST_SET="unit:cluster"       ;;
+        -C|--cluster-only) TEST_SET="cluster"            ;;
+        -f|--full)         TEST_SET="unit:cluster:full"  ;;
+        -F|--full-only)    TEST_SET="full"               ;;
+        -v|--verbose)      GO_TEST_OPTS+=( "-v" )        ;;
+        -n|--no-cache)     GO_TEST_OPTS+=( "-count=1" )  ;;
+           --oss)          GO_TEST_OPTS+=( "-tags=oss" ) ;;
+        --)                shift; break                  ;;
     esac
     shift
 done


### PR DESCRIPTION
./test.sh -C or ./test.sh -F can be used to run only the custom
cluster tests or only the long running systests. On my machine
these take approx. 7 minutes and 11 minutes to finish
respectively. These flags can be used to run them as separate
jobs in parallel in CI so we can run all the tests for each PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3791)
<!-- Reviewable:end -->
