### PR TITLE
docs: Set v1.0.17 as latest.

### DIFF
--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -19,8 +19,9 @@ HOST=https://docs.dgraph.io
 # append '(latest)' to the version string, and build script can place the
 # artifact in an appropriate location
 VERSIONS_ARRAY=(
-'v1.0.16'
+'v1.0.17'
 'master'
+'v1.0.16'
 'v1.0.15'
 'v1.0.14'
 'v1.0.13'


### PR DESCRIPTION
This change updates the build script to set the Dgraph v1.0.17 as the default and latest version for https://docs.dgraph.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3892)
<!-- Reviewable:end -->
