### PR TITLE
Fix shortest path search adjacency list generation

### DIFF
--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -732,7 +732,6 @@ func TestShortestPath_filter(t *testing.T) {
 				follow
 				path @filter(not anyofterms(name, "alice"))
 			}
-
 			me(func: uid(A)) {
 				name
 			}

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -710,8 +710,8 @@ func TestShortestPath4(t *testing.T) {
 	query := `
 		{
 			A as shortest(from:1, to:1003) {
-				follow
 				path
+				follow
 			}
 
 			me(func: uid( A)) {
@@ -729,8 +729,8 @@ func TestShortestPath_filter(t *testing.T) {
 	query := `
 		{
 			A as shortest(from:1, to:1002) {
-				follow
 				path @filter(not anyofterms(name, "alice"))
+				follow
 			}
 			me(func: uid(A)) {
 				name

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -710,8 +710,8 @@ func TestShortestPath4(t *testing.T) {
 	query := `
 		{
 			A as shortest(from:1, to:1003) {
-				path
 				follow
+				path
 			}
 
 			me(func: uid( A)) {
@@ -729,8 +729,8 @@ func TestShortestPath_filter(t *testing.T) {
 	query := `
 		{
 			A as shortest(from:1, to:1002) {
-				path @filter(not anyofterms(name, "alice"))
 				follow
+				path @filter(not anyofterms(name, "alice"))
 			}
 
 			me(func: uid(A)) {

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -202,11 +202,23 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 							rch <- err
 							return
 						}
-						adjacencyMap[fromUID][toUID] = mapItem{
-							cost:  cost,
-							facet: facet,
-							attr:  subgraph.Attr,
+
+						if temp, ok := adjacencyMap[fromUID][toUID]; ok {
+							if temp.cost > cost {
+								adjacencyMap[fromUID][toUID] = mapItem{
+									cost:  cost,
+									facet: facet,
+									attr:  subgraph.Attr,
+								}
+							}
+						} else {
+							adjacencyMap[fromUID][toUID] = mapItem{
+								cost:  cost,
+								facet: facet,
+								attr:  subgraph.Attr,
+							}
 						}
+
 						numEdges++
 					}
 				}

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -203,15 +203,7 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 							return
 						}
 
-						if temp, ok := adjacencyMap[fromUID][toUID]; ok {
-							if temp.cost > cost {
-								adjacencyMap[fromUID][toUID] = mapItem{
-									cost:  cost,
-									facet: facet,
-									attr:  subgraph.Attr,
-								}
-							}
-						} else {
+						if temp, ok := adjacencyMap[fromUID][toUID]; !ok || temp.cost > cost {
 							adjacencyMap[fromUID][toUID] = mapItem{
 								cost:  cost,
 								facet: facet,


### PR DESCRIPTION
Use shortest path to query the shortest path, if it is a multiple edge (predicate) query, such as 

    {
        path as shortest(from: 0x6aed0c1, to: 0x6aed0c4) {
            friend @facets(weight)
            spouse
        }
        path(func: uid(path)) {
            name
        }
    }

The adjacency list ( adjacencyMap ) will have the data of the spouse replaced with the data of friend@(weight). If the weight of friend@(weight) is less than the weight of the spouse, the path that may be found is not the shortest.

The code submitted here guarantees that the weight of the data in the adjacency list is the smallest, ensuring that the shortest path found has the smallest total weight.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4194)
<!-- Reviewable:end -->
