### PR TITLE
Improves title of a paragraph related to Alpha

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1204,7 +1204,7 @@ See the `initContainers` configuration in
 [dgraph-ha.yaml](https://github.com/dgraph-io/dgraph/blob/master/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml)
 to learn more.
 
-## More about Dgraph
+## More about Dgraph Alpha
 
 On its HTTP port, a Dgraph Alpha exposes a number of admin endpoints.
 


### PR DESCRIPTION
```
Hey, the title here should be "More About Dgraph Alpha" ->
https://docs.dgraph.io/deploy/#more-about-dgraph
```

https://dgraph.slack.com/archives/C13LH03RR/p1569570221345600

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4078)
<!-- Reviewable:end -->
