### PR TITLE
Fix flakiness in TestMetrics.

### DIFF
--- a/posting/lists.go
+++ b/posting/lists.go
@@ -119,28 +119,35 @@ func updateMemoryMetrics(lc *y.Closer) {
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
+	update := func() {
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+
+		inUse := ms.HeapInuse + ms.StackInuse
+		// From runtime/mstats.go:
+		// HeapIdle minus HeapReleased estimates the amount of memory
+		// that could be returned to the OS, but is being retained by
+		// the runtime so it can grow the heap without requesting more
+		// memory from the OS. If this difference is significantly
+		// larger than the heap size, it indicates there was a recent
+		// transient spike in live heap size.
+		idle := ms.HeapIdle - ms.HeapReleased
+
+		ostats.Record(context.Background(),
+			x.MemoryInUse.M(int64(inUse)),
+			x.MemoryIdle.M(int64(idle)),
+			x.MemoryProc.M(int64(getMemUsage())))
+	}
+	// Call update immediately so that Dgraph does report memory stats without
+	// having to wait for the first tick.
+	update()
+
 	for {
 		select {
 		case <-lc.HasBeenClosed():
 			return
 		case <-ticker.C:
-			var ms runtime.MemStats
-			runtime.ReadMemStats(&ms)
-
-			inUse := ms.HeapInuse + ms.StackInuse
-			// From runtime/mstats.go:
-			// HeapIdle minus HeapReleased estimates the amount of memory
-			// that could be returned to the OS, but is being retained by
-			// the runtime so it can grow the heap without requesting more
-			// memory from the OS. If this difference is significantly
-			// larger than the heap size, it indicates there was a recent
-			// transient spike in live heap size.
-			idle := ms.HeapIdle - ms.HeapReleased
-
-			ostats.Record(context.Background(),
-				x.MemoryInUse.M(int64(inUse)),
-				x.MemoryIdle.M(int64(idle)),
-				x.MemoryProc.M(int64(getMemUsage())))
+			update()
 		}
 	}
 }

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -138,7 +138,7 @@ func updateMemoryMetrics(lc *y.Closer) {
 			x.MemoryIdle.M(int64(idle)),
 			x.MemoryProc.M(int64(getMemUsage())))
 	}
-	// Call update immediately so that Dgraph does report memory stats without
+	// Call update immediately so that Dgraph reports memory stats without
 	// having to wait for the first tick.
 	update()
 


### PR DESCRIPTION
Memory stats are currently updated only after the first tick is
detected, which causes the test to fail. This PR changes the logic to
update the metrics immediately and with each tick after that, which
fixes the flakiness of TestMetrics.

Fixes #4050

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4051)
<!-- Reviewable:end -->
