### PR TITLE
Write group_id files to postings directories during restore.

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -38,7 +38,6 @@ import (
 var Bulk x.SubCommand
 
 var defaultOutDir = "./out"
-var groupFile = "group_id"
 
 func init() {
 	Bulk.Cmd = &cobra.Command{
@@ -194,12 +193,7 @@ func run() {
 		x.Check(os.MkdirAll(dir, 0700))
 		opt.shardOutputDirs = append(opt.shardOutputDirs, dir)
 
-		groupFile := filepath.Join(dir, groupFile)
-		f, err := os.OpenFile(groupFile, os.O_CREATE|os.O_WRONLY, 0600)
-		x.Check(err)
-		x.Check2(f.WriteString(strconv.Itoa(i + 1)))
-		x.Check2(f.WriteString("\n"))
-		x.Check(f.Close())
+		x.Check(x.WriteGroupIdFile(dir, uint32(i+1)))
 	}
 
 	// Create a directory just for bulk loader's usage.

--- a/ee/backup/restore.go
+++ b/ee/backup/restore.go
@@ -55,7 +55,11 @@ func RunRestore(pdir, location, backupId string) (uint64, error) {
 		if err != nil {
 			return nil
 		}
-		return loadFromBackup(db, gzReader, preds)
+		if err := loadFromBackup(db, gzReader, preds); err != nil {
+			return err
+		}
+
+		return x.WriteGroupIdFile(dir, uint32(groupId))
 	})
 }
 

--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -248,6 +249,13 @@ func runRestore(t *testing.T, backupLocation, lastDir string, commitTs uint64) m
 	t.Logf("--- Restoring from: %q", backupLocation)
 	_, err := backup.RunRestore("./data/restore", backupLocation, lastDir)
 	require.NoError(t, err)
+
+	for i, pdir := range []string{"p1", "p2", "p3"} {
+		pdir = filepath.Join("./data/restore", pdir)
+		groupId, err := x.ReadGroupIdFile(pdir)
+		require.NoError(t, err)
+		require.Equal(t, uint32(i+1), groupId)
+	}
 
 	restored, err := testutil.GetPValues("./data/restore/p1", "movie", commitTs)
 	require.NoError(t, err)

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -257,6 +258,13 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})
 	require.NoError(t, err)
+
+	for i, pdir := range []string{"p1", "p2", "p3"} {
+		pdir = filepath.Join("./data/restore", pdir)
+		groupId, err := x.ReadGroupIdFile(pdir)
+		require.NoError(t, err)
+		require.Equal(t, uint32(i+1), groupId)
+	}
 
 	restored, err := testutil.GetPValues("./data/restore/p1", "movie", commitTs)
 	require.NoError(t, err)

--- a/x/x.go
+++ b/x/x.go
@@ -109,6 +109,11 @@ const (
 {"predicate":"dgraph.user.group","list":true, "reverse": true, "type": "uid"},
 {"predicate":"dgraph.group.acl","type":"string"}
 `
+	// GroupIdFileName is the name of the file storing the ID of the group to which
+	// the data in a postings directory belongs. This ID is used to join the proper
+	// group the first time an Alpha comes up with data from a restored backup or a
+	// bulk load.
+	GroupIdFileName = "group_id"
 )
 
 var (


### PR DESCRIPTION
This PR changes the restore command to write a group_id file containing
the ID of the group to which the data belongs. This is the same
mechanism used by the bulk loader to ensure alphas with data for
reserved predicates are always assigned to the right group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4365)
<!-- Reviewable:end -->
