### PR TITLE
Create dgraph/standalone Docker image

### DIFF
--- a/contrib/standalone/Dockerfile
+++ b/contrib/standalone/Dockerfile
@@ -1,0 +1,11 @@
+FROM dgraph/dgraph:latest
+LABEL MAINTAINER="Dgraph Labs <contact@dgraph.io>"
+
+# Ratel port
+EXPOSE 8000
+# REST API port
+EXPOSE 8080
+
+ADD run.sh .
+RUN chmod +x run.sh
+CMD ["./run.sh"]

--- a/contrib/standalone/Dockerfile
+++ b/contrib/standalone/Dockerfile
@@ -5,6 +5,8 @@ LABEL MAINTAINER="Dgraph Labs <contact@dgraph.io>"
 EXPOSE 8000
 # REST API port
 EXPOSE 8080
+# gRPC API port
+EXPOSE 9080
 
 ADD run.sh .
 RUN chmod +x run.sh

--- a/contrib/standalone/Makefile
+++ b/contrib/standalone/Makefile
@@ -1,0 +1,3 @@
+.PHONY: build
+build:
+	docker build -t dgraph/standalone:latest .

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -5,10 +5,11 @@ set -e
 
 lru_kb=$(cat /proc/meminfo | grep MemTotal | sed "s/.* \([0-9]*\) .*/\1/")
 lru_mb=$(expr $lru_kb / 1024)
+
+echo -e "\033[0;33m
+Warning: This standalone version is meant for quickstart purposes only.
+         It is NOT RECOMMENDED for production environments.\033[0;0m"
+
 echo "running alpha with LRU size of $lru_mb MB"
-echo ""
-echo "The standalone version is meant for quickstart purposes only. It is NOT
-RECOMMENDED for production environments."
-echo ""
 # TODO properly handle SIGTERM for all three processes.
 dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# fail if any error occurs
+set -e
+
+lru_kb=$(cat /proc/meminfo | grep MemTotal | sed "s/.* \([0-9]*\) .*/\1/")
+lru_mb=$(expr $lru_kb / 1024)
+echo "running alpha with LRU size of $lru_mb MB"
+dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -6,4 +6,5 @@ set -e
 lru_kb=$(cat /proc/meminfo | grep MemTotal | sed "s/.* \([0-9]*\) .*/\1/")
 lru_mb=$(expr $lru_kb / 1024)
 echo "running alpha with LRU size of $lru_mb MB"
+# TODO properly handle SIGTERM for all three processes.
 dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -10,6 +10,5 @@ echo -e "\033[0;33m
 Warning: This standalone version is meant for quickstart purposes only.
          It is NOT RECOMMENDED for production environments.\033[0;0m"
 
-echo "running alpha with LRU size of $lru_mb MB"
 # TODO properly handle SIGTERM for all three processes.
 dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -4,7 +4,7 @@
 set -e
 
 lru_kb=$(cat /proc/meminfo | grep MemTotal | sed "s/.* \([0-9]*\) .*/\1/")
-lru_mb=$(expr $lru_kb / 1024)
+lru_mb=$(expr $lru_kb / 1024 / 3) # one-third of host memory
 
 echo -e "\033[0;33m
 Warning: This standalone version is meant for quickstart purposes only.

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -6,5 +6,9 @@ set -e
 lru_kb=$(cat /proc/meminfo | grep MemTotal | sed "s/.* \([0-9]*\) .*/\1/")
 lru_mb=$(expr $lru_kb / 1024)
 echo "running alpha with LRU size of $lru_mb MB"
+echo ""
+echo "The standalone version is meant for quickstart purposes only. It is NOT
+RECOMMENDED for production environments."
+echo ""
 # TODO properly handle SIGTERM for all three processes.
 dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb


### PR DESCRIPTION
This will allow us to run dgraph in a single docker command:

```bash
$ docker run -tP dgraph/standalone
```

Please @danielmai, can you modify this so this image is built with each release and nightly too?
This will make our "getting started" much easier!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3899)
<!-- Reviewable:end -->
