### PR TITLE
[BREAKING] Language sorting on Indexed data.

### DIFF
--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -331,7 +331,7 @@ func (m *mapper) addIndexMapEntries(nq gql.NQuad, de *pb.DirectedEdge) {
 		x.Check(err)
 
 		// Extract tokens.
-		toks, err := tok.BuildTokens(schemaVal.Value, tok.GetLangTokenizer(toker, nq.Lang))
+		toks, err := tok.BuildTokens(schemaVal.Value, tok.GetTokenizerForLang(toker, nq.Lang))
 		x.Check(err)
 
 		// Store index posting.

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -306,7 +306,7 @@ func (l *loader) conflictKeysForNQuad(nq *api.NQuad) ([]uint64, error) {
 		if err != nil {
 			errs = append(errs, err.Error())
 		}
-		toks, err := tok.BuildTokens(schemaVal.Value, tok.GetLangTokenizer(token, nq.Lang))
+		toks, err := tok.BuildTokens(schemaVal.Value, tok.GetTokenizerForLang(token, nq.Lang))
 		if err != nil {
 			errs = append(errs, err.Error())
 		}

--- a/posting/index.go
+++ b/posting/index.go
@@ -72,7 +72,7 @@ func indexTokens(info *indexMutationInfo) ([]string, error) {
 
 	var tokens []string
 	for _, it := range info.tokenizers {
-		toks, err := tok.BuildTokens(sv.Value, tok.GetLangTokenizer(it, lang))
+		toks, err := tok.BuildTokens(sv.Value, tok.GetTokenizerForLang(it, lang))
 		if err != nil {
 			return tokens, err
 		}
@@ -449,7 +449,7 @@ func deleteTokensFor(attr, tokenizerName string, hasLang bool) error {
 	if hasLang {
 		// We just need the tokenizer identifier for ExactTokenizer having language.
 		// It will be same for all the language.
-		tokenizer = tok.GetLangTokenizer(tokenizer, "en")
+		tokenizer = tok.GetTokenizerForLang(tokenizer, "en")
 	}
 	prefix = append(prefix, tokenizer.Identifier())
 	if err := pstore.DropPrefix(prefix); err != nil {

--- a/posting/index.go
+++ b/posting/index.go
@@ -439,12 +439,17 @@ func (l *List) AddMutationWithIndex(ctx context.Context, edge *pb.DirectedEdge,
 }
 
 // deleteTokensFor deletes the index for the given attribute and token.
-func deleteTokensFor(attr, tokenizerName string) error {
+func deleteTokensFor(attr, tokenizerName string, hasLang bool) error {
 	pk := x.ParsedKey{Attr: attr}
 	prefix := pk.IndexPrefix()
 	tokenizer, ok := tok.GetTokenizer(tokenizerName)
 	if !ok {
 		return errors.Errorf("Could not find valid tokenizer for %s", tokenizerName)
+	}
+	if hasLang {
+		// We just need the tokenizer identifier for ExactTokenizer having language.
+		// It will be same for all the language.
+		tokenizer = tok.GetLangTokenizer(tokenizer, "en")
 	}
 	prefix = append(prefix, tokenizer.Identifier())
 	if err := pstore.DropPrefix(prefix); err != nil {
@@ -785,7 +790,13 @@ func rebuildIndex(ctx context.Context, rb *IndexRebuild) error {
 	glog.Infof("Deleting index for attr %s and tokenizers %s", rb.Attr,
 		rebuildInfo.tokenizersToDelete)
 	for _, tokenizer := range rebuildInfo.tokenizersToDelete {
-		if err := deleteTokensFor(rb.Attr, tokenizer); err != nil {
+		if err := deleteTokensFor(rb.Attr, tokenizer, false); err != nil {
+			return err
+		}
+		if tokenizer != "exact" {
+			continue
+		}
+		if err := deleteTokensFor(rb.Attr, tokenizer, true); err != nil {
 			return err
 		}
 	}
@@ -804,7 +815,13 @@ func rebuildIndex(ctx context.Context, rb *IndexRebuild) error {
 		rebuildInfo.tokenizersToRebuild)
 	// Before rebuilding, the existing index needs to be deleted.
 	for _, tokenizer := range rebuildInfo.tokenizersToRebuild {
-		if err := deleteTokensFor(rb.Attr, tokenizer); err != nil {
+		if err := deleteTokensFor(rb.Attr, tokenizer, false); err != nil {
+			return err
+		}
+		if tokenizer != "exact" {
+			continue
+		}
+		if err := deleteTokensFor(rb.Attr, tokenizer, true); err != nil {
 			return err
 		}
 	}
@@ -824,6 +841,7 @@ func rebuildIndex(ctx context.Context, rb *IndexRebuild) error {
 				Value: p.Value,
 				Tid:   types.TypeID(p.ValType),
 			}
+			edge.Lang = string(p.LangTag)
 
 			for {
 				err := txn.addIndexMutations(ctx, &indexMutationInfo{

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -236,12 +236,12 @@ type Speaker {
 }
 
 name                           : string @index(term, exact, trigram) @count @lang .
-name_lang					   : string @lang .
+name_lang                      : string @lang .
 lang_type                      : string @index(exact) .
-name_lang_index				   : string @index(exact) @lang .
+name_lang_index                : string @index(exact) @lang .
 alt_name                       : [string] @index(term, exact, trigram) @count .
 alias                          : string @index(exact, term, fulltext) .
-alias_lang					   : string @index(exact) @lang .
+alias_lang                     : string @index(exact) @lang .
 abbr                           : string .
 dob                            : dateTime @index(year) .
 dob_day                        : dateTime @index(day) .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -294,7 +294,9 @@ noindex_age                    : int .
 noindex_dob                    : datetime .
 noindex_alive                  : bool .
 noindex_salary                 : float .
-language                       : [string] .
+language                       : [string] .\
+name_lang_index                : string @index(exact) @lang .
+name_index                	   : string @index(exact) .
 `
 
 func populateCluster() {
@@ -307,6 +309,19 @@ func populateCluster() {
 	testutil.AssignUids(100000)
 
 	err = addTriplesToCluster(`
+
+	<10101> <name_lang_index> "zon"@sv .
+	<10101> <name_lang_index> "öffnen"@de .
+	<10102> <name_lang_index> "öppna"@sv .
+	<10102> <name_lang_index> "zumachen"@de .
+
+
+	<10103> <name_index> "zon" .
+	<10104> <name_index> "öffnen" .
+	<10105> <name_index> "öppna" .
+	<10106> <name_index> "zumachen" .
+
+
 		<1> <name> "Michonne" .
 		<2> <name> "King Lear" .
 		<3> <name> "Margaret" .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -238,8 +238,10 @@ type Speaker {
 name                           : string @index(term, exact, trigram) @count @lang .
 name_lang					   : string @lang .
 lang_type                      : string @index(exact) .
+name_lang_index				   : string @index(exact) @lang .
 alt_name                       : [string] @index(term, exact, trigram) @count .
 alias                          : string @index(exact, term, fulltext) .
+alias_lang					   : string @index(exact) @lang .
 abbr                           : string .
 dob                            : dateTime @index(year) .
 dob_day                        : dateTime @index(day) .
@@ -370,9 +372,13 @@ func populateCluster() {
 		<10007> <name> "Elizabeth" .
 		<10101> <name_lang> "zon"@sv .
 		<10101> <name_lang> "öffnen"@de .
+		<10101> <name_lang_index> "zon"@sv .
+		<10101> <name_lang_index> "öffnen"@de .
 		<10101> <lang_type> "Test" .
 		<10102> <name_lang> "öppna"@sv .
 		<10102> <name_lang> "zumachen"@de .
+		<10102> <name_lang_index> "öppna"@sv .
+		<10102> <name_lang_index> "zumachen"@de .
 		<10102> <lang_type> "Test" .
 		<11000> <name> "Baz Luhrmann"@en .
 		<11001> <name> "Strictly Ballroom"@en .
@@ -513,6 +519,12 @@ func populateCluster() {
 		<25> <alias> "Bob Joe" .
 		<31> <alias> "Allan Matt" .
 		<101> <alias> "John Oliver" .
+
+		<23> <alias_lang> "Zambo Alice"@en .
+		<24> <alias_lang> "John Alice"@en .
+		<25> <alias_lang> "Bob Joe"@en .
+		<31> <alias_lang> "Allan Matt"@en .
+		<101> <alias_lang> "John Oliver"@en .
 
 		<1> <bin_data> "YmluLWRhdGE=" .
 

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -294,9 +294,7 @@ noindex_age                    : int .
 noindex_dob                    : datetime .
 noindex_alive                  : bool .
 noindex_salary                 : float .
-language                       : [string] .\
-name_lang_index                : string @index(exact) @lang .
-name_index                	   : string @index(exact) .
+language                       : [string] .
 `
 
 func populateCluster() {
@@ -309,19 +307,6 @@ func populateCluster() {
 	testutil.AssignUids(100000)
 
 	err = addTriplesToCluster(`
-
-	<10101> <name_lang_index> "zon"@sv .
-	<10101> <name_lang_index> "öffnen"@de .
-	<10102> <name_lang_index> "öppna"@sv .
-	<10102> <name_lang_index> "zumachen"@de .
-
-
-	<10103> <name_index> "zon" .
-	<10104> <name_index> "öffnen" .
-	<10105> <name_index> "öppna" .
-	<10106> <name_index> "zumachen" .
-
-
 		<1> <name> "Michonne" .
 		<2> <name> "King Lear" .
 		<3> <name> "Margaret" .

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -200,8 +200,8 @@ func TestToFastJSONOrderLang(t *testing.T) {
 	query := `
 		{
 			me(func: uid(0x01)) {
-				friend(first:2, orderdesc: alias@en) {
-					alias
+				friend(first: 2, orderdesc: alias_lang@en) {
+					alias_lang@en
 				}
 			}
 		}
@@ -209,7 +209,17 @@ func TestToFastJSONOrderLang(t *testing.T) {
 
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"friend":[{"alias":"Zambo Alice"},{"alias":"John Oliver"}]}]}}`,
+		`{
+			"data": {
+				"me": [{
+					"friend": [{
+						"alias_lang@en": "Zambo Alice"
+					}, {
+						"alias_lang@en": "John Oliver"
+					}]
+				}]
+			}
+		}`,
 		js)
 }
 

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -959,6 +959,69 @@ func TestLanguageOrderIndexed2(t *testing.T) {
 		js)
 }
 
+func TestLanguageOrderIndexed3(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderasc: name_lang_index)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": []
+			}
+		}`,
+		js)
+}
+
+func TestLanguageOrderIndexed4(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderasc: name_lang_index@hi)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": []
+			}
+		}`,
+		js)
+}
+
+func TestLanguageOrderIndexedPaginationOffset(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderasc: name_lang_index@sv, first: 1, offset: 1)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": [{
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}]
+			}
+		}`,
+		js)
+}
+
 // Test sorting / ordering by dob.
 func TestToFastJSONOrderDesc_pawan(t *testing.T) {
 

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -907,6 +907,58 @@ func TestLanguageOrderNonIndexed2(t *testing.T) {
 		js)
 }
 
+func TestLanguageOrderIndexed1(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderasc: name_lang_index@de)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": [{
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}, {
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}]
+			}
+		}`,
+		js)
+}
+
+func TestLanguageOrderIndexed2(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderasc: name_lang_index@sv)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": [{
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}, {
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}]
+			}
+		}`,
+		js)
+}
+
 // Test sorting / ordering by dob.
 func TestToFastJSONOrderDesc_pawan(t *testing.T) {
 

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -999,6 +999,58 @@ func TestLanguageOrderIndexed4(t *testing.T) {
 		js)
 }
 
+func TestLanguageOrderIndexed5(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderdesc: name_lang_index@de)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": [{
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}, {
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}]
+			}
+		}`,
+		js)
+}
+
+func TestLanguageOrderIndexed6(t *testing.T) {
+	query := `
+	{
+		q(func:eq(lang_type, "Test"), orderdesc: name_lang_index@sv)  {
+			name_lang_index@de
+			name_lang_index@sv
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{
+			"data": {
+				"q": [{
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}, {
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}]
+			}
+		}`,
+		js)
+}
+
 func TestLanguageOrderIndexedPaginationOffset(t *testing.T) {
 	query := `
 	{

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -636,19 +636,19 @@ func TestHasOrderDesc(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": ""
-			  },
-			  {
-				"name": ""
-			  },
-			  {
-				"name": "Badger"
-			  },
-			  {
 				"name": "name"
 			  },
 			  {
 				"name": "expand"
+			  },
+			  {
+				"name": "Shoreline Amphitheater"
+			  },
+			  {
+				"name": "School B"
+			  },
+			  {
+				"name": "School A"
 			  }
 			]
 		  }
@@ -665,19 +665,19 @@ func TestHasOrderDescOffset(t *testing.T) {
 		"data": {
 			"q": [
 			  {
-				"name": "Shoreline Amphitheater"
-			  },
-			  {
-				"name": "School B"
-			  },
-			  {
-				"name": "School A"
-			  },
-			  {
 				"name": "San Mateo School District"
 			  },
 			  {
 				"name": "San Mateo High School"
+			  },
+			  {
+				"name": "San Mateo County"
+			  },
+			  {
+				"name": "San Carlos Airport"
+			  },
+			  {
+				"name": "San Carlos"
 			  }
 			]
 		  }

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -67,7 +67,7 @@ func init() {
 		return port
 	}
 
-	grpcPort = getPort("TEST_PORT_ALPHA", 8180)
+	grpcPort = getPort("TEST_PORT_ALPHA", 9180)
 	SockAddr = fmt.Sprintf("localhost:%d", grpcPort)
 	SockAddrHttp = fmt.Sprintf("localhost:%d", grpcPort-1000)
 

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -67,7 +67,7 @@ func init() {
 		return port
 	}
 
-	grpcPort = getPort("TEST_PORT_ALPHA", 9180)
+	grpcPort = getPort("TEST_PORT_ALPHA", 8180)
 	SockAddr = fmt.Sprintf("localhost:%d", grpcPort)
 	SockAddrHttp = fmt.Sprintf("localhost:%d", grpcPort-1000)
 

--- a/tok/langbase.go
+++ b/tok/langbase.go
@@ -31,10 +31,10 @@ var langBaseCache struct {
 	m map[string]string
 }
 
-// langBase returns the BCP47 base of a language.
+// LangBase returns the BCP47 base of a language.
 // If the confidence of the matching is better than none, we return that base.
 // Otherwise, we return "en" (English) which is a good default.
-func langBase(lang string) string {
+func LangBase(lang string) string {
 	if lang == "" {
 		return enBase // default to this
 	}

--- a/tok/langbase_test.go
+++ b/tok/langbase_test.go
@@ -53,7 +53,7 @@ func TestLangBase(t *testing.T) {
 
 	var out string
 	for _, tc := range tests {
-		out = langBase(tc.in)
+		out = LangBase(tc.in)
 		require.Equal(t, tc.out, out)
 	}
 }

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -309,8 +309,8 @@ func (t ExactTokenizer) IsLossy() bool    { return false }
 
 // LangTokenizer returns the exact string along with language prefix as a token.
 type LangTokenizer struct {
-	lang string
-	cl   *collate.Collator
+	lang   string
+	cl     *collate.Collator
 	buffer *collate.Buffer
 }
 
@@ -321,11 +321,11 @@ func (t LangTokenizer) Tokens(v interface{}) ([]string, error) {
 		lang := LangBase(t.lang)
 		encodedTerm := t.cl.KeyFromString(t.buffer, term)
 
-		term := make([]byte, 0, len(lang) + 2 + len(encodedTerm))
+		term := make([]byte, 0, len(lang)+2+len(encodedTerm))
 		term = append(term, []byte(lang)...)
 		term = append(term, IdentDelimiter)
 		term = append(term, encodedTerm...)
-		
+
 		t.buffer.Reset()
 		return []string{string(term)}, nil
 	}

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -93,7 +93,6 @@ func init() {
 	registerTokenizer(MonthTokenizer{})
 	registerTokenizer(DayTokenizer{})
 	registerTokenizer(ExactTokenizer{})
-	registerTokenizer(LangTokenizer{})
 	registerTokenizer(BoolTokenizer{})
 	registerTokenizer(TrigramTokenizer{})
 	registerTokenizer(HashTokenizer{})
@@ -292,34 +291,24 @@ func (t TermTokenizer) Identifier() byte { return IdentTerm }
 func (t TermTokenizer) IsSortable() bool { return false }
 func (t TermTokenizer) IsLossy() bool    { return true }
 
-// ExactTokenizer returns the exact string as a token.
-type ExactTokenizer struct{}
-
-func (t ExactTokenizer) Name() string { return "exact" }
-func (t ExactTokenizer) Type() string { return "string" }
-func (t ExactTokenizer) Tokens(v interface{}) ([]string, error) {
-	if term, ok := v.(string); ok {
-		return []string{term}, nil
-	}
-	return nil, errors.Errorf("Exact indices only supported for string types")
-}
-func (t ExactTokenizer) Identifier() byte { return IdentExact }
-func (t ExactTokenizer) IsSortable() bool { return true }
-func (t ExactTokenizer) IsLossy() bool    { return false }
-
-// LangTokenizer returns the exact string along with language prefix as a token.
-type LangTokenizer struct {
+// ExactTokenizer returns the exact string as a token. If collator is provided for
+// any language then it also adds the language in the prefix .
+type ExactTokenizer struct {
 	langBase string
 	cl       *collate.Collator
 	buffer   *collate.Buffer
 }
 
-func (t LangTokenizer) Name() string { return "lang" }
-func (t LangTokenizer) Type() string { return "string" }
-func (t LangTokenizer) Tokens(v interface{}) ([]string, error) {
+func (t ExactTokenizer) Name() string { return "exact" }
+func (t ExactTokenizer) Type() string { return "string" }
+func (t ExactTokenizer) Tokens(v interface{}) ([]string, error) {
 	val, ok := v.(string)
 	if !ok {
-		return nil, errors.Errorf("Lang indices only supported for string types")
+		return nil, errors.Errorf("Exact indices only supported for string types")
+	}
+
+	if t.cl == nil {
+		return []string{val}, nil
 	}
 
 	encodedTerm := t.cl.KeyFromString(t.buffer, val)
@@ -332,10 +321,19 @@ func (t LangTokenizer) Tokens(v interface{}) ([]string, error) {
 	t.buffer.Reset()
 	return []string{string(term)}, nil
 }
-func (t LangTokenizer) Identifier() byte { return IdentExactLang }
-func (t LangTokenizer) IsSortable() bool { return true }
-func (t LangTokenizer) IsLossy() bool    { return false }
-func (t LangTokenizer) Prefix() []byte {
+
+func (t ExactTokenizer) Identifier() byte {
+	if t.cl == nil {
+		return IdentExact
+	}
+	return IdentExactLang
+}
+func (t ExactTokenizer) IsSortable() bool { return true }
+func (t ExactTokenizer) IsLossy() bool    { return false }
+func (t ExactTokenizer) Prefix() []byte {
+	if t.cl == nil {
+		return []byte{IdentExact}
+	}
 	prefix := []byte{IdentExactLang}
 	prefix = append(prefix, []byte(t.langBase)...)
 	prefix = append(prefix, IdentDelimiter)

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -66,7 +66,7 @@ func TestFullTextTokenizer(t *testing.T) {
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 
-	tokens, err := BuildTokens("Stemming works!", GetLangTokenizer(tokenizer, "en"))
+	tokens, err := BuildTokens("Stemming works!", GetTokenizerForLang(tokenizer, "en"))
 	require.Nil(t, err)
 	require.Equal(t, 2, len(tokens))
 	id := tokenizer.Identifier()
@@ -134,7 +134,7 @@ func TestFullTextTokenizerLang(t *testing.T) {
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 
-	tokens, err := BuildTokens("Katzen und Auffassung und Auffassung", GetLangTokenizer(tokenizer, "de"))
+	tokens, err := BuildTokens("Katzen und Auffassung und Auffassung", GetTokenizerForLang(tokenizer, "de"))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(tokens))
 	id := tokenizer.Identifier()
@@ -216,7 +216,7 @@ func TestFullTextTokenizerCJKChinese(t *testing.T) {
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 
-	got, err := BuildTokens("他是一个薪水很高的商人", GetLangTokenizer(tokenizer, "zh"))
+	got, err := BuildTokens("他是一个薪水很高的商人", GetTokenizerForLang(tokenizer, "zh"))
 	require.NoError(t, err)
 
 	id := tokenizer.Identifier()
@@ -241,7 +241,7 @@ func TestFullTextTokenizerCJKKorean(t *testing.T) {
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 
-	got, err := BuildTokens("그는 큰 급여를 가진 사업가입니다.", GetLangTokenizer(tokenizer, "ko"))
+	got, err := BuildTokens("그는 큰 급여를 가진 사업가입니다.", GetTokenizerForLang(tokenizer, "ko"))
 	require.NoError(t, err)
 
 	id := tokenizer.Identifier()
@@ -261,7 +261,7 @@ func TestFullTextTokenizerCJKJapanese(t *testing.T) {
 	require.True(t, has)
 	require.NotNil(t, tokenizer)
 
-	got, err := BuildTokens("彼は大きな給与を持つ実業家です", GetLangTokenizer(tokenizer, "ja"))
+	got, err := BuildTokens("彼は大きな給与を持つ実業家です", GetTokenizerForLang(tokenizer, "ja"))
 	require.NoError(t, err)
 
 	id := tokenizer.Identifier()

--- a/tok/tokens.go
+++ b/tok/tokens.go
@@ -42,8 +42,10 @@ func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
 		if err != nil {
 			langTag = enLangTag
 		}
-		return LangTokenizer{langBase: LangBase(lang), cl: collate.New(langTag),
+		return ExactTokenizer{langBase: LangBase(lang), cl: collate.New(langTag),
 			buffer: &collate.Buffer{}}
+	default:
+		return t
 	}
 }
 

--- a/tok/tokens.go
+++ b/tok/tokens.go
@@ -18,6 +18,8 @@ package tok
 
 import (
 	"github.com/pkg/errors"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 )
 
 // GetLangTokenizer returns the correct full-text tokenizer for the given language.
@@ -30,8 +32,12 @@ func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
 		// We must return a new instance because another goroutine might be calling this
 		// with a different lang.
 		return FullTextTokenizer{lang: lang}
-	default:
-		return t
+	case ExactTokenizer:
+		langTag, err := language.Parse(lang)
+		if err != nil {
+			langTag, _ = language.Parse("en")
+		}
+		return LangTokenizer{lang: lang, cl: collate.New(langTag), buffer: &collate.Buffer{}}
 	}
 }
 

--- a/tok/tokens.go
+++ b/tok/tokens.go
@@ -22,6 +22,10 @@ import (
 	"golang.org/x/text/language"
 )
 
+var (
+	enLangTag, _ = language.Parse("en")
+)
+
 // GetLangTokenizer returns the correct full-text tokenizer for the given language.
 func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
 	if lang == "" {
@@ -34,10 +38,12 @@ func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
 		return FullTextTokenizer{lang: lang}
 	case ExactTokenizer:
 		langTag, err := language.Parse(lang)
+		// We default to english if the language is not supported.
 		if err != nil {
-			langTag, _ = language.Parse("en")
+			langTag = enLangTag
 		}
-		return LangTokenizer{lang: lang, cl: collate.New(langTag), buffer: &collate.Buffer{}}
+		return LangTokenizer{langBase: LangBase(lang), cl: collate.New(langTag),
+			buffer: &collate.Buffer{}}
 	}
 }
 

--- a/tok/tokens.go
+++ b/tok/tokens.go
@@ -26,8 +26,8 @@ var (
 	enLangTag, _ = language.Parse("en")
 )
 
-// GetLangTokenizer returns the correct full-text tokenizer for the given language.
-func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
+// GetTokenizerForLang returns the correct full-text tokenizer for the given language.
+func GetTokenizerForLang(t Tokenizer, lang string) Tokenizer {
 	if lang == "" {
 		return t
 	}
@@ -42,6 +42,7 @@ func GetLangTokenizer(t Tokenizer, lang string) Tokenizer {
 		if err != nil {
 			langTag = enLangTag
 		}
+		// If this gets expensive memory-vise, then convert it to sync.Pool.
 		return ExactTokenizer{langBase: LangBase(lang), cl: collate.New(langTag),
 			buffer: &collate.Buffer{}}
 	default:

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -225,12 +225,15 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 
 	var prefix []byte
 	if len(order.Langs) > 0 {
-		// Only one languge is allowed.
+		// Only one language is allowed.
 		lang := order.Langs[0]
 		tokenizer = tok.GetLangTokenizer(tokenizer, lang)
-		prefix = []byte{tokenizer.Identifier()}
-		prefix = append(prefix, []byte(tok.LangBase(lang))...)
-		prefix = append(prefix, byte(tok.IdentDelimiter))
+		langTokenizer, ok := tokenizer.(tok.LangTokenizer)
+		if !ok {
+			return resultWithError(errors.Errorf(
+				"Invalid tokenizer for language %s.", lang))
+		}
+		prefix = langTokenizer.Prefix()
 	} else {
 		prefix = []byte{tokenizer.Identifier()}
 	}

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -227,7 +227,7 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 	if len(order.Langs) > 0 {
 		// Only one languge is allowed.
 		lang := order.Langs[0]
-		tokenizer = tok.GetLangTokenizer(tokenizer, lang)
+		tokenizer = tok.GetTokenizerForLang(tokenizer, lang)
 		langTokenizer, ok := tokenizer.(*tok.ExactTokenizer)
 		if !ok {
 			return resultWithError(errors.Errorf(

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -225,13 +225,13 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 
 	var prefix []byte
 	if len(order.Langs) > 0 {
-		// Only one language is allowed.
+		// Only one languge is allowed.
 		lang := order.Langs[0]
 		tokenizer = tok.GetLangTokenizer(tokenizer, lang)
-		langTokenizer, ok := tokenizer.(tok.LangTokenizer)
+		langTokenizer, ok := tokenizer.(*tok.ExactTokenizer)
 		if !ok {
 			return resultWithError(errors.Errorf(
-				"Invalid tokenizer for language %s.", lang))
+				"Failed to get tokenizer for Attribute %s for language %s.", order.Attr, lang))
 		}
 		prefix = langTokenizer.Prefix()
 	} else {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -228,7 +228,7 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 		// Only one languge is allowed.
 		lang := order.Langs[0]
 		tokenizer = tok.GetTokenizerForLang(tokenizer, lang)
-		langTokenizer, ok := tokenizer.(*tok.ExactTokenizer)
+		langTokenizer, ok := tokenizer.(tok.ExactTokenizer)
 		if !ok {
 			return resultWithError(errors.Errorf(
 				"Failed to get tokenizer for Attribute %s for language %s.", order.Attr, lang))

--- a/worker/stringfilter.go
+++ b/worker/stringfilter.go
@@ -102,7 +102,7 @@ func tokenizeValue(value types.Val, filter *stringFilter) []string {
 	// tokenizer was used in previous stages of query processing, it has to be available
 	x.AssertTrue(found)
 
-	tokens, err := tok.BuildTokens(value.Value, tok.GetLangTokenizer(tokenizer, filter.lang))
+	tokens, err := tok.BuildTokens(value.Value, tok.GetTokenizerForLang(tokenizer, filter.lang))
 	if err != nil {
 		glog.Errorf("Error while building tokens: %s", err)
 		return []string{}

--- a/worker/task.go
+++ b/worker/task.go
@@ -1730,7 +1730,7 @@ func parseSrcFn(q *pb.Query) (*functionContext, error) {
 			return nil, errors.Errorf("Could not find tokenizer with name %q", tokerName)
 		}
 		fc.tokens, _ = tok.BuildTokens(valToTok.Value,
-			tok.GetLangTokenizer(tokenizer, langForFunc(q.Langs)))
+			tok.GetTokenizerForLang(tokenizer, langForFunc(q.Langs)))
 		fc.intersectDest = needsIntersect(f)
 		fc.n = len(fc.tokens)
 	case regexFn:

--- a/worker/task.go
+++ b/worker/task.go
@@ -1619,8 +1619,15 @@ func parseSrcFn(q *pb.Query) (*functionContext, error) {
 				// In case of non-indexed predicate we won't have any tokens.
 				continue
 			}
+
+			var lang string
+			if len(q.Langs) > 0 {
+				// Only one languge is allowed.
+				lang = q.Langs[0]
+			}
+
 			// Get tokens ge / le ineqValueToken.
-			if tokens, fc.ineqValueToken, err = getInequalityTokens(q.ReadTs, attr, f,
+			if tokens, fc.ineqValueToken, err = getInequalityTokens(q.ReadTs, attr, f, lang,
 				fc.ineqValue); err != nil {
 				return nil, err
 			}

--- a/worker/task.go
+++ b/worker/task.go
@@ -1622,7 +1622,7 @@ func parseSrcFn(q *pb.Query) (*functionContext, error) {
 
 			var lang string
 			if len(q.Langs) > 0 {
-				// Only one languge is allowed.
+				// Only one language is allowed.
 				lang = q.Langs[0]
 			}
 

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -110,7 +110,7 @@ func pickTokenizer(attr string, f string) (tok.Tokenizer, error) {
 
 // getInequalityTokens gets tokens ge / le compared to given token using the first sortable
 // index that is found for the predicate.
-func getInequalityTokens(readTs uint64, attr, f string,
+func getInequalityTokens(readTs uint64, attr, f, lang string,
 	ineqValue types.Val) ([]string, string, error) {
 	tokenizer, err := pickTokenizer(attr, f)
 	if err != nil {
@@ -119,7 +119,8 @@ func getInequalityTokens(readTs uint64, attr, f string,
 
 	// Get the token for the value passed in function.
 	// XXX: the lang should be query.Langs, but it only matters in edge case test below.
-	ineqTokens, err := tok.BuildTokens(ineqValue.Value, tok.GetLangTokenizer(tokenizer, "en"))
+	tokenizer = tok.GetLangTokenizer(tokenizer, lang)
+	ineqTokens, err := tok.BuildTokens(ineqValue.Value, tokenizer)
 	if err != nil {
 		return nil, "", err
 	}

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -119,7 +119,7 @@ func getInequalityTokens(readTs uint64, attr, f, lang string,
 
 	// Get the token for the value passed in function.
 	// XXX: the lang should be query.Langs, but it only matters in edge case test below.
-	tokenizer = tok.GetLangTokenizer(tokenizer, lang)
+	tokenizer = tok.GetTokenizerForLang(tokenizer, lang)
 	ineqTokens, err := tok.BuildTokens(ineqValue.Value, tokenizer)
 	if err != nil {
 		return nil, "", err


### PR DESCRIPTION
This will fix the sorting of an indexed field having lang directive.
Fixes #4005 
This PR change the data format for predicate that has lang directive and exact index.
Users upgrading from older version of dgraph must rebuild the index.
Example: 
name: string @index(exact) @lang .
Since name predicate has lang directive and exact index. This needs to be deleted and recreated again.
Alter the schema as
name: string @lang .
This will delete the old index data and the alter the schema as
name: string @index(exact) @lang .
This will recreate the index with new data format.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4316)
<!-- Reviewable:end -->
