### PR TITLE
Exposing Badger stats to the prometheus_metrics page

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -35,22 +35,30 @@ func TestMetrics(t *testing.T) {
 
 	requiredMetrics := []string{
 		// Go Runtime Metrics
-		"go_goroutines", "go_memstats_gc_cpu_fraction", "go_memstats_heap_alloc_bytes",
-		"go_memstats_heap_idle_bytes", "go_memstats_heap_inuse_bytes", "dgraph_latency_bucket",
-		// TODO: add support for the following Badger metrics, which is currently only available
-		// through /debug/vars. Consider manually add them as OpenCensus metrics, and then
-		// test them here
-
-		// "badger_disk_reads_total", "badger_disk_writes_total", "badger_gets_total",
-		// "badger_memtable_gets_total", "badger_puts_total", "badger_read_bytes",
-		// "badger_written_bytes",
-
+		"go_goroutines",
+		"go_memstats_gc_cpu_fraction",
+		"go_memstats_heap_alloc_bytes",
+		"go_memstats_heap_idle_bytes",
+		"go_memstats_heap_inuse_bytes",
+		"dgraph_latency_bucket",
+		// Badger Mertics
+		"dgraph_badger_disk_reads_total",
+		"dgraph_badger_disk_writes_total",
+		"dgraph_badger_gets_total",
+		"dgraph_badger_memtable_gets_total",
+		"dgraph_badger_puts_total",
+		"dgraph_badger_read_bytes",
+		"dgraph_badger_written_bytes",
 		// Dgraph Memory Metrics
-		"dgraph_memory_idle_bytes", "dgraph_memory_inuse_bytes", "dgraph_memory_proc_bytes",
+		"dgraph_memory_idle_bytes",
+		"dgraph_memory_inuse_bytes",
+		"dgraph_memory_proc_bytes",
 		// Dgraph Activity Metrics
-		"dgraph_active_mutations_total", "dgraph_pending_proposals_total",
+		"dgraph_active_mutations_total",
+		"dgraph_pending_proposals_total",
 		"dgraph_pending_queries_total",
-		"dgraph_num_queries_total", "dgraph_alpha_health_status",
+		"dgraph_num_queries_total",
+		"dgraph_alpha_health_status",
 	}
 	for _, requiredM := range requiredMetrics {
 		_, ok := metricsMap[requiredM]

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -144,7 +144,7 @@ func updateMemoryMetrics() {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
 	inUse := ms.HeapInuse + ms.StackInuse
-	// From runtime/mstats.go:
+	// From https://golang.org/src/runtime/mstats.go
 	// HeapIdle minus HeapReleased estimates the amount of memory
 	// that could be returned to the OS, but is being retained by
 	// the runtime so it can grow the heap without requesting more

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -126,9 +126,10 @@ var (
 	}
 
 	countStats     = []stats.Measure{NumQueries, NumEdges, RaftAppliedIndex, MaxAssignedTs}
-	lastValueStats = []stats.Measure{PendingQueries, PendingProposals, MemoryInUse, MemoryIdle, MemoryProc,
-		ActiveMutations, AlphaHealth, BadgerDiskReadsTotal, BadgerDiskWritesTotal, BadgerGetsTotal,
-		BadgerMemtableGetsTotal, BadgerPutsTotal, BadgerReadBytes, BadgerWrittenBytes}
+	lastValueStats = []stats.Measure{PendingQueries, PendingProposals, MemoryInUse, MemoryIdle,
+		MemoryProc, ActiveMutations, AlphaHealth, BadgerDiskReadsTotal, BadgerDiskWritesTotal,
+		BadgerGetsTotal, BadgerMemtableGetsTotal, BadgerPutsTotal, BadgerReadBytes,
+		BadgerWrittenBytes}
 
 	allViews = []*view.View{
 		{

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -82,19 +82,25 @@ var (
 	MaxAssignedTs = stats.Int64("max_assigned_ts",
 		"Latest max assigned timestamp", stats.UnitDimensionless)
 
-	// Badger stats
+	// BadgerDiskReadsTotal records the number of disk reads in Badger
 	BadgerDiskReadsTotal = stats.Int64("badger_disk_reads_total",
 		"Total count of disk reads in Badger", stats.UnitDimensionless)
+	// BadgerDiskWritesTotal records the number of disk writes in Badger
 	BadgerDiskWritesTotal = stats.Int64("badger_disk_writes_total",
 		"Total count of disk writes in Badger", stats.UnitDimensionless)
+	// BadgerGetsTotal records the number of call's to Badger's get
 	BadgerGetsTotal = stats.Int64("badger_gets_total",
 		"Total count of calls to Badger’s get.", stats.UnitDimensionless)
+	// BadgerMemtableGetsTotal records the number of memtable accesses to Badger's get
 	BadgerMemtableGetsTotal = stats.Int64("badger_memtable_gets_total",
 		"Total count of memtable accesses to Badger’s get.'", stats.UnitDimensionless)
+	// BadgerPutsTotal records the number of calls to Badger's put
 	BadgerPutsTotal = stats.Int64("badger_puts_total",
 		"Total count of calls to Badger’s put.", stats.UnitDimensionless)
+	// BadgerReadBytes records the number of bytes read from Badger
 	BadgerReadBytes = stats.Int64("badger_read_bytes",
 		"Total bytes read from Badger.'", stats.UnitBytes)
+	// BadgerWrittenBytes records the number of bytes written to Badger
 	BadgerWrittenBytes = stats.Int64("badger_written_bytes",
 		"Total bytes written to Badger.", stats.UnitBytes)
 


### PR DESCRIPTION
Currently the Badger stats are only available at the /debug/vars page. This PR adds the stats to the prometheus_metrics page so that the stats history can be exported and visualized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3921)
<!-- Reviewable:end -->
