### PR TITLE
Add support for interfaces to the GraphQL layer.

### DIFF
--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -132,7 +132,9 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 
 		res["uid"] = srcUID
 		if m.MutationType() == schema.AddMutation {
-			res["dgraph.type"] = mutatedType.Name()
+			dgraphTypes := []string{mutatedType.Name()}
+			dgraphTypes = append(dgraphTypes, mutatedType.Interfaces()...)
+			res["dgraph.type"] = dgraphTypes
 		}
 
 		return res, nil
@@ -224,9 +226,9 @@ func rewriteObject(
 	for field, val := range obj {
 		var res interface{}
 		var err error
-		fieldName := fmt.Sprintf("%s.%s", typ.Name(), field)
 
 		fieldDef := typ.Field(field)
+		fieldName := fmt.Sprintf("%s.%s", fieldDef.ParentInterface(), field)
 
 		switch val := val.(type) {
 		case map[string]interface{}:

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -228,7 +228,7 @@ func rewriteObject(
 		var err error
 
 		fieldDef := typ.Field(field)
-		fieldName := fmt.Sprintf("%s.%s", fieldDef.ParentInterface(), field)
+		fieldName := fmt.Sprintf("%s.%s", fieldDef.ParentType(), field)
 
 		switch val := val.(type) {
 		case map[string]interface{}:

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -55,8 +55,7 @@ func TestMutationRewriting(t *testing.T) {
 	require.NoError(t, err, "Unable to unmarshal tests to yaml.")
 
 	gqlSchema := test.LoadSchemaFromFile(t, "schema.graphql")
-
-	rewritererToTest := NewMutationRewriter()
+	rewriterToTest := NewMutationRewriter()
 
 	for _, tcase := range tests {
 		t.Run(tcase.Name, func(t *testing.T) {
@@ -75,7 +74,7 @@ func TestMutationRewriting(t *testing.T) {
 
 			mut := test.GetMutation(t, op)
 
-			jsonMut, err := rewritererToTest.Rewrite(mut)
+			jsonMut, err := rewriterToTest.Rewrite(mut)
 
 			test.RequireJSONEq(t, tcase.Error, err)
 			if tcase.Error == nil {

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -19,7 +19,7 @@
     underlying Dgraph edge names"
   dgraphmuation: |
     { "uid":"_:newnode",
-      "dgraph.type":"Author",
+      "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
       "Author.dob":"2000-01-01",
       "Author.posts":[]
@@ -39,7 +39,7 @@
     injected and all data transformed to underlying Dgraph edge names"
   dgraphmuation: |
     { "uid":"_:newnode",
-      "dgraph.type":"Author",
+      "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
       "Author.posts":[]
     }
@@ -60,7 +60,7 @@
     getting injected and all data transformed to underlying Dgraph edge names"
   dgraphmuation: |
     { "uid":"_:newnode",
-      "dgraph.type":"Author",
+      "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
       "Author.posts":[]
     }
@@ -86,7 +86,7 @@
     Dgraph JSON mutation"
   dgraphmuation: |
     { "uid":"_:newnode",
-      "dgraph.type":"Author",
+      "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
       "Author.country": { "uid": "0x123" },
       "Author.posts":[]
@@ -134,7 +134,7 @@
     a new 'posts' edge."
   dgraphmuation: |
     { "uid" : "_:newnode",
-      "dgraph.type" : "Post",
+      "dgraph.type" : ["Post"],
       "Post.title" : "Exciting post",
       "Post.text" : "A really good post",
       "Post.author": {

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -197,3 +197,36 @@
       "dgraph.type": ["Human", "Character", "Employee"]
     }
 
+
+-
+  name: "Update mutation for a type that implements an interface"
+  gqlmutation: |
+    mutation updateHuman($patch: UpdateHumanInput!) {
+      updateHuman(input: $patch) {
+        human {
+          name
+          dob
+          female
+        }
+      }
+    }
+  gqlvariables: |
+    { "patch":
+      {
+        "id": "0x123",
+        "patch": { "name": "Bob",
+          "dob": "2000-01-01",
+          "female": true,
+          "ename": "employee no. 1"
+        }
+      }
+    }
+  explanation: "The mutation should get rewritten with correct edges from the interface."
+  dgraphmuation: |
+    { "uid" : "0x123",
+      "Character.name": "Bob",
+      "Employee.ename": "employee no. 1",
+      "Human.dob": "2000-01-01",
+      "Human.female": true
+    }
+

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -167,3 +167,31 @@
       "Post.text": "updated text"
     }
 
+-
+  name: "Update mutation for a type that implements an"
+  gqlmutation: |
+    mutation addHuman($human: HumanInput!) {
+      addHuman(input: $human) {
+        human {
+          name
+          dob
+          female
+        }
+      }
+    }
+  gqlvariables: |
+    { "human":
+      { "name": "Bob",
+        "dob": "2000-01-01",
+        "female": true
+      }
+    }
+  explanation: "The update should get rewritten with correct edges from the interface."
+  dgraphmuation: |
+    { "uid" : "_:newnode",
+      "Character.name": "Bob",
+      "Human.dob": "2000-01-01",
+      "Human.female": true,
+      "dgraph.type": ["Human", "Character"]
+    }
+

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -230,3 +230,20 @@
       "Human.female": true
     }
 
+-
+  name: "Update mutation for an interface"
+  gqlmutation: |
+    mutation {
+      updateCharacter(input: {id: "0x123", patch: {name:"Bob"}}) {
+        character {
+          id
+          name
+        }
+      }
+    }
+  explanation: "The mutation should get rewritten with correct edges from the interface."
+  dgraphmuation: |
+    { "uid" : "0x123",
+      "Character.name": "Bob"
+    }
+

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -168,7 +168,7 @@
     }
 
 -
-  name: "Update mutation for a type that implements an"
+  name: "Add mutation for a type that implements an interface"
   gqlmutation: |
     mutation addHuman($human: HumanInput!) {
       addHuman(input: $human) {
@@ -183,15 +183,17 @@
     { "human":
       { "name": "Bob",
         "dob": "2000-01-01",
-        "female": true
+        "female": true,
+        "ename": "employee no. 1"
       }
     }
-  explanation: "The update should get rewritten with correct edges from the interface."
+  explanation: "The mutation should get rewritten with correct edges from the interface."
   dgraphmuation: |
     { "uid" : "_:newnode",
       "Character.name": "Bob",
+      "Employee.ename": "employee no. 1",
       "Human.dob": "2000-01-01",
       "Human.female": true,
-      "dgraph.type": ["Human", "Character"]
+      "dgraph.type": ["Human", "Character", "Employee"]
     }
 

--- a/dgraph/cmd/graphql/dgraph/query.go
+++ b/dgraph/cmd/graphql/dgraph/query.go
@@ -200,7 +200,7 @@ func addSelectionSetFrom(q *gql.GraphQuery, field schema.Field) {
 		if f.Type().Name() == schema.IDType {
 			child.Attr = "uid"
 		} else {
-			child.Attr = field.Type().DgraphPredicate(f.Name())
+			child.Attr = f.DgraphPredicate()
 		}
 
 		addFilter(child, f)

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -707,6 +707,6 @@
         id : uid
         name : Character.name
         female : Human.female
-        ename : Human.ename
+        ename : Employee.ename
       }
     }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -622,7 +622,7 @@
     }
 
 -
-  name: "query type which implements an interface"
+  name: "getHuman which implements an interface"
   gqlquery: |
     query {
       getHuman(id: "0x1") {
@@ -636,6 +636,29 @@
   dgquery: |-
     query {
       getHuman(func: uid(0x1)) @filter(type(Human)) {
+        id : uid
+        name : Character.name
+        ename : Employee.ename
+        dob : Human.dob
+        female : Human.female
+      }
+    }
+
+-
+  name: "queryHuman which implements an interface"
+  gqlquery: |
+    query {
+      queryHuman {
+        id
+        name
+        ename
+        dob
+        female
+      }
+    }
+  dgquery: |-
+    query {
+      queryHuman(func: type(Human)) {
         id : uid
         name : Character.name
         ename : Employee.ename

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -666,3 +666,24 @@
         female : Human.female
       }
     }
+
+-
+  name: "filter with order for type which implements an interface"
+  gqlquery: |
+    query {
+      queryHuman (filter: { name: { anyofterms: "GraphQL" } }, order: { asc: ename }) {
+        id
+        name
+        ename
+        dob
+      }
+    }
+  dgquery: |-
+    query {
+      queryHuman(func: type(Human), orderasc: Employee.ename) @filter(anyofterms(Character.name, "GraphQL")) {
+        id : uid
+        name : Character.name
+        ename : Employee.ename
+        dob : Human.dob
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -620,3 +620,26 @@
         name : Author.name
       }
     }
+
+-
+  name: "query type which implements an interface"
+  gqlquery: |
+    query {
+      getHuman(id: "0x1") {
+        id
+        name
+        ename
+        dob
+        female
+      }
+    }
+  dgquery: |-
+    query {
+      getHuman(func: uid(0x1)) @filter(type(Human)) {
+        id : uid
+        name : Character.name
+        ename : Employee.ename
+        dob : Human.dob
+        female : Human.female
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -710,3 +710,30 @@
         ename : Employee.ename
       }
     }
+
+-
+  name: "queryCharacter with fragment on multiple types"
+  gqlquery: |
+    query {
+      queryCharacter {
+        id
+        name
+        ... on Human {
+          female
+          ename
+        }
+        ... on Director {
+          movies
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCharacter(func: type(Character)) {
+        id : uid
+        name : Character.name
+        female : Human.female
+        ename : Employee.ename
+        movies : Director.movies
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -687,3 +687,26 @@
         dob : Human.dob
       }
     }
+
+-
+  name: "queryCharacter with fragment for human"
+  gqlquery: |
+    query {
+      queryCharacter {
+        name
+        id
+        ... on Human {
+          female
+          ename
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCharacter(func: type(Character)) {
+        id : uid
+        name : Character.name
+        female : Human.female
+        dob : Human.dob
+      }
+    }

--- a/dgraph/cmd/graphql/dgraph/query_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/query_test.yaml
@@ -693,8 +693,8 @@
   gqlquery: |
     query {
       queryCharacter {
-        name
         id
+        name
         ... on Human {
           female
           ename
@@ -707,6 +707,6 @@
         id : uid
         name : Character.name
         female : Human.female
-        dob : Human.dob
+        ename : Human.ename
       }
     }

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -32,7 +32,6 @@ enum PostType {
         Opinion
 }
 
-# TODO - Make this recursive by referencing a character within here.
 interface Character {
         id: ID!
         name: String! @searchable

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -41,6 +41,10 @@ interface Employee {
         ename: String!
 }
 
+type Director implements Character {
+        movies: [String!]
+}
+
 type Human implements Character & Employee {
         dob: DateTime
         female: Boolean

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -35,7 +35,7 @@ enum PostType {
 # TODO - Make this recursive by referencing a character within here.
 interface Character {
         id: ID!
-        name: String!
+        name: String! @searchable
 }
 
 interface Employee {
@@ -44,7 +44,7 @@ interface Employee {
 
 type Human implements Character & Employee {
         id: ID!
-        name: String!
+        name: String! @searchable
         ename: String!
         dob: DateTime
         female: Boolean

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -42,9 +42,6 @@ interface Employee {
 }
 
 type Human implements Character & Employee {
-        id: ID!
-        name: String! @searchable
-        ename: String!
         dob: DateTime
         female: Boolean
 }

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -1,4 +1,4 @@
-# Test schema that contains an example of everything that's useful to 
+# Test schema that contains an example of everything that's useful to
 # test for query rewriting.
 
 type Country {
@@ -30,4 +30,17 @@ enum PostType {
         Fact
         Question
         Opinion
+}
+
+# TODO - Make this recursive by referencing a character within here.
+interface Character {
+        id: ID!
+        name: String!
+}
+
+type Human implements Character {
+        id: ID!
+        name: String!
+        dob: DateTime
+        female: Boolean
 }

--- a/dgraph/cmd/graphql/dgraph/schema.graphql
+++ b/dgraph/cmd/graphql/dgraph/schema.graphql
@@ -38,9 +38,14 @@ interface Character {
         name: String!
 }
 
-type Human implements Character {
+interface Employee {
+        ename: String!
+}
+
+type Human implements Character & Employee {
         id: ID!
         name: String!
+        ename: String!
         dob: DateTime
         female: Boolean
 }

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -355,8 +355,6 @@ func completeSchema(sch *ast.Schema, definitions []string) {
 		if defn.Kind == ast.Interface {
 			// addInputType doesn't make sense as interface is like an abstract class and we can't
 			// create objects of its type.
-
-			// TODO - Verify that reference type makes sense here.
 			addUpdateMutation(sch, defn)
 			addDeleteMutation(sch, defn)
 

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -305,23 +305,25 @@ func completeSchema(sch *ast.Schema, definitions []string) {
 			continue
 		}
 
+		// Common types to both Interface and Object.
+		addReferenceType(sch, defn)
+		addPatchType(sch, defn)
+		addUpdateType(sch, defn)
+		addUpdatePayloadType(sch, defn)
+		addDeletePayloadType(sch, defn)
+
 		if defn.Kind == ast.Interface {
-			addPatchType(sch, defn)
-			addUpdateType(sch, defn)
-			addUpdatePayloadType(sch, defn)
-			addDeletePayloadType(sch, defn)
+			// addInputType doesn't make sense as interface is like an abstract class and we can't
+			// create objects of its type.
+
+			// TODO - Verify that reference type makes sense here.
 			addUpdateMutation(sch, defn)
 			addDeleteMutation(sch, defn)
 
 		} else if defn.Kind == ast.Object {
 			// types and inputs needed for mutations
 			addInputType(sch, defn)
-			addReferenceType(sch, defn)
-			addPatchType(sch, defn)
-			addUpdateType(sch, defn)
 			addAddPayloadType(sch, defn)
-			addUpdatePayloadType(sch, defn)
-			addDeletePayloadType(sch, defn)
 			addMutations(sch, defn)
 		}
 

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -224,7 +224,7 @@ invalid_schemas:
     name: "Type implements an interface which wasn't defined"
     input: |
       type X implements Y {
-        y: String @searchable(by: bogus)
+        y: String
       }
     errlist: [
       {"message": Undefined type "Y".,
@@ -239,7 +239,7 @@ invalid_schemas:
       }
       type X implements Y {
         id: ID
-        y: String @searchable(by: bogus)
+        y: String
       }
     errlist: [
       {"message": "Field X.id can only be defined once.",
@@ -254,7 +254,7 @@ invalid_schemas:
       }
       type X implements Y {
         id: String
-        y: String @searchable(by: bogus)
+        y: String
       }
     errlist: [
       {"message": "Field X.id can only be defined once.",
@@ -288,23 +288,6 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Field Z.id can only be defined once.",
-      "locations":[{"line":2, "column":3}]}
-      ]
-
-  -
-    name: "Type implements from two interfaces where both have the same field"
-    input: |
-      interface X {
-        name: String
-      }
-      interface Y {
-        name: String
-      }
-      type Z implements X & Y {
-        email: String
-      }
-    errlist: [
-      {"message": "Field Z.name can only be defined once.",
       "locations":[{"line":2, "column":3}]}
       ]
 

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -275,7 +275,7 @@ invalid_schemas:
       ]
 
   -
-    name: "Type implemets from two interfaces where both have ID"
+    name: "Type implements from two interfaces where both have ID"
     input: |
       interface X {
         id: ID
@@ -288,6 +288,23 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Field Z.id can only be defined once.",
+      "locations":[{"line":2, "column":3}]}
+      ]
+
+  -
+    name: "Type implements from two interfaces where both have the same field"
+    input: |
+      interface X {
+        name: String
+      }
+      interface Y {
+        name: String
+      }
+      type Z implements X & Y {
+        email: String
+      }
+    errlist: [
+      {"message": "Field Z.name can only be defined once.",
       "locations":[{"line":2, "column":3}]}
       ]
 

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -221,14 +221,6 @@ invalid_schemas:
       ]
 
 
-#  -
-#    name: "Interface implemented by type not defined"
-#    input: |
-#      type Droid implements Character {
-#        primaryFunction: String
-#      }
-#    errlist: [{"message": "Undefined type \"Character\"."}]
-
 valid_schemas:
   -
     name: "hasInverse directive on singleton"

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -47,10 +47,9 @@ invalid_schemas:
         x: X!
       }
     errlist: [
-      {"message":"You can't add scalar definitions. Only type and enums are allowed in initial schema.", "locations":[{"line":1, "column":8}]},
-      {"message":"You can't add interface definitions. Only type and enums are allowed in initial schema.", "locations":[{"line":2, "column":11}]},
-      {"message":"You can't add union definitions. Only type and enums are allowed in initial schema.", "locations":[{"line":5, "column":7}]},
-      {"message":"You can't add input_object definitions. Only type and enums are allowed in initial schema.", "locations":[{"line":6, "column":7}]},
+      {"message":"You can't add scalar definitions. Only type, interface and enums are allowed in initial schema.", "locations":[{"line":1, "column":8}]},
+      {"message":"You can't add union definitions. Only type, interface and enums are allowed in initial schema.", "locations":[{"line":5, "column":7}]},
+      {"message":"You can't add input_object definitions. Only type, interface and enums are allowed in initial schema.", "locations":[{"line":6, "column":7}]},
     ]
 
   -
@@ -82,7 +81,7 @@ invalid_schemas:
     input: |
       union U = R | S | T
     errlist: [
-      {"message":"You can't add union definitions. Only type and enums are allowed in initial schema.", "locations":[{"line":1, "column":7}]}
+      {"message":"You can't add union definitions. Only type, interface and enums are allowed in initial schema.", "locations":[{"line":1, "column":7}]}
     ]
 
   -
@@ -143,12 +142,12 @@ invalid_schemas:
         id: ID! @searchable(by: term)
       }
     errlist: [
-      {"message": "Type X; Field id: has the @searchable directive but fields of type ID are 
-          not searchable.", 
+      {"message": "Type X; Field id: has the @searchable directive but fields of type ID are
+          not searchable.",
       "locations":[{"line":2, "column":12}]},
-      {"message": "Type Y; Field id: has the @searchable directive but the argument term doesn't 
-          apply to field type ID.  Searchable term applies to fields of type String. Fields of type 
-          ID are not searchable.", 
+      {"message": "Type Y; Field id: has the @searchable directive but the argument term doesn't
+          apply to field type ID.  Searchable term applies to fields of type String. Fields of type
+          ID are not searchable.",
       "locations":[{"line":5, "column":12}]}
       ]
 
@@ -162,8 +161,8 @@ invalid_schemas:
         y: String
       }
     errlist: [
-      {"message": "Type X; Field y: has the @searchable directive but fields of type Y 
-          are not searchable.", 
+      {"message": "Type X; Field y: has the @searchable directive but fields of type Y
+          are not searchable.",
       "locations":[{"line":2, "column":9}]}
       ]
 
@@ -177,9 +176,9 @@ invalid_schemas:
         y: String
       }
     errlist: [
-      {"message": "Type X; Field y: has the @searchable directive but the argument term doesn't 
-          apply to field type Y.  Searchable term applies to fields of type String. Fields of 
-          type Y are not searchable.", 
+      {"message": "Type X; Field y: has the @searchable directive but the argument term doesn't
+          apply to field type Y.  Searchable term applies to fields of type String. Fields of
+          type Y are not searchable.",
       "locations":[{"line":2, "column":9}]}
       ]
 
@@ -190,9 +189,9 @@ invalid_schemas:
         y: Int @searchable(by: term)
       }
     errlist: [
-      {"message": "Type X; Field y: has the @searchable directive but the argument term doesn't 
-          apply to field type Int.  Searchable term applies to fields of type String. Fields of 
-          type Int are searchable by just @searchable.", 
+      {"message": "Type X; Field y: has the @searchable directive but the argument term doesn't
+          apply to field type Int.  Searchable term applies to fields of type String. Fields of
+          type Int are searchable by just @searchable.",
       "locations":[{"line":2, "column":11}]}
       ]
 
@@ -203,9 +202,9 @@ invalid_schemas:
         y: String @searchable(by: day)
       }
     errlist: [
-      {"message": "Type X; Field y: has the @searchable directive but the argument day doesn't 
-          apply to field type String.  Searchable day applies to fields of type DateTime. Fields 
-          of type String are searchable by exact, fulltext, hash, term and trigram.", 
+      {"message": "Type X; Field y: has the @searchable directive but the argument day doesn't
+          apply to field type String.  Searchable day applies to fields of type DateTime. Fields
+          of type String are searchable by exact, fulltext, hash, term and trigram.",
       "locations":[{"line":2, "column":14}]}
       ]
 
@@ -216,10 +215,19 @@ invalid_schemas:
         y: String @searchable(by: bogus)
       }
     errlist: [
-      {"message": "Type X; Field y: the argument to @searchable bogus isn't valid.Fields of type 
-          String are searchable by exact, fulltext, hash, term and trigram.", 
+      {"message": "Type X; Field y: the argument to @searchable bogus isn't valid.Fields of type
+          String are searchable by exact, fulltext, hash, term and trigram.",
       "locations":[{"line":2, "column":14}]}
       ]
+
+
+#  -
+#    name: "Interface implemented by type not defined"
+#    input: |
+#      type Droid implements Character {
+#        primaryFunction: String
+#      }
+#    errlist: [{"message": "Undefined type \"Character\"."}]
 
 valid_schemas:
   -

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -220,6 +220,47 @@ invalid_schemas:
       "locations":[{"line":2, "column":14}]}
       ]
 
+  -
+    name: "Type implements an interface which wasn't defined"
+    input: |
+      type X implements Y {
+        y: String @searchable(by: bogus)
+      }
+    errlist: [
+      {"message": Undefined type "Y".,
+      "locations":[{"line":1, "column":6}]}
+      ]
+
+  -
+    name: "Type implemets an interface with the field definition repeated"
+    input: |
+      interface Y {
+        id: ID
+      }
+      type X implements Y {
+        id: ID
+        y: String @searchable(by: bogus)
+      }
+    errlist: [
+      {"message": "Field X.id can only be defined once.",
+      "locations":[{"line":5, "column":3}]}
+      ]
+
+  -
+    name: "Type defines an interface with the field name repeated but different type"
+    input: |
+      interface Y {
+        id: ID
+      }
+      type X implements Y {
+        id: String
+        y: String @searchable(by: bogus)
+      }
+    errlist: [
+      {"message": "Field X.id can only be defined once.",
+      "locations":[{"line":5, "column":3}]}
+      ]
+
 
 valid_schemas:
   -

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -274,6 +274,23 @@ invalid_schemas:
       "locations":[{"line":5, "column":1}]}
       ]
 
+  -
+    name: "Type implemets from two interfaces where both have ID"
+    input: |
+      interface X {
+        id: ID
+      }
+      interface Y {
+        id: ID
+      }
+      type Z implements X & Y {
+        name: String
+      }
+    errlist: [
+      {"message": "Field Z.id can only be defined once.",
+      "locations":[{"line":2, "column":3}]}
+      ]
+
 
 valid_schemas:
   -

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -247,7 +247,7 @@ invalid_schemas:
       ]
 
   -
-    name: "Type defines an interface with the field name repeated but different type"
+    name: "Type implements an interface with the field name repeated but different type"
     input: |
       interface Y {
         id: ID
@@ -259,6 +259,19 @@ invalid_schemas:
     errlist: [
       {"message": "Field X.id can only be defined once.",
       "locations":[{"line":5, "column":3}]}
+      ]
+
+  -
+    name: "Type implemets an interface with no field of its own"
+    input: |
+      interface Y {
+        id: ID
+      }
+      type X implements Y {
+      }
+    errlist: [
+      {"message": "expected at least one definition, found }",
+      "locations":[{"line":5, "column":1}]}
       ]
 
 

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -33,14 +33,15 @@ func init() {
 }
 
 func dataTypeCheck(defn *ast.Definition) *gqlerror.Error {
-	if defn.Kind != ast.Object && defn.Kind != ast.Enum {
-		return gqlerror.ErrorPosf(
-			defn.Position,
-			"You can't add %s definitions. Only type and enums are allowed in initial schema.",
-			strings.ToLower(string(defn.Kind)),
-		)
+	if defn.Kind == ast.Object || defn.Kind == ast.Enum || defn.Kind == ast.Interface {
+		return nil
 	}
-	return nil
+	return gqlerror.ErrorPosf(
+		defn.Position,
+		"You can't add %s definitions. "+
+			"Only type, interface and enums are allowed in initial schema.",
+		strings.ToLower(string(defn.Kind)),
+	)
 }
 
 func nameCheck(defn *ast.Definition) *gqlerror.Error {

--- a/dgraph/cmd/graphql/schema/schemagen.go
+++ b/dgraph/cmd/graphql/schema/schemagen.go
@@ -105,7 +105,7 @@ func NewHandler(input string) (Handler, error) {
 
 	sch, gqlErr := validator.ValidateSchemaDocument(doc)
 	if gqlErr != nil {
-		return nil, gqlErr
+		return nil, gqlerror.List{gqlErr}
 	}
 
 	gqlErrList = postGQLValidation(sch, defns)

--- a/dgraph/cmd/graphql/schema/schemagen.go
+++ b/dgraph/cmd/graphql/schema/schemagen.go
@@ -85,7 +85,7 @@ func NewHandler(input string) (Handler, error) {
 
 	doc, gqlErr := parser.ParseSchemas(validator.Prelude, &ast.Source{Input: input})
 	if gqlErr != nil {
-		return nil, gqlErr
+		return nil, gqlerror.List{gqlErr}
 	}
 
 	gqlErrList := preGQLValidation(doc)

--- a/dgraph/cmd/graphql/schema/schemagen_test.go
+++ b/dgraph/cmd/graphql/schema/schemagen_test.go
@@ -52,6 +52,7 @@ func TestDGSchemaGen(t *testing.T) {
 				require.NoError(t, errs)
 
 				dgSchema := schHandler.DGSchema()
+
 				if diff := cmp.Diff(sch.Output, dgSchema); diff != "" {
 					t.Errorf("schema mismatch (-want +got):\n%s", diff)
 				}
@@ -77,7 +78,6 @@ func TestSchemaString(t *testing.T) {
 			require.NoError(t, errs)
 
 			newSchemaStr := schHandler.GQLSchema()
-
 			outputFileName := outputDir + testFile.Name()
 			str2, err := ioutil.ReadFile(outputFileName)
 			require.NoError(t, err)

--- a/dgraph/cmd/graphql/schema/schemagen_test.go
+++ b/dgraph/cmd/graphql/schema/schemagen_test.go
@@ -52,7 +52,6 @@ func TestDGSchemaGen(t *testing.T) {
 				require.NoError(t, errs)
 
 				dgSchema := schHandler.DGSchema()
-
 				if diff := cmp.Diff(sch.Output, dgSchema); diff != "" {
 					t.Errorf("schema mismatch (-want +got):\n%s", diff)
 				}

--- a/dgraph/cmd/graphql/schema/schemagen_test.yml
+++ b/dgraph/cmd/graphql/schema/schemagen_test.yml
@@ -163,4 +163,36 @@ schemas:
       X.dt4: dateTime @index(day) .
       X.dt5: dateTime @index(hour) .
       X.e: string @index(exact) .
-      
+
+  -
+    name: "interface and types interact properly"
+    input: |
+      interface A {
+        id: ID!
+        name: String!
+      }
+      type B implements A {
+        id: ID!
+        name: String!
+        correct: Boolean
+      }
+      type C implements A {
+        id: ID!
+        name: String!
+        dob: DateTime!
+      }
+    output: |
+      type A {
+        A.name: string
+      }
+      A.name: string .
+      type B {
+        A.name: string
+        B.correct: bool
+      }
+      B.correct: bool .
+      type C {
+        A.name: string
+        C.dob: dateTime
+      }
+      C.dob: dateTime .

--- a/dgraph/cmd/graphql/schema/schemagen_test.yml
+++ b/dgraph/cmd/graphql/schema/schemagen_test.yml
@@ -169,10 +169,10 @@ schemas:
     input: |
       interface A {
         id: ID!
-        name: String!
+        name: String! @searchable(by: exact)
       }
       type B implements A {
-        correct: Boolean
+        correct: Boolean @searchable
       }
       type C implements A {
         dob: DateTime!
@@ -181,12 +181,12 @@ schemas:
       type A {
         A.name: string
       }
-      A.name: string .
+      A.name: string @index(exact) .
       type B {
         A.name: string
         B.correct: bool
       }
-      B.correct: bool .
+      B.correct: bool @index(bool) .
       type C {
         A.name: string
         C.dob: dateTime

--- a/dgraph/cmd/graphql/schema/schemagen_test.yml
+++ b/dgraph/cmd/graphql/schema/schemagen_test.yml
@@ -172,13 +172,9 @@ schemas:
         name: String!
       }
       type B implements A {
-        id: ID!
-        name: String!
         correct: Boolean
       }
       type C implements A {
-        id: ID!
-        name: String!
         dob: DateTime!
       }
     output: |

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
@@ -6,13 +6,19 @@ interface Character {
 }
 
 type Human implements Character {
-    # For Dgraph GraphQL layer, it's not necessary to re-list
-    # the fields from an interface being implemented.
+    id: ID!
+    name: String! @searchable(by: exact)
+    friends: [Character]
+    appearsIn: [Episode!]! @searchable
     starships: [Starship]
     totalCredits: Int
 }
 
 type Droid implements Character {
+    id: ID!
+    name: String! @searchable(by: exact)
+    friends: [Character]
+    appearsIn: [Episode!]! @searchable
     primaryFunction: String
 }
 

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
@@ -1,0 +1,29 @@
+interface Character {
+    id: ID!
+    name: String! @searchable(by: exact)
+    friends: [Character]
+    appearsIn: [Episode!]! @searchable
+}
+
+type Human implements Character {
+    # For Dgraph GraphQL layer, it's not necessary to re-list
+    # the fields from an interface being implemented.
+    starships: [Starship]
+    totalCredits: Int
+}
+
+type Droid implements Character {
+    primaryFunction: String
+}
+
+enum Episode {
+    NEWHOPE
+    EMPIRE
+    JEDI
+}
+
+type Starship {
+    id: ID!
+    name: String! @searchable(by: term)
+    length: Float
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/interfaces-with-types.graphql
@@ -6,19 +6,11 @@ interface Character {
 }
 
 type Human implements Character {
-    id: ID!
-    name: String! @searchable(by: exact)
-    friends: [Character]
-    appearsIn: [Episode!]! @searchable
     starships: [Starship]
     totalCredits: Int
 }
 
 type Droid implements Character {
-    id: ID!
-    name: String! @searchable(by: exact)
-    friends: [Character]
-    appearsIn: [Episode!]! @searchable
     primaryFunction: String
 }
 

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/type-implements-multiple-interfaces.graphql
@@ -1,0 +1,21 @@
+interface Character {
+    id: ID!
+    name: String! @searchable(by: exact)
+    friends: [Character]
+}
+
+interface Employee {
+    employeeId: String!
+    title: String!
+}
+
+type Human implements Character & Employee {
+    id: ID!
+    name: String! @searchable(by: exact)
+    friends: [Character]
+
+    employeeId: String!
+    title: String!
+
+    totalCredits: Int
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/input/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/input/type-implements-multiple-interfaces.graphql
@@ -10,12 +10,5 @@ interface Employee {
 }
 
 type Human implements Character & Employee {
-    id: ID!
-    name: String! @searchable(by: exact)
-    friends: [Character]
-
-    employeeId: String!
-    title: String!
-
     totalCredits: Int
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -1,0 +1,313 @@
+#######################
+# Input Schema
+#######################
+
+interface Character {
+	id: ID!
+	name: String! @searchable(by: exact)
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+}
+
+type Human implements Character {
+	id: ID!
+	name: String! @searchable(by: exact)
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
+	totalCredits: Int
+}
+
+type Droid implements Character {
+	id: ID!
+	name: String! @searchable(by: exact)
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+	primaryFunction: String
+}
+
+enum Episode {
+	NEWHOPE
+	EMPIRE
+	JEDI
+}
+
+type Starship {
+	id: ID!
+	name: String! @searchable(by: term)
+	length: Float
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddDroidPayload {
+	droid: Droid
+}
+
+type AddHumanPayload {
+	human: Human
+}
+
+type AddStarshipPayload {
+	starship: Starship
+}
+
+type DeleteDroidPayload {
+	msg: String
+}
+
+type DeleteHumanPayload {
+	msg: String
+}
+
+type DeleteStarshipPayload {
+	msg: String
+}
+
+type UpdateDroidPayload {
+	droid: Droid
+}
+
+type UpdateHumanPayload {
+	human: Human
+}
+
+type UpdateStarshipPayload {
+	starship: Starship
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum DroidOrderable {
+	name
+	primaryFunction
+}
+
+enum HumanOrderable {
+	name
+	totalCredits
+}
+
+enum StarshipOrderable {
+	name
+	length
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input DroidFilter {
+	name: StringExactFilter
+	appearsIn: Episode
+	and: DroidFilter
+	or: DroidFilter
+	not: DroidFilter
+}
+
+input DroidInput {
+	name: String!
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int): [Episode!]!
+	primaryFunction: String
+}
+
+input DroidOrder {
+	asc: DroidOrderable
+	desc: DroidOrderable
+	then: DroidOrder
+}
+
+input DroidRef {
+	id: ID!
+}
+
+input HumanFilter {
+	name: StringExactFilter
+	appearsIn: Episode
+	and: HumanFilter
+	or: HumanFilter
+	not: HumanFilter
+}
+
+input HumanInput {
+	name: String!
+	friends: [Character]
+	appearsIn: [Episode!]!
+	starships: [StarshipRef]
+	totalCredits: Int
+}
+
+input HumanOrder {
+	asc: HumanOrderable
+	desc: HumanOrderable
+	then: HumanOrder
+}
+
+input HumanRef {
+	id: ID!
+}
+
+input PatchDroid {
+	name: String
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int): [Episode!]
+	primaryFunction: String
+}
+
+input PatchHuman {
+	name: String
+	friends: [Character]
+	appearsIn: [Episode!]
+	starships: [StarshipRef]
+	totalCredits: Int
+}
+
+input PatchStarship {
+	name: String
+	length: Float
+}
+
+input StarshipFilter {
+	name: StringTermFilter
+	and: StarshipFilter
+	or: StarshipFilter
+	not: StarshipFilter
+}
+
+input StarshipInput {
+	name: String!
+	length: Float
+}
+
+input StarshipOrder {
+	asc: StarshipOrderable
+	desc: StarshipOrderable
+	then: StarshipOrder
+}
+
+input StarshipRef {
+	id: ID!
+}
+
+input UpdateDroidInput {
+	id: ID!
+	patch: PatchDroid!
+}
+
+input UpdateHumanInput {
+	id: ID!
+	patch: PatchHuman!
+}
+
+input UpdateStarshipInput {
+	id: ID!
+	patch: PatchStarship!
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getHuman(id: ID!): Human
+	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
+	getDroid(id: ID!): Droid
+	queryDroid(filter: DroidFilter, order: DroidOrder, first: Int, offset: Int): [Droid]
+	getStarship(id: ID!): Starship
+	queryStarship(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addHuman(input: HumanInput!): AddHumanPayload
+	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
+	deleteHuman(id: ID!): DeleteHumanPayload
+	addDroid(input: DroidInput!): AddDroidPayload
+	updateDroid(input: UpdateDroidInput!): UpdateDroidPayload
+	deleteDroid(id: ID!): DeleteDroidPayload
+	addStarship(input: StarshipInput!): AddStarshipPayload
+	updateStarship(input: UpdateStarshipInput!): UpdateStarshipPayload
+	deleteStarship(id: ID!): DeleteStarshipPayload
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -5,15 +5,15 @@
 interface Character {
 	id: ID!
 	name: String! @searchable(by: exact)
-	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int): [Episode!]! @searchable
 }
 
 type Human implements Character {
 	id: ID!
 	name: String! @searchable(by: exact)
-	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int): [Episode!]! @searchable
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
 }
@@ -21,8 +21,8 @@ type Human implements Character {
 type Droid implements Character {
 	id: ID!
 	name: String! @searchable(by: exact)
-	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int, filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	appearsIn(first: Int, offset: Int, first: Int, offset: Int): [Episode!]! @searchable
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	appearsIn(first: Int, offset: Int): [Episode!]! @searchable
 	primaryFunction: String
 }
 
@@ -128,6 +128,10 @@ type AddStarshipPayload {
 	starship: Starship
 }
 
+type DeleteCharacterPayload {
+	msg: String
+}
+
 type DeleteDroidPayload {
 	msg: String
 }
@@ -138,6 +142,10 @@ type DeleteHumanPayload {
 
 type DeleteStarshipPayload {
 	msg: String
+}
+
+type UpdateCharacterPayload {
+	character: Character
 }
 
 type UpdateDroidPayload {
@@ -155,6 +163,10 @@ type UpdateStarshipPayload {
 #######################
 # Generated Enums
 #######################
+
+enum CharacterOrderable {
+	name
+}
 
 enum DroidOrderable {
 	name
@@ -175,6 +187,20 @@ enum StarshipOrderable {
 # Generated Inputs
 #######################
 
+input CharacterFilter {
+	name: StringExactFilter
+	appearsIn: Episode
+	and: CharacterFilter
+	or: CharacterFilter
+	not: CharacterFilter
+}
+
+input CharacterOrder {
+	asc: CharacterOrderable
+	desc: CharacterOrderable
+	then: CharacterOrder
+}
+
 input DroidFilter {
 	name: StringExactFilter
 	appearsIn: Episode
@@ -185,8 +211,8 @@ input DroidFilter {
 
 input DroidInput {
 	name: String!
-	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	appearsIn(first: Int, offset: Int): [Episode!]!
+	friends: [Character]
+	appearsIn: [Episode!]!
 	primaryFunction: String
 }
 
@@ -226,10 +252,16 @@ input HumanRef {
 	id: ID!
 }
 
+input PatchCharacter {
+	name: String
+	friends: [Character]
+	appearsIn: [Episode!]
+}
+
 input PatchDroid {
 	name: String
-	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	appearsIn(first: Int, offset: Int): [Episode!]
+	friends: [Character]
+	appearsIn: [Episode!]
 	primaryFunction: String
 }
 
@@ -268,6 +300,11 @@ input StarshipRef {
 	id: ID!
 }
 
+input UpdateCharacterInput {
+	id: ID!
+	patch: PatchCharacter!
+}
+
 input UpdateDroidInput {
 	id: ID!
 	patch: PatchDroid!
@@ -288,6 +325,8 @@ input UpdateStarshipInput {
 #######################
 
 type Query {
+	getCharacter(id: ID!): Character
+	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	getHuman(id: ID!): Human
 	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	getDroid(id: ID!): Droid
@@ -301,6 +340,8 @@ type Query {
 #######################
 
 type Mutation {
+	updateCharacter(input: UpdateCharacterInput!): UpdateCharacterPayload
+	deleteCharacter(id: ID!): DeleteCharacterPayload
 	addHuman(input: HumanInput!): AddHumanPayload
 	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
 	deleteHuman(id: ID!): DeleteHumanPayload

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -201,6 +201,10 @@ input CharacterOrder {
 	then: CharacterOrder
 }
 
+input CharacterRef {
+	id: ID!
+}
+
 input DroidFilter {
 	name: StringExactFilter
 	appearsIn: Episode

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -1,0 +1,236 @@
+#######################
+# Input Schema
+#######################
+
+interface Character {
+	id: ID!
+	name: String! @searchable(by: exact)
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+}
+
+interface Employee {
+	employeeId: String!
+	title: String!
+}
+
+type Human implements Character & Employee {
+	id: ID!
+	name: String! @searchable(by: exact)
+	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	employeeId: String!
+	title: String!
+	totalCredits: Int
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @searchable(by: DgraphIndex!) on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddHumanPayload {
+	human: Human
+}
+
+type DeleteCharacterPayload {
+	msg: String
+}
+
+type DeleteHumanPayload {
+	msg: String
+}
+
+type UpdateCharacterPayload {
+	character: Character
+}
+
+type UpdateHumanPayload {
+	human: Human
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum CharacterOrderable {
+	name
+}
+
+enum EmployeeOrderable {
+	employeeId
+	title
+}
+
+enum HumanOrderable {
+	name
+	employeeId
+	title
+	totalCredits
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input CharacterFilter {
+	name: StringExactFilter
+	and: CharacterFilter
+	or: CharacterFilter
+	not: CharacterFilter
+}
+
+input CharacterOrder {
+	asc: CharacterOrderable
+	desc: CharacterOrderable
+	then: CharacterOrder
+}
+
+input EmployeeOrder {
+	asc: EmployeeOrderable
+	desc: EmployeeOrderable
+	then: EmployeeOrder
+}
+
+input HumanFilter {
+	name: StringExactFilter
+	and: HumanFilter
+	or: HumanFilter
+	not: HumanFilter
+}
+
+input HumanInput {
+	name: String!
+	friends: [Character]
+	employeeId: String!
+	title: String!
+	totalCredits: Int
+}
+
+input HumanOrder {
+	asc: HumanOrderable
+	desc: HumanOrderable
+	then: HumanOrder
+}
+
+input HumanRef {
+	id: ID!
+}
+
+input PatchCharacter {
+	name: String
+	friends: [Character]
+}
+
+input PatchHuman {
+	name: String
+	friends: [Character]
+	employeeId: String
+	title: String
+	totalCredits: Int
+}
+
+input UpdateCharacterInput {
+	id: ID!
+	patch: PatchCharacter!
+}
+
+input UpdateHumanInput {
+	id: ID!
+	patch: PatchHuman!
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getCharacter(id: ID!): Character
+	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	queryEmployee(order: EmployeeOrder, first: Int, offset: Int): [Employee]
+	getHuman(id: ID!): Human
+	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	updateCharacter(input: UpdateCharacterInput!): UpdateCharacterPayload
+	deleteCharacter(id: ID!): DeleteCharacterPayload
+	addHuman(input: HumanInput!): AddHumanPayload
+	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
+	deleteHuman(id: ID!): DeleteHumanPayload
+}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -14,11 +14,11 @@ interface Employee {
 }
 
 type Human implements Character & Employee {
+	employeeId: String!
+	title: String!
 	id: ID!
 	name: String! @searchable(by: exact)
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	employeeId: String!
-	title: String!
 	totalCredits: Int
 }
 
@@ -134,9 +134,9 @@ enum EmployeeOrderable {
 }
 
 enum HumanOrderable {
-	name
 	employeeId
 	title
+	name
 	totalCredits
 }
 
@@ -175,10 +175,10 @@ input HumanFilter {
 }
 
 input HumanInput {
-	name: String!
-	friends: [Character]
 	employeeId: String!
 	title: String!
+	name: String!
+	friends: [Character]
 	totalCredits: Int
 }
 
@@ -198,10 +198,10 @@ input PatchCharacter {
 }
 
 input PatchHuman {
-	name: String
-	friends: [Character]
 	employeeId: String
 	title: String
+	name: String
+	friends: [Character]
 	totalCredits: Int
 }
 

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -157,6 +157,10 @@ input CharacterOrder {
 	then: CharacterOrder
 }
 
+input CharacterRef {
+	id: ID!
+}
+
 input EmployeeOrder {
 	asc: EmployeeOrderable
 	desc: EmployeeOrderable

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -304,8 +304,7 @@ func (f *field) SelectionSet() (flds []Field) {
 		if fragment, ok := s.(*ast.InlineFragment); ok {
 			// This is the case where an inline fragment is defined within a query
 			// block. Usually this is for requesting some fields for a concrete type
-			// within a query for an interface. We use the fld.ObjectDefinition in
-			// that case.
+			// within a query for an interface.
 			for _, s := range fragment.SelectionSet {
 				if fld, ok := s.(*ast.Field); ok {
 					pt := parentType(f.op.inSchema, fld.ObjectDefinition, fld.Name)

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -560,7 +560,7 @@ func (t *astType) String() string {
 
 func (t *astType) IDField() FieldDefinition {
 	def := t.inSchema.Types[t.Name()]
-	if def.Kind != ast.Object {
+	if def.Kind != ast.Object && def.Kind != ast.Interface {
 		return nil
 	}
 

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -284,6 +284,13 @@ func (f *field) SelectionSet() (flds []Field) {
 		if fld, ok := s.(*ast.Field); ok {
 			flds = append(flds, &field{field: fld, op: f.op})
 		}
+		if fragment, ok := s.(*ast.InlineFragment); ok {
+			for _, s := range fragment.SelectionSet {
+				if fld, ok := s.(*ast.Field); ok {
+					flds = append(flds, &field{field: fld, op: f.op})
+				}
+			}
+		}
 	}
 
 	return

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -577,9 +577,5 @@ func (t *astType) IDField() FieldDefinition {
 }
 
 func (t *astType) Interfaces() []string {
-	typ := t.inSchema.Types[t.typ.NamedType]
-	if typ == nil {
-		return []string{}
-	}
-	return t.inSchema.Types[t.typ.NamedType].Interfaces
+	return t.inSchema.Types[t.typ.Name()].Interfaces
 }

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -513,6 +513,20 @@ func (t *astType) ListType() Type {
 // DgraphPredicate returns the name of the predicate in Dgraph that represents this
 // type's field fld.  Mostly this will be type_name.field_name,.
 func (t *astType) DgraphPredicate(fld string) string {
+	implements := t.Interfaces()
+	if len(implements) == 0 {
+		return fmt.Sprintf("%s.%s", t.Name(), fld)
+	}
+
+	for _, i := range implements {
+		typDef := t.inSchema.Types[i]
+		for _, field := range typDef.Fields {
+			if field.Name == fld {
+				return fmt.Sprintf("%s.%s", typDef.Name, fld)
+			}
+		}
+	}
+
 	return fmt.Sprintf("%s.%s", t.Name(), fld)
 }
 
@@ -563,5 +577,9 @@ func (t *astType) IDField() FieldDefinition {
 }
 
 func (t *astType) Interfaces() []string {
+	typ := t.inSchema.Types[t.typ.NamedType]
+	if typ == nil {
+		return []string{}
+	}
 	return t.inSchema.Types[t.typ.NamedType].Interfaces
 }

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -547,21 +547,8 @@ func (t *astType) ListType() Type {
 // DgraphPredicate returns the name of the predicate in Dgraph that represents this
 // type's field fld.  Mostly this will be type_name.field_name,.
 func (t *astType) DgraphPredicate(fld string) string {
-	implements := t.Interfaces()
-	if len(implements) == 0 {
-		return fmt.Sprintf("%s.%s", t.Name(), fld)
-	}
-
-	for _, i := range implements {
-		typDef := t.inSchema.Types[i]
-		for _, field := range typDef.Fields {
-			if field.Name == fld {
-				return fmt.Sprintf("%s.%s", typDef.Name, fld)
-			}
-		}
-	}
-
-	return fmt.Sprintf("%s.%s", t.Name(), fld)
+	pt := parentType(t.inSchema, t.inSchema.Types[t.typ.Name()], fld)
+	return fmt.Sprintf("%s.%s", pt, fld)
 }
 
 func (t *astType) String() string {

--- a/dgraph/cmd/graphql/test/test.go
+++ b/dgraph/cmd/graphql/test/test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -54,6 +55,7 @@ func LoadSchemaFromFile(t *testing.T, gqlFile string) schema.Schema {
 	require.NoError(t, err, "Unable to read schema file")
 
 	handler, err := schema.NewHandler(string(gql))
+	fmt.Println(handler.GQLSchema())
 	require.NoError(t, err, "input schema contained errors")
 
 	return LoadSchema(t, handler.GQLSchema())

--- a/dgraph/cmd/graphql/test/test.go
+++ b/dgraph/cmd/graphql/test/test.go
@@ -18,7 +18,6 @@ package test
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"testing"
 
@@ -56,7 +55,6 @@ func LoadSchemaFromFile(t *testing.T, gqlFile string) schema.Schema {
 
 	handler, err := schema.NewHandler(string(gql))
 	require.NoError(t, err, "input schema contained errors")
-	fmt.Println(handler.GQLSchema())
 
 	return LoadSchema(t, handler.GQLSchema())
 }

--- a/dgraph/cmd/graphql/test/test.go
+++ b/dgraph/cmd/graphql/test/test.go
@@ -55,8 +55,8 @@ func LoadSchemaFromFile(t *testing.T, gqlFile string) schema.Schema {
 	require.NoError(t, err, "Unable to read schema file")
 
 	handler, err := schema.NewHandler(string(gql))
-	fmt.Println(handler.GQLSchema())
 	require.NoError(t, err, "input schema contained errors")
+	fmt.Println(handler.GQLSchema())
 
 	return LoadSchema(t, handler.GQLSchema())
 }


### PR DESCRIPTION
This PR adds support for interfaces and inline fragments to request type specific information within a query for interfaces.

Things to do
- [x] Generate a GraphQL schema and Dgraph schema if the user gives us an interface definition.
- [x] Modify mutations to store interface definition with the type.
- [x] Support the queries and make sure they work both for Types and Interfaces.
- [x] Add test cases for mutation + query rewrite for interface types.
- [x] Support fragments inside query for interface.
- [ ] Add integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4026)
<!-- Reviewable:end -->
