### PR TITLE
light touches on error messages

### DIFF
--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -23,7 +23,7 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/vektah/gqlparser/gqlerror"
+	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 )
 
@@ -71,50 +71,6 @@ const (
 // a bool where true indicates that the mutation itself succeeded and false indicates
 // that some error prevented the actual mutation.
 func (mr *mutationResolver) resolve(ctx context.Context) (*resolved, bool) {
-	// A mutation operation can contain any number of mutation fields.  Those should be executed
-	// serially.
-	// (spec https://graphql.github.io/graphql-spec/June2018/#sec-Normal-and-Serial-Execution)
-	//
-	// The spec is ambigous about what to do in the case of errors during that serial execution
-	// - apparently deliberatly so; see this comment from Lee Byron:
-	// https://github.com/graphql/graphql-spec/issues/277#issuecomment-385588590
-	// and clarification
-	// https://github.com/graphql/graphql-spec/pull/438
-	//
-	// A reasonable interpretation of that is to stop a list of mutations after the first error -
-	// which seems like the natural semantics and is what we enforce here.
-	//
-	// What we aren't following the exact semantics for is the error propagation.
-	// According to the spec
-	// https://graphql.github.io/graphql-spec/June2018/#sec-Executing-Selection-Sets,
-	// https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability
-	// and the commentry here:
-	// https://github.com/graphql/graphql-spec/issues/277
-	//
-	// If we had a schema with:
-	//
-	// type Mutation {
-	// 	 push(val: Int!): Int!
-	// }
-	//
-	// and then ran operation:
-	//
-	//  mutation {
-	// 	  one: push(val: 1)
-	// 	  thirteen: push(val: 13)
-	// 	  two: push(val: 2)
-	//  }
-	//
-	// if `push(val: 13)` fails with an error, then only errors should be returned from the whole
-	// mutation` - because the result value is ! and one of them failed, the error should propagate
-	// to the entire operation. That is, even though `push(val: 1)` succeeded and we already
-	// calculated its result value, we should squash that and return null data and an error.
-	// (nothing in GraphQL says where any transaction or persistence boundries lie)
-	//
-	// We aren't doing that below - we aren't even inspecting if the result type is !.  For now,
-	// we'll return any data we've already calculated and following errors.  However:
-	// TODO: we should be picking through all results and propagating errors according to spec
-	// TODO: and, we should have all mutation return types not have ! so we avoid the above
 
 	var res *resolved
 	var mutationSucceeded bool
@@ -128,8 +84,9 @@ func (mr *mutationResolver) resolve(ctx context.Context) (*resolved, bool) {
 		res, mutationSucceeded = mr.resolveMutation(ctx)
 	default:
 		return &resolved{
-			err: gqlerror.Errorf(
-				"Only add, delete and update mutations are implemented")}, mutationFailed
+			err: errors.Errorf(
+				"Mutation %s was not executed because only add, delete and update "+
+					"mutations are implemented.", mr.mutation.Name())}, mutationFailed
 	}
 
 	var b bytes.Buffer
@@ -158,28 +115,27 @@ func (mr *mutationResolver) resolveMutation(ctx context.Context) (*resolved, boo
 
 	mut, err := mr.mutationRewriter.Rewrite(mr.mutation)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation")
+		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation %s", mr.mutation.Name())
 		return res, mutationFailed
 	}
 
 	assigned, err := mr.dgraph.Mutate(ctx, mut)
 	if err != nil {
-		res.err = schema.GQLWrapLocationf(err,
-			mr.mutation.Location(),
-			"mutation %s failed", mr.mutation.Name())
+		res.err = schema.GQLWrapLocationf(
+			err, mr.mutation.Location(), "mutation %s failed", mr.mutation.Name())
 		return res, mutationFailed
 	}
 
 	dgQuery, err := mr.queryRewriter.FromMutationResult(mr.mutation, assigned)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation %s",
+		res.err = schema.GQLWrapf(err, "couldn't rewrite query for mutation %s",
 			mr.mutation.Name())
 		return res, mutationSucceeded
 	}
 
 	resp, err := mr.dgraph.Query(ctx, dgQuery)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "mutation %s created a node but query failed",
+		res.err = schema.GQLWrapf(err, "mutation %s succeeded but query failed",
 			mr.mutation.Name())
 		return res, mutationSucceeded
 	}
@@ -200,7 +156,7 @@ func (mr *mutationResolver) resolveDeleteMutation(ctx context.Context) (*resolve
 
 	query, mut, err := mr.mutationRewriter.RewriteDelete(mr.mutation)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation")
+		res.err = schema.GQLWrapf(err, "couldn't rewrite mutation %s", mr.mutation.Name())
 		return res, mutationFailed
 	}
 

--- a/dgraph/cmd/graphql/resolve/query.go
+++ b/dgraph/cmd/graphql/resolve/query.go
@@ -60,7 +60,7 @@ func (qr *queryResolver) resolve(ctx context.Context) *resolved {
 
 	dgQuery, err := qr.queryRewriter.Rewrite(qr.query)
 	if err != nil {
-		res.err = schema.GQLWrapf(err, "couldn't rewrite query")
+		res.err = schema.GQLWrapf(err, "couldn't rewrite query %s", qr.query.ResponseName())
 		return res
 	}
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -197,15 +197,24 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 			resp.AddData(res.data)
 		}
 	case op.IsMutation():
-		// Mutations, unlike queries, are handled serially and the results are
-		// not independent: e.g. if one mutation errors, we don't run the
-		// remaining mutations.
+		// A mutation operation can contain any number of mutation fields.  Those should be executed
+		// serially.
+		// (spec https://graphql.github.io/graphql-spec/June2018/#sec-Normal-and-Serial-Execution)
+		//
+		// The spec is ambiguous about what to do in the case of errors during that serial execution
+		// - apparently deliberately so; see this comment from Lee Byron:
+		// https://github.com/graphql/graphql-spec/issues/277#issuecomment-385588590
+		// and clarification
+		// https://github.com/graphql/graphql-spec/pull/438
+		//
+		// A reasonable interpretation of that is to stop a list of mutations after the first error -
+		// which seems like the natural semantics and is what we enforce here.
 		allSuccessful := true
 
 		for _, m := range op.Mutations() {
 			if !allSuccessful {
 				resp.WithError(x.GqlErrorf(
-					"mutation %s was not executed because of a previous error",
+					"Mutation %s was not executed because of a previous error.",
 					m.ResponseName()).
 					WithLocations(m.Location()))
 
@@ -225,7 +234,7 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 			resp.AddData(res.data)
 		}
 	case op.IsSubscription():
-		resp.WithError(errors.New("Subscriptions not yet supported"))
+		resp.WithError(errors.New("Subscriptions not yet supported."))
 	}
 
 	return resp

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -234,7 +234,7 @@ func (r *RequestResolver) Resolve(ctx context.Context) *schema.Response {
 			resp.AddData(res.data)
 		}
 	case op.IsSubscription():
-		resp.WithError(errors.New("Subscriptions not yet supported."))
+		resp.WithError(errors.Errorf("Subscriptions not yet supported."))
 	}
 
 	return resp

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -429,7 +429,7 @@ func TestManyMutationsWithError(t *testing.T) {
 				"add2" : null
 			}`,
 			errors: x.GqlErrorList{
-				&x.GqlError{Message: `couldn't rewrite mutation because ` +
+				&x.GqlError{Message: `couldn't rewrite mutation addPost because ` +
 					`ID argument (hi) was not able to be parsed`},
 				&x.GqlError{Message: `Mutation add3 was not executed because of ` +
 					`a previous error.`,

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -415,8 +415,8 @@ func TestManyMutationsWithError(t *testing.T) {
 				&x.GqlError{Message: `mutation addPost failed because ` +
 					`Dgraph mutation failed because _bad stuff happend_`,
 					Locations: []x.Location{{Line: 6, Column: 4}}},
-				&x.GqlError{Message: `mutation add3 was not executed because of ` +
-					`a previous error`,
+				&x.GqlError{Message: `Mutation add3 was not executed because of ` +
+					`a previous error.`,
 					Locations: []x.Location{{Line: 10, Column: 4}}}},
 		},
 		"Rewriting error": {
@@ -431,8 +431,8 @@ func TestManyMutationsWithError(t *testing.T) {
 			errors: x.GqlErrorList{
 				&x.GqlError{Message: `couldn't rewrite mutation because ` +
 					`ID argument (hi) was not able to be parsed`},
-				&x.GqlError{Message: `mutation add3 was not executed because of ` +
-					`a previous error`,
+				&x.GqlError{Message: `Mutation add3 was not executed because of ` +
+					`a previous error.`,
 					Locations: []x.Location{{Line: 10, Column: 4}}}},
 		},
 	}


### PR DESCRIPTION
Mostly GraphQL error messages are full sentences, intended to help a developer who's made a mistake - they aren't really for display on the screen to end users.  So it's normally best if they contain the error and help in how to fix it or an indication of what went wrong.

For example, you often get things like:

`Cannot query field "names" on type "Author\". Did you mean "name"?`

I'm working towards making all our errors more helpful.  This PR just adds at least the mutation/query name to a few errors ... over the next few weeks as we build more examples over this, I'll keep touching things up as I bump into the error messages to make sure they say helpful things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4135)
<!-- Reviewable:end -->
