### PR TITLE
GraphQL: Minor improvements to tests.

### DIFF
--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -940,7 +940,7 @@ func TestQueryInterfaceAfterAddMutation(t *testing.T) {
 			"queryCharacter": [
 			  {
 				"name": "Han Solo",
-				"appearsIn": "EMPIRE",
+				"appearsIn": ["EMPIRE"],
 				"starships": [
 				  {
 					"name": "Millennium Falcon",
@@ -951,7 +951,7 @@ func TestQueryInterfaceAfterAddMutation(t *testing.T) {
 			  },
 			  {
 				"name": "R2-D2",
-				"appearsIn": "EMPIRE",
+				"appearsIn": ["EMPIRE"],
 				"primaryFunction": "Robot"
 			  }
 			]
@@ -987,7 +987,7 @@ func TestQueryInterfaceAfterAddMutation(t *testing.T) {
 		"queryCharacter": [
 		  {
 			"name": "Han Solo",
-			"appearsIn": "EMPIRE",
+			"appearsIn": ["EMPIRE"],
 			"starships": [
 			  {
 				"name": "Millennium Falcon",
@@ -1023,7 +1023,7 @@ func TestQueryInterfaceAfterAddMutation(t *testing.T) {
 		"queryHuman": [
 		  {
 			"name": "Han Solo",
-			"appearsIn": "EMPIRE",
+			"appearsIn": ["EMPIRE"],
 			"starships": [
 			  {
 				"name": "Millennium Falcon",
@@ -1059,7 +1059,7 @@ func TestQueryInterfaceAfterAddMutation(t *testing.T) {
 		"queryHuman": [
 		  {
 			"name": "Han Solo",
-			"appearsIn": "EMPIRE",
+			"appearsIn": ["EMPIRE"],
 			"starships": [
 			  {
 				"name": "Millennium Falcon",

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -250,6 +250,7 @@ func addPost(t *testing.T, authorID, countryID string) *post {
 				text
 				isPublished
 				tags
+				numLikes
 				author {
 					id
 					name
@@ -265,6 +266,7 @@ func addPost(t *testing.T, authorID, countryID string) *post {
 			"title":       "Test Post",
 			"text":        "This post is just a test.",
 			"isPublished": true,
+			"numLikes":    1000,
 			"tags":        []string{"example", "test"},
 			"author":      map[string]interface{}{"id": authorID},
 		}},
@@ -277,6 +279,7 @@ func addPost(t *testing.T, authorID, countryID string) *post {
 			"text": "This post is just a test.",
 			"isPublished": true,
 			"tags": ["example", "test"],
+			"numLikes": 1000,
 			"author": {
 				"id": "%s",
 				"name": "Test Author",
@@ -320,6 +323,7 @@ func requirePost(t *testing.T, postID string, expectedPost *post) {
 				text
 				isPublished
 				tags
+				numLikes
 				author {
 					id
 					name

--- a/dgraph/cmd/graphql/e2e_query_test.go
+++ b/dgraph/cmd/graphql/e2e_query_test.go
@@ -419,43 +419,41 @@ func authorTest(t *testing.T, filter interface{}, expected []*author) {
 	}
 }
 
-// FIXME: Int is currently not working in API.  It's because it doesn't deserialize properly.
-// We just need to look at the expected type and make sure it's an in.  There's a card in Asana.
-// func TestIntFilters(t *testing.T) {
-// 	cases := map[string]struct {
-// 		Filter   interface{}
-// 		Expected []*post
-// 	}{
-// 		"less than": {
-// 			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"lt": 87}},
-// 			Expected: []*post{
-// 				{Title: "GraphQL in Dgraph doco"},
-// 				{Title: "Random post"}}},
-// 		"less or equal": {
-// 			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"le": 87}},
-// 			Expected: []*post{
-// 				{Title: "GraphQL in Dgraph doco"},
-// 				{Title: "Learning GraphQL in Dgraph"},
-// 				{Title: "Random post"}}},
-// 		"equal": {
-// 			Filter:   map[string]interface{}{"numLikes": map[string]interface{}{"eq": 87}},
-// 			Expected: []*post{{Title: "Learning GraphQL in Dgraph"}}},
-// 		"greater or equal": {
-// 			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"ge": 87}},
-// 			Expected: []*post{
-// 				{Title: "Introducing GraphQL in Dgraph"},
-// 				{Title: "Learning GraphQL in Dgraph"}}},
-// 		"greater than": {
-// 			Filter:   map[string]interface{}{"numLikes": map[string]interface{}{"gt": 87}},
-// 			Expected: []*post{{Title: "Introducing GraphQL in Dgraph"}}},
-// 	}
+func TestIntFilters(t *testing.T) {
+	cases := map[string]struct {
+		Filter   interface{}
+		Expected []*post
+	}{
+		"less than": {
+			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"lt": 87}},
+			Expected: []*post{
+				{Title: "GraphQL doco"},
+				{Title: "Random post"}}},
+		"less or equal": {
+			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"le": 87}},
+			Expected: []*post{
+				{Title: "GraphQL doco"},
+				{Title: "Learning GraphQL in Dgraph"},
+				{Title: "Random post"}}},
+		"equal": {
+			Filter:   map[string]interface{}{"numLikes": map[string]interface{}{"eq": 87}},
+			Expected: []*post{{Title: "Learning GraphQL in Dgraph"}}},
+		"greater or equal": {
+			Filter: map[string]interface{}{"numLikes": map[string]interface{}{"ge": 87}},
+			Expected: []*post{
+				{Title: "Introducing GraphQL in Dgraph"},
+				{Title: "Learning GraphQL in Dgraph"}}},
+		"greater than": {
+			Filter:   map[string]interface{}{"numLikes": map[string]interface{}{"gt": 87}},
+			Expected: []*post{{Title: "Introducing GraphQL in Dgraph"}}},
+	}
 
-// 	for name, test := range cases {
-// 		t.Run(name, func(t *testing.T) {
-// 			postTest(t, test.Filter, test.Expected)
-// 		})
-// 	}
-// }
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			postTest(t, test.Filter, test.Expected)
+		})
+	}
+}
 
 func TestBooleanFilters(t *testing.T) {
 	cases := map[string]struct {

--- a/dgraph/cmd/graphql/e2e_query_test.go
+++ b/dgraph/cmd/graphql/e2e_query_test.go
@@ -253,6 +253,7 @@ func TestManyQueries(t *testing.T) {
 		tags
 		isPublished
 		postType
+		numLikes
 	}
 	`
 
@@ -296,6 +297,7 @@ func TestQueriesWithError(t *testing.T) {
 		tags
 		isPublished
 		postType
+		numLikes
 	}
 	`
 

--- a/dgraph/cmd/graphql/e2e_schema_test.go
+++ b/dgraph/cmd/graphql/e2e_schema_test.go
@@ -67,6 +67,7 @@ const (
 			"predicate": "Character.appearsIn",
 			"type": "string",
 			"index": true,
+			"list": true,
 			"tokenizer": [
 			  "exact"
 			]
@@ -229,7 +230,7 @@ const (
 			  },
 			  {
 				"name": "Character.appearsIn",
-				"type": "string"
+				"type": "[string]"
 			  }
 			],
 			"name": "Character"
@@ -251,7 +252,7 @@ const (
 			  },
 			  {
 				"name": "Character.appearsIn",
-				"type": "string"
+				"type": "[string]"
 			  },
 			  {
 				"name": "Droid.primaryFunction",
@@ -281,7 +282,7 @@ const (
 			  },
 			  {
 				"name": "Character.appearsIn",
-				"type": "string"
+				"type": "[string]"
 			  },
 			  {
 				"name": "Human.starships",

--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -100,7 +100,7 @@ type post struct {
 	Title       string
 	Text        string
 	Tags        []string
-	NulLikes    int
+	NumLikes    int
 	IsPublished bool
 	PostType    string
 	Author      author

--- a/dgraph/cmd/graphql/http.go
+++ b/dgraph/cmd/graphql/http.go
@@ -107,7 +107,9 @@ func (gh *graphqlHandler) resolverForRequest(r *http.Request) (rr *resolve.Reque
 
 		switch mediaType {
 		case "application/json":
-			if err = json.NewDecoder(r.Body).Decode(&rr.GqlReq); err != nil {
+			d := json.NewDecoder(r.Body)
+			d.UseNumber()
+			if err = d.Decode(&rr.GqlReq); err != nil {
 				rr.WithError(
 					gqlerror.Errorf("Not a valid GraphQL request body: %s", err))
 				return

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -291,6 +291,17 @@ invalid_schemas:
       "locations":[{"line":2, "column":3}]}
       ]
 
+  -
+    name: "List of Boolean is not allowed"
+    input: |
+      type X {
+        q: [Boolean]
+      }
+    errlist: [
+      {"message": "[Boolean] lists are invalid. Only Boolean scalar fields are allowed.",
+      "locations":[{"line":2, "column":3}]}
+      ]
+
 
 valid_schemas:
   -

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -118,6 +118,13 @@ func listValidityCheck(field *ast.FieldDefinition) *gqlerror.Error {
 		)
 	}
 
+	// [Boolean] is not allowed as dgraph schema doesn't support [bool] yet.
+	if field.Type.Elem != nil && field.Type.Elem.Name() == "Boolean" &&
+		field.Type.NamedType == "" {
+		return gqlerror.ErrorPosf(
+			field.Position, "[Boolean] lists are invalid. Only Boolean scalar fields are allowed.")
+	}
+
 	return nil
 }
 

--- a/dgraph/cmd/graphql/schema/schemagen.go
+++ b/dgraph/cmd/graphql/schema/schemagen.go
@@ -215,9 +215,13 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 						fmt.Fprintf(&preds, "%s.%s: %s%s .\n", typName, f.Name, typStr, indexStr)
 					}
 				case ast.Enum:
-					fmt.Fprintf(&typeDef, "  %s.%s: string\n", typName, f.Name)
+					typStr = fmt.Sprintf(
+						"%s%s%s",
+						prefix, "string", suffix,
+					)
+					fmt.Fprintf(&typeDef, "  %s.%s: %s\n", typName, f.Name, typStr)
 					if parentInt == "" {
-						fmt.Fprintf(&preds, "%s.%s: string @index(exact) .\n", typName, f.Name)
+						fmt.Fprintf(&preds, "%s.%s: %s @index(exact) .\n", typName, f.Name, typStr)
 					}
 				}
 			}

--- a/dgraph/cmd/graphql/schema/schemagen_test.go
+++ b/dgraph/cmd/graphql/schema/schemagen_test.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	dschema "github.com/dgraph-io/dgraph/schema"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/gqlerror"
@@ -55,6 +56,8 @@ func TestDGSchemaGen(t *testing.T) {
 				if diff := cmp.Diff(sch.Output, dgSchema); diff != "" {
 					t.Errorf("schema mismatch (-want +got):\n%s", diff)
 				}
+				_, err := dschema.Parse(dgSchema)
+				require.NoError(t, err)
 			})
 		}
 	}

--- a/dgraph/cmd/graphql/schema/schemagen_test.yml
+++ b/dgraph/cmd/graphql/schema/schemagen_test.yml
@@ -54,7 +54,6 @@ schemas:
         p: Int
         pList: [Int]
         q: Boolean
-        qList: [Boolean]
         r: String
         rList: [String]
         s: DateTime
@@ -68,7 +67,6 @@ schemas:
         X.p: int
         X.pList: [int]
         X.q: bool
-        X.qList: [bool]
         X.r: string
         X.rList: [string]
         X.s: dateTime
@@ -79,7 +77,6 @@ schemas:
       X.p: int .
       X.pList: [int] .
       X.q: bool .
-      X.qList: [bool] .
       X.r: string .
       X.rList: [string] .
       X.s: dateTime .
@@ -92,13 +89,17 @@ schemas:
     input: |
       type X {
         e: E
+        f: [E]
       }
       enum E { A }
     output: |
       type X {
         X.e: string
+        X.f: [string]
       }
       X.e: string @index(exact) .
+      X.f: [string] @index(exact) .
+
 
   -
     name: "Searchable indexes are correct"


### PR DESCRIPTION
* Validate the dgraph schema generated as part of `TestDGSchemaGen`.
* Disallow `[Boolean]` for now as Dgraph doesn't support it yet.
* Generate correct schema for `[Enum]` and add a test case for it.
* Fix issue where `int` was being interpreted as `float` when passed as a GraphQL variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4121)
<!-- Reviewable:end -->
