### PR TITLE
docs: Document drop data and drop type operations via curl.

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -556,6 +556,10 @@ To drop all data and schema:
 ```sh
 $ curl -X POST localhost:8080/alter -d '{"drop_all": true}'
 ```
+To drop all data only (keep schema):
+```sh
+$ curl -X POST localhost:8080/alter -d '{"drop_op": "DATA"}'
+```
 
 ### Start a transaction
 

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -548,14 +548,21 @@ If all goes well, the response should be `{"code":"Success","message":"Done"}`.
 Other operations can be performed via the `/alter` endpoint as well. A specific
 predicate or the entire database can be dropped.
 
-E.g. to drop the predicate `name`:
+To drop the predicate `name`:
 ```sh
 $ curl -X POST localhost:8080/alter -d '{"drop_attr": "name"}'
 ```
+
+To drop the type `Film`:
+```sh
+$ curl -X POST localhost:8080/alter -d '{"drop_op": "TYPE", "drop_value": "Film"}'
+```
+
 To drop all data and schema:
 ```sh
 $ curl -X POST localhost:8080/alter -d '{"drop_all": true}'
 ```
+
 To drop all data only (keep schema):
 ```sh
 $ curl -X POST localhost:8080/alter -d '{"drop_op": "DATA"}'


### PR DESCRIPTION
Document both the `"drop_op": "DATA"` and `"drop_op": "TYPE"` operations via the /alter HTTP API introduced in v1.1.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4324)
<!-- Reviewable:end -->
