### PR TITLE
refactor complete schema functions

### DIFF
--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -272,23 +272,23 @@ func addDeletePayloadType(schema *ast.Schema, defn *ast.Definition) {
 }
 
 func addGetQuery(schema *ast.Schema, defn *ast.Definition) {
-	schema.Query.Fields = append(schema.Query.Fields,
-		&ast.FieldDefinition{
-			Description: "Get " + defn.Name + " by ID",
-			Name:        "get" + defn.Name,
-			Type: &ast.Type{
-				NamedType: defn.Name,
-			},
-			Arguments: []*ast.ArgumentDefinition{
-				&ast.ArgumentDefinition{
-					Name: "id",
-					Type: &ast.Type{
-						NamedType: idTypeFor(defn),
-						NonNull:   true,
-					},
+	qry := &ast.FieldDefinition{
+		Description: "Get " + defn.Name + " by ID",
+		Name:        "get" + defn.Name,
+		Type: &ast.Type{
+			NamedType: defn.Name,
+		},
+		Arguments: []*ast.ArgumentDefinition{
+			&ast.ArgumentDefinition{
+				Name: "id",
+				Type: &ast.Type{
+					NamedType: idTypeFor(defn),
+					NonNull:   true,
 				},
 			},
-		})
+		},
+	}
+	schema.Query.Fields = append(schema.Query.Fields, qry)
 }
 
 func addFilterQuery(schema *ast.Schema, defn *ast.Definition) {
@@ -340,23 +340,23 @@ func addAddMutation(schema *ast.Schema, defn *ast.Definition) {
 }
 
 func addUpdateMutation(schema *ast.Schema, defn *ast.Definition) {
-	schema.Mutation.Fields = append(schema.Mutation.Fields,
-		&ast.FieldDefinition{
-			Description: "Update a " + defn.Name,
-			Name:        "update" + defn.Name,
-			Type: &ast.Type{
-				NamedType: "Update" + defn.Name + "Payload",
-			},
-			Arguments: []*ast.ArgumentDefinition{
-				&ast.ArgumentDefinition{
-					Name: "input",
-					Type: &ast.Type{
-						NamedType: "Update" + defn.Name + "Input",
-						NonNull:   true,
-					},
+	upd := &ast.FieldDefinition{
+		Description: "Update a " + defn.Name,
+		Name:        "update" + defn.Name,
+		Type: &ast.Type{
+			NamedType: "Update" + defn.Name + "Payload",
+		},
+		Arguments: []*ast.ArgumentDefinition{
+			&ast.ArgumentDefinition{
+				Name: "input",
+				Type: &ast.Type{
+					NamedType: "Update" + defn.Name + "Input",
+					NonNull:   true,
 				},
 			},
-		})
+		},
+	}
+	schema.Mutation.Fields = append(schema.Mutation.Fields, upd)
 }
 
 func addDeleteMutation(schema *ast.Schema, defn *ast.Definition) {

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -211,7 +211,7 @@ func addPatchType(schema *ast.Schema, defn *ast.Definition) {
 		Name:   "Patch" + defn.Name,
 		Fields: getNonIDFields(schema, defn),
 	}
-	schema.Types[defn.Name+"Update"] = patchDefn
+	schema.Types["Patch"+defn.Name] = patchDefn
 
 	for _, fld := range patchDefn.Fields {
 		fld.Type.NonNull = false

--- a/dgraph/cmd/graphql/schema/testdata/output/schema1
+++ b/dgraph/cmd/graphql/schema/testdata/output/schema1
@@ -75,11 +75,6 @@ input AuthorRef {
 	id: ID!
 }
 
-input UpdateAuthorInput {
-	id: ID!
-	patch: PatchAuthor!
-}
-
 input PatchAuthor {
 	name: String
 	posts: [PostRef!]
@@ -106,6 +101,11 @@ input PostInput {
 
 input PostRef {
 	id: ID!
+}
+
+input UpdateAuthorInput {
+	id: ID!
+	patch: PatchAuthor!
 }
 
 input UpdatePostInput {

--- a/dgraph/cmd/graphql/schema/testdata/output/schema2
+++ b/dgraph/cmd/graphql/schema/testdata/output/schema2
@@ -62,11 +62,6 @@ input AuthorRef {
 	id: ID!
 }
 
-input UpdateAuthorInput {
-	id: ID!
-	patch: PatchAuthor!
-}
-
 input PatchAuthor {
 	posts: [PostRef!]
 }
@@ -85,6 +80,11 @@ input PostInput {
 
 input PostRef {
 	id: ID!
+}
+
+input UpdateAuthorInput {
+	id: ID!
+	patch: PatchAuthor!
 }
 
 input UpdatePostInput {


### PR DESCRIPTION
There was once a reason why these built and returned types, but that's since gone.  This way looks nicer, and we are moving to a spot where sometimes things will get added and sometimes not - that decisions should live down in the function itself, not at the top level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3864)
<!-- Reviewable:end -->
