### PR TITLE
Only allow one alias per predicate.

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2695,6 +2695,9 @@ func godeep(it *lex.ItemIterator, gq *GraphQuery) error {
 				return err
 			}
 			if peekIt[0].Typ == itemColon {
+				if len(alias) > 0 {
+					return item.Errorf("Invalid colon after alias declaration")
+				}
 				alias = val
 				it.Next() // Consume the itemcolon
 				continue

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1646,6 +1646,22 @@ func TestParse_alias1(t *testing.T) {
 	require.Equal(t, childAttrs(res.Query[0].Children[1]), []string{"type.object.name.hi"})
 }
 
+func TestParseBadAlias(t *testing.T) {
+	query := `
+		{
+			me(func: uid(0x0a)) {
+				name: type.object.name.en: after_colon
+				bestFriend: friends(first: 10) {
+					name: type.object.name.hi
+				}
+			}
+		}
+	`
+	_, err := Parse(Request{Str: query})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid colon after alias declaration")
+}
+
 func TestParse_block(t *testing.T) {
 	query := `
 		{


### PR DESCRIPTION
There's a bug in the parser that allows queries like this to be
considered correct.

```
{
  q(func: uid(1)) {
    name: name_pred: other_stuff
  }
}
```

The parser should return an error for such queries since it's trying to
define more than one alias.

Fixes #4235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4236)
<!-- Reviewable:end -->
