### PR TITLE
Added some schema rules to dgraph layer

### DIFF
--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -202,7 +202,7 @@ var directiveValidators = map[string]directiveValidator{
 }
 
 var defnValidations, typeValidations []func(defn *ast.Definition) *gqlerror.Error
-var fieldValidations []func(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error
+var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) *gqlerror.Error
 
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	// Lets leave out copying the arguments as types in input schemas are not supposed to contain
@@ -322,7 +322,7 @@ func applyFieldValidations(field *ast.FieldDefinition, typ *ast.Definition) gqle
 	var errs []*gqlerror.Error
 
 	for _, rule := range fieldValidations {
-		errs = appendIfNotNull(errs, rule(field, typ))
+		errs = appendIfNotNull(errs, rule(typ, field))
 	}
 
 	return errs

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -202,7 +202,7 @@ var directiveValidators = map[string]directiveValidator{
 }
 
 var defnValidations, typeValidations []func(defn *ast.Definition) *gqlerror.Error
-var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) *gqlerror.Error
+var fieldValidations []func(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error
 
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	// Lets leave out copying the arguments as types in input schemas are not supposed to contain
@@ -322,7 +322,7 @@ func applyFieldValidations(field *ast.FieldDefinition, typ *ast.Definition) gqle
 	var errs []*gqlerror.Error
 
 	for _, rule := range fieldValidations {
-		errs = appendIfNotNull(errs, rule(typ, field))
+		errs = appendIfNotNull(errs, rule(field, typ))
 	}
 
 	return errs

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -295,7 +295,7 @@ func postGQLValidation(schema *ast.Schema, definitions []string) gqlerror.List {
 		errs = append(errs, applyDefnValidations(typ, typeValidations)...)
 
 		for _, field := range typ.Fields {
-			errs = append(errs, applyFieldValidations(field, typ)...)
+			errs = append(errs, applyFieldValidations(typ, field)...)
 
 			for _, dir := range field.Directives {
 				errs = appendIfNotNull(errs,
@@ -318,7 +318,7 @@ func applyDefnValidations(defn *ast.Definition,
 	return errs
 }
 
-func applyFieldValidations(field *ast.FieldDefinition, typ *ast.Definition) gqlerror.List {
+func applyFieldValidations(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.List {
 	var errs []*gqlerror.Error
 
 	for _, rule := range fieldValidations {

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -29,10 +29,10 @@ invalid_schemas:
     name: "No ID list of any kind"
     input: |
       type A {
-        posts: [ID]
+        f: [ID]
       }
     errlist: [
-      {"message": "[ID] lists are invalid. Only ID scalar fields are allowed.", "locations": [{"line":2, "column": 3}]}
+      {"message": "Type A; Field f: ID lists are invalid.", "locations": [{"line":2, "column": 3}]}
     ]
 
 
@@ -40,10 +40,10 @@ invalid_schemas:
     name: "No nested list of any kind"
     input: |
       type A {
-        posts: [[String]]
+        f: [[String]]
       }
     errlist: [
-      {"message": "[[String]] Nested lists are invalid. Only single lists are allowed.", "locations": [{"line":2, "column": 3}]}
+      {"message": "[[String]] Nested lists are invalid.", "locations": [{"line":2, "column": 3}]}
     ]
 
   -
@@ -53,7 +53,7 @@ invalid_schemas:
         f(a: Int): String
       }
     errlist: [
-      {"message": "Arguments was provided to the field f. Fields don't support arguments.", "locations": [{"line": 2, "column": 3}]}
+      {"message": "Type T; Field f: You can't give arguments to fields.", "locations": [{"line": 2, "column": 3}]}
     ]
 
 
@@ -106,7 +106,7 @@ invalid_schemas:
       }
     errlist: [
       {"message":"Fields i1, i2, i3 and l2 are listed as IDs for type X, but a type can have only one ID field. Pick a single field as the ID for type X.", "locations":[{"line":2, "column":3}, {"line":3, "column":3}, {"line":4, "column":3}, {"line":6, "column": 3}]},
-      {"message": "[ID] lists are invalid. Only ID scalar fields are allowed.", "locations": [{"line": 6, "column": 3}]}
+      {"message": "Type X; Field l2: ID lists are invalid.", "locations": [{"line": 6, "column": 3}]}
     ]
 
   -
@@ -331,7 +331,7 @@ invalid_schemas:
         q: [Boolean]
       }
     errlist: [
-      {"message": "[Boolean] lists are invalid. Only Boolean scalar fields are allowed.",
+      {"message": "Type X; Field q: Boolean lists are invalid.",
       "locations":[{"line":2, "column":3}]}
       ]
 

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -56,6 +56,17 @@ invalid_schemas:
       {"message": "Arguments was provided to the field f. Fields don't support arguments.", "locations": [{"line": 2, "column": 3}]}
     ]
 
+
+  -
+    name: "Reference type that is not in input schema"
+    input: |
+      type T {
+          f: Author
+      }
+    errlist: [
+      {"message": "Undefined type Author.", "locations": [{"line": 2, "column": 8}]}
+    ]
+
   -
     name: "Unsupported definitions in initial schema"
     input: |

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -53,7 +53,7 @@ invalid_schemas:
         f: [[String]]
       }
     errlist: [
-      {"message": "[[String]] Nested lists are invalid.", "locations": [{"line":2, "column": 3}]}
+      {"message": "Type A; Field f: Nested lists are invalid.", "locations": [{"line":2, "column": 3}]}
     ]
 
   -

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -26,13 +26,34 @@ invalid_schemas:
     ]
 
   -
-    name: "Invalid list type"
+    name: "No ID list of any kind"
     input: |
       type A {
-        posts: [A]!
+        posts: [ID]
       }
     errlist: [
-      {"message":"[A]! lists are invalid. Valid options are [A!]! and [A!].", "locations":[{"line":2, "column":3}]},
+      {"message": "[ID] lists are invalid. Only ID scalar fields are allowed.", "locations": [{"line":2, "column": 3}]}
+    ]
+
+
+  -
+    name: "No nested list of any kind"
+    input: |
+      type A {
+        posts: [[String]]
+      }
+    errlist: [
+      {"message": "[[String]] Nested lists are invalid. Only single lists are allowed.", "locations": [{"line":2, "column": 3}]}
+    ]
+
+  -
+    name: "There shoudnt be arguments on any field"
+    input: |
+      type T {
+        f(a: Int): String
+      }
+    errlist: [
+      {"message": "Arguments was provided to the field f. Fields don't support arguments.", "locations": [{"line": 2, "column": 3}]}
     ]
 
   -
@@ -70,10 +91,11 @@ invalid_schemas:
         i2: ID!
         i3: ID!
         l1: [X]!
+        l2: [ID]
       }
     errlist: [
-      {"message":"Fields i1, i2 and i3 are listed as IDs for type X, but a type can have only one ID field. Pick a single field as the ID for type X.", "locations":[{"line":2, "column":3}, {"line":3, "column":3}, {"line":4, "column":3}]},
-      {"message":"[X]! lists are invalid. Valid options are [X!]! and [X!].", "locations":[{"line":5, "column":3}]},
+      {"message":"Fields i1, i2, i3 and l2 are listed as IDs for type X, but a type can have only one ID field. Pick a single field as the ID for type X.", "locations":[{"line":2, "column":3}, {"line":3, "column":3}, {"line":4, "column":3}, {"line":6, "column": 3}]},
+      {"message": "[ID] lists are invalid. Only ID scalar fields are allowed.", "locations": [{"line": 6, "column": 3}]}
     ]
 
   -

--- a/dgraph/cmd/graphql/schema/gqlschema_test.yml
+++ b/dgraph/cmd/graphql/schema/gqlschema_test.yml
@@ -12,6 +12,16 @@ invalid_schemas:
     ]
 
   -
+    name: "UID as a field name"
+    input: |
+      type P {
+        uid: String
+      }
+    errlist: [
+      {"message":"Type P; Field uid: uid is a reserved keyword and you cannot declare a field with this name.", "locations": [{"line":2, "column": 3}]},
+    ]
+
+  -
     name: "Query, Mutation in initial schema"
     input: |
       type Query {

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -155,8 +155,8 @@ func listValidityCheck(typ *ast.Definition, field *ast.FieldDefinition) *gqlerro
 	// Nested lists are not allowed.
 	if field.Type.Elem.Elem != nil {
 		return gqlerror.ErrorPosf(field.Position,
-			"%s Nested lists are invalid.",
-			field.Type.Dump())
+			"Type %s; Field %s: Nested lists are invalid.",
+			typ.Name, field.Name)
 	}
 
 	return nil

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -106,17 +106,15 @@ func idCountCheck(typ *ast.Definition) *gqlerror.Error {
 	return nil
 }
 
-func isValidTypeForList(typeName string) bool {
-	switch typeName {
-	case
-		"Boolean",
-		"ID":
-		return true
+func isValidTypeForList(field *ast.Type, typ *ast.Definition) bool {
+	if isIDType(typ, field) {
+		return false
 	}
-	return false
+
+	return field.Name() != "Boolean"
 }
 
-func fieldArgumentCheck(field *ast.FieldDefinition) *gqlerror.Error {
+func fieldArgumentCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error {
 	if field.Arguments != nil {
 		return gqlerror.ErrorPosf(
 			field.Position,
@@ -127,7 +125,7 @@ func fieldArgumentCheck(field *ast.FieldDefinition) *gqlerror.Error {
 	return nil
 }
 
-func listValidityCheck(field *ast.FieldDefinition) *gqlerror.Error {
+func listValidityCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error {
 	// Checks if the field is nil.
 	if field.Type.Elem == nil {
 		return nil
@@ -135,7 +133,7 @@ func listValidityCheck(field *ast.FieldDefinition) *gqlerror.Error {
 
 	// ID and Boolean list are not allowed.
 	// [Boolean] is not allowed as dgraph schema doesn't support [bool] yet.
-	if isValidTypeForList(field.Type.Elem.Name()) && field.Type.NamedType == "" {
+	if !isValidTypeForList(field.Type.Elem, typ) && field.Type.NamedType == "" {
 		return gqlerror.ErrorPosf(
 			field.Position, "[%[1]s] lists are invalid. Only %[1]s "+
 				"scalar fields are allowed.", field.Type.Elem.Name())

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -118,8 +118,8 @@ func fieldArgumentCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerr
 	if field.Arguments != nil {
 		return gqlerror.ErrorPosf(
 			field.Position,
-			"Arguments was provided to the field %s. Fields don't support arguments.",
-			field.Name,
+			"Type %s; Field %s: You can't give arguments to fields.",
+			typ.Name, field.Name,
 		)
 	}
 	return nil
@@ -135,14 +135,14 @@ func listValidityCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerro
 	// [Boolean] is not allowed as dgraph schema doesn't support [bool] yet.
 	if !isValidTypeForList(field.Type.Elem, typ) && field.Type.NamedType == "" {
 		return gqlerror.ErrorPosf(
-			field.Position, "[%[1]s] lists are invalid. Only %[1]s "+
-				"scalar fields are allowed.", field.Type.Elem.Name())
+			field.Position, "Type %s; Field %s: %s lists are invalid.",
+			typ.Name, field.Name, field.Type.Elem.Name())
 	}
 
 	// Nested lists are not allowed.
 	if field.Type.Elem.Elem != nil {
 		return gqlerror.ErrorPosf(field.Position,
-			"%s Nested lists are invalid. Only single lists are allowed.",
+			"%s Nested lists are invalid.",
 			field.Type.Dump())
 	}
 

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -127,6 +127,18 @@ func fieldArgumentCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerr
 }
 
 func listValidityCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error {
+
+	if err := fieldArgumentCheck(field, typ); err != nil {
+		return err
+	}
+
+	if isReservedKeyWord(field.Name) {
+		return gqlerror.ErrorPosf(
+			field.Position, "Type %s; Field %s: %s is a reserved keyword and "+
+				"you cannot declare a field with this name.",
+			typ.Name, field.Name, field.Name)
+	}
+
 	// Checks if the field is nil.
 	if field.Type.Elem == nil {
 		return nil
@@ -145,10 +157,6 @@ func listValidityCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerro
 		return gqlerror.ErrorPosf(field.Position,
 			"%s Nested lists are invalid.",
 			field.Type.Dump())
-	}
-
-	if err := fieldArgumentCheck(field, typ); err != nil {
-		return err
 	}
 
 	return nil

--- a/dgraph/cmd/graphql/schema/rules.go
+++ b/dgraph/cmd/graphql/schema/rules.go
@@ -30,7 +30,6 @@ func init() {
 
 	typeValidations = append(typeValidations, idCountCheck)
 	fieldValidations = append(fieldValidations, listValidityCheck)
-	fieldValidations = append(fieldValidations, fieldArgumentCheck)
 }
 
 func dataTypeCheck(defn *ast.Definition) *gqlerror.Error {
@@ -107,11 +106,13 @@ func idCountCheck(typ *ast.Definition) *gqlerror.Error {
 }
 
 func isValidTypeForList(field *ast.Type, typ *ast.Definition) bool {
-	if isIDType(typ, field) {
+	switch field.Name() {
+	case
+		"ID",
+		"Boolean":
 		return false
 	}
-
-	return field.Name() != "Boolean"
+	return true
 }
 
 func fieldArgumentCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerror.Error {
@@ -144,6 +145,10 @@ func listValidityCheck(field *ast.FieldDefinition, typ *ast.Definition) *gqlerro
 		return gqlerror.ErrorPosf(field.Position,
 			"%s Nested lists are invalid.",
 			field.Type.Dump())
+	}
+
+	if err := fieldArgumentCheck(field, typ); err != nil {
+		return err
 	}
 
 	return nil
@@ -289,7 +294,7 @@ func isScalar(s string) bool {
 }
 
 func isReservedKeyWord(name string) bool {
-	if isScalar(name) || name == "Query" || name == "Mutation" {
+	if isScalar(name) || name == "Query" || name == "Mutation" || name == "uid" {
 		return true
 	}
 


### PR DESCRIPTION
- no [ID] lists of any kind
- changed my mind on lists.  Any combination of [T!]!, [T], [T!], [T]! is allowed, but no nested lists of any kind [[T]] (see also Input processing)
- there shouldn't be arguments on any fields: e.g. `type T { f(a: Int) }` isn't allowed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4177)
<!-- Reviewable:end -->
