### PR TITLE
Fix segmentation fault in backup.

### DIFF
--- a/ee/backup/handler.go
+++ b/ee/backup/handler.go
@@ -94,6 +94,20 @@ type Credentials struct {
 	anonymous    bool
 }
 
+func (creds *Credentials) hasCredentials() bool {
+	if creds == nil {
+		return false
+	}
+	return creds.accessKey != "" && creds.secretKey != ""
+}
+
+func (creds *Credentials) isAnonymous() bool {
+	if creds == nil {
+		return false
+	}
+	return creds.anonymous
+}
+
 // GetCredentialsFromRequest extracts the credentials from a backup request.
 func GetCredentialsFromRequest(req *pb.BackupRequest) *Credentials {
 	return &Credentials{

--- a/ee/backup/s3_handler.go
+++ b/ee/backup/s3_handler.go
@@ -55,10 +55,6 @@ type s3Handler struct {
 	uri                      *url.URL
 }
 
-func (h *s3Handler) hasCredentials() bool {
-	return h.creds.accessKey != "" && h.creds.secretKey != ""
-}
-
 // setup creates a new session, checks valid bucket at uri.Path, and configures a minio client.
 // setup also fills in values used by the handler in subsequent calls.
 // Returns a new S3 minio client, otherwise a nil client with an error.
@@ -70,9 +66,9 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 	glog.V(2).Infof("Backup using host: %s, path: %s", uri.Host, uri.Path)
 
 	var creds credentials.Value
-	if h.creds.anonymous {
+	if h.creds.isAnonymous() {
 		// No need to setup credentials.
-	} else if !h.hasCredentials() {
+	} else if !h.creds.hasCredentials() {
 		var provider credentials.Provider
 		switch uri.Scheme {
 		case "s3":

--- a/ee/backup/s3_handler.go
+++ b/ee/backup/s3_handler.go
@@ -66,9 +66,10 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 	glog.V(2).Infof("Backup using host: %s, path: %s", uri.Host, uri.Path)
 
 	var creds credentials.Value
-	if h.creds.isAnonymous() {
+	switch {
+	case h.creds.isAnonymous():
 		// No need to setup credentials.
-	} else if !h.creds.hasCredentials() {
+	case !h.creds.hasCredentials():
 		var provider credentials.Provider
 		switch uri.Scheme {
 		case "s3":
@@ -96,7 +97,7 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 		// If no credentials can be retrieved, an attempt to access the destination
 		// with no credentials will be made.
 		creds, _ = provider.Retrieve() // error is always nil
-	} else {
+	default:
 		creds.AccessKeyID = h.creds.accessKey
 		creds.SecretAccessKey = h.creds.secretKey
 		creds.SessionToken = h.creds.sessionToken

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -43,9 +43,10 @@ var (
 	restoreDir = "./data/restore"
 	testDirs   = []string{backupDir, restoreDir}
 
-	mc                *minio.Client
-	bucketName        = "dgraph-backup"
-	backupDestination = "minio://minio1:9001/dgraph-backup?secure=false"
+	mc             *minio.Client
+	bucketName     = "dgraph-backup"
+	backupDst      = "minio://minio1:9001/dgraph-backup?secure=false"
+	localBackupDst = "minio://localhost:9001/dgraph-backup?secure=false"
 
 	alphaContainers = []string{
 		"alpha1",
@@ -98,12 +99,16 @@ func TestBackupMinio(t *testing.T) {
 	}
 	require.True(t, moveOk)
 
+	// Setup environmental variables for use during restore.
+	os.Setenv("MINIO_ACCESS_KEY", "accesskey")
+	os.Setenv("MINIO_SECRET_KEY", "secretkey")
+
 	// Setup test directories.
 	dirSetup(t)
 
 	// Send backup request.
 	_ = runBackup(t, 3, 1)
-	restored := runRestore(t, backupDir, "", math.MaxUint64)
+	restored := runRestore(t, "", math.MaxUint64)
 
 	checks := []struct {
 		blank, expected string
@@ -131,7 +136,7 @@ func TestBackupMinio(t *testing.T) {
 
 	// Perform first incremental backup.
 	_ = runBackup(t, 6, 2)
-	restored = runRestore(t, backupDir, "", incr1.Txn.CommitTs)
+	restored = runRestore(t, "", incr1.Txn.CommitTs)
 
 	checks = []struct {
 		blank, expected string
@@ -155,7 +160,7 @@ func TestBackupMinio(t *testing.T) {
 
 	// Perform second incremental backup.
 	_ = runBackup(t, 9, 3)
-	restored = runRestore(t, backupDir, "", incr2.Txn.CommitTs)
+	restored = runRestore(t, "", incr2.Txn.CommitTs)
 
 	checks = []struct {
 		blank, expected string
@@ -179,7 +184,7 @@ func TestBackupMinio(t *testing.T) {
 
 	// Perform second full backup.
 	dirs := runBackupInternal(t, true, 12, 4)
-	restored = runRestore(t, backupDir, "", incr3.Txn.CommitTs)
+	restored = runRestore(t, "", incr3.Txn.CommitTs)
 
 	// Check all the values were restored to their most recent value.
 	checks = []struct {
@@ -216,7 +221,7 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	}
 
 	resp, err := http.PostForm("http://localhost:8180/admin/backup", url.Values{
-		"destination": []string{backupDestination},
+		"destination": []string{backupDst},
 		"force_full":  []string{forceFullStr},
 	})
 	require.NoError(t, err)
@@ -246,14 +251,17 @@ func runBackupInternal(t *testing.T, forceFull bool, numExpectedFiles,
 	return dirs
 }
 
-func runRestore(t *testing.T, backupLocation, lastDir string, commitTs uint64) map[string]string {
+func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string {
 	// Recreate the restore directory to make sure there's no previous data when
 	// calling restore.
 	require.NoError(t, os.RemoveAll(restoreDir))
 	require.NoError(t, os.MkdirAll(restoreDir, os.ModePerm))
 
-	t.Logf("--- Restoring from: %q", backupLocation)
-	_, err := backup.RunRestore("./data/restore", backupLocation, lastDir)
+	t.Logf("--- Restoring from: %q", localBackupDst)
+	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore"}
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})
 	require.NoError(t, err)
 
 	restored, err := testutil.GetPValues("./data/restore/p1", "movie", commitTs)

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -47,12 +47,6 @@ var (
 	bucketName     = "dgraph-backup"
 	backupDst      = "minio://minio1:9001/dgraph-backup?secure=false"
 	localBackupDst = "minio://localhost:9001/dgraph-backup?secure=false"
-
-	alphaContainers = []string{
-		"alpha1",
-		"alpha2",
-		"alpha3",
-	}
 )
 
 func TestBackupMinio(t *testing.T) {


### PR DESCRIPTION
Properly treat nil credentials in the S3 handler. Right now, restore
passes a nil credentials object. The S3 handler should handle it as
an empty set of credentials instead of failing with a segfault.

The existing test has been modified to use restore with a minio endpoint,
which triggers the bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4314)
<!-- Reviewable:end -->
