### PR TITLE
Adding log lines to help troubleshoot snapshot and rollup

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -403,6 +403,7 @@ func (n *node) processRollups() {
 			return
 		case readTs = <-n.rollupCh:
 		case <-tick.C:
+			glog.V(3).Infof("Evaluating rollup readTs:%d last:%d rollup:%v", readTs, last, readTs > last)
 			if readTs <= last {
 				break // Break out of the select case.
 			}
@@ -691,6 +692,9 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 						// Save some cycles by only calculating snapshot if the checkpoint has gone
 						// quite a bit further than the first index.
 						calculate = chk >= first+uint64(x.WorkerConfig.SnapshotAfter)
+						glog.V(3).Infof("Evaluating snapshot first:%d chk:%d (chk-first:%d) "+
+							"snapshotAfter:%d snap:%v", first, chk, chk-first,
+							x.WorkerConfig.SnapshotAfter, calculate)
 					}
 				}
 				// We keep track of the applied index in the p directory. Even if we don't take


### PR DESCRIPTION
During troubleshooting it's sometimes useful to see that the snapshot and rollup logic are being evaluated, and know the decision of the evaluation. This PR adds the logs at verbose level 3 to help with the troubleshooting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3889)
<!-- Reviewable:end -->
