### PR TITLE
Fix panic handling in GraphQL layer

### DIFF
--- a/dgraph/cmd/graphql/api/panics.go
+++ b/dgraph/cmd/graphql/api/panics.go
@@ -28,13 +28,13 @@ import (
 //
 // If PanicHandler recovers from a panic, it logs a stack trace, creates an error
 // and applies fn to the error.
-func PanicHandler(reqestID string, fn func(error)) {
+func PanicHandler(requestID string, fn func(error)) {
 	if err := recover(); err != nil {
-		glog.Errorf("[%s] panic: %s.\n trace: %s", reqestID, err, string(debug.Stack()))
+		glog.Errorf("[%s] panic: %s.\n trace: %s", requestID, err, string(debug.Stack()))
 
 		fn(errors.Errorf("[%s] Internal Server Error - a panic was trapped.  "+
 			"This indicates a bug in the GraphQL server.  A stack trace was logged.  "+
 			"Please let us know : https://github.com/dgraph-io/dgraph/issues.",
-			reqestID))
+			requestID))
 	}
 }

--- a/dgraph/cmd/graphql/api/panics.go
+++ b/dgraph/cmd/graphql/api/panics.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package api
+
+import (
+	"runtime/debug"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+// PanicHandler catches panics to make sure that we recover from panics during
+// GraphQL request execution and return an appropriate error.
+//
+// If PanicHandler recovers from a panic, it logs a stack trace, creates an error
+// and applies fn to the error.
+func PanicHandler(reqestID string, fn func(error)) {
+	if err := recover(); err != nil {
+		glog.Errorf("[%s] panic: %s.\n trace: %s", reqestID, err, string(debug.Stack()))
+
+		fn(errors.Errorf("[%s] Internal Server Error - a panic was trapped.  "+
+			"This indicates a bug in the GraphQL server.  A stack trace was logged.  "+
+			"Please let us know : https://github.com/dgraph-io/dgraph/issues.",
+			reqestID))
+	}
+}

--- a/dgraph/cmd/graphql/e2e_error_test.go
+++ b/dgraph/cmd/graphql/e2e_error_test.go
@@ -34,7 +34,7 @@ import (
 // bug triggers a panic.  Here, this is mocked up with httptest and a dgraph package
 // that just panics.
 //
-// Not really an e2e test cause it uses httptest and mocs up a panicing Dgraph, but
+// Not really an e2e test cause it uses httptest and mocks up a panicing Dgraph, but
 // uses all the e2e infrastructure.
 func TestPanicCatcher(t *testing.T) {
 

--- a/dgraph/cmd/graphql/e2e_error_test.go
+++ b/dgraph/cmd/graphql/e2e_error_test.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/test"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
+	"github.com/dgraph-io/dgraph/gql"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPanicCatcher tests that the GraphQL server behaves properly when an internal
+// bug triggers a panic.  Here, this is mocked up with httptest and a dgraph package
+// that just panics.
+//
+// Not really an e2e test cause it uses httptest and mocs up a panicing Dgraph, but
+// uses all the e2e infrastructure.
+func TestPanicCatcher(t *testing.T) {
+
+	// queries and mutations have different panic paths.
+	//
+	// Because queries run concurrently in their own goroutine, any panics are
+	// caught by a panic handler deferred when starting those goroutines.
+	//
+	// Mutations run serially in the same goroutine as the original http handler,
+	// so a panic here is caught by the panic catching http handler that wraps
+	// the http stack.
+
+	tests := map[string]*GraphQLParams{
+		"query": &GraphQLParams{Query: `query { queryCountry { name } }`},
+		"mutation": &GraphQLParams{
+			Query: `mutation {
+						addCountry(input: { name: "A Country" }) { country { id } }
+					}`,
+		},
+	}
+
+	gqlSchema := test.LoadSchemaFromFile(t, "e2e_test_schema.graphql")
+
+	handler := web.GraphQLHTTPHandler(
+		gqlSchema,
+		&panicClient{},
+		dgraph.NewQueryRewriter(),
+		dgraph.NewMutationRewriter())
+
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			gqlResponse := test.ExecuteAsPost(t, ts.URL)
+
+			require.Equal(t, x.GqlErrorList{
+				{Message: fmt.Sprintf("[%s] Internal Server Error - a panic was trapped.  "+
+					"This indicates a bug in the GraphQL server.  A stack trace was logged.  "+
+					"Please let us know : https://github.com/dgraph-io/dgraph/issues.",
+					gqlResponse.Extensions["requestID"].(string))}},
+				gqlResponse.Errors)
+
+			require.Nil(t, gqlResponse.Data)
+		})
+	}
+}
+
+type panicClient struct{}
+
+func (dg *panicClient) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
+	panic("bugz!!!")
+}
+
+func (dg *panicClient) Mutate(ctx context.Context, val interface{}) (map[string]string, error) {
+	panic("bugz!!!")
+}
+
+func (dg *panicClient) DeleteNodes(ctx context.Context, query, mutation string) error {
+	panic("bugz!!!")
+}

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -460,7 +460,7 @@ func deleteCountry(
 	t *testing.T,
 	filter map[string]interface{},
 	deleteCountryExpected string,
-	expectedErrors []*x.GqlError) {
+	expectedErrors x.GqlErrorList) {
 
 	deleteCountryParams := &GraphQLParams{
 		Query: `mutation deleteCountry($filter: CountryFilter!) {
@@ -481,7 +481,7 @@ func deleteAuthor(
 	t *testing.T,
 	authorID string,
 	deleteAuthorExpected string,
-	expectedErrors []*x.GqlError) {
+	expectedErrors x.GqlErrorList) {
 
 	deleteAuthorParams := &GraphQLParams{
 		Query: `mutation deleteAuthor($filter: AuthorFilter!) {
@@ -507,7 +507,7 @@ func deletePost(
 	t *testing.T,
 	postID string,
 	deletePostExpected string,
-	expectedErrors []*x.GqlError) {
+	expectedErrors x.GqlErrorList) {
 
 	deletePostParams := &GraphQLParams{
 		Query: `mutation deletePost($filter: PostFilter!) {
@@ -539,7 +539,7 @@ func TestDeleteWrongID(t *testing.T) {
 	newAuthor := addAuthor(t, newCountry.ID)
 
 	expectedData := `{ "deleteCountry": null }`
-	expectedErrors := []*x.GqlError{
+	expectedErrors := x.GqlErrorList{
 		&x.GqlError{Message: `input: couldn't complete deleteCountry because ` +
 			fmt.Sprintf(`input: Node with id %s is not of type Country`, newAuthor.ID)}}
 
@@ -742,7 +742,7 @@ func TestManyMutationsWithQueryError(t *testing.T) {
 		"add3": { "country": { "id": "_UID_", "name": "abc" } }
 	}`, newCountry.ID)
 
-	expectedErrors := []*x.GqlError{
+	expectedErrors := x.GqlErrorList{
 		&x.GqlError{Message: `Non-nullable field 'name' (type String!) was not present ` +
 			`in result from Dgraph.  GraphQL error propagation triggered.`,
 			Locations: []x.Location{{Line: 18, Column: 7}},

--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -77,7 +77,7 @@ type GraphQLParams struct {
 // see https://graphql.github.io/graphql-spec/June2018/#sec-Response
 type GraphQLResponse struct {
 	Data       json.RawMessage        `json:"data,omitempty"`
-	Errors     []*x.GqlError          `json:"errors,omitempty"`
+	Errors     x.GqlErrorList         `json:"errors,omitempty"`
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -176,6 +176,10 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 
 			go func(q schema.Query, storeAt int) {
 				defer wg.Done()
+				defer api.PanicHandler(api.RequestID(ctx),
+					func(err error) {
+						allResolved[storeAt] = &resolved{err: err}
+					})
 
 				allResolved[storeAt] = (&queryResolver{
 					query:         q,

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
+
 	"github.com/dgraph-io/dgo"
 	dgoapi "github.com/dgraph-io/dgo/protos/api"
 	"github.com/dgraph-io/dgraph/x"
@@ -41,7 +44,6 @@ import (
 	"github.com/vektah/gqlparser/validator"
 	_ "github.com/vektah/gqlparser/validator/rules" // make gql validator init() all rules
 
-	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 )
 
@@ -172,12 +174,12 @@ func run() error {
 		return errors.Wrap(gqlErr, "while validating GraphQL schema")
 	}
 
-	handler := &graphqlHandler{
-		dgraphClient: dgraphClient,
-		schema:       schema.AsSchema(gqlSchema),
-	}
-
-	http.Handle("/graphql", recoveryHandler(api.WithRequestID(handler)))
+	http.Handle("/graphql",
+		web.GraphQLHTTPHandler(
+			schema.AsSchema(gqlSchema),
+			dgraph.AsDgraph(dgraphClient),
+			dgraph.NewQueryRewriter(),
+			dgraph.NewMutationRewriter()))
 
 	trace.ApplyConfig(trace.Config{
 		DefaultSampler:             trace.ProbabilitySampler(GraphQL.Conf.GetFloat64("trace")),

--- a/dgraph/cmd/graphql/web/http.go
+++ b/dgraph/cmd/graphql/web/http.go
@@ -14,19 +14,17 @@
  * limitations under the License.
  */
 
-package graphql
+package web
 
 import (
 	"encoding/json"
 	"fmt"
 	"mime"
 	"net/http"
-	"runtime/debug"
 
 	"github.com/golang/glog"
 	"go.opencensus.io/trace"
 
-	"github.com/dgraph-io/dgo"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/resolve"
@@ -35,31 +33,27 @@ import (
 	"github.com/pkg/errors"
 )
 
-func recoveryHandler(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			// This function makes sure that we recover from panics during execution of the request
-			// and return appropriate error to the user.
-			if err := recover(); err != nil {
-				glog.Errorf("panic: %s while executing request with ID: %s, trace: %s", err,
-					api.RequestID(r.Context()), string(debug.Stack()))
-				rr := schema.ErrorResponse(
-					errors.New("Internal Server Error"),
-					api.RequestID(r.Context()))
-				w.Header().Set("Content-Type", "application/json")
-				if _, err := rr.WriteTo(w); err != nil {
-					glog.Error(err)
-				}
-			}
-		}()
-
-		next.ServeHTTP(w, r)
-	})
+type graphqlHandler struct {
+	schema           schema.Schema
+	dgraphClient     dgraph.Client
+	queryRewriter    dgraph.QueryRewriter
+	mutationRewriter dgraph.MutationRewriter
 }
 
-type graphqlHandler struct {
-	dgraphClient *dgo.Dgraph
-	schema       schema.Schema
+// GraphQLHTTPHandler returns a http.Handler that serves GraphQL.
+func GraphQLHTTPHandler(
+	schema schema.Schema,
+	dgraphClient dgraph.Client,
+	queryRewriter dgraph.QueryRewriter,
+	mutationRewriter dgraph.MutationRewriter) http.Handler {
+
+	return api.WithRequestID(recoveryHandler(
+		&graphqlHandler{
+			schema:           schema,
+			dgraphClient:     dgraphClient,
+			queryRewriter:    queryRewriter,
+			mutationRewriter: mutationRewriter,
+		}))
 }
 
 // ServeHTTP handles GraphQL queries and mutations that get resolved
@@ -91,15 +85,12 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (gh *graphqlHandler) isValid() bool {
-	return !(gh == nil || gh.schema == nil || gh.dgraphClient == nil)
+	return !(gh == nil || gh.schema == nil || gh.dgraphClient == nil ||
+		gh.queryRewriter == nil || gh.mutationRewriter == nil)
 }
 
 func (gh *graphqlHandler) resolverForRequest(r *http.Request) (*resolve.RequestResolver, error) {
-	rr := resolve.New(
-		gh.schema,
-		dgraph.AsDgraph(gh.dgraphClient),
-		dgraph.NewQueryRewriter(),
-		dgraph.NewMutationRewriter())
+	rr := resolve.New(gh.schema, gh.dgraphClient, gh.queryRewriter, gh.mutationRewriter)
 
 	switch r.Method {
 	case http.MethodGet:
@@ -131,4 +122,21 @@ func (gh *graphqlHandler) resolverForRequest(r *http.Request) (*resolve.RequestR
 	}
 
 	return rr, nil
+}
+
+func recoveryHandler(next http.Handler) http.Handler {
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqID := api.RequestID(r.Context())
+		defer api.PanicHandler(reqID,
+			func(err error) {
+				rr := schema.ErrorResponse(err, reqID)
+				w.Header().Set("Content-Type", "application/json")
+				if _, err = rr.WriteTo(w); err != nil {
+					glog.Errorf("[%s] %s", reqID, err)
+				}
+			})
+
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
We have a panic handler at the top of the http handler stack to catch any bugs and make sure the server doesn't crash.  

But it doesn't work because there's also goroutines in the pipeline, so some bugs would still crash the server.

This PR fixes that panic catching and refactors how the http handlers are created so that this aspect of the server can be testable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4126)
<!-- Reviewable:end -->
