### PR TITLE
Change representation of types in schema query responses.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1244,10 +1244,12 @@ func formatTypes(types []*pb.TypeUpdate) []map[string]interface{} {
 	for _, typ := range types {
 		typeMap := make(map[string]interface{})
 		typeMap["name"] = typ.TypeName
-		fields := make([]string, len(typ.Fields))
+		fields := make([]map[string]string, len(typ.Fields))
 
 		for i, field := range typ.Fields {
-			fields[i] = field.Predicate
+			m := make(map[string]string, 1)
+			m["name"] = field.Predicate
+			fields[i] = m
 		}
 		typeMap["fields"] = fields
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1237,37 +1237,6 @@ func validatePredName(name string) error {
 	return nil
 }
 
-// formatField takes a SchemaUpdate representing a field in a type and converts
-// it into a map containing keys for the type name and the type.
-func formatField(field *pb.SchemaUpdate) map[string]string {
-	fieldMap := make(map[string]string)
-	fieldMap["name"] = field.Predicate
-	typ := ""
-	if field.List {
-		typ += "["
-	}
-
-	if field.ValueType == pb.Posting_OBJECT {
-		typ += field.ObjectTypeName
-	} else {
-		typeId := types.TypeID(field.ValueType)
-		typ += typeId.Name()
-	}
-
-	if field.NonNullable {
-		typ += "!"
-	}
-	if field.List {
-		typ += "]"
-	}
-	if field.NonNullableList {
-		typ += "!"
-	}
-	fieldMap["type"] = typ
-
-	return fieldMap
-}
-
 // formatTypes takes a list of TypeUpdates and converts them in to a list of
 // maps in a format that is human-readable to be marshaled into JSON.
 func formatTypes(types []*pb.TypeUpdate) []map[string]interface{} {
@@ -1275,12 +1244,12 @@ func formatTypes(types []*pb.TypeUpdate) []map[string]interface{} {
 	for _, typ := range types {
 		typeMap := make(map[string]interface{})
 		typeMap["name"] = typ.TypeName
-		typeMap["fields"] = make([]map[string]string, 0)
+		fields := make([]string, len(typ.Fields))
 
-		for _, field := range typ.Fields {
-			fieldMap := formatField(field)
-			typeMap["fields"] = append(typeMap["fields"].([]map[string]string), fieldMap)
+		for i, field := range typ.Fields {
+			fields[i] = field.Predicate
 		}
+		typeMap["fields"] = fields
 
 		res = append(res, typeMap)
 	}

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2119,21 +2119,16 @@ func TestQueryUnknownType(t *testing.T) {
 	require.JSONEq(t, `{"data": {}}`, js)
 }
 
-// TODO(martinmr): Change type query representation since the type of a field is no longer
-// relevant.
 func TestQuerySingleType(t *testing.T) {
 	query := `schema(type: Person) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[{"name":"Person",
-		"fields":[{"name":"name", "type":"default"}, {"name":"pet", "type":"default"}]}]}}`,
-		js)
+	require.JSONEq(t, `{"data": {"types":[{"name":"Person","fields":["name", "pet"]}]}}`, js)
 }
 
 func TestQueryMultipleTypes(t *testing.T) {
 	query := `schema(type: [Person, Animal]) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[{"name":"Animal",
-		"fields":[{"name":"name", "type":"default"}]},
-	{"name":"Person", "fields":[{"name":"name", "type": "default"},
-		{"name":"pet", "type":"default"}]}]}}`, js)
+	require.JSONEq(t, `{"data": {"types":[
+		{"name":"Animal","fields":["name"]},
+		{"name":"Person", "fields":["name", "pet"]}]}}`, js)
 }

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2122,15 +2122,17 @@ func TestQueryUnknownType(t *testing.T) {
 func TestQuerySingleType(t *testing.T) {
 	query := `schema(type: Person) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[{"name":"Person","fields":["name", "pet"]}]}}`, js)
+	require.JSONEq(t, `{"data": {"types":[{"name":"Person",
+		"fields":[{"name":"name"}, {"name":"pet"}]}]}}`,
+		js)
 }
 
 func TestQueryMultipleTypes(t *testing.T) {
 	query := `schema(type: [Person, Animal]) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[
-		{"name":"Animal","fields":["name"]},
-		{"name":"Person", "fields":["name", "pet"]}]}}`, js)
+	require.JSONEq(t, `{"data": {"types":[{"name":"Animal",
+		"fields":[{"name":"name"}]},
+	{"name":"Person", "fields":[{"name":"name"}, {"name":"pet"}]}]}}`, js)
 }
 
 func TestRegexInFilterNoDataOnRoot(t *testing.T) {

--- a/systest/bulk_live_cases_test.go
+++ b/systest/bulk_live_cases_test.go
@@ -281,7 +281,7 @@ func TestLoadTypes(t *testing.T) {
 	// Ensures that the index keys are written to disk after commit.
 	time.Sleep(time.Second)
 	t.Run("All queries", s.testCase("schema(type: Person) {}",
-		`{"types":[{"name":"Person", "fields":[{"name":"name", "type":"default"}]}]}`))
+		`{"types":[{"name":"Person", "fields":["name"]}]}`))
 }
 
 // This test is similar to TestCount but the friend predicate is not a list. The bulk loader

--- a/systest/bulk_live_cases_test.go
+++ b/systest/bulk_live_cases_test.go
@@ -281,7 +281,7 @@ func TestLoadTypes(t *testing.T) {
 	// Ensures that the index keys are written to disk after commit.
 	time.Sleep(time.Second)
 	t.Run("All queries", s.testCase("schema(type: Person) {}",
-		`{"types":[{"name":"Person", "fields":["name"]}]}`))
+		`{"types":[{"name":"Person", "fields":[{"name":"name"}]}]}`))
 }
 
 // This test is similar to TestCount but the friend predicate is not a list. The bulk loader

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -1574,7 +1574,8 @@ func DropType(t *testing.T, c *dgo.Dgraph) {
 	query := `schema(type: Person) {}`
 	resp, err := c.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	testutil.CompareJSON(t, `{"types":[{"name":"Person", "fields":["name"]}]}`, string(resp.Json))
+	testutil.CompareJSON(t, `{"types":[{"name":"Person", "fields":[{"name":"name"}]}]}`,
+		string(resp.Json))
 
 	require.NoError(t, c.Alter(ctx, &api.Operation{
 		DropOp:    api.Operation_TYPE,

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -1574,8 +1574,7 @@ func DropType(t *testing.T, c *dgo.Dgraph) {
 	query := `schema(type: Person) {}`
 	resp, err := c.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	testutil.CompareJSON(t, `{"types":[{"name":"Person",
-		"fields":[{"name":"name", "type":"default"}]}]}`, string(resp.Json))
+	testutil.CompareJSON(t, `{"types":[{"name":"Person", "fields":["name"]}]}`, string(resp.Json))
 
 	require.NoError(t, c.Alter(ctx, &api.Operation{
 		DropOp:    api.Operation_TYPE,


### PR DESCRIPTION
Now that the types are simplified, the types should be returned as map
containing the name and the list of fields in the type.

Fixes #4111

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4113)
<!-- Reviewable:end -->
