### PR TITLE
Replace errors.Errorf with fmt.Errorf in AssertTruefNoTrace.

### DIFF
--- a/x/error.go
+++ b/x/error.go
@@ -29,6 +29,7 @@ package x
 // (3) You want to generate a new error with stack trace info. Use errors.Errorf.
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -91,7 +92,7 @@ func AssertTruef(b bool, format string, args ...interface{}) {
 // AssertTruefNoTrace is AssertTruef without a stack trace.
 func AssertTruefNoTrace(b bool, format string, args ...interface{}) {
 	if !b {
-		log.Fatalf("%+v", errors.Errorf(format, args...))
+		log.Fatalf("%+v", fmt.Errorf(format, args...))
 	}
 }
 


### PR DESCRIPTION
errors.Errorf prints the trace, which is not the right thing to do in
this function (it's specifically called when the trace is not wanted).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3830)
<!-- Reviewable:end -->
