### PR TITLE
Fix bug in backup KeyToList function.

### DIFF
--- a/ee/backup/backup.go
+++ b/ee/backup/backup.go
@@ -264,15 +264,12 @@ func (pr *Processor) toBackupList(key []byte, itr *badger.Iterator) (*bpb.KVList
 				return list, nil
 			}
 
-			// Manually advance the iterator. This cannot be done in the for
-			// statement because ReadPostingList advances the iterator so this
-			// only needs to be done for BitSchemaPosting entries.
-			itr.Next()
-
 		default:
 			return nil, errors.Errorf(
 				"Unexpected meta: %d for key: %s", item.UserMeta(), hex.Dump(key))
 		}
+
+		itr.Next()
 	}
 
 	// This shouldn't be reached but it's being added here because the golang


### PR DESCRIPTION
Previously, the KeyToList function used during backup assumed that
ReadPostingList takes you to the next key so calling iterator.Next
manually is not needed. This is not the case. The fix is either to make
ReadPostingList call iterator.Next before returning or doing it in the
KeyToList function. The latter has been chosen in this PR to preserve
the existing behavior of ReadPostingList.

It's still not clear why only the bulk loader triggered this issue.