### PR TITLE
Named queries without variables support

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1033,6 +1033,9 @@ func getSchema(it *lex.ItemIterator) (*pb.SchemaRequest, error) {
 // parseGqlVariables parses the the graphQL variable declaration.
 func parseGqlVariables(it *lex.ItemIterator, vmap varMap) error {
 	expectArg := true
+	if item, ok := it.PeekOne(); ok && item.Typ == itemRightRound {
+		return nil
+	}
 	for it.Next() {
 		var varName string
 		// Get variable name.

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -64,6 +64,18 @@ query works() {
 	require.NoError(t, err)
 }
 
+func TestParseQueryNameQueryWithoutBrackers(t *testing.T) {
+	query := `
+query works {
+  q(func: has(name)) {
+    name
+  }
+}
+`
+	_, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+}
+
 func TestParseVarError(t *testing.T) {
 	query := `
 	{

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -52,6 +52,18 @@ func TestParseCountValError(t *testing.T) {
 	require.Contains(t, err.Error(), "Count of a variable is not allowed")
 }
 
+func TestParseQueryNamedQuery(t *testing.T) {
+	query := `
+query works() {
+  q(func: has(name)) {
+    name
+  }
+}
+`
+	_, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+}
+
 func TestParseVarError(t *testing.T) {
 	query := `
 	{


### PR DESCRIPTION
Added support for queries with empty named queries 
```
query works() {
  q(func: has(name)) {
    name
  }
}
```

Fixes #3994

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4028)
<!-- Reviewable:end -->
