### PR TITLE
Add equivalent of Dgraph set and delete update mutations

### DIFF
--- a/dgraph/cmd/graphql/dgraph/dgo.go
+++ b/dgraph/cmd/graphql/dgraph/dgo.go
@@ -58,6 +58,10 @@ func Mutate(
 	stop := x.SpanTimer(span, "dgraph.Mutate")
 	defer stop()
 
+	if query == nil && len(mutations) == 0 {
+		return nil, nil, nil
+	}
+
 	queryStr := AsString(query)
 
 	if glog.V(3) {

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -459,8 +459,6 @@ func TestUpdateDelete(t *testing.T) {
 	gqlResponse := updateParams.ExecuteAsPost(t, graphqlURL)
 	require.Nil(t, gqlResponse.Errors)
 
-	fmt.Println(string([]byte(gqlResponse.Data)))
-
 	require.JSONEq(t, `{
 			"updatePost": {
 				"post": [
@@ -475,7 +473,7 @@ func TestUpdateDelete(t *testing.T) {
 		}`,
 		string([]byte(gqlResponse.Data)))
 
-	newPost.Text = ""                  // was delete because the given val was correct
+	newPost.Text = ""                  // was deleted because the given val was correct
 	newPost.Tags = []string{"example"} // the intersection of the tags was deleted
 	newPost.IsPublished = false        // must have been deleted because was set to nil in the patch
 	// newPost.NumLikes stays the same because the value in the patch was wrong

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -444,7 +444,7 @@ func TestUpdateDelete(t *testing.T) {
 
 	updateParams := &GraphQLParams{
 		Query: `mutation updPost($filter: PostFilter!, $del: PatchPost!) {
-			updatePost(input: { filter: $filter, delete: $del }) {
+			updatePost(input: { filter: $filter, remove: $del }) {
 				post {
 					text
 					isPublished

--- a/dgraph/cmd/graphql/e2e_mutation_test.go
+++ b/dgraph/cmd/graphql/e2e_mutation_test.go
@@ -427,10 +427,67 @@ func TestUpdateMutationByNameNoMatch(t *testing.T) {
 	cleanUp(t, []*country{newCountry, anotherCountry}, []*author{}, []*post{})
 }
 
+func TestUpdateDelete(t *testing.T) {
+	newCountry := addCountry(t, postExecutor)
+	newAuthor := addAuthor(t, newCountry.ID, postExecutor)
+	newPost := addPost(t, newAuthor.ID, newCountry.ID, postExecutor)
+
+	filter := map[string]interface{}{
+		"ids": []string{newPost.PostID},
+	}
+	delPatch := map[string]interface{}{
+		"text":        "This post is just a test.",
+		"isPublished": nil,
+		"tags":        []string{"test", "notatag"},
+		"numLikes":    999,
+	}
+
+	updateParams := &GraphQLParams{
+		Query: `mutation updPost($filter: PostFilter!, $del: PatchPost!) {
+			updatePost(input: { filter: $filter, delete: $del }) {
+				post {
+					text
+					isPublished
+					tags
+					numLikes
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{"filter": filter, "del": delPatch},
+	}
+
+	gqlResponse := updateParams.ExecuteAsPost(t, graphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+
+	fmt.Println(string([]byte(gqlResponse.Data)))
+
+	require.JSONEq(t, `{
+			"updatePost": {
+				"post": [
+					{
+						"text": null,
+						"isPublished": null,
+						"tags": ["example"],
+						"numLikes": 1000
+					}
+				]
+			}
+		}`,
+		string([]byte(gqlResponse.Data)))
+
+	newPost.Text = ""                  // was delete because the given val was correct
+	newPost.Tags = []string{"example"} // the intersection of the tags was deleted
+	newPost.IsPublished = false        // must have been deleted because was set to nil in the patch
+	// newPost.NumLikes stays the same because the value in the patch was wrong
+	requirePost(t, newPost.PostID, newPost, postExecutor)
+
+	cleanUp(t, []*country{newCountry}, []*author{newAuthor}, []*post{newPost})
+}
+
 func updateCountry(t *testing.T, filter map[string]interface{}, newName string) {
 	updateParams := &GraphQLParams{
 		Query: `mutation newName($filter: CountryFilter!, $newName: String!) {
-			updateCountry(input: { filter: $filter, patch: { name: $newName } }) {
+			updateCountry(input: { filter: $filter, set: { name: $newName } }) {
 				country {
 					id
 					name
@@ -996,7 +1053,7 @@ func updateCharacter(t *testing.T, id string) {
 			"filter": map[string]interface{}{
 				"ids": []string{id},
 			},
-			"patch": map[string]interface{}{
+			"set": map[string]interface{}{
 				"name": "Han Solo",
 			},
 		}},

--- a/dgraph/cmd/graphql/resolve/add_mutation_test.yaml
+++ b/dgraph/cmd/graphql/resolve/add_mutation_test.yaml
@@ -17,7 +17,7 @@
     }
   explanation: "A uid and type should get injected and all data transformed to
     underlying Dgraph edge names"
-  dgraphmutation: |
+  dgraphset: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -37,7 +37,7 @@
     }
   explanation: "The input should be used for the mutation, with a uid and type getting
     injected and all data transformed to underlying Dgraph edge names"
-  dgraphmutation: |
+  dgraphset: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -58,7 +58,7 @@
     { "name":  "A.N. Author" }
   explanation: "The input and variables should be used for the mutation, with a uid and type
     getting injected and all data transformed to underlying Dgraph edge names"
-  dgraphmutation: |
+  dgraphset: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -84,7 +84,7 @@
     }
   explanation: "The reference to country should get transformed to 'uid' for the
     Dgraph JSON mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid":"_:newnode",
       "dgraph.type":["Author"],
       "Author.name":"A.N. Author",
@@ -132,7 +132,7 @@
     }
   explanation: "The reference to the author node should be transformed to include
     a new 'posts' edge."
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "_:newnode",
       "dgraph.type" : ["Post"],
       "Post.title" : "Exciting post",
@@ -164,7 +164,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "_:newnode",
       "Character.name": "Bob",
       "Employee.ename": "employee no. 1",
@@ -192,7 +192,7 @@
       }
     }
   explanation: "The add mutation should get rewritten into a Dgraph upsert mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "dgraph.type": ["State"],
       "State.name": "NSW",
@@ -225,7 +225,7 @@
       }
     }
   explanation: "The add mutation should get rewritten into a Dgraph upsert mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "dgraph.type": ["Editor"],
       "Editor.name": "A.N. Editor",

--- a/dgraph/cmd/graphql/resolve/delete_mutation_test.yaml
+++ b/dgraph/cmd/graphql/resolve/delete_mutation_test.yaml
@@ -9,7 +9,8 @@
       { "ids": ["0x1", "0x2"] }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmutation: uid(x) * * .
+  dgraphdelete: |-
+    { "uid": "uid(x)" }
   dgraphquery: |-
     query {
       x as deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author))
@@ -29,7 +30,8 @@
       }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmutation: uid(x) * * .
+  dgraphdelete: |-
+    { "uid": "uid(x)" }
   dgraphquery: |-
     query {
       x as deleteAuthor(func: uid(0x1, 0x2)) @filter((eq(Author.name, "A.N. Author") AND type(Author)))
@@ -49,7 +51,8 @@
       }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
-  dgraphmutation: uid(x) * * .
+  dgraphdelete: |-
+    { "uid": "uid(x)" }
   dgraphquery: |-
     query {
       x as deleteAuthor(func: type(Author)) @filter((eq(Author.dob, "2000-01-01") AND eq(Author.name, "A.N. Author")))

--- a/dgraph/cmd/graphql/resolve/mutation_rewriter.go
+++ b/dgraph/cmd/graphql/resolve/mutation_rewriter.go
@@ -220,7 +220,7 @@ func (urw *updateRewriter) Rewrite(
 
 	inp := m.ArgValue(schema.InputArgName).(map[string]interface{})
 	setArg := inp["set"]
-	delArg := inp["delete"]
+	delArg := inp["remove"]
 
 	if setArg == nil && delArg == nil {
 		return nil, nil, nil

--- a/dgraph/cmd/graphql/resolve/mutation_rewriter.go
+++ b/dgraph/cmd/graphql/resolve/mutation_rewriter.go
@@ -203,7 +203,7 @@ func (mrw *addRewriter) FromMutationResult(
 // - set becomes the Dgraph set mutation
 // - delete becomes the Dgraph delete mutation
 //
-// The semantics is the same the Dgraph mutation semantics.
+// The semantics is the same as the Dgraph mutation semantics.
 // - Any values in set become the new values for those predicates (or add to the existing
 //   values for lists)
 // - Any nulls in set are ignored.

--- a/dgraph/cmd/graphql/resolve/mutation_rewriter.go
+++ b/dgraph/cmd/graphql/resolve/mutation_rewriter.go
@@ -347,7 +347,7 @@ func (drw *deleteRewriter) Rewrite(m schema.Mutation) (
 
 	return rewriteUpsertQueryFromMutation(m),
 		[]*dgoapi.Mutation{{
-			DelNquads: []byte(deleteUIDVarMutation),
+			DeleteJson: []byte(deleteUIDVarMutation),
 		}},
 		nil
 }

--- a/dgraph/cmd/graphql/resolve/update_mutation_test.yaml
+++ b/dgraph/cmd/graphql/resolve/update_mutation_test.yaml
@@ -44,7 +44,7 @@
       { "filter": {
           "ids": ["0x123", "0x124"]
         },
-        "delete": {
+        "remove": {
           "text": "delete this text"
         }
       }
@@ -75,7 +75,7 @@
       { "filter": {
           "ids": ["0x123", "0x124"]
         },
-        "delete": {
+        "remove": {
           "text": null
         }
       }

--- a/dgraph/cmd/graphql/resolve/update_mutation_test.yaml
+++ b/dgraph/cmd/graphql/resolve/update_mutation_test.yaml
@@ -1,5 +1,5 @@
 -
-  name: "Update mutation with variables"
+  name: "Update set mutation with variables"
   gqlmutation: |
     mutation updatePost($patch: UpdatePostInput!) {
       updatePost(input: $patch) {
@@ -13,15 +13,77 @@
       { "filter": {
           "ids": ["0x123", "0x124"]
         },
-        "patch": {
+        "set": {
           "text": "updated text"
         }
       }
     }
-  explanation: "The update patch should get rewritten into the Dgraph mutation"
-  dgraphmutation: |
+  explanation: "The update patch should get rewritten into the Dgraph set mutation"
+  dgraphset: |
     { "uid" : "uid(x)",
       "Post.text": "updated text"
+    }
+  dgraphquery: |-
+    query {
+      x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124))
+    }
+  condition: "@if(gt(len(x), 0))"
+
+-
+  name: "Update delete mutation with variables and value"
+  gqlmutation: |
+    mutation updatePost($patch: UpdatePostInput!) {
+      updatePost(input: $patch) {
+        post {
+          postId
+        }
+      }
+    }
+  gqlvariables: |
+    { "patch":
+      { "filter": {
+          "ids": ["0x123", "0x124"]
+        },
+        "delete": {
+          "text": "delete this text"
+        }
+      }
+    }
+  explanation: "The update patch should get rewritten into the Dgraph delete mutation"
+  dgraphdelete: |
+    { "uid" : "uid(x)",
+      "Post.text": "delete this text"
+    }
+  dgraphquery: |-
+    query {
+      x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124))
+    }
+  condition: "@if(gt(len(x), 0))"
+
+-
+  name: "Update delete mutation with variables and null"
+  gqlmutation: |
+    mutation updatePost($patch: UpdatePostInput!) {
+      updatePost(input: $patch) {
+        post {
+          postId
+        }
+      }
+    }
+  gqlvariables: |
+    { "patch":
+      { "filter": {
+          "ids": ["0x123", "0x124"]
+        },
+        "delete": {
+          "text": null
+        }
+      }
+    }
+  explanation: "The update patch should get rewritten into the Dgraph mutation"
+  dgraphdelete: |
+    { "uid" : "uid(x)",
+      "Post.text": null
     }
   dgraphquery: |-
     query {
@@ -47,7 +109,7 @@
         "filter": {
           "ids": ["0x123"]
         },
-        "patch": { "name": "Bob",
+        "set": { "name": "Bob",
           "dob": "2000-01-01",
           "female": true,
           "ename": "employee no. 1"
@@ -55,7 +117,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "Character.name": "Bob",
       "Employee.ename": "employee no. 1",
@@ -72,7 +134,7 @@
   name: "Update mutation for an interface"
   gqlmutation: |-
     mutation {
-      updateCharacter(input: {filter: { ids: ["0x123"] }, patch: {name:"Bob"}}) {
+      updateCharacter(input: {filter: { ids: ["0x123"] }, set: {name:"Bob"}}) {
         character {
           id
           name
@@ -80,7 +142,7 @@
       }
     }
   explanation: "The mutation should get rewritten with correct edges from the interface."
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "Character.name": "Bob"
     }
@@ -105,13 +167,13 @@
       { "filter": {
           "tags": { "eq": "foo"}
         },
-        "patch": {
+        "set": {
           "text": "updated text"
         }
       }
     }
   explanation: "The update patch should get rewritten into the Dgraph mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "Post.text": "updated text"
     }
@@ -136,13 +198,13 @@
       { "filter": {
           "code": { "eq": "nsw" }
         },
-        "patch": {
+        "set": {
           "name": "nsw"
         }
       }
     }
   explanation: "The update mutation should get rewritten into a Dgraph upsert mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "State.name": "nsw"
     }
@@ -168,13 +230,13 @@
           "code": { "eq": "editor" },
           "ids": [ "0x1", "0x2" ]
         },
-        "patch": {
+        "set": {
           "name": "A.N. Editor"
         }
       }
     }
   explanation: "The update mutation should get rewritten into a Dgraph upsert mutation"
-  dgraphmutation: |
+  dgraphset: |
     { "uid" : "uid(x)",
       "Editor.name": "A.N. Editor"
     }

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -443,10 +443,15 @@ func addUpdateType(schema *ast.Schema, defn *ast.Definition) {
 				},
 			}},
 			&ast.FieldDefinition{
-				Name: "patch",
+				Name: "set",
 				Type: &ast.Type{
 					NamedType: "Patch" + defn.Name,
-					NonNull:   true,
+				},
+			},
+			&ast.FieldDefinition{
+				Name: "delete",
+				Type: &ast.Type{
+					NamedType: "Patch" + defn.Name,
 				},
 			}),
 	}

--- a/dgraph/cmd/graphql/schema/gqlschema.go
+++ b/dgraph/cmd/graphql/schema/gqlschema.go
@@ -449,7 +449,7 @@ func addUpdateType(schema *ast.Schema, defn *ast.Definition) {
 				},
 			},
 			&ast.FieldDefinition{
-				Name: "delete",
+				Name: "remove",
 				Type: &ast.Type{
 					NamedType: "Patch" + defn.Name,
 				},

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -167,7 +167,8 @@ input TRef {
 
 input UpdateTInput {
 	filter: TFilter!
-	patch: PatchT!
+	set: PatchT
+	delete: PatchT
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -168,7 +168,7 @@ input TRef {
 input UpdateTInput {
 	filter: TFilter!
 	set: PatchT
-	delete: PatchT
+	remove: PatchT
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -231,12 +231,14 @@ input StringHashFilter_StringRegExpFilter {
 
 input UpdateAuthorInput {
 	filter: AuthorFilter!
-	patch: PatchAuthor!
+	set: PatchAuthor
+	delete: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost!
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -232,13 +232,13 @@ input StringHashFilter_StringRegExpFilter {
 input UpdateAuthorInput {
 	filter: AuthorFilter!
 	set: PatchAuthor
-	delete: PatchAuthor
+	remove: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost!
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -160,12 +160,14 @@ input PostRef {
 
 input UpdateAuthorInput {
 	filter: AuthorFilter!
-	patch: PatchAuthor!
+	set: PatchAuthor
+	delete: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -161,13 +161,13 @@ input PostRef {
 input UpdateAuthorInput {
 	filter: AuthorFilter!
 	set: PatchAuthor
-	delete: PatchAuthor
+	remove: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -317,25 +317,25 @@ input StarshipRef {
 input UpdateCharacterInput {
 	filter: CharacterFilter!
 	set: PatchCharacter
-	delete: PatchCharacter
+	remove: PatchCharacter
 }
 
 input UpdateDroidInput {
 	filter: DroidFilter!
 	set: PatchDroid
-	delete: PatchDroid
+	remove: PatchDroid
 }
 
 input UpdateHumanInput {
 	filter: HumanFilter!
 	set: PatchHuman
-	delete: PatchHuman
+	remove: PatchHuman
 }
 
 input UpdateStarshipInput {
 	filter: StarshipFilter!
 	set: PatchStarship
-	delete: PatchStarship
+	remove: PatchStarship
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -316,22 +316,26 @@ input StarshipRef {
 
 input UpdateCharacterInput {
 	filter: CharacterFilter!
-	patch: PatchCharacter!
+	set: PatchCharacter
+	delete: PatchCharacter
 }
 
 input UpdateDroidInput {
 	filter: DroidFilter!
-	patch: PatchDroid!
+	set: PatchDroid
+	delete: PatchDroid
 }
 
 input UpdateHumanInput {
 	filter: HumanFilter!
-	patch: PatchHuman!
+	set: PatchHuman
+	delete: PatchHuman
 }
 
 input UpdateStarshipInput {
 	filter: StarshipFilter!
-	patch: PatchStarship!
+	set: PatchStarship
+	delete: PatchStarship
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -134,7 +134,7 @@ input PostOrder {
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -133,7 +133,8 @@ input PostOrder {
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -185,7 +185,7 @@ input PostOrder {
 input UpdateAuthorInput {
 	filter: AuthorFilter!
 	set: PatchAuthor
-	delete: PatchAuthor
+	remove: PatchAuthor
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -184,7 +184,8 @@ input PostOrder {
 
 input UpdateAuthorInput {
 	filter: AuthorFilter!
-	patch: PatchAuthor!
+	set: PatchAuthor
+	delete: PatchAuthor
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -209,12 +209,14 @@ input StringFullTextFilter_StringTermFilter {
 
 input UpdateAuthorInput {
 	filter: AuthorFilter!
-	patch: PatchAuthor!
+	set: PatchAuthor
+	delete: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -210,13 +210,13 @@ input StringFullTextFilter_StringTermFilter {
 input UpdateAuthorInput {
 	filter: AuthorFilter!
 	set: PatchAuthor
-	delete: PatchAuthor
+	remove: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -272,7 +272,7 @@ input StringFullTextFilter_StringHashFilter_StringTermFilter_StringRegExpFilter 
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -271,7 +271,8 @@ input StringFullTextFilter_StringHashFilter_StringTermFilter_StringRegExpFilter 
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -150,7 +150,7 @@ input PostRef {
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -149,7 +149,8 @@ input PostRef {
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -144,7 +144,8 @@ input PatchMessage {
 
 input UpdateMessageInput {
 	filter: MessageFilter!
-	patch: PatchMessage!
+	set: PatchMessage
+	delete: PatchMessage
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -145,7 +145,7 @@ input PatchMessage {
 input UpdateMessageInput {
 	filter: MessageFilter!
 	set: PatchMessage
-	delete: PatchMessage
+	remove: PatchMessage
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -211,12 +211,14 @@ input PatchHuman {
 
 input UpdateCharacterInput {
 	filter: CharacterFilter!
-	patch: PatchCharacter!
+	set: PatchCharacter
+	delete: PatchCharacter
 }
 
 input UpdateHumanInput {
 	filter: HumanFilter!
-	patch: PatchHuman!
+	set: PatchHuman
+	delete: PatchHuman
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -212,13 +212,13 @@ input PatchHuman {
 input UpdateCharacterInput {
 	filter: CharacterFilter!
 	set: PatchCharacter
-	delete: PatchCharacter
+	remove: PatchCharacter
 }
 
 input UpdateHumanInput {
 	filter: HumanFilter!
 	set: PatchHuman
-	delete: PatchHuman
+	remove: PatchHuman
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -187,12 +187,14 @@ input PostRef {
 
 input UpdateAuthorInput {
 	filter: AuthorFilter!
-	patch: PatchAuthor!
+	set: PatchAuthor
+	delete: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
-	patch: PatchPost!
+	set: PatchPost
+	delete: PatchPost
 }
 
 #######################

--- a/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/dgraph/cmd/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -188,13 +188,13 @@ input PostRef {
 input UpdateAuthorInput {
 	filter: AuthorFilter!
 	set: PatchAuthor
-	delete: PatchAuthor
+	remove: PatchAuthor
 }
 
 input UpdatePostInput {
 	filter: PostFilter!
 	set: PatchPost
-	delete: PatchPost
+	remove: PatchPost
 }
 
 #######################


### PR DESCRIPTION
Initial cut of update mutations was just the equivalent of Dgraph's `set`.  This adds update mutations that have both `set` and `delete`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4333)
<!-- Reviewable:end -->
