### PR TITLE
Add a /admin endpoint 

### DIFF
--- a/dgraph/cmd/graphql/admin.go
+++ b/dgraph/cmd/graphql/admin.go
@@ -40,7 +40,7 @@ const (
 	adminSchema = `
  type Schema {
 	schema: String!  # the input schema, not the expanded schema
-	date: DateTime! #@search(by: day)
+	date: DateTime!
  }
  
  type Health {
@@ -126,9 +126,10 @@ func (hr *healthResolver) Resolve(ctx context.Context, query schema.Query) *reso
 // A addSchemaResolver serves as the mutation rewriter and executor in handling
 // the addSchema mutation.
 type addSchemaResolver struct {
-	dgraph *dgo.Dgraph // the Dgraph that gets its schema changed
+	// the Dgraph that gets its schema changed
+	dgraph *dgo.Dgraph
 
-	// generated from the mutation input
+	// schema that is generated from the mutation input
 	newGQLSchema    schema.Schema
 	newDgraphSchema string
 
@@ -137,7 +138,8 @@ type addSchemaResolver struct {
 	baseMutationRewriter resolve.MutationRewriter
 	baseMutationExecutor resolve.MutationExecutor
 
-	gqlServer web.IServeGraphQL // The GraphQL endpoint that's being admin'd.
+	// The GraphQL server that's being admin'd
+	gqlServer web.IServeGraphQL
 
 	// When the schema changes, we use these to create a new RequestResolver for
 	// the main graphql endpoint (gqlServer) and thus refresh the API.

--- a/dgraph/cmd/graphql/admin.go
+++ b/dgraph/cmd/graphql/admin.go
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graphql
+
+import (
+	"context"
+	"time"
+
+	"github.com/dgraph-io/dgo/v2"
+	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/resolve"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
+	"github.com/dgraph-io/dgraph/gql"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+)
+
+const (
+	// GraphQL schema for /admin endpoint.
+	//
+	// Eventually we should generate this from just the types definition.
+	// But for now, that would add too much into the schema, so this is
+	// hand crafted to be one of our schemas so we can pass it into the
+	// pipeline.
+	adminSchema = `
+ type Schema {
+	schema: String!  # the input schema, not the expanded schema
+	date: DateTime! #@search(by: day)
+ }
+ 
+ type Health {
+	message: String!
+	status: HealthStatus!
+ }
+ 
+ enum HealthStatus {
+	OK
+	DgraphUnreachable
+ }
+ 
+ scalar DateTime
+ 
+ type SchemaDiff {
+	types: [TypeDiff!]
+ }
+ 
+ type TypeDiff {
+	name: String!
+	new: Boolean
+	newFields: [String!]
+	missingFields: [String!]
+ }
+ 
+ type AddSchemaPayload {
+	schema: Schema
+	diff: SchemaDiff
+ }
+ 
+ type UpdateSchemaPayload {
+	schema: Schema
+ }
+ 
+ input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+ }
+ 
+ input SchemaFilter {
+	date: DateTimeFilter
+	and: SchemaFilter
+	or: SchemaFilter
+	not: SchemaFilter
+ }
+ 
+ input SchemaInput {
+	schema: String!
+	dateAdded: DateTime
+ }
+ 
+ input SchemaOrder {
+	asc: SchemaOrderable
+	desc: SchemaOrderable
+	then: SchemaOrder
+ }
+ 
+ enum SchemaOrderable {
+	date
+ }
+ 
+ type Query {
+	querySchema(filter: SchemaFilter, order: SchemaOrder, first: Int, offset: Int): [Schema]
+	health: Health
+ }
+ 
+ type Mutation {
+	addSchema(input: SchemaInput!) : AddSchemaPayload
+ }
+ `
+)
+
+type healthResolver struct{}
+
+func (hr *healthResolver) Resolve(ctx context.Context, query schema.Query) *resolve.Resolved {
+	// TODO: The actual algorithm for determining health goes here...
+	return &resolve.Resolved{Data: []byte(`"message" : "I'm alive"`)}
+}
+
+// A addSchemaResolver serves as the mutation rewriter and executor in handling
+// the addSchema mutation.
+type addSchemaResolver struct {
+	dgraph *dgo.Dgraph // the Dgraph that gets its schema changed
+
+	// generated from the mutation input
+	newGQLSchema    schema.Schema
+	newDgraphSchema string
+
+	// The underlying executor and rewriter that persist the schema into Dgraph as
+	// GraphQL metadata
+	baseMutationRewriter resolve.MutationRewriter
+	baseMutationExecutor resolve.MutationExecutor
+
+	gqlServer web.IServeGraphQL // The GraphQL endpoint that's being admin'd.
+
+	// When the schema changes, we use these to create a new RequestResolver for
+	// the main graphql endpoint (gqlServer) and thus refresh the API.
+	fns               *resolve.ResolverFns
+	withIntrospection bool
+}
+
+// NewAdminResolver creates a GraphQL request resolver for the /admin endpoint.
+func NewAdminResolver(
+	dg *dgo.Dgraph,
+	gqlServer web.IServeGraphQL,
+	fns *resolve.ResolverFns) *resolve.RequestResolver {
+
+	adminSchema, err := schema.FromString(adminSchema)
+	if err != nil {
+		panic(err)
+	}
+
+	return resolve.New(adminSchema, newAdminResolverFactory(dg, gqlServer, fns))
+}
+
+func newAdminResolverFactory(
+	dg *dgo.Dgraph,
+	gqlServer web.IServeGraphQL,
+	fns *resolve.ResolverFns) resolve.ResolverFactory {
+	// The args ^^ are the rewriters and executors used by the endpoint being admin'd.
+	// These are the ones used by the admin endpoint itself.
+	mutRw := resolve.NewMutationRewriter()
+	qryRw := resolve.NewQueryRewriter()
+	qryExec := resolve.DgoAsQueryExecutor(dg)
+	mutExec := resolve.DgoAsMutationExecutor(dg)
+
+	return resolve.NewResolverFactory().
+		WithQueryResolver("health",
+			func(q schema.Query) resolve.QueryResolver { return &healthResolver{} }).
+		WithMutationResolver("addSchema",
+			func(m schema.Mutation) resolve.MutationResolver {
+				addResolver := &addSchemaResolver{
+					gqlServer:            gqlServer,
+					dgraph:               dg,
+					baseMutationRewriter: mutRw,
+					baseMutationExecutor: mutExec,
+					fns:                  fns,
+					withIntrospection:    true}
+
+				return resolve.NewMutationResolver(
+					addResolver,
+					qryExec,
+					addResolver,
+					resolve.StdMutationCompletion(m.Name()))
+			}).
+		WithQueryResolver("querySchema",
+			func(q schema.Query) resolve.QueryResolver {
+				return resolve.NewQueryResolver(
+					qryRw,
+					qryExec,
+					resolve.StdQueryCompletion())
+			}).
+		WithSchemaIntrospection()
+}
+
+func (asr *addSchemaResolver) Rewrite(m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+	sch, err := getSchemaInput(m)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	schHandler, err := schema.NewHandler(sch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asr.newGQLSchema, err = schema.FromString(schHandler.GQLSchema())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asr.newDgraphSchema = schHandler.DGSchema()
+
+	m.SetArgTo(schema.InputArgName, map[string]interface{}{"schema": sch, "date": time.Now()})
+	return asr.baseMutationRewriter.Rewrite(m)
+}
+
+func (asr *addSchemaResolver) FromMutationResult(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	mutated map[string][]string) (*gql.GraphQuery, error) {
+	return asr.baseMutationRewriter.FromMutationResult(mutation, assigned, mutated)
+}
+
+func (asr *addSchemaResolver) Mutate(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error) {
+
+	assigned, mutated, err := asr.baseMutationExecutor.Mutate(ctx, query, mutations)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if glog.V(3) {
+		glog.Infof("Altering Dgraph schema:\n\n%s\n", asr.newDgraphSchema)
+	}
+
+	err = asr.dgraph.Alter(ctx, &dgoapi.Operation{Schema: asr.newDgraphSchema})
+	if err != nil {
+		return nil, nil, schema.GQLWrapf(err,
+			"succeeded in saving GraphQL schema but failed to alter Dgraph schema "+
+				"(you should retry)")
+	}
+
+	resolverFactory := resolve.NewResolverFactory().
+		WithConventionResolvers(asr.newGQLSchema, asr.fns)
+
+	if asr.withIntrospection {
+		resolverFactory.WithSchemaIntrospection()
+	}
+
+	resolvers := resolve.New(asr.newGQLSchema, resolverFactory)
+	asr.gqlServer.ServeGQL(resolvers)
+
+	return assigned, mutated, nil
+}
+
+func getSchemaInput(m schema.Mutation) (string, error) {
+	input, ok := m.ArgValue(schema.InputArgName).(map[string]interface{})
+	if !ok {
+		return "", errors.New("couldn't get input argument")
+	}
+
+	return input["schema"].(string), nil
+}

--- a/dgraph/cmd/graphql/admin.go
+++ b/dgraph/cmd/graphql/admin.go
@@ -49,8 +49,9 @@ const (
  }
  
  enum HealthStatus {
-	OK
-	DgraphUnreachable
+	ErrNoConnection
+	NoGraphQLSchema
+	Healthy
  }
  
  scalar DateTime
@@ -114,13 +115,22 @@ const (
 	addSchema(input: SchemaInput!) : AddSchemaPayload
  }
  `
+
+	// Heath status codes
+	errNoConnection healthStatus = "ErrNoConnection"
+	noGraphQLSchema healthStatus = "noGraphQLSchema"
+	healthy         healthStatus = "Healthy"
 )
 
-type healthResolver struct{}
+type healthStatus string
 
-func (hr *healthResolver) Resolve(ctx context.Context, query schema.Query) *resolve.Resolved {
-	// TODO: The actual algorithm for determining health goes here...
-	return &resolve.Resolved{Data: []byte(`"message" : "I'm alive"`)}
+type schemaDef struct {
+	Schema string    `json:"schema,omitempty"`
+	Date   time.Time `json:"date,omitempty"`
+}
+
+type healthResolver struct {
+	status healthStatus
 }
 
 // A addSchemaResolver serves as the mutation rewriter and executor in handling

--- a/dgraph/cmd/graphql/admin/admin.go
+++ b/dgraph/cmd/graphql/admin/admin.go
@@ -135,7 +135,8 @@ func newAdminResolverFactory(
 	dg *dgo.Dgraph,
 	gqlServer web.IServeGraphQL,
 	fns *resolve.ResolverFns) resolve.ResolverFactory {
-	// The args ^^ are the rewriters and executors used by the endpoint being admin'd.
+
+	// The args are the rewriters and executors used by the endpoint being admin'd.
 	// These are the ones used by the admin endpoint itself.
 	mutRw := resolve.NewMutationRewriter()
 	qryRw := resolve.NewQueryRewriter()

--- a/dgraph/cmd/graphql/admin/health.go
+++ b/dgraph/cmd/graphql/admin/health.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dgraph-io/dgraph/gql"
+)
+
+const (
+	errNoConnection healthStatus = "ErrNoConnection"
+	noGraphQLSchema healthStatus = "noGraphQLSchema"
+	healthy         healthStatus = "Healthy"
+)
+
+type healthStatus string
+
+type healthResolver struct {
+	status healthStatus
+}
+
+var statusMessage = map[healthStatus]string{
+	errNoConnection: "Unable to contact Dgraph",
+	noGraphQLSchema: "Dgraph connection established but there's no GraphQL schema.",
+	healthy:         "Dgraph connection established and serving GraphQL schema.",
+}
+
+func (hr *healthResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
+	s := hr.status
+	return []byte(fmt.Sprintf(`{"message":"%s","status":%s`, statusMessage[s], string(s))), nil
+}

--- a/dgraph/cmd/graphql/admin/schema.go
+++ b/dgraph/cmd/graphql/admin/schema.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/dgraph-io/dgo/v2"
+	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/resolve"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
+	"github.com/dgraph-io/dgraph/gql"
+	"github.com/golang/glog"
+)
+
+// A addSchemaResolver serves as the mutation rewriter and executor in handling
+// the addSchema mutation.
+type addSchemaResolver struct {
+	// the Dgraph that gets its schema changed
+	dgraph *dgo.Dgraph
+
+	// schema that is generated from the mutation input
+	newGQLSchema    schema.Schema
+	newDgraphSchema string
+
+	// The underlying executor and rewriter that persist the schema into Dgraph as
+	// GraphQL metadata
+	baseMutationRewriter resolve.MutationRewriter
+	baseMutationExecutor resolve.MutationExecutor
+
+	// The GraphQL server that's being admin'd
+	gqlServer web.IServeGraphQL
+
+	// When the schema changes, we use these to create a new RequestResolver for
+	// the main graphql endpoint (gqlServer) and thus refresh the API.
+	fns               *resolve.ResolverFns
+	withIntrospection bool
+}
+
+func (asr *addSchemaResolver) Rewrite(m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+	sch, err := getSchemaInput(m)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	schHandler, err := schema.NewHandler(sch)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asr.newGQLSchema, err = schema.FromString(schHandler.GQLSchema())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	asr.newDgraphSchema = schHandler.DGSchema()
+
+	m.SetArgTo(schema.InputArgName, map[string]interface{}{"schema": sch, "date": time.Now()})
+	return asr.baseMutationRewriter.Rewrite(m)
+}
+
+func (asr *addSchemaResolver) FromMutationResult(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	mutated map[string][]string) (*gql.GraphQuery, error) {
+	return asr.baseMutationRewriter.FromMutationResult(mutation, assigned, mutated)
+}
+
+func (asr *addSchemaResolver) Mutate(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error) {
+
+	assigned, mutated, err := asr.baseMutationExecutor.Mutate(ctx, query, mutations)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if glog.V(3) {
+		glog.Infof("Altering Dgraph schema:\n\n%s\n", asr.newDgraphSchema)
+	}
+
+	err = asr.dgraph.Alter(ctx, &dgoapi.Operation{Schema: asr.newDgraphSchema})
+	if err != nil {
+		return nil, nil, schema.GQLWrapf(err,
+			"succeeded in saving GraphQL schema but failed to alter Dgraph schema "+
+				"(you should retry)")
+	}
+
+	resolverFactory := resolve.NewResolverFactory().
+		WithConventionResolvers(asr.newGQLSchema, asr.fns)
+
+	if asr.withIntrospection {
+		resolverFactory.WithSchemaIntrospection()
+	}
+
+	resolvers := resolve.New(asr.newGQLSchema, resolverFactory)
+	asr.gqlServer.ServeGQL(resolvers)
+
+	return assigned, mutated, nil
+}
+
+func getSchemaInput(m schema.Mutation) (string, error) {
+	input, ok := m.ArgValue(schema.InputArgName).(map[string]interface{})
+	if !ok {
+		return "", errors.New("couldn't get input argument")
+	}
+
+	return input["schema"].(string), nil
+}

--- a/dgraph/cmd/graphql/admin/schema.go
+++ b/dgraph/cmd/graphql/admin/schema.go
@@ -55,7 +55,9 @@ type addSchemaResolver struct {
 	withIntrospection bool
 }
 
-func (asr *addSchemaResolver) Rewrite(m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+func (asr *addSchemaResolver) Rewrite(
+	m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+
 	sch, err := getSchemaInput(m)
 	if err != nil {
 		return nil, nil, err

--- a/dgraph/cmd/graphql/admin/schema.go
+++ b/dgraph/cmd/graphql/admin/schema.go
@@ -18,8 +18,10 @@ package admin
 
 import (
 	"context"
-	"errors"
 	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/dgo/v2"
 	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
@@ -27,7 +29,6 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
 	"github.com/dgraph-io/dgraph/gql"
-	"github.com/golang/glog"
 )
 
 // A addSchemaResolver serves as the mutation rewriter and executor in handling
@@ -120,7 +121,7 @@ func (asr *addSchemaResolver) Mutate(
 func getSchemaInput(m schema.Mutation) (string, error) {
 	input, ok := m.ArgValue(schema.InputArgName).(map[string]interface{})
 	if !ok {
-		return "", errors.New("couldn't get input argument")
+		return "", errors.Errorf("couldn't get argument %s", schema.InputArgName)
 	}
 
 	return input["schema"].(string), nil

--- a/dgraph/cmd/graphql/e2e_error_test.go
+++ b/dgraph/cmd/graphql/e2e_error_test.go
@@ -17,6 +17,7 @@
 package graphql
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http/httptest"
@@ -94,12 +95,15 @@ func TestPanicCatcher(t *testing.T) {
 
 	gqlSchema := test.LoadSchemaFromFile(t, "e2e_test_schema.graphql")
 
-	resolverFactory :=
-		resolve.NewResolverFactory(
-			resolve.NewQueryRewriter(),
-			resolve.NewMutationRewriter(),
-			&panicClient{},
-			&panicClient{})
+	fns := &resolve.ResolverFns{
+		Qrw: resolve.NewQueryRewriter(),
+		Mrw: resolve.NewMutationRewriter(),
+		Drw: resolve.NewDeleteRewriter(),
+		Qe:  &panicClient{},
+		Me:  &panicClient{}}
+
+	resolverFactory := resolve.NewResolverFactory().
+		WithConventionResolvers(gqlSchema, fns)
 
 	resolvers := resolve.New(gqlSchema, resolverFactory)
 	server := web.NewServer(resolvers)
@@ -125,14 +129,12 @@ func TestPanicCatcher(t *testing.T) {
 
 type panicClient struct{}
 
-func (dg *panicClient) Query(
-	resCtx *resolve.ResolverContext,
-	query *gql.GraphQuery) ([]byte, error) {
+func (dg *panicClient) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
 	panic("bugz!!!")
 }
 
 func (dg *panicClient) Mutate(
-	resCtx *resolve.ResolverContext,
+	ctx context.Context,
 	query *gql.GraphQuery,
 	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error) {
 	panic("bugz!!!")

--- a/dgraph/cmd/graphql/resolve/mutation.go
+++ b/dgraph/cmd/graphql/resolve/mutation.go
@@ -19,7 +19,9 @@ package resolve
 import (
 	"context"
 
+	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
+	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/x"
 	otrace "go.opencensus.io/trace"
 )
@@ -49,6 +51,105 @@ import (
 //
 // For now, all mutations are only 1 level deep (cause of how we build the
 // input objects) and only create a single node (again cause of inputs)
+
+// A MutationResolver can resolve a single mutation.
+type MutationResolver interface {
+	Resolve(ctx context.Context, mutation schema.Mutation) (*Resolved, bool)
+}
+
+// A MutationRewriter can transform a GraphQL mutation into a Dgraph mutation and
+// can build a Dgraph gql.GraphQuery to follow a GraphQL mutation.
+//
+// Mutations come in like:
+//
+// mutation addAuthor($auth: AuthorInput!) {
+//   addAuthor(input: $auth) {
+// 	   author {
+// 	     id
+// 	     name
+// 	   }
+//   }
+// }
+//
+// Where `addAuthor(input: $auth)` implies a mutation that must get run - written
+// to a Dgraph mutation by Rewrite.  The GraphQL following `addAuthor(...)`implies
+// a query to run and return the newly created author, so the
+// mutation query rewriting is dependent on the context set up by the result of
+// the mutation.
+type MutationRewriter interface {
+	// Rewrite rewrites GraphQL mutation m into a Dgraph mutation - that could
+	// be as simple as a single DelNquads, or could be a Dgraph upsert mutation
+	// with a query and multiple mutations guarded by conditions.
+	Rewrite(m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error)
+
+	// FromMutationResult takes a GraphQL mutation and the results of a Dgraph
+	// mutation and constructs a Dgraph query.  It's used to find the return
+	// value from a GraphQL mutation - i.e. we've run the mutation indicated by m
+	// now we need to query Dgraph to satisfy all the result fields in m.
+	FromMutationResult(
+		m schema.Mutation,
+		assigned map[string]string,
+		mutated map[string][]string) (*gql.GraphQuery, error)
+}
+
+// A MutationExecutor can execute a mutation and returns the assigned map, the
+// mutated map and any errors.
+type MutationExecutor interface {
+	// Mutate performs the actual mutation and returns a map of newly assigned nodes,
+	// a map of variable->[]uid from upsert mutations and any errors.  If an error
+	// occurs, that indicates that the mutation failed in some way significant enough
+	// way as to not continue procissing this mutation or others in the same request.
+	Mutate(
+		ctx context.Context,
+		query *gql.GraphQuery,
+		mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error)
+}
+
+// MutationResolverFunc is an adapter that allows to build a MutationResolver from
+// a function.  Based on the http.HandlerFunc pattern.
+type MutationResolverFunc func(ctx context.Context, mutation schema.Mutation) (*Resolved, bool)
+
+// MutationExecutionFunc is an adapter that allows us to compose mutation execution and build a
+// MutationExecuter from a function.  Based on the http.HandlerFunc pattern.
+type MutationExecutionFunc func(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error)
+
+// Resolve calls mr(ctx, mutation)
+func (mr MutationResolverFunc) Resolve(
+	ctx context.Context,
+	mutation schema.Mutation) (*Resolved, bool) {
+
+	return mr(ctx, mutation)
+}
+
+// Mutate calls me(ctx, query, mutations)
+func (me MutationExecutionFunc) Mutate(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error) {
+	return me(ctx, query, mutations)
+}
+
+// NewMutationResolver creates a new mutation resolver.  The resolver runs the pipeline:
+// 1) rewrite the mutation using mr (return error if failed)
+// 2) execute the mutation with me (return error if failed)
+// 3) write a query for the mutation with mr (return error if failed)
+// 4) execute the query with qe (return error if failed)
+// 5) process the result with rc
+func NewMutationResolver(
+	mr MutationRewriter,
+	qe QueryExecutor,
+	me MutationExecutor,
+	rc ResultCompleter) MutationResolver {
+	return &mutationResolver{
+		mutationRewriter: mr,
+		queryExecutor:    qe,
+		mutationExecutor: me,
+		resultCompleter:  rc,
+	}
+}
 
 // mutationResolver can resolve a single GraphQL mutation field
 type mutationResolver struct {

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -206,16 +206,17 @@ type QueryResolverFunc func(ctx context.Context, query schema.Query) *Resolved
 // a function.  Based on the http.HandlerFunc pattern.
 type MutationResolverFunc func(ctx context.Context, mutation schema.Mutation) (*Resolved, bool)
 
-// CompletionFunc is an adapter that allows us to compose completions and build a ResultCompleter from
-// a function.  Based on the http.HandlerFunc pattern.
-type CompletionFunc func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error)
+// CompletionFunc is an adapter that allows us to compose completions and build a
+// ResultCompleter from a function.  Based on the http.HandlerFunc pattern.
+type CompletionFunc func(
+	ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error)
 
 // QueryRewritingFunc is an adapter that allows us to build a QueryRewriter from
 // a function.  Based on the http.HandlerFunc pattern.
 type QueryRewritingFunc func(q schema.Query) (*gql.GraphQuery, error)
 
-// QueryExecutionFunc is an adapter that allows us to compose query execution and build a QueryExecuter from
-// a function.  Based on the http.HandlerFunc pattern.
+// QueryExecutionFunc is an adapter that allows us to compose query execution and
+// build a QueryExecuter from a function.  Based on the http.HandlerFunc pattern.
 type QueryExecutionFunc func(ctx context.Context, query *gql.GraphQuery) ([]byte, error)
 
 // MutationExecutionFunc is an adapter that allows us to compose mutation execution and build a
@@ -231,7 +232,10 @@ func (qr QueryResolverFunc) Resolve(ctx context.Context, query schema.Query) *Re
 }
 
 // Resolve calls mr(ctx, mutation)
-func (mr MutationResolverFunc) Resolve(ctx context.Context, mutation schema.Mutation) (*Resolved, bool) {
+func (mr MutationResolverFunc) Resolve(
+	ctx context.Context,
+	mutation schema.Mutation) (*Resolved, bool) {
+
 	return mr(ctx, mutation)
 }
 
@@ -559,13 +563,14 @@ func noopCompletion(
 // so the completed result should be
 // q1: {...}
 func removeObjectCompletion(cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-		res, err := cf(ctx, field, result, err)
-		if len(res) >= 2 {
-			res = res[1 : len(res)-1]
-		}
-		return res, err
-	})
+	return CompletionFunc(
+		func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
+			res, err := cf(ctx, field, result, err)
+			if len(res) >= 2 {
+				res = res[1 : len(res)-1]
+			}
+			return res, err
+		})
 }
 
 // addRootFieldCompletion adds an extra object name to the start of a result.
@@ -576,7 +581,8 @@ func removeObjectCompletion(cf CompletionFunc) CompletionFunc {
 //   `foo { ... }`
 // So `addFoo: ...` is added.
 func addRootFieldCompletion(name string, cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
+	return CompletionFunc(func(
+		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
 
 		res, err := cf(ctx, field, result, err)
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -457,7 +457,8 @@ func addRootFieldCompletion(name string, cf CompletionFunc) CompletionFunc {
 //   `addFoo(...) { foo { ... } }`
 // But cf's error paths begin at `foo`, so `addFoo` needs to be added to all.
 func addPathCompletion(name string, cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
+	return CompletionFunc(func(
+		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
 
 		res, err := cf(ctx, field, result, err)
 

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -118,7 +118,7 @@ type Mutation {
 }
 `
 
-func (ex *executor) Query(resCtx *ResolverContext, query *gql.GraphQuery) ([]byte, error) {
+func (ex *executor) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
 	ex.failQuery--
 	if ex.failQuery == 0 {
 		return nil, schema.GQLWrapf(errors.New("_bad stuff happend_"), "Dgraph query failed")
@@ -126,7 +126,7 @@ func (ex *executor) Query(resCtx *ResolverContext, query *gql.GraphQuery) ([]byt
 	return []byte(ex.resp), nil
 }
 
-func (ex *executor) Mutate(resCtx *ResolverContext,
+func (ex *executor) Mutate(ctx context.Context,
 	query *gql.GraphQuery,
 	mutations []*dgoapi.Mutation) (map[string]string, map[string][]string, error) {
 	ex.failMutation--
@@ -467,11 +467,12 @@ func resolveWithClient(
 	ex *executor) *schema.Response {
 	resolver := New(
 		gqlSchema,
-		NewResolverFactory(
-			NewQueryRewriter(),
-			NewMutationRewriter(),
-			ex,
-			ex))
+		NewResolverFactory().WithConventionResolvers(gqlSchema, &ResolverFns{
+			Qrw: NewQueryRewriter(),
+			Mrw: NewMutationRewriter(),
+			Qe:  ex,
+			Me:  ex,
+		}))
 
 	return resolver.Resolve(context.Background(), &schema.Request{Query: gqlQuery, Variables: vars})
 }

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -74,6 +74,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/admin"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/resolve"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/web"
 
@@ -228,7 +229,7 @@ func run() error {
 	resolvers := resolve.New(gqlSchema, resolverFactory)
 	mainServer := web.NewServer(resolvers)
 
-	adminResolvers := NewAdminResolver(dgraphClient, mainServer, fns)
+	adminResolvers := admin.NewAdminResolver(dgraphClient, mainServer, fns)
 	adminServer := web.NewServer(adminResolvers)
 
 	http.Handle("/graphql", mainServer.HTTPHandler())

--- a/dgraph/cmd/graphql/run.go
+++ b/dgraph/cmd/graphql/run.go
@@ -87,9 +87,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/vektah/gqlparser/ast"
-	"github.com/vektah/gqlparser/parser"
-	"github.com/vektah/gqlparser/validator"
 	_ "github.com/vektah/gqlparser/validator/rules" // make gql validator init() all rules
 
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
@@ -209,39 +206,33 @@ func run() error {
 		return fmt.Errorf("No GraphQL schema was found")
 	}
 
-	// validator.Prelude includes a bunch of predefined types which help with schema introspection
-	// queries, hence we include it as part of the schema.
-	doc, gqlErr := parser.ParseSchemas(validator.Prelude,
-		&ast.Source{Input: string(schemas.Schemas[0].Schema)})
-	if gqlErr != nil {
-		return errors.Wrap(gqlErr, "while parsing GraphQL schema")
+	gqlSchema, err := schema.FromString(string(schemas.Schemas[0].Schema))
+	if err != nil {
+		return err
 	}
 
-	gqlSchema, gqlErr := validator.ValidateSchemaDocument(doc)
-	if gqlErr != nil {
-		return errors.Wrap(gqlErr, "while validating GraphQL schema")
-	}
+	fns := &resolve.ResolverFns{
+		Qrw: resolve.NewQueryRewriter(),
+		Mrw: resolve.NewMutationRewriter(),
+		Drw: resolve.NewDeleteRewriter(),
+		Qe:  resolve.DgoAsQueryExecutor(dgraphClient),
+		Me:  resolve.DgoAsMutationExecutor(dgraphClient)}
 
-	queryRewriter := resolve.NewQueryRewriter()
-	mutationRewriter := resolve.NewMutationRewriter()
-	queryExecutor := resolve.DgoAsQueryExecutor(dgraphClient)
-	mutationExecutor := resolve.DgoAsMutationExecutor(dgraphClient)
-
-	resolverFactory :=
-		resolve.NewResolverFactory(
-			queryRewriter,
-			mutationRewriter,
-			queryExecutor,
-			mutationExecutor)
+	resolverFactory := resolve.NewResolverFactory().
+		WithConventionResolvers(gqlSchema, fns)
 
 	// We don't have to add schema introspection here.  Often GraphQL servers turn
 	// off schema introspection in production.  So this can easily be optional.
 	resolverFactory.WithSchemaIntrospection()
 
-	resolvers := resolve.New(schema.AsSchema(gqlSchema), resolverFactory)
+	resolvers := resolve.New(gqlSchema, resolverFactory)
 	mainServer := web.NewServer(resolvers)
 
+	adminResolvers := NewAdminResolver(dgraphClient, mainServer, fns)
+	adminServer := web.NewServer(adminResolvers)
+
 	http.Handle("/graphql", mainServer.HTTPHandler())
+	http.Handle("/admin", adminServer.HTTPHandler())
 
 	trace.ApplyConfig(trace.Config{
 		DefaultSampler:             trace.ProbabilitySampler(GraphQL.Conf.GetFloat64("trace")),
@@ -255,6 +246,7 @@ func run() error {
 	// TODO:
 	// the ports and urls etc that the endpoint serves should be input options
 	glog.Infof("Bringing up GraphQL HTTP API at 127.0.0.1:9000/graphql")
+	glog.Infof("Bringing up GraphQL HTTP admin API at 127.0.0.1:9000/admin")
 	return errors.Wrap(http.ListenAndServe(":9000", nil), "GraphQL server failed")
 }
 

--- a/dgraph/cmd/graphql/schema/introspection.go
+++ b/dgraph/cmd/graphql/schema/introspection.go
@@ -21,7 +21,7 @@ import (
 // queries or we might get rid of the types defined in wrappers.go and use the types defined in
 // gqlgen instead if they make more sense.
 
-// Introspect performs an introspection query given a field that's expected to be either
+// Introspect performs an introspection query given a query that's expected to be either
 // __schema or __type.
 func Introspect(q Query) (json.RawMessage, error) {
 	if q.Name() != "__schema" && q.Name() != "__type" {

--- a/dgraph/cmd/graphql/schema/introspection.go
+++ b/dgraph/cmd/graphql/schema/introspection.go
@@ -23,25 +23,28 @@ import (
 
 // Introspect performs an introspection query given a field that's expected to be either
 // __schema or __type.
-func Introspect(f Field) (json.RawMessage, error) {
-	if f.Name() != "__schema" && f.Name() != "__type" {
+func Introspect(q Query) (json.RawMessage, error) {
+	if q.Name() != "__schema" && q.Name() != "__type" {
 		return nil, errors.New("call to introspect for field that isn't an introspection query " +
-			"this indicates an internal bug ... let us know")
+			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}
 
-	sch, ok := f.Operation().Schema().(*schema)
+	sch, ok := q.Operation().Schema().(*schema)
 	if !ok {
-		return nil, errors.New("couldn't convert schema to internal type")
+		return nil, errors.New("couldn't convert schema to internal type " +
+			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}
 
-	op, ok := f.Operation().(*operation)
+	op, ok := q.Operation().(*operation)
 	if !ok {
-		return nil, errors.New("couldn't convert operation to internal type")
+		return nil, errors.New("couldn't convert operation to internal type " +
+			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}
 
-	qu, ok := f.(*query)
+	qu, ok := q.(*query)
 	if !ok {
-		return nil, errors.New("couldn't convert query to internal type")
+		return nil, errors.New("couldn't convert query to internal type " +
+			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}
 
 	reqCtx := &requestContext{

--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -334,7 +334,10 @@ func mutatedTypeMapping(s *ast.Schema,
 		// for UpdateTPayload and get the type from the first field. There is no direct way to get
 		// the type from the definition of an object. We use Update and not Add here because
 		// Interfaces only have Update.
-		def := s.Types["Update"+mutatedTypeName+"Payload"]
+		var def *ast.Definition
+		if def = s.Types["Update"+mutatedTypeName+"Payload"]; def == nil {
+			def = s.Types["Add"+mutatedTypeName+"Payload"]
+		}
 
 		if def == nil {
 			continue


### PR DESCRIPTION
This adds a /admin endpoint that allows you to admin the GraphQL layer.

There's a bunch of functionality possible.  ATM, this just allows you to alter the schema - when you submit a mutation that alters the schema, the /graphql endpoint responds and serves the new schema.

Coming in next PRs
* remove `dgraph graphql init ... ` command
* add `health()` query
* change server startup, so it doesn't need graphql schema in Dgraph when it starts (the initial schema is added via the /admin endpoint)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4178)
<!-- Reviewable:end -->
