### PR TITLE
Startup with introspection of empty schema

### DIFF
--- a/dgraph/cmd/graphql/admin/admin.go
+++ b/dgraph/cmd/graphql/admin/admin.go
@@ -39,6 +39,12 @@ import (
 const (
 	errMsgServerNotReady = "Unavailable: Server has not yet connected to Dgraph."
 
+	errNoGraphQLSchema = "Not resolving %s. There's no GraphQL schema in Dgraph.  " +
+		"Use the /admin API to add a GraphQL schema"
+	errResolverNotFound = "%s was not executed because no suitable resolver could be found - " +
+		"this indicates a resolver or validation bug " +
+		"(Please let us know : https://github.com/dgraph-io/dgraph/issues)"
+
 	// The schema fragment that's needed in Dgraph to operate the GraphQL layer.
 	// FIXME: dgraphAdminSchema will change to this once we have @dgraph(pred: "...")
 	// dgraphAdminSchema = `
@@ -188,12 +194,7 @@ func NewServers(
 		panic(err)
 	}
 
-	rf := resolve.NewResolverFactory()
-	if withIntrospection {
-		rf.WithSchemaIntrospection()
-	}
-
-	resolvers := resolve.New(gqlSchema, rf)
+	resolvers := resolve.New(gqlSchema, resolverFactoryWithErrorMsg(errNoGraphQLSchema))
 	mainServer := web.NewServer(resolvers)
 
 	fns := &resolve.ResolverFns{
@@ -237,7 +238,7 @@ func newAdminResolver(
 }
 
 func newAdminResolverFactory() resolve.ResolverFactory {
-	rf := resolve.NewResolverFactory().
+	rf := resolverFactoryWithErrorMsg(errResolverNotFound).
 		WithQueryResolver("health",
 			func(q schema.Query) resolve.QueryResolver {
 				health := &healthResolver{
@@ -416,9 +417,25 @@ func getCurrentGraphQLSchema(r *resolve.RequestResolver) (*schemaDef, error) {
 	return result.QuerySchema[0], nil
 }
 
+func resolverFactoryWithErrorMsg(msg string) resolve.ResolverFactory {
+	errFunc := func(name string) error { return errors.Errorf(msg, name) }
+	qErr :=
+		resolve.QueryResolverFunc(func(ctx context.Context, query schema.Query) *resolve.Resolved {
+			return &resolve.Resolved{Err: errFunc(query.ResponseName())}
+		})
+
+	mErr := resolve.MutationResolverFunc(
+		func(ctx context.Context, mutation schema.Mutation) (*resolve.Resolved, bool) {
+			return &resolve.Resolved{Err: errFunc(mutation.ResponseName())}, false
+		})
+
+	return resolve.NewResolverFactory(qErr, mErr)
+}
+
 func (as *adminServer) resetSchema(gqlSchema schema.Schema) {
 
-	resolverFactory := resolve.NewResolverFactory().WithConventionResolvers(gqlSchema, as.fns)
+	resolverFactory := resolverFactoryWithErrorMsg(errResolverNotFound).
+		WithConventionResolvers(gqlSchema, as.fns)
 	if as.withIntrospection {
 		resolverFactory.WithSchemaIntrospection()
 	}

--- a/dgraph/cmd/graphql/e2e_error_test.go
+++ b/dgraph/cmd/graphql/e2e_error_test.go
@@ -102,7 +102,7 @@ func TestPanicCatcher(t *testing.T) {
 		Qe:  &panicClient{},
 		Me:  &panicClient{}}
 
-	resolverFactory := resolve.NewResolverFactory().
+	resolverFactory := resolve.NewResolverFactory(nil, nil).
 		WithConventionResolvers(gqlSchema, fns)
 
 	resolvers := resolve.New(gqlSchema, resolverFactory)

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -214,27 +214,18 @@ func (rf *resolverFactory) WithConventionResolvers(
 }
 
 // NewResolverFactory returns a ResolverFactory that resolves requests via
-// query/mutation rewriting and execution through Dgraph.
-func NewResolverFactory() ResolverFactory {
-
-	errFunc := func(name string) error {
-		return errors.Errorf("%s was not executed because no suitable resolver could be found - "+
-			"this indicates a resolver or validation bug "+
-			"(Please let us know : https://github.com/dgraph-io/dgraph/issues)", name)
-	}
+// query/mutation rewriting and execution through Dgraph.  If the factory gets asked
+// to resolve a query/mutation it doesn't know how to rewriter, it uses
+// the queryError/mutationError to build an error result.
+func NewResolverFactory(
+	queryError QueryResolverFunc, mutationError MutationResolverFunc) ResolverFactory {
 
 	return &resolverFactory{
 		queryResolvers:    make(map[string]func(schema.Query) QueryResolver),
 		mutationResolvers: make(map[string]func(schema.Mutation) MutationResolver),
 
-		queryError: QueryResolverFunc(func(ctx context.Context, query schema.Query) *Resolved {
-			return &Resolved{Err: errFunc(query.ResponseName())}
-		}),
-
-		mutationError: MutationResolverFunc(
-			func(ctx context.Context, mutation schema.Mutation) (*Resolved, bool) {
-				return &Resolved{Err: errFunc(mutation.ResponseName())}, resolverFailed
-			}),
+		queryError:    queryError,
+		mutationError: mutationError,
 	}
 }
 

--- a/dgraph/cmd/graphql/resolve/resolver.go
+++ b/dgraph/cmd/graphql/resolve/resolver.go
@@ -215,7 +215,7 @@ func (rf *resolverFactory) WithConventionResolvers(
 
 // NewResolverFactory returns a ResolverFactory that resolves requests via
 // query/mutation rewriting and execution through Dgraph.  If the factory gets asked
-// to resolve a query/mutation it doesn't know how to rewriter, it uses
+// to resolve a query/mutation it doesn't know how to rewrite, it uses
 // the queryError/mutationError to build an error result.
 func NewResolverFactory(
 	queryError QueryResolverFunc, mutationError MutationResolverFunc) ResolverFactory {

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -467,7 +467,7 @@ func resolveWithClient(
 	ex *executor) *schema.Response {
 	resolver := New(
 		gqlSchema,
-		NewResolverFactory().WithConventionResolvers(gqlSchema, &ResolverFns{
+		NewResolverFactory(nil, nil).WithConventionResolvers(gqlSchema, &ResolverFns{
 			Qrw: NewQueryRewriter(),
 			Mrw: NewMutationRewriter(),
 			Qe:  ex,


### PR DESCRIPTION
Adds introspection to the initial setup, so you can point `__schema` at it when it starts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4226)
<!-- Reviewable:end -->
