### PR TITLE
 compose: Add flag to run Ratel.

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -81,6 +81,7 @@ type options struct {
 	LocalBin      bool
 	Tag           string
 	WhiteList     bool
+	Ratel         bool
 }
 
 var opts options
@@ -248,6 +249,17 @@ func getJaeger() service {
 	return svc
 }
 
+func getRatel() service {
+	svc := service{
+		Image:         "dgraph/dgraph:" + opts.Tag,
+		ContainerName: "ratel",
+		Ports: []string{
+			toExposedPort(8000),
+		},
+	}
+	return svc
+}
+
 func addMetrics(cfg *composeConfig) {
 	cfg.Volumes["prometheus-volume"] = stringMap{}
 	cfg.Volumes["grafana-volume"] = stringMap{}
@@ -363,6 +375,8 @@ func main() {
 		"Docker tag for dgraph/dgraph image. Requires -l=false to use binary from docker container.")
 	cmd.PersistentFlags().BoolVarP(&opts.WhiteList, "whitelist", "w", false,
 		"include a whitelist if true")
+	cmd.PersistentFlags().BoolVar(&opts.Ratel, "ratel", false,
+		"include ratel service")
 
 	err := cmd.ParseFlags(os.Args)
 	if err != nil {
@@ -421,6 +435,10 @@ func main() {
 
 	if opts.Jaeger {
 		services["jaeger"] = getJaeger()
+	}
+
+	if opts.Ratel {
+		services["ratel"] = getRatel()
 	}
 
 	if opts.Metrics {

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -256,6 +256,7 @@ func getRatel() service {
 		Ports: []string{
 			toExposedPort(8000),
 		},
+		Command: "dgraph-ratel",
 	}
 	return svc
 }


### PR DESCRIPTION
Sometimes you want to use Ratel alongside the cluster created via the compose tool. This adds a
`--ratel` flag to run Ratel accessible at http://localhost:8000.

Run default compose cluster with Ratel running at http://localhost:8000
```
./compose --ratel
```

Run default compose cluster with Ratel running at port 8001

```
./compose --ratel --ratel_port=8001
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3802)
<!-- Reviewable:end -->
