### PR TITLE
Don't apply enterprise state for oss builds.

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -17,10 +17,8 @@
 package zero
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"strconv"
@@ -232,38 +230,6 @@ func (st *state) getState(w http.ResponseWriter, r *http.Request) {
 		x.SetStatus(w, x.ErrorNoData, err.Error())
 		return
 	}
-}
-
-// applyEnterpriseLicense accepts a PGP message as a POST request body, verifies that it was
-// signed using our private key and applies the license which has maxNodes and Expiry to the
-// cluster.
-func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) {
-	x.AddCorsHeaders(w)
-	if r.Method == "OPTIONS" {
-		return
-	}
-	if r.Method != http.MethodPost {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidMethod, "Invalid method")
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	b, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
-		return
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	if err := st.zero.applyEnterpriseLicense(ctx, bytes.NewReader(b)); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
-		return
-	}
-	x.SetStatus(w, x.Success, "Done")
 }
 
 func (st *state) serveHTTP(l net.Listener) {

--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -18,21 +18,20 @@
 
 package zero
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/dgraph-io/badger/y"
+)
 
 // dummy function as enterprise features are not available in oss binary.
-func (n *node) proposeTrialLicense() {
-	return
+func (n *node) proposeTrialLicense() error {
+	return nil
 }
 
-// dummy function as enterprise features are not available in oss binary.
-func (s *Server) updateEnterpriseState() {
-	return
-}
-
-// dummy function as enterprise features are not available in oss binary.
-func (s *Server) licenseExpiryWarning() {
-	return
+// periodically checks the validity of the enterprise license and updates the membership state.
+func (n *node) updateEnterpriseState(closer *y.Closer) {
+	closer.Done()
 }
 
 func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) {

--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -18,6 +18,8 @@
 
 package zero
 
+import "net/http"
+
 // dummy function as enterprise features are not available in oss binary.
 func (n *node) proposeTrialLicense() {
 	return
@@ -31,4 +33,8 @@ func (s *Server) updateEnterpriseState() {
 // dummy function as enterprise features are not available in oss binary.
 func (s *Server) licenseExpiryWarning() {
 	return
+}
+
+func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
 }

--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -1,0 +1,34 @@
+// +build oss
+
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zero
+
+// dummy function as enterprise features are not available in oss binary.
+func (n *node) proposeTrialLicense() {
+	return
+}
+
+// dummy function as enterprise features are not available in oss binary.
+func (s *Server) updateEnterpriseState() {
+	return
+}
+
+// dummy function as enterprise features are not available in oss binary.
+func (s *Server) licenseExpiryWarning() {
+	return
+}

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -75,15 +75,11 @@ func (n *node) updateEnterpriseState(closer *y.Closer) {
 		case <-ticker.C:
 			counter++
 			license := n.server.license()
-			if license == nil {
-				continue
-			}
-
-			expiry := time.Unix(license.GetExpiryTs(), 0)
 			if !license.GetEnabled() {
 				continue
 			}
 
+			expiry := time.Unix(license.GetExpiryTs(), 0)
 			timeToExpire := expiry.Sub(time.Now())
 			// We only want to print this log once a day.
 			if counter%intervalsInDay == 0 && timeToExpire > 0 && timeToExpire < humanize.Week {

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -1,0 +1,86 @@
+// +build !oss
+
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Dgraph Community License (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ *     https://github.com/dgraph-io/dgraph/blob/master/licenses/DCL.txt
+ */
+
+package zero
+
+import (
+	"math"
+	"time"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	humanize "github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+)
+
+// proposeTrialLicense proposes an enterprise license valid for 30 days.
+func (n *node) proposeTrialLicense() {
+	// Apply enterprise license valid for 30 days from now.
+	proposal := &pb.ZeroProposal{
+		License: &pb.License{
+			MaxNodes: math.MaxUint64,
+			ExpiryTs: time.Now().Add(humanize.Month).Unix(),
+		},
+	}
+	for {
+		err := n.proposeAndWait(context.Background(), proposal)
+		if err == nil {
+			glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
+			return
+		}
+		if err == errInvalidProposal {
+			glog.Errorf("invalid proposal error while proposing enteprise state")
+			return
+		}
+		glog.Errorf("While proposing enterprise state: %v. Retrying...", err)
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// updateEnterpriseState periodically checks the validity of the enterprise license
+// based on its expiry.
+func (s *Server) updateEnterpriseState() {
+	s.Lock()
+	defer s.Unlock()
+
+	// Return early if license is not enabled. This would happen when user didn't supply us a
+	// license file yet.
+	if s.state.GetLicense() == nil {
+		return
+	}
+
+	enabled := s.state.GetLicense().GetEnabled()
+	expiry := time.Unix(s.state.License.ExpiryTs, 0)
+	s.state.License.Enabled = time.Now().Before(expiry)
+	if enabled && !s.state.License.Enabled {
+		// License was enabled earlier and has just now been disabled.
+		glog.Infof("Enterprise license has expired and enterprise features would be disabled now. " +
+			"Talk to us at contact@dgraph.io to get a new license.")
+	}
+}
+
+// Prints out an info log about the expiry of the license if its about to expire in less than a
+// week.
+func (s *Server) licenseExpiryWarning() {
+	s.RLock()
+	defer s.RUnlock()
+
+	if s.state.GetLicense() == nil {
+		return
+	}
+	enabled := s.state.GetLicense().GetEnabled()
+	expiry := time.Unix(s.state.License.ExpiryTs, 0)
+	timeToExpire := expiry.Sub(time.Now())
+	if enabled && timeToExpire > 0 && timeToExpire < humanize.Week {
+		glog.Infof("Enterprise license is going to expire in %s.", humanize.Time(expiry))
+	}
+}

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -52,7 +52,7 @@ func (s *Server) license() *pb.License {
 	return proto.Clone(s.state.GetLicense()).(*pb.License)
 }
 
-func (s *Server) disableLicense() {
+func (s *Server) expireLicense() {
 	s.Lock()
 	defer s.Unlock()
 	s.state.License.Enabled = false
@@ -86,9 +86,9 @@ func (n *node) updateEnterpriseState(closer *y.Closer) {
 				glog.Warningf("Enterprise license is going to expire in %s.", humanize.Time(expiry))
 			}
 
-			enabled := time.Now().Before(expiry)
-			if !enabled {
-				n.server.disableLicense()
+			active := time.Now().Before(expiry)
+			if !active {
+				n.server.expireLicense()
 				glog.Warningf("Enterprise license has expired and enterprise features would be " +
 					"disabled now. Talk to us at contact@dgraph.io to get a new license.")
 			}

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -93,7 +93,7 @@ func (n *node) updateEnterpriseState(closer *y.Closer) {
 			enabled := time.Now().Before(expiry)
 			if !enabled {
 				n.server.disableLicense()
-				glog.Warningf("Enterprise license has expired and enterprise features would be" +
+				glog.Warningf("Enterprise license has expired and enterprise features would be " +
 					"disabled now. Talk to us at contact@dgraph.io to get a new license.")
 			}
 		case <-closer.HasBeenClosed():

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -34,7 +34,7 @@ func (n *node) proposeTrialLicense() error {
 	proposal := &pb.ZeroProposal{
 		License: &pb.License{
 			MaxNodes: math.MaxUint64,
-			ExpiryTs: time.Now().Add(humanize.Month).Unix(),
+			ExpiryTs: time.Now().UTC().Add(humanize.Month).Unix(),
 		},
 	}
 	err := n.proposeAndWait(context.Background(), proposal)
@@ -79,14 +79,14 @@ func (n *node) updateEnterpriseState(closer *y.Closer) {
 				continue
 			}
 
-			expiry := time.Unix(license.GetExpiryTs(), 0)
-			timeToExpire := expiry.Sub(time.Now())
+			expiry := time.Unix(license.GetExpiryTs(), 0).UTC()
+			timeToExpire := expiry.Sub(time.Now().UTC())
 			// We only want to print this log once a day.
 			if counter%intervalsInDay == 0 && timeToExpire > 0 && timeToExpire < humanize.Week {
 				glog.Warningf("Enterprise license is going to expire in %s.", humanize.Time(expiry))
 			}
 
-			active := time.Now().Before(expiry)
+			active := time.Now().UTC().Before(expiry)
 			if !active {
 				n.server.expireLicense()
 				glog.Warningf("Enterprise license has expired and enterprise features would be " +

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -19,15 +19,17 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/dgraph-io/badger/y"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	humanize "github.com/dustin/go-humanize"
+	"github.com/gogo/protobuf/proto"
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 )
 
 // proposeTrialLicense proposes an enterprise license valid for 30 days.
-func (n *node) proposeTrialLicense() {
+func (n *node) proposeTrialLicense() error {
 	// Apply enterprise license valid for 30 days from now.
 	proposal := &pb.ZeroProposal{
 		License: &pb.License{
@@ -35,57 +37,63 @@ func (n *node) proposeTrialLicense() {
 			ExpiryTs: time.Now().Add(humanize.Month).Unix(),
 		},
 	}
-	for {
-		err := n.proposeAndWait(context.Background(), proposal)
-		if err == nil {
-			glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
-			return
-		}
-		if err == errInvalidProposal {
-			glog.Errorf("invalid proposal error while proposing enteprise state")
-			return
-		}
-		glog.Errorf("While proposing enterprise state: %v. Retrying...", err)
-		time.Sleep(3 * time.Second)
+	err := n.proposeAndWait(context.Background(), proposal)
+	if err != nil {
+		return err
+
 	}
+	glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
+	return nil
 }
 
-// updateEnterpriseState periodically checks the validity of the enterprise license
-// based on its expiry.
-func (s *Server) updateEnterpriseState() {
-	s.Lock()
-	defer s.Unlock()
-
-	// Return early if license is not enabled. This would happen when user didn't supply us a
-	// license file yet.
-	if s.state.GetLicense() == nil {
-		return
-	}
-
-	enabled := s.state.GetLicense().GetEnabled()
-	expiry := time.Unix(s.state.License.ExpiryTs, 0)
-	s.state.License.Enabled = time.Now().Before(expiry)
-	if enabled && !s.state.License.Enabled {
-		// License was enabled earlier and has just now been disabled.
-		glog.Infof("Enterprise license has expired and enterprise features would be disabled now. " +
-			"Talk to us at contact@dgraph.io to get a new license.")
-	}
-}
-
-// Prints out an info log about the expiry of the license if its about to expire in less than a
-// week.
-func (s *Server) licenseExpiryWarning() {
+func (s *Server) license() *pb.License {
 	s.RLock()
 	defer s.RUnlock()
+	return proto.Clone(s.state.GetLicense()).(*pb.License)
+}
 
-	if s.state.GetLicense() == nil {
-		return
-	}
-	enabled := s.state.GetLicense().GetEnabled()
-	expiry := time.Unix(s.state.License.ExpiryTs, 0)
-	timeToExpire := expiry.Sub(time.Now())
-	if enabled && timeToExpire > 0 && timeToExpire < humanize.Week {
-		glog.Infof("Enterprise license is going to expire in %s.", humanize.Time(expiry))
+func (s *Server) disableLicense() {
+	s.Lock()
+	defer s.Unlock()
+	s.state.License.Enabled = false
+}
+
+// periodically checks the validity of the enterprise license and
+// 1. Sets license.Enabled to false in membership state if license has expired.
+// 2. Prints out warning once every day a week before the license is set to expire.
+func (n *node) updateEnterpriseState(closer *y.Closer) {
+	defer closer.Done()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	intervalsInDay := int64(24*time.Hour) / int64(5*time.Second)
+	var counter int64
+	for {
+
+		select {
+		case <-ticker.C:
+			counter++
+			license := n.server.license()
+			expiry := time.Unix(license.ExpiryTs, 0)
+			if !license.GetEnabled() {
+				continue
+			}
+
+			timeToExpire := expiry.Sub(time.Now())
+			if counter%intervalsInDay == 0 && timeToExpire > 0 && timeToExpire < humanize.Week {
+				glog.Warningf("Enterprise license is going to expire in %s.", humanize.Time(expiry))
+			}
+
+			enabled := time.Now().Before(expiry)
+			if !enabled {
+				n.server.disableLicense()
+				glog.Warningf("Enterprise license has expired and enterprise features would be" +
+					"disabled now. Talk to us at contact@dgraph.io to get a new license.")
+			}
+		case <-closer.HasBeenClosed():
+			return
+		}
 	}
 }
 
@@ -113,7 +121,7 @@ func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) 
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	if err := st.zero.applyEnterpriseLicense(ctx, bytes.NewReader(b)); err != nil {
+	if err := st.zero.applyLicense(ctx, bytes.NewReader(b)); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
 		return

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -516,26 +516,7 @@ func (n *node) initAndStartNode() error {
 				time.Sleep(3 * time.Second)
 			}
 
-			// Apply enterprise license valid for 30 days from now.
-			proposal := &pb.ZeroProposal{
-				License: &pb.License{
-					MaxNodes: math.MaxUint64,
-					ExpiryTs: time.Now().Add(humanize.Month).Unix(),
-				},
-			}
-			for {
-				err := n.proposeAndWait(context.Background(), proposal)
-				if err == nil {
-					glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
-					return
-				}
-				if err == errInvalidProposal {
-					glog.Errorf("invalid proposal error while proposing enteprise state")
-					return
-				}
-				glog.Errorf("While proposing enterprise state: %v. Retrying...", err)
-				time.Sleep(3 * time.Second)
-			}
+			n.proposeTrialLicense()
 		}()
 	}
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -370,8 +370,8 @@ func (n *node) applyProposal(e raftpb.Entry) (string, error) {
 		}
 		state.License = p.License
 		// Check expiry and set enabled accordingly.
-		expiry := time.Unix(state.License.ExpiryTs, 0)
-		state.License.Enabled = time.Now().Before(expiry)
+		expiry := time.Unix(state.License.ExpiryTs, 0).UTC()
+		state.License.Enabled = time.Now().UTC().Before(expiry)
 	}
 
 	if p.MaxLeaseId > state.MaxLeaseId {

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -745,7 +745,7 @@ func (s *Server) latestMembershipState(ctx context.Context) (*pb.MembershipState
 	return ms, nil
 }
 
-func (s *Server) applyEnterpriseLicense(ctx context.Context, signedData io.Reader) error {
+func (s *Server) applyLicense(ctx context.Context, signedData io.Reader) error {
 	var l license
 	if err := verifySignature(signedData, strings.NewReader(publicKey), &l); err != nil {
 		return errors.Wrapf(err, "while extracting enterprise details from the license")


### PR DESCRIPTION
Separate out all code which proposes the license and checks for its validity into two different files, `license.go` and `license_ee.go`. This ensures that license related operations are only done for `!oss` builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3847)
<!-- Reviewable:end -->
