### PR TITLE
Run GraphQL queries concurrently

### DIFF
--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -86,6 +86,15 @@ type RequestResolver struct {
 	resp   *schema.Response
 }
 
+// A resolved is the result of resolving a single query or mutation.
+// A schema.Request may contain any number of queries or mutations (never both).
+// RequestResolver.Resolve() resolves all of them by finding the resolved answers
+// of the component queries/mutations and joining into a single schema.Response.
+type resolved struct {
+	data []byte
+	err  error
+}
+
 // New creates a new RequestResolver
 func New(s schema.Schema, dg dgraph.Client) *RequestResolver {
 	return &RequestResolver{

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -175,22 +175,14 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 				continue
 			}
 
-			mr := &MutationResolver{
+			mr := &mutationResolver{
 				mutation: m,
 				schema:   r.Schema,
 				dgraph:   r.dgraph,
 			}
-			resp, err := mr.Resolve(ctx)
-			r.WithError(err)
-			if len(resp) > 0 {
-				var b bytes.Buffer
-				b.WriteRune('"')
-				b.WriteString(m.ResponseName())
-				b.WriteString(`":`)
-				b.Write(resp)
-
-				r.resp.AddData(b.Bytes())
-			}
+			res := mr.resolve(ctx)
+			r.WithError(res.err)
+			r.resp.AddData(res.data)
 		}
 	case op.IsSubscription():
 		schema.ErrorResponsef("[%s] Subscriptions not yet supported", api.RequestID(ctx))


### PR DESCRIPTION
If a GraphQL query request contains multiple queries, they are expected to be executed in parallel.  Spec says:  "the executor can execute the entries in a grouped field set in whatever order it chooses (normally in parallel)."

However the result must be assembled in the order that the queries were written in the request: "should preserve this order by writing the map entries in the same order as those fields were requested as defined by query execution"

The first cut of query execution ran queries serially.  This fixes that to run concurrently.

(it's also a precursor to adding tracing/timing through the API's execution)

There's (either existing or coming) enough testing that the query pipeline returns the right results that this is just an implementation detail and doesn't need any explicit testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3833)
<!-- Reviewable:end -->
