### PR TITLE
Change to GraphQL "data: null" interpretation

### DIFF
--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -116,7 +116,6 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 	}
 
 	if r.resp.Errors != nil {
-		r.resp.Data.Reset()
 		return r.resp
 	}
 

--- a/dgraph/cmd/graphql/schema/response_test.go
+++ b/dgraph/cmd/graphql/schema/response_test.go
@@ -24,26 +24,6 @@ import (
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
-func TestWithNullData_WritesNull(t *testing.T) {
-	resp := &Response{}
-
-	resp.WithNullData()
-	buf := new(bytes.Buffer)
-	resp.WriteTo(buf)
-
-	assert.JSONEq(t, `{"data":null, "errors":null}`, buf.String())
-}
-
-func TestWithNullData_WritesWithError(t *testing.T) {
-	resp := &Response{Errors: gqlerror.List{gqlerror.Errorf("An Error")}}
-
-	resp.WithNullData()
-	buf := new(bytes.Buffer)
-	resp.WriteTo(buf)
-
-	assert.JSONEq(t, `{"data":null, "errors":[{"message":"An Error"}]}`, buf.String())
-}
-
 func TestAddData_AddInitial(t *testing.T) {
 	resp := &Response{}
 


### PR DESCRIPTION
GraphQL spec says: "If an error was encountered during the execution that prevented a valid response, the data entry in the response should be null."

I had originally interpreted that as meaning that if there's any sort of "error" (couldn't rewrite query, failed to execute Dgraph query, etc.) that we should be returning `{ "data": null }`, but I don't think that's right.

If there's an error down in the pipeline, it get's caught, we add to the GraphQL error list, and set that result to null, so you might thus end up with something like

```
data : {
  q1 : null,
  q2 { ... }
},
```

Which is what the spec says elsewhere should happen.  Sol, I'm interpreting "prevented a valid response" as meaning something really bad happened.  ATM that's just if we fail to actually form a "valid response" as json.

I might also wrap the HTTP pipeline with middleware that will catch any panics, log them and also return `{ "data": null }`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3834)
<!-- Reviewable:end -->
