### PR TITLE
contrib: Add --jepsen-root flag and update usage help text to Jepsen runner script.

### DIFF
--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -15,7 +15,7 @@
  */
 
 // Runs Dgraph Jepsen tests with a local Dgraph binary.
-// Set JEPSEN_ROOT environment variable before running.
+// Set the --jepsen-root flag or the JEPSEN_ROOT environment variable before running.
 //
 // Example usage:
 //
@@ -117,7 +117,8 @@ var (
 	// Script flags
 	dryRun = pflag.BoolP("dry-run", "y", false,
 		"Echo commands that would run, but don't execute them.")
-	ciOutput = pflag.BoolP("ci-output", "q", false,
+	jepsenRoot = pflag.StringP("jepsen-root", "r", os.Getenv("JEPSEN_ROOT"), "Directory path to jepsen repo.")
+	ciOutput   = pflag.BoolP("ci-output", "q", false,
 		"Output TeamCity test result directives instead of Jepsen test output.")
 	testAll = pflag.Bool("test-all", false, "Run all workload and nemesis combinations.")
 )
@@ -146,7 +147,7 @@ func commandContext(ctx context.Context, cmd ...string) *exec.Cmd {
 func jepsenUp() {
 	cmd := command("./up.sh",
 		"--dev", "--daemon", "--compose", "../dgraph/docker/docker-compose.yml")
-	cmd.Dir = os.Getenv("JEPSEN_ROOT") + "/docker/"
+	cmd.Dir = *jepsenRoot + "/docker/"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -159,7 +160,7 @@ func jepsenDown() {
 		"-f", "./docker-compose.yml",
 		"-f", "../dgraph/docker/docker-compose.yml",
 		"down")
-	cmd.Dir = os.Getenv("JEPSEN_ROOT") + "/docker/"
+	cmd.Dir = *jepsenRoot + "/docker/"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -86,13 +86,16 @@ var (
 
 	// Jepsen test flags
 	workload = pflag.StringP("workload", "w", "",
-		"Test workload to run.")
+		"Test workload to run. Specify a space-separated list of workloads. "+
+			fmt.Sprintf("%q", availableWorkloads))
 	nemesis = pflag.StringP("nemesis", "n", "",
-		"A space-separated, comma-separated list of nemesis types.")
+		"A space-separated, comma-separated list of nemesis types. "+
+			"Specify a space-separated list of nemeses."+
+			fmt.Sprintf("%q", availableNemeses))
 	timeLimit = pflag.IntP("time-limit", "l", 600,
 		"Time limit per Jepsen test in seconds.")
 	concurrency = pflag.String("concurrency", "6n",
-		"Number of concurrent workers. \"6n\" means 6 workers per node.")
+		"Number of concurrent workers per test. \"6n\" means 6 workers per node.")
 	rebalanceInterval = pflag.String("rebalance-interval", "10h",
 		"Interval of Dgraph's tablet rebalancing.")
 	localBinary = pflag.StringP("local-binary", "b", "/gobin/dgraph",

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -15,15 +15,15 @@
  */
 
 // Runs Dgraph Jepsen tests with a local Dgraph binary.
-// Set the --jepsen-root flag or the JEPSEN_ROOT environment variable before running.
+// Set the --jepsen-root flag to the path of the Jepsen repo directory.
 //
 // Example usage:
 //
 // Runs all test and nemesis combinations (36 total)
-//     ./jepsen --test-all
+//     ./jepsen --jepsen-root $JEPSEN_ROOT --test-all
 //
 // Runs bank test with partition-ring nemesis for 10 minutes
-//     ./jepsen --jepsen.workload bank --jepsen.nemesis partition-ring
+//     ./jepsen --jepsen-root $JEPSEN_ROOT --workload bank --nemesis partition-ring
 
 package main
 

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -132,8 +132,9 @@ var (
 		"Directory path to jepsen repo. This sets the JEPSEN_ROOT env var for Jepsen ./up.sh.")
 	ciOutput = pflag.BoolP("ci-output", "q", false,
 		"Output TeamCity test result directives instead of Jepsen test output.")
-	testAll = pflag.Bool("test-all", false, "Run the following workload and nemesis combinations: "+
-		fmt.Sprintf("Workloads:%v, Nemeses:%v", testAllWorkloads, testAllNemeses))
+	testAll = pflag.Bool("test-all", false,
+		"Run the following workload and nemesis combinations: "+
+			fmt.Sprintf("Workloads:%v, Nemeses:%v", testAllWorkloads, testAllNemeses))
 )
 
 func command(cmd ...string) *exec.Cmd {

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -81,10 +81,11 @@ var (
 		"partition-ring",
 		"move-tablet",
 	}
-	// testAllWorkloads configures
+
 	testAllWorkloads = availableWorkloads
 	testAllNemeses   = []string{
 		"none",
+		// the kill nemeses run together
 		"kill-alpha,kill-zero",
 		"partition-ring",
 		"move-tablet",

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -30,6 +30,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -293,7 +294,17 @@ func tcStart(testName string) func(pass int) {
 }
 
 func main() {
-	pflag.Usage = func() {}
+	pflag.ErrHelp = errors.New("")
+	pflag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		pflag.PrintDefaults()
+
+		fmt.Printf("\nExample usage:\n")
+		fmt.Printf("$ %v --jepsen-root $JEPSEN_ROOT -w bank -n none\n", os.Args[0])
+		fmt.Printf("$ %v --jepsen-root $JEPSEN_ROOT -w 'bank delete' "+
+			"-n 'none kill-alpha,kill-zero move-tablet'\n", os.Args[0])
+		fmt.Printf("$ %v --jepsen-root $JEPSEN_ROOT --test-all\n", os.Args[0])
+	}
 	pflag.Parse()
 
 	if *jepsenRoot == "" {
@@ -318,20 +329,8 @@ func main() {
 	}
 
 	if *workload == "" || *nemesis == "" {
-		fmt.Printf("You must specify at least one workload and at least one nemesis.\n")
-
-		fmt.Printf("Available workloads:\n")
-		for _, w := range availableWorkloads {
-			fmt.Printf("\t%v\n", w)
-		}
-		fmt.Printf("Available nemeses:\n")
-		for _, n := range availableNemeses {
-			fmt.Printf("\t%v\n", n)
-		}
-		fmt.Printf("Example commands:\n")
-		fmt.Printf("$ %v -w bank -n none\n", os.Args[0])
-		fmt.Printf("$ %v -w 'bank delete' -n 'none kill-alpha,kill-zero move-tablet'\n", os.Args[0])
-		fmt.Printf("$ %v --test-all\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "You must specify at least one workload and at least one nemesis.\n")
+		fmt.Fprintf(os.Stderr, "See --help for example usage.\n")
 		os.Exit(1)
 	}
 

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -117,8 +117,9 @@ var (
 	// Script flags
 	dryRun = pflag.BoolP("dry-run", "y", false,
 		"Echo commands that would run, but don't execute them.")
-	jepsenRoot = pflag.StringP("jepsen-root", "r", os.Getenv("JEPSEN_ROOT"), "Directory path to jepsen repo.")
-	ciOutput   = pflag.BoolP("ci-output", "q", false,
+	jepsenRoot = pflag.StringP("jepsen-root", "r", os.Getenv("JEPSEN_ROOT"),
+		"Directory path to jepsen repo. Also settable with JEPSEN_ROOT env var.")
+	ciOutput = pflag.BoolP("ci-output", "q", false,
 		"Output TeamCity test result directives instead of Jepsen test output.")
 	testAll = pflag.Bool("test-all", false, "Run all workload and nemesis combinations.")
 )
@@ -150,6 +151,8 @@ func jepsenUp() {
 	cmd.Dir = *jepsenRoot + "/docker/"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	env := os.Environ()
+	cmd.Env = append(env, fmt.Sprintf("JEPSEN_ROOT=%s", *jepsenRoot))
 	if err := cmd.Run(); err != nil {
 		log.Fatal(err)
 	}
@@ -281,8 +284,8 @@ func tcStart(testName string) func(pass int) {
 func main() {
 	pflag.Parse()
 
-	if os.Getenv("JEPSEN_ROOT") == "" {
-		log.Fatal("JEPSEN_ROOT must be set.")
+	if *jepsenRoot == "" {
+		log.Fatal("--jepsen-root must be set.")
 	}
 	if os.Getenv("GOPATH") == "" {
 		log.Fatal("GOPATH must be set.")


### PR DESCRIPTION
* Add `--jepsen-root` flag to set the path to the Jepsen repo directory instead of relying on a JEPSEN_ROOT environment variable to be pre-set.
* Show list of possible workload and nemesis options in the flag help text for `--workload` and `--nemesis` options.
* Show example commands at the end of `-h`/`--help` output:
```
Example usage:
$ ./jepsen --jepsen-root $JEPSEN_ROOT -w bank -n none
$ ./jepsen --jepsen-root $JEPSEN_ROOT -w 'bank delete' -n 'none kill-alpha,kill-zero move-tablet'
$ ./jepsen --jepsen-root $JEPSEN_ROOT --test-all
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3938)
<!-- Reviewable:end -->
