### PR TITLE
Pad encData to 17 bytes before decoding

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -139,7 +139,7 @@ func (d *Decoder) unpackBlock() []uint64 {
 			// Decode4 decodes 4 uids from encData. It moves slice(encData) forward while
 			// decoding and expects it to be of length >= 4 at all the stages. Padding
 			// with zero to make sure length is always >= 4.
-			encData = append(encData, 0, 0, 0)
+			encData = append(encData, bytes.Repeat([]byte{0}, 17-len(encData))...)
 		}
 
 		groupvarint.Decode4(tmpUids, encData)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -137,8 +137,10 @@ func (d *Decoder) unpackBlock() []uint64 {
 	for uint32(len(d.uids)) < block.NumUids {
 		if len(encData) < 17 {
 			// Decode4 decodes 4 uids from encData. It moves slice(encData) forward while
-			// decoding and expects it to be of length >= 4 at all the stages. Padding
-			// with zero to make sure length is always >= 4.
+			// decoding and expects it to be of length >= 4 at all the stages.
+			// The SSE code tries to read 16 bytes past the header(1 byte).
+			// So we are padding encData to increase its length to 17 bytes.
+			// This is a workaround for https://github.com/dgryski/go-groupvarint/issues/1
 			encData = append(encData, bytes.Repeat([]byte{0}, 17-len(encData))...)
 		}
 


### PR DESCRIPTION
Fixes #4020 
We tried to reproduce the issue.

### Setup
  * 1 Alpha
  * 1 Zero
  * Live loader processing 1 million dataset

### Linux
* We couldn't reproduce the issue. It works fine irrespective of length of the encoded data given that we append at least 3 bytes.

### Windows
* Doesn't work with padding of only 3 bytes. Stack trace is below.
* Works fine when concurrency parameter is set to 1 in live loader
* Works fine when encoded data is appended with enough 0 bytes to ensure a length of 17 bytes

```
(dlv) bt                                                                                                                                                                                                                  0  0x0000000000437ce0 in runtime.fatalthrow
    at c:/go/src/runtime/panic.go:820
 1  0x0000000000437b69 in runtime.throw
    at c:/go/src/runtime/panic.go:774
 2  0x000000000044c443 in runtime.sigpanic
    at c:/go/src/runtime/signal_windows.go:236
 3  0x0000000000fe79b1 in github.com/dgraph-io/dgraph/vendor/github.com/dgryski/go-groupvarint.Decode4
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/vendor/github.com/dgryski/go-groupvarint/decode_amd64.s:10
 4  0x0000000000fe9baa in github.com/dgraph-io/dgraph/codec.(*Decoder).unpackBlock.func1
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/codec/codec.go:159
 5  0x0000000000fe86aa in github.com/dgraph-io/dgraph/codec.(*Decoder).unpackBlock
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/codec/codec.go:160
 6  0x0000000000fe8b02 in github.com/dgraph-io/dgraph/codec.(*Decoder).Seek
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/codec/codec.go:192
 7  0x0000000001004b46 in github.com/dgraph-io/dgraph/posting.(*pIterator).init
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/posting/list.go:127
 8  0x0000000001007fa2 in github.com/dgraph-io/dgraph/posting.(*List).iterate
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/posting/list.go:615
 9  0x0000000001008800 in github.com/dgraph-io/dgraph/posting.(*List).length
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/posting/list.go:691
10  0x0000000000ffe520 in github.com/dgraph-io/dgraph/posting.(*Txn).addMutationHelper
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/posting/index.go:356
11  0x0000000000ffefdd in github.com/dgraph-io/dgraph/posting.(*List).AddMutationWithIndex
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/posting/index.go:394
12  0x00000000011d4b8b in github.com/dgraph-io/dgraph/worker.runMutation
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/worker/mutation.go:115
13  0x000000000120b9f4 in github.com/dgraph-io/dgraph/worker.(*node).applyMutations.func3
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/worker/draft.go:289
14  0x000000000120bc49 in github.com/dgraph-io/dgraph/worker.(*node).applyMutations.func4
    at C:/Users/manga/go/src/github.com/dgraph-io/dgraph/worker/draft.go:318
15  0x0000000000468131 in runtime.goexit
    at c:/go/src/runtime/asm_amd64.s:1357
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4066)
<!-- Reviewable:end -->
