### PR TITLE
Remove unnecessary pushd.

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -31,11 +31,8 @@ function restartCluster {
 }
 
 function stopCluster {
-  basedir=$(dirname "${BASH_SOURCE[0]}")/../..
-  pushd $basedir/dgraph >/dev/null
   docker ps --filter label="cluster=test" --format "{{.Names}}" \
   | xargs -r docker stop | sed 's/^/Stopped /'
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" \
   | xargs -r docker rm | sed 's/^/Removed /'
-  popd >/dev/null
 }


### PR DESCRIPTION
It's breaking the tests for pydgraph (because the basedir is assigned a
different value when the script is run from TeamCity).

The pushd is fairly unnecessary here so the easiest solution is removing
them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4372)
<!-- Reviewable:end -->
