### PR TITLE
Speed up JSON chunker.

### DIFF
--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -178,6 +178,8 @@ func (*jsonChunker) Begin(r *bufio.Reader) error {
 
 func (*jsonChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	out := new(bytes.Buffer)
+	// We used to grow the buffer here just like in the RDF chunker, but
+	// this caused a lot of allocations and GC cycles and impacted live loader throughput.
 
 	// For RDF, the loader just reads the input and the mapper parses it into nquads,
 	// so do the same for JSON. But since JSON is not line-oriented like RDF, it's a little

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -178,7 +178,6 @@ func (*jsonChunker) Begin(r *bufio.Reader) error {
 
 func (*jsonChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
 	out := new(bytes.Buffer)
-	out.Grow(1 << 20)
 
 	// For RDF, the loader just reads the input and the mapper parses it into nquads,
 	// so do the same for JSON. But since JSON is not line-oriented like RDF, it's a little


### PR DESCRIPTION
Remove a buffer size allocation in the JSON chunker that was taking up
a lot of time in the CPU profile while live loading, which had a huge
impact to live loading JSON data. I tried loading a JSON array of a
million objects structured like the following:

    [{"uid":"0x1", "pred": "val"}, ...]

Before this change:

    Number of TXs run            : 1010
    Number of N-Quads processed  : 1009929
    Time spent                   : 5m22.79806804s
    N-Quads processed per second : 3136

After this change:

    Number of TXs run            : 1010
    Number of N-Quads processed  : 1009929
    Time spent                   : 13.396047868s
    N-Quads processed per second : 77686

Here's the CPU profile of the 5-minute live loading session 1-million edges (without this change), which shows the expensive GC path with (*jsonChunker).Chunk: [cpu.pprof.gz](https://github.com/dgraph-io/dgraph/files/3508415/cpu.pprof.gz).

```
go tool pprof -web ./cpu.pprof.gz
```

![cpupprof](https://user-images.githubusercontent.com/2251820/63149257-6d4a8a00-bfb8-11e9-8b6f-e9b3350eeb65.png)

```
(pprof) list \).Chunk
Total: 11.83mins
ROUTINE ======================== github.com/dgraph-io/dgraph/chunker.(*jsonChunker).Chunk in src/github.com/dgraph-io/dgraph/chunker/chunk.go
     350ms   4.11mins (flat, cum) 34.72% of Total
         .          .    174:		return errors.Errorf("JSON file must contain array. Found: %v", ch)
         .          .    175:	}
         .          .    176:	return nil
         .          .    177:}
         .          .    178:
      20ms       20ms    179:func (*jsonChunker) Chunk(r *bufio.Reader) (*bytes.Buffer, error) {
      10ms      290ms    180:	out := new(bytes.Buffer)
         .   4.05mins    181:	out.Grow(1 << 20)
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3825)
<!-- Reviewable:end -->
