### PR TITLE
Make test util functions that create clients return an error.

### DIFF
--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -78,13 +78,17 @@ func Parse(b []byte, op int) ([]*api.NQuad, error) {
 
 func (exp *Experiment) verify() {
 	// insert the data into dgraph
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		exp.t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
+
 	ctx := context.Background()
 	require.NoError(exp.t, dg.Alter(ctx, &api.Operation{DropAll: true}), "drop all failed")
 	require.NoError(exp.t, dg.Alter(ctx, &api.Operation{Schema: exp.schema}),
 		"schema change failed")
 
-	_, err := dg.NewTxn().Mutate(ctx,
+	_, err = dg.NewTxn().Mutate(ctx,
 		&api.Mutation{Set: exp.nqs, CommitNow: true})
 	require.NoError(exp.t, err, "mutation failed")
 

--- a/contrib/integration/acctupsert/main.go
+++ b/contrib/integration/acctupsert/main.go
@@ -69,7 +69,8 @@ func init() {
 
 func main() {
 	flag.Parse()
-	c := testutil.DgraphClientWithGroot(*alpha)
+	c, err := testutil.DgraphClientWithGroot(*alpha)
+	x.Check(err)
 	setup(c)
 	fmt.Println("Doing upserts")
 	doUpserts(c)

--- a/contrib/integration/swap/main.go
+++ b/contrib/integration/swap/main.go
@@ -78,7 +78,8 @@ func main() {
 		fmt.Printf("%15s: %3d\n", w.word, w.count)
 	}
 
-	c := testutil.DgraphClientWithGroot(*alpha)
+	c, err := testutil.DgraphClientWithGroot(*alpha)
+	x.Check(err)
 	uids := setup(c, sents)
 
 	// Check invariants before doing any mutations as a sanity check.

--- a/contrib/integration/testtxn/main_test.go
+++ b/contrib/integration/testtxn/main_test.go
@@ -48,7 +48,8 @@ var addr string = testutil.SockAddr
 func TestMain(m *testing.M) {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	testutil.AssignUids(200)
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	x.CheckfNoTrace(err)
 	s.dg = dg
 
 	r := m.Run()
@@ -740,14 +741,15 @@ query countAnswers($num: int) {
 )
 
 func TestCountIndexConcurrentTxns(t *testing.T) {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	x.Check(err)
 	testutil.DropAll(t, dg)
 	alterSchema(dg, "answer: [uid] @count .")
 
 	// Expected edge count of 0x100: 1
 	txn0 := dg.NewTxn()
 	mu := api.Mutation{SetNquads: []byte("<0x100> <answer> <0x200> .")}
-	_, err := txn0.Mutate(ctxb, &mu)
+	_, err = txn0.Mutate(ctxb, &mu)
 	x.Check(err)
 	err = txn0.Commit(ctxb)
 	x.Check(err)
@@ -796,14 +798,15 @@ func TestCountIndexConcurrentTxns(t *testing.T) {
 }
 
 func TestCountIndexSerialTxns(t *testing.T) {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	x.Check(err)
 	testutil.DropAll(t, dg)
 	alterSchema(dg, "answer: [uid] @count .")
 
 	// Expected Edge count of 0x100: 1
 	txn0 := dg.NewTxn()
 	mu := api.Mutation{SetNquads: []byte("<0x100> <answer> <0x200> .")}
-	_, err := txn0.Mutate(ctxb, &mu)
+	_, err = txn0.Mutate(ctxb, &mu)
 	require.NoError(t, err)
 	err = txn0.Commit(ctxb)
 	require.NoError(t, err)
@@ -845,14 +848,15 @@ func TestCountIndexSerialTxns(t *testing.T) {
 }
 
 func TestCountIndexSameTxn(t *testing.T) {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	x.Check(err)
 	testutil.DropAll(t, dg)
 	alterSchema(dg, "answer: [uid] @count .")
 
 	// Expected Edge count of 0x100: 1
 	txn0 := dg.NewTxn()
 	mu := api.Mutation{SetNquads: []byte("<0x100> <answer> <0x200> .")}
-	_, err := txn0.Mutate(ctxb, &mu)
+	_, err = txn0.Mutate(ctxb, &mu)
 	x.Check(err)
 	err = txn0.Commit(ctxb)
 	x.Check(err)

--- a/dgraph/cmd/counter/increment_test.go
+++ b/dgraph/cmd/counter/increment_test.go
@@ -134,7 +134,10 @@ func readBestEffort(t *testing.T, dg *dgo.Dgraph, pred string, M int) {
 }
 
 func setup(t *testing.T) *dgo.Dgraph {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	ctx := context.Background()
 	op := api.Operation{DropAll: true}
 

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -19,6 +19,7 @@ package live
 import (
 	"context"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"runtime"
@@ -162,7 +163,11 @@ func TestMain(m *testing.M) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	testDataDir = path.Dir(thisFile)
 
-	dg = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	var err error
+	dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		log.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 
 	// Try to create any files in a dedicated temp directory that gets cleaned up
 	// instead of all over /tmp or the working directory.

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"io/ioutil"
+	"log"
 	"os"
 	"path"
 	"runtime"
@@ -175,7 +176,11 @@ func TestMain(m *testing.M) {
 	_, thisFile, _, _ := runtime.Caller(0)
 	testDataDir = path.Dir(thisFile)
 
-	dg = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	var err error
+	dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		log.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	x.Check(dg.Alter(
 		context.Background(), &api.Operation{DropAll: true}))
 

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -30,7 +30,10 @@ func TestCurlAuthorization(t *testing.T) {
 	}
 
 	glog.Infof("testing with port %s", testutil.SockAddr)
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	createAccountAndData(t, dg)
 
 	// test query through curl

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -91,10 +91,16 @@ func TestReservedPredicates(t *testing.T) {
 	// cannot be altered even if the permissions allow it.
 	ctx := context.Background()
 
-	dg1 := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg1, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	alterReservedPredicates(t, dg1)
 
-	dg2 := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg2, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	if err := dg2.Login(ctx, x.GrootId, "password"); err != nil {
 		t.Fatalf("unable to login using the groot account:%v", err)
 	}
@@ -107,12 +113,18 @@ func TestAuthorization(t *testing.T) {
 	}
 
 	glog.Infof("testing with port 9180")
-	dg1 := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg1, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	testAuthorization(t, dg1)
 	glog.Infof("done")
 
 	glog.Infof("testing with port 9182")
-	dg2 := testutil.DgraphClientWithGroot(":9182")
+	dg2, err := testutil.DgraphClientWithGroot(":9182")
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	testAuthorization(t, dg2)
 	glog.Infof("done")
 }
@@ -346,10 +358,13 @@ func TestPredicateRegex(t *testing.T) {
 	}
 
 	glog.Infof("testing with port 9180")
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	createAccountAndData(t, dg)
 	ctx := context.Background()
-	err := dg.Login(ctx, userid, userpassword)
+	err = dg.Login(ctx, userid, userpassword)
 	require.NoError(t, err, "Logging in with the current password should have succeeded")
 
 	// the operations should be allowed when no rule is defined (the fail open approach)
@@ -418,7 +433,10 @@ func TestPredicateRegex(t *testing.T) {
 }
 
 func TestAccessWithoutLoggingIn(t *testing.T) {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 
 	createAccountAndData(t, dg)
 	// without logging in,

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestGetUID(t *testing.T) {
@@ -2284,7 +2285,9 @@ func TestCountUidWithAlias(t *testing.T) {
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {
-	client = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	var err error
+	client, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+	x.CheckfNoTrace(err)
 
 	populateCluster()
 	os.Exit(m.Run())

--- a/systest/21million/run_test.go
+++ b/systest/21million/run_test.go
@@ -48,7 +48,10 @@ func TestQueries(t *testing.T) {
 	queryDir := path.Join(path.Dir(thisFile), "queries")
 
 	// For this test we DON'T want to start with an empty database.
-	dg := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 
 	files, err := ioutil.ReadDir(queryDir)
 	x.CheckfNoTrace(err)

--- a/systest/bulk_live_fixture_test.go
+++ b/systest/bulk_live_fixture_test.go
@@ -59,8 +59,12 @@ type suiteOpts struct {
 }
 
 func newSuiteInternal(t *testing.T, opts suiteOpts) *suite {
-	dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	err := dg.Alter(context.Background(), &api.Operation{
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
+
+	err = dg.Alter(context.Background(), &api.Operation{
 		DropAll: true,
 	})
 	if err != nil {
@@ -185,7 +189,10 @@ func (s *suite) testCase(query, wantResult string) func(*testing.T) {
 	return func(t *testing.T) {
 		if !s.opts.skipLiveLoader {
 			// Check results of the live loader.
-			dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			if err != nil {
+				t.Fatalf("Error while getting a dgraph client: %v", err)
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel()
 
@@ -199,7 +206,10 @@ func (s *suite) testCase(query, wantResult string) func(*testing.T) {
 
 		if !s.opts.skipBulkLoader {
 			// Check results of the bulk loader.
-			dg := testutil.DgraphClient("localhost:" + s.bulkCluster.alphaPort)
+			dg, err := testutil.DgraphClient("localhost:" + s.bulkCluster.alphaPort)
+			if err != nil {
+				t.Fatalf("Error while getting a dgraph client: %v", err)
+			}
 			ctx2, cancel2 := context.WithTimeout(context.Background(), time.Minute)
 			defer cancel2()
 

--- a/systest/live_pw_test.go
+++ b/systest/live_pw_test.go
@@ -30,7 +30,10 @@ import (
 func TestLivePassword(t *testing.T) {
 	wrap := func(fn func(*testing.T, *dgo.Dgraph)) func(*testing.T) {
 		return func(t *testing.T) {
-			dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			if err != nil {
+				t.Fatalf("Error while getting a dgraph client: %v", err)
+			}
 			fn(t, dg)
 			require.NoError(t, dg.Alter(
 				context.Background(), &api.Operation{DropAll: true}))

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -40,7 +40,10 @@ import (
 func TestSystem(t *testing.T) {
 	wrap := func(fn func(*testing.T, *dgo.Dgraph)) func(*testing.T) {
 		return func(t *testing.T) {
-			dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			if err != nil {
+				t.Fatalf("Error while getting a dgraph client: %v", err)
+			}
 			require.NoError(t, dg.Alter(
 				context.Background(), &api.Operation{DropAll: true}))
 			fn(t, dg)

--- a/systest/posting-list-benchmark/main.go
+++ b/systest/posting-list-benchmark/main.go
@@ -84,8 +84,10 @@ func runBenchmark() {
 			opt.mutationsPerTxn, opt.numMutations)
 	}
 
-	dg := testutil.DgraphClientWithGroot(opt.addr)
-	var err error
+	dg, err := testutil.DgraphClientWithGroot(opt.addr)
+	if err != nil {
+		log.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 
 	// Drop all existing data.
 	for {

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -34,7 +34,10 @@ import (
 func TestQuery(t *testing.T) {
 	wrap := func(fn func(*testing.T, *dgo.Dgraph)) func(*testing.T) {
 		return func(t *testing.T) {
-			dg := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+			if err != nil {
+				t.Fatalf("Error while getting a dgraph client: %v", err)
+			}
 			require.NoError(t, dg.Alter(context.Background(), &api.Operation{DropAll: true}))
 			fn(t, dg)
 		}

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -79,9 +79,8 @@ func init() {
 // DgraphClientDropAll creates a Dgraph client and drops all existing data.
 // It is intended to be called from TestMain() to establish a Dgraph connection shared
 // by all tests, so there is no testing.T instance for it to use.
-func DgraphClientDropAll(serviceAddr string) *dgo.Dgraph {
-	dg := DgraphClient(serviceAddr)
-	var err error
+func DgraphClientDropAll(serviceAddr string) (*dgo.Dgraph, error) {
+	dg, err := DgraphClient(serviceAddr)
 	for {
 		// keep retrying until we succeed or receive a non-retriable error
 		err := dg.Alter(context.Background(), &api.Operation{DropAll: true})
@@ -90,18 +89,19 @@ func DgraphClientDropAll(serviceAddr string) *dgo.Dgraph {
 		}
 		time.Sleep(time.Second)
 	}
-	x.CheckfNoTrace(err)
 
-	return dg
+	return dg, err
 }
 
 // DgraphClientWithGroot creates a Dgraph client with groot permissions set up.
 // It is intended to be called from TestMain() to establish a Dgraph connection shared
 // by all tests, so there is no testing.T instance for it to use.
-func DgraphClientWithGroot(serviceAddr string) *dgo.Dgraph {
-	dg := DgraphClient(serviceAddr)
+func DgraphClientWithGroot(serviceAddr string) (*dgo.Dgraph, error) {
+	dg, err := DgraphClient(serviceAddr)
+	if err != nil {
+		return nil, err
+	}
 
-	var err error
 	ctx := context.Background()
 	for {
 		// keep retrying until we succeed or receive a non-retriable error
@@ -111,22 +111,21 @@ func DgraphClientWithGroot(serviceAddr string) *dgo.Dgraph {
 		}
 		time.Sleep(time.Second)
 	}
-	x.CheckfNoTrace(err)
 
-	return dg
+	return dg, err
 }
 
 // DgraphClient creates a Dgraph client.
 // It is intended to be called from TestMain() to establish a Dgraph connection shared
 // by all tests, so there is no testing.T instance for it to use.
-func DgraphClient(serviceAddr string) *dgo.Dgraph {
+func DgraphClient(serviceAddr string) (*dgo.Dgraph, error) {
 	conn, err := grpc.Dial(serviceAddr, grpc.WithInsecure())
-	x.CheckfNoTrace(err)
+	if err != nil {
+		return nil, err
+	}
 
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
-	x.CheckfNoTrace(err)
-
-	return dg
+	return dg, nil
 }
 
 // DgraphClientWithCerts creates a Dgraph client with TLS configured using the given
@@ -324,9 +323,7 @@ func VerifyCurlCmd(t *testing.T, args []string,
 }
 
 // AssignUids talks to zero to assign the given number of uids.
-func AssignUids(num uint64) {
+func AssignUids(num uint64) error {
 	_, err := http.Get(fmt.Sprintf("http://"+SockAddrZeroHttp+"/assign?what=uids&num=%d", num))
-	if err != nil {
-		panic(fmt.Sprintf("Could not assign uids. Got error %v", err.Error()))
-	}
+	return err
 }

--- a/tlstest/certrequest/certrequest_test.go
+++ b/tlstest/certrequest/certrequest_test.go
@@ -11,8 +11,11 @@ import (
 )
 
 func TestAccessOverPlaintext(t *testing.T) {
-	dg := testutil.DgraphClient(testutil.SockAddr)
-	err := dg.Alter(context.Background(), &api.Operation{DropAll: true})
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
+	err = dg.Alter(context.Background(), &api.Operation{DropAll: true})
 	require.Error(t, err, "The authentication handshake should have failed")
 }
 

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -36,7 +36,10 @@ import (
 func TestSnapshot(t *testing.T) {
 	snapshotTs := uint64(0)
 
-	dg1 := testutil.DgraphClient("localhost:9180")
+	dg1, err := testutil.DgraphClient("localhost:9180")
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	require.NoError(t, dg1.Alter(context.Background(), &api.Operation{
 		DropOp: api.Operation_ALL,
 	}))
@@ -44,7 +47,7 @@ func TestSnapshot(t *testing.T) {
 		Schema: "value: int .",
 	}))
 
-	err := testutil.DockerStop("alpha2")
+	err = testutil.DockerStop("alpha2")
 	require.NoError(t, err)
 
 	for i := 1; i <= 200; i++ {
@@ -59,7 +62,10 @@ func TestSnapshot(t *testing.T) {
 	err = testutil.DockerStart("alpha2")
 	require.NoError(t, err)
 
-	dg2 := testutil.DgraphClient("localhost:9182")
+	dg2, err := testutil.DgraphClient("localhost:9182")
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	verifySnapshot(t, dg2, 200)
 
 	err = testutil.DockerStop("alpha2")
@@ -77,7 +83,10 @@ func TestSnapshot(t *testing.T) {
 	err = testutil.DockerStart("alpha2")
 	require.NoError(t, err)
 
-	dg2 = testutil.DgraphClient("localhost:9182")
+	dg2, err = testutil.DgraphClient("localhost:9182")
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	verifySnapshot(t, dg2, 400)
 }
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -133,10 +133,13 @@ func initTest(t *testing.T, schemaStr string) {
 }
 
 func initClusterTest(t *testing.T, schemaStr string) *dgo.Dgraph {
-	dg := testutil.DgraphClient(testutil.SockAddr)
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	if err != nil {
+		t.Fatalf("Error while getting a dgraph client: %v", err)
+	}
 	testutil.DropAll(t, dg)
 
-	err := dg.Alter(context.Background(), &api.Operation{Schema: schemaStr})
+	err = dg.Alter(context.Background(), &api.Operation{Schema: schemaStr})
 	require.NoError(t, err)
 	populateClusterGraph(t, dg)
 


### PR DESCRIPTION
Right now, the code immediately panics if there's an issue creating the
client. This makes the test binaries immediatly panic instead of
continuing with the rest of the tests.

There are a few tests where the issue is still happening. These are the
places where a testing.T object is not avaliable (thus, it's not
possible to call t.Fatalf).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4176)
<!-- Reviewable:end -->
