### PR TITLE
GraphQL layer: Add ability to delete using TypeFilters

### DIFF
--- a/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
@@ -1,5 +1,5 @@
 -
-  name: "Delete mutation with ids"
+  name: "Only id filter"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {
       deleteAuthor(filter: $filter)
@@ -17,9 +17,12 @@
       "Author.posts":[]
     }
   dgraphquery: |
+    query {
+      deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author))
+    }
 
 -
-  name: "Delete mutation with multiple filters"
+  name: "Multiple filters including id"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {
       deleteAuthor(filter: $filter)
@@ -28,12 +31,11 @@
     { "filter":
       {
         "ids": ["0x1", "0x2"],
-        "name": { "eq": "A.N. Author" },
-        "dob": { "eq": "2000-01-01" }
+        "name": { "eq": "A.N. Author" }
       }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -41,3 +43,32 @@
       "Author.posts":[]
     }
   dgraphquery: |
+    query {
+      deleteAuthor(func: uid(0x1, 0x2)) @filter((eq(Author.name, "A.N. Author") AND type(Author)))
+    }
+
+-
+  name: "Multiple non-id filters"
+  gqlmutation: |
+    mutation deleteAuthor($filter: AuthorFilter!) {
+      deleteAuthor(filter: $filter)
+    }
+  gqlvariables: |
+    { "filter":
+      {
+        "name": { "eq": "A.N. Author" },
+        "dob": { "eq": "2000-01-01" }
+      }
+    }
+  explanation: "The correct mutation and query should be built using variable and filters."
+  dgraphmutation: |
+    { "uid":"_:newnode",
+      "dgraph.type":["Author"],
+      "Author.name":"A.N. Author",
+      "Author.dob":"2000-01-01",
+      "Author.posts":[]
+    }
+  dgraphquery: |
+    query {
+      deleteAuthor(func: type(Author)) @filter((eq(Author.dob, "2000-01-01") AND eq(Author.name, "A.N. Author")))
+    }

--- a/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
@@ -9,16 +9,10 @@
       { "ids": ["0x1", "0x2"] }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmuation: |
-    { "uid":"_:newnode",
-      "dgraph.type":["Author"],
-      "Author.name":"A.N. Author",
-      "Author.dob":"2000-01-01",
-      "Author.posts":[]
-    }
-  dgraphquery: |
+  dgraphmutation: uid(x) * * .
+  dgraphquery: |-
     query {
-      deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author))
+      x as deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author))
     }
 
 -
@@ -35,16 +29,10 @@
       }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmutation: |
-    { "uid":"_:newnode",
-      "dgraph.type":["Author"],
-      "Author.name":"A.N. Author",
-      "Author.dob":"2000-01-01",
-      "Author.posts":[]
-    }
-  dgraphquery: |
+  dgraphmutation: uid(x) * * .
+  dgraphquery: |-
     query {
-      deleteAuthor(func: uid(0x1, 0x2)) @filter((eq(Author.name, "A.N. Author") AND type(Author)))
+      x as deleteAuthor(func: uid(0x1, 0x2)) @filter((eq(Author.name, "A.N. Author") AND type(Author)))
     }
 
 -
@@ -61,14 +49,8 @@
       }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmutation: |
-    { "uid":"_:newnode",
-      "dgraph.type":["Author"],
-      "Author.name":"A.N. Author",
-      "Author.dob":"2000-01-01",
-      "Author.posts":[]
-    }
-  dgraphquery: |
+  dgraphmutation: uid(x) * * .
+  dgraphquery: |-
     query {
-      deleteAuthor(func: type(Author)) @filter((eq(Author.dob, "2000-01-01") AND eq(Author.name, "A.N. Author")))
+      x as deleteAuthor(func: type(Author)) @filter((eq(Author.dob, "2000-01-01") AND eq(Author.name, "A.N. Author")))
     }

--- a/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/delete_mutation_test.yaml
@@ -1,0 +1,43 @@
+-
+  name: "Delete mutation with ids"
+  gqlmutation: |
+    mutation deleteAuthor($filter: AuthorFilter!) {
+      deleteAuthor(filter: $filter)
+    }
+  gqlvariables: |
+    { "filter":
+      { "ids": ["0x1", "0x2"] }
+    }
+  explanation: "The correct mutation and query should be built using variable and filters."
+  dgraphmuation: |
+    { "uid":"_:newnode",
+      "dgraph.type":["Author"],
+      "Author.name":"A.N. Author",
+      "Author.dob":"2000-01-01",
+      "Author.posts":[]
+    }
+  dgraphquery: |
+
+-
+  name: "Delete mutation with multiple filters"
+  gqlmutation: |
+    mutation deleteAuthor($filter: AuthorFilter!) {
+      deleteAuthor(filter: $filter)
+    }
+  gqlvariables: |
+    { "filter":
+      {
+        "ids": ["0x1", "0x2"],
+        "name": { "eq": "A.N. Author" },
+        "dob": { "eq": "2000-01-01" }
+      }
+    }
+  explanation: "The correct mutation and query should be built using variable and filters."
+  dgraphmuation: |
+    { "uid":"_:newnode",
+      "dgraph.type":["Author"],
+      "Author.name":"A.N. Author",
+      "Author.dob":"2000-01-01",
+      "Author.posts":[]
+    }
+  dgraphquery: |

--- a/dgraph/cmd/graphql/dgraph/dgo.go
+++ b/dgraph/cmd/graphql/dgraph/dgo.go
@@ -45,6 +45,7 @@ import (
 type Client interface {
 	Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error)
 	Mutate(ctx context.Context, val interface{}) (map[string]string, error)
+	Do(ctx context.Context, req *dgoapi.Request) error
 	DeleteNode(ctx context.Context, uid uint64) error
 	AssertType(ctx context.Context, uid uint64, typ string) error
 }
@@ -172,4 +173,11 @@ func (dg *dgraph) AssertType(ctx context.Context, uid uint64, typ string) error 
 	}
 
 	return nil
+}
+
+// Do is used to make a request to Dgraph. It can be used for doing a query,
+// mutation or conditional upserts.
+func (dg *dgraph) Do(ctx context.Context, req *dgoapi.Request) error {
+	err := dg.Do(ctx, req)
+	return schema.GQLWrapf(err, "unable to make do request")
 }

--- a/dgraph/cmd/graphql/dgraph/graphquery.go
+++ b/dgraph/cmd/graphql/dgraph/graphquery.go
@@ -38,6 +38,9 @@ func asString(query *gql.GraphQuery) string {
 
 func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string, root bool) {
 	b.WriteString(prefix)
+	if query.Var != "" {
+		b.WriteString(fmt.Sprintf("%s as ", query.Var))
+	}
 	if query.Alias != "" {
 		b.WriteString(query.Alias)
 		b.WriteString(" : ")

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -26,7 +26,9 @@ import (
 )
 
 const (
-	createdNode = "newnode"
+	createdNode            = "newnode"
+	deleteMutationQueryVar = "x"
+	deleteUidVarMutation   = `uid(x) * * .`
 )
 
 // MutationRewriter can transform a GraphQL mutation into a Dgraph JSON mutation.
@@ -163,8 +165,9 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 }
 
 func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
+	// The query needs to assign the results to a variable, so that the mutation can use them.
 	dgQuery := &gql.GraphQuery{
-		Var:  "x",
+		Var:  deleteMutationQueryVar,
 		Attr: m.ResponseName(),
 	}
 
@@ -174,7 +177,6 @@ func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
 		addTypeFunc(dgQuery, m.MutatedTypeName())
 	}
 	addFilter(dgQuery, m, m.MutatedTypeName())
-
 	return dgQuery
 }
 
@@ -190,7 +192,7 @@ func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mut
 	query = asString(q)
 	// The query stores the result of the filter variable in a variable called x, so we need to
 	// send a delete mutation with the same variable.
-	mutation = `uid(x) * * .`
+	mutation = deleteUidVarMutation
 	return query, mutation, nil
 }
 

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -180,7 +180,6 @@ func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
 
 func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mutation string,
 	err error) {
-
 	if m.MutationType() != schema.DeleteMutation {
 		return "", "", gqlerror.Errorf(
 			"internal error - call to build Dgraph mutation for %s mutation type",
@@ -189,6 +188,7 @@ func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mut
 
 	q := rewriteMutationAsQuery(m)
 	query = asString(q)
+	fmt.Println(query)
 	// The query stores the result of the filter variable in a variable called x, so we need to
 	// send a delete mutation with the same variable.
 	mutation = `uid(x) * * .`

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -176,7 +176,7 @@ func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
 	} else {
 		addTypeFunc(dgQuery, m.MutatedTypeName())
 	}
-	addFilter(dgQuery, m, m.MutatedTypeName())
+	addFilter(dgQuery, m)
 	return dgQuery
 }
 

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -188,7 +188,6 @@ func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mut
 
 	q := rewriteMutationAsQuery(m)
 	query = asString(q)
-	fmt.Println(query)
 	// The query stores the result of the filter variable in a variable called x, so we need to
 	// send a delete mutation with the same variable.
 	mutation = `uid(x) * * .`

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -170,6 +170,7 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 
 func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
 	dgQuery := &gql.GraphQuery{
+		Var:  "x",
 		Attr: m.ResponseName(),
 	}
 
@@ -194,8 +195,10 @@ func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mut
 
 	q := rewriteMutationAsQuery(m)
 	query = asString(q)
-	fmt.Println(query)
-	return query, "", nil
+	// The query stores the result of the filter variable in a variable called x, so we need to
+	// send a delete mutation with the same variable.
+	mutation = `uid(x) * * .`
+	return query, mutation, nil
 }
 
 func getUpdUID(m schema.Mutation) (uint64, error) {

--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -75,17 +75,11 @@ func NewMutationRewriter() MutationRewriter {
 func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 
 	if m.MutationType() != schema.AddMutation &&
-		m.MutationType() != schema.UpdateMutation &&
-		m.MutationType() != schema.DeleteMutation {
+		m.MutationType() != schema.UpdateMutation {
 		return nil,
 			gqlerror.Errorf(
 				"internal error - call to build Dgraph mutation for %s mutation type",
 				m.MutationType())
-	}
-
-	if m.MutationType() == schema.DeleteMutation {
-
-		return nil, nil
 	}
 
 	// ATM mutations aren't very deep.  At worst, a mutation can be one object with

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -152,12 +152,11 @@ func TestDeleteMutationRewriting(t *testing.T) {
 			require.NoError(t, err)
 
 			mut := test.GetMutation(t, op)
-
-			q, _, err := rewriterToTest.RewriteDelete(mut)
+			q, m, err := rewriterToTest.RewriteDelete(mut)
 
 			test.RequireJSONEq(t, tcase.Error, err)
 			if tcase.Error == nil {
-				// test.RequireJSONEqStr(t, tcase.DgraphMutation, m)
+				require.Equal(t, tcase.DgraphMutation, m)
 				require.Equal(t, tcase.DgraphQuery, q)
 			}
 		})

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -38,13 +38,13 @@ import (
 // ensure that those errors get caught before they reach rewriting.
 
 type TestCase struct {
-	Name          string
-	GQLMutation   string
-	GQLVariables  string
-	Explanation   string
-	DgraphMuation string
-	DgraphQuery   string
-	Error         *gqlerror.Error
+	Name           string
+	GQLMutation    string
+	GQLVariables   string
+	Explanation    string
+	DgraphMutation string
+	DgraphQuery    string
+	Error          *gqlerror.Error
 }
 
 func TestMutationRewriting(t *testing.T) {
@@ -79,7 +79,7 @@ func TestMutationRewriting(t *testing.T) {
 
 			test.RequireJSONEq(t, tcase.Error, err)
 			if tcase.Error == nil {
-				test.RequireJSONEqStr(t, tcase.DgraphMuation, jsonMut)
+				test.RequireJSONEqStr(t, tcase.DgraphMutation, jsonMut)
 			}
 		})
 	}
@@ -153,12 +153,12 @@ func TestDeleteMutationRewriting(t *testing.T) {
 
 			mut := test.GetMutation(t, op)
 
-			m, q, err := rewriterToTest.RewriteDelete(mut)
+			q, _, err := rewriterToTest.RewriteDelete(mut)
 
 			test.RequireJSONEq(t, tcase.Error, err)
 			if tcase.Error == nil {
-				test.RequireJSONEqStr(t, tcase.DgraphMuation, m)
-				test.RequireJSONEqStr(t, tcase.DgraphQuery, q)
+				// test.RequireJSONEqStr(t, tcase.DgraphMutation, m)
+				require.Equal(t, tcase.DgraphQuery, q)
 			}
 		})
 	}

--- a/dgraph/cmd/graphql/dgraph/mutation_test.yaml
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.yaml
@@ -17,7 +17,7 @@
     }
   explanation: "A uid and type should get injected and all data transformed to
     underlying Dgraph edge names"
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -37,7 +37,7 @@
     }
   explanation: "The input should be used for the mutation, with a uid and type getting
     injected and all data transformed to underlying Dgraph edge names"
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -58,7 +58,7 @@
     { "name":  "A.N. Author" }
   explanation: "The input and variables should be used for the mutation, with a uid and type
     getting injected and all data transformed to underlying Dgraph edge names"
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -84,7 +84,7 @@
     }
   explanation: "The reference to country should get transformed to 'uid' for the
     Dgraph JSON mutation"
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -132,7 +132,7 @@
     }
   explanation: "The reference to the author node should be transformed to include
     a new 'posts' edge."
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid" : "_:newnode",
       "dgraph.type" : ["Post"],
       "Post.title" : "Exciting post",
@@ -162,7 +162,7 @@
       }
     }
   explanation: "The update patch should get rewritten into the Dgraph mutation"
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid" : "0x123",
       "Post.text": "updated text"
     }
@@ -188,7 +188,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid" : "_:newnode",
       "Character.name": "Bob",
       "Employee.ename": "employee no. 1",
@@ -222,7 +222,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid" : "0x123",
       "Character.name": "Bob",
       "Employee.ename": "employee no. 1",
@@ -242,7 +242,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmuation: |
+  dgraphmutation: |
     { "uid" : "0x123",
       "Character.name": "Bob"
     }

--- a/dgraph/cmd/graphql/dgraph/query.go
+++ b/dgraph/cmd/graphql/dgraph/query.go
@@ -166,12 +166,12 @@ func rewriteAsQuery(field schema.Field) *gql.GraphQuery {
 // It gets us the correct type to add to a filter in case of a deleteMutation.
 func trimTypeName(typ schema.Type) string {
 	const (
-		delete  = "Delete"
+		del     = "Delete"
 		payload = "Payload"
 	)
 	typName := typ.Name()
-	if strings.HasPrefix(typName, delete) && strings.HasSuffix(typName, payload) {
-		typName = strings.TrimSuffix(strings.TrimPrefix(typName, delete), payload)
+	if strings.HasPrefix(typName, del) && strings.HasSuffix(typName, payload) {
+		typName = strings.TrimSuffix(strings.TrimPrefix(typName, del), payload)
 	}
 	return typName
 }

--- a/dgraph/cmd/graphql/dgraph/query.go
+++ b/dgraph/cmd/graphql/dgraph/query.go
@@ -317,7 +317,7 @@ func addFilter(q *gql.GraphQuery, field schema.Field, typ string) {
 // filter: { title: { anyofterms: "GraphQL" }, and: { not: { ... } } }
 // etc
 //
-// typ is the GraphQL type we are filtering on, and is needed to turn for example
+// typ is the name of the GraphQL type we are filtering on, and is needed to turn for example
 // title (the GraphQL field) into Post.title (to Dgraph predicate).
 //
 // buildFilter turns any one filter object into a conjunction

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -410,10 +410,12 @@ func deleteCountry(
 	expectedErrors []*x.GqlError) {
 
 	deleteCountryParams := &GraphQLParams{
-		Query: `mutation deleteCountry($del: ID!) {
-			deleteCountry(id: $del) { msg }
+		Query: `mutation deleteCountry($filter: CountryFilter!) {
+			deleteCountry(filter: $filter) { msg }
 		}`,
-		Variables: map[string]interface{}{"del": countryID},
+		Variables: map[string]interface{}{"filter": map[string]interface{}{
+			"ids": []string{countryID},
+		}},
 	}
 
 	gqlResponse := deleteCountryParams.ExecuteAsPost(t, graphqlURL)
@@ -506,9 +508,9 @@ func TestManyMutations(t *testing.T) {
 		Variables: map[string]interface{}{
 			"name1": "Testland1", "del": newCountry.ID, "name2": "Testland2"},
 	}
-	multiMutationExpected := `{ 
+	multiMutationExpected := `{
 		"add1": { "country": { "id": "_UID_", "name": "Testland1" } },
-		"deleteCountry" : { "msg": "Deleted" }, 
+		"deleteCountry" : { "msg": "Deleted" },
 		"add2": { "country": { "id": "_UID_", "name": "Testland2" } }
 	}`
 
@@ -578,7 +580,7 @@ func TestManyMutationsWithError(t *testing.T) {
 		}`,
 		Variables: map[string]interface{}{"del": newAuthor.ID},
 	}
-	expectedData := `{ 
+	expectedData := `{
 		"add1": { "country": { "id": "_UID_", "name": "Testland" } },
 		"deleteCountry" : null
 	}`

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -407,23 +407,24 @@ func TestDeleteMutationWithMultipleIds(t *testing.T) {
 }
 
 func TestDeleteMutationWithSingleId(t *testing.T) {
-	country := addCountry(t)
+	newCountry := addCountry(t)
 	anotherCountry := addCountry(t)
 	t.Run("delete Country", func(t *testing.T) {
 		deleteCountryExpected := `{"deleteCountry" : { "msg": "Deleted" } }`
-		filter := map[string]interface{}{"ids": []string{country.ID}}
+		filter := map[string]interface{}{"ids": []string{newCountry.ID}}
 		deleteCountry(t, filter, deleteCountryExpected, nil)
 	})
 
 	// In this case anotherCountry shouldn't be deleted.
 	t.Run("check Country is deleted", func(t *testing.T) {
-		requireCountry(t, country.ID, nil)
+		requireCountry(t, newCountry.ID, nil)
 		requireCountry(t, anotherCountry.ID, anotherCountry)
 	})
+	cleanUp(t, []*country{anotherCountry}, nil, nil)
 }
 
 func TestDeleteMutationByName(t *testing.T) {
-	country := addCountry(t)
+	newCountry := addCountry(t)
 	anotherCountry := addCountry(t)
 	anotherCountry.Name = "New country"
 	updateCountry(t, anotherCountry)
@@ -432,7 +433,7 @@ func TestDeleteMutationByName(t *testing.T) {
 	t.Run("delete Country", func(t *testing.T) {
 		filter := map[string]interface{}{
 			"name": map[string]interface{}{
-				"regexp": "/" + country.Name + "/",
+				"regexp": "/" + newCountry.Name + "/",
 			},
 		}
 		deleteCountry(t, filter, deleteCountryExpected, nil)
@@ -440,13 +441,10 @@ func TestDeleteMutationByName(t *testing.T) {
 
 	// In this case anotherCountry shouldn't be deleted.
 	t.Run("check Country is deleted", func(t *testing.T) {
-		requireCountry(t, country.ID, nil)
+		requireCountry(t, newCountry.ID, nil)
 		requireCountry(t, anotherCountry.ID, anotherCountry)
 	})
-	t.Run("cleanup", func(t *testing.T) {
-		filter := map[string]interface{}{"ids": []string{anotherCountry.ID}}
-		deleteCountry(t, filter, deleteCountryExpected, nil)
-	})
+	cleanUp(t, []*country{anotherCountry}, nil, nil)
 }
 
 func deleteCountry(
@@ -523,7 +521,8 @@ func deletePost(
 func TestDeleteWrongID(t *testing.T) {
 	t.Skip()
 	// Skipping the test for now because wrong type of node while deleting is not an error.
-	// Modify the test to have some other mutation that fails.
+	// After Dgraph returns the number of nodes modified from upsert, modify this test to check
+	// count of nodes modified is 0.
 	newCountry := addCountry(t)
 	newAuthor := addAuthor(t, newCountry.ID)
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -200,8 +200,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 		return res
 	}
 
-	err = mr.dgraph.DeleteNodes(ctx, query, mut)
-	if err != nil {
+	if err = mr.dgraph.DeleteNodes(ctx, query, mut); err != nil {
 		res.err = schema.GQLWrapf(err,
 			"[%s] mutation %s failed", api.RequestID(ctx), mr.mutation.Name())
 		return res

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -201,8 +201,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 	}
 
 	if err = mr.dgraph.DeleteNodes(ctx, query, mut); err != nil {
-		res.err = schema.GQLWrapf(err,
-			"[%s] mutation %s failed", api.RequestID(ctx), mr.mutation.Name())
+		res.err = schema.GQLWrapf(err, "mutation %s failed", mr.mutation.Name())
 		return res
 	}
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -19,6 +19,7 @@ package resolve
 import (
 	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
@@ -199,6 +200,8 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation")
 		return res
 	}
+	fmt.Println(query)
+	fmt.Println(mut)
 
 	err = mr.dgraph.DeleteNodes(ctx, query, mut)
 	if err != nil {

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -19,7 +19,6 @@ package resolve
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
@@ -200,8 +199,6 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation")
 		return res
 	}
-	fmt.Println(query)
-	fmt.Println(mut)
 
 	err = mr.dgraph.DeleteNodes(ctx, query, mut)
 	if err != nil {

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -194,13 +194,13 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) *resolved
 			mr.mutation.MutationType())
 	}
 
-	mut, err := mr.mutationRewriter.Rewrite(mr.mutation)
+	query, mut, err := mr.mutationRewriter.RewriteDelete(mr.mutation)
 	if err != nil {
 		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation")
 		return res
 	}
 
-	_, err = mr.dgraph.Mutate(ctx, mut)
+	err = mr.dgraph.DeleteNodes(ctx, query, mut)
 	if err != nil {
 		res.err = schema.GQLWrapf(err,
 			"[%s] mutation %s failed", api.RequestID(ctx), mr.mutation.Name())

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	dgoapi "github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/test"
@@ -60,8 +61,8 @@ type Author {
 	id: ID!
 	name: String!
 	dob: DateTime
-	postsRequired: [Post!]!	
-	postsElmntRequired: [Post!]	
+	postsRequired: [Post!]!
+	postsElmntRequired: [Post!]
 	postsNullable: [Post]
 	postsNullableListRequired: [Post]!
 }
@@ -125,6 +126,10 @@ func (dg *dgraphClient) DeleteNode(ctx context.Context, uid uint64) error {
 }
 
 func (dg *dgraphClient) AssertType(ctx context.Context, uid uint64, typ string) error {
+	return nil
+}
+
+func (dg *dgraphClient) Do(ctx context.Context, req *dgoapi.Request) error {
 	return nil
 }
 
@@ -241,13 +246,13 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 			explanation: "Field 'dob' is nullable, so null should be inserted " +
 				"if the mutation's query doesn't return a value.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ 
-				{ "title": "A Post", 
-				"text": "Some text", 
+			queryResponse: `{ "post" : [
+				{ "title": "A Post",
+				"text": "Some text",
 				"author": { "name": "A.N. Author" } } ] }`,
-			expected: `{ "addPost": { "post" : 
-				{ "title": "A Post", 
-				"text": "Some text", 
+			expected: `{ "addPost": { "post" :
+				{ "title": "A Post",
+				"text": "Some text",
 				"author": { "name": "A.N. Author", "dob": null } } } }`,
 		},
 		"Add mutation triggers GraphQL error propagation": {
@@ -255,9 +260,9 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 				"the author is squashed to null, but that's also non-nullable, so the " +
 				"propagates to the query root.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ 
-				{ "title": "A Post", 
-				"text": "Some text", 
+			queryResponse: `{ "post" : [
+				{ "title": "A Post",
+				"text": "Some text",
 				"author": { "dob": "2000-01-01" } } ] }`,
 			expected: `{ "addPost": { "post" : null } }`,
 			errors: gqlerror.List{&gqlerror.Error{
@@ -306,13 +311,13 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 			explanation: "Field 'dob' is nullable, so null should be inserted " +
 				"if the mutation's query doesn't return a value.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ 
-				{ "title": "A Post", 
-				"text": "Some text", 
+			queryResponse: `{ "post" : [
+				{ "title": "A Post",
+				"text": "Some text",
 				"author": { "name": "A.N. Author" } } ] }`,
-			expected: `{ "updatePost": { "post" : 
-				{ "title": "A Post", 
-				"text": "Some text", 
+			expected: `{ "updatePost": { "post" :
+				{ "title": "A Post",
+				"text": "Some text",
 				"author": { "name": "A.N. Author", "dob": null } } } }`,
 		},
 		"Update Mutation triggers GraphQL error propagation": {
@@ -320,9 +325,9 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 				"the author is squashed to null, but that's also non-nullable, so the " +
 				"propagates to the query root.",
 			mutResponse: map[string]string{"newnode": "0x1"},
-			queryResponse: `{ "post" : [ { 
-				"title": "A Post", 
-				"text": "Some text", 
+			queryResponse: `{ "post" : [ {
+				"title": "A Post",
+				"text": "Some text",
 				"author": { "dob": "2000-01-01" } } ] }`,
 			expected: `{ "updatePost": { "post" : null } }`,
 			errors: gqlerror.List{&gqlerror.Error{

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	dgoapi "github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/test"
@@ -120,16 +119,12 @@ func (dg *dgraphClient) Mutate(ctx context.Context, val interface{}) (map[string
 	return dg.assigned, nil
 }
 
-func (dg *dgraphClient) DeleteNode(ctx context.Context, uid uint64) error {
+func (dg *dgraphClient) DeleteNodes(ctx context.Context, query, mutation string) error {
 	// Not needed in testing responses
 	return nil
 }
 
 func (dg *dgraphClient) AssertType(ctx context.Context, uid uint64, typ string) error {
-	return nil
-}
-
-func (dg *dgraphClient) Do(ctx context.Context, req *dgoapi.Request) error {
 	return nil
 }
 

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -697,7 +697,7 @@ func addUpdatePayloadType(schema *ast.Schema, defn *ast.Definition) {
 }
 
 func addDeletePayloadType(schema *ast.Schema, defn *ast.Definition) {
-	if !hasID(defn) {
+	if !hasFilterable(defn) {
 		return
 	}
 
@@ -806,7 +806,7 @@ func addUpdateMutation(schema *ast.Schema, defn *ast.Definition) {
 }
 
 func addDeleteMutation(schema *ast.Schema, defn *ast.Definition) {
-	if !hasID(defn) {
+	if !hasFilterable(defn) {
 		return
 	}
 
@@ -818,11 +818,8 @@ func addDeleteMutation(schema *ast.Schema, defn *ast.Definition) {
 		},
 		Arguments: []*ast.ArgumentDefinition{
 			&ast.ArgumentDefinition{
-				Name: "id",
-				Type: &ast.Type{
-					NamedType: idTypeFor(defn),
-					NonNull:   true,
-				},
+				Name: "filter",
+				Type: &ast.Type{NamedType: defn.Name + "Filter", NonNull: true},
 			},
 		},
 	}

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -184,8 +184,8 @@ type Query {
 type Mutation {
 	addPost(input: PostInput!): AddPostPayload
 	updatePost(input: UpdatePostInput!): UpdatePostPayload
-	deletePost(id: ID!): DeletePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 	addAuthor(input: AuthorInput!): AddAuthorPayload
 	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
-	deleteAuthor(id: ID!): DeleteAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -349,14 +349,14 @@ type Query {
 
 type Mutation {
 	updateCharacter(input: UpdateCharacterInput!): UpdateCharacterPayload
-	deleteCharacter(id: ID!): DeleteCharacterPayload
+	deleteCharacter(filter: CharacterFilter!): DeleteCharacterPayload
 	addHuman(input: HumanInput!): AddHumanPayload
 	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
-	deleteHuman(id: ID!): DeleteHumanPayload
+	deleteHuman(filter: HumanFilter!): DeleteHumanPayload
 	addDroid(input: DroidInput!): AddDroidPayload
 	updateDroid(input: UpdateDroidInput!): UpdateDroidPayload
-	deleteDroid(id: ID!): DeleteDroidPayload
+	deleteDroid(filter: DroidFilter!): DeleteDroidPayload
 	addStarship(input: StarshipInput!): AddStarshipPayload
 	updateStarship(input: UpdateStarshipInput!): UpdateStarshipPayload
-	deleteStarship(id: ID!): DeleteStarshipPayload
+	deleteStarship(filter: StarshipFilter!): DeleteStarshipPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -88,6 +88,10 @@ type AddPostPayload {
 	post: Post
 }
 
+type DeletePostPayload {
+	msg: String
+}
+
 #######################
 # Generated Enums
 #######################
@@ -131,4 +135,5 @@ type Query {
 
 type Mutation {
 	addPost(input: PostInput!): AddPostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -204,6 +204,6 @@ type Mutation {
 	addPost(input: PostInput!): AddPostPayload
 	addAuthor(input: AuthorInput!): AddAuthorPayload
 	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
-	deleteAuthor(id: ID!): DeleteAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 	addGenre(input: GenreInput!): AddGenrePayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -226,8 +226,8 @@ type Query {
 type Mutation {
 	addAuthor(input: AuthorInput!): AddAuthorPayload
 	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
-	deleteAuthor(id: ID!): DeleteAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 	addPost(input: PostInput!): AddPostPayload
 	updatePost(input: UpdatePostInput!): UpdatePostPayload
-	deletePost(id: ID!): DeletePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -220,5 +220,5 @@ type Query {
 type Mutation {
 	addPost(input: PostInput!): AddPostPayload
 	updatePost(input: UpdatePostInput!): UpdatePostPayload
-	deletePost(id: ID!): DeletePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -166,5 +166,5 @@ type Query {
 type Mutation {
 	addPost(input: PostInput!): AddPostPayload
 	updatePost(input: UpdatePostInput!): UpdatePostPayload
-	deletePost(id: ID!): DeletePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -161,5 +161,5 @@ type Query {
 type Mutation {
 	addMessage(input: MessageInput!): AddMessagePayload
 	updateMessage(input: UpdateMessageInput!): UpdateMessagePayload
-	deleteMessage(id: ID!): DeleteMessagePayload
+	deleteMessage(filter: MessageFilter!): DeleteMessagePayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -235,8 +235,8 @@ type Query {
 
 type Mutation {
 	updateCharacter(input: UpdateCharacterInput!): UpdateCharacterPayload
-	deleteCharacter(id: ID!): DeleteCharacterPayload
+	deleteCharacter(filter: CharacterFilter!): DeleteCharacterPayload
 	addHuman(input: HumanInput!): AddHumanPayload
 	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
-	deleteHuman(id: ID!): DeleteHumanPayload
+	deleteHuman(filter: HumanFilter!): DeleteHumanPayload
 }

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -211,8 +211,8 @@ type Query {
 type Mutation {
 	addPost(input: PostInput!): AddPostPayload
 	updatePost(input: UpdatePostInput!): UpdatePostPayload
-	deletePost(id: ID!): DeletePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 	addAuthor(input: AuthorInput!): AddAuthorPayload
 	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
-	deleteAuthor(id: ID!): DeleteAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -547,7 +547,7 @@ func (t *astType) ListType() Type {
 // type's field fld.  Mostly this will be type_name.field_name,.
 func (t *astType) DgraphPredicate(fld string) string {
 	const (
-		delete  = "Delete"
+		del     = "Delete"
 		payload = "Payload"
 	)
 
@@ -556,8 +556,8 @@ func (t *astType) DgraphPredicate(fld string) string {
 	// implementation. When we get a deleteXYZ mutation which has a response type of
 	// DeleteTypePayload, to find the actual type we trim the prefix and suffix.
 	// TODO - Do all this as part of pre-processing and remove special handling here.
-	if strings.HasPrefix(typName, delete) && strings.HasSuffix(typName, payload) {
-		typName = strings.TrimSuffix(strings.TrimPrefix(typName, delete), payload)
+	if strings.HasPrefix(typName, del) && strings.HasSuffix(typName, payload) {
+		typName = strings.TrimSuffix(strings.TrimPrefix(typName, del), payload)
 	}
 	pt := parentType(t.inSchema, t.inSchema.Types[typName], fld)
 	return fmt.Sprintf("%s.%s", pt, fld)

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -546,7 +546,20 @@ func (t *astType) ListType() Type {
 // DgraphPredicate returns the name of the predicate in Dgraph that represents this
 // type's field fld.  Mostly this will be type_name.field_name,.
 func (t *astType) DgraphPredicate(fld string) string {
-	pt := parentType(t.inSchema, t.inSchema.Types[t.typ.Name()], fld)
+	const (
+		delete  = "Delete"
+		payload = "Payload"
+	)
+
+	typName := t.Name()
+	// This isn't the most clean solution but something that fits in with the current
+	// implementation. When we get a deleteXYZ mutation which has a response type of
+	// DeleteTypePayload, to find the actual type we trim the prefix and suffix.
+	// TODO - Do all this as part of pre-processing and remove special handling here.
+	if strings.HasPrefix(typName, delete) && strings.HasSuffix(typName, payload) {
+		typName = strings.TrimSuffix(strings.TrimPrefix(typName, delete), payload)
+	}
+	pt := parentType(t.inSchema, t.inSchema.Types[typName], fld)
 	return fmt.Sprintf("%s.%s", pt, fld)
 }
 


### PR DESCRIPTION
This PR adds the ability to delete multiple nodes for a type by ids or other filters. 

TODO
---
- [x] Add an integration test for this to verify we only delete a subset of nodes and that filter actually works.
- [ ] Create an issue in Dgraph to get more information as a result of Upsert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4064)
<!-- Reviewable:end -->
