### PR TITLE
Set GO111MODULE=on environment variable in Makefile.

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -22,6 +22,8 @@ BUILD_VERSION ?= $(shell git describe --always --tags)
 BUILD_TAGS    ?=
 GOPATH        ?= $(shell go env GOPATH)
 
+export GO111MODULE := on
+
 # Build-time Go variables
 dgraphVersion  = github.com/dgraph-io/dgraph/x.dgraphVersion
 gitBranch      = github.com/dgraph-io/dgraph/x.gitBranch

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/google/codesearch v1.0.0
 	github.com/google/uuid v1.0.0
 	github.com/minio/minio-go v0.0.0-20181109183348-774475480ffe
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/paulmach/go.geojson v0.0.0-20170327170536-40612a87147b
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,6 @@ require (
 	github.com/google/codesearch v1.0.0
 	github.com/google/uuid v1.0.0
 	github.com/minio/minio-go v0.0.0-20181109183348-774475480ffe
-	github.com/onsi/ginkgo v1.7.0 // indirect
-	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/paulmach/go.geojson v0.0.0-20170327170536-40612a87147b
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
This fixes Dgraph builds when using Go versions prior to 1.13 and Dgraph is built within GOPATH. In previous version of Go, Go modules is not activated if the package resides in GOPATH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4167)
<!-- Reviewable:end -->
