### PR TITLE
Adding more details for mutation error messages with scalar/uid type mismatch

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -349,10 +349,10 @@ func ValidateAndConvert(edge *pb.DirectedEdge, su *pb.SchemaUpdate) error {
 		return nil
 
 	case !schemaType.IsScalar() && storageType.IsScalar():
-		return errors.Errorf(`Input for predicate "%s" of type uid is scalar. Edge: %v`, edge.Attr, edge)
+		return errors.Errorf("Input for predicate %q of type uid is scalar. Edge: %v", edge.Attr, edge)
 
 	case schemaType.IsScalar() && !storageType.IsScalar():
-		return errors.Errorf(`Input for predicate "%s" of type scalar is uid. Edge: %v`, edge.Attr, edge)
+		return errors.Errorf("Input for predicate %q of type scalar is uid. Edge: %v", edge.Attr, edge)
 
 	// The suggested storage type matches the schema, OK!
 	case storageType == schemaType && schemaType != types.DefaultID:

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -349,10 +349,10 @@ func ValidateAndConvert(edge *pb.DirectedEdge, su *pb.SchemaUpdate) error {
 		return nil
 
 	case !schemaType.IsScalar() && storageType.IsScalar():
-		return errors.Errorf("Input for predicate %s of type uid is scalar", edge.Attr)
+		return errors.Errorf(`Input for predicate "%s" of type uid is scalar. Edge: %v`, edge.Attr, edge)
 
 	case schemaType.IsScalar() && !storageType.IsScalar():
-		return errors.Errorf("Input for predicate %s of type scalar is uid. Edge: %v", edge.Attr, edge)
+		return errors.Errorf(`Input for predicate "%s" of type scalar is uid. Edge: %v`, edge.Attr, edge)
 
 	// The suggested storage type matches the schema, OK!
 	case storageType == schemaType && schemaType != types.DefaultID:


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph-js/issues/61

- Adding quotes around the predicate name
- Adding edge in the error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4317)
<!-- Reviewable:end -->
