### PR TITLE
Don't traverse immutable layer if deleteBelowTs > 0

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -107,6 +107,10 @@ func (it *pIterator) init(l *List, afterUid, deleteBelowTs uint64) error {
 			deleteBelowTs, l.minTs)
 	}
 
+	if deleteBelowTs > 0 {
+		return nil
+	}
+
 	it.l = l
 	it.splitIdx = it.selectInitialSplit(afterUid)
 	if len(it.l.plist.Splits) > 0 {

--- a/posting/list.go
+++ b/posting/list.go
@@ -107,10 +107,6 @@ func (it *pIterator) init(l *List, afterUid, deleteBelowTs uint64) error {
 			deleteBelowTs, l.minTs)
 	}
 
-	if deleteBelowTs > 0 {
-		return nil
-	}
-
 	it.l = l
 	it.splitIdx = it.selectInitialSplit(afterUid)
 	if len(it.l.plist.Splits) > 0 {
@@ -125,9 +121,13 @@ func (it *pIterator) init(l *List, afterUid, deleteBelowTs uint64) error {
 
 	it.afterUid = afterUid
 	it.deleteBelowTs = deleteBelowTs
+	if deleteBelowTs > 0 {
+		return nil
+	}
 
 	it.uidPosting = &pb.Posting{}
 	it.dec = &codec.Decoder{Pack: it.plist.Pack}
+
 	it.uids = it.dec.Seek(it.afterUid, codec.SeekCurrent)
 	it.uidx = 0
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -122,12 +122,13 @@ func (it *pIterator) init(l *List, afterUid, deleteBelowTs uint64) error {
 	it.afterUid = afterUid
 	it.deleteBelowTs = deleteBelowTs
 	if deleteBelowTs > 0 {
+		// We don't need to iterate over the immutable layer if this is > 0. Returning here would
+		// mean it.uids is empty and valid() would return false.
 		return nil
 	}
 
 	it.uidPosting = &pb.Posting{}
 	it.dec = &codec.Decoder{Pack: it.plist.Pack}
-
 	it.uids = it.dec.Seek(it.afterUid, codec.SeekCurrent)
 	it.uidx = 0
 


### PR DESCRIPTION
`S P *` deletions were not working when data was loaded using bulk loader or was in the immutable layer. This PR makes sure we don't iterate over the immutable layer when we have a delete marker. Earlier after doing a `S P *` deletion, we were still returning the first uid from the immutable layer.

Fixes #4182

This bug was introduced in https://github.com/dgraph-io/dgraph/pull/3105.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4204)
<!-- Reviewable:end -->
