### PR TITLE
Add support for expand on type

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2831,15 +2831,10 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 					}
 					child.NeedsVar[len(child.NeedsVar)-1].Typ = ListVar
 					child.Expand = child.NeedsVar[len(child.NeedsVar)-1].Name
-				case "_all_":
-					child.Expand = "_all_"
-				case "_forward_":
-					child.Expand = "_forward_"
-				case "_reverse_":
-					child.Expand = "_reverse_"
 				default:
-					return item.Errorf("Invalid argument %v in expand()", item.Val)
+					child.Expand = item.Val
 				}
+
 				it.Next() // Consume ')'
 				gq.Children = append(gq.Children, child)
 				// Note: curp is not set to nil. So it can have children, filters, etc.


### PR DESCRIPTION
close #3903 
This PR will add support to use type on expand function. 
# Changes made
- Removed restriction in expand function for using only the specified keyword like `_all_`. Now expand function can take any paramenter. But the given parameter should be assoicated with type. 
- subgraph is expanded from the type predicates. 

Now, user can query like this
```
{
  q(func: type(Person)) {
    dgraph.type
    expand(Person)
  }
}
```
Signed-off-by: பாலாஜி ஜின்னா <balaji@dgraph.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3949)
<!-- Reviewable:end -->
