### PR TITLE
Enforce type required fields when @type directive is used.

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -85,6 +85,10 @@ type GraphQuery struct {
 	// True for blocks that don't have a starting function and hence no starting nodes. They are
 	// used to aggregate and get variables defined in another block.
 	IsEmpty bool
+
+	// EnforcedType is the name of the type inside the @type directive. It will be used for
+	// type processing. For example, it will be used to enforce non-nullable fields in types.
+	EnforcedType string
 }
 
 // RecurseArgs stores the arguments needed to process the @recurse directive.
@@ -2045,6 +2049,7 @@ func parseType(it *lex.ItemIterator, gq *GraphQuery) error {
 			},
 		},
 	}
+	gq.EnforcedType = typeName
 
 	return nil
 }

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4784,6 +4784,7 @@ func TestTypeInPredicate(t *testing.T) {
 	require.Equal(t, "type", gq.Query[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Filter.Func.Args))
 	require.Equal(t, "Person", gq.Query[0].Children[0].Filter.Func.Args[0].Value)
+	require.Equal(t, "Person", gq.Query[0].Children[0].EnforcedType)
 
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Children))
 	require.Equal(t, "name", gq.Query[0].Children[0].Children[0].Attr)
@@ -4810,6 +4811,7 @@ func TestMultipleTypeDirectives(t *testing.T) {
 	require.Equal(t, "type", gq.Query[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Filter.Func.Args))
 	require.Equal(t, "Person", gq.Query[0].Children[0].Filter.Func.Args[0].Value)
+	require.Equal(t, "Person", gq.Query[0].Children[0].EnforcedType)
 
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Children))
 	require.Equal(t, "pet", gq.Query[0].Children[0].Children[0].Attr)
@@ -4817,4 +4819,5 @@ func TestMultipleTypeDirectives(t *testing.T) {
 	require.Equal(t, "type", gq.Query[0].Children[0].Children[0].Filter.Func.Name)
 	require.Equal(t, 1, len(gq.Query[0].Children[0].Children[0].Filter.Func.Args))
 	require.Equal(t, "Animal", gq.Query[0].Children[0].Children[0].Filter.Func.Args[0].Value)
+	require.Equal(t, "Animal", gq.Query[0].Children[0].Children[0].EnforcedType)
 }

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -226,6 +226,29 @@ type Node {
 	name: string
 }
 
+type Student {
+	legal_name: string!
+	preferred_name: string
+	dob: dateTime!
+	class: [Class!]
+}
+
+type Class {
+	full_name: string!
+	description: string
+}
+
+type Profesor {
+	legal_name: string!
+	title: string
+	department: [uid]!
+}
+
+type Department {
+	full_name: string!
+	founded: int
+}
+
 name                           : string @index(term, exact, trigram) @count @lang .
 alias                          : string @index(exact, term, fulltext) .
 dob                            : dateTime @index(year) .
@@ -264,6 +287,10 @@ previous_model                 : uid @reverse .
 created_at                     : datetime @index(hour) .
 updated_at                     : datetime @index(year) .
 number                         : int @index(int) .
+classmate                      : [uid] .
+class                          : [uid] .
+department                     : [uid] .
+founded                        : int .
 `
 
 func populateCluster() {
@@ -548,6 +575,43 @@ func populateCluster() {
 		<202> <model> "Prius" .
 		<202> <model> "プリウス"@jp .
 		<202> <dgraph.type> "CarModel" .
+
+		<300> <legal_name> "Student 1" .
+		<300> <preferred_name> "Micheal" .
+		<300> <dob> "2010-01-01" .
+		<300> <class> <310> .
+		<300> <class> <311> .
+		<300> <dgraph.type> "Student" .
+
+		<301> <legal_name> "Student 2" .
+		<301> <preferred_name> "Albert" .
+		<301> <class> <310> .
+		<301> <class> <311> .
+		<301> <dgraph.type> "Student" .
+
+		<302> <classmate> <300> .
+		<302> <classmate> <301> .
+
+		<310> <full_name> "Algebra 1" .
+		<310> <description> "First course of introductory algebra" .
+		<310> <professor> <320> .
+		<310> <professor> <321> .
+		<310> <dgraph.type> "Class" .
+
+		<311> <description> "Second course of introductory algebra" .
+		<311> <dgraph.type> "Class" .
+
+		<320> <full_name> "Algebra 1 professor" .
+		<320> <title> "Tenured professor" .
+		<320> <department> <330> .
+		<320> <dgraph.type> "Professor" .
+
+		<321> <title> "Teaching assistant" .
+		<321> <department> <330> .
+		<321> <dgraph.type> "Profesor" .
+
+		<330> <founded> "1947" .
+		<330> <dgraph.type> "Department" .
 	`)
 
 	addGeoPointToCluster(1, "loc", []float64{1.1, 2.0})

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -236,17 +236,24 @@ type Student {
 type Class {
 	full_name: string!
 	description: string
+	professor: [Professor]
+	term: Term!
 }
 
 type Profesor {
 	legal_name: string!
 	title: string
-	department: [uid]!
+	department: uid!
 }
 
 type Department {
 	full_name: string!
 	founded: int
+}
+
+type Term {
+	year: int!
+	season: string!
 }
 
 name                           : string @index(term, exact, trigram) @count @lang .
@@ -289,8 +296,9 @@ updated_at                     : datetime @index(year) .
 number                         : int @index(int) .
 classmate                      : [uid] .
 class                          : [uid] .
-department                     : [uid] .
+department                     : uid .
 founded                        : int .
+term                           : uid .
 `
 
 func populateCluster() {
@@ -596,10 +604,14 @@ func populateCluster() {
 		<310> <description> "First course of introductory algebra" .
 		<310> <professor> <320> .
 		<310> <professor> <321> .
+		<310> <term> <315> .
 		<310> <dgraph.type> "Class" .
 
 		<311> <description> "Second course of introductory algebra" .
 		<311> <dgraph.type> "Class" .
+
+		<315> <year> "2019" .
+		<315> <dgraph.type> "Term" .
 
 		<320> <full_name> "Algebra 1 professor" .
 		<320> <title> "Tenured professor" .

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -2284,7 +2284,7 @@ func TestCountUidWithAlias(t *testing.T) {
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {
-	client = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	client = testutil.DgraphClient(testutil.SockAddr)
 
 	populateCluster()
 	os.Exit(m.Run())

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -2284,7 +2284,7 @@ func TestCountUidWithAlias(t *testing.T) {
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {
-	client = testutil.DgraphClient(testutil.SockAddr)
+	client = testutil.DgraphClientWithGroot(testutil.SockAddr)
 
 	populateCluster()
 	os.Exit(m.Run())

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -373,7 +373,7 @@ func TestRequiredTypeFieldsBasic(t *testing.T) {
 			{"dob":"2010-01-01T00:00:00Z", "legal_name":"Student 1", "preferred_name":"Micheal"}]}]}}`, js)
 }
 
-func TestRequiredTypeFieldsRecursive(t *testing.T) {
+func TestRequiredTypeFieldsRecursive1(t *testing.T) {
 	q1 := `{
 		q(func: uid(302)) {
 			classmate {
@@ -418,6 +418,47 @@ func TestRequiredTypeFieldsRecursive(t *testing.T) {
 			{"dob":"2010-01-01T00:00:00Z", "legal_name":"Student 1", "preferred_name":"Micheal",
 			"class":[
 				{"description":"First course of introductory algebra", "full_name":"Algebra 1"}]}]}]}}`, js)
+}
+
+func TestRequiredTypeFieldsRecursive2(t *testing.T) {
+	q1 := `{
+		q(func: uid(310)) {
+			description
+			full_name
+			professor {
+				full_name
+				title
+			}
+			term {
+				year
+				season
+			}
+		}
+	}`
+	js := processQueryNoErr(t, q1)
+	require.JSONEq(t, `{"data": {"q":[
+		{"description":"First course of introductory algebra", "full_name":"Algebra 1",
+		"professor":[
+			{"full_name":"Algebra 1 professor", "title":"Tenured professor"},
+			{"title":"Teaching assistant"}],
+		"term":{"year":2019}}]}}`, js)
+
+	q2 := `{
+		q(func: uid(310)) @type(Class) {
+			description
+			full_name
+			professor {
+				full_name
+				title
+			}
+			term {
+				year
+				season
+			}
+		}
+	}`
+	js = processQueryNoErr(t, q2)
+	require.JSONEq(t, `{"data": {"q":[]}}`, js)
 }
 
 func TestRequiredTypeMultiple(t *testing.T) {
@@ -496,8 +537,8 @@ func TestTypeRequiredUid(t *testing.T) {
 	js := processQueryNoErr(t, q1)
 	require.JSONEq(t, `{"data": {"q":[
 		{"professor":[
-			{"full_name":"Algebra 1 professor", "title":"Tenured professor", "department":[{"founded":1947}]},
-			{"title": "Teaching assistant", "department":[{"founded":1947}]}]}]}}`, js)
+			{"full_name":"Algebra 1 professor", "title":"Tenured professor", "department":{"founded":1947}},
+			{"title": "Teaching assistant", "department":{"founded":1947}}]}]}}`, js)
 
 	q2 := `{
 		q(func: uid(310)) {
@@ -515,5 +556,5 @@ func TestTypeRequiredUid(t *testing.T) {
 	require.JSONEq(t, `{"data": {"q":[
 		{"professor":[
 			{"full_name":"Algebra 1 professor", "title":"Tenured professor",
-			"department":[{"founded":1947}]}]}]}}`, js)
+			"department":{"founded":1947}}]}]}}`, js)
 }


### PR DESCRIPTION
Required (non-nullable in GraphQL lingo) fields mean that objects
that do not contain said fields should not be returned in the output.
This PR adds the initial implementation of required fields enforcement.

A couple things are missing:
- Dealing with non-nullable lists (e.g [string]!)
- @type directive does not work at the query root. This is a known
  issue that will be fixed in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/3973)
<!-- Reviewable:end -->
