### PR TITLE
fix mutation paths

### DIFF
--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -746,7 +746,7 @@ func TestManyMutationsWithQueryError(t *testing.T) {
 		&x.GqlError{Message: `Non-nullable field 'name' (type String!) was not present ` +
 			`in result from Dgraph.  GraphQL error propagation triggered.`,
 			Locations: []x.Location{{Line: 18, Column: 7}},
-			Path:      []interface{}{"author", "country", "name"}}}
+			Path:      []interface{}{"add2", "author", "country", "name"}}}
 
 	gqlResponse := multiMutationParams.ExecuteAsPost(t, graphqlURL)
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -132,6 +132,10 @@ func (mr *mutationResolver) resolve(ctx context.Context) (*resolved, bool) {
 				"Only add, delete and update mutations are implemented")}, mutationFailed
 	}
 
+	// Mutations have an extra element to their result path.  Because the mutation
+	// always looks like `addBlaa(...) { blaa { ... } }` and what's resolved above
+	// is the `blaa { ... }`, both the result and any error paths need a prefox
+	// of `addBlaa`
 	var b bytes.Buffer
 	b.WriteRune('"')
 	b.WriteString(mr.mutation.ResponseName())
@@ -141,8 +145,18 @@ func (mr *mutationResolver) resolve(ctx context.Context) (*resolved, bool) {
 	} else {
 		b.WriteString("null")
 	}
-
 	res.data = b.Bytes()
+
+	resErrs := schema.AsGQLErrors(res.err)
+	var errs x.GqlErrorList = make([]*x.GqlError, len(resErrs))
+	for i, err := range resErrs {
+		if len(err.Path) > 0 {
+			err.Path = append([]interface{}{mr.mutation.ResponseName()}, err.Path...)
+		}
+		errs[i] = err
+	}
+	res.err = errs
+
 	return res, mutationSucceeded
 }
 

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -134,7 +134,7 @@ func (mr *mutationResolver) resolve(ctx context.Context) (*resolved, bool) {
 
 	// Mutations have an extra element to their result path.  Because the mutation
 	// always looks like `addBlaa(...) { blaa { ... } }` and what's resolved above
-	// is the `blaa { ... }`, both the result and any error paths need a prefox
+	// is the `blaa { ... }`, both the result and any error paths need a prefix
 	// of `addBlaa`
 	var b bytes.Buffer
 	b.WriteRune('"')

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -278,7 +278,7 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 				Message: `Non-nullable field 'name' (type String!) ` +
 					`was not present in result from Dgraph.  GraphQL error propagation triggered.`,
 				Locations: []x.Location{{Column: 6, Line: 7}},
-				Path:      []interface{}{"post", "author", "name"}}},
+				Path:      []interface{}{"addPost", "post", "author", "name"}}},
 		},
 	}
 
@@ -343,7 +343,7 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 				Message: `Non-nullable field 'name' (type String!) ` +
 					`was not present in result from Dgraph.  GraphQL error propagation triggered.`,
 				Locations: []x.Location{{Column: 6, Line: 7}},
-				Path:      []interface{}{"post", "author", "name"}}},
+				Path:      []interface{}{"updatePost", "post", "author", "name"}}},
 		},
 	}
 


### PR DESCRIPTION
Fixes a small bug that means the path array for errors in mutations didn't include the actual response name.

was accidentally push straight to the main branch ... so I reverted that and then reverted the reverts here :-(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4129)
<!-- Reviewable:end -->
