### PR TITLE
Add some e2e GraphQL validation tests

### DIFF
--- a/dgraph/cmd/graphql/e2e_error_test.go
+++ b/dgraph/cmd/graphql/e2e_error_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+type ErrorCase struct {
+	Name       string
+	GQLRequest string
+	variables  map[string]interface{}
+	Errors     x.GqlErrorList
+}
+
+// TestRequestValidationErrors just makes sure we are catching validation failures.
+// Mostly this is provided by an external lib, so just checking we hit common cases.
+func TestRequestValidationErrors(t *testing.T) {
+	b, err := ioutil.ReadFile("e2e_error_test.yaml")
+	require.NoError(t, err, "Unable to read test file")
+
+	var tests []ErrorCase
+	err = yaml.Unmarshal(b, &tests)
+	require.NoError(t, err, "Unable to unmarshal test cases from yaml.")
+
+	for _, tcase := range tests {
+		t.Run(tcase.Name, func(t *testing.T) {
+			test := &GraphQLParams{
+				Query:     tcase.GQLRequest,
+				Variables: tcase.variables,
+			}
+			gqlResponse := test.ExecuteAsPost(t, graphqlURL)
+
+			require.Nil(t, gqlResponse.Data)
+			if diff := cmp.Diff(tcase.Errors, gqlResponse.Errors); diff != "" {
+				t.Errorf("errors mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/dgraph/cmd/graphql/e2e_error_test.yaml
+++ b/dgraph/cmd/graphql/e2e_error_test.yaml
@@ -1,0 +1,88 @@
+-
+  name: "Unknown root field"
+  gqlrequest: |
+    query {
+      getAuthorszzz(id: "0x1") { name }
+    }
+  gqlvariables: 
+    { }
+  errors:
+    [ { "message": "Cannot query field \"getAuthorszzz\" on type \"Query\". Did you mean \"getAuthor\"?",
+      "locations": [ { "line": 2, "column": 3 } ] } ]
+    
+-
+  name: "Unknown field"
+  gqlrequest: |
+    query {
+      getAuthor(id: "0x1") { 
+        namezzz 
+      }
+    }
+  gqlvariables: 
+    { }
+  errors:
+    [ { "message": "Cannot query field \"namezzz\" on type \"Author\". Did you mean \"name\"?",
+      "locations": [ { "line": 3, "column": 5 } ] } ]
+
+-
+  name: "Undefined variable"
+  gqlrequest: |
+    query {
+      getAuthor(id: $theID) { name }
+    }
+  gqlvariables: 
+    { }
+  errors:
+    [ { "message": "Variable \"$theID\" is not defined.",
+      "locations": [ { "line": 2, "column": 17 } ] } ]
+
+-
+  name: "input of wrong type"
+  gqlrequest: |
+    query {
+      queryAuthor(filter: { reputation: { le: "hi there" } }) { name }
+    }
+  gqlvariables: 
+    { }
+  errors:
+    [ { "message": "Expected type Float, found \"hi there\".",
+      "locations": [ { "line": 2, "column": 44 } ] } ]
+
+-
+  name: "unkown variable type"
+  gqlrequest: |
+    query queryAuthor($filter: AuthorFiltarzzz!) {
+      queryAuthor(filter: $filter) { name }
+    }
+  gqlvariables: 
+    { "filter": "type was wrong" }
+  errors:
+    [ { "message": "Variable \"$filter\" of type \"AuthorFiltarzzz!\" used in position 
+        expecting type \"AuthorFilter\".",
+      "locations": [ { "line": 2, "column": 23 } ] },
+      { "message": "Unknown type \"AuthorFiltarzzz\".",
+      "locations": [ { "line": 1, "column": 1 } ] } ]
+
+-
+  name: "variable of wrong type"
+  gqlrequest: |
+    query queryAuthor($filter: AuthorFilter!) {
+      queryAuthor(filter: $filter) { name }
+    }
+  gqlvariables: 
+    { "filter": 57 }
+  errors:
+    [ { "message": "must be defined",
+      "path": [ "variable", "filter"] } ]
+
+-
+  name: "variable field of wrong type"
+  gqlrequest: |
+    query queryAuthor($filter: AuthorFilter!) {
+      queryAuthor(filter: $filter) { name }
+    }
+  gqlvariables: 
+    { "filter": { "reputation": { le: "hi there" } } }
+  errors:
+    [ { "message": "must be defined",
+      "path": [ "variable", "filter"] } ]

--- a/dgraph/cmd/graphql/e2e_error_test.yaml
+++ b/dgraph/cmd/graphql/e2e_error_test.yaml
@@ -14,15 +14,13 @@
   name: "Unknown field"
   gqlrequest: |
     query {
-      getAuthor(id: "0x1") { 
-        namezzz 
-      }
+      getAuthor(id: "0x1") { namezzz }
     }
   gqlvariables: 
     { }
   errors:
     [ { "message": "Cannot query field \"namezzz\" on type \"Author\". Did you mean \"name\"?",
-      "locations": [ { "line": 3, "column": 5 } ] } ]
+      "locations": [ { "line": 2, "column": 26 } ] } ]
 
 -
   name: "Undefined variable"
@@ -49,7 +47,7 @@
       "locations": [ { "line": 2, "column": 44 } ] } ]
 
 -
-  name: "unkown variable type"
+  name: "unknown variable type"
   gqlrequest: |
     query queryAuthor($filter: AuthorFiltarzzz!) {
       queryAuthor(filter: $filter) { name }


### PR DESCRIPTION
We don't currently have any testing around validation of GraphQL requests - as in GraphQL validation of the query.  

For us this all comes from a library, so we don't need the extensive testing that's in that, but tests like this for common errors at least show what we are expecting, and if we accidentally deleted the code that validates request, this would show us.

(Note: the CI tests here will fail until https://github.com/dgraph-io/dgraph/pull/4126 is merged through)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4130)
<!-- Reviewable:end -->
