### PR TITLE
Copy xid string to reduce memory usage in bulk loader

### DIFF
--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -241,7 +241,16 @@ func (m *mapper) uid(xid string) uint64 {
 }
 
 func (m *mapper) lookupUid(xid string) uint64 {
-	uid, isNew := m.xids.AssignUid(xid)
+	// We create a copy of xid string here because it is stored in
+	// the map in AssignUid and going to be around throughout the process.
+	// We don't want to keep the whole line that we read from file alive.
+	// xid is a substring of the line that we read from the file and if
+	// xid is alive, the whole line is going to be alive and won't be GC'd.
+	// Also, checked that sb goes on the stack whereas sb.String() goes on
+	// heap. Note that the calls to the strings.Builder.* are inlined.
+	sb := strings.Builder{}
+	sb.WriteString(xid)
+	uid, isNew := m.xids.AssignUid(sb.String())
 	if !m.opt.StoreXids || !isNew {
 		return uid
 	}


### PR DESCRIPTION
## After Stats
Max resident memory - 31.1G
Time taken by map phase - 39.3 Minute
Time taken by reduce phase - 33 Minute

## Before Stats
Max resident memory - 34.2G
Time taken by map phase - 39 Minute
Time taken by reduce phase - 30 Minute

## After Profile at 10 min
```
File: dgraph
Build ID: 43fce895410216c7e6d92f3051b3d1af285c99a8
Type: inuse_space
Time: Nov 20, 2019 at 6:05pm (IST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 7.72GB, 98.74% of 7.81GB total
Dropped 41 nodes (cum <= 0.04GB)
Showing top 10 nodes out of 28
      flat  flat%   sum%        cum   cum%
    3.80GB 48.66% 48.66%     3.80GB 48.69%  github.com/dgraph-io/dgraph/xidmap.(*XidMap).AssignUid
    1.54GB 19.72% 68.39%     1.54GB 19.72%  strings.(*Builder).WriteString
    0.95GB 12.13% 80.52%     0.95GB 12.13%  github.com/dgraph-io/dgraph/posting.glob..func1
    0.78GB  9.99% 90.50%     0.78GB  9.99%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.newMapper.func1
    0.29GB  3.67% 94.18%     0.29GB  3.67%  github.com/dgraph-io/dgraph/x.generateKey
    0.11GB  1.41% 95.59%     0.11GB  1.41%  github.com/dgraph-io/dgraph/types.Marshal
    0.08GB  1.08% 96.67%     0.08GB  1.08%  sync.(*poolChain).pushHead
    0.08GB  1.07% 97.74%     0.86GB 11.06%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addMapEntry
    0.05GB  0.63% 98.37%     0.05GB  0.63%  bytes.makeSlice
    0.03GB  0.37% 98.74%     0.07GB  0.89%  github.com/dgraph-io/dgraph/chunker.(*rdfChunker).Parse
(pprof) 
```

## Before Profile at 10 min
```
File: dgraph
Build ID: 6f3453d2b4bba8317363a2d7bd282fd23cb465c9
Type: inuse_space
Time: Nov 20, 2019 at 6:38pm (IST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 
Showing nodes accounting for 10.78GB, 98.43% of 10.95GB total
Dropped 60 nodes (cum <= 0.05GB)
Showing top 10 nodes out of 23
      flat  flat%   sum%        cum   cum%
    4.63GB 42.30% 42.30%     4.63GB 42.30%  bytes.(*Buffer).ReadString
    3.83GB 34.98% 77.27%     3.83GB 35.00%  github.com/dgraph-io/dgraph/xidmap.(*XidMap).AssignUid
    0.98GB  8.91% 86.18%     0.98GB  8.91%  github.com/dgraph-io/dgraph/posting.glob..func1
    0.76GB  6.92% 93.10%     0.76GB  6.92%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.newMapper.func1
    0.28GB  2.52% 95.62%     0.28GB  2.52%  github.com/dgraph-io/dgraph/x.generateKey
    0.10GB  0.89% 96.51%     0.10GB  0.89%  github.com/dgraph-io/dgraph/types.Marshal
    0.09GB  0.81% 97.32%     0.85GB  7.73%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*mapper).addMapEntry
    0.08GB  0.76% 98.08%     0.08GB  0.76%  sync.(*poolChain).pushHead
    0.04GB  0.35% 98.43%     4.71GB 42.99%  github.com/dgraph-io/dgraph/chunker.(*rdfChunker).Parse
         0     0% 98.43%     6.10GB 55.69%  github.com/dgraph-io/dgraph/dgraph/cmd/bulk.(*loader).mapStage.func1
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4287)
<!-- Reviewable:end -->
