### PR TITLE
Create restore directory when running "dgraph restore".

### DIFF
--- a/ee/backup/restore.go
+++ b/ee/backup/restore.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"path/filepath"
 
 	"github.com/dgraph-io/badger/v2"
@@ -34,6 +35,11 @@ import (
 
 // RunRestore calls badger.Load and tries to load data into a new DB.
 func RunRestore(pdir, location, backupId string) (uint64, error) {
+	// Create the pdir if it doesn't exist.
+	if err := os.MkdirAll(pdir, 0700); err != nil {
+		return 0, err
+	}
+
 	// Scan location for backup files and load them. Each file represents a node group,
 	// and we create a new p dir for each.
 	return Load(location, backupId, func(r io.Reader, groupId int, preds predicateSet) error {

--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -244,7 +244,6 @@ func runRestore(t *testing.T, backupLocation, lastDir string, commitTs uint64) m
 	// Recreate the restore directory to make sure there's no previous data when
 	// calling restore.
 	require.NoError(t, os.RemoveAll(restoreDir))
-	require.NoError(t, os.MkdirAll(restoreDir, os.ModePerm))
 
 	t.Logf("--- Restoring from: %q", backupLocation)
 	_, err := backup.RunRestore("./data/restore", backupLocation, lastDir)
@@ -262,7 +261,6 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 	// Recreate the restore directory to make sure there's no previous data when
 	// calling restore.
 	require.NoError(t, os.RemoveAll(restoreDir))
-	require.NoError(t, os.MkdirAll(restoreDir, os.ModePerm))
 
 	_, err := backup.RunRestore("./data/restore", backupLocation, lastDir)
 	require.Error(t, err)

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -249,7 +249,6 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	// Recreate the restore directory to make sure there's no previous data when
 	// calling restore.
 	require.NoError(t, os.RemoveAll(restoreDir))
-	require.NoError(t, os.MkdirAll(restoreDir, os.ModePerm))
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore"}
@@ -270,7 +269,6 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 	// Recreate the restore directory to make sure there's no previous data when
 	// calling restore.
 	require.NoError(t, os.RemoveAll(restoreDir))
-	require.NoError(t, os.MkdirAll(restoreDir, os.ModePerm))
 
 	_, err := backup.RunRestore("./data/restore", backupLocation, lastDir)
 	require.Error(t, err)


### PR DESCRIPTION
As of now, "dgraph restore" crashes if the directory passed to the
"-p" flag (the directory where the restored p directories are stored).
This change ensures that dgraph tries to create the directory before
starting to restore a backup.

Tested by modifying the tests to stop manually creating this directory.

Fixes #4315

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4352)
<!-- Reviewable:end -->
