### PR TITLE
docs: Add unofficial Rust client to client libraries page.

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -460,6 +460,10 @@ These third-party clients are contributed by the community and are not officiall
 - https://github.com/liveforeverx/dlex
 - https://github.com/ospaarmann/exdgraph
 
+### Rust
+
+- https://github.com/Swoorup/dgraph-rs
+
 ## Raw HTTP
 
 {{% notice "warning" %}}


### PR DESCRIPTION
This Rust client for Dgraph was recommended in the Slack community by @insanitybit. Thanks for sharing!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3928)
<!-- Reviewable:end -->
