### PR TITLE
Only run GC if the memory has shrunk or expanded by more than 0.5GB.

### DIFF
--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -38,9 +38,9 @@ func main() {
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 
-		minDiff := uint64(5e8)
+		minDiff := uint64(512 << 20)
 		var lastMs runtime.MemStats
-		var lastNum uint32
+		var lastNumGC uint32
 		var ms runtime.MemStats
 
 		for range ticker.C {
@@ -52,19 +52,19 @@ func main() {
 				diff = lastMs.HeapAlloc - ms.HeapAlloc
 			}
 
-			if ms.NumGC >= lastNum {
+			if ms.NumGC > lastNumGC {
 				// GC was already run by the Go runtime. No need to run it again.
-				lastNum = ms.NumGC
+				lastNumGC = ms.NumGC
 			} else if diff < minDiff {
 				// Do not run the GC if the allocated memory has not shrunk or expanded by
 				// more than 0.5GB since the last time the memory stats were collected.
-				lastNum = ms.NumGC
-			} else {
+				lastNumGC = ms.NumGC
+			} else if ms.NumGC == lastNumGC {
 				runtime.GC()
 				glog.V(2).Infof("GC: %d. InUse: %s. Idle: %s\n", ms.NumGC,
 					humanize.Bytes(ms.HeapInuse),
 					humanize.Bytes(ms.HeapIdle-ms.HeapReleased))
-				lastNum = ms.NumGC + 1
+				lastNumGC = ms.NumGC + 1
 			}
 			lastMs = ms
 		}


### PR DESCRIPTION
The GC is being manually called too many times. This change reduces the
number of times it's run by only calling it if the allocated memory in
the heap has shrunk or expanded by more than half a GB and if it's not
being run in the last ten seconds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4075)
<!-- Reviewable:end -->
