### PR TITLE
Fix field look up for interfaces

### DIFF
--- a/dgraph/cmd/graphql/schema/wrappers.go
+++ b/dgraph/cmd/graphql/schema/wrappers.go
@@ -631,9 +631,16 @@ func (m *mutation) ConcreteType(dgraphTypes []interface{}) string {
 }
 
 func (t *astType) Field(name string) FieldDefinition {
+
+	typName := t.Name()
+	parentInt := parentInterface(t.inSchema, t.inSchema.Types[typName], name)
+	if parentInt != "" {
+		typName = parentInt
+	}
+
 	return &fieldDefinition{
 		// this ForName lookup is a loop in the underlying schema :-(
-		fieldDef: t.inSchema.Types[t.Name()].Fields.ForName(name),
+		fieldDef: t.inSchema.Types[typName].Fields.ForName(name),
 		inSchema: t.inSchema,
 	}
 }


### PR DESCRIPTION
When we look up the definition for a field, we should return the base definition from an interface (if it exists) not the one from the type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4222)
<!-- Reviewable:end -->
