### PR TITLE
Set default type predicates as lists.

### DIFF
--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -102,7 +102,11 @@ func (s *schemaStore) validateType(de *pb.DirectedEdge, objectIsUID bool) {
 		sch, ok = s.schemaMap[de.Attr]
 		if !ok {
 			sch = &pb.SchemaUpdate{ValueType: de.ValueType}
-			if objectIsUID {
+			// For type uid or default, set List to true. This is done for UIDs because previously
+			// all predicates of type uid were implicitly considered lists. It's done for the
+			// default type to prevent data loss when users insert data before setting the schema to
+			// their desired type.
+			if objectIsUID || de.ValueType == pb.Posting_DEFAULT {
 				sch.List = true
 			}
 			s.schemaMap[de.Attr] = sch

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -198,9 +198,11 @@ func createSchema(attr string, typ types.TypeID) {
 		s.ValueType = typ.Enum()
 	} else {
 		s = pb.SchemaUpdate{ValueType: typ.Enum(), Predicate: attr}
-		// For type UidID, set List to true. This is done because previously
-		// all predicates of type UidID were implicitly considered lists.
-		if typ == types.UidID {
+		// For type uid or default, set List to true. This is done for UIDs because previously
+		// all predicates of type uid were implicitly considered lists. It's done for the
+		// default type to prevent data loss when users insert data before setting the schema to
+		// their desired type.
+		if typ == types.UidID || typ == types.DefaultID {
 			s.List = true
 		}
 	}


### PR DESCRIPTION
If users add multiple entries to predicates of default type, the current
behavior is to overwrite existing values. This can lead to data loss in
cases where users didn't intend to do that or forgot to set a schema for
the predicate beforehand.

This change makes it so that predicates of default type are created as
lists.

Fixes #3788

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3792)
<!-- Reviewable:end -->
