### PR TITLE
Drain apply channel when a snapshot is received

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -920,7 +920,7 @@ func (n *node) Run() {
 				case entry.Index < applied:
 					n.elog.Printf("Skipping over already applied entry: %d", entry.Index)
 					n.Applied.Done(entry.Index)
-				default:  
+				default:
 					proposal := &pb.Proposal{}
 					if err := proposal.Unmarshal(entry.Data); err != nil {
 						x.Fatalf("Unable to unmarshal proposal: %v %q\n", err, entry.Data)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -659,7 +659,6 @@ func (n *node) updateRaftProgress() error {
 	//
 	// Let's check what we already have. And only update if the new snap.Index is ahead of the last
 	// stored applied.
-	
 	applied, err := n.Store.Checkpoint()
 	if err != nil {
 		return err
@@ -736,11 +735,11 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 	}
 }
 
-func (n* node) drainApplyChan() {
+func (n *node) drainApplyChan() {
 	for {
 		select {
 		case proposals := <-n.applyCh:
-			glog.Infof("Draining %d proposals\n",  len(proposals))
+			glog.Infof("Draining %d proposals\n", len(proposals))
 			for _, proposal := range proposals {
 				n.Proposals.Done(proposal.Key, nil)
 				n.Applied.Done(proposal.Index)
@@ -841,7 +840,7 @@ func (n *node) Run() {
 					maxIndex := n.Applied.LastIndex()
 					glog.Infof("Drain applyCh by reaching %d before"+
 						" retrieving snapshot\n", maxIndex)
-					n.drainApplyChan() 
+					n.drainApplyChan()
 
 					if err := n.Applied.WaitForMark(context.Background(), maxIndex); err != nil {
 						glog.Errorf("Error waiting for mark for index %d: %+v", maxIndex, err)

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -908,21 +908,19 @@ func (n *node) Run() {
 				// possible sequentially
 				n.Applied.Begin(entry.Index)
 
-				if entry.Type == raftpb.EntryConfChange {
+				switch {
+				case entry.Type == raftpb.EntryConfChange:
 					n.applyConfChange(entry)
 					// Not present in proposal map.
 					n.Applied.Done(entry.Index)
 					groups().triggerMembershipSync()
-
-				} else if len(entry.Data) == 0 {
+				case len(entry.Data) == 0:
 					n.elog.Printf("Found empty data at index: %d", entry.Index)
 					n.Applied.Done(entry.Index)
-
-				} else if entry.Index < applied {
+				case entry.Index < applied:
 					n.elog.Printf("Skipping over already applied entry: %d", entry.Index)
 					n.Applied.Done(entry.Index)
-
-				} else {
+				default:  
 					proposal := &pb.Proposal{}
 					if err := proposal.Unmarshal(entry.Data); err != nil {
 						x.Fatalf("Unable to unmarshal proposal: %v %q\n", err, entry.Data)


### PR DESCRIPTION
Drain apply channel when a snapshot is received; set node to unhealthy status while snapshot is applied. Fixes DGRAPH-671 and DGRAPH-672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4273)
<!-- Reviewable:end -->
