### PR TITLE
docs: Update UIDs in query examples.

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -52,7 +52,7 @@ Query Example: "Blade Runner" movie data found by UID.
 
 {{< runnable >}}
 {
-  bladerunner(func: uid(0x579683)) {
+  bladerunner(func: uid(0x2066e)) {
     uid
     name@en
     initial_release_date
@@ -81,7 +81,7 @@ Multiple IDs can be specified in a list to the `uid` function.
 Query Example:
 {{< runnable >}}
 {
-  movies(func: uid(0x579683, 0x5af1c7)) {
+  movies(func: uid(0x25280, 0x707f9)) {
     uid
     name@en
     initial_release_date
@@ -628,7 +628,7 @@ Query Example: If the UID of a node is known, values for the node can be read di
 
 {{< runnable >}}
 {
-  films(func: uid(0x7de2ec)) {
+  films(func: uid(0x1daf5)) {
     name@hi
     actor.film {
       performance.film {
@@ -704,12 +704,12 @@ While the `uid` function filters nodes at the current level based on UID, functi
 `uid_in` cannot be used at root, it accepts one UID constant as its argument (not a variable).
 
 
-Query Example: The collaborations of Marc Caro and Jean-Pierre Jeunet (UID 0x679de1).  If the UID of Jean-Pierre Jeunet is known, querying this way removes the need to have a block extracting his UID into a variable and the extra edge traversal and filter for `~director.film`.
+Query Example: The collaborations of Marc Caro and Jean-Pierre Jeunet (UID 0x99706).  If the UID of Jean-Pierre Jeunet is known, querying this way removes the need to have a block extracting his UID into a variable and the extra edge traversal and filter for `~director.film`.
 {{< runnable >}}
 {
   caro(func: eq(name@en, "Marc Caro")) {
     name@en
-    director.film @filter(uid_in(~director.film, 0x679de1)){
+    director.film @filter(uid_in(~director.film, 0x99706)) {
       name@en
     }
   }
@@ -1039,13 +1039,13 @@ Query Example: The first five of Baz Luhrmann's films, sorted by UID order.
 }
 {{< /runnable >}}
 
-The fifth movie is the Australian movie classic Strictly Ballroom.  It has UID `0x8116e4`.  The results after Strictly Ballroom can now be obtained with `after`.
+The fifth movie is the Australian movie classic Strictly Ballroom.  It has UID `0x99e44`.  The results after Strictly Ballroom can now be obtained with `after`.
 
 {{< runnable >}}
 {
   me(func: allofterms(name@en, "Baz Luhrmann")) {
     name@en
-    director.film (first:5, after: 0x8116e4) {
+    director.film (first:5, after: 0x99e44) {
       uid
       name@en
     }


### PR DESCRIPTION
There are new UIDs with the v1.1.0 update for the Playground cluster at
https://play.dgraph.io, so the query examples in the docs that use UID
literals are updated with the new values.

Fixes #3986.