### PR TITLE
Change the mapper output directory from $TMP/shards to $TMP/map_output

### DIFF
--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -89,7 +89,7 @@ func (m *mapper) openOutputFile(shardIdx int) (*os.File, error) {
 	fileNum := atomic.AddUint32(&m.mapFileId, 1)
 	filename := filepath.Join(
 		m.opt.TmpDir,
-		"map_output",
+		mapShardDir,
 		fmt.Sprintf("%03d", shardIdx),
 		fmt.Sprintf("%06d.map.gz", fileNum),
 	)

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -89,7 +89,7 @@ func (m *mapper) openOutputFile(shardIdx int) (*os.File, error) {
 	fileNum := atomic.AddUint32(&m.mapFileId, 1)
 	filename := filepath.Join(
 		m.opt.TmpDir,
-		"shards",
+		"map_output",
 		fmt.Sprintf("%03d", shardIdx),
 		fmt.Sprintf("%06d.map.gz", fileNum),
 	)

--- a/dgraph/cmd/bulk/merge_shards.go
+++ b/dgraph/cmd/bulk/merge_shards.go
@@ -27,7 +27,7 @@ import (
 )
 
 func mergeMapShardsIntoReduceShards(opt options) {
-	mapShards := shardDirs(opt.TmpDir)
+	mapShards := shardDirs(opt.TmpDir + "/map_output")
 
 	var reduceShards []string
 	for i := 0; i < opt.ReduceShards; i++ {
@@ -47,14 +47,14 @@ func mergeMapShardsIntoReduceShards(opt options) {
 	}
 }
 
-func shardDirs(tmpDir string) []string {
-	dir, err := os.Open(filepath.Join(tmpDir, "shards"))
+func shardDirs(d string) []string {
+	dir, err := os.Open(d)
 	x.Check(err)
 	shards, err := dir.Readdirnames(0)
 	x.Check(err)
 	dir.Close()
 	for i, shard := range shards {
-		shards[i] = filepath.Join(tmpDir, "shards", shard)
+		shards[i] = filepath.Join(d, shard)
 	}
 
 	// Allow largest shards to be shuffled first.

--- a/dgraph/cmd/bulk/merge_shards.go
+++ b/dgraph/cmd/bulk/merge_shards.go
@@ -26,12 +26,17 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
+const (
+	mapShardDir    = "map_output"
+	reduceShardDir = "shards"
+)
+
 func mergeMapShardsIntoReduceShards(opt options) {
-	mapShards := shardDirs(opt.TmpDir + "/map_output")
+	mapShards := shardDirs(filepath.Join(opt.TmpDir, mapShardDir))
 
 	var reduceShards []string
 	for i := 0; i < opt.ReduceShards; i++ {
-		shardDir := filepath.Join(opt.TmpDir, "shards", fmt.Sprintf("shard_%d", i))
+		shardDir := filepath.Join(opt.TmpDir, reduceShardDir, fmt.Sprintf("shard_%d", i))
 		x.Check(os.MkdirAll(shardDir, 0755))
 		reduceShards = append(reduceShards, shardDir)
 	}

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 
 	"github.com/dgraph-io/badger"
@@ -45,7 +46,7 @@ type reducer struct {
 }
 
 func (r *reducer) run() error {
-	dirs := shardDirs(r.opt.TmpDir + "/shards")
+	dirs := shardDirs(filepath.Join(r.opt.TmpDir, reduceShardDir))
 	x.AssertTrue(len(dirs) == r.opt.ReduceShards)
 	x.AssertTrue(len(r.opt.shardOutputDirs) == r.opt.ReduceShards)
 

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -45,7 +45,7 @@ type reducer struct {
 }
 
 func (r *reducer) run() error {
-	dirs := shardDirs(r.opt.TmpDir)
+	dirs := shardDirs(r.opt.TmpDir + "/shards")
 	x.AssertTrue(len(dirs) == r.opt.ReduceShards)
 	x.AssertTrue(len(r.opt.shardOutputDirs) == r.opt.ReduceShards)
 


### PR DESCRIPTION
In #3959 , bulk loader crashes when trying to move a directory into itself with a new name
/dgraph/tmp/shards/shard_0
/dgraph/tmp/shards/shard_0/shard_0

The bulk loader logic is
1. the mapper produce output as 
.../tmp/shards/000
.../tmp/shards/001

2. read the list of shards under .../tmp/shards/
3. create the reducer shards as
.../tmp/shards/shard_0
.../tmp/shards/shard_1

4. move the list read in step 2 into the reducer shards created in step 3

Though I cannot reproduce the problem, but it seems creating of the reducer shard directory .../tmp/shards/shard_0 and listing all the mapper shards in step 2 are re-ordered. Something similar is mentioned in https://github.com/etcd-io/etcd/issues/6368

This PR avoids such possibilities by putting the mapper output into an independent directory
../tmp/map_output, so that the program works correctly even if the reordering happens.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3960)
<!-- Reviewable:end -->
