### PR TITLE
Periodically run GC in all dgraph commands.

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -204,27 +204,6 @@ func run() {
 		defer os.RemoveAll(opt.TmpDir)
 	}
 
-	// Bulk loader can take up a lot of RAM. So, run GC often.
-	go func() {
-		ticker := time.NewTicker(10 * time.Second)
-		defer ticker.Stop()
-
-		var lastNum uint32
-		var ms runtime.MemStats
-		for range ticker.C {
-			runtime.ReadMemStats(&ms)
-			fmt.Printf("GC: %d. InUse: %s. Idle: %s\n", ms.NumGC, humanize.Bytes(ms.HeapInuse),
-				humanize.Bytes(ms.HeapIdle-ms.HeapReleased))
-			if ms.NumGC > lastNum {
-				// GC was already run by the Go runtime. No need to run it again.
-				lastNum = ms.NumGC
-			} else {
-				runtime.GC()
-				lastNum = ms.NumGC + 1
-			}
-		}
-	}()
-
 	loader := newLoader(opt)
 	if !opt.SkipMapPhase {
 		loader.mapStage()

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -28,11 +28,9 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 )
 

--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd"
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
 )
 
 func main() {
@@ -45,6 +47,9 @@ func main() {
 				lastNum = ms.NumGC
 			} else {
 				runtime.GC()
+				glog.V(2).Infof("GC: %d. InUse: %s. Idle: %s\n", ms.NumGC,
+					humanize.Bytes(ms.HeapInuse),
+					humanize.Bytes(ms.HeapIdle-ms.HeapReleased))
 				lastNum = ms.NumGC + 1
 			}
 		}


### PR DESCRIPTION
Currently, only the bulk loader is making sure the garbage collector is
run periodically. This PR moves that logic to main.go so that it's run
by all dgraph commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4032)
<!-- Reviewable:end -->
