### PR TITLE
Added Support for val function inside Upsert 

### DIFF
--- a/chunker/rdf_state.go
+++ b/chunker/rdf_state.go
@@ -136,12 +136,7 @@ func lexText(l *lex.Lexer) lex.StateFn {
 				l.Depth = atSubject
 			}
 
-		case isSpace(r):
-			continue
-
-		// Because we only support UID and VAL functions, it's okay
-		// to check only for alphabets. In future, we can change it.
-		case (r >= 'a' || r <= 'z') || (r >= 'A' && r <= 'Z'):
+		case r == 'u' || r == 'v':
 			if l.Depth != atSubject && l.Depth != atObject {
 				return l.Errorf("Unexpected char '%s'", r)
 			}
@@ -149,6 +144,8 @@ func lexText(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemText)
 			return lexVariable
 
+		case isSpace(r):
+			continue
 
 		default:
 			l.Errorf("Invalid input: %c at lexText", r)
@@ -460,7 +457,7 @@ func lexVariable(l *lex.Lexer) lex.StateFn {
 
 func isSpecificChar(r rune) func(c rune) bool {
 	return (func(c rune) bool {
-		return r == c;
+		return r == c
 	})
 }
 

--- a/chunker/rdf_state.go
+++ b/chunker/rdf_state.go
@@ -138,7 +138,7 @@ func lexText(l *lex.Lexer) lex.StateFn {
 
 		case r == 'u' || r == 'v':
 			if l.Depth != atSubject && l.Depth != atObject {
-				return l.Errorf("Unexpected char '%s'", r)
+				return l.Errorf("Unexpected char '%c'", r)
 			}
 			l.Backup()
 			l.Emit(itemText)

--- a/chunker/rdf_state.go
+++ b/chunker/rdf_state.go
@@ -136,6 +136,8 @@ func lexText(l *lex.Lexer) lex.StateFn {
 				l.Depth = atSubject
 			}
 
+		// This should happen when there is either UID or Val funciton
+		// hence, we are just checking for u or v
 		case r == 'u' || r == 'v':
 			if l.Depth != atSubject && l.Depth != atObject {
 				return l.Errorf("Unexpected char '%c'", r)

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1406,60 +1406,123 @@ upsert {
 	require.Contains(t, res, "user3")
 	require.Contains(t, res, "Fuller Street, SF")
 
-	// Check for val in upsert. Adding interest to everyone's account
+	// Resetting the val in upsert, to check if the values are not switched
 	m3 := `
-  upsert {
-    query {
-      u as var(func: has(amount)) {
-        amt as amount 
-      }
-    }
-
-    mutation {
-      set {
-        uid(u) <amount> val(amt) .
-      }
+upsert {
+  query {
+    u as var(func: has(amount)) {
+      amt as amount 
     }
   }
+
+  mutation {
+    set {
+      uid(u) <amount> val(amt) .
+    }
+  }
+}
   `
 
 	_, _, _, err = mutationWithTs(m3, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
 	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
-	expected_res := `
-	{
-	"data": {
-		"q": [{
-			"name": "user3",
-			"branch": "Fuller Street, SF",
-			"amount": 1000.000000
-		}, {
-			"name": "user1",
-			"branch": "Fuller Street, SF",
-			"amount": 10.000000
-		}, {
-			"name": "user2",
-			"branch": "Fuller Street, SF",
-			"amount": 100.000000
-		}]
-	}
+	expectedRes := `
+{
+  "data": {
+    "q": [{
+       "name": "user3",
+       "branch": "Fuller Street, SF",
+       "amount": 1000.000000
+     }, {
+       "name": "user1",
+       "branch": "Fuller Street, SF",
+       "amount": 10.000000
+     }, {
+       "name": "user2",
+       "branch": "Fuller Street, SF",
+       "amount": 100.000000
+     }]
+   }
 }`
-	testutil.CompareJSON(t, res, expected_res)
+	testutil.CompareJSON(t, res, expectedRes)
+
+	// Checking for error when some wrong field is being used
+	m5 := `
+upsert {
+  query {
+    u as var(func: has(amount)) {
+      amt as nofield
+    }
+  }
+
+  mutation {
+    set {
+      uid(u) <amount> val(amt) .
+    }
+  }
+}
+  `
+
+	_, _, _, err = mutationWithTs(m5, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	//Checking support for aggregate variable in upsert
+	m6 := `
+upsert {
+  query {
+    u as var(func: has(amount)) {
+      amt as amount 
+    }
+    me() {
+      max_amt as max(val(amt))
+    }
+  }
+
+  mutation {
+    set {
+      uid(u) <amount> val(max_amt) .
+    }
+  }
+}
+  `
+	_, _, _, err = mutationWithTs(m6, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	expectedRes = `
+{
+  "data": {
+    "q": [{
+       "name": "user3",
+       "branch": "Fuller Street, SF",
+       "amount": 1000.000000
+     }, {
+       "name": "user1",
+       "branch": "Fuller Street, SF",
+       "amount": 1000.000000
+     }, {
+       "name": "user2",
+       "branch": "Fuller Street, SF",
+       "amount": 1000.000000
+     }]
+   }
+}`
+	testutil.CompareJSON(t, res, expectedRes)
 
 	// Bulk Delete: delete everyone's branch
 	m4 := `
-  upsert {
-    query {
-      u as var(func: has(branch))
-    }
+upsert {
+  query {
+    u as var(func: has(branch))
+  }
 
-    mutation {
-      delete {
-        uid(u) <branch> * .
-      }
+  mutation {
+    delete {
+      uid(u) <branch> * .
     }
-  }`
+  }
+}`
 	_, _, _, err = mutationWithTs(m4, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
@@ -1467,26 +1530,6 @@ upsert {
 	require.NoError(t, err)
 	require.NotContains(t, res, "San Francisco")
 	require.NotContains(t, res, "Fuller Street, SF")
-
-	// Checking for error when some wrong field is being used
-	m5 := `
-  upsert {
-    query {
-      u as var(func: has(amount)) {
-        amt as nofield
-      }
-    }
-
-    mutation {
-      set {
-        uid(u) <nofield> val(amt) .
-      }
-    }
-  }
-  `
-
-	_, _, _, err = mutationWithTs(m5, "application/rdf", false, true, 0)
-	require.NoError(t, err)
 }
 
 func TestDeleteCountIndex(t *testing.T) {

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1486,7 +1486,7 @@ upsert {
   `
 
 	_, _, _, err = mutationWithTs(m5, "application/rdf", false, true, 0)
-	require.Contains(t, err.Error(), "strconv.ParseUint: parsing \"val(amt)\": invalid syntax")
+	require.NoError(t, err)
 }
 
 func TestDeleteCountIndex(t *testing.T) {

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1467,6 +1467,26 @@ upsert {
 	require.NoError(t, err)
 	require.NotContains(t, res, "San Francisco")
 	require.NotContains(t, res, "Fuller Street, SF")
+
+	// Checking for error when some wrong field is being used
+	m5 := `
+  upsert {
+    query {
+      u as var(func: has(amount)) {
+        amt as nofield
+      }
+    }
+
+    mutation {
+      set {
+        uid(u) <nofield> val(amt) .
+      }
+    }
+  }
+  `
+
+	_, _, _, err = mutationWithTs(m5, "application/rdf", false, true, 0)
+	require.Contains(t, err.Error(), "strconv.ParseUint: parsing \"val(amt)\": invalid syntax")
 }
 
 func TestDeleteCountIndex(t *testing.T) {

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -195,8 +195,7 @@ services:
     image: minio/minio:latest
     container_name: minio1
     env_file:
-      - ./minio.env
-            #      - $GOPATH/src/github.com/dgraph-io/dgraph/dgraph/minio.env
+      - $GOPATH/src/github.com/dgraph-io/dgraph/dgraph/minio.env
     working_dir: /data/minio1
     ports:
       - 9001:9001

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -195,7 +195,8 @@ services:
     image: minio/minio:latest
     container_name: minio1
     env_file:
-      - $GOPATH/src/github.com/dgraph-io/dgraph/dgraph/minio.env
+      - ./minio.env
+            #      - $GOPATH/src/github.com/dgraph-io/dgraph/dgraph/minio.env
     working_dir: /data/minio1
     ports:
       - 9001:9001

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -747,7 +747,7 @@ func updateValInNQuads(nquads []*api.NQuad, req query.Request) []*api.NQuad {
 			continue
 		}
 
-		key, err := strconv.ParseUint(nq.Subject, 10, 64)
+		key, err := strconv.ParseUint(nq.Subject, 0, 64)
 		if err != nil {
 			// Key conversion failed, ignoring the nquad. Ideally,
 			// it shouldn't happen as this is the result of a query.

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -57,6 +57,12 @@ func TestParseNQuads(t *testing.T) {
 	}, nqs)
 }
 
+func TestValNquads(t *testing.T) {
+	nquads := `uid(m) <name> val(f) .`
+	_, err := chunker.ParseRDFs([]byte(nquads))
+	require.NoError(t, err)
+}
+
 func TestParseNQuadsWindowsNewline(t *testing.T) {
 	nquads := "_:a <predA> \"A\" .\r\n_:b <predB> \"B\" ."
 	nqs, err := chunker.ParseRDFs([]byte(nquads))


### PR DESCRIPTION
Added VAL function to Upsert mutations.
This allows the user to do queries like 

```
// Bulk update a query
upsert {
  query {
    u as var(func: has(amount)) {
      amt as amount 
    }
    me () {
      updated_amt as math(amt+1)
    }
  }

// Set variables to an aggregate variable
upsert {
  query {
    u as var(func: has(amount)) {
      amt as amount 
    }
    me() {
      max_amt as max(val(amt))
    }
  }
  mutation {
    set {
      uid(u) <amount> val(max_amt) .
    }
  }
}

// Delete specific values
upsert {
  query {
    u as var(func: has(amount)) {
      amt as amount
    }
  }
  
  mutation {
    delete {
      uid(u) <amount> val(amt) .
    }
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3877)
<!-- Reviewable:end -->
