### PR TITLE
GraphQL CORS

### DIFF
--- a/dgraph/cmd/graphql/http.go
+++ b/dgraph/cmd/graphql/http.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/resolve"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/vektah/gqlparser/ast"
 	"github.com/vektah/gqlparser/gqlerror"
 )
@@ -62,6 +63,7 @@ type graphqlHandler struct {
 // via GraphQL->Dgraph->GraphQL.  It writes a valid GraphQL JSON response
 // to w.
 func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 


### PR DESCRIPTION
Add CORS headers.

Same as we do elsewhere - e.g. in alpha : https://github.com/dgraph-io/dgraph/blob/b05e01b26facba0aee4d62117750e06790b77ce7/dgraph/cmd/alpha/http.go#L56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3953)
<!-- Reviewable:end -->
