### PR TITLE
Remove uses of x.Check in tests in favor of t.Fatalf

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -184,13 +184,17 @@ func BenchmarkGzip(b *testing.B) {
 		for _, uid := range uids {
 			n := binary.PutUvarint(tmp, uid)
 			_, err := buf.Write(tmp[:n])
-			x.Check(err)
+			if err != nil {
+				b.Fatalf("Error while writing to buffer: %s", err.Error())
+			}
 		}
 
 		var out bytes.Buffer
 		zw := gzip.NewWriter(&out)
 		_, err := zw.Write(buf.Bytes())
-		x.Check(err)
+		if err != nil {
+			b.Fatalf("Error while writing to gzip writer: %s", err.Error())
+		}
 
 		data = out.Bytes()
 	}
@@ -211,7 +215,9 @@ func benchmarkUidPackEncode(b *testing.B, blockSize int) {
 	for i := 0; i < b.N; i++ {
 		pack := Encode(uids, blockSize)
 		out, err := pack.Marshal()
-		x.Check(err)
+		if err != nil {
+			b.Fatalf("Error marshaling uid pack: %s", err.Error())
+		}
 		data = out
 	}
 	b.Logf("Output size: %s. Compression: %.2f",

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -114,7 +114,9 @@ func queryWithGz(queryText, contentType, debug, timeout string, gzReq, gzResp bo
 	}
 
 	var r res
-	x.Check(json.Unmarshal(body, &r))
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", nil, err
+	}
 
 	// Check for errors
 	if len(r.Errors) != 0 {
@@ -146,7 +148,9 @@ func queryWithTs(queryText, contentType, debug string, ts uint64) (string, uint6
 	}
 
 	var r res
-	x.Check(json.Unmarshal(body, &r))
+	if err := json.Unmarshal(body, &r); err != nil {
+		return "", 0, err
+	}
 	startTs := r.Extensions.Txn.StartTs
 
 	// Remove the extensions.
@@ -178,7 +182,9 @@ func mutationWithTs(m, t string, isJson bool, commitNow bool, ts uint64) (
 	}
 
 	var r res
-	x.Check(json.Unmarshal(body, &r))
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, nil, 0, err
+	}
 	startTs := r.Extensions.Txn.StartTs
 
 	return r.Extensions.Txn.Keys, r.Extensions.Txn.Preds, startTs, nil

--- a/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
+++ b/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc"
@@ -161,7 +160,9 @@ func mutateExistingAllowed2(t *testing.T, dg *dgo.Dgraph) {
 
 func TestMutationsDisallow(t *testing.T) {
 	conn, err := grpc.Dial(disallowModeAlpha, grpc.WithInsecure())
-	x.Check(err)
+	if err != nil {
+		t.Fatalf("Cannot perform drop all op: %s", err.Error())
+	}
 	defer conn.Close()
 
 	t.Run("disallow drop all in no mutations mode",
@@ -176,11 +177,15 @@ func TestMutationsDisallow(t *testing.T) {
 
 func TestMutationsStrict(t *testing.T) {
 	conn1, err := grpc.Dial(strictModeAlphaGroup1, grpc.WithInsecure())
-	x.Check(err)
+	if err != nil {
+		t.Fatalf("Cannot perform drop all op: %s", err.Error())
+	}
 	defer conn1.Close()
 
 	conn2, err := grpc.Dial(strictModeAlphaGroup2, grpc.WithInsecure())
-	x.Check(err)
+	if err != nil {
+		t.Fatalf("Cannot perform drop all op: %s", err.Error())
+	}
 	defer conn2.Close()
 
 	t.Run("allow group1 drop all in strict mutations mode",

--- a/dgraph/cmd/counter/increment_test.go
+++ b/dgraph/cmd/counter/increment_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
@@ -146,7 +145,9 @@ func setup(t *testing.T) *dgo.Dgraph {
 	md := metadata.New(nil)
 	md.Append("auth-token", "mrjn2")
 	ctx = metadata.NewOutgoingContext(ctx, md)
-	x.Check(dg.Alter(ctx, &op))
+	if err := dg.Alter(ctx, &op); err != nil {
+		t.Fatalf("Cannot perform drop all op: %s", err.Error())
+	}
 
 	conf := viper.New()
 	conf.Set("pred", "counter.val")

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -98,7 +98,7 @@ func TestBackupMinio(t *testing.T) {
 	require.True(t, moveOk)
 
 	// Setup test directories.
-	dirSetup()
+	dirSetup(t)
 
 	// Send backup request.
 	_ = runBackup(t, 3, 1)
@@ -200,7 +200,7 @@ func TestBackupMinio(t *testing.T) {
 	runFailingRestore(t, backupDir, "", incr3.Txn.CommitTs)
 
 	// Clean up test directories.
-	dirCleanup()
+	dirCleanup(t)
 }
 
 func runBackup(t *testing.T, numExpectedFiles, numExpectedDirs int) []string {
@@ -274,17 +274,21 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 	require.Contains(t, err.Error(), "expected a BackupNum value of 1")
 }
 
-func dirSetup() {
+func dirSetup(t *testing.T) {
 	// Clean up data from previous runs.
-	dirCleanup()
+	dirCleanup(t)
 
 	for _, dir := range testDirs {
-		x.Check(os.MkdirAll(dir, os.ModePerm))
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			t.Fatalf("Error while creaing directory: %s", err.Error())
+		}
 	}
 }
 
-func dirCleanup() {
-	x.Check(os.RemoveAll("./data"))
+func dirCleanup(t *testing.T) {
+	if err := os.RemoveAll("./data"); err != nil {
+		t.Fatalf("Error removing direcotory: %s", err.Error())
+	}
 }
 
 func copyToLocalFs(t *testing.T) {

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -24,18 +24,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
-	"google.golang.org/grpc"
 )
-
-func getNewClient() *dgo.Dgraph {
-	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
-	x.Check(err)
-	return dgo.NewDgraphClient(api.NewDgraphClient(conn))
-}
 
 func setSchema(schema string) {
 	err := client.Alter(context.Background(), &api.Operation{

--- a/systest/21million/run_test.go
+++ b/systest/21million/run_test.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/stretchr/testify/require"
 )
 

--- a/systest/21million/run_test.go
+++ b/systest/21million/run_test.go
@@ -54,7 +54,9 @@ func TestQueries(t *testing.T) {
 	}
 
 	files, err := ioutil.ReadDir(queryDir)
-	x.CheckfNoTrace(err)
+	if err != nil {
+		t.Fatalf("Error reading directory: %s", err.Error())
+	}
 
 	savepath := ""
 	diffs := 0
@@ -66,7 +68,9 @@ func TestQueries(t *testing.T) {
 			filename := path.Join(queryDir, file.Name())
 			reader, cleanup := chunker.FileReader(filename)
 			bytes, err := ioutil.ReadAll(reader)
-			x.CheckfNoTrace(err)
+			if err != nil {
+				t.Fatalf("Error reading file: %s", err.Error())
+			}
 			contents := string(bytes[:])
 			cleanup()
 

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -124,8 +124,9 @@ func TestXidmapMemory(t *testing.T) {
 
 func BenchmarkXidmap(b *testing.B) {
 	conn, err := x.SetupConnection(testutil.SockAddrZero, nil, false)
-	x.Check(err)
-	x.AssertTrue(conn != nil)
+	if err != nil {
+		b.Fatalf("Error setting up connection: %s", err.Error())
+	}
 
 	var counter uint64
 	xidmap := New(conn, nil)


### PR DESCRIPTION
Where possible, I have removed calls to x.Check in the tests and
replaced them with calls to t.Fatalf or b.Fatalf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4180)
<!-- Reviewable:end -->
