### PR TITLE
Don't delete group if there is no member in the group

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -201,11 +201,6 @@ func (n *node) handleMemberProposal(member *pb.Member) error {
 			delete(group.Members, member.Id)
 			state.Removed = append(state.Removed, m)
 		}
-		// else already removed.
-		if len(group.Members) == 0 {
-			glog.V(3).Infof("Deleting group Id %d (no members) ...", member.GroupId)
-			delete(state.Groups, member.GroupId)
-		}
 		return nil
 	}
 	if !has && len(group.Members) >= n.server.NumReplicas {

--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -156,8 +156,13 @@ func TestNodes(t *testing.T) {
 	state2, err = testutil.GetState()
 	require.NoError(t, err)
 
-	if _, ok := state2.Groups["3"]; ok {
-		t.Errorf("node removal failed")
+	group, ok := state2.Groups["3"]
+	if !ok {
+		t.Errorf("group is removed")
+	}
+
+	if len(group.Members) != 0 {
+		t.Errorf("Expected 0 members but got %d", len(group.Members))
 	}
 
 	doTestQuery(t, dg)

--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -158,11 +158,11 @@ func TestNodes(t *testing.T) {
 
 	group, ok := state2.Groups["3"]
 	if !ok {
-		t.Errorf("group is removed")
+		t.Errorf("group 3 is removed")
 	}
 
 	if len(group.Members) != 0 {
-		t.Errorf("Expected 0 members but got %d", len(group.Members))
+		t.Errorf("Expected 0 members in group 3 but got %d", len(group.Members))
 	}
 
 	doTestQuery(t, dg)
@@ -193,8 +193,12 @@ func TestNodes(t *testing.T) {
 	state2, err = testutil.GetState()
 	require.NoError(t, err)
 
-	if _, ok := state2.Groups["2"]; ok {
-		t.Errorf("node removal failed")
+	if group, ok = state2.Groups["2"]; !ok {
+		t.Errorf("group 2 is removed")
+	}
+
+	if len(group.Members) != 0 {
+		t.Errorf("Expected 0 members in group 2 but got %d", len(group.Members))
 	}
 
 	doTestQuery(t, dg)

--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -157,13 +157,10 @@ func TestNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	group, ok := state2.Groups["3"]
-	if !ok {
-		t.Errorf("group 3 is removed")
-	}
+	require.True(t, ok, "group 3 is removed")
 
-	if len(group.Members) != 0 {
-		t.Errorf("Expected 0 members in group 3 but got %d", len(group.Members))
-	}
+	require.Equal(t, len(group.Members), int(0),
+		fmt.Sprintf("Expected 0 members in group 3 but got %d", len(group.Members)))
 
 	doTestQuery(t, dg)
 
@@ -193,10 +190,8 @@ func TestNodes(t *testing.T) {
 	state2, err = testutil.GetState()
 	require.NoError(t, err)
 
-	if group, ok = state2.Groups["2"]; !ok {
-		t.Errorf("group 2 is removed")
-	}
-
+	group, ok = state2.Groups["2"]
+	require.True(t, ok, "group 2 is removed")
 	if len(group.Members) != 0 {
 		t.Errorf("Expected 0 members in group 2 but got %d", len(group.Members))
 	}


### PR DESCRIPTION
Manually tested by having two alpha with 1 replica count. removed one alpha and joined a new alpha. Alpha joined back to the existing group as expected
Signed-off-by: பாலாஜி <balaji@dgraph.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4274)
<!-- Reviewable:end -->
