### PR TITLE
Fix handling of depth parameter for shortest path query.

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -359,6 +359,11 @@ func populateCluster() {
 		<53> <name> "C" .
 		<54> <name> "D" .
 		<55> <name> "E" .
+		<56> <name> "F" .
+		<57> <name> "G" .
+		<58> <name> "H" .
+		<59> <name> "I" .
+		<60> <name> "J" .
 
 		<1> <full_name> "Michonne's large name for hashing" .
 
@@ -633,6 +638,13 @@ func populateCluster() {
 		<54> <connects> <52>  (weight=1) .
 		<54> <connects> <53>  (weight=10) .
 		<54> <connects> <55>  (weight=1) .
+
+
+		# tests for testing hop behavior for shortest path queries
+		<56> <connects> <57> (weight=1) .
+		<56> <connects> <58> (weight=1) .
+		<58> <connects> <59> (weight=1) .
+		<59> <connects> <60> (weight=1) .
 	`)
 
 	addGeoPointToCluster(1, "loc", []float64{1.1, 2.0})

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -354,6 +354,12 @@ func populateCluster() {
 		<11003> <name> "No. 5 the film"@en .
 		<11100> <name> "expand" .
 
+		<51> <name> "A" .
+		<52> <name> "B" .
+		<53> <name> "C" .
+		<54> <name> "D" .
+		<55> <name> "E" .
+
 		<1> <full_name> "Michonne's large name for hashing" .
 
 		<1> <noindex_name> "Michonne's name not indexed" .
@@ -610,12 +616,6 @@ func populateCluster() {
 		<502> <boss> <510> .
 		<510> <newfriend> <511> .
 		<510> <newfriend> <512> .
-
-		<51> <name> "A" .
-		<52> <name> "B" .
-		<53> <name> "C" .
-		<54> <name> "D" .
-		<55> <name> "E" .
 
 		<51> <connects> <52>  (weight=10) .
 		<51> <connects> <53>  (weight=1) .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -615,6 +615,7 @@ func populateCluster() {
 		<52> <name> "B" .
 		<53> <name> "C" .
 		<54> <name> "D" .
+		<55> <name> "E" .
 
 		<51> <connects> <52>  (weight=10) .
 		<51> <connects> <53>  (weight=1) .
@@ -631,6 +632,7 @@ func populateCluster() {
 		<54> <connects> <51>  (weight=10) .
 		<54> <connects> <52>  (weight=1) .
 		<54> <connects> <53>  (weight=10) .
+		<54> <connects> <55>  (weight=1) .
 	`)
 
 	addGeoPointToCluster(1, "loc", []float64{1.1, 2.0})

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -610,6 +610,27 @@ func populateCluster() {
 		<502> <boss> <510> .
 		<510> <newfriend> <511> .
 		<510> <newfriend> <512> .
+
+		<51> <name> "A" .
+		<52> <name> "B" .
+		<53> <name> "C" .
+		<54> <name> "D" .
+
+		<51> <connects> <52>  (weight=10) .
+		<51> <connects> <53>  (weight=1) .
+		<51> <connects> <54>  (weight=10) .
+
+		<53> <connects> <51>  (weight=10) .
+		<53> <connects> <52>  (weight=10) .
+		<53> <connects> <54>  (weight=1) .
+
+		<52> <connects> <51>  (weight=10) .
+		<52> <connects> <53>  (weight=10) .
+		<52> <connects> <54>  (weight=10) .
+
+		<54> <connects> <51>  (weight=10) .
+		<54> <connects> <52>  (weight=1) .
+		<54> <connects> <53>  (weight=10) .
 	`)
 
 	addGeoPointToCluster(1, "loc", []float64{1.1, 2.0})

--- a/query/query.go
+++ b/query/query.go
@@ -179,7 +179,7 @@ type params struct {
 
 	// ExploreDepth is used by recurse and shortest path queries to specify the maximum graph
 	// depth to explore.
-	ExploreDepth uint64
+	ExploreDepth *uint64
 
 	// IsInternal determines if processTask has to be called or not.
 	IsInternal bool
@@ -627,7 +627,7 @@ func (args *params) fill(gq *gql.GraphQuery) error {
 			if err != nil {
 				return err
 			}
-			args.ExploreDepth = depth
+			args.ExploreDepth = &depth
 		}
 
 		if v, ok := gq.Args["numpaths"]; ok {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -153,9 +153,9 @@ func TestQueryCountEmptyNames(t *testing.T) {
 		{in: `{q(func: has(name)) @filter(eq(name, "")) {count(uid)}}`,
 			out: `{"data":{"q": [{"count":2}]}}`},
 		{in: `{q(func: has(name)) @filter(gt(name, "")) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":52}]}}`},
+			out: `{"data":{"q": [{"count":57}]}}`},
 		{in: `{q(func: has(name)) @filter(ge(name, "")) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":54}]}}`},
+			out: `{"data":{"q": [{"count":59}]}}`},
 		{in: `{q(func: has(name)) @filter(lt(name, "")) {count(uid)}}`,
 			out: `{"data":{"q": [{"count":0}]}}`},
 		{in: `{q(func: has(name)) @filter(le(name, "")) {count(uid)}}`,
@@ -166,7 +166,7 @@ func TestQueryCountEmptyNames(t *testing.T) {
 			out: `{"data":{"q": [{"count":2}]}}`},
 		// NOTE: match with empty string filters values greater than the max distance.
 		{in: `{q(func: has(name)) @filter(match(name, "", 8)) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":34}]}}`},
+			out: `{"data":{"q": [{"count":39}]}}`},
 		{in: `{q(func: has(name)) @filter(uid_in(name, "")) {count(uid)}}`,
 			failure: `Value "" in uid_in is not a number`},
 	}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -153,9 +153,9 @@ func TestQueryCountEmptyNames(t *testing.T) {
 		{in: `{q(func: has(name)) @filter(eq(name, "")) {count(uid)}}`,
 			out: `{"data":{"q": [{"count":2}]}}`},
 		{in: `{q(func: has(name)) @filter(gt(name, "")) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":47}]}}`},
+			out: `{"data":{"q": [{"count":52}]}}`},
 		{in: `{q(func: has(name)) @filter(ge(name, "")) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":49}]}}`},
+			out: `{"data":{"q": [{"count":54}]}}`},
 		{in: `{q(func: has(name)) @filter(lt(name, "")) {count(uid)}}`,
 			out: `{"data":{"q": [{"count":0}]}}`},
 		{in: `{q(func: has(name)) @filter(le(name, "")) {count(uid)}}`,
@@ -166,7 +166,7 @@ func TestQueryCountEmptyNames(t *testing.T) {
 			out: `{"data":{"q": [{"count":2}]}}`},
 		// NOTE: match with empty string filters values greater than the max distance.
 		{in: `{q(func: has(name)) @filter(match(name, "", 8)) {count(uid)}}`,
-			out: `{"data":{"q": [{"count":29}]}}`},
+			out: `{"data":{"q": [{"count":34}]}}`},
 		{in: `{q(func: has(name)) @filter(uid_in(name, "")) {count(uid)}}`,
 			failure: `Value "" in uid_in is not a number`},
 	}

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -817,7 +817,6 @@ func TestShortestPathWithDepth_direct_path_is_shortest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth})
 			require.NoError(t, err)
-			fmt.Println(string(js))
 			require.JSONEq(t, tc.output, js)
 		})
 	}
@@ -1048,7 +1047,6 @@ func TestShortestPath_filter(t *testing.T) {
 			}
 		}`
 	js := processQueryNoErr(t, query)
-	fmt.Println(js)
 	require.JSONEq(t,
 		`{"data": {"_path_":[{"uid":"0x1","_weight_":3,"follow":{"uid":"0x1f","follow":{"uid":"0x3e9","path":{"uid":"0x3ea"}}}}],"me":[{"name":"Michonne"},{"name":"Andrea"},{"name":"Bob"},{"name":"Matt"}]}}`,
 		js)

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -701,11 +701,11 @@ func TestShortestPathWithDepth(t *testing.T) {
 	tests := []struct {
 		name, depth, output string
 	}{
-		// {
-		// 	"depth 0",
-		// 	"0",
-		// 	`{"data": {}}`,
-		// },
+		{
+			"depth 0",
+			"0",
+			`{"data":{"path":[]}}`,
+		},
 		{
 			"depth 1",
 			"1",
@@ -785,11 +785,11 @@ func TestShortestPathWithDepth_direct_path_is_shortest(t *testing.T) {
 	tests := []struct {
 		name, depth, output string
 	}{
-		// {
-		// 	"depth 0",
-		// 	"0",
-		// 	`{"data": {}}`,
-		// },
+		{
+			"depth 0",
+			"0",
+			`{"data":{"path":[]}}`,
+		},
 		{
 			"depth 1",
 			"1",
@@ -884,11 +884,11 @@ func TestShortestPathWithDepth_no_direct_path(t *testing.T) {
 	tests := []struct {
 		name, depth, output string
 	}{
-		// {
-		// 	"depth 0",
-		// 	"0",
-		// 	`{"data": {}}`,
-		// },
+		{
+			"depth 0",
+			"0",
+			`{"data":{"path":[]}}`,
+		},
 		{
 			"depth 1",
 			"1",

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -618,11 +618,11 @@ func TestShortestPathWithDepth(t *testing.T) {
 	// Shortest path between A and B is the path A => C => D => B but if the depth is less than 3
 	// then the direct path between A and B should be returned.
 	query := `
-	query test ($depth: int) {
+	query test ($depth: int, $numpaths: int) {
 		a as var(func: eq(name, "A"))
 		b as var(func: eq(name, "B"))
 
-		path as shortest(from: uid(a), to: uid(b), depth: $depth) {
+		path as shortest(from: uid(a), to: uid(b), depth: $depth, numpaths: $numpaths) {
 			connects @facets(weight)
 		}
 
@@ -699,39 +699,65 @@ func TestShortestPathWithDepth(t *testing.T) {
 	}`
 
 	tests := []struct {
-		name, depth, output string
+		depth, numpaths, output string
 	}{
 		{
-			"depth 0",
 			"0",
+			"1",
 			`{"data":{"path":[]}}`,
 		},
 		{
-			"depth 1",
+			"1",
 			"1",
 			directPath,
 		},
 		{
-			"depth 2",
 			"2",
+			"1",
 			directPath,
 		},
 		{
-			"depth 3",
 			"3",
+			"1",
 			shortestPath,
 		},
 		{
-			"depth 10",
 			"10",
+			"1",
 			shortestPath,
 		},
+		// {
+		// 	"0",
+		// 	"10",
+		// 	`{"data":{"path":[]}}`,
+		// },
+		// // {
+		// 	"1",
+		// 	"10",
+		// 	directPath,
+		// },
+		// {
+		// 	"2",
+		// 	"10",
+		// 	directPath,
+		// },
+		// {
+		// 	"3",
+		// 	"10",
+		// 	shortestPath,
+		// },
+		// {
+		// 	"10",
+		// 	"10",
+		// 	shortestPath,
+		// },
 	}
 
 	t.Parallel()
 	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth})
+		t.Run(fmt.Sprintf("depth_%s_numpaths_%s", tc.depth, tc.numpaths), func(t *testing.T) {
+			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth,
+				"$numpaths": tc.numpaths})
 			require.NoError(t, err)
 			require.JSONEq(t, tc.output, js)
 		})

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -726,12 +726,12 @@ func TestShortestPathWithDepth(t *testing.T) {
 			"1",
 			shortestPath,
 		},
+		{
+			"0",
+			"10",
+			`{"data":{"path":[]}}`,
+		},
 		// {
-		// 	"0",
-		// 	"10",
-		// 	`{"data":{"path":[]}}`,
-		// },
-		// // {
 		// 	"1",
 		// 	"10",
 		// 	directPath,

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -728,7 +728,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 		},
 	}
 
-	// t.Parallel()
+	t.Parallel()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth})
@@ -812,7 +812,7 @@ func TestShortestPathWithDepth_direct_path_is_shortest(t *testing.T) {
 		},
 	}
 
-	// t.Parallel()
+	t.Parallel()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth})
@@ -911,7 +911,7 @@ func TestShortestPathWithDepth_no_direct_path(t *testing.T) {
 		},
 	}
 
-	// t.Parallel()
+	t.Parallel()
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			js, err := processQueryWithVars(t, query, map[string]string{"$depth": tc.depth})
@@ -1015,7 +1015,7 @@ func TestShortestPath2(t *testing.T) {
 }
 
 func TestShortestPath4(t *testing.T) {
-
+	// TODO - Result for this seems wrong because 1 connects to 31 through path with a weight of 0.1
 	query := `
 		{
 			A as shortest(from:1, to:1003) {
@@ -1034,7 +1034,8 @@ func TestShortestPath4(t *testing.T) {
 }
 
 func TestShortestPath_filter(t *testing.T) {
-
+	// TODO (pawan) - Debug this later.
+	t.Skip()
 	query := `
 		{
 			A as shortest(from:1, to:1002) {

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -1033,8 +1033,6 @@ func TestShortestPath4(t *testing.T) {
 }
 
 func TestShortestPath_filter(t *testing.T) {
-	// TODO (pawan) - Debug this later.
-	t.Skip()
 	query := `
 		{
 			A as shortest(from:1, to:1002) {

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -716,7 +716,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 		{
 			"2",
 			"1",
-			directPath,
+			shortestPath,
 		},
 		{
 			"3",
@@ -929,7 +929,7 @@ func TestShortestPathWithDepth_no_direct_path(t *testing.T) {
 		{
 			"depth 2",
 			"2",
-			emptyPath,
+			shortestPath,
 		},
 		{
 			"depth 3",

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -733,6 +733,8 @@ func TestShortestPathWithDepth(t *testing.T) {
 			"10",
 			emptyPath,
 		},
+		// The test cases below are for k-shortest path queries with varying depths. They don't pass
+		// right now and hence are commented out...
 		// {
 		// 	"1",
 		// 	"10",

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -698,13 +698,15 @@ func TestShortestPathWithDepth(t *testing.T) {
 		}
 	}`
 
+	emptyPath := `{"data":{"path":[]}}`
+
 	tests := []struct {
 		depth, numpaths, output string
 	}{
 		{
 			"0",
 			"1",
-			`{"data":{"path":[]}}`,
+			emptyPath,
 		},
 		{
 			"1",
@@ -729,7 +731,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 		{
 			"0",
 			"10",
-			`{"data":{"path":[]}}`,
+			emptyPath,
 		},
 		// {
 		// 	"1",
@@ -907,23 +909,25 @@ func TestShortestPathWithDepth_no_direct_path(t *testing.T) {
 		}
 	  }`
 
+	emptyPath := `{"data":{"path":[]}}`
+
 	tests := []struct {
 		name, depth, output string
 	}{
 		{
 			"depth 0",
 			"0",
-			`{"data":{"path":[]}}`,
+			emptyPath,
 		},
 		{
 			"depth 1",
 			"1",
-			`{"data":{"path":[]}}`,
+			emptyPath,
 		},
 		{
 			"depth 2",
 			"2",
-			`{"data":{"path":[]}}`,
+			emptyPath,
 		},
 		{
 			"depth 3",

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -1015,7 +1015,6 @@ func TestShortestPath2(t *testing.T) {
 }
 
 func TestShortestPath4(t *testing.T) {
-	// TODO - Result for this seems wrong because 1 connects to 31 through path with a weight of 0.1
 	query := `
 		{
 			A as shortest(from:1, to:1003) {

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -414,10 +414,10 @@ func TestHasOrderAsc(t *testing.T) {
 				"name": ""
 			  },
 			  {
-				"name": "Alex"
+				"name": "A"
 			  },
 			  {
-				"name": "Alice"
+				"name": "Alex"
 			  },
 			  {
 				"name": "Alice"
@@ -447,10 +447,10 @@ func TestHasOrderAscOffset(t *testing.T) {
 				"name": "Alice"
 			  },
 			  {
-				"name": "Alice\""
+				"name": "Alice"
 			  },
 			  {
-				"name": "Andre"
+				"name": "Alice\""
 			  }
 			]
 		  }

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -292,9 +292,9 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	heap.Push(&pq, srcNode)
 
 	numHops := -1
-	maxHops := int(sg.Params.ExploreDepth)
-	if maxHops == 0 {
-		maxHops = int(math.MaxInt32)
+	maxHops := math.MaxInt32
+	if sg.Params.ExploreDepth != nil {
+		maxHops = int(*sg.Params.ExploreDepth)
 	}
 	minWeight := sg.Params.MinWeight
 	maxWeight := sg.Params.MaxWeight
@@ -461,11 +461,12 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	heap.Push(&pq, srcNode)
 
 	numHops := 0
-	maxHops := int(sg.Params.ExploreDepth)
-	// TODO - Depth 0 works same as max depth. Fix it so that when depth: 0 is explicitly supplied,
-	// it should return an empty path.
+	maxHops := math.MaxInt32
+	if sg.Params.ExploreDepth != nil {
+		maxHops = int(*sg.Params.ExploreDepth)
+	}
 	if maxHops == 0 {
-		maxHops = int(math.MaxInt32)
+		return nil, nil
 	}
 
 	// next is a channel on to which we send a signal so as to perform another level of expansion.

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -181,6 +181,11 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 					continue
 				}
 
+				// Call updateUidMatrix to ensure that entries in the uidMatrix are updated after
+				// intersecting with DestUIDs. This should ideally be called during query
+				// processing but doesn't seem to be called for shortest path queries. So we call
+				// it explicitly here to ensure the results are correct.
+				subgraph.updateUidMatrix()
 				// Send the destuids in res chan.
 				for mIdx, fromUID := range subgraph.SrcUIDs.Uids {
 					// This can happen when trying to go traverse a predicate of type password

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -301,6 +301,10 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	if sg.Params.ExploreDepth != nil {
 		maxHops = int(*sg.Params.ExploreDepth)
 	}
+	if maxHops == 0 {
+		return nil, nil
+	}
+
 	minWeight := sg.Params.MinWeight
 	maxWeight := sg.Params.MaxWeight
 	next := make(chan bool, 2)

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -531,8 +531,8 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 				case <-ctx.Done():
 					return nil, ctx.Err()
 				}
+				numHops++
 			}
-			numHops++
 		}
 
 		neighbours := adjacencyMap[item.uid]

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -510,11 +510,8 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 			totalWeight = item.cost
 			break
 		}
-		if numHops >= maxHops {
-			break
-		}
 
-		if item.hop > numHops-1 {
+		if numHops < maxHops && item.hop > numHops-1 {
 			// Explore the next level by calling processGraph and add them to the queue.
 			if !stopExpansion {
 				next <- true
@@ -581,7 +578,9 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	var result []uint64
 	cur := sg.Params.To
 	totalWeight = dist[cur].cost
-	for i := numHops; i >= 0; i-- {
+	// The length of the path can be greater than numHops hence we loop over the dist map till we
+	// reach sg.Params.From node. See test TestShortestPathWithDepth/depth_2_numpaths_1
+	for i := 0; i < len(dist); i++ {
 		result = append(result, cur)
 		if cur == sg.Params.From {
 			break

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -507,7 +507,6 @@ func shortestPath(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 	for pq.Len() > 0 {
 		item := heap.Pop(&pq).(*queueItem)
 		if item.uid == sg.Params.To {
-			totalWeight = item.cost
 			break
 		}
 

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -19,7 +19,6 @@ package query
 import (
 	"container/heap"
 	"context"
-	"fmt"
 	"math"
 	"sync"
 
@@ -204,7 +203,8 @@ func (sg *SubGraph) expandOut(ctx context.Context,
 							return
 						}
 
-						fmt.Println("from: ", fromUID, "to: ", toUID, "cost: ", cost)
+						// TODO - This simplify overrides the adjacency matrix. What happens if the
+						// cost along the second attribute is more than that along the first.
 						adjacencyMap[fromUID][toUID] = mapItem{
 							cost:  cost,
 							facet: facet,


### PR DESCRIPTION
Fixes #4169. This change doesn't fix handling of `depth` for k-shortest path query, it only does so for shortest path query with numpaths as 1. A separate change is required for fixing depth for shortest path queries with `numpaths > 1`.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4347)
<!-- Reviewable:end -->
