### PR TITLE
Recover from panics while executing graphql requests.

### DIFF
--- a/dgraph/cmd/graphql/http.go
+++ b/dgraph/cmd/graphql/http.go
@@ -42,6 +42,7 @@ func recoveryHandler(next http.Handler) http.Handler {
 				glog.Errorf("panic: %s while executing request with ID: %s, trace: %s", err,
 					api.RequestID(r.Context()), string(debug.Stack()))
 				rr := schema.ErrorResponsef("Internal Server Error")
+				w.Header().Set("Content-Type", "application/json")
 				if _, err := rr.WriteTo(w); err != nil {
 					glog.Error(err)
 				}

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -167,7 +167,7 @@ func run() error {
 		schema:       gqlschema,
 	}
 
-	http.Handle("/graphql", api.WithRequestID(handler))
+	http.Handle("/graphql", recoveryHandler(api.WithRequestID(handler)))
 
 	// TODO:
 	// the ports and urls etc that the endpoint serves should be input options

--- a/dgraph/cmd/graphql/schema/response.go
+++ b/dgraph/cmd/graphql/schema/response.go
@@ -94,16 +94,13 @@ func (r *Response) WriteTo(w io.Writer) (int64, error) {
 		return int64(i), err
 	}
 
-	var js []byte
-	var err error
-
-		js, err = json.Marshal(struct {
-			Errors gqlerror.List   `json:"errors,omitempty"`
-			Data   json.RawMessage `json:"data,omitempty"`
-		}{
-			Errors: r.Errors,
-			Data:   r.Data.Bytes(),
-		})
+	js, err := json.Marshal(struct {
+		Errors gqlerror.List   `json:"errors,omitempty"`
+		Data   json.RawMessage `json:"data,omitempty"`
+	}{
+		Errors: r.Errors,
+		Data:   r.Data.Bytes(),
+	})
 
 	if err != nil {
 		msg := "Internal error - failed to marshal a valid JSON response"


### PR DESCRIPTION
Adds logic to recover from panic during execution of graphql requests and log the stack trace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3894)
<!-- Reviewable:end -->
