### PR TITLE
docs: Update instructions to build Dgraph from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,21 @@ docker pull dgraph/dgraph:latest
 
 ## Install from Source
 
-If you want to install from source, you can use `go get` to install to `$GOPATH/bin`.
+If you want to install from source, install Go 1.11+ or later and the following dependencies:
+
+Ubuntu:
+```bash
+sudo apt-get update
+sudo apt-get install gcc make
+```
+
+Then clone the Dgraph repository and use `make install` to install the Dgraph binary to `$GOPATH/bin`.
+
 
 ```bash
-go get -v github.com/dgraph-io/dgraph/dgraph
+git clone https://github.com/dgraph-io/dgraph.git
+cd ./dgraph
+make install
 ```
 
 ## Get Started

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -49,17 +49,27 @@ dgraph
 #### Building from Source
 
 {{% notice "note" %}}
-Ratel UI is closed source right now, so you cannot build it from source. But you can connect to your Dgraph instance
-through Ratel UI installed using any of the methods listed above.
+You can build the Ratel UI from source seperately following its build
+[instructions](https://github.com/dgraph-io/ratel/blob/master/INSTRUCTIONS.md).
+Ratel UI is distributed via Dgraph releases using any of the download methods
+listed above.
 {{% /notice %}}
 
-Make sure you have [Go](https://golang.org/dl/) (version >= 1.8) installed.
+Make sure you have [Go](https://golang.org/dl/) v1.11+ installed.
+
+You'll need the following dependencies to install Dgraph using `make`:
+```bash
+sudo apt-get update
+sudo apt-get install gcc make
+```
 
 After installing Go, run
 ```sh
 # This should install dgraph binary in your $GOPATH/bin.
 
-go get -v github.com/dgraph-io/dgraph/dgraph
+git clone https://github.com/dgraph-io/dgraph.git
+cd ./dgraph
+make install
 ```
 
 If you get errors related to `grpc` while building them, your


### PR DESCRIPTION
Fixes #4272.

These instructions are updated for the build process with Go modules.
Dgraph's own dependencies are not fetched when using `go get`, so
cloning the repository and running `make install` (go build / go install)
within the source directory works the expected way.

* Use `make`.
* Update Ratel build instructions, referring to github.com/dgraph-io/ratel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4300)
<!-- Reviewable:end -->
