### PR TITLE
Remove usage of deprecated methods.

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -46,6 +46,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/status"
 )
 
 // Error constants representing different types of errors.
@@ -121,7 +122,7 @@ func ShouldCrash(err error) bool {
 	if err == nil {
 		return false
 	}
-	errStr := grpc.ErrorDesc(err)
+	errStr := status.Convert(err).Message()
 	return strings.Contains(errStr, "REUSE_RAFTID") ||
 		strings.Contains(errStr, "REUSE_ADDR") ||
 		strings.Contains(errStr, "NO_ADDR") ||


### PR DESCRIPTION
ErrorDesc in the grpc is deprecated. It's been replaced by the
recommended methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4076)
<!-- Reviewable:end -->
