### PR TITLE
Remove comparison between negative integers and usigned int var.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1283,7 +1283,7 @@ func (n *node) calculateSnapshot(startIdx uint64, discardN int) (*pb.Snapshot, e
 		span.Annotate(nil, "maxCommitTs is zero")
 		return nil, nil
 	}
-	if snapshotIdx <= 0 {
+	if snapshotIdx == 0 {
 		// It is possible that there are no pending transactions. In that case,
 		// snapshotIdx would be zero.
 		snapshotIdx = lastEntry.Index


### PR DESCRIPTION
Currently snapshotIdx is being compared against negative values.
snapshotIdx is an unsigned int so this comparison would always be true.
Rewrite the comparision to `snapshotIdx == 0`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4070)
<!-- Reviewable:end -->
