### PR TITLE
cmd: fix config file from env variable issue in subcommands

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -129,8 +129,8 @@ func initCmds() {
 
 		for _, sc := range subcommands {
 			// Set config file is provided for each subcommand, this is done
-			// for individual subcommand because each subcommand has it's own config
-			// prefix, like `dgraph zero` expects the prefix to be `DGRAPH_ZERO`
+			// for individual subcommand because each subcommand has its own config
+			// prefix, like `dgraph zero` expects the prefix to be `DGRAPH_ZERO`.
 			cfg := sc.Conf.GetString("config")
 			if cfg == "" {
 				continue

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -127,11 +127,14 @@ func initCmds() {
 			x.CheckfNoTrace(os.Chdir(cwd))
 		}
 
-		cfg := rootConf.GetString("config")
-		if cfg == "" {
-			return
-		}
 		for _, sc := range subcommands {
+			// Set config file is provided for each subcommand, this is done
+			// for individual subcommand because each subcommand has it's own config
+			// prefix, like `dgraph zero` expects the prefix to be `DGRAPH_ZERO`
+			cfg := sc.Conf.GetString("config")
+			if cfg == "" {
+				continue
+			}
 			sc.Conf.SetConfigFile(cfg)
 			x.Check(errors.Wrapf(sc.Conf.ReadInConfig(), "reading config"))
 			setGlogFlags(sc.Conf)


### PR DESCRIPTION
* Fixes #4311
* Each subcommand can specify the config file to use using the
environment varaible which is of the form `<ENV_PREFIX>_CONFIG`, for
example `DGRAPH_ZERO_CONFIG`.

So with a `config.json` looking like this we can override the config
variables.

```json
{
     "my": "localhost:5180",
     "port_offset": 100,
     "idx": 1
}
```

Override the configuration using the above config file using the command

```bash
DGRAPH_ALPHA_CONFIG=config.json dgraph alpha

DGRAPH_ZERO_CONFIG=config.json dgraph zero
```

Signed-off-by: Deepesh Pathak <deepshpathak@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4344)
<!-- Reviewable:end -->
