### PR TITLE
Add filter rewriting to GraphQL

### DIFF
--- a/dgraph/cmd/graphql/dgraph/graphquery.go
+++ b/dgraph/cmd/graphql/dgraph/graphquery.go
@@ -23,21 +23,20 @@ import (
 	"github.com/dgraph-io/dgraph/gql"
 )
 
+// asString writes query as an indented GraphQL+- query string.  AsString doesn't
+// validate query, and so doesn't return an error if query is 'malformed' - it might
+// just write something that wouldn't parse as a Dgraph query.
 func asString(query *gql.GraphQuery) string {
-	if query == nil {
-		return ""
-	}
-
 	var b strings.Builder
 
 	b.WriteString("query {\n")
-	writeQuery(&b, query, "  ")
+	writeQuery(&b, query, "  ", true)
 	b.WriteString("}")
 
 	return b.String()
 }
 
-func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
+func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string, root bool) {
 	b.WriteString(prefix)
 	if query.Alias != "" {
 		b.WriteString(query.Alias)
@@ -45,13 +44,26 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 	}
 	b.WriteString(query.Attr)
 
-	writeFunction(b, query.Func)
-	writeFilter(b, query.Filter)
+	if root {
+		writeFunction(b, query)
+	}
+
+	if query.Filter != nil {
+		b.WriteString(" @filter(")
+		writeFilter(b, query.Filter)
+		b.WriteRune(')')
+	}
+
+	if !root && hasOrderOrPage(query) {
+		b.WriteString(" (")
+		writeOrderAndPage(b, query, false)
+		b.WriteRune(')')
+	}
 
 	if len(query.Children) > 0 {
 		b.WriteString(" {\n")
 		for _, c := range query.Children {
-			writeQuery(b, c, prefix+"  ")
+			writeQuery(b, c, prefix+"  ", false)
 		}
 		b.WriteString(prefix)
 		b.WriteString("}")
@@ -59,29 +71,95 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 	b.WriteString("\n")
 }
 
-func writeFunction(b *strings.Builder, f *gql.Function) {
-	if f != nil {
-		b.WriteString(fmt.Sprintf("(func: %s(0x%x))", f.Name, f.UID[0]))
-		// there's only uid(...) functions so far
+func writeFunction(b *strings.Builder, q *gql.GraphQuery) {
+	if q.Func == nil {
+		return
 	}
+
+	if q.Func.Name == "uid" && len(q.Func.UID) == 1 {
+		b.WriteString(fmt.Sprintf("(func: %s(0x%x))", q.Func.Name, q.Func.UID[0]))
+	} else if q.Func.Name == "type" && len(q.Func.Args) == 1 {
+		b.WriteString(fmt.Sprintf("(func: %s(%s)", q.Func.Name, q.Func.Args[0].Value))
+		writeOrderAndPage(b, q, true)
+		b.WriteRune(')')
+	}
+	// there's only uid(...) and type(...) functions at root level
 }
 
 func writeFilterFunction(b *strings.Builder, f *gql.Function) {
-	if f != nil {
-		b.WriteString(fmt.Sprintf("%s(%s)", f.Name, f.Args[0].Value))
-	}
-}
-
-func writeFilter(b *strings.Builder, f *gql.FilterTree) {
 	if f == nil {
 		return
 	}
 
-	if f.Func.Name == "type" {
-		b.WriteString(fmt.Sprintf(" @filter(type(%s))", f.Func.Args[0].Value))
-	} else {
-		b.WriteString(" @filter(")
-		writeFilterFunction(b, f.Func)
-		b.WriteString(")")
+	if len(f.Args) == 1 {
+		b.WriteString(fmt.Sprintf("%s(%s)", f.Name, f.Args[0].Value))
+	} else if len(f.Args) == 2 {
+		b.WriteString(fmt.Sprintf("%s(%s, %s)", f.Name, f.Args[0].Value, f.Args[1].Value))
+	}
+}
+
+func writeFilter(b *strings.Builder, ft *gql.FilterTree) {
+	if ft == nil {
+		return
+	}
+
+	switch ft.Op {
+	case "and", "or":
+		b.WriteRune('(')
+		for i, child := range ft.Child {
+			if i > 0 && i <= len(ft.Child)-1 {
+				b.WriteString(fmt.Sprintf(" %s ", strings.ToUpper(ft.Op)))
+			}
+			writeFilter(b, child)
+		}
+		b.WriteRune(')')
+	case "not":
+		if len(ft.Child) > 0 {
+			b.WriteString("NOT (")
+			writeFilter(b, ft.Child[0])
+			b.WriteRune(')')
+		}
+	default:
+		writeFilterFunction(b, ft.Func)
+	}
+}
+
+func hasOrderOrPage(q *gql.GraphQuery) bool {
+	_, hasFirst := q.Args["first"]
+	_, hasOffset := q.Args["offset"]
+	return len(q.Order) > 0 || hasFirst || hasOffset
+}
+
+func writeOrderAndPage(b *strings.Builder, query *gql.GraphQuery, root bool) {
+	var wroteOrder, wroteFirst bool
+
+	for _, ord := range query.Order {
+		if root {
+			b.WriteString(", ")
+		}
+		if ord.Desc {
+			b.WriteString("orderdesc: ")
+		} else {
+			b.WriteString("orderasc: ")
+		}
+		b.WriteString(ord.Attr)
+		wroteOrder = true
+	}
+
+	if first, ok := query.Args["first"]; ok {
+		if root || wroteOrder {
+			b.WriteString(", ")
+		}
+		b.WriteString("first: ")
+		b.WriteString(first)
+		wroteFirst = true
+	}
+
+	if offset, ok := query.Args["offset"]; ok {
+		if root || wroteOrder || wroteFirst {
+			b.WriteString(", ")
+		}
+		b.WriteString("offset: ")
+		b.WriteString(offset)
 	}
 }

--- a/dgraph/cmd/graphql/dgraph/mutation_query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_query_test.yaml
@@ -106,3 +106,30 @@
         }
       }
     }
+
+-
+  name: "can do deep filter"
+  gqlquery: |
+    mutation {
+      ADD_UPDATE_MUTATION {
+        post {
+          postID
+          title
+          author {
+            name
+            posts(filter: { title: { anyofterms: "GraphQL" } })
+          }
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      post(func: uid(0x4)) {
+        postID : uid
+        title : Post.title
+        author : Post.author {
+          name : Author.name
+          posts : Author.posts @filter(anyofterms(Post.title, "GraphQL"))
+        }
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -46,92 +46,6 @@ type TestCase struct {
 	Error         *gqlerror.Error
 }
 
-var testGQLSchema = `
-scalar ID
-scalar String
-scalar DateTime
-
-directive @hasInverse(field: String!) on FIELD_DEFINITION
-
-type Country {
-	id: ID!
-	name: String!	
-}
-
-type Author {
-	id: ID!
-	name: String!
-	dob: DateTime
-	country: Country
-	posts: [Post!] @hasInverse(field: "author")
-}
-
-type Post {
-	postID: ID!
-	title: String!
-	text: String
-	author: Author! @hasInverse(field: "posts")
-}
-
-type Mutation {
-	addAuthor(input: AuthorInput!): AddAuthorPayload
-
-	addPost(input: PostInput!): AddPostPayload
-	updatePost(input: UpdatePostInput!): UpdatePostPayload
-}
-
-type Query {
-	getAuthor(id: ID!): Author
-}
-
-input AuthorInput {
-	name: String!
-	dob: DateTime
-	country: CountryRef
-	posts: [PostRef!]
-}
-
-type AddAuthorPayload {
-    author: Author
-}
-
-input AuthorRef {
-    id: ID!
-}
-
-input CountryRef {
-    id: ID!
-}
-
-input PostInput {
-	title: String!
-	text: String
-	author: AuthorRef!
-}
-
-input PostRef {
-    postID: ID!
-}
-
-type AddPostPayload {
-    post: Post
-}
-
-input PatchPost {
-	title: String
-	text: String
-}
-
-input UpdatePostInput {
-	postID: ID!
-	patch: PatchPost!
-}
-
-type UpdatePostPayload {
-    post: Post
-}
-`
-
 func TestMutationRewriting(t *testing.T) {
 	b, err := ioutil.ReadFile("mutation_test.yaml")
 	require.NoError(t, err, "Unable to read test file")
@@ -140,7 +54,7 @@ func TestMutationRewriting(t *testing.T) {
 	err = yaml.Unmarshal(b, &tests)
 	require.NoError(t, err, "Unable to unmarshal tests to yaml.")
 
-	gqlSchema := schema.AsSchema(test.LoadSchema(t, testGQLSchema))
+	gqlSchema := test.LoadSchemaFromFile(t, "schema.graphql")
 
 	rewritererToTest := NewMutationRewriter()
 
@@ -184,7 +98,7 @@ func TestMutationQueryRewriting(t *testing.T) {
 	err = yaml.Unmarshal(b, &tests)
 	require.NoError(t, err, "Unable to unmarshal tests to yaml.")
 
-	gqlSchema := schema.AsSchema(test.LoadSchema(t, testGQLSchema))
+	gqlSchema := test.LoadSchemaFromFile(t, "schema.graphql")
 
 	testRewriter := NewQueryRewriter()
 

--- a/dgraph/cmd/graphql/dgraph/query.go
+++ b/dgraph/cmd/graphql/dgraph/query.go
@@ -338,7 +338,7 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 						Name: fn,
 						Args: []gql.Arg{
 							{Value: fmt.Sprintf("%s.%s", typ.Name(), field)},
-							{Value: maybeQuoteArg(val)},
+							{Value: maybeQuoteArg(fn, val)},
 						},
 					},
 				})
@@ -346,12 +346,13 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 				// isPublished: true -> eq(isPublished, true)
 				// OR an enum case
 				// postType: Question -> eq(postType, "Question")
+				fn := "eq"
 				ands = append(ands, &gql.FilterTree{
 					Func: &gql.Function{
-						Name: "eq",
+						Name: fn,
 						Args: []gql.Arg{
 							{Value: fmt.Sprintf("%s.%s", typ.Name(), field)},
-							{Value: maybeQuoteArg(dgFunc)},
+							{Value: maybeQuoteArg(fn, dgFunc)},
 						},
 					},
 				})
@@ -379,9 +380,12 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 	}
 }
 
-func maybeQuoteArg(arg interface{}) string {
+func maybeQuoteArg(fn string, arg interface{}) string {
 	switch arg := arg.(type) {
 	case string: // dateTime also parsed as string
+		if fn == "regexp" {
+			return fmt.Sprintf("%v", arg)
+		}
 		return fmt.Sprintf("%q", arg)
 	default:
 		return fmt.Sprintf("%v", arg)

--- a/dgraph/cmd/graphql/dgraph/query_test.go
+++ b/dgraph/cmd/graphql/dgraph/query_test.go
@@ -42,7 +42,7 @@ func TestQueryRewriting(t *testing.T) {
 	err = yaml.Unmarshal(b, &tests)
 	require.NoError(t, err, "Unable to unmarshal tests to yaml.")
 
-	gqlSchema := schema.AsSchema(test.LoadSchema(t, testGQLSchema))
+	gqlSchema := test.LoadSchemaFromFile(t, "schema.graphql")
 
 	testRewriter := NewQueryRewriter()
 

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -545,7 +545,7 @@
     }
   dgquery: |-
     query {
-      queryCountry(func: type(Country)) @filter(regexp(Country.name, "/.*ust.*/")) {
+      queryCountry(func: type(Country)) @filter(regexp(Country.name, /.*ust.*/)) {
         name : Country.name
       }
     }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -136,3 +136,416 @@
         }
       }
     }
+
+-
+  name: "Query with no args is query for everything of that type"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter gets rewritten as @filter"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filters in same input object implies AND"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, dob: { le: "2001-01-01" }, reputation: { gt: 2.5 } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((le(Author.dob, "2001-01-01") AND eq(Author.name, "A. N. Author") AND gt(Author.reputation, 2.5))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with nested 'and'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, and: { dob: { le: "2001-01-01" }, and: { reputation: { gt: 2.5 } } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(((gt(Author.reputation, 2.5) AND le(Author.dob, "2001-01-01")) AND eq(Author.name, "A. N. Author"))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with 'or'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, or: { dob: { le: "2001-01-01" } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR le(Author.dob, "2001-01-01"))) {
+        name : Author.name
+      }
+    }
+
+
+-
+  name: "Filter with implied and as well as 'or'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, reputation: { gt: 2.5 }, or: { dob: { le: "2001-01-01" } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(((eq(Author.name, "A. N. Author") AND gt(Author.reputation, 2.5)) OR le(Author.dob, "2001-01-01"))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with implied and nested in 'or'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, or: { reputation: { gt: 2.5 }, dob: { le: "2001-01-01" } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (le(Author.dob, "2001-01-01") AND gt(Author.reputation, 2.5)))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter nested 'or'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, or: { reputation: { gt: 2.5 }, or: { dob: { le: "2001-01-01" } } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (gt(Author.reputation, 2.5) OR le(Author.dob, "2001-01-01")))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with 'not"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { not: { reputation: { gt: 2.5 } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(NOT (gt(Author.reputation, 2.5))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with first"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, first: 10) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), first: 10) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with first and offset"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, first: 10, offset: 10) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with order asc"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, order: { asc: reputation }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), orderasc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with order desc"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, order: { desc: reputation }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), orderdesc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+
+-
+  name: "Filter with nested order"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, order: { desc: reputation, then: { asc: dob } }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), orderdesc: Author.reputation, orderasc: Author.dob) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Filter with order, first and offset"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } }, order: { desc: reputation }, first: 10, offset: 10) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author), orderdesc: Author.reputation, first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "Deep filter"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter: { title: { anyofterms: "GraphQL" } }) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) {
+          title : Post.title
+        }
+      }
+    }
+
+
+-
+  name: "Deep filter with first"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter: { title: { anyofterms: "GraphQL" } }, first: 10) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) (first: 10) {
+          title : Post.title
+        }
+      }
+    }
+
+-
+  name: "Deep filter with order, first and offset"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter: { title: { anyofterms: "GraphQL" } }, order: { asc: numLikes }, first: 10, offset: 10) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) (orderasc: Post.numLikes, first: 10, offset: 10) {
+          title : Post.title
+        }
+      }
+    }
+
+
+-
+  name: "All Float filters work"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { reputation: { gt: 1.1 }, or: { reputation: { ge: 1.1 }, or: { reputation: { lt: 1.1 }, or: { reputation: { le: 1.1 }, or: { reputation: { eq: 1.1 } } } } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((gt(Author.reputation, 1.1) OR (ge(Author.reputation, 1.1) OR (lt(Author.reputation, 1.1) OR (le(Author.reputation, 1.1) OR eq(Author.reputation, 1.1)))))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "All DateTime filters work"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { dob: { gt: "2000-01-01" }, or: { dob: { ge: "2000-01-01" }, or: { dob: { lt: "2000-01-01" }, or: { dob: { le: "2000-01-01" }, or: { dob: { eq: "2000-01-01" } } } } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter((gt(Author.dob, "2000-01-01") OR (ge(Author.dob, "2000-01-01") OR (lt(Author.dob, "2000-01-01") OR (le(Author.dob, "2000-01-01") OR eq(Author.dob, "2000-01-01")))))) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "All Int filters work"
+  gqlquery: |
+    query {
+      queryPost(filter: { numLikes: { gt: 10 }, or: { numLikes: { ge: 10 }, or: { numLikes: { lt: 10 }, or: { numLikes: { le: 10 }, or: { numLikes: { eq: 10 } } } } } } ) {
+        title
+      }
+    }
+  dgquery: |-
+    query {
+      queryPost(func: type(Post)) @filter((gt(Post.numLikes, 10) OR (ge(Post.numLikes, 10) OR (lt(Post.numLikes, 10) OR (le(Post.numLikes, 10) OR eq(Post.numLikes, 10)))))) {
+        title : Post.title
+      }
+    }
+
+-
+  name: "All String hash filters work"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+      }
+    }
+
+-
+  name: "All String exact filters work"
+  gqlquery: |
+    query {
+      queryCountry(filter: { name: { gt: "AAA" }, or: { name: { ge: "AAA" }, or: { name: { lt: "AAA" }, or: { name: { le: "AAA" }, or: { name: { eq: "AAA" } } } } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryCountry(func: type(Country)) @filter((gt(Country.name, "AAA") OR (ge(Country.name, "AAA") OR (lt(Country.name, "AAA") OR (le(Country.name, "AAA") OR eq(Country.name, "AAA")))))) {
+        name : Country.name
+      }
+    }
+
+-
+  name: "All String term filters work"
+  gqlquery: |
+    query {
+      queryPost(filter: { title: { anyofterms: "GraphQL"}, or: { title: { allofterms: "GraphQL" } } } ) {
+        title
+      }
+    }
+  dgquery: |-
+    query {
+      queryPost(func: type(Post)) @filter((anyofterms(Post.title, "GraphQL") OR allofterms(Post.title, "GraphQL"))) {
+        title : Post.title
+      }
+    }
+
+
+-
+  name: "All String fulltext filters work"
+  gqlquery: |
+    query {
+      queryPost(filter: { text: { anyoftext: "GraphQL"}, or: { text: { alloftext: "GraphQL" } } } ) {
+        title
+      }
+    }
+  dgquery: |-
+    query {
+      queryPost(func: type(Post)) @filter((anyoftext(Post.text, "GraphQL") OR alloftext(Post.text, "GraphQL"))) {
+        title : Post.title
+      }
+    }
+
+-
+  name: "All String regexp filters work"
+  gqlquery: |
+    query {
+      queryCountry(filter: { name: { regexp: "/.*ust.*/" }}) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryCountry(func: type(Country)) @filter(regexp(Country.name, "/.*ust.*/")) {
+        name : Country.name
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -1,0 +1,33 @@
+# Test schema that contains an example of everything that's useful to 
+# test for query rewriting.
+
+type Country {
+        id: ID!
+        name: String! @searchable(by: "trigram")
+}
+
+type Author {
+        id: ID!
+        name: String! @searchable(by: "hash")
+        dob: DateTime @searchable
+        reputation: Float @searchable
+        country: Country
+        posts: [Post!] @hasInverse(field: "author")
+}
+
+type Post {
+        postID: ID!
+        title: String! @searchable(by: "term")
+        text: String @searchable(by: "fulltext")
+        tags: [String] @searchable(by: "exact")
+        numLikes: Int @searchable
+        isPublished: Boolean @searchable
+        postType: PostType @searchable
+        author: Author! @hasInverse(field: "posts")
+}
+
+enum PostType {
+        Fact
+        Question
+        Opinion
+}

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/test"
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
 	"gopkg.in/yaml.v2"
 )
@@ -55,8 +54,6 @@ type QueryCase struct {
 }
 
 var testGQLSchema = `
-scalar ID
-scalar String
 scalar DateTime
 
 type Author {
@@ -349,16 +346,16 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 	}
 }
 
-func resolve(gqlSchema *ast.Schema, gqlQuery string, dgResponse string) *schema.Response {
+func resolve(gqlSchema schema.Schema, gqlQuery string, dgResponse string) *schema.Response {
 	return resolveWithClient(gqlSchema, gqlQuery, &dgraphClient{resp: dgResponse})
 }
 
 func resolveWithClient(
-	gqlSchema *ast.Schema,
+	gqlSchema schema.Schema,
 	gqlQuery string,
 	client dgraph.Client) *schema.Response {
 	resolver := New(
-		schema.AsSchema(gqlSchema),
+		gqlSchema,
 		client,
 		dgraph.NewQueryRewriter(),
 		dgraph.NewMutationRewriter())

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -309,6 +309,8 @@ func (q *query) QueryType() QueryType {
 		return GetQuery
 	case q.Name() == "__schema" || q.Name() == "__type":
 		return SchemaQuery
+	case strings.HasPrefix(q.Name(), "query"):
+		return FilterQuery
 	default:
 		return NotSupportedQuery
 	}


### PR DESCRIPTION
This adds the runtime translation of GraphQL queries with filters into Dgraph Queries.

So
```
query queryPost {
  queryPost {
    postID
    title
    ...
  }
}
```

becomes

```
query {
  queryPost(func: type(Post)) {
    postID : uid
    title : Post.title
    ...
  }
}
```

And

```
query queryAuthor {
  queryAuthor(filter: { name: { eq: "Michael" } }) {
    id
    name
    posts(filter: { title: { anyofterms: "GraphQL"}}, first: 2, order: { desc: numLikes }) {
      title
    }
  }
}
```

becomes

```
query {
  queryAuthor(func: type(Author)) @filter(eq(Author.name, "Michael")) {
    id : uid
    name : Author.name
    posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) (orderdesc: Post.numLikes, first: 2) {
      title : Post.title
    }
  }
}
```

etc...
