### PR TITLE
Do not require the last type declaration to have a new line.

### DIFF
--- a/schema/parse.go
+++ b/schema/parse.go
@@ -316,10 +316,11 @@ func parseTypeDeclaration(it *lex.ItemIterator) (*pb.TypeUpdate, error) {
 		switch item.Typ {
 		case itemRightCurl:
 			it.Next()
-			if it.Item().Typ != itemNewLine {
-				return nil, it.Item().Errorf("Expected new line after type declaration. Got %v",
-					it.Item().Val)
+			if it.Item().Typ != itemNewLine && it.Item().Typ != lex.ItemEOF {
+				return nil, it.Item().Errorf(
+					"Expected new line or EOF after type declaration. Got %v", it.Item())
 			}
+			it.Prev()
 
 			typeUpdate.Fields = fields
 			return typeUpdate, nil

--- a/schema/parse_test.go
+++ b/schema/parse_test.go
@@ -381,6 +381,19 @@ func TestParseEmptyType(t *testing.T) {
 
 }
 
+func TestParseTypeEOF(t *testing.T) {
+	reset()
+	result, err := Parse(`
+		type Person {
+		}`)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(result.Types))
+	require.Equal(t, &pb.TypeUpdate{
+		TypeName: "Person",
+	}, result.Types[0])
+
+}
+
 func TestParseSingleType(t *testing.T) {
 	reset()
 	result, err := Parse(`
@@ -666,7 +679,7 @@ func TestParseTypeErrMissingNewLine(t *testing.T) {
 		}type Animal {}
 	`)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Expected new line after type declaration")
+	require.Contains(t, err.Error(), "Expected new line or EOF after type declaration")
 }
 
 func TestParseTypeErrMissingColon(t *testing.T) {


### PR DESCRIPTION
Currently, one has to add a new line to the type declarations, even if
it's the last thing in the schema update. This PR changes the parser so
that the a type declaration does not require a new line if it's the last
thing in the schema update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3926)
<!-- Reviewable:end -->
