### PR TITLE
docs: Add tip and trick to sort by nested predicate values.

### DIFF
--- a/wiki/content/tips/index.md
+++ b/wiki/content/tips/index.md
@@ -56,9 +56,9 @@ Use the `has` function among the value variables to search on non-indexed predic
 }
 {{< /runnable >}}
 
-## Sort edge by value of a nested node
+## Sort edge by nested node values
 
-Use [query variables]({{ relref "query-language/index.md#query-variables" }}) to bring nested values up to the level of the edge to be sorted.
+Dgraph [sorting][{{< relref "query-language/index.md#sorting" >}}] is based on a single level of the subgraph. To sort a level by the values of a deeper level, use [query variables]({{ relref "query-language/index.md#query-variables" }}) to bring nested values up to the level of the edge to be sorted.
 
 {{< runnable >}}
 {
@@ -88,5 +88,4 @@ Use [query variables]({{ relref "query-language/index.md#query-variables" }}) to
     }
   }
 }
-
 {{< /runnable >}}

--- a/wiki/content/tips/index.md
+++ b/wiki/content/tips/index.md
@@ -58,13 +58,13 @@ Use the `has` function among the value variables to search on non-indexed predic
 
 ## Sort edge by value of a nested node
 
-Make use of variables to bring nested values up to the level of the edge to be sorted.
+Use [query variables]({{ relref "query-language/index.md#query-variables" }}) to bring nested values up to the level of the edge to be sorted.
 
 {{< runnable >}}
 {
-  movies as var(func: gt(count(~genre), 30000), orderasc: name@en) {
+  spielbergMovies as var(func: allofterms(name@en, "steven spielberg")) {
     name@en
-    ~genre (orderasc: name@en, first: 2) @filter(gt(count(starring), 2)) {
+    director.film (orderasc: name@en, first: 2) {
       starring {
         performance.actor {
           ActorName as name@en
@@ -76,9 +76,9 @@ Make use of variables to bring nested values up to the level of the edge to be s
     }
   }
 
-  movies(func: uid(movies)) {
+  movies(func: uid(spielbergMovies)) @cascade {
     name@en
-    director.film: ~genre (orderasc: name@en, first: 2) @filter(gt(count(starring), 2)) {
+    director.film (orderasc: name@en, first: 2) {
       name@en
       starring (orderasc: val(Stars), first: 2) {
         performance.actor {
@@ -88,4 +88,5 @@ Make use of variables to bring nested values up to the level of the edge to be s
     }
   }
 }
+
 {{< /runnable >}}

--- a/wiki/content/tips/index.md
+++ b/wiki/content/tips/index.md
@@ -55,3 +55,37 @@ Use the `has` function among the value variables to search on non-indexed predic
   }
 }
 {{< /runnable >}}
+
+## Sort edge by value of a nested node
+
+Make use of variables to bring nested values up to the level of the edge to be sorted.
+
+{{< runnable >}}
+{
+  movies as var(func: gt(count(~genre), 30000), orderasc: name@en) {
+    name@en
+    ~genre (orderasc: name@en, first: 2) @filter(gt(count(starring), 2)) {
+      starring {
+        performance.actor {
+          ActorName as name@en
+        }
+        # Stars is a uid-to-value map mapping
+        # starring edges to performance.actor names
+        Stars as min(val(ActorName))
+      }
+    }
+  }
+
+  movies(func: uid(movies)) {
+    name@en
+    director.film: ~genre (orderasc: name@en, first: 2) @filter(gt(count(starring), 2)) {
+      name@en
+      starring (orderasc: val(Stars), first: 2) {
+        performance.actor {
+          name@en
+        }
+      }
+    }
+  }
+}
+{{< /runnable >}}

--- a/wiki/content/tips/index.md
+++ b/wiki/content/tips/index.md
@@ -60,11 +60,13 @@ Use the `has` function among the value variables to search on non-indexed predic
 
 Dgraph [sorting][{{< relref "query-language/index.md#sorting" >}}] is based on a single level of the subgraph. To sort a level by the values of a deeper level, use [query variables]({{ relref "query-language/index.md#query-variables" }}) to bring nested values up to the level of the edge to be sorted.
 
+Example: Get all actors from a Steven Spielberg movie sorted alphabetically. The actor's name is not accessed from a single traversal from the `starring` edge; the name is accessible via `performance.actor`.
+
 {{< runnable >}}
 {
   spielbergMovies as var(func: allofterms(name@en, "steven spielberg")) {
     name@en
-    director.film (orderasc: name@en, first: 2) {
+    director.film (orderasc: name@en, first: 1) {
       starring {
         performance.actor {
           ActorName as name@en
@@ -78,9 +80,9 @@ Dgraph [sorting][{{< relref "query-language/index.md#sorting" >}}] is based on a
 
   movies(func: uid(spielbergMovies)) @cascade {
     name@en
-    director.film (orderasc: name@en, first: 2) {
+    director.film (orderasc: name@en, first: 1) {
       name@en
-      starring (orderasc: val(Stars), first: 2) {
+      starring (orderasc: val(Stars)) {
         performance.actor {
           name@en
         }


### PR DESCRIPTION
Add a new example to the Tips and Tricks section of the docs to run a query that sorts by an edge value of a nested predicate.

e.g., For the following structure
film -> starring -> performance.actor -> name

Write a query that sorts the starring edge by [performance.actor->name].

This is possible in GraphQL+- by creating a variable that maps the starring edge to actor names. It involves effectively writing the query twice in two query blocks. The first block creates the variable and the second block uses the variable for sorting.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3809)
<!-- Reviewable:end -->
