### PR TITLE
Add testing to ensure GQL error propagation gets called on mutations

### DIFF
--- a/dgraph/cmd/graphql/resolve/resolver_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_test.go
@@ -267,24 +267,24 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 			explanation: "Field 'dob' is nullable, so null should be inserted " +
 				"if the mutation's query doesn't return a value.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "name": "A.N. Author" } } ] }`,
-			expected: `{ "addPost": { "post" : ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "name": "A.N. Author", "dob": null } } } }`,
+			queryResponse: `{ "post" : [ 
+				{ "title": "A Post", 
+				"text": "Some text", 
+				"author": { "name": "A.N. Author" } } ] }`,
+			expected: `{ "addPost": { "post" : 
+				{ "title": "A Post", 
+				"text": "Some text", 
+				"author": { "name": "A.N. Author", "dob": null } } } }`,
 		},
 		"Add mutation triggers GraphQL error propagation": {
 			explanation: "An Author's name is non-nullable, so if that's missing, " +
 				"the author is squashed to null, but that's also non-nullable, so the " +
 				"propagates to the query root.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "dob": "2000-01-01" } } ] }`,
+			queryResponse: `{ "post" : [ 
+				{ "title": "A Post", 
+				"text": "Some text", 
+				"author": { "dob": "2000-01-01" } } ] }`,
 			expected: `{ "addPost": { "post" : null } }`,
 			errors: gqlerror.List{&gqlerror.Error{
 				Message: `Non-nullable field 'name' (type String!) ` +
@@ -342,24 +342,24 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 			explanation: "Field 'dob' is nullable, so null should be inserted " +
 				"if the mutation's query doesn't return a value.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "name": "A.N. Author" } } ] }`,
-			expected: `{ "updatePost": { "post" : ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "name": "A.N. Author", "dob": null } } } }`,
+			queryResponse: `{ "post" : [ 
+				{ "title": "A Post", 
+				"text": "Some text", 
+				"author": { "name": "A.N. Author" } } ] }`,
+			expected: `{ "updatePost": { "post" : 
+				{ "title": "A Post", 
+				"text": "Some text", 
+				"author": { "name": "A.N. Author", "dob": null } } } }`,
 		},
 		"Update Mutation triggers GraphQL error propagation": {
 			explanation: "An Author's name is non-nullable, so if that's missing, " +
 				"the author is squashed to null, but that's also non-nullable, so the " +
 				"propagates to the query root.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ ` +
-				`{ "title": "A Post", ` +
-				`"text": "Some text", ` +
-				`"author": { "dob": "2000-01-01" } } ] }`,
+			queryResponse: `{ "post" : [ { 
+				"title": "A Post", 
+				"text": "Some text", 
+				"author": { "dob": "2000-01-01" } } ] }`,
 			expected: `{ "updatePost": { "post" : null } }`,
 			errors: gqlerror.List{&gqlerror.Error{
 				Message: `Non-nullable field 'name' (type String!) ` +

--- a/dgraph/cmd/graphql/resolve/resolver_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_test.go
@@ -151,7 +151,7 @@ func TestResolver(t *testing.T) {
 
 	doc, gqlErr := parser.ParseSchema(&ast.Source{Input: testGQLSchema})
 	require.Nil(t, gqlErr)
-	// ^^ We can't use no error here because gqlErr is of type *gqlerror.Error,
+	// ^^ We can't use NoError here because gqlErr is of type *gqlerror.Error,
 	// so passing into something that just expects an error, will always be a
 	// non-nil interface.
 
@@ -225,6 +225,7 @@ func TestResponseOrder(t *testing.T) {
 
 	doc, gqlErr := parser.ParseSchema(&ast.Source{Input: testGQLSchema})
 	require.Nil(t, gqlErr)
+	// see note above about NoError
 
 	gqlSchema, gqlErr := validator.ValidateSchemaDocument(doc)
 	require.Nil(t, gqlErr)
@@ -296,6 +297,7 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 
 	doc, gqlErr := parser.ParseSchema(&ast.Source{Input: testGQLSchema})
 	require.Nil(t, gqlErr)
+	// see note above about NoError
 
 	gqlSchema, gqlErr := validator.ValidateSchemaDocument(doc)
 	require.Nil(t, gqlErr)
@@ -371,6 +373,7 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 
 	doc, gqlErr := parser.ParseSchema(&ast.Source{Input: testGQLSchema})
 	require.Nil(t, gqlErr)
+	// see note above about NoError
 
 	gqlSchema, gqlErr := validator.ValidateSchemaDocument(doc)
 	require.Nil(t, gqlErr)


### PR DESCRIPTION
Doesn't need much of a review, just adds some testing around mutations.

Will merge after https://github.com/dgraph-io/dgraph/pull/3796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3799)
<!-- Reviewable:end -->
