### PR TITLE
More fixes to allow tests to run with no cluster.

### DIFF
--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -58,13 +58,14 @@ func TestBackupMinio(t *testing.T) {
 	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
 	require.NoError(t, err)
 	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+	ctx := context.Background()
+	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
+
 	mc, err = testutil.NewMinioClient()
 	require.NoError(t, err)
 	require.NoError(t, mc.MakeBucket(bucketName, ""))
 
 	// Add initial data.
-	ctx := context.Background()
-	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `movie: string .`}))
 	original, err := dg.NewTxn().Mutate(ctx, &api.Mutation{
 		CommitNow: true,

--- a/tlstest/acl/acl_over_tls_test.go
+++ b/tlstest/acl/acl_over_tls_test.go
@@ -5,11 +5,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
+	"testing"
 
 	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
@@ -94,17 +94,17 @@ func dgraphClientWithCerts(serviceAddr string, conf *viper.Viper) (*dgo.Dgraph, 
 	return dg, nil
 }
 
-func ExampleLoginOverTLS() {
+func TestLoginOverTLS(t *testing.T) {
 	conf := viper.New()
 	conf.Set("tls_cacert", "../tls/ca.crt")
 	conf.Set("tls_server_name", "node")
 
 	dg, err := dgraphClientWithCerts(testutil.SockAddr, conf)
 	if err != nil {
-		glog.Fatalf("Unable to get dgraph client: %v", err)
+		t.Fatalf("Unable to get dgraph client: %s", err.Error())
 	}
 	if err := dg.Login(context.Background(), "groot", "password"); err != nil {
-		glog.Fatalf("Unable to login using the groot account: %v", err)
+		t.Fatalf("Unable to login using the groot account: %v", err.Error())
 	}
 
 	// Output:


### PR DESCRIPTION
- In the minio backup test, drop the data earlier so the test fails
earlier if there's no cluster.
- Convert example to test and use t.Fatalf instead of glog.Fatalf.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4188)
<!-- Reviewable:end -->
