### PR TITLE
Breaking change: Change _all_ functionality to only include the preds in the type.

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -205,6 +205,7 @@ type CarModel {
 	model
 	year
 	previous_model
+	<~previous_model>
 }
 
 type SchoolInfo {

--- a/query/query.go
+++ b/query/query.go
@@ -1832,11 +1832,6 @@ func expandSubgraph(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 			}
 
 			preds = getPredicatesFromTypes(types)
-			rpreds, err := getReversePredicates(ctx, preds)
-			if err != nil {
-				return out, err
-			}
-			preds = append(preds, rpreds...)
 		default:
 			span.Annotate(nil, "expand default")
 			// We already have the predicates populated from the var.

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -291,7 +291,7 @@ func TestTypeExpandAll(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"q":[
-		{"make":"Ford","model":"Focus","year":2008},
+		{"make":"Ford","model":"Focus","year":2008, "~previous_model": [{"uid":"0xc9"}]},
 		{"make":"Ford","model":"Focus","year":2009, "previous_model": {"uid":"0xc8"}}
 	]}}`, js)
 }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -291,7 +291,7 @@ func TestTypeExpandAll(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"q":[
-		{"make":"Ford","model":"Focus","year":2008, "~previous_model": [{"uid":"0xc9"}]},
+		{"make":"Ford","model":"Focus","year":2008},
 		{"make":"Ford","model":"Focus","year":2009, "previous_model": {"uid":"0xc8"}}
 	]}}`, js)
 }

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1825,16 +1825,12 @@ type Pet {
 When `expand(_all_)` is called on this node, Dgraph will first check which types
 the node has (`Animal` and `Pet`). Then it will get the definitions of 
 `Animal` and `Pet` and build a list of predicates.
-Finally, it will query the schema to check if any of those predicates have a
-reverse node. If, for example, there's a reverse node in the `owner` predicate,
-the final list of predicates to expand will be:
 
 ```
 name
 species
 dob
 owner
-~owner
 veterinarian
 ```
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -1821,8 +1821,8 @@ type Pet {
 ```
 
 When `expand(_all_)` is called on this node, Dgraph will first check which types
-the node has (`Animal` and `Pet`). Then it will get the definitions of 
-`Animal` and `Pet` and build a list of predicates.
+the node has (`Animal` and `Pet`). Then it will get the definitions of `Animal`
+and `Pet` and build a list of predicates from their type definitions.
 
 ```
 name


### PR DESCRIPTION
Reverse edges are no longer included unless the type explicitly includes
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4120)
<!-- Reviewable:end -->
