### PR TITLE
Add script to vendor dependecies in old commits.

### DIFF
--- a/contrib/scripts/install-dependencies.sh
+++ b/contrib/scripts/install-dependencies.sh
@@ -1,0 +1,14 @@
+# Use this script if make install does not work because of dependency issues.
+# Make sure to run the script from the dgraph repository root.
+
+# Vendor opencensus.
+rm -rf vendor/go.opencensus.io/
+govendor fetch go.opencensus.io/...@v0.19.2
+# Vendor prometheus.
+rm -rf vendor/github.com/prometheus/
+govendor fetch github.com/prometheus/client_golang/prometheus/...@v0.9.2
+# Vendor gRPC.
+govendor fetch google.golang.org/grpc/...@v1.13.0
+# Vendor dgo (latest version before API changes).
+govendor fetch github.com/dgraph-io/dgo...@v1.0.0
+


### PR DESCRIPTION
Some old commits cannot be built because of missing or incompatible
dependencies. This script vendors opencensus, grpc, dgo, and
prometheous. Script was tested and works with old commits (e.g from
March 2019).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4141)
<!-- Reviewable:end -->
