### PR TITLE
Remove gqlerror in favour of x.GqlError

### DIFF
--- a/dgraph/cmd/graphql/dgraph/mutation.go
+++ b/dgraph/cmd/graphql/dgraph/mutation.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/gql"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -79,7 +79,7 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 	if m.MutationType() != schema.AddMutation &&
 		m.MutationType() != schema.UpdateMutation {
 		return nil,
-			gqlerror.Errorf(
+			errors.Errorf(
 				"internal error - call to build Dgraph mutation for %s mutation type",
 				m.MutationType())
 	}
@@ -153,15 +153,13 @@ func (mrw *mutationRewriter) Rewrite(m schema.Mutation) (interface{}, error) {
 		// GraphQL validation means we shouldn't get here till those bulk mutations
 		// are added to the schema.
 		return nil,
-			gqlerror.Errorf(
-				"internal error - call to build a list of mutations, but that " +
-					"isn't supported yet.")
+			errors.New("call to build a list of mutations, but that isn't supported yet")
 	}
 
 	return nil,
-		gqlerror.Errorf(
-			"internal error - call to build Dgraph mutation with input of unrecognized type; " +
-				"this indicates a GraphQL validation error.")
+		errors.New(
+			"tried to build Dgraph mutation with input of unrecognized type; " +
+				"this indicates a GraphQL validation error")
 }
 
 func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
@@ -183,7 +181,7 @@ func rewriteMutationAsQuery(m schema.Mutation) *gql.GraphQuery {
 func (mrw *mutationRewriter) RewriteDelete(m schema.Mutation) (query string, mutation string,
 	err error) {
 	if m.MutationType() != schema.DeleteMutation {
-		return "", "", gqlerror.Errorf(
+		return "", "", errors.Errorf(
 			"internal error - call to build Dgraph mutation for %s mutation type",
 			m.MutationType())
 	}
@@ -208,8 +206,7 @@ func asUID(val interface{}) (uint64, error) {
 	uid, err := strconv.ParseUint(id, 0, 64)
 
 	if !ok || err != nil {
-		return 0, gqlerror.Errorf(
-			"ID argument (%s) was not able to be parsed", id)
+		return 0, errors.Errorf("ID argument (%s) was not able to be parsed", id)
 	}
 
 	return uid, nil

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -77,8 +77,9 @@ func TestMutationRewriting(t *testing.T) {
 
 			jsonMut, err := rewriterToTest.Rewrite(mut)
 
-			test.RequireJSONEq(t, tcase.Error, err)
-			if tcase.Error == nil {
+			if tcase.Error != nil || err != nil {
+				require.Equal(t, tcase.Error.Error(), err.Error())
+			} else {
 				test.RequireJSONEqStr(t, tcase.DgraphMutation, jsonMut)
 			}
 		})

--- a/dgraph/cmd/graphql/dgraph/mutation_test.go
+++ b/dgraph/cmd/graphql/dgraph/mutation_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/test"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
-	"github.com/vektah/gqlparser/gqlerror"
 	"gopkg.in/yaml.v2"
 )
 
@@ -44,7 +44,7 @@ type TestCase struct {
 	Explanation    string
 	DgraphMutation string
 	DgraphQuery    string
-	Error          *gqlerror.Error
+	Error          *x.GqlError
 }
 
 func TestMutationRewriting(t *testing.T) {

--- a/dgraph/cmd/graphql/dgraph/query.go
+++ b/dgraph/cmd/graphql/dgraph/query.go
@@ -25,7 +25,7 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/pkg/errors"
 )
 
 // QueryRewriter can build a Dgraph gql.GraphQuery from a GraphQL query, and
@@ -96,7 +96,7 @@ func (qr *queryRewriter) Rewrite(gqlQuery schema.Query) (*gql.GraphQuery, error)
 	case schema.FilterQuery:
 		return rewriteAsQuery(gqlQuery), nil
 	default:
-		return nil, gqlerror.Errorf("unimplemented query type %s", gqlQuery.QueryType())
+		return nil, errors.Errorf("unimplemented query type %s", gqlQuery.QueryType())
 	}
 }
 
@@ -125,7 +125,7 @@ func (qr *queryRewriter) FromMutationResult(
 		return rewriteAsGet(gqlMutation.QueryField(), uid), nil
 
 	default:
-		return nil, gqlerror.Errorf("can't rewrite %s mutations to Dgraph query",
+		return nil, errors.Errorf("can't rewrite %s mutations to Dgraph query",
 			gqlMutation.MutationType())
 	}
 }

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -164,7 +164,9 @@ func (mr *mutationResolver) resolveMutation(ctx context.Context) (*resolved, boo
 
 	assigned, err := mr.dgraph.Mutate(ctx, mut)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "mutation %s failed", mr.mutation.Name())
+		res.err = schema.GQLWrapLocationf(err,
+			mr.mutation.Location(),
+			"mutation %s failed", mr.mutation.Name())
 		return res, mutationFailed
 	}
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"sync"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
-	"github.com/vektah/gqlparser/gqlerror"
 )
 
 const (
@@ -94,7 +92,6 @@ type RequestResolver struct {
 	dgraph           dgraph.Client
 	queryRewriter    dgraph.QueryRewriter
 	mutationRewriter dgraph.MutationRewriter
-	resp             *schema.Response
 }
 
 // A resolved is the result of resolving a single query or mutation.
@@ -115,15 +112,9 @@ func New(
 	return &RequestResolver{
 		Schema:           s,
 		dgraph:           dg,
-		resp:             &schema.Response{},
 		queryRewriter:    queryRewriter,
 		mutationRewriter: mutRewriter,
 	}
-}
-
-// WithError generates GraphQL errors from err and records those in r.
-func (r *RequestResolver) WithError(err error) {
-	r.resp.Errors = append(r.resp.Errors, schema.AsGQLErrors(err)...)
 }
 
 // Resolve processes r.GqlReq and returns a GraphQL response.
@@ -135,27 +126,27 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 	stop := x.SpanTimer(span, methodResolve)
 	defer stop()
 
-	r.resp.Extensions = &schema.Extensions{
-		RequestID: api.RequestID(ctx),
-	}
+	reqID := api.RequestID(ctx)
 
 	if r == nil {
-		glog.Errorf("Call to Resolve with nil RequestResolver")
-		r.WithError(errors.New("Internal error"))
+		glog.Errorf("[%s] Call to Resolve with nil RequestResolver", reqID)
+		return schema.ErrorResponse(errors.New("Internal error"), reqID)
 	}
 
 	if r.Schema == nil {
-		glog.Errorf("Call to Resolve with no schema")
-		r.WithError(errors.New("Internal error"))
+		glog.Errorf("[%s] Call to Resolve with no schema", reqID)
+		return schema.ErrorResponse(errors.New("Internal error"), reqID)
 	}
 
 	op, err := r.Schema.Operation(r.GqlReq)
 	if err != nil {
-		r.WithError(err)
+		return schema.ErrorResponse(err, reqID)
 	}
 
-	if r.resp.Errors != nil {
-		return r.resp
+	resp := &schema.Response{
+		Extensions: &schema.Extensions{
+			RequestID: reqID,
+		},
 	}
 
 	if glog.V(3) {
@@ -163,7 +154,7 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 		if err != nil {
 			glog.Infof("Failed to marshal variables for logging : %s", err)
 		}
-		glog.Infof("Resolving GQL request: \n%s\nWith Variables: \n%s\n", r.GqlReq.Query, string(b))
+		glog.Infof("[%s] Resolving GQL request: \n%s\nWith Variables: \n%s\n", reqID, r.GqlReq.Query, string(b))
 	}
 
 	// A single request can contain either queries or mutations - not both.
@@ -201,8 +192,8 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 		for _, res := range allResolved {
 			// Errors and data in the same response is valid.  Both WithError and
 			// AddData handle nil cases.
-			r.WithError(res.err)
-			r.resp.AddData(res.data)
+			resp.WithError(res.err)
+			resp.AddData(res.data)
 		}
 	case op.IsMutation():
 		// Mutations, unlike queries, are handled serially and the results are
@@ -212,9 +203,11 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 
 		for _, m := range op.Mutations() {
 			if !allSuccessful {
-				r.WithError(
-					gqlerror.Errorf("mutation %s was not executed because of a previous error",
-						m.ResponseName()))
+				resp.WithError(x.GqlErrorf(
+					"mutation %s was not executed because of a previous error",
+					m.ResponseName()).
+					WithLocations(m.Location()))
+
 				continue
 			}
 
@@ -227,14 +220,14 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 			}
 			var res *resolved
 			res, allSuccessful = mr.resolve(ctx)
-			r.WithError(res.err)
-			r.resp.AddData(res.data)
+			resp.WithError(res.err)
+			resp.AddData(res.data)
 		}
 	case op.IsSubscription():
-		schema.ErrorResponsef("Subscriptions not yet supported")
+		resp.WithError(errors.New("Subscriptions not yet supported"))
 	}
 
-	return r.resp
+	return resp
 }
 
 // Once a result has been returned from Dgraph, that result needs to be worked
@@ -255,7 +248,7 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 //    got back a null/error, then that's fine, just set it to null.  But if we asked
 //    for something non-nullable and got a null/error, then the object we are building
 //    is in an error state, and we should propagate that up to it's parent, and so
-//    on, untill we reach a nullable field, or the top level.
+//    on, until we reach a nullable field, or the top level.
 //
 // The completeXYZ() functions below essentially covers the value completion alg from
 // https://graphql.github.io/graphql-spec/June2018/#sec-Value-Completion.
@@ -263,7 +256,7 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 // https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability
 // and the spec requirements for response
 // https://graphql.github.io/graphql-spec/June2018/#sec-Response.
-
+//
 // There's three basic types to consider here: GraphQL object types (equals json
 // objects in the result), list types (equals lists of objects or scalars), and
 // values (either scalar values, lists or objects).
@@ -299,8 +292,11 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 // if there's no result, or
 //   { "query-name": ... }
 // if there is a result.
+//
+// Returned errors are generally lists of errors resulting from the value completion
+// algorithm that may emit multiple errors
 func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []byte) (
-	[]byte, gqlerror.List) {
+	[]byte, error) {
 	span := trace.FromContext(ctx)
 	stop := x.SpanTimer(span, "completeDgraphResult")
 	defer stop()
@@ -316,7 +312,7 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 	//
 	//    { }  --->  { "q": null }
 
-	var errs gqlerror.List
+	var errs x.GqlErrorList
 	errLoc := field.Location()
 
 	nullResponse := func() []byte {
@@ -327,16 +323,14 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 		return buf.Bytes()
 	}
 
-	dgraphError := func() ([]byte, gqlerror.List) {
+	dgraphError := func() ([]byte, error) {
 		glog.Errorf("[%s] Could not process Dgraph result : \n%s",
 			api.RequestID(ctx), string(dgResult))
-		return nullResponse(), gqlerror.List{
-			&gqlerror.Error{
-				Message: "Couldn't process result from Dgraph.  " +
+		return nullResponse(),
+			x.GqlErrorf("Couldn't process the result from Dgraph.  " +
 					"This probably indicates a bug in the Dgraph GraphQL layer.  " +
-					"Please let us know : https://github.com/dgraph-io/dgraph/issues.",
-				Locations: []gqlerror.Location{{Line: errLoc.Line, Column: errLoc.Column}},
-			}}
+				"Please let us know : https://github.com/dgraph-io/dgraph/issues.").
+				WithLocations(errLoc)
 	}
 
 	// Dgraph should only return {} or a JSON object.  Also,
@@ -350,9 +344,8 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 			api.RequestID(ctx),
 			errors.Wrap(err, "failed to unmarshal Dgraph query result"),
 			string(dgResult))
-		return nullResponse(), schema.AsGQLErrors(
-			schema.GQLWrapLocationf(err, errLoc.Line, errLoc.Column,
-				"Internal error (couldn't unmarshal Dgraph result)"))
+		return nullResponse(),
+			schema.GQLWrapLocationf(err, errLoc, "couldn't unmarshal Dgraph result")
 	}
 
 	switch val := valToComplete[field.ResponseName()].(type) {
@@ -379,19 +372,17 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 				//
 				// We'll continue and just try the first item to return some data.
 
-				glog.Errorf("[%s] Got a list result from Dgraph when expecting a one-item list.\n"+
-					"GraphQL query was : %s\nDgraph Result was : %s\n",
-					api.RequestID(ctx), api.QueryString(ctx), string(dgResult))
+				glog.Errorf("[%s] Got a list of length %v from Dgraph when expecting a "+
+					"one-item list.\n"+
+					"GraphQL query was : %s\n",
+					api.RequestID(ctx), len(val), api.QueryString(ctx))
 
 				errs = append(errs,
-					&gqlerror.Error{
-						Message: fmt.Sprintf(
-							"Dgraph returned a list, but %s (type %s) was expecting just one item. "+
+					x.GqlErrorf(
+						"Dgraph returned a list, but %s (type %s) was expecting just one item.  "+
 								"The first item in the list was used to produce the result. "+
 								"Logged as a potential bug; see the API log for more details.",
-							field.Name(), field.Type().String()),
-						Locations: []gqlerror.Location{{Line: errLoc.Line, Column: errLoc.Column}},
-					})
+						field.Name(), field.Type().String()).WithLocations(errLoc))
 			}
 
 			valToComplete[field.ResponseName()] = internalVal
@@ -428,11 +419,11 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 		// This isn't really an observable GraphQL error, so no need to add anything
 		// to the payload of errors for the result.
 		glog.Errorf("[%s] Top level completeObject didn't return a result.  "+
-			"That's only possible if the query result it non-nullable.  "+
+			"That's only possible if the query result is non-nullable.  "+
 			"There's something wrong in the GraphQL schema.  \n"+
-			"GraphQL query was : %s\nDgraph Result was : %s\n",
-			api.RequestID(ctx), api.QueryString(ctx), string(dgResult))
-		return nullResponse(), errs
+			"GraphQL query was : %s\n",
+			api.RequestID(ctx), api.QueryString(ctx))
+		return nullResponse(), append(errs, gqlErrs...)
 	}
 
 	return completed, append(errs, gqlErrs...)
@@ -471,10 +462,13 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 //
 // if "dob" were non-nullable (maybe it's type is DateTime!), then the result is
 // nil and the error propagates to the enclosing level.
-func completeObject(path []interface{}, typ schema.Type, fields []schema.Field, res map[string]interface{}) (
-	[]byte, gqlerror.List) {
+func completeObject(
+	path []interface{},
+	typ schema.Type,
+	fields []schema.Field,
+	res map[string]interface{}) ([]byte, x.GqlErrorList) {
 
-	var errs gqlerror.List
+	var errs x.GqlErrorList
 	var buf bytes.Buffer
 	comma := ""
 
@@ -521,7 +515,10 @@ func completeObject(path []interface{}, typ schema.Type, fields []schema.Field, 
 
 // completeValue applies the value completion algorithm to a single value, which
 // could turn out to be a list or object or scalar value.
-func completeValue(path []interface{}, field schema.Field, val interface{}) ([]byte, gqlerror.List) {
+func completeValue(
+	path []interface{},
+	field schema.Field,
+	val interface{}) ([]byte, x.GqlErrorList) {
 
 	switch val := val.(type) {
 	case map[string]interface{}:
@@ -549,15 +546,13 @@ func completeValue(path []interface{}, field schema.Field, val interface{}) ([]b
 				return []byte("null"), nil
 			}
 
-			errLoc := field.Location()
-			gqlErr := &gqlerror.Error{
-				Message: fmt.Sprintf(
+			gqlErr := x.GqlErrorf(
 					"Non-nullable field '%s' (type %s) was not present in result from Dgraph.  "+
-						"GraphQL error propagation triggered.", field.Name(), field.Type()),
-				Locations: []gqlerror.Location{{Line: errLoc.Line, Column: errLoc.Column}},
-				Path:      copyPath(path),
-			}
-			return nil, gqlerror.List{gqlErr}
+					"GraphQL error propagation triggered.", field.Name(), field.Type()).
+				WithLocations(field.Location())
+			gqlErr.Path = copyPath(path)
+
+			return nil, x.GqlErrorList{gqlErr}
 		}
 
 		// val is a scalar
@@ -566,21 +561,18 @@ func completeValue(path []interface{}, field schema.Field, val interface{}) ([]b
 		// we just unmarshaled this val.
 		json, err := json.Marshal(val)
 		if err != nil {
-			errLoc := field.Location()
-			gqlErr := &gqlerror.Error{
-				Message: fmt.Sprintf(
+			gqlErr := x.GqlErrorf(
 					"Error marshalling value for field '%s' (type %s).  "+
 						"Resolved as null (which may trigger GraphQL error propagation) ",
-					field.Name(), field.Type()),
-				Locations: []gqlerror.Location{{Line: errLoc.Line, Column: errLoc.Column}},
-				Path:      copyPath(path),
-			}
+				field.Name(), field.Type()).
+				WithLocations(field.Location())
+			gqlErr.Path = copyPath(path)
 
 			if field.Type().Nullable() {
-				return []byte("null"), gqlerror.List{gqlErr}
+				return []byte("null"), x.GqlErrorList{gqlErr}
 			}
 
-			return nil, gqlerror.List{gqlErr}
+			return nil, x.GqlErrorList{gqlErr}
 		}
 
 		return json, nil
@@ -604,9 +596,13 @@ func completeValue(path []interface{}, field schema.Field, val interface{}) ([]b
 //
 // If the list has non-nullable elements (a type like [T!]) and any of those
 // elements resolve to null, then the whole list is crushed to null.
-func completeList(path []interface{}, field schema.Field, values []interface{}) ([]byte, gqlerror.List) {
+func completeList(
+	path []interface{},
+	field schema.Field,
+	values []interface{}) ([]byte, x.GqlErrorList) {
+
 	var buf bytes.Buffer
-	var errs gqlerror.List
+	var errs x.GqlErrorList
 	comma := ""
 
 	if field.Type().ListType() == nil {
@@ -652,20 +648,25 @@ func completeList(path []interface{}, field schema.Field, values []interface{}) 
 	return buf.Bytes(), errs
 }
 
-func mismatched(path []interface{}, field schema.Field, values []interface{}) ([]byte, gqlerror.List) {
+func mismatched(
+	path []interface{},
+	field schema.Field,
+	values []interface{}) ([]byte, x.GqlErrorList) {
+
 	errLoc := field.Location()
 
-	glog.Error("completeList() called in resolving %s (Line: %v, Column: %v), but its type is %s.\n"+
-		"That could indicate the Dgraph schema doesn't match the GraphQL schema."+
+	glog.Error("completeList() called in resolving %s (Line: %v, Column: %v), "+
+		"but its type is %s.\n"+
+		"That could indicate the Dgraph schema doesn't match the GraphQL schema.",
 		field.Name(), errLoc.Line, errLoc.Column, field.Type().Name())
 
-	gqlErr := &gqlerror.Error{
+	gqlErr := &x.GqlError{
 		Message: "Dgraph returned a list, but GraphQL was expecting just one item.  " +
 			"This indicates an internal error - " +
 			"probably a mismatch between GraphQL and Dgraph schemas.  " +
 			"The value was resolved as null (which may trigger GraphQL error propagation) " +
 			"and as much other data as possible returned.",
-		Locations: []gqlerror.Location{{Line: errLoc.Line, Column: errLoc.Column}},
+		Locations: []x.Location{{Line: errLoc.Line, Column: errLoc.Column}},
 		Path:      copyPath(path),
 	}
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -328,7 +328,7 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 			api.RequestID(ctx), string(dgResult))
 		return nullResponse(),
 			x.GqlErrorf("Couldn't process the result from Dgraph.  " +
-					"This probably indicates a bug in the Dgraph GraphQL layer.  " +
+				"This probably indicates a bug in the Dgraph GraphQL layer.  " +
 				"Please let us know : https://github.com/dgraph-io/dgraph/issues.").
 				WithLocations(field.Location())
 	}
@@ -380,8 +380,8 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 				errs = append(errs,
 					x.GqlErrorf(
 						"Dgraph returned a list, but %s (type %s) was expecting just one item.  "+
-								"The first item in the list was used to produce the result. "+
-								"Logged as a potential bug; see the API log for more details.",
+							"The first item in the list was used to produce the result. "+
+							"Logged as a potential bug; see the API log for more details.",
 						field.Name(), field.Type().String()).WithLocations(field.Location()))
 			}
 
@@ -547,7 +547,7 @@ func completeValue(
 			}
 
 			gqlErr := x.GqlErrorf(
-					"Non-nullable field '%s' (type %s) was not present in result from Dgraph.  "+
+				"Non-nullable field '%s' (type %s) was not present in result from Dgraph.  "+
 					"GraphQL error propagation triggered.", field.Name(), field.Type()).
 				WithLocations(field.Location())
 			gqlErr.Path = copyPath(path)
@@ -562,8 +562,8 @@ func completeValue(
 		json, err := json.Marshal(val)
 		if err != nil {
 			gqlErr := x.GqlErrorf(
-					"Error marshalling value for field '%s' (type %s).  "+
-						"Resolved as null (which may trigger GraphQL error propagation) ",
+				"Error marshalling value for field '%s' (type %s).  "+
+					"Resolved as null (which may trigger GraphQL error propagation) ",
 				field.Name(), field.Type()).
 				WithLocations(field.Location())
 			gqlErr.Path = copyPath(path)

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -154,7 +154,8 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 		if err != nil {
 			glog.Infof("Failed to marshal variables for logging : %s", err)
 		}
-		glog.Infof("[%s] Resolving GQL request: \n%s\nWith Variables: \n%s\n", reqID, r.GqlReq.Query, string(b))
+		glog.Infof("[%s] Resolving GQL request: \n%s\nWith Variables: \n%s\n",
+			reqID, r.GqlReq.Query, string(b))
 	}
 
 	// A single request can contain either queries or mutations - not both.

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -413,7 +413,7 @@ func TestManyMutationsWithError(t *testing.T) {
 			}`,
 			errors: x.GqlErrorList{
 				&x.GqlError{Message: `mutation addPost failed because ` +
-					`Dgraph query failed because _bad stuff happend_`,
+					`Dgraph mutation failed because _bad stuff happend_`,
 					Locations: []x.Location{{Line: 6, Column: 4}}},
 				&x.GqlError{Message: `mutation add3 was not executed because of ` +
 					`a previous error`,

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.yaml
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.yaml
@@ -251,8 +251,8 @@
   expected: |
     { "getAuthor": { "name": "A.N. Author" } }
   errors:
-    [ { "message": "Dgraph returned a list, but getAuthor (type Author) was expecting just one item. 
-          The first item in the list was used to produce the result. 
+    [ { "message": "Dgraph returned a list, but getAuthor (type Author) was expecting just one 
+          item.  The first item in the list was used to produce the result. 
           Logged as a potential bug; see the API log for more details.",
         "locations": [ { "column":3, "line":2 } ] } ]
 
@@ -270,7 +270,7 @@
   expected: |
     { "getAuthor": null }
   errors:
-    [ { "message": "input:2: Internal error (couldn't unmarshal Dgraph result) 
+    [ { "message": "couldn't unmarshal Dgraph result 
           because invalid character 's' looking for beginning of object key string" ,
         "locations": [ { "column":3, "line":2 } ] } ]
 

--- a/dgraph/cmd/graphql/schema/errors.go
+++ b/dgraph/cmd/graphql/schema/errors.go
@@ -139,8 +139,7 @@ func GQLWrapLocationf(err error, loc x.Location, format string, args ...interfac
 	if gqlable, ok = wrapped.(*gqlableError); !ok {
 		panic("GQLWrapf didn't result in a gqlableError")
 	}
-	gqlable.gqlErr.Locations =
-		append(gqlable.gqlErr.Locations, loc)
+	gqlable.gqlErr.Locations = append(gqlable.gqlErr.Locations, loc)
 
 	return gqlable
 }

--- a/dgraph/cmd/graphql/schema/errors.go
+++ b/dgraph/cmd/graphql/schema/errors.go
@@ -17,42 +17,95 @@
 package schema
 
 import (
+	"bytes"
+	"fmt"
+
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
 type gqlableError struct {
-	gqlErr *gqlerror.Error
+	gqlErr *x.GqlError
 	cause  error
 }
 
-func (gqlerr *gqlableError) Error() string {
-	return gqlerr.gqlErr.Error() + " because " + gqlerr.cause.Error()
+func (gqlable *gqlableError) Error() string {
+	var buf bytes.Buffer
+	buf.WriteString(gqlable.gqlErr.Message)
+	buf.WriteString(" because ")
+	switch cause := gqlable.cause.(type) {
+	case *x.GqlError:
+		// Avoid writing locations into the error string.
+		buf.WriteString(cause.Message)
+	default:
+		buf.WriteString(cause.Error())
+	}
+	return buf.String()
+}
+
+func (gqlable *gqlableError) locations() []x.Location {
+	switch cause := gqlable.cause.(type) {
+	case *gqlableError:
+		return append(cause.locations(), gqlable.gqlErr.Locations...)
+	case *x.GqlError:
+		return append(cause.Locations, gqlable.gqlErr.Locations...)
+	default:
+		return gqlable.gqlErr.Locations
+	}
 }
 
 // AsGQLErrors formats an error as a list of GraphQL errors.
-// A gqlerror.List gets returned as is, a gqlerror.Error gets returned as a one
+// A []*x.GqlError gets returned as is, an x.GqlError  gets returned as a one
 // item list, GQLWrap'd errors have their messages formatted from all underlying causes,
-// and all other errors get printed into a gqlerror.Error.  A nil input results
+// and all other errors get printed into a x.GqlError .  A nil input results
 // in nil output.
-func AsGQLErrors(err error) gqlerror.List {
+func AsGQLErrors(err error) x.GqlErrorList {
 	if err == nil {
 		return nil
 	}
 
 	switch e := err.(type) {
 	case *gqlerror.Error:
-		return gqlerror.List{e}
+		return x.GqlErrorList{toGqlError(e)}
+	case *x.GqlError:
+		return x.GqlErrorList{e}
 	case gqlerror.List:
+		return toGqlErrorList(e)
+	case x.GqlErrorList:
 		return e
 	case *gqlableError:
-		return gqlerror.List{&gqlerror.Error{
+		return x.GqlErrorList{&x.GqlError{
 			Message:   e.Error(),
-			Locations: e.gqlErr.Locations,
-			// include things like Path when we use it
+			Locations: e.locations(),
+			Path:      e.gqlErr.Path,
 		}}
 	default:
-		return gqlerror.List{gqlerror.Errorf(e.Error())}
+		return x.GqlErrorList{&x.GqlError{Message: e.Error()}}
 	}
+}
+
+func toGqlError(err *gqlerror.Error) *x.GqlError {
+	return &x.GqlError{
+		Message:   err.Message,
+		Locations: convertLocations(err.Locations),
+		Path:      err.Path,
+	}
+}
+
+func toGqlErrorList(errs gqlerror.List) x.GqlErrorList {
+	var result x.GqlErrorList
+	for _, err := range errs {
+		result = append(result, toGqlError(err))
+	}
+	return result
+}
+
+func convertLocations(locs []gqlerror.Location) []x.Location {
+	var result []x.Location
+	for _, loc := range locs {
+		result = append(result, x.Location{Line: loc.Line, Column: loc.Column})
+	}
+	return result
 }
 
 // GQLWrapf takes an existing error and wraps it as a GraphQL error.
@@ -67,23 +120,15 @@ func GQLWrapf(err error, format string, args ...interface{}) error {
 		return nil
 	}
 
-	wrapped := &gqlableError{
-		gqlErr: gqlerror.Errorf(format, args...),
+	return &gqlableError{
+		gqlErr: &x.GqlError{Message: fmt.Sprintf(format, args...)},
 		cause:  err,
 	}
-
-	if gqlErr, ok := err.(*gqlableError); ok {
-		wrapped.gqlErr.Locations = gqlErr.gqlErr.Locations
-	} else if gqlErr, ok := err.(*gqlerror.Error); ok {
-		wrapped.gqlErr.Locations = gqlErr.Locations
-	}
-
-	return wrapped
 }
 
 // GQLWrapLocationf wraps an error as a GraphQL error and includes location
 // information in the GraphQL error.
-func GQLWrapLocationf(err error, line int, col int, format string, args ...interface{}) error {
+func GQLWrapLocationf(err error, loc x.Location, format string, args ...interface{}) error {
 	wrapped := GQLWrapf(err, format, args...)
 	if wrapped == nil {
 		return nil
@@ -95,13 +140,13 @@ func GQLWrapLocationf(err error, line int, col int, format string, args ...inter
 		panic("GQLWrapf didn't result in a gqlableError")
 	}
 	gqlable.gqlErr.Locations =
-		append(gqlable.gqlErr.Locations, gqlerror.Location{Line: line, Column: col})
+		append(gqlable.gqlErr.Locations, loc)
 
 	return gqlable
 }
 
 // Cause returns the underlying cause of an error.  If it's a GQLWrapf'd
-// error, the wraping is unwound to the orriginal cause, otherwise, the
+// error, the wraping is unwound to the original cause, otherwise, the
 // cause is err.
 func Cause(err error) error {
 	if gqlErr, ok := err.(*gqlableError); ok {

--- a/dgraph/cmd/graphql/schema/errors_test.go
+++ b/dgraph/cmd/graphql/schema/errors_test.go
@@ -111,8 +111,8 @@ func TestGQLWrapf_IsAlwaysgqlableError(t *testing.T) {
 	tests := []struct {
 		err error
 	}{
-		{GQLWrapf(errors.New("An error occured"), "mutation failed")},
-		{GQLWrapf(GQLWrapf(errors.New("A Dgraph error occured"), "couldn't check ID type"),
+		{GQLWrapf(errors.New("An error occurred"), "mutation failed")},
+		{GQLWrapf(GQLWrapf(errors.New("A Dgraph error occurred"), "couldn't check ID type"),
 			"delete mutation failed")},
 		{GQLWrapf(x.GqlErrorf("of bad GraphQL input"), "couldn't generate query")},
 	}

--- a/dgraph/cmd/graphql/schema/request.go
+++ b/dgraph/cmd/graphql/schema/request.go
@@ -17,8 +17,9 @@
 package schema
 
 import (
+	"github.com/pkg/errors"
+
 	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/gqlerror"
 	"github.com/vektah/gqlparser/parser"
 	"github.com/vektah/gqlparser/validator"
 )
@@ -37,7 +38,7 @@ type Request struct {
 // operation, all GraphQL errors encountered are returned.
 func (s *schema) Operation(req *Request) (Operation, error) {
 	if req == nil || req.Query == "" {
-		return nil, gqlerror.Errorf("no query string supplied in request")
+		return nil, errors.New("no query string supplied in request")
 	}
 
 	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: req.Query})
@@ -52,7 +53,7 @@ func (s *schema) Operation(req *Request) (Operation, error) {
 
 	op := doc.Operations.ForName(req.OperationName)
 	if op == nil {
-		return nil, gqlerror.Errorf("unable to find operation to resolve")
+		return nil, errors.New("unable to find operation to resolve")
 	}
 
 	vars, gqlErr := validator.VariableValues(s.schema, op, req.Variables)

--- a/dgraph/cmd/graphql/schema/response.go
+++ b/dgraph/cmd/graphql/schema/response.go
@@ -19,12 +19,12 @@ package schema
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-
-	"github.com/vektah/gqlparser/gqlerror"
 )
 
 // GraphQL spec on response is here:
@@ -35,13 +35,7 @@ import (
 
 // Response represents a GraphQL response
 type Response struct {
-	// Dgraph response type (x.go) is similar, should I be leaning on that?
-	// ATM, no, cause I'm trying to follow the spec really closely, e.g:
-	// - spec error format is different to x.errRes
-	// - I think we should mostly return 200 status code
-	// - for spec we need to return errors and data in same response
-
-	Errors     gqlerror.List
+	Errors     x.GqlErrorList
 	Data       bytes.Buffer
 	Extensions *Extensions
 }
@@ -52,20 +46,20 @@ type Extensions struct {
 	RequestID string `json:"requestID,omitempty"`
 }
 
-// ErrorResponsef returns a Response containing a single GraphQL error with a
-// message obtained by Sprintf-ing the argugments
-func ErrorResponsef(format string, args ...interface{}) *Response {
+// ErrorResponse formats an error as a list of GraphQL errors and builds
+// a response with that error list and no data.  Because it doesn't add data, it
+// should be used before starting execution - GraphQL spec requires no data if an
+// error is detected before execution begins.
+func ErrorResponse(err error, requestID string) *Response {
 	return &Response{
-		Errors: gqlerror.List{gqlerror.Errorf(format, args...)},
+		Errors:     AsGQLErrors(err),
+		Extensions: &Extensions{RequestID: requestID},
 	}
 }
 
-// ErrorResponse formats an error as a list of GraphQL errors and builds
-// a response with that error list and no data.
-func ErrorResponse(err error) *Response {
-	return &Response{
-		Errors: AsGQLErrors(err),
-	}
+// WithError generates GraphQL errors from err and records those in r.
+func (r *Response) WithError(err error) {
+	r.Errors = append(r.Errors, AsGQLErrors(err)...)
 }
 
 // AddData adds p to r's data buffer.  If p is empty, the call has no effect.
@@ -96,13 +90,13 @@ func (r *Response) AddData(p []byte) {
 func (r *Response) WriteTo(w io.Writer) (int64, error) {
 	if r == nil {
 		i, err := w.Write([]byte(
-			`{ "errors": [ { "message": "Internal error - no response to write." } ], ` +
-				` "data": null }`))
+			`{ "errors": [{"message": "Internal error - no response to write."}], ` +
+				` "data": null, "extensions": { "requestID": "unknown request ID" } }`))
 		return int64(i), err
 	}
 
 	js, err := json.Marshal(struct {
-		Errors     gqlerror.List   `json:"errors,omitempty"`
+		Errors     []*x.GqlError   `json:"errors,omitempty"`
 		Data       json.RawMessage `json:"data,omitempty"`
 		Extensions *Extensions     `json:"extensions,omitempty"`
 	}{
@@ -112,9 +106,17 @@ func (r *Response) WriteTo(w io.Writer) (int64, error) {
 	})
 
 	if err != nil {
+		var reqID string
+		if r.Extensions != nil {
+			reqID = r.Extensions.RequestID
+		} else {
+			reqID = "unknown request ID"
+		}
 		msg := "Internal error - failed to marshal a valid JSON response"
-		glog.Errorf("%+v", errors.Wrap(err, msg))
-		js = []byte(`{ "errors": [ { "message": "` + msg + `" } ], "data": null }`)
+		glog.Errorf("[%s] %+v", reqID, errors.Wrap(err, msg))
+		js = []byte(fmt.Sprintf(
+			`{ "errors": [{"message": "%s"}], "data": null, "extensions": { "requestID": "%s" } }`,
+			msg, reqID))
 	}
 
 	i, err := w.Write(js)

--- a/dgraph/cmd/graphql/schema/response_test.go
+++ b/dgraph/cmd/graphql/schema/response_test.go
@@ -20,48 +20,211 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/vektah/gqlparser/gqlerror"
 )
 
-func TestAddData_AddInitial(t *testing.T) {
-	resp := &Response{}
+func TestDataAndErrors(t *testing.T) {
 
-	resp.AddData([]byte(`"Some": "Data"`))
-	buf := new(bytes.Buffer)
-	resp.WriteTo(buf)
+	tests := map[string]struct {
+		data     []string
+		errors   []error
+		expected string
+	}{
+		"empty response": {
+			data:     nil,
+			errors:   nil,
+			expected: `{"extensions": { "requestID": "reqID"}}`,
+		},
+		"add initial": {
+			data:     []string{`"Some": "Data"`},
+			errors:   nil,
+			expected: `{"data": {"Some": "Data"}, "extensions": { "requestID": "reqID"}}`,
+		},
+		"add nothing": {
+			data:     []string{`"Some": "Data"`, ""},
+			errors:   nil,
+			expected: `{"data": {"Some": "Data"}, "extensions": { "requestID": "reqID"}}`,
+		},
+		"add more": {
+			data:   []string{`"Some": "Data"`, `"And": "More"`},
+			errors: nil,
+			expected: `{
+				"data": {"Some": "Data", "And": "More"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+		"errors and data": {
+			data:   []string{`"Some": "Data"`, `"And": "More"`},
+			errors: []error{errors.New("An Error")},
+			expected: `{
+				"errors":[{"message":"An Error"}],
+				"data": {"Some": "Data", "And": "More"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+		"many errors": {
+			data:   []string{`"Some": "Data"`},
+			errors: []error{errors.New("An Error"), errors.New("Another Error")},
+			expected: `{
+				"errors":[{"message":"An Error"}, {"message":"Another Error"}],
+				"data": {"Some": "Data"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+		"gql error": {
+			data: []string{`"Some": "Data"`},
+			errors: []error{
+				&x.GqlError{Message: "An Error", Locations: []x.Location{{Line: 1, Column: 1}}}},
+			expected: `{
+				"errors":[{"message":"An Error", "locations": [{"line":1,"column":1}]}],
+				"data": {"Some": "Data"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+		"gql error with path": {
+			data: []string{`"Some": "Data"`},
+			errors: []error{
+				&x.GqlError{
+					Message:   "An Error",
+					Locations: []x.Location{{Line: 1, Column: 1}},
+					Path:      []interface{}{"q", 2, "n"}}},
+			expected: `{
+				"errors":[{
+					"message":"An Error", 
+					"locations": [{"line":1,"column":1}],
+					"path": ["q", 2, "n"]}],
+				"data": {"Some": "Data"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+		"gql error list": {
+			data: []string{`"Some": "Data"`},
+			errors: []error{x.GqlErrorList{
+				&x.GqlError{Message: "An Error", Locations: []x.Location{{Line: 1, Column: 1}}},
+				&x.GqlError{Message: "Another Error", Locations: []x.Location{{Line: 1, Column: 1}}}}},
+			expected: `{
+				"errors":[
+					{"message":"An Error", "locations": [{"line":1,"column":1}]}, 
+					{"message":"Another Error", "locations": [{"line":1,"column":1}]}],
+				"data": {"Some": "Data"}, 
+				"extensions": { "requestID": "reqID"}}`,
+		},
+	}
 
-	assert.JSONEq(t, `{"data": {"Some": "Data"}}`, buf.String())
+	for name, tcase := range tests {
+		t.Run(name, func(t *testing.T) {
+			resp := &Response{Extensions: &Extensions{RequestID: "reqID"}}
+
+			for _, d := range tcase.data {
+				resp.AddData([]byte(d))
+			}
+			for _, e := range tcase.errors {
+				resp.WithError(e)
+			}
+
+			buf := new(bytes.Buffer)
+			resp.WriteTo(buf)
+
+			assert.JSONEq(t, tcase.expected, buf.String())
+		})
+	}
 }
 
-func TestAddData_AddNothing(t *testing.T) {
-	resp := &Response{}
-
-	resp.AddData([]byte(`"Some": "Data"`))
-	resp.AddData([]byte{})
-	buf := new(bytes.Buffer)
-	resp.WriteTo(buf)
-
-	assert.JSONEq(t, `{"data": {"Some": "Data"}}`, buf.String())
-}
-func TestAddData_AddMore(t *testing.T) {
-	resp := &Response{}
-
-	resp.AddData([]byte(`"Some": "Data"`))
-	resp.AddData([]byte(`"And": "More"`))
-	buf := new(bytes.Buffer)
-	resp.WriteTo(buf)
-
-	assert.JSONEq(t, `{"data": {"Some": "Data", "And": "More"}}`, buf.String())
-}
-
-func TestWriteTo_ErrorsAndData(t *testing.T) {
-	resp := &Response{Errors: gqlerror.List{gqlerror.Errorf("An Error")}}
-	resp.AddData([]byte(`"Some": "Data"`))
+func TestWriteTo_BadDataWithReqID(t *testing.T) {
+	resp := &Response{Extensions: &Extensions{RequestID: "reqID"}}
+	resp.AddData([]byte(`"not json"`))
 
 	buf := new(bytes.Buffer)
 	resp.WriteTo(buf)
 
 	assert.JSONEq(t,
-		`{"errors":[{"message":"An Error"}], "data": {"Some": "Data"}}`, buf.String())
+		`{"errors":[{"message":"Internal error - failed to marshal a valid JSON response"}], 
+		"data": null, 
+		"extensions": { "requestID": "reqID"}}`,
+		buf.String())
+}
+
+func TestWriteTo_BadData(t *testing.T) {
+	resp := &Response{}
+	resp.AddData([]byte(`"not json"`))
+
+	buf := new(bytes.Buffer)
+	resp.WriteTo(buf)
+
+	assert.JSONEq(t,
+		`{"errors":[{"message":"Internal error - failed to marshal a valid JSON response"}], 
+		"data": null, 
+		"extensions": { "requestID": "unknown request ID"}}`,
+		buf.String())
+}
+
+func TestErrorResponse(t *testing.T) {
+
+	tests := map[string]struct {
+		err      error
+		expected string
+	}{
+		"an error": {
+			err:      errors.New("An Error"),
+			expected: `{"errors":[{"message":"An Error"}], "extensions": {"requestID":"reqID"}}`,
+		},
+
+		"an x.GqlError": {
+			err: x.GqlErrorf("A GraphQL error").
+				WithLocations(x.Location{Line: 1, Column: 2}),
+			expected: `{"errors":[{"message": "A GraphQL error", "locations": [{"column":2, "line":1}]}],
+		"extensions": {"requestID":"reqID"}}`},
+		"an x.GqlErrorList": {
+			err: x.GqlErrorList{
+				x.GqlErrorf("A GraphQL error"),
+				x.GqlErrorf("Another GraphQL error").WithLocations(x.Location{Line: 1, Column: 2})},
+			expected: `{"errors":[
+				{"message":"A GraphQL error"}, 
+				{"message":"Another GraphQL error", "locations": [{"column":2, "line":1}]}],
+				"extensions": {"requestID":"reqID"}}`},
+		"a gqlerror": {
+			err: &gqlerror.Error{
+				Message:   "A GraphQL error",
+				Locations: []gqlerror.Location{{Line: 1, Column: 2}}},
+			expected: `{
+				"errors":[{"message":"A GraphQL error", "locations": [{"line":1,"column":2}]}], 
+				"extensions": {"requestID":"reqID"}}`,
+		},
+		"a list of gql errors": {
+			err: gqlerror.List{
+				gqlerror.Errorf("A GraphQL error"),
+				&gqlerror.Error{
+					Message:   "Another GraphQL error",
+					Locations: []gqlerror.Location{{Line: 1, Column: 2}}}},
+			expected: `{"errors":[
+				{"message":"A GraphQL error"}, 
+				{"message":"Another GraphQL error", "locations": [{"line":1,"column":2}]}], 
+				"extensions": {"requestID":"reqID"}}`,
+		},
+	}
+
+	for name, tcase := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// ErrorResponse doesn't add data - it should only be called before starting
+			// execution - so in all cases no data should be present.
+			resp := ErrorResponse(tcase.err, "reqID")
+
+			buf := new(bytes.Buffer)
+			resp.WriteTo(buf)
+
+			assert.JSONEq(t, tcase.expected, buf.String())
+		})
+	}
+}
+
+func TestNilResponse(t *testing.T) {
+	var resp *Response
+
+	buf := new(bytes.Buffer)
+	resp.WriteTo(buf)
+
+	assert.JSONEq(t,
+		`{"errors":[{"message":"Internal error - no response to write."}], 
+		"data": null, 
+		"extensions": {"requestID":"unknown request ID"}}`,
+		buf.String())
 }

--- a/x/x.go
+++ b/x/x.go
@@ -190,9 +190,11 @@ func (gqlErr *GqlError) Error() string {
 
 func (errList GqlErrorList) Error() string {
 	var buf bytes.Buffer
-	for _, gqlErr := range errList {
+	for i, gqlErr := range errList {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
 		buf.WriteString(gqlErr.Error())
-		buf.WriteByte('\n')
 	}
 	return buf.String()
 }

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -94,3 +94,34 @@ func TestValidateAddress(t *testing.T) {
 		}
 	})
 }
+
+func TestGqlError(t *testing.T) {
+	tests := map[string]struct {
+		err error
+		req string
+	}{
+		"GqlError": {
+			err: GqlErrorf("A GraphQL error"),
+			req: "A GraphQL error",
+		},
+		"GqlError with a location": {
+			err: GqlErrorf("A GraphQL error").WithLocations(Location{Line: 1, Column: 8}),
+			req: "A GraphQL error (Locations: [{Line: 1, Column: 8}])",
+		},
+		"GqlError with many locations": {
+			err: GqlErrorf("A GraphQL error").
+				WithLocations(Location{Line: 1, Column: 2}, Location{Line: 1, Column: 8}),
+			req: "A GraphQL error (Locations: [{Line: 1, Column: 2}, {Line: 1, Column: 8}])",
+		},
+		"GqlErrorList": {
+			err: GqlErrorList{GqlErrorf("A GraphQL error"), GqlErrorf("Another GraphQL error")},
+			req: "A GraphQL error\nAnother GraphQL error\n",
+		},
+	}
+
+	for name, tcase := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, tcase.req, tcase.err.Error())
+		})
+	}
+}

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -115,7 +115,7 @@ func TestGqlError(t *testing.T) {
 		},
 		"GqlErrorList": {
 			err: GqlErrorList{GqlErrorf("A GraphQL error"), GqlErrorf("Another GraphQL error")},
-			req: "A GraphQL error\nAnother GraphQL error\n",
+			req: "A GraphQL error\nAnother GraphQL error",
 		},
 	}
 


### PR DESCRIPTION
We started with the gql parser gqlerror, but the intention was always to add an error type to x package and use that instead.

Now that there's an x.GqlError, this PR moves our error handling to that error type.

This also has the side effect of making error output more friendly - e.g. gqlerror put "input: ..." in front of all the composed errors, which wasn't nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4123)
<!-- Reviewable:end -->
