### PR TITLE
Enforce type predicates when using the type directive.

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2037,9 +2037,6 @@ func parseType(it *lex.ItemIterator, gq *GraphQuery) error {
 		return it.Item().Errorf("Expected ) after the type name in type directive")
 	}
 
-	// For now @type(TypeName) is equivalent of filtering using the type function.
-	// Later the type declarations will be used to ensure that the fields inside
-	// each block correspond to the specified type.
 	gq.Filter = &FilterTree{
 		Func: &Function{
 			Name: "type",

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -85,6 +85,11 @@ type GraphQuery struct {
 	// True for blocks that don't have a starting function and hence no starting nodes. They are
 	// used to aggregate and get variables defined in another block.
 	IsEmpty bool
+
+	// If the graph contains a @type directive, the type information will be used
+	// to enforce the results. For example, child subgraphs with an attribute that does
+	// not belong to the type will be ignored.
+	EnforcedType string
 }
 
 // RecurseArgs stores the arguments needed to process the @recurse directive.
@@ -2045,6 +2050,7 @@ func parseType(it *lex.ItemIterator, gq *GraphQuery) error {
 			},
 		},
 	}
+	gq.EnforcedType = typeName
 
 	return nil
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4780,6 +4780,7 @@ func TestTypeInPredicate(t *testing.T) {
 	require.Equal(t, "uid", gq.Query[0].Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children))
 	require.Equal(t, "friend", gq.Query[0].Children[0].Attr)
+	require.Equal(t, "Person", gq.Query[0].Children[0].EnforcedType)
 
 	require.Equal(t, "type", gq.Query[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Filter.Func.Args))
@@ -4806,6 +4807,7 @@ func TestMultipleTypeDirectives(t *testing.T) {
 	require.Equal(t, "uid", gq.Query[0].Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children))
 	require.Equal(t, "friend", gq.Query[0].Children[0].Attr)
+	require.Equal(t, "Person", gq.Query[0].Children[0].EnforcedType)
 
 	require.Equal(t, "type", gq.Query[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Filter.Func.Args))
@@ -4813,6 +4815,7 @@ func TestMultipleTypeDirectives(t *testing.T) {
 
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Children))
 	require.Equal(t, "pet", gq.Query[0].Children[0].Children[0].Attr)
+	require.Equal(t, "Animal", gq.Query[0].Children[0].Children[0].EnforcedType)
 
 	require.Equal(t, "type", gq.Query[0].Children[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Children[0].Filter.Func.Args))

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -548,6 +548,8 @@ func populateCluster() {
 		<202> <model> "Prius" .
 		<202> <model> "プリウス"@jp .
 		<202> <dgraph.type> "CarModel" .
+
+		<3> <favorite_music> "Country" .
 	`)
 
 	addGeoPointToCluster(1, "loc", []float64{1.1, 2.0})

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2136,6 +2136,8 @@ func TestBasicTypeEnforcement(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"enemy":[{"name":"Margaret", "favorite_music":"Country"},
 		{"name":"Leonard"}]}]}}`, js)
 
+	// The predicate favorite_music is not in the Person type so results for this predicate
+	// should be discarded.
 	q2 := `
 		{
 			me(func: uid(0x2)) {

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2121,6 +2121,36 @@ func TestMultipleTypeDirectivesInPredicate(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"enemy":[{"name":"Margaret", "pet":[{"name":"Bear"}]}, {"name":"Leonard"}]}]}}`, js)
 }
 
+func TestBasicTypeEnforcement(t *testing.T) {
+	q1 := `
+		{
+			me(func: uid(0x2)) {
+				enemy { 
+					name
+					favorite_music
+				}
+			}
+		}
+	`
+	js := processQueryNoErr(t, q1)
+	require.JSONEq(t, `{"data": {"me":[{"enemy":[{"name":"Margaret", "favorite_music":"Country"},
+		{"name":"Leonard"}]}]}}`, js)
+
+	q2 := `
+		{
+			me(func: uid(0x2)) {
+				enemy @type(Person) {
+					name
+					favorite_music
+				}
+			}
+		}
+	`
+	js = processQueryNoErr(t, q2)
+	require.JSONEq(t, `{"data": {"me":[{"enemy":[{"name":"Margaret"}, {"name":"Leonard"}]}]}}`, js)
+
+}
+
 func TestMaxPredicateSize(t *testing.T) {
 	// Create a string that has more than than 2^16 chars.
 	var b strings.Builder


### PR DESCRIPTION
Until now, the type directive is just an alias for a filter. This PR
changes the behavior so that only results for predicates of the given
type are returned in a block that has a type directive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3927)
<!-- Reviewable:end -->
