### PR TITLE
Add standalone Dockerfile for dgraph/dgraph:master.

### DIFF
--- a/contrib/standalone/Dockerfile.master
+++ b/contrib/standalone/Dockerfile.master
@@ -1,0 +1,13 @@
+FROM dgraph/dgraph:master
+LABEL MAINTAINER="Dgraph Labs <contact@dgraph.io>"
+
+# Ratel port
+EXPOSE 8000
+# REST API port
+EXPOSE 8080
+# gRPC API port
+EXPOSE 9080
+
+ADD run.sh .
+RUN chmod +x run.sh
+CMD ["./run.sh"]


### PR DESCRIPTION
This will be used for Docker Hub autobuilds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4373)
<!-- Reviewable:end -->
