### PR TITLE
make RAM calculation only available on darwin and linux

### DIFF
--- a/edgraph/config.go
+++ b/edgraph/config.go
@@ -100,8 +100,8 @@ func (opt *Options) validate() {
 	x.Check(err)
 	x.AssertTruef(pd != wd, "Posting and WAL directory cannot be the same ('%s').", opt.PostingDir)
 	if opt.AllottedMemory < 0 {
-		if availableMemory > MinAllottedMemory {
-			opt.AllottedMemory = 0.25 * float64(availableMemory)
+		if allottedMemory := 0.25 * float64(availableMemory); allottedMemory > MinAllottedMemory {
+			opt.AllottedMemory = allottedMemory
 			glog.Infof(
 				"LRU memory (--lru_mb) set to %vMB, 25%% of the total RAM found (%vMB)\n"+
 					"For more information on --lru_mb please read "+

--- a/edgraph/config_mem.go
+++ b/edgraph/config_mem.go
@@ -1,0 +1,14 @@
+// +build: linux darwin
+// +build: cgo
+
+// This file is compiled on linux and darwin when cgo is enabled.
+
+package edgraph
+
+// #include <unistd.h>
+import "C"
+
+func init() {
+	bytes := int64(C.sysconf(C._SC_PHYS_PAGES) * C.sysconf(C._SC_PAGE_SIZE))
+	availableMemory = bytes / 1024 / 1024
+}

--- a/edgraph/config_mem.go
+++ b/edgraph/config_mem.go
@@ -1,5 +1,5 @@
-// +build: linux darwin
-// +build: cgo
+// +build linux darwin
+// +build cgo
 
 // This file is compiled on linux and darwin when cgo is enabled.
 


### PR DESCRIPTION
Currently, the build is failing on Windows due to some of the symbols not being defined.

This PR moves the calculation of the total size in RAM to a file that is only taken into account when on darwin or linux as long as CGO is enabled.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3912)
<!-- Reviewable:end -->
