### PR TITLE
Add line and colum numbers to JSON errors thrown by HTTP endpoints.

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -581,6 +581,7 @@ func (sju *skipJSONUnmarshal) UnmarshalJSON(bs []byte) error {
 }
 
 // convertJSONError adds line and character information to the JSON error.
+// Idea taken from: https://bit.ly/2moFIVS
 func convertJSONError(input string, err error) error {
 	if err == nil {
 		return nil


### PR DESCRIPTION
Implementation idea taken from
https://adrianhesketh.com/2017/03/18/getting-line-and-character-positions-from-gos-json-unmarshal-errors/

Fixes #3965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4012)
<!-- Reviewable:end -->
