### PR TITLE
release/v1.0: Remove query cache which is causing contention.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -502,7 +502,7 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (resp *api.Respons
 		if req.StartTs == 0 {
 			req.StartTs = posting.Oracle().MaxAssigned()
 		}
-		queryRequest.Cache = worker.NoTxnCache
+		queryRequest.Cache = worker.NoCache
 	}
 	if req.StartTs == 0 {
 		req.StartTs = State.getTimestamp(req.ReadOnly)

--- a/worker/task.go
+++ b/worker/task.go
@@ -695,7 +695,8 @@ func (qs *queryState) handleUidPostings(
 
 const (
 	UseTxnCache = iota
-	NoTxnCache
+	// NoCache indicates no caches should be used
+	NoCache
 )
 
 // processTask processes the query, accumulates and returns the result.
@@ -729,9 +730,8 @@ func processTask(ctx context.Context, q *pb.Query, gid uint32) (*pb.Result, erro
 	if q.Cache == UseTxnCache {
 		qs.cache = posting.Oracle().CacheAt(q.ReadTs)
 	}
-	if qs.cache == nil {
-		qs.cache = posting.NewLocalCache(q.ReadTs)
-	}
+	// For now, remove the query level cache. It is causing contention for queries with high
+	// fan-out.
 
 	out, err := qs.helpProcessTask(ctx, q, gid)
 	if err != nil {


### PR DESCRIPTION
This change is already in v1.1.0 and master from https://github.com/dgraph-io/dgraph/pull/3805.

This change is like #3805 but **only to remove the query-level cache**.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4071)
<!-- Reviewable:end -->
