### PR TITLE
Review Type System In Docs

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2188,9 +2188,9 @@ Queries using the `expand(_all_)`, `expand(_reverse_)`, or `expand(_forward_)`
 functions now require that the types of the nodes to expand have been properly
 set. Refer to that section for more information.
 
-In addition, reverse edges must be specified in the Schema Type. In both directions. The reverse edge can be an Alias ​​or even the same value as the outcoming edge. Also queries with `expand(_all_)` and `expand(_reverse_)` will be expanded normally.
+In addition, reverse edges must be specified in the Schema Type. In both directions. The reverse edge can be an alias ​​or even the same value as the outcoming edge. Also queries with `expand(_all_)` and `expand(_reverse_)` will be expanded normally.
 
-{{% notice "note" %}} Note: You do not have to specify a predicate for "author" inside Article Type. Because this is an Alias.{{% /notice  %}}
+{{% notice "note" %}} Note: You do not have to specify a predicate for "author" inside Article Type because this is an alias.{{% /notice  %}}
 
 E.g.
 ```
@@ -2207,20 +2207,20 @@ type Article {
   author: [Author]
 }
 ```
-In the above example "author" inside "Article" Type represents a reverse edge to be used as Alias. As in the query below.
+In the above example "author" inside "Article" type represents a reverse edge to be used as alias. As in the query below.
 
 ```
 {
-		q(func: type(Article)) {
-			uid
-			points
-			title
-			author : ~articles {
-				name
-				age
-			}
-		}
-	}
+  q(func: type(Article)) {
+    uid
+    points
+    title
+    author : ~articles {
+      name
+      age
+    }
+  }
+}
 ```
 
 ### Predicates i18n

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1823,8 +1823,13 @@ type Animal {
 
 type Pet {
     owner: uid
-    veterinarian: uid
+    veterinarian: Person
 }
+
+type Person {
+    name: string
+}
+
 ```
 
 When `expand(_all_)` is called on this node, Dgraph will first check which types
@@ -2103,8 +2108,8 @@ student_name: string @index(exact) .
 textbook_name: string @lang @index(fulltext) .
 ```
 
-Types also support list attributes (i.e `friends: [uid]`) and non-nullable types
-(i.e `friends: [uid]!`). However, the type of the attributes are not being used
+Types also support list attributes (i.e `friends: [Person]`) and non-nullable types
+(i.e `friends: [Person]!`). However, the type of the attributes are not being used
 right now, as the type system is still a work in progress. It's a good idea to
 properly think about how they should be setup to avoid any issues once the type
 system starts using them.
@@ -2182,6 +2187,41 @@ err := c.Alter(context.Background(), &api.Operation{
 Queries using the `expand(_all_)`, `expand(_reverse_)`, or `expand(_forward_)`
 functions now require that the types of the nodes to expand have been properly
 set. Refer to that section for more information.
+
+In addition, reverse edges must be specified in the Schema Type. In both directions. The reverse edge can be an Alias ​​or even the same value as the outcoming edge. Also queries with `expand(_all_)` and `expand(_reverse_)` will be expanded normally.
+
+{{% notice "note" %}} Note: You do not have to specify a predicate for "author" inside Article Type. Because this is an Alias.{{% /notice  %}}
+
+E.g.
+```
+type Author {
+  name: string
+  age: int
+  nationality: string
+  articles: [Article]
+}
+
+type Article {
+  title: string
+  points: int
+  author: [Author]
+}
+```
+In the above example "author" inside "Article" Type represents a reverse edge to be used as Alias. As in the query below.
+
+```
+{
+		q(func: type(Article)) {
+			uid
+			points
+			title
+			author : ~articles {
+				name
+				age
+			}
+		}
+	}
+```
 
 ### Predicates i18n
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1817,13 +1817,13 @@ the following definitions:
 ```
 type Animal {
     name: string
-    species: uid
+    species: Specie
     dob: datetime
 }
 
 type Pet {
-    owner: uid
-    veterinarian: Person
+    owner: Person
+    veterinarian: [Person]
 }
 
 type Person {
@@ -2188,7 +2188,7 @@ Queries using the `expand(_all_)`, `expand(_reverse_)`, or `expand(_forward_)`
 functions now require that the types of the nodes to expand have been properly
 set. Refer to that section for more information.
 
-In addition, reverse edges must be specified in the Schema Type. In both directions. The reverse edge can be an alias ​​or even the same value as the outcoming edge. Also queries with `expand(_all_)` and `expand(_reverse_)` will be expanded normally.
+In addition, reverse edges must be specified in the schema type in both directions. The reverse edge can be an alias ​​or even the same value as the outcoming edge. Also queries with `expand(_all_)` and `expand(_reverse_)` will be expanded normally.
 
 {{% notice "note" %}} Note: You do not have to specify a predicate for "author" inside Article Type because this is an alias.{{% /notice  %}}
 


### PR DESCRIPTION
* I modified the use of "uid" to specifically a Type. This way it does not confuse the user and makes a pattern explicit.
* I've added an example which we can explain the use of Types with reverse. Using two directions in the System Type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3884)
<!-- Reviewable:end -->
