### PR TITLE
Use txn writer to write schema postings

### DIFF
--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -143,8 +143,6 @@ func (s *schemaStore) getPredicates(db *badger.DB) []string {
 }
 
 func (s *schemaStore) write(db *badger.DB, preds []string) {
-	// Write schema always at timestamp 1, s.state.writeTs may not be equal to 1
-	// if bulk loader was restarted or other similar scenarios.
 	w := posting.NewTxnWriter(db)
 	for _, pred := range preds {
 		sch, ok := s.schemaMap[pred]
@@ -154,6 +152,8 @@ func (s *schemaStore) write(db *badger.DB, preds []string) {
 		k := x.SchemaKey(pred)
 		v, err := sch.Marshal()
 		x.Check(err)
+		// Write schema and types always at timestamp 1, s.state.writeTs may not be equal to 1
+		// if bulk loader was restarted or other similar scenarios.
 		x.Check(w.SetAt(k, v, posting.BitSchemaPosting, 1))
 	}
 


### PR DESCRIPTION
Fixes #3916 

Although I was not able to reproduce this. Stacktrace suggests, while writing schema to Badger, it got crashed with error: `Txn is too big to fit into one request`. This might be because, we are using single transaction to write schema for all predicates.
This PR, replaces single transaction with TxnWriter to write schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4296)
<!-- Reviewable:end -->
