### PR TITLE
Use txn.Get in addReverseMutation

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1422,3 +1422,52 @@ upsert {
 	require.NotContains(t, res, "San Francisco")
 	require.NotContains(t, res, "Fuller Street, SF")
 }
+
+func TestDeleteCountIndex(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`
+<game_answer>: uid @count @reverse .
+<name>: int @index(int) .`))
+
+	m1 := `
+{
+set {
+  _:1 <game_answer> _:2 .
+  _:1 <name> "1" .
+  _:2 <game_answer> _:3 .
+  _:2 <name> "2" .
+  _:4 <game_answer> _:2 .
+  _:3 <name> "3" .
+  _:4 <name> "4" .
+}
+}`
+
+	_, _, _, err := mutationWithTs(m1, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	m2 := `
+upsert {
+query {
+  u3 as var(func: eq(name, "3"))
+  u2 as var(func: eq(name, "2"))
+}
+mutation {
+  delete {
+      uid(u2) <game_answer> uid(u3) .
+  }
+}
+}`
+	_, _, _, err = mutationWithTs(m2, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	q1 := `
+{
+    me(func: eq(count(~game_answer), 1)) {
+      name
+      count(~game_answer)
+    }
+  }`
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+	require.NotContains(t, res, "count(~game_answer)")
+}

--- a/posting/index.go
+++ b/posting/index.go
@@ -169,7 +169,7 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 
 func (txn *Txn) addReverseMutation(ctx context.Context, t *pb.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
-	plist, err := txn.cache.GetFromDelta(key)
+	plist, err := txn.Get(key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We cannot use txn.cache.GetFromDeltas for reverse mutations becasue
cache will not have deltas corresponding to reverse key. Fixes #3840