### PR TITLE
Bugfix: Set found to false to avoid deleting index edge when value doesn't match.

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1294,14 +1294,15 @@ func TestDeleteAllSP2(t *testing.T) {
 }
 
 func TestDeleteScalarValue(t *testing.T) {
-	var s = `name: string .`
+	var s = `name: string @index(exact) .`
 	require.NoError(t, schema.ParseBytes([]byte(""), 1))
 	require.NoError(t, alterSchemaWithRetry(s))
 
 	var m = `
 	{
 	  set {
-	    <0x12345> <name> "xxx" .
+		<0x12345> <name> "xxx" .
+		<0x12346> <name> "xxx" .
 	  }
 	}
 	`
@@ -1342,6 +1343,17 @@ func TestDeleteScalarValue(t *testing.T) {
 	require.NoError(t, err)
 	require.JSONEq(t, `{"data": {"me":[{"name":"xxx"}]}}`, output)
 
+	indexQuery := `
+	{
+		me(func: eq(name, "xxx")) {
+			name
+		}
+	}
+	`
+	output, err = runGraphqlQuery(indexQuery)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data": {"me":[{"name":"xxx"}, {"name":"xxx"}]}}`, output)
+
 	var d2 = `
 	{
       delete {
@@ -1356,6 +1368,11 @@ func TestDeleteScalarValue(t *testing.T) {
 	output, err = runGraphqlQuery(q)
 	require.NoError(t, err)
 	require.JSONEq(t, `{"data": {"me":[]}}`, output)
+
+	// Verify index was also updated this time and one of the triples got deleted.
+	output, err = runGraphqlQuery(indexQuery)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data": {"me":[{"name": "xxx"}]}}`, output)
 }
 
 func TestDeleteValueLang(t *testing.T) {

--- a/posting/index.go
+++ b/posting/index.go
@@ -329,6 +329,12 @@ func (txn *Txn) addMutationHelper(ctx context.Context, l *List, doUpdateIndex bo
 			return val, found, emptyCountParams, err
 		}
 
+		// This is a scalar value of non-list type and a delete edge mutation, so if the value
+		// given by the user doesn't match the value we have, we return found to be false, to avoid
+		// deleting the uid from index posting list.
+		// This second check is required because we fingerprint the scalar values as math.MaxUint64,
+		// so even though they might be different the check in the doUpdateIndex block above would
+		// return found to be true.
 		if pFound && !(bytes.Equal(currPost.Value, newPost.Value) &&
 			types.TypeID(currPost.ValType) == types.TypeID(newPost.ValType)) {
 			return val, false, emptyCountParams, nil

--- a/posting/index.go
+++ b/posting/index.go
@@ -331,7 +331,7 @@ func (txn *Txn) addMutationHelper(ctx context.Context, l *List, doUpdateIndex bo
 
 		if pFound && !(bytes.Equal(currPost.Value, newPost.Value) &&
 			types.TypeID(currPost.ValType) == types.TypeID(newPost.ValType)) {
-			return val, found, emptyCountParams, err
+			return val, false, emptyCountParams, err
 		}
 	}
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -331,7 +331,7 @@ func (txn *Txn) addMutationHelper(ctx context.Context, l *List, doUpdateIndex bo
 
 		if pFound && !(bytes.Equal(currPost.Value, newPost.Value) &&
 			types.TypeID(currPost.ValType) == types.TypeID(newPost.ValType)) {
-			return val, false, emptyCountParams, err
+			return val, false, emptyCountParams, nil
 		}
 	}
 


### PR DESCRIPTION
Fixes #3803 

Return found as false to avoid deleting index corresponding to a uid when the value doesn't match. For scalar values, after fingerprinting found is always true as values get fingerprinted to `math.MaxUint64`. Hence we return found as false from this second check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3843)
<!-- Reviewable:end -->
