### PR TITLE
Invoke "set -e" inside test scripts.

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -1,6 +1,8 @@
-#!/bin/bash -e
+#!/bin/bash
 # Containers MUST be labeled with "cluster:test" to be restarted and stopped
 # by these functions.
+
+set -e
 
 # May be called with an argument which is a docker compose file
 # to use *instead of* the default docker-compose.yml.

--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
+set -e
 readonly ME=${0##*/}
 readonly SRCDIR=$(dirname $0)
 

--- a/systest/loader-benchmark/loader-benchmark.sh
+++ b/systest/loader-benchmark/loader-benchmark.sh
@@ -1,5 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 
+set -e
 readonly ME=${0##*/}
 readonly SRCDIR=$(dirname $0)
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 #
 # usage: test.sh [pkg_regex]
 
@@ -23,6 +23,7 @@
 # Keep in mind that the test build will overwrite the "dgraph"
 # binary in your $GOPATH/bin with the Linux-ELF binary for Docker.
 
+set -e
 readonly ME=${0##*/}
 readonly DGRAPH_ROOT=${GOPATH:-$HOME}/src/github.com/dgraph-io/dgraph
 


### PR DESCRIPTION
Putting the option in the shebang could cause it to be missed when the
script is called by doing something like "bash test.sh".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4181)
<!-- Reviewable:end -->
