### PR TITLE
Print sha256 of execuatble in the build details.

### DIFF
--- a/x/init.go
+++ b/x/init.go
@@ -18,8 +18,8 @@ package x
 
 import (
 	"crypto/sha256"
-	"io"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"


### PR DESCRIPTION
Example output:

```
alpha1    | Dgraph version   : v1.0.12-rc3-672-gc2f2b0e5
alpha1    | Dgraph SHA-256   : e37235e5a7179572bf741020b49ace0530548b9c06c22a1ce6022a450f9f3a91
alpha1    | Commit SHA-1     : c2f2b0e5
alpha1    | Commit timestamp : 2019-08-16 10:45:17 -0700
alpha1    | Branch           : master
alpha1    | Go version       : go1.12.7
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3828)
<!-- Reviewable:end -->
