### PR TITLE
Add E2E tests for delete and update

### DIFF
--- a/dgraph/cmd/graphql/dgraph/dgo.go
+++ b/dgraph/cmd/graphql/dgraph/dgo.go
@@ -122,7 +122,7 @@ func (dg *dgraph) DeleteNode(ctx context.Context, uid uint64) error {
 
 	mu := &dgoapi.Mutation{
 		CommitNow: true,
-		DelNquads: []byte(fmt.Sprintf("<0x%x> * * .", uid)),
+		DelNquads: []byte(fmt.Sprintf("<%#x> * * .", uid)),
 	}
 
 	_, err := dg.client.NewTxn().Mutate(ctx, mu)
@@ -168,7 +168,7 @@ func (dg *dgraph) AssertType(ctx context.Context, uid uint64, typ string) error 
 	}
 
 	if len(decode.CheckID) != 1 {
-		return gqlerror.Errorf("Node with id %s is not of type %s", string(uid), typ)
+		return gqlerror.Errorf("Node with id %#x is not of type %s", uid, typ)
 	}
 
 	return nil

--- a/dgraph/cmd/graphql/dgraph/graphquery.go
+++ b/dgraph/cmd/graphql/dgraph/graphquery.go
@@ -81,7 +81,7 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	}
 
 	if q.Func.Name == "uid" && len(q.Func.UID) == 1 {
-		b.WriteString(fmt.Sprintf("(func: uid(0x%x))", q.Func.UID[0]))
+		b.WriteString(fmt.Sprintf("(func: uid(%#x))", q.Func.UID[0]))
 	} else if q.Func.Name == "type" && len(q.Func.Args) == 1 {
 		b.WriteString(fmt.Sprintf("(func: type(%s)", q.Func.Args[0].Value))
 		writeOrderAndPage(b, q, true)

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -122,7 +122,7 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			srcUID = fmt.Sprintf("0x%x", uid)
+			srcUID = fmt.Sprintf("%#x", uid)
 		}
 
 		res, err := rewriteObject(mutatedType, nil, srcUID, val)

--- a/dgraph/cmd/graphql/e2e_query_test.go
+++ b/dgraph/cmd/graphql/e2e_query_test.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func queryCountryByRegExp(t *testing.T, regexp string, expectedCountries []*country) {
+	getCountryParams := &GraphQLParams{
+		Query: `query queryCountry($regexp: String!) {
+			queryCountry(filter: { name: { regexp: $regexp } }) {
+				name
+			}
+		}`,
+		Variables: map[string]interface{}{"regexp": regexp},
+	}
+
+	gqlResponse := getCountryParams.ExecuteAsPost(t, graphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+
+	var expected, result struct {
+		QueryCountry []*country
+	}
+	expected.QueryCountry = expectedCountries
+	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
+	require.NoError(t, err)
+
+	if diff := cmp.Diff(expected, result); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -71,7 +71,7 @@ type GraphQLParams struct {
 // see https://graphql.github.io/graphql-spec/June2018/#sec-Response
 type GraphQLResponse struct {
 	Data       json.RawMessage        `json:"data,omitempty"`
-	Errors     []x.GqlError           `json:"errors,omitempty"`
+	Errors     []*x.GqlError          `json:"errors,omitempty"`
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -129,16 +129,17 @@ func (mr *mutationResolver) resolve(ctx context.Context) *resolved {
 				"[%s] Only add, delete and update mutations are implemented", api.RequestID(ctx))}
 	}
 
+	var b bytes.Buffer
+	b.WriteRune('"')
+	b.WriteString(mr.mutation.ResponseName())
+	b.WriteString(`": `)
 	if len(res.data) > 0 {
-		var b bytes.Buffer
-		b.WriteRune('"')
-		b.WriteString(mr.mutation.ResponseName())
-		b.WriteString(`": `)
 		b.Write(res.data)
-
-		res.data = b.Bytes()
+	} else {
+		b.WriteString("null")
 	}
 
+	res.data = b.Bytes()
 	return res
 }
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -203,8 +203,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 	err = mr.dgraph.AssertType(ctx, uid, mr.mutation.MutatedTypeName())
 	if err != nil {
 		return &resolved{
-			err: schema.GQLWrapf(err, "[%s] couldn't complete %s",
-				api.RequestID(ctx), mr.mutation.Name())}
+			err: schema.GQLWrapf(err, "couldn't complete %s", mr.mutation.Name())}
 	}
 
 	err = mr.dgraph.DeleteNode(ctx, uid)

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -209,8 +209,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 
 	err = mr.dgraph.DeleteNode(ctx, uid)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "[%s] couldn't complete %s",
-			api.RequestID(ctx), mr.mutation.Name())
+		res.err = schema.GQLWrapf(err, "couldn't complete %s", mr.mutation.Name())
 		// FIXME: ^^ also add the GraphQL path etc to link properly to the operation
 		return res
 	}

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -207,8 +207,8 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 		for _, m := range op.Mutations() {
 			if r.resp.Errors != nil {
 				r.WithError(
-					gqlerror.Errorf("[%s] mutation %s not executed because of previous error",
-						api.RequestID(ctx), m.ResponseName()))
+					gqlerror.Errorf("mutation %s not executed because of previous error",
+						m.ResponseName()))
 				continue
 			}
 


### PR DESCRIPTION
Adds E2E testing for delete mutations and update mutations.

This is it for E2E mutation testing for now.  (Queries to come)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4022)
<!-- Reviewable:end -->
