### PR TITLE
Return error instead of panic when geo data is corrupted

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1625,14 +1625,14 @@ func TestGeoCorruptData(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	query := `
+	q := `
 {
   all(func: has(loc)) {
       uid
       loc
   }
 }`
-	_, err = dg.NewReadOnlyTxn().Query(ctx, query)
+	_, err = dg.NewReadOnlyTxn().Query(ctx, q)
 	require.Contains(t, err.Error(), "wkb: unknown byte order: 1111011")
 }
 
@@ -1670,14 +1670,14 @@ func TestGeoValidWkbData(t *testing.T) {
 		Set:       []*api.NQuad{n},
 	})
 	require.NoError(t, err)
-	query := `
+	q := `
 {
   all(func: has(loc)) {
       uid
       loc
   }
 }`
-	resp, err := dg.NewReadOnlyTxn().Query(ctx, query)
+	resp, err := dg.NewReadOnlyTxn().Query(ctx, q)
 	require.NoError(t, err)
 	require.Contains(t, string(resp.Json), `{"type":"Point","coordinates":[1,2]}`)
 }

--- a/query/query.go
+++ b/query/query.go
@@ -394,7 +394,10 @@ func convertWithBestEffort(tv *pb.TaskValue, attr string) (types.Val, error) {
 
 	// creates appropriate type from binary format
 	sv, err := types.Convert(v, v.Tid)
-	x.Checkf(err, "Error while interpreting appropriate type from binary")
+	if err != nil {
+		// This can happen when a mutation ingests corrupt data into the database.
+		return v, errors.Wrap(err, "Error while interpreting appropriate type from binary")
+	}
 	return sv, nil
 }
 

--- a/query/query.go
+++ b/query/query.go
@@ -396,7 +396,7 @@ func convertWithBestEffort(tv *pb.TaskValue, attr string) (types.Val, error) {
 	sv, err := types.Convert(v, v.Tid)
 	if err != nil {
 		// This can happen when a mutation ingests corrupt data into the database.
-		return v, errors.Wrap(err, "Error while interpreting appropriate type from binary")
+		return v, errors.Wrapf(err, "error interpreting appropriate type for %v", attr)
 	}
 	return sv, nil
 }

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -24,14 +24,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 	geom "github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/geojson"
 	"github.com/twpayne/go-geom/encoding/wkb"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -2202,9 +2200,9 @@ func TestMultiRegexInFilter2(t *testing.T) {
 }
 
 func TestGeoDataInvalidString(t *testing.T) {
-	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
-	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+
 	ctx := context.Background()
 	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
@@ -2229,9 +2227,9 @@ func TestGeoDataInvalidString(t *testing.T) {
 // succeeds querying the data returns an error. Ideally, we should not accept
 // invalid data in a mutation though that is left as future work.
 func TestGeoCorruptData(t *testing.T) {
-	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
-	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+
 	ctx := context.Background()
 	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
@@ -2266,9 +2264,9 @@ func TestGeoCorruptData(t *testing.T) {
 // As far as I (Aman) know, this is something that should not be used
 // by a common user unless user knows what she is doing.
 func TestGeoValidWkbData(t *testing.T) {
-	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
-	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+
 	ctx := context.Background()
 	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2225,6 +2225,9 @@ func TestGeoDataInvalidString(t *testing.T) {
 	require.Contains(t, err.Error(), "geom: unsupported layout NoLayout")
 }
 
+// This test shows that GeoVal API doesn't accept string data. Though, mutation
+// succeeds querying the data returns an error. Ideally, we should not accept
+// invalid data in a mutation though that is left as future work.
 func TestGeoCorruptData(t *testing.T) {
 	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
 	require.NoError(t, err)
@@ -2259,6 +2262,9 @@ func TestGeoCorruptData(t *testing.T) {
 	require.Contains(t, err.Error(), "wkb: unknown byte order: 1111011")
 }
 
+// This test shows how we could use the GeoVal API to store geo data.
+// As far as I (Aman) know, this is something that should not be used
+// by a common user unless user knows what she is doing.
 func TestGeoValidWkbData(t *testing.T) {
 	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
 	require.NoError(t, err)

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -18,12 +18,20 @@ package query
 
 import (
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/dgraph-io/dgo/v2"
+	"github.com/dgraph-io/dgo/v2/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+	geom "github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/encoding/geojson"
+	"github.com/twpayne/go-geom/encoding/wkb"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -2191,4 +2199,105 @@ func TestMultiRegexInFilter2(t *testing.T) {
 		res := processQueryNoErr(t, query)
 		require.JSONEq(t, `{"data": {"q": [{"firstName": "Han", "lastName":"Solo"}]}}`, res)
 	}
+}
+
+func TestGeoDataInvalidString(t *testing.T) {
+	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	require.NoError(t, err)
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+	ctx := context.Background()
+	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
+	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
+
+	n := &api.NQuad{
+		Subject:   "_:test",
+		Predicate: "loc",
+		ObjectValue: &api.Value{
+			Val: &api.Value_StrVal{
+				StrVal: `{"type": "Point", "coordintaes": [1.0, 2.0]}`,
+			},
+		},
+	}
+	_, err = dg.NewTxn().Mutate(ctx, &api.Mutation{
+		CommitNow: true,
+		Set:       []*api.NQuad{n},
+	})
+	require.Contains(t, err.Error(), "geom: unsupported layout NoLayout")
+}
+
+func TestGeoCorruptData(t *testing.T) {
+	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	require.NoError(t, err)
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+	ctx := context.Background()
+	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
+	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
+
+	n := &api.NQuad{
+		Subject:   "_:test",
+		Predicate: "loc",
+		ObjectValue: &api.Value{
+			Val: &api.Value_GeoVal{
+				GeoVal: []byte(`{"type": "Point", "coordinates": [1.0, 2.0]}`),
+			},
+		},
+	}
+	_, err = dg.NewTxn().Mutate(ctx, &api.Mutation{
+		CommitNow: true,
+		Set:       []*api.NQuad{n},
+	})
+	require.NoError(t, err)
+
+	query := `
+{
+  all(func: has(loc)) {
+      uid
+      loc
+  }
+}`
+	_, err = dg.NewReadOnlyTxn().Query(ctx, query)
+	require.Contains(t, err.Error(), "wkb: unknown byte order: 1111011")
+}
+
+func TestGeoValidWkbData(t *testing.T) {
+	conn, err := grpc.Dial(testutil.SockAddr, grpc.WithInsecure())
+	require.NoError(t, err)
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+	ctx := context.Background()
+	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
+	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
+	s := `{"type": "Point", "coordinates": [1.0, 2.0]}`
+	var gt geom.T
+	if err := geojson.Unmarshal([]byte(s), &gt); err != nil {
+		panic(err)
+	}
+	data, err := wkb.Marshal(gt, binary.LittleEndian)
+	if err != nil {
+		panic(err)
+	}
+	n := &api.NQuad{
+		Subject:   "_:test",
+		Predicate: "loc",
+		ObjectValue: &api.Value{
+			Val: &api.Value_GeoVal{
+				GeoVal: data,
+			},
+		},
+	}
+
+	_, err = dg.NewTxn().Mutate(ctx, &api.Mutation{
+		CommitNow: true,
+		Set:       []*api.NQuad{n},
+	})
+	require.NoError(t, err)
+	query := `
+{
+  all(func: has(loc)) {
+      uid
+      loc
+  }
+}`
+	resp, err := dg.NewReadOnlyTxn().Query(ctx, query)
+	require.NoError(t, err)
+	require.Contains(t, string(resp.Json), `{"type":"Point","coordinates":[1,2]}`)
 }


### PR DESCRIPTION
Fixes #3740

We can still add corrupted data into the database. I think, there should be separate effort to fix that. Adding corrupt data is possible for other types as well. This PR ensures that alpha doesn't crash when corrupt data is encountered while querying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4318)
<!-- Reviewable:end -->
