### PR TITLE
docs: Fix quoting issue in curl command.

### DIFF
--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -384,7 +384,7 @@ To run a `delete` mutation:
 curl -H "Content-Type: application/rdf" -X POST localhost:8080/mutate?commitNow=true -d $'
 {
   delete {
-    # Example: Alice's UID is 0x56f33
+    # Example: The UID of Alice is 0x56f33
     <0x56f33> <name> * .
   }
 }'


### PR DESCRIPTION
The single quote used in the comment of the curl POST body was interpreted as closing the single-quoted shell argument, which is an error when trying to run the command when copy/pasting from the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4011)
<!-- Reviewable:end -->
