### PR TITLE
Add Apollo tracing to GraphQL layer

### DIFF
--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -142,7 +142,7 @@ func (mr *mutationResolver) resolve(ctx context.Context) *resolved {
 
 func (mr *mutationResolver) resolveAddMutation(ctx context.Context) *resolved {
 	res := &resolved{}
-	res.trace = make([]*schema.ResolverTrace, 2)
+	res.trace = make([]*schema.ResolverTrace, 0, 2)
 	trace, timer := traceWithTimer(mr.timers, mr.mutation, "Mutation")
 	res.trace = append(res.trace, trace)
 	trace.Path = []interface{}{mr.mutation.ResponseName()}
@@ -249,7 +249,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 
 func (mr *mutationResolver) resolveUpdateMutation(ctx context.Context) *resolved {
 	res := &resolved{}
-	res.trace = make([]*schema.ResolverTrace, 2)
+	res.trace = make([]*schema.ResolverTrace, 0, 2)
 	trace, timer := traceWithTimer(mr.timers, mr.mutation, "Mutation")
 	res.trace = append(res.trace, trace)
 	trace.Path = []interface{}{mr.mutation.ResponseName()}

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -92,8 +92,9 @@ type RequestResolver struct {
 // RequestResolver.Resolve() resolves all of them by finding the resolved answers
 // of the component queries/mutations and joining into a single schema.Response.
 type resolved struct {
-	data []byte
-	err  error
+	data  []byte
+	err   error
+	trace []*schema.ResolverTrace
 }
 
 // New creates a new RequestResolver

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -146,7 +146,10 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 		Tracing:   trace,
 	}
 
-	op, err := r.Schema.Operation(r.GqlReq)
+	op, err := r.Schema.Operation(
+		r.GqlReq,
+		timers.NewOffsetTimer(&trace.Parsing),
+		timers.NewOffsetTimer(&trace.Validation))
 	if err != nil {
 		return schema.ErrorResponse(err)
 	}

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -110,20 +110,33 @@ type Mutation {
 }
 `
 
-func (dg *dgraphClient) Query(ctx context.Context, query *dgraph.QueryBuilder) ([]byte, error) {
+func (dg *dgraphClient) Query(
+	ctx context.Context,
+	query *dgraph.QueryBuilder,
+	dgTimer schema.OffsetTimer) ([]byte, error) {
 	return []byte(dg.resp), nil
 }
 
-func (dg *dgraphClient) Mutate(ctx context.Context, val interface{}) (map[string]string, error) {
+func (dg *dgraphClient) Mutate(
+	ctx context.Context,
+	val interface{},
+	dgTimer schema.OffsetTimer) (map[string]string, error) {
 	return dg.assigned, nil
 }
 
-func (dg *dgraphClient) DeleteNode(ctx context.Context, uid uint64) error {
+func (dg *dgraphClient) DeleteNode(
+	ctx context.Context,
+	uid uint64,
+	dgTimer schema.OffsetTimer) error {
 	// Not needed in testing responses
 	return nil
 }
 
-func (dg *dgraphClient) AssertType(ctx context.Context, uid uint64, typ string) error {
+func (dg *dgraphClient) AssertType(
+	ctx context.Context,
+	uid uint64,
+	typ string,
+	dgTimer schema.OffsetTimer) error {
 	return nil
 }
 

--- a/dgraph/cmd/graphql/resolve/resolver_query_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_query_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
@@ -40,21 +41,34 @@ type queryRecorder struct {
 	query string
 }
 
-func (qr *queryRecorder) Query(ctx context.Context, qb *dgraph.QueryBuilder) ([]byte, error) {
+func (qr *queryRecorder) Query(
+	ctx context.Context,
+	qb *dgraph.QueryBuilder,
+	dgTimer schema.OffsetTimer) ([]byte, error) {
 	var err error
 	qr.query, err = qb.AsQueryString()
 	return []byte("{}"), err
 }
 
-func (qr *queryRecorder) Mutate(ctx context.Context, val interface{}) (map[string]string, error) {
+func (qr *queryRecorder) Mutate(
+	ctx context.Context,
+	val interface{},
+	dgTimer schema.OffsetTimer) (map[string]string, error) {
 	return map[string]string{"newnode": "0x4"}, nil
 }
 
-func (qr *queryRecorder) DeleteNode(ctx context.Context, uid uint64) error {
+func (qr *queryRecorder) DeleteNode(
+	ctx context.Context,
+	uid uint64,
+	dgTimer schema.OffsetTimer) error {
 	return nil
 }
 
-func (qr *queryRecorder) AssertType(ctx context.Context, uid uint64, typ string) error {
+func (qr *queryRecorder) AssertType(
+	ctx context.Context,
+	uid uint64,
+	typ string,
+	dgTimer schema.OffsetTimer) error {
 	return nil
 }
 

--- a/dgraph/cmd/graphql/schema/request.go
+++ b/dgraph/cmd/graphql/schema/request.go
@@ -35,16 +35,24 @@ type Request struct {
 // schema s. If the request is GraphQL valid, it must contain a single valid
 // Operation.  If either the request is malformed or doesn't contain a valid
 // operation, all GraphQL errors encountered are returned.
-func (s schema) Operation(req *Request) (Operation, error) {
+func (s schema) Operation(
+	req *Request,
+	parsingTimer OffsetTimer,
+	validationTimer OffsetTimer) (Operation, error) {
+
 	if req == nil || req.Query == "" {
 		return nil, gqlerror.Errorf("no query string supplied in request")
 	}
 
+	parsingTimer.Start()
 	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: req.Query})
+	parsingTimer.Stop()
 	if gqlErr != nil {
 		return nil, gqlErr
 	}
 
+	validationTimer.Start()
+	defer validationTimer.Stop() // this time should also include variable validation
 	listErr := validator.Validate(s.schema, doc)
 	if len(listErr) != 0 {
 		return nil, listErr

--- a/dgraph/cmd/graphql/schema/response.go
+++ b/dgraph/cmd/graphql/schema/response.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -41,8 +42,93 @@ type Response struct {
 	// - I think we should mostly return 200 status code
 	// - for spec we need to return errors and data in same response
 
-	Errors gqlerror.List
-	Data   bytes.Buffer
+	Errors     gqlerror.List
+	Data       bytes.Buffer
+	Extensions *Extensions
+}
+
+// Extensions : GraphQL specifies allowing "extensions" in results, but the
+// format is up to the implementation.
+type Extensions struct {
+	RequestID string `json:"requestID,omitempty"`
+	Tracing   *Trace `json:"tracing,omitempty"`
+}
+
+// Trace : Apollo Tracing is a GraphQL extension for tracing resolver performance.
+// https://github.com/apollographql/apollo-tracing
+// Not part of the standard itself, it gets reported in GraphQL "extensions".
+// It's for reporting tracing data through all the resolvers in a GraphQL query.
+// Our results aren't as 'deep' as a traditional GraphQL server in that the Dgraph
+// layer resolves in a single step, rather than iteratively.  So we'll report on
+// all the top level queries/mutations.
+//
+// Currently, only reporting in the GraphQL result, but also planning to allow
+// exposing to Apollo Engine as per:
+// https://www.apollographql.com/docs/references/setup-analytics/#engine-reporting-endpoint
+type Trace struct {
+	// (comments from Apollo Tracing spec)
+
+	Version int64 `json:"version"`
+
+	// Timestamps in RFC 3339 format.
+	StartTime time.Time `json:"startTime"`
+	EndTime   time.Time `json:"endTime"`
+
+	// Duration in nanoseconds, relative to the request start, as an integer.
+	Duration int64 `json:"duration"`
+
+	Parsing    *OffsetDuration  `json:"parsing,omitempty"`
+	Validation *OffsetDuration  `json:"validation,omitempty"`
+	Execution  []*ResolverTrace `json:"execution,omitempty"`
+}
+
+// An OffsetDuration records the offset start and duration of GraphQL parsing/validation.
+type OffsetDuration struct {
+	// (comments from Apollo Tracing spec)
+
+	// Offset in nanoseconds, relative to the request start, as an integer
+	StartOffset int64 `json:"startOffset"`
+
+	// Duration in nanoseconds, relative to start of operation, as an integer.
+	Duration int64 `json:"duration"`
+}
+
+// LabeledOffsetDuration is an OffsetDuration with a string label.
+type LabeledOffsetDuration struct {
+	Label string `json:"label"`
+	OffsetDuration
+}
+
+// A ResolverTrace is a trace of one resolver.  In a traditional GraphQL server,
+// resolving say a query, would result in a ResolverTrace for the query itself
+// (with duration spanning the time to resolve the entire query) and traces for
+// every field in the query (with duration for just that field).
+//
+// Dgraph GraphQL layer resolves Queries in a single step, so each query has only
+// one associated ResolverTrace.  Mutations require two steps - the mutation itself
+// and the following query.  So mutations will have a ResolverTrace with duration
+// spanning the entire mutation (including the query part), and a trace of the query.
+// To give insight into what's actually happening there, the Dgraph time is also
+// recorded.  So for a mutation you can see total duration, mutation duration,
+// query duration and also amount of time spent by the API orchestrating the
+// mutation/query.
+type ResolverTrace struct {
+	// (comments from Apollo Tracing spec)
+
+	// the response path of the current resolver - same format as path in error
+	// result format specified in the GraphQL specification
+	Path       []interface{} `json:"path"`
+	ParentType string        `json:"parentType"`
+	FieldName  string        `json:"fieldName"`
+	ReturnType string        `json:"returnType"`
+
+	// Offset relative to request start and total duration or resolving
+	OffsetDuration
+
+	// Dgraph isn't in Apollo tracing.  It records the offsets and times
+	// of Dgraph operations for the query/mutation (including network latency)
+	// in nanoseconds.
+	Dgraph []*LabeledOffsetDuration `json:"dgraph"`
 }
 
 // ErrorResponsef returns a Response containing a single GraphQL error with a
@@ -97,13 +183,15 @@ func (r *Response) WriteTo(w io.Writer) (int64, error) {
 	var js []byte
 	var err error
 
-		js, err = json.Marshal(struct {
-			Errors gqlerror.List   `json:"errors,omitempty"`
-			Data   json.RawMessage `json:"data,omitempty"`
-		}{
-			Errors: r.Errors,
-			Data:   r.Data.Bytes(),
-		})
+	js, err = json.Marshal(struct {
+		Errors     gqlerror.List   `json:"errors,omitempty"`
+		Data       json.RawMessage `json:"data,omitempty"`
+		Extensions *Extensions     `json:"extensions,omitempty"`
+	}{
+		Errors:     r.Errors,
+		Data:       r.Data.Bytes(),
+		Extensions: r.Extensions,
+	})
 
 	if err != nil {
 		msg := "Internal error - failed to marshal a valid JSON response"

--- a/dgraph/cmd/graphql/schema/response.go
+++ b/dgraph/cmd/graphql/schema/response.go
@@ -77,8 +77,8 @@ type Trace struct {
 	// Duration in nanoseconds, relative to the request start, as an integer.
 	Duration int64 `json:"duration"`
 
-	Parsing    *OffsetDuration  `json:"parsing,omitempty"`
-	Validation *OffsetDuration  `json:"validation,omitempty"`
+	Parsing    OffsetDuration   `json:"parsing,omitempty"`
+	Validation OffsetDuration   `json:"validation,omitempty"`
 	Execution  []*ResolverTrace `json:"execution,omitempty"`
 }
 

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -57,7 +57,9 @@ const (
 
 // Schema represents a valid GraphQL schema
 type Schema interface {
-	Operation(r *Request) (Operation, error)
+	Operation(r *Request,
+		parsingTimer OffsetTimer,
+		validationTimer OffsetTimer) (Operation, error)
 }
 
 // An Operation is a single valid GraphQL operation.  It contains either


### PR DESCRIPTION
Adds the Apollo tracing spec to GraphQL layer results: https://github.com/apollographql/apollo-tracing

Apollo tracing can be used like here to return some tracing data in "extensions" of the response payload, and can also push tracing info to Apollo Engine for dev-ops stats etc.  Here we just do the first part.

I'm not really keen to wrap any testing around this or to lock it in at this stage.  For the moment, it's just a nice dev artefact to get some insight into what's going on inside the pipeline for every request.  I expect pretty soon we'll add a flag to turn it off, add some E2E benchmark testing, and probably add the ability to push these stats to Apollo Engine.  At that point, we should lock in its behaviour, so we know it's working in a way that those external tools expect.   (there's cards on the Asana board for all those points.)

With this PR, responses always come back like:

![image](https://user-images.githubusercontent.com/13693742/63314091-f0b60380-c349-11e9-97cd-2ea7dd89aac1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3836)
<!-- Reviewable:end -->
