### PR TITLE
Touchup types docs

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1788,10 +1788,9 @@ Query Example: Actors from Tim Burton movies and how many roles they have played
 
 ## Expand Predicates
 
-The `expand()` function can be used to expand the predicates in a node. Starting
-with version 1.1, the keyword `_predicate_` has been deprecated. Instead, to
-properly use the `expand()` function, the use of the type system is required.
-Refer to the section on the type system to check how to set the types of a given
+The `expand()` function can be used to expand the predicates out of a node. To
+ use `expand()`, the the [type system]({{< relref "#type-system" >}}) is required.
+Refer to the section on the type system to check how to set the types
 nodes. The rest of this section assumes familiarity with that section.
 
 There are four ways to use the `expand` function.
@@ -1806,12 +1805,12 @@ There are four ways to use the `expand` function.
 * If `_reverse_` is passed as an argument to `expand()`, only the reverse
   predicates at each node in that level are retrieved.
 
-The last three keywords require that the node's types have been set to properly
-work. Dgraph will look for all the types that have been assigned to this node,
+The last three keywords require that the node's have types. Dgraph will look 
+for all the types that have been assigned to a node,
 query the types to check which attributes they have, and use those to compute
 the list of predicates to expand.
 
-For example, consider a node that has the following types `Animal` and `Pet`, which have 
+For example, consider a node that has types `Animal` and `Pet`, which have 
 the following definitions:
 
 ```
@@ -1828,7 +1827,8 @@ type Pet {
 ```
 
 When `expand(_all_)` is called on this node, Dgraph will first check which types
-the node has. Then it will query the definitions of the types and build a list.
+the node has (`Animal` and `Pet`). Then it will get the definitions of 
+`Animal` and `Pet` and build a list of predicates.
 Finally, it will query the schema to check if any of those predicates have a
 reverse node. If, for example, there's a reverse node in the `owner` predicate,
 the final list of predicates to expand will be:
@@ -1842,10 +1842,9 @@ owner
 veterinarian
 ```
 
-If the predicate has no string without a language tag, `expand()` won't expand
-it (see [language preference]({{< relref "#language-support" >}})). For example,
-above `name` generally doesn't have strings without tags in the dataset, so
-`name@.` is required.
+For `string` predicates, `expand` only returns values not tagged with a language
+(see [language preference]({{< relref "#language-support" >}})).  So it's often 
+required to add `name@fr` or `name@.` as well as expand to a query.
 
 ## Cascade Directive
 
@@ -2055,16 +2054,12 @@ Reverse edges are also computed if specified by a schema mutation.
 
 ### Type System
 
-Starting in version 1.1, Dgraph has support for a type system. At the moment,
-the type system is basic but can be used already to categorize nodes and query
+Dgraph supports a type system that can be used to categorize nodes and query
 them based on their type. The type system is also used during expand queries.
-
-Keep in mind that the type system is a work in progress and more features will
-be added in coming versions.
 
 #### Type definition
 
-Types are defined using the GraphQL standard. Here's an example of a basic type.
+Types are defined using a GraphQL-like syntax. For example:
 
 ```
 type Student {
@@ -2072,27 +2067,30 @@ type Student {
   dob: datetime
   home_address: string
   year: int
+  friends: [uid]
 }
 ```
 
 Types are declared along with the schema using the Alter endpoint. In order to
-properly support the above type, we need a predicate for each of the attributes
-in the type as shown below:
+properly support the above type, a predicate for each of the attributes
+in the type is also needed, such as:
 
 ```
-name: string .
+name: string @index(term) .
 dob: datetime .
 home_address: string .
 year: int .
+friends: [uid] .
 ```
 
-If a predicate contains a reverse index, you can assume that both the predicate and
-the reverse predicate are part of any type definition that contains that predicate.
+If a `uid` predicate contains a reverse index, both the predicate and the reverse 
+predicate are part of any type definition that contains that predicate.
 Expand queries will follow that convention.
 
-To use the same attribute in multiple types, make sure the type and indexes
-required for both are the same. Otherwise, use separate attribute and predicate
-names for each type. Below there is a small example.
+Edges can be used in multiple types: for example, `name` might be used for both a person
+and a pet.  Sometimes, however, it's required to use a different predicate for each type 
+to represent a similar concept.  For example, if student names and book names required 
+different indexes, then the predicates must be different.
 
 ```
 type Student {
@@ -2107,14 +2105,9 @@ student_name: string @index(exact) .
 textbook_name: string @lang @index(fulltext) .
 ```
 
-Types also support list attributes (i.e `friends: [uid]`) and non-nullable types
-(i.e `friends: [uid]!`). However, the type of the attributes are not being used
-right now, as the type system is still a work in progress. It's a good idea to
-properly think about how they should be setup to avoid any issues once the type
-system starts using them.
+Types also support lists like `friends: [uid]` or `tags: [string]`.
 
-If you send a type definition through the Alter endpoint for a type that already
-exists, the current definition will be overwritten.
+Altering the schema for a type that already exists, overwrites the existing definition.
 
 #### Setting the type of a node
 
@@ -2137,7 +2130,7 @@ types. Here's an example of how to set the types of a node:
 
 #### Using types during queries
 
-The type system can be used as a top level function in the query language. Here's an example:
+Types can be used as a top level function in the query language. For example:
 
 ```
 {
@@ -2148,15 +2141,15 @@ The type system can be used as a top level function in the query language. Here'
 }
 ```
 
-This query will only return nodes whose type has been previously set to `Animal`.
+This query will only return nodes whose type is set to `Animal`.
 
-The types can also be used to filter results inside the queries. For example:
+Types can also be used to filter results inside a query. For example:
 
 ```
 {
   q(func: has(parent)) {
     uid
-    parent @type(Person) {
+    parent @filter(type(Person)) {
       uid
       name
     }
@@ -2164,8 +2157,8 @@ The types can also be used to filter results inside the queries. For example:
 }
 ```
 
-This query will return the nodes that have a parent predicate but only if the
-type of the parent node has been previously set to `Person`.
+This query will return the nodes that have a parent predicate and only the 
+`parent`'s of type `Person`.
 
 #### Deleting a type
 
@@ -2183,9 +2176,8 @@ err := c.Alter(context.Background(), &api.Operation{
 
 #### Expand queries and types
 
-Queries using the `expand(_all_)`, `expand(_reverse_)`, or `expand(_forward_)`
-functions now require that the types of the nodes to expand have been properly
-set. Refer to that section for more information.
+Queries using [expand]({{< relref "#expand-predicates" >}}) (i.e.: `expand(_all_)`, 
+`expand(_reverse_)`, or `expand(_forward_)`) require that the nodes to expand have types. 
 
 ### Predicates i18n
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1789,7 +1789,7 @@ Query Example: Actors from Tim Burton movies and how many roles they have played
 ## Expand Predicates
 
 The `expand()` function can be used to expand the predicates out of a node. To
- use `expand()`, the the [type system]({{< relref "#type-system" >}}) is required.
+ use `expand()`, the [type system]({{< relref "#type-system" >}}) is required.
 Refer to the section on the type system to check how to set the types
 nodes. The rest of this section assumes familiarity with that section.
 
@@ -1805,7 +1805,7 @@ There are four ways to use the `expand` function.
 * If `_reverse_` is passed as an argument to `expand()`, only the reverse
   predicates at each node in that level are retrieved.
 
-The last three keywords require that the node's have types. Dgraph will look 
+The last three keywords require that the nodes have types. Dgraph will look 
 for all the types that have been assigned to a node,
 query the types to check which attributes they have, and use those to compute
 the list of predicates to expand.
@@ -2084,7 +2084,7 @@ friends: [uid] .
 ```
 
 If a `uid` predicate contains a reverse index, both the predicate and the reverse 
-predicate are part of any type definition that contains that predicate.
+predicate are part of any type definition which contain that predicate.
 Expand queries will follow that convention.
 
 Edges can be used in multiple types: for example, `name` might be used for both a person


### PR DESCRIPTION
Just some light touches around types docs to make language clearer.

Removes mention of `!`, which isn't supported yet.

Also removes mention of `@type(...)`, which we can add back later once https://github.com/dgraph-io/dgraph/issues/3961 is fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3962)
<!-- Reviewable:end -->
