### PR TITLE
Bug Fix: Remove Check2 at writeResponse

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -276,7 +276,9 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	writeEntry("extensions", js)
 	out.WriteRune('}')
 
-	x.Check2(writeResponse(w, r, out.Bytes()))
+	if _, err := writeResponse(w, r, out.Bytes()); err != nil {
+		glog.Errorln("Unable to write response: ", err)
+	}
 }
 
 func mutationHandler(w http.ResponseWriter, r *http.Request) {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -277,6 +277,8 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 	out.WriteRune('}')
 
 	if _, err := writeResponse(w, r, out.Bytes()); err != nil {
+		// If client crashes before server could write response, writeResponse will error out,
+		// Check2 will fatal and shut the server down in such scenario. We don't want that.
 		glog.Errorln("Unable to write response: ", err)
 	}
 }


### PR DESCRIPTION
Check2 will fatal if there is error in `writeResponse`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3900)
<!-- Reviewable:end -->
