### PR TITLE
GraphQL API Headers

### DIFF
--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -210,6 +211,11 @@ func runGQLRequest(req *http.Request) ([]byte, error) {
 	// GraphQL server should always return OK, even when there are errors
 	if status := resp.StatusCode; status != http.StatusOK {
 		return nil, errors.Errorf("unexpected status code: %v", status)
+	}
+
+	// GraphQL server should always set "Content-Type" to "application/json"
+	if strings.ToLower(resp.Header.Get("Content-Type")) != "application/json" {
+		return nil, errors.Errorf("unexpected content type: %v", resp.Header.Get("Content-Type"))
 	}
 
 	defer resp.Body.Close()

--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -213,12 +213,10 @@ func runGQLRequest(req *http.Request) ([]byte, error) {
 		return nil, errors.Errorf("unexpected status code: %v", status)
 	}
 
-	// GraphQL server should always set "Content-Type" to "application/json"
 	if strings.ToLower(resp.Header.Get("Content-Type")) != "application/json" {
 		return nil, errors.Errorf("unexpected content type: %v", resp.Header.Get("Content-Type"))
 	}
 
-	// Cors headers should be set
 	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
 		return nil, errors.Errorf("cors headers weren't set in response")
 	}

--- a/dgraph/cmd/graphql/e2e_test.go
+++ b/dgraph/cmd/graphql/e2e_test.go
@@ -218,6 +218,11 @@ func runGQLRequest(req *http.Request) ([]byte, error) {
 		return nil, errors.Errorf("unexpected content type: %v", resp.Header.Get("Content-Type"))
 	}
 
+	// Cors headers should be set
+	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
+		return nil, errors.Errorf("cors headers weren't set in response")
+	}
+
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/dgraph/cmd/graphql/web/http.go
+++ b/dgraph/cmd/graphql/web/http.go
@@ -125,7 +125,6 @@ func commonHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		x.AddCorsHeaders(w)
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 
 		next.ServeHTTP(w, r)
 	})

--- a/dgraph/cmd/graphql/web/http.go
+++ b/dgraph/cmd/graphql/web/http.go
@@ -47,13 +47,13 @@ func GraphQLHTTPHandler(
 	queryRewriter dgraph.QueryRewriter,
 	mutationRewriter dgraph.MutationRewriter) http.Handler {
 
-	return api.WithRequestID(recoveryHandler(
+	return api.WithRequestID(recoveryHandler(commonHeaders(
 		&graphqlHandler{
 			schema:           schema,
 			dgraphClient:     dgraphClient,
 			queryRewriter:    queryRewriter,
 			mutationRewriter: mutationRewriter,
-		}))
+		})))
 }
 
 // ServeHTTP handles GraphQL queries and mutations that get resolved


### PR DESCRIPTION
Moving common headers to a middleware function.

We'll be adding a couple more handlers and I want to make sure we never miss the bits that should always be set.  It also saves redoing things like was happening in in the recoveryHandler.

Is this worthwhile?  Is there anything else that should always be set?  Maybe "Strict-Transport-Security" at some stage?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4139)
<!-- Reviewable:end -->
