### PR TITLE
Fix bug in credential overriding in backup.

### DIFF
--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -96,7 +96,7 @@ func processHttpBackupRequest(ctx context.Context, r *http.Request) error {
 	if err != nil {
 		return err
 	}
-	handler, err := backup.NewUriHandler(uri)
+	handler, err := backup.NewUriHandler(uri, backup.GetCredentialsFromRequest(&req))
 	if err != nil {
 		return err
 	}

--- a/ee/backup/backup.go
+++ b/ee/backup/backup.go
@@ -97,7 +97,7 @@ func (pr *Processor) WriteBackup(ctx context.Context) (*pb.Status, error) {
 		return &emptyRes, err
 	}
 
-	handler, err := NewUriHandler(uri)
+	handler, err := NewUriHandler(uri, GetCredentialsFromRequest(pr.Request))
 	if err != nil {
 		return &emptyRes, err
 	}
@@ -169,7 +169,7 @@ func (pr *Processor) CompleteBackup(ctx context.Context, manifest *Manifest) err
 		return err
 	}
 
-	handler, err := NewUriHandler(uri)
+	handler, err := NewUriHandler(uri, GetCredentialsFromRequest(pr.Request))
 	if err != nil {
 		return err
 	}

--- a/ee/backup/handler_test.go
+++ b/ee/backup/handler_test.go
@@ -30,7 +30,7 @@ func TestGetHandler(t *testing.T) {
 		{in: "something", out: nil},
 	}
 	for _, tc := range tests {
-		actual := getHandler(tc.in)
+		actual := getHandler(tc.in, nil)
 		require.Equal(t, tc.out, actual)
 	}
 }

--- a/ee/backup/s3_handler.go
+++ b/ee/backup/s3_handler.go
@@ -55,7 +55,7 @@ type s3Handler struct {
 	uri                      *url.URL
 }
 
-func (h *s3Handler) overrideCredentials() bool {
+func (h *s3Handler) hasCredentials() bool {
 	return h.creds.accessKey != "" && h.creds.secretKey != ""
 }
 
@@ -72,7 +72,7 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 	var creds credentials.Value
 	if h.creds.anonymous {
 		// No need to setup credentials.
-	} else if !h.overrideCredentials() {
+	} else if !h.hasCredentials() {
 		var provider credentials.Provider
 		switch uri.Scheme {
 		case "s3":

--- a/ee/backup/s3_handler.go
+++ b/ee/backup/s3_handler.go
@@ -51,12 +51,12 @@ type s3Handler struct {
 	pwriter                  *io.PipeWriter
 	preader                  *io.PipeReader
 	cerr                     chan error
-	req                      *pb.BackupRequest
+	creds                    *Credentials
 	uri                      *url.URL
 }
 
-func (h *s3Handler) credentialsInRequest() bool {
-	return h.req.GetAccessKey() != "" && h.req.GetSecretKey() != ""
+func (h *s3Handler) overrideCredentials() bool {
+	return h.creds.accessKey != "" && h.creds.secretKey != ""
 }
 
 // setup creates a new session, checks valid bucket at uri.Path, and configures a minio client.
@@ -70,9 +70,9 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 	glog.V(2).Infof("Backup using host: %s, path: %s", uri.Host, uri.Path)
 
 	var creds credentials.Value
-	if h.req.GetAnonymous() {
+	if h.creds.anonymous {
 		// No need to setup credentials.
-	} else if !h.credentialsInRequest() {
+	} else if !h.overrideCredentials() {
 		var provider credentials.Provider
 		switch uri.Scheme {
 		case "s3":
@@ -101,9 +101,9 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 		// with no credentials will be made.
 		creds, _ = provider.Retrieve() // error is always nil
 	} else {
-		creds.AccessKeyID = h.req.GetAccessKey()
-		creds.SecretAccessKey = h.req.GetSecretKey()
-		creds.SessionToken = h.req.GetSessionToken()
+		creds.AccessKeyID = h.creds.accessKey
+		creds.SecretAccessKey = h.creds.secretKey
+		creds.SessionToken = h.creds.sessionToken
 	}
 
 	secure := uri.Query().Get("secure") != "false" // secure by default
@@ -200,7 +200,6 @@ func (h *s3Handler) GetLatestManifest(uri *url.URL) (*Manifest, error) {
 func (h *s3Handler) CreateBackupFile(uri *url.URL, req *pb.BackupRequest) error {
 	glog.V(2).Infof("S3Handler got uri: %+v. Host: %s. Path: %s\n", uri, uri.Host, uri.Path)
 
-	h.req = req
 	mc, err := h.setup(uri)
 	if err != nil {
 		return err
@@ -215,7 +214,6 @@ func (h *s3Handler) CreateBackupFile(uri *url.URL, req *pb.BackupRequest) error 
 func (h *s3Handler) CreateManifest(uri *url.URL, req *pb.BackupRequest) error {
 	glog.V(2).Infof("S3Handler got uri: %+v. Host: %s. Path: %s\n", uri, uri.Host, uri.Path)
 
-	h.req = req
 	mc, err := h.setup(uri)
 	if err != nil {
 		return err


### PR DESCRIPTION
Right now, the credentials were only being used in a part of the
process, which meant the process would fail if the default credentials
are invalid or expired.

This rewrites the handler to accept the credentials before the process
starts.

Manually checked that overriding now works as expected by setting the
default credentials incorrectly and getting the backup to work by
overriding the credentials.

Fixes #4044

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4047)
<!-- Reviewable:end -->
