### PR TITLE
Updated docs for querying with graphql vars

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -3101,8 +3101,14 @@ fragment TestFragB {
 ## GraphQL Variables
 
 `Variables` can be defined and used in queries which helps in query reuse and avoids costly string building in clients at runtime by passing a separate variable map. A variable starts with a `$` symbol.
+In Dgraph v1.1 and above, for **HTTP requests** with GraphQL Variables, we need to use `Content-Type: application/json` header and pass data with a JSON object containing `query` and `variables`.
 
-For `HTTP` requests with GraphQL Variables in Dgraph v1.1 and above, we need to make use of `Content-Type: application/json` header and pass data with a JSON object with `query` and `variables`.
+```sh
+curl -H "Content-Type: application/json" localhost:8080/query -XPOST -d $'{
+  "query": "query test($a: string) { test(func: eq(name, $a)) { \n uid \n name \n } }",
+  "variables": { "$a": "Alice" }
+}' | python -m json.tool | less
+```
 
 {{< runnable vars="{\"$a\": \"5\", \"$b\": \"10\", \"$name\": \"Steven Spielberg\"}" >}}
 query test($a: int, $b: int, $name: string) {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -3102,6 +3102,8 @@ fragment TestFragB {
 
 `Variables` can be defined and used in queries which helps in query reuse and avoids costly string building in clients at runtime by passing a separate variable map. A variable starts with a `$` symbol.
 
+For `HTTP` requests with GraphQL Variables in Dgraph v1.1 and above, we need to make use of `Content-Type: application/json` header and pass data with a JSON object with `query` and `variables`.
+
 {{< runnable vars="{\"$a\": \"5\", \"$b\": \"10\", \"$name\": \"Steven Spielberg\"}" >}}
 query test($a: int, $b: int, $name: string) {
   me(func: allofterms(name@en, $name)) {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -3101,7 +3101,7 @@ fragment TestFragB {
 ## GraphQL Variables
 
 `Variables` can be defined and used in queries which helps in query reuse and avoids costly string building in clients at runtime by passing a separate variable map. A variable starts with a `$` symbol.
-In Dgraph v1.1 and above, for **HTTP requests** with GraphQL Variables, we need to use `Content-Type: application/json` header and pass data with a JSON object containing `query` and `variables`.
+For **HTTP requests** with GraphQL Variables, we must use `Content-Type: application/json` header and pass data with a JSON object containing `query` and `variables`.
 
 ```sh
 curl -H "Content-Type: application/json" localhost:8080/query -XPOST -d $'{


### PR DESCRIPTION
Added documentation about change in querying with graphql variables for Dgraph v1.1.


This PR is dependent on another PR from [dgraph-io/hugo-docs/pull/26](https://github.com/dgraph-io/hugo-docs/pull/26).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3868)
<!-- Reviewable:end -->
