### PR TITLE
Fix flaky backup tests.

### DIFF
--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -85,7 +85,7 @@ func processHttpBackupRequest(ctx context.Context, r *http.Request) error {
 	req := pb.BackupRequest{
 		ReadTs:       ts.ReadOnly,
 		Destination:  destination,
-		UnixTs:       time.Now().UTC().Format("20060102.150405"),
+		UnixTs:       time.Now().UTC().Format("20060102.150405.000"),
 		AccessKey:    accessKey,
 		SecretKey:    secretKey,
 		SessionToken: sessionToken,

--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -214,8 +215,9 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	})
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.NoError(t, testutil.GetError(resp.Body))
-	time.Sleep(time.Second)
+	buf, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(buf), "Backup completed.")
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs()

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"net/url"
@@ -219,9 +220,9 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	})
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.NoError(t, testutil.GetError(resp.Body))
-	// TODO(martinmr): remove this sleep.
-	time.Sleep(time.Second)
+	buf, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(buf), "Backup completed.")
 
 	// Verify that the right amount of files and directories were created.
 	copyToLocalFs(t)

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -17,11 +17,8 @@
 package testutil
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math"
 
 	"github.com/dgraph-io/badger"
@@ -31,7 +28,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 // GetPValues reads the specified p directory and returns the values for the given

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -95,16 +95,3 @@ func GetPValues(pdir, attr string, readTs uint64) (map[string]string, error) {
 	}
 	return values, err
 }
-
-// GetError reads the response from a backup request and returns an error if it indicates
-// that the request failed.
-func GetError(rc io.ReadCloser) error {
-	b, err := ioutil.ReadAll(rc)
-	if err != nil {
-		return errors.Wrapf(err, "while reading")
-	}
-	if bytes.Contains(b, []byte("Error")) {
-		return errors.Errorf("%s", string(b))
-	}
-	return nil
-}


### PR DESCRIPTION
The backup folders were using the timestamp up to the second but when
the test runs with no pauses, multiple backup might get the same folder
name. This PR changes the format to use milliseconds in the name to
avoid collisions. Users won't be making backups that fast so the chances
of a collision happening in real-time use is very small.

Fixes #3394 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3804)
<!-- Reviewable:end -->
