### PR TITLE
Update GitHub issue templates with section headers.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,6 @@ about: File a bug report.
 <!-- If you suspect this could be a bug, follow the template. -->
 
 ### What version of Dgraph are you using?
-<!-- paste the output of `dgraph version` here -->
 
 ### Have you tried reproducing the issue with the latest release?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,19 +4,19 @@ about: File a bug report.
 
 ---
 
-If you suspect this could be a bug, follow the template.
+<!-- If you suspect this could be a bug, follow the template. -->
 
-- What version of Dgraph are you using?
+### What version of Dgraph are you using?
+<!-- paste the output of `dgraph version` here -->
 
-
-- Have you tried reproducing the issue with latest release?
-
-
-- What is the hardware spec (RAM, OS)?
+### Have you tried reproducing the issue with the latest release?
 
 
-- Steps to reproduce the issue (command/config used to run Dgraph).
+### What is the hardware spec (RAM, OS)?
 
 
-- Expected behaviour and actual result.
+### Steps to reproduce the issue (command/config used to run Dgraph).
+
+
+### Expected behaviour and actual result.
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,5 +4,7 @@ about: Suggest improvements, additions, or revisions to Dgraph documentation.
 
 ---
 
-If you think Dgraph's documentation at https://docs.dgraph.io is lacking, please
-explain it here.
+## Documentation
+
+<!-- If you think Dgraph's documentation at https://docs.dgraph.io is lacking, please -->
+<!-- explain it here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ about: Suggest a new feature
 
 ## Experience Report
 
-<!-- Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions. -->
+Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions.
 
 ### What you wanted to do
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ about: Suggest a new feature
 
 ## Experience Report
 
-Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions.
+<!-- Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions. -->
 
 ### What you wanted to do
 


### PR DESCRIPTION
* Update the Bug Report template with headers, so that 1) it's easier to read and 2) using bullet-points in the "steps to reproduce" section doesn't conflict with the section bullet points now that they're headers.
* Update the Documentation template with a "Documentation" header and comment out the note.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3929)
<!-- Reviewable:end -->
