### PR TITLE
Do not store non-pointer values in sync.Pool.

### DIFF
--- a/query/shortest.go
+++ b/query/shortest.go
@@ -358,6 +358,9 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 			}
 
 			curPath := pathPool.Get().(*[]pathInfo)
+			if curPath == nil {
+				return nil, errors.Errorf("Sync pool returned a nil pointer")
+			}
 			if cap(*curPath) < len(*item.path.route)+1 {
 				// We can't use it due to insufficient capacity. Put it back.
 				pathPool.Put(curPath)


### PR DESCRIPTION
A sync.Pool is used to avoid unnecessary allocations and reduce the
amount of work the garbage collector has to do.  When passing a value
that is not a pointer to a function that accepts an interface, the value
needs to be placed on the heap, which means an additional allocation.
Slices are a common thing to put in sync.Pools, and they’re structs with
3 fields (length, capacity, and a pointer to an array). In order to
avoid the extra allocation, one should store a pointer to the slice
instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4089)
<!-- Reviewable:end -->
