### PR TITLE
Fix bug with conditional updates

### DIFF
--- a/dgraph/cmd/graphql/resolve/mutation_rewriter.go
+++ b/dgraph/cmd/graphql/resolve/mutation_rewriter.go
@@ -193,6 +193,10 @@ func (mrw *mutationRewriter) FromMutationResult(
 		return rewriteAsGet(mutation.QueryField(), uid), nil
 
 	case schema.UpdateMutation:
+		if len(assigned) > 0 {
+			return nil, schema.GQLWrapf(errors.New("received assigned uids from Dgraph for update"+
+				"mutation"), "assigned: %s should have been empty", assigned)
+		}
 		var uids []uint64
 		if len(mutated) > 0 {
 			// This is the case of a conditional upsert where we should get uids from mutated.

--- a/dgraph/cmd/graphql/resolve/mutation_rewriter.go
+++ b/dgraph/cmd/graphql/resolve/mutation_rewriter.go
@@ -24,6 +24,7 @@ import (
 	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/graphql/schema"
 	"github.com/dgraph-io/dgraph/gql"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
 
@@ -194,8 +195,10 @@ func (mrw *mutationRewriter) FromMutationResult(
 
 	case schema.UpdateMutation:
 		if len(assigned) > 0 {
-			return nil, schema.GQLWrapf(errors.New("received assigned uids from Dgraph for update"+
-				"mutation"), "assigned: %s should have been empty", assigned)
+			glog.Errorf("Received unexpected assigned uids: %v for update mutation from Dgraph.",
+				assigned)
+			return nil, schema.GQLWrapf(errors.New("(internal error) received unexpected result "+
+				"from Dgraph for update mutation"), "internal error, unexpected result from Dgraph")
 		}
 		var uids []uint64
 		if len(mutated) > 0 {

--- a/dgraph/cmd/graphql/resolve/mutation_test.go
+++ b/dgraph/cmd/graphql/resolve/mutation_test.go
@@ -122,9 +122,15 @@ func TestMutationQueryRewriting(t *testing.T) {
 				require.NoError(t, err)
 				gqlMutation := test.GetMutation(t, op)
 
+				assigned := map[string]string{}
+				mutated := map[string][]string{}
+				if name == "Add Post " {
+					assigned["newnode"] = "0x4"
+				} else {
+					mutated[mutationQueryVar] = []string{"0x4"}
+				}
 				dgQuery, err := testRewriter.FromMutationResult(
-					gqlMutation, map[string]string{"newnode": "0x4"},
-					map[string][]string{mutationQueryVar: []string{"0x4"}})
+					gqlMutation, assigned, mutated)
 
 				require.Nil(t, err)
 				require.Equal(t, tcase.DGQuery, dgraph.AsString(dgQuery))

--- a/dgraph/cmd/graphql/resolve/mutation_test.go
+++ b/dgraph/cmd/graphql/resolve/mutation_test.go
@@ -45,6 +45,7 @@ type TestCase struct {
 	Explanation    string
 	DgraphMutation string
 	DgraphQuery    string
+	Condition      string
 	Error          *x.GqlError
 }
 
@@ -82,6 +83,7 @@ func TestMutationRewriting(t *testing.T) {
 				require.Equal(t, tcase.Error.Error(), err.Error())
 			} else {
 				require.Len(t, muts, 1)
+				require.Equal(t, tcase.Condition, muts[0].Cond)
 				jsonMut := string(muts[0].SetJson)
 				require.JSONEq(t, tcase.DgraphMutation, jsonMut)
 				require.Equal(t, tcase.DgraphQuery, dgraph.AsString(q))

--- a/dgraph/cmd/graphql/resolve/mutation_test.yaml
+++ b/dgraph/cmd/graphql/resolve/mutation_test.yaml
@@ -172,6 +172,7 @@
     query {
       x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124))
     }
+  condition: "@if(gt(len(x), 0))"
 
 -
   name: "Add mutation for a type that implements an interface"
@@ -241,6 +242,7 @@
     query {
       x as updateHuman(func: type(Human)) @filter(uid(0x123))
     }
+  condition: "@if(gt(len(x), 0))"
 
 -
   name: "Update mutation for an interface"
@@ -262,6 +264,7 @@
     query {
       x as updateCharacter(func: type(Character)) @filter(uid(0x123))
     }
+  condition: "@if(gt(len(x), 0))"
 
 -
   name: "Update mutation using filters"
@@ -292,3 +295,5 @@
     query {
       x as updatePost(func: type(Post)) @filter(eq(Post.tags, "foo"))
     }
+  condition: "@if(gt(len(x), 0))"
+

--- a/dgraph/cmd/graphql/resolve/resolver_error_test.go
+++ b/dgraph/cmd/graphql/resolve/resolver_error_test.go
@@ -316,7 +316,6 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 		"Update Mutation adds missing nullable fields": {
 			explanation: "Field 'dob' is nullable, so null should be inserted " +
 				"if the mutation's query doesn't return a value.",
-			mutResponse: map[string]string{"newnode": "0x1"},
 			queryResponse: `{ "post" : [
 				{ "title": "A Post",
 				"text": "Some text",
@@ -330,7 +329,6 @@ func TestUpdateMutationUsesErrorPropagation(t *testing.T) {
 			explanation: "An Author's name is non-nullable, so if that's missing, " +
 				"the author is squashed to null, but that's also non-nullable, so the " +
 				"propagates to the query root.",
-			mutResponse: map[string]string{"newnode": "0x1"},
 			queryResponse: `{ "post" : [ {
 				"title": "A Post",
 				"text": "Some text",


### PR DESCRIPTION
Updates using filters could end up creating new nodes because we use upsert. Modified the upsert to be a conditional upsert which should avoid creating new nodes. We also return an error if the updateMutation receives assigned uids.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4306)
<!-- Reviewable:end -->
