### PR TITLE
Generate GraphQL schema for search

### DIFF
--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -384,8 +384,8 @@ func addFieldFilters(schema *ast.Schema, defn *ast.Definition) {
 		addFilterArgument(schema, fld)
 
 		// Ordering and pagination, however, only makes sense for fields of
-		// list types.
-		if fld.Type.Elem != nil {
+		// list types (not scalar lists).
+		if _, scalar := scalarToDgraph[fld.Type.Name()]; !scalar && fld.Type.Elem != nil {
 			addOrderArgument(schema, fld)
 
 			// Pagination even makes sense when there's no orderables because

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
@@ -5,7 +5,7 @@ type Post {
 
     tags: [String] @searchable(by: trigram)
     tagsHash: [String] @searchable(by: hash)
-    exactHash: [String] @searchable(by: exact)
+    tagsExact: [String] @searchable(by: exact)
 
     publishByYear: DateTime @searchable(by: year)
     publishByMonth: DateTime @searchable(by: month)

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
@@ -1,0 +1,25 @@
+type Post {
+	postID: ID!
+	title: String! @searchable(by: term)
+	text: String @searchable(by: fulltext)
+
+    tags: [String] @searchable(by: trigram)
+    tagsHash: [String] @searchable(by: hash)
+    exactHash: [String] @searchable(by: exact)
+
+    publishByYear: DateTime @searchable(by: year)
+    publishByMonth: DateTime @searchable(by: month)
+    publishByDay: DateTime @searchable(by: day)
+    publishByHour: DateTime @searchable(by: hour)
+
+    numLikes: Int @searchable
+	score: Float @searchable
+	isPublished: Boolean @searchable
+	postType: PostType @searchable
+}
+
+enum PostType {
+	Fact
+	Question
+	Opinion
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables
@@ -3,16 +3,16 @@ type Post {
 	title: String! @searchable(by: term)
 	text: String @searchable(by: fulltext)
 
-    tags: [String] @searchable(by: trigram)
-    tagsHash: [String] @searchable(by: hash)
-    tagsExact: [String] @searchable(by: exact)
+	tags: [String] @searchable(by: trigram)
+	tagsHash: [String] @searchable(by: hash)
+	tagsExact: [String] @searchable(by: exact)
 
-    publishByYear: DateTime @searchable(by: year)
-    publishByMonth: DateTime @searchable(by: month)
-    publishByDay: DateTime @searchable(by: day)
-    publishByHour: DateTime @searchable(by: hour)
+	publishByYear: DateTime @searchable(by: year)
+	publishByMonth: DateTime @searchable(by: month)
+	publishByDay: DateTime @searchable(by: day)
+	publishByHour: DateTime @searchable(by: hour)
 
-    numLikes: Int @searchable
+	numLikes: Int @searchable
 	score: Float @searchable
 	isPublished: Boolean @searchable
 	postType: PostType @searchable

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables-references
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/searchables-references
@@ -1,0 +1,13 @@
+type Author {
+	id: ID!
+	name: String! @searchable(by: hash)
+	dob: DateTime  # Have something not searchable
+	posts: [Post]  # This should have arguments added for a filter on Post
+}
+
+type Post {
+	postID: ID!
+	title: String! @searchable(by: term)
+	text: String @searchable(by: fulltext)
+	datePublished: DateTime   # Have something not searchable
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/enums-generate-nothing
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/enums-generate-nothing
@@ -32,8 +32,62 @@ enum DgraphIndex {
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
 
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
 #######################
 # Generated Types
+#######################
+
+#######################
+# Generated Enums
 #######################
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse
@@ -9,7 +9,7 @@ type Post {
 
 type Author {
 	id: ID!
-	posts: [Post!]! @hasInverse(field: "author")
+	posts(first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
 }
 
 #######################
@@ -35,6 +35,56 @@ enum DgraphIndex {
 
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
 
 #######################
 # Generated Types
@@ -65,12 +115,12 @@ type UpdatePostPayload {
 }
 
 #######################
-# Generated Inputs
+# Generated Enums
 #######################
 
-input AuthorFilter {
-	dgraph: String
-}
+#######################
+# Generated Inputs
+#######################
 
 input AuthorInput {
 	posts: [PostRef!]!
@@ -86,10 +136,6 @@ input PatchAuthor {
 
 input PatchPost {
 	author: AuthorRef
-}
-
-input PostFilter {
-	dgraph: String
 }
 
 input PostInput {
@@ -116,9 +162,9 @@ input UpdatePostInput {
 
 type Query {
 	getPost(id: ID!): Post
-	queryPost(filter: PostFilter!): [Post]
+	queryPost(first: Int, offset: Int): [Post]
 	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter!): [Author]
+	queryAuthor(first: Int, offset: Int): [Author]
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables
@@ -1,0 +1,223 @@
+#######################
+# Input Schema
+#######################
+
+type Post {
+	postID: ID!
+	title: String! @searchable(by: term)
+	text: String @searchable(by: fulltext)
+	tags(first: Int, offset: Int): [String] @searchable(by: trigram)
+	tagsHash(first: Int, offset: Int): [String] @searchable(by: hash)
+	exactHash(first: Int, offset: Int): [String] @searchable(by: exact)
+	publishByYear: DateTime @searchable(by: year)
+	publishByMonth: DateTime @searchable(by: month)
+	publishByDay: DateTime @searchable(by: day)
+	publishByHour: DateTime @searchable(by: hour)
+	numLikes: Int @searchable
+	score: Float @searchable
+	isPublished: Boolean @searchable
+	postType: PostType @searchable
+}
+
+enum PostType {
+	Fact
+	Question
+	Opinion
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddPostPayload {
+	post: Post
+}
+
+type DeletePostPayload {
+	msg: String
+}
+
+type UpdatePostPayload {
+	post: Post
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum PostOrderable {
+	title
+	text
+	tags
+	tagsHash
+	exactHash
+	publishByYear
+	publishByMonth
+	publishByDay
+	publishByHour
+	numLikes
+	score
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input PatchPost {
+	title: String
+	text: String
+	tags: [String]
+	tagsHash: [String]
+	exactHash: [String]
+	publishByYear: DateTime
+	publishByMonth: DateTime
+	publishByDay: DateTime
+	publishByHour: DateTime
+	numLikes: Int
+	score: Float
+	isPublished: Boolean
+	postType: PostType
+}
+
+input PostFilter {
+	title: StringTermFilter
+	text: StringFullTextFilter
+	tags: StringRegExpFilter
+	tagsHash: StringHashFilter
+	exactHash: StringExactFilter
+	publishByYear: DateTimeFilter
+	publishByMonth: DateTimeFilter
+	publishByDay: DateTimeFilter
+	publishByHour: DateTimeFilter
+	numLikes: IntFilter
+	score: FloatFilter
+	isPublished: Boolean
+	postType: PostType
+	and: PostFilter
+	or: PostFilter
+	not: PostFilter
+}
+
+input PostInput {
+	title: String!
+	text: String
+	tags: [String]
+	tagsHash: [String]
+	exactHash: [String]
+	publishByYear: DateTime
+	publishByMonth: DateTime
+	publishByDay: DateTime
+	publishByHour: DateTime
+	numLikes: Int
+	score: Float
+	isPublished: Boolean
+	postType: PostType
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
+}
+
+input PostRef {
+	postID: ID!
+}
+
+input UpdatePostInput {
+	postID: ID!
+	patch: PatchPost!
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getPost(id: ID!): Post
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addPost(input: PostInput!): AddPostPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(id: ID!): DeletePostPayload
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables
@@ -6,9 +6,9 @@ type Post {
 	postID: ID!
 	title: String! @searchable(by: term)
 	text: String @searchable(by: fulltext)
-	tags(first: Int, offset: Int): [String] @searchable(by: trigram)
-	tagsHash(first: Int, offset: Int): [String] @searchable(by: hash)
-	exactHash(first: Int, offset: Int): [String] @searchable(by: exact)
+	tags: [String] @searchable(by: trigram)
+	tagsHash: [String] @searchable(by: hash)
+	tagsExact: [String] @searchable(by: exact)
 	publishByYear: DateTime @searchable(by: year)
 	publishByMonth: DateTime @searchable(by: month)
 	publishByDay: DateTime @searchable(by: day)
@@ -124,7 +124,7 @@ enum PostOrderable {
 	text
 	tags
 	tagsHash
-	exactHash
+	tagsExact
 	publishByYear
 	publishByMonth
 	publishByDay
@@ -142,7 +142,7 @@ input PatchPost {
 	text: String
 	tags: [String]
 	tagsHash: [String]
-	exactHash: [String]
+	tagsExact: [String]
 	publishByYear: DateTime
 	publishByMonth: DateTime
 	publishByDay: DateTime
@@ -158,7 +158,7 @@ input PostFilter {
 	text: StringFullTextFilter
 	tags: StringRegExpFilter
 	tagsHash: StringHashFilter
-	exactHash: StringExactFilter
+	tagsExact: StringExactFilter
 	publishByYear: DateTimeFilter
 	publishByMonth: DateTimeFilter
 	publishByDay: DateTimeFilter
@@ -177,7 +177,7 @@ input PostInput {
 	text: String
 	tags: [String]
 	tagsHash: [String]
-	exactHash: [String]
+	tagsExact: [String]
 	publishByYear: DateTime
 	publishByMonth: DateTime
 	publishByDay: DateTime

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references
@@ -1,0 +1,231 @@
+#######################
+# Input Schema
+#######################
+
+type Author {
+	id: ID!
+	name: String! @searchable(by: hash)
+	dob: DateTime
+	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+}
+
+type Post {
+	postID: ID!
+	title: String! @searchable(by: term)
+	text: String @searchable(by: fulltext)
+	datePublished: DateTime
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAuthorPayload {
+	author: Author
+}
+
+type AddPostPayload {
+	post: Post
+}
+
+type DeleteAuthorPayload {
+	msg: String
+}
+
+type DeletePostPayload {
+	msg: String
+}
+
+type UpdateAuthorPayload {
+	author: Author
+}
+
+type UpdatePostPayload {
+	post: Post
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AuthorOrderable {
+	name
+	dob
+}
+
+enum PostOrderable {
+	title
+	text
+	datePublished
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AuthorFilter {
+	name: StringHashFilter
+	and: AuthorFilter
+	or: AuthorFilter
+	not: AuthorFilter
+}
+
+input AuthorInput {
+	name: String!
+	dob: DateTime
+	posts: [PostRef]
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
+}
+
+input AuthorRef {
+	id: ID!
+}
+
+input PatchAuthor {
+	name: String
+	dob: DateTime
+	posts: [PostRef]
+}
+
+input PatchPost {
+	title: String
+	text: String
+	datePublished: DateTime
+}
+
+input PostFilter {
+	title: StringTermFilter
+	text: StringFullTextFilter
+	and: PostFilter
+	or: PostFilter
+	not: PostFilter
+}
+
+input PostInput {
+	title: String!
+	text: String
+	datePublished: DateTime
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
+}
+
+input PostRef {
+	postID: ID!
+}
+
+input UpdateAuthorInput {
+	id: ID!
+	patch: PatchAuthor!
+}
+
+input UpdatePostInput {
+	postID: ID!
+	patch: PatchPost!
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	getPost(id: ID!): Post
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAuthor(input: AuthorInput!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(id: ID!): DeleteAuthorPayload
+	addPost(input: PostInput!): AddPostPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(id: ID!): DeletePostPayload
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type
@@ -33,6 +33,56 @@ enum DgraphIndex {
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
 
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
 #######################
 # Generated Types
 #######################
@@ -50,17 +100,29 @@ type UpdateMessagePayload {
 }
 
 #######################
-# Generated Inputs
+# Generated Enums
 #######################
 
-input MessageFilter {
-	dgraph: String
+enum MessageOrderable {
+	content
+	author
+	datePosted
 }
+
+#######################
+# Generated Inputs
+#######################
 
 input MessageInput {
 	content: String!
 	author: String
 	datePosted: DateTime
+}
+
+input MessageOrder {
+	asc: MessageOrderable
+	desc: MessageOrderable
+	then: MessageOrder
 }
 
 input MessageRef {
@@ -84,7 +146,7 @@ input UpdateMessageInput {
 
 type Query {
 	getMessage(id: ID!): Message
-	queryMessage(filter: MessageFilter!): [Message]
+	queryMessage(order: MessageOrder, first: Int, offset: Int): [Message]
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum
@@ -39,6 +39,56 @@ enum DgraphIndex {
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
 
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
 #######################
 # Generated Types
 #######################
@@ -56,6 +106,15 @@ type UpdatePostPayload {
 }
 
 #######################
+# Generated Enums
+#######################
+
+enum PostOrderable {
+	title
+	text
+}
+
+#######################
 # Generated Inputs
 #######################
 
@@ -65,14 +124,16 @@ input PatchPost {
 	postType: PostType
 }
 
-input PostFilter {
-	dgraph: String
-}
-
 input PostInput {
 	title: String!
 	text: String
 	postType: PostType!
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
 }
 
 input PostRef {
@@ -90,7 +151,7 @@ input UpdatePostInput {
 
 type Query {
 	getPost(id: ID!): Post
-	queryPost(filter: PostFilter!): [Post]
+	queryPost(order: PostOrder, first: Int, offset: Int): [Post]
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference
@@ -38,6 +38,56 @@ enum DgraphIndex {
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
 
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
 #######################
 # Generated Types
 #######################
@@ -67,15 +117,30 @@ type UpdatePostPayload {
 }
 
 #######################
+# Generated Enums
+#######################
+
+enum AuthorOrderable {
+	name
+}
+
+enum PostOrderable {
+	title
+	text
+}
+
+#######################
 # Generated Inputs
 #######################
 
-input AuthorFilter {
-	dgraph: String
-}
-
 input AuthorInput {
 	name: String!
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
 }
 
 input AuthorRef {
@@ -92,14 +157,16 @@ input PatchPost {
 	author: AuthorRef
 }
 
-input PostFilter {
-	dgraph: String
-}
-
 input PostInput {
 	title: String!
 	text: String
 	author: AuthorRef!
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
 }
 
 input PostRef {
@@ -122,9 +189,9 @@ input UpdatePostInput {
 
 type Query {
 	getPost(id: ID!): Post
-	queryPost(filter: PostFilter!): [Post]
+	queryPost(order: PostOrder, first: Int, offset: Int): [Post]
 	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter!): [Author]
+	queryAuthor(order: AuthorOrder, first: Int, offset: Int): [Author]
 }
 
 #######################


### PR DESCRIPTION
Takes an input GraphQL schema with `@searchable(...)` and generates enough GraphQL schema to do enable search.

For example:  for something like

```
type Author {
	id: ID!
	name: String! @searchable(by: hash)
	dob: DateTime  
	posts: [Post]  
}

type Post {
	postID: ID!
	title: String! @searchable(by: term)
	text: String @searchable(by: fulltext)
	datePublished: DateTime  
}
```

It generates filters in `queryPost` and `queryAuthor` to search posts by title and text and authors by name.

It also adds arguments so that an Author's posts can searched.  E.g. Author becomes

```
type Author {
	...
	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3943)
<!-- Reviewable:end -->
