### PR TITLE
Fixing broken links for get started docs of master branch of docs

### DIFF
--- a/wiki/content/get-started-old/index.md
+++ b/wiki/content/get-started-old/index.md
@@ -2,7 +2,7 @@
 title = "Get Started (Old)"
 +++
 
-{{% notice "note" %}}This is an older version of the Getting Started page. You can see the latest page [here](/get-started). {{% /notice %}}
+{{% notice "note" %}}This is an older version of the Getting Started page. You can see the latest page [here](../get-started). {{% /notice %}}
 
 ## Dgraph
 

--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -2,7 +2,7 @@
 title = "Get Started with Dgraph"
 +++
 
-{{% notice "note" %}}You can see an older version of the Getting Started page [here](/get-started-old).{{% /notice %}}
+{{% notice "note" %}}You can see an older version of the Getting Started page [here](../get-started-old).{{% /notice %}}
 
 ## Tutorials
 

--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -68,8 +68,8 @@ title = "Get Started with Dgraph"
 - Go to [Clients]({{< relref "clients/index.md" >}}) to see how to communicate
 with Dgraph from your application.
 - Take the [Tour](https://tour.dgraph.io) for a guided tour of how to write queries in Dgraph.
-- A wider range of queries can also be found in the [Query Language](/query-language) reference.
-- See [Deploy](/deploy) if you wish to run Dgraph
+- A wider range of queries can also be found in the [Query Language]({{< relref "query-language/index.md" >}}) reference.
+- See [Deploy]({{< relref "deploy/index.md" >}}) if you wish to run Dgraph
   in a cluster.
 
 ## Need Help

--- a/wiki/content/tutorial-1/index.md
+++ b/wiki/content/tutorial-1/index.md
@@ -8,7 +8,7 @@ title = "Get Started with Dgraph - Introduction"
 
 In this tutorial, we'll learn how to build the following graph on Dgraph,
 
-![The simple graph](/images/tutorials/1/gs-1.JPG)
+![The simple graph](../images/tutorials/1/gs-1.JPG)
 
 In the process, we'll learn about:
 
@@ -40,7 +40,7 @@ docker run --rm -it -p 8000:8000 -p 8080:8080 -p 9080:9080 dgraph/standalone:lat
 ### Nodes and Edges
 In this section, we'll build a simple graph with two nodes and an edge connecting them.
 
-![The simple graph](/images/tutorials/1/gs-1.JPG)
+![The simple graph](../images/tutorials/1/gs-1.JPG)
 
 In a Graph Database, concepts or entities are represented as nodes.
 May it be a sale, a transaction, a place, or a person, all these entities are
@@ -59,11 +59,11 @@ The `dgraph/standalone` image setup comes with the useful Dgraph UI called Ratel
 Just visit [http://localhost:8000](http://localhost:8000) from your browser, and you will be able to access it.
 
 
-![ratel-1](/images/tutorials/1/gs-2.png)
+![ratel-1](../images/tutorials/1/gs-2.png)
 
 We'll be using the latest stable release of Ratel.
 
-![ratel-2](/images/tutorials/1/gs-3.png)
+![ratel-2](../images/tutorials/1/gs-3.png)
 
 ### Mutations using Ratel
 
@@ -110,11 +110,11 @@ A small modification to the mutation will fix it, so it creates an edge in betwe
 }
 ```
 
-![explain mutation](/images/tutorials/1/explain-query.JPG)
+![explain mutation](../images/tutorials/1/explain-query.JPG)
 
 Let's execute this mutation. Click Run and boom!
 
-![Query-gif](/images/tutorials/1/mutate-example.gif)
+![Query-gif](../images/tutorials/1/mutate-example.gif)
 
 You can see in the response that two UIDs (Universal IDentifiers) have been created.
 The two values in the `"uids"` field of the response correspond
@@ -138,7 +138,7 @@ The expression `has(name)` returns all the nodes with a predicate `name` associa
 Go to the `Query` tab this time and type in the query above.
 Then, click `Run` on the top right of the screen.
 
-![query-1](/images/tutorials/1/query-1.png)
+![query-1](../images/tutorials/1/query-1.png)
 
 Ratel renders a graph visualization of the result.
 
@@ -147,11 +147,11 @@ matching the ones, we saw in the mutation's response.
 
 You can also view the JSON results in the JSON tab on the right.
 
-![query-2](/images/tutorials/1/query-2.png)
+![query-2](../images/tutorials/1/query-2.png)
 
 #### Understanding the query
 
-![Illustration with explanation](/images/tutorials/1/explain-query-2.JPG)
+![Illustration with explanation](../images/tutorials/1/explain-query-2.JPG)
 
 The first part of the query is the user-defined function name.
 In our query, we have named it as `people`. However, you could use any other name.

--- a/wiki/content/tutorial-1/index.md
+++ b/wiki/content/tutorial-1/index.md
@@ -227,7 +227,7 @@ They also can be used to create an edge between existing nodes!
 
 Sounds interesting?
 
-Check out our next tutorial of the getting started series [here](/tutorial-2/).
+Check out our next tutorial of the getting started series [here](../tutorial-2/).
 
 ## Need Help
 

--- a/wiki/content/tutorial-2/index.md
+++ b/wiki/content/tutorial-2/index.md
@@ -8,7 +8,7 @@ In the [previous tutorial](/tutorial-1/) of getting started,
 we learned some of the basics of Dgraph. 
 Including how to run the database, add new nodes and predicates, and query them back.
 
-![Graph](/images/tutorials/2/graph-1.jpg)
+![Graph](../images/tutorials/2/graph-1.jpg)
 
 In this tutorial, we'll build the above Graph and learn more about operations using the UID (Universal Identifier) of the nodes.
 Specifically, we'll learn about:
@@ -48,7 +48,7 @@ Go to Ratel's mutate tab, paste the mutation below in the text area, and click R
 }
 ```
 
-![mutation-1](/images/tutorials/2/a-add-data.gif)
+![mutation-1](../images/tutorials/2/a-add-data.gif)
 
 ## Query using UIDs
 The UID of the nodes can be used to query them back.
@@ -74,7 +74,7 @@ Go to the query tab, type in the query below, and click Run.
 
 Now, from the result, copy the UID of Michael's node. 
 
-![get-uid](/images/tutorials/2/b-get-uid-1.png)
+![get-uid](../images/tutorials/2/b-get-uid-1.png)
 
 In the query below, replace the placeholder `MICHAELS_UID` with the UID you just copied, and run the query.
 
@@ -88,7 +88,7 @@ In the query below, replace the placeholder `MICHAELS_UID` with the UID you just
 }
 ```
 
-![get_node_from_uid](/images/tutorials/2/c-query-uid.png)
+![get_node_from_uid](../images/tutorials/2/c-query-uid.png)
 *Note: `MICHAELS_UID` appears as `0x8` in the images. The UID you get on your machine might have a different value.*
 
 You can see that the `uid` function returns the node matching the UID for Michael's node.
@@ -128,7 +128,7 @@ You can see that Michael's age is updated to 41.
 }
 ```
 
-![update check](/images/tutorials/2/d-update-check.png)
+![update check](../images/tutorials/2/d-update-check.png)
 
 Similarly, you can also add new predicates to an existing node.
 Since the predicate `country` doesn't exist for the node for `Michael`, it creates a new one.
@@ -151,7 +151,7 @@ Let's say, `Leyla` starts to follow `Michael`.
 
 We know that this relationship between them has to represented by creating the `follows` edge between them.
 
-![Graph](/images/tutorials/2/graph-2.jpg)
+![Graph](../images/tutorials/2/graph-2.jpg)
 
 First, let's copy the UIDs of nodes for `Leyla` and `Michael` from Ratel.
 
@@ -195,7 +195,7 @@ Let's run a traversal query and then understand it in detail.
 
 Here's the result. 
 
-![traversal-result](/images/tutorials/2/e-traversal.png)
+![traversal-result](../images/tutorials/2/e-traversal.png)
 
 
 The query has three parts:
@@ -222,7 +222,7 @@ Since Michael follows only one person, the traversal returns just one node.
 These are `level-2` nodes. The root nodes constitute the nodes for `level-1`.
 Again, we need to specify which predicates you want to get back from `level-2` nodes.
 
-![get_node_from_uid](/images/tutorials/2/j-explain.JPG)
+![get_node_from_uid](../images/tutorials/2/j-explain.JPG)
 
 You can extend the query to make use of `level-2` nodes and traverse the Graph further and deeper.
 Let's explore that in the next section.
@@ -253,7 +253,7 @@ That's when we say that the query is deep!
 }
 ```
 
-![level-3-query](/images/tutorials/2/f-level-3-traverse.png)
+![level-3-query](../images/tutorials/2/f-level-3-traverse.png)
 
 Here is one more example from the extention of the last query.
 
@@ -278,7 +278,7 @@ Here is one more example from the extention of the last query.
 }
 ```
 
-![level 3](/images/tutorials/2/g-level-4-traversal.png)
+![level 3](../images/tutorials/2/g-level-4-traversal.png)
 
 This query is really long! The query is four levels deep.
 In other words, the depth of the query is four.
@@ -312,7 +312,7 @@ The depth parameter specifies the maximum depth the traversal query should consi
 
 Let's run the recursive traversal query after replacing the placeholder with the UID of node for Michael.
 
-![recurse](/images/tutorials/2/h-recursive-traversal.png)
+![recurse](../images/tutorials/2/h-recursive-traversal.png)
 
 
 [Check out the docs](https://docs.dgraph.io/query-language/#recurse-query) for detailed instructions on using the `recurse` directive.
@@ -349,7 +349,7 @@ Let's delete the `age` predicate of the node for `Michael`.
 }
 ```
 
-![recurse](/images/tutorials/2/i-delete.png)
+![recurse](../images/tutorials/2/i-delete.png)
 
 ## Wrapping up
 In this tutorial, we learned about the CRUD operations using UIDs.

--- a/wiki/content/tutorial-2/index.md
+++ b/wiki/content/tutorial-2/index.md
@@ -4,7 +4,7 @@ title = "Get Started with Dgraph - Basic Operations"
 
 **Welcome to the second tutorial of getting started with Dgraph.**
 
-In the [previous tutorial](/tutorial-1/) of getting started,
+In the [previous tutorial](../tutorial-1/) of getting started,
 we learned some of the basics of Dgraph. 
 Including how to run the database, add new nodes and predicates, and query them back.
 
@@ -93,7 +93,7 @@ In the query below, replace the placeholder `MICHAELS_UID` with the UID you just
 
 You can see that the `uid` function returns the node matching the UID for Michael's node.
 
-Refer to the [previous tutorial](/tutorial-1/) if you have questions related to the structure of the query in general.
+Refer to the [previous tutorial](../tutorial-1/) if you have questions related to the structure of the query in general.
 
 ## Updating predicates
 You can also update one or more predicates of a node using its UID.
@@ -361,7 +361,7 @@ Did you know that you could search predicates based on their value?
 
 Sounds interesting?
 
-Check out our next tutorial of the getting started series [here](/tutorial-3/).
+Check out our next tutorial of the getting started series [here](../tutorial-3/).
 
 ## Need Help
 

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -4,7 +4,7 @@ title = "Get Started with Dgraph - Basic Types and Operations on them"
 
 **Welcome to the third tutorial of getting started with Dgraph.**
 
-In the [previous tutorial](/tutorial-2/) of getting started,
+In the [previous tutorial](../tutorial-2/) of getting started,
 we learned about the CRUD operations using UIDs.
 We also learned about traversals and recursive traversals.
 
@@ -635,7 +635,7 @@ Sounds interesting?
 
 See you all soon in the next tutorial. Till then, happy Graphing!
 
-Check out our next tutorial of the getting started series [here](/tutorial-4/).
+Check out our next tutorial of the getting started series [here](../tutorial-4/).
 
 ### Need Help
 

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -26,7 +26,7 @@ You can see the accompanying video below.
 Let's start by building the following graph of a simple blog application.
 Here's the Graph model of our application
 
-![main graph model](/images/tutorials/3/a-main-graph.JPG)
+![main graph model](../images/tutorials/3/a-main-graph.JPG)
 
 The above graph has three entities: Author, Blog posts, and Tags.
 The nodes in the graph represent these entities.
@@ -180,7 +180,7 @@ Go to Ratel, click on the mutate tab, paste the following mutation, and click Ru
 
 Our Graph is ready!
 
-![rating-blog-rating](/images/tutorials/3/l-fullgraph-2.png)
+![rating-blog-rating](../images/tutorials/3/l-fullgraph-2.png)
 
 Our Graph has:
 
@@ -197,7 +197,7 @@ You can see the auto-detected data types using the Ratel UI.
 Click on the schema tab on the left and then check the `Type` column.
 You'll see the predicate names and their corresponding data types.
 
-![rating-blog-rating](/images/tutorials/3/a-initial.png)
+![rating-blog-rating](../images/tutorials/3/a-initial.png)
 
 These data types include `string`, `float`, and `int` and `uid`.
 Besides them, Dgraph also offers three more basic data types: `geo`, `dateTime`, and `bool`.
@@ -234,7 +234,7 @@ First, let's query for all the Authors and their ratings.
   }
 }
 ```
-![authors](/images/tutorials/3/a-find-rating-2.png)
+![authors](../images/tutorials/3/a-find-rating-2.png)
 
 Refer to the [first episode](https://blog.dgraph.io/post/tutorial-1-getting-started/) if you have any questions related to the structure of the query in general.
 
@@ -284,7 +284,7 @@ Let's try it out.
   }
 }
 ```
-![index missing](/images/tutorials/3/b-index-missing.png)
+![index missing](../images/tutorials/3/b-index-missing.png)
 
 We got an error! The index for the `rating` predicate is missing.
 You cannot query for the value of a predicate unless you've added an index for it.
@@ -324,12 +324,12 @@ Here's the sequence of steps:
 - Click on the `rating` predicate from the list.
 - Tick the index option in the Properties UI on the right.
 
-![Add schema](/images/tutorials/3/c-add-schema.png)
+![Add schema](../images/tutorials/3/c-add-schema.png)
 
 We successfully added the index for `rating` predicate!
 Let's rerun our previous query.
 
-![rating](/images/tutorials/3/d-rating-query.png)
+![rating](../images/tutorials/3/d-rating-query.png)
 
 We successfully queried for author nodes with a rating of 4.0 or more.
 
@@ -354,7 +354,7 @@ We need to just traverse the `published` edge starting from the `author` nodes.
   }
 }
 ```
-![rating-blog-rating](/images/tutorials/3/e-rating-blog.png)
+![rating-blog-rating](../images/tutorials/3/e-rating-blog.png)
 _Check out our [previous tutorial](https://blog.dgraph.io/post/tutorial-2-getting-started/) if you have questions around graph traversal queries._
 
 
@@ -378,14 +378,14 @@ Similarly, let's extend our previous query to fetch the tags of these blog posts
 }
 ```
 
-![rating-blog-rating](/images/tutorials/3/m-four-blogs.png)
+![rating-blog-rating](../images/tutorials/3/m-four-blogs.png)
 _Note: Author nodes are in blue, blogs posts in green, and tags in pink._
 
 We have two authors, four blog posts, and their tags in the result.
 
 If you take a closer look at the result, there's a blog post with 12 dislikes.
 
-![Dislikes](/images/tutorials/3/i-dislikes-2.png)
+![Dislikes](../images/tutorials/3/i-dislikes-2.png)
 
 Let's filter and fetch only the popular blog posts.
 Let's query for only those blog posts with fewer than 10 dislikes.
@@ -422,18 +422,18 @@ Here's the query.
   }
 }
 ```
-![Dislikes](/images/tutorials/3/j-dislike-index-2.png)
+![Dislikes](../images/tutorials/3/j-dislike-index-2.png)
 
 Oops! We forgot to add the index for the dislike predicate!
 
 Go to the Schema tab, find the `dislikes` predicate, add the index from the UI.
 
-![Add index](/images/tutorials/3/g-dislike-index-3.png)
+![Add index](../images/tutorials/3/g-dislike-index-3.png)
 _Note: Notice that the `dislike` predicate is of integer type._
 
 Let's rerun the query.
 
-![rating-blog-rating](/images/tutorials/3/n-three-blogs.png)
+![rating-blog-rating](../images/tutorials/3/n-three-blogs.png)
 
 Now, we only have three blogs in the result.
 The blog with 12 dislikes is filtered out.
@@ -450,7 +450,7 @@ Let's run the following query and find all the tags in the database.
 }
 ```
 
-![tags](/images/tutorials/3/o-tags.png)
+![tags](../images/tutorials/3/o-tags.png)
 
 We got all the tags in the database.
 My favorite tag is `devrel`. What's yours?
@@ -471,7 +471,7 @@ Here are the steps to fetch all blog posts which are tagged `devrel`.
 Let's start by adding an index to the `tag_name` predicate.
 Go to Ratel, click `tag_name` predicate from the list.
 
-![string index](/images/tutorials/3/p-string-index-2.png)
+![string index](../images/tutorials/3/p-string-index-2.png)
 
 You can see that there are five choices for indices that can be applied to any `string` predicate.
 The `fulltext`, `term`, and `trigram` are advanced string indices.
@@ -489,7 +489,7 @@ The `hash` index would normally be the most performant to be used with the `eq` 
 
 Let's add the `hash` index to the `tag_name` predicate.
 
-![string index](/images/tutorials/3/m-hash.png)
+![string index](../images/tutorials/3/m-hash.png)
 
 Let's use the `eq` comparator, and fetch the root node with `tag_name` set to `devrel`.
 
@@ -501,7 +501,7 @@ Let's use the `eq` comparator, and fetch the root node with `tag_name` set to `d
 }
 ```
 
-![string index](/images/tutorials/3/q-devrel-2.png)
+![string index](../images/tutorials/3/q-devrel-2.png)
 
 We finally have the node we wanted!
 
@@ -530,7 +530,7 @@ Don't be surprised as this is expected.
 
 Let's observe our Graph model again.
 
-![main graph model](/images/tutorials/3/a-main-graph.JPG)
+![main graph model](../images/tutorials/3/a-main-graph.JPG)
 
 We know that the edges in Dgraph have directions.
 You can see that the `tagged` edge points from a `blog post` node to a `tag` node.
@@ -558,7 +558,7 @@ Let's add the `tilde (~)` at the beginning of the `tagged` edge and initiate a r
 ```
 
 
-![string index](/images/tutorials/3/r-reverse-2.png)
+![string index](../images/tutorials/3/r-reverse-2.png)
 
 We got an error!
 
@@ -566,7 +566,7 @@ Reverse traversals require an index on their predicate.
 
 Let's go to Ratel and add the `reverse` index to the edge.
 
-![string index](/images/tutorials/3/r-reverse-1.png)
+![string index](../images/tutorials/3/r-reverse-1.png)
 
 
 Let's re-run the reverse edge traversal.
@@ -584,9 +584,9 @@ Let's re-run the reverse edge traversal.
 }
 ```
 
-![uid index](/images/tutorials/3/s-devrel-blogs.png)
+![uid index](../images/tutorials/3/s-devrel-blogs.png)
 
-![uid index](/images/tutorials/3/s-devrel-blogs-2.png)
+![uid index](../images/tutorials/3/s-devrel-blogs-2.png)
 
 Phew! Now we got all the blog posts that are tagged `devrel`.
 
@@ -595,7 +595,7 @@ It requires you to reverse traverse the `published` predicate.
 
 Let's add the reverse index to the `published` edge.
 
-![uid index](/images/tutorials/3/t-reverse-published.png)
+![uid index](../images/tutorials/3/t-reverse-published.png)
 
 Now, let's run the following query.
 
@@ -616,9 +616,9 @@ Now, let's run the following query.
 }
 ```
 
-![uid index](/images/tutorials/3/u-author-reverse-1.png)
+![uid index](../images/tutorials/3/u-author-reverse-1.png)
 
-![uid index](/images/tutorials/3/u-author-reverse-2.png)
+![uid index](../images/tutorials/3/u-author-reverse-2.png)
 
 With our previous query, we just traversed the entire graph in the reverse order.
 Starting from the tag nodes, we traversed up to the author nodes.

--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -20,7 +20,7 @@ Let's learn more about them!
 Let's start with building a simple food review Graph.
 Here's the Graph model.
 
-![model](/images/tutorials/4/a-graph-model.jpg)
+![model](../images/tutorials/4/a-graph-model.jpg)
 
 The above Graph has three entities: Food, Comment, and Country.
 
@@ -117,7 +117,7 @@ _Note: If this mutation syntax is new to you, refer to the [first tutorial](/tut
 
 Here's our Graph!
 
-![full graph](/images/tutorials/4/a-full-graph.png)
+![full graph](../images/tutorials/4/a-full-graph.png)
 
 Our Graph has:
 
@@ -128,7 +128,7 @@ Our Graph has:
 You can also see that Dgraph has auto-detected the data types of the predicates.
 You can check that out from the schema tab.
 
-![full graph](/images/tutorials/4/c-schema.png)
+![full graph](../images/tutorials/4/c-schema.png)
 
 _Note: Check out the [previous tutorial](/tutorial-3/) to know more about data types in Dgraph._
 
@@ -167,7 +167,7 @@ Now, Let's fetch only the food items and their reviews,
 
 As expected, these comments are in different languages.
 
-![full graph](/images/tutorials/4/b-comments.png)
+![full graph](../images/tutorials/4/b-comments.png)
 
 But can we fetch the reviews based on their language?
 Can we write a query which says: _Hey Dgraph, can you give me only the reviews written in Chinese?_
@@ -225,7 +225,7 @@ Let's run the above mutation.
 
 Go to the mutate tab, paste the mutation, and click Run.
 
-![lang error](/images/tutorials/4/d-lang-error.png)
+![lang error](../images/tutorials/4/d-lang-error.png)
 
 We got an error! Using the language tag requires you to add the `@lang` directive to the schema.
 
@@ -236,11 +236,11 @@ Follow the instructions below to add the `@lang` directive to the `comment` pred
 - Tick mark the `lang` directive.
 - Click on the `Update` button.
 
-![lang error](/images/tutorials/4/e-update-lang.png)
+![lang error](../images/tutorials/4/e-update-lang.png)
 
 Let's re-run the mutation.
 
-![lang error](/images/tutorials/4/f-mutation-success.png)
+![lang error](../images/tutorials/4/f-mutation-success.png)
 
 Success!
 
@@ -280,7 +280,7 @@ In the [previous article](/tutorial-3/), we learned about using the `eq` operato
 
 Using that knowledge, let's first add the `hash` index for the `food_name` predicate.
 
-![hash index](/images/tutorials/4/g-hash.png)
+![hash index](../images/tutorials/4/g-hash.png)
 
 Now, go to the query tab, paste the query in the text area, and click Run.
 
@@ -295,7 +295,7 @@ Now, go to the query tab, paste the query in the text area, and click Run.
 }
 ```
 
-![hash index](/images/tutorials/4/h-comment.png)
+![hash index](../images/tutorials/4/h-comment.png)
 
 By default, the query only returns the untagged comment.
 
@@ -313,7 +313,7 @@ Let's query for a review for `Sushi` in Japanese.
 }
 ```
 
-![Japanese](/images/tutorials/4/i-japanese.png)
+![Japanese](../images/tutorials/4/i-japanese.png)
 
 Now, let's query for a review for `Sushi` in Russian.
 
@@ -328,7 +328,7 @@ Now, let's query for a review for `Sushi` in Russian.
 }
 ```
 
-![Russian](/images/tutorials/4/j-russian.png)
+![Russian](../images/tutorials/4/j-russian.png)
 
 You can also fetch all the comments for `Sushi` written in any language.
 
@@ -343,7 +343,7 @@ You can also fetch all the comments for `Sushi` written in any language.
 }
 ```
 
-![Russian](/images/tutorials/4/k-star.png)
+![Russian](../images/tutorials/4/k-star.png)
 
 Here is the table with the syntax for various ways of making use of language tags while querying.
 
@@ -360,7 +360,7 @@ Here is the table with the syntax for various ways of making use of language tag
 
 If you remember, we had initially added a Russian dish `Borscht` with its review in `Russian`.
 
-![Russian](/images/tutorials/4/l-russian.png)
+![Russian](../images/tutorials/4/l-russian.png)
 
 If you notice, we haven't used the language tag `@ru` for the review written in Russian.
 
@@ -368,7 +368,7 @@ Hence, if we query for all the reviews written in `Russian`, the review for `Bor
 
 Only the review for `Sushi,` written in `Russian`, makes it to the list.
 
-![Russian](/images/tutorials/4/m-sushi.png)
+![Russian](../images/tutorials/4/m-sushi.png)
 
 So, here's the lesson of the day!
 

--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -4,7 +4,7 @@ title = "Get Started with Dgraph - Multi-language strings"
 
 **Welcome to the fourth tutorial of getting started with Dgraph.**
 
-In the [previous tutorial](/tutorial-3/), we learned about Datatypes, Indexing, Filtering, and Reverse traversals in Dgraph.
+In the [previous tutorial](../tutorial-3/), we learned about Datatypes, Indexing, Filtering, and Reverse traversals in Dgraph.
 
 In this tutorial, we'll learn about using multi-language strings and operations on them using the language tags.
 
@@ -113,7 +113,7 @@ Let's go, amigos!
   ]
 }
 ```
-_Note: If this mutation syntax is new to you, refer to the [first tutorial](/tutorial-1/) to learn basics of mutation in Dgraph._
+_Note: If this mutation syntax is new to you, refer to the [first tutorial](../tutorial-1/) to learn basics of mutation in Dgraph._
 
 Here's our Graph!
 
@@ -130,7 +130,7 @@ You can check that out from the schema tab.
 
 ![full graph](../images/tutorials/4/c-schema.png)
 
-_Note: Check out the [previous tutorial](/tutorial-3/) to know more about data types in Dgraph._
+_Note: Check out the [previous tutorial](../tutorial-3/) to know more about data types in Dgraph._
 
 Let's write a query to fetch all the food items, their reviews, and their country of origin.
 
@@ -150,7 +150,7 @@ Go to the query tab, paste the query, and click Run.
 }
 ```
 
-_Note: Check the [second tutorial](/tutorial-2/) if you want to learn more about traversal queries like the above one_
+_Note: Check the [second tutorial](../tutorial-2/) if you want to learn more about traversal queries like the above one_
 
 Now, Let's fetch only the food items and their reviews,
 
@@ -219,7 +219,7 @@ In the above mutation:
 
 In the mutation above, Dgraph creates a new node for the reviews, and stores `comment`, `comment@ru`, and `comment@jp` in different predicates inside the same node.
 
-_Note: If you're not clear about basic terminology like `predicates`, do read the [first tutorial](/tutorial-1/)._
+_Note: If you're not clear about basic terminology like `predicates`, do read the [first tutorial](../tutorial-1/)._
 
 Let's run the above mutation.
 
@@ -276,7 +276,7 @@ In our next section, let's make use of the language tags in our queries.
 #### Querying using language tags.
 Let's obtain the review comments only for `Sushi`.
 
-In the [previous article](/tutorial-3/), we learned about using the `eq` operator and the `hash` index to query for string predicate values.
+In the [previous article](../tutorial-3/), we learned about using the `eq` operator and the `hash` index to query for string predicate values.
 
 Using that knowledge, let's first add the `hash` index for the `food_name` predicate.
 
@@ -388,11 +388,12 @@ Sounds interesting?
 See you all soon in the next tutorial. Till then, happy Graphing!
 
 ## What's Next?
+
 - Go to [Clients]({{< relref "clients/index.md" >}}) to see how to communicate
 with Dgraph from your application.
 - Take the [Tour](https://tour.dgraph.io) for a guided tour of how to write queries in Dgraph.
-- A wider range of queries can also be found in the [Query Language](/query-language) reference.
-- See [Deploy](/deploy) if you wish to run Dgraph
+- A wider range of queries can also be found in the [Query Language]({{< relref "query-language/index.md" >}}) reference.
+- See [Deploy]({{< relref "deploy/index.md" >}}) if you wish to run Dgraph
   in a cluster.
 
 ## Need Help


### PR DESCRIPTION
Fixes the issue of broken links in [version other than the latest](https://docs.dgraph.io/master/tutorial-1/), as it could be seen in the image below.

![Dgraph docs master screenshot](https://i.imgur.com/7TQj2qJ.png)

---

While running with the `local.sh` script, this issue wasn't seen.
I think that we should bring versioning to the local development environment like in the docs site.

@paulftw what do you think about it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4326)
<!-- Reviewable:end -->
