### PR TITLE
Fix how query responses are sent in upsert HTTP responses.

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -423,25 +423,8 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 	mp["code"] = x.Success
 	mp["message"] = "Done"
 	mp["uids"] = resp.Uids
-
-	// add query response if any, usual op if resp.Json == '{}' (i.e. l <= 2)
-	l := len(resp.Json)
-	if l > 2 && resp.Json[l-1] == '}' {
-		data, err := json.Marshal(mp)
-		if err != nil {
-			x.SetStatusWithData(w, x.Error, err.Error())
-			return
-		}
-
-		out := bytes.NewBuffer(resp.Json[:(l - 1)])
-		out.WriteRune(',')
-
-		// data[0] must be '{'
-		out.Write(data[1:])
-		response["data"] = json.RawMessage(out.Bytes())
-	} else {
-		response["data"] = mp
-	}
+	mp["queries"] = json.RawMessage(resp.Json)
+	response["data"] = mp
 
 	js, err := json.Marshal(response)
 	if err != nil {

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -31,13 +31,7 @@ import (
 )
 
 type QueryResult struct {
-	Q []struct {
-		UID string
-	}
-	User1 []struct {
-		UID string
-	}
-	User2 []struct {
+	Queries map[string][]struct {
 		UID string
 	}
 }
@@ -68,7 +62,7 @@ upsert {
 	require.Equal(t, []string{"1-email", "1-name"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 
 	// query should return the wrong name
 	q1 := `
@@ -104,7 +98,7 @@ upsert {
 	require.Equal(t, []string{"1-name"}, mr.preds)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.Q))
+	require.Equal(t, 1, len(result.Queries["q"]))
 
 	// query should return correct name
 	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
@@ -172,7 +166,7 @@ func TestUpsertExampleJSON(t *testing.T) {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 3, len(result.Q))
+	require.Equal(t, 3, len(result.Queries["q"]))
 
 	q1 := `
 {
@@ -461,7 +455,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.Q))
+	require.Equal(t, 1, len(result.Queries["q"]))
 
 	q1 := `
 {
@@ -495,7 +489,7 @@ upsert {
 	require.NoError(t, err)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.User1))
+	require.Equal(t, 1, len(result.Queries["user1"]))
 
 	q2 := `
 {
@@ -552,8 +546,8 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.User1))
-	require.Equal(t, 1, len(result.User2))
+	require.Equal(t, 1, len(result.Queries["user1"]))
+	require.Equal(t, 1, len(result.Queries["user2"]))
 
 	q1 := `
 {
@@ -589,8 +583,8 @@ upsert {
 	require.NoError(t, err)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.User1))
-	require.Equal(t, 1, len(result.User2))
+	require.Equal(t, 1, len(result.Queries["user1"]))
+	require.Equal(t, 1, len(result.Queries["user2"]))
 
 	q2 := `
 {
@@ -713,8 +707,8 @@ friend: uid @reverse .`))
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.User1))
-	require.Equal(t, 1, len(result.User2))
+	require.Equal(t, 1, len(result.Queries["user1"]))
+	require.Equal(t, 1, len(result.Queries["user2"]))
 
 	q1 := `
 {
@@ -777,7 +771,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 
 	q := `
 {
@@ -911,7 +905,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 }
 
 func TestConditionalUpsertExample0(t *testing.T) {
@@ -940,7 +934,7 @@ upsert {
 	require.Equal(t, []string{"1-email", "1-name"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 
 	// Trying again, should be a NOOP
 	mr, err = mutationWithTs(m1, "application/rdf", false, true, 0)
@@ -982,7 +976,7 @@ upsert {
 	require.Equal(t, []string{"1-name"}, mr.preds)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.Q))
+	require.Equal(t, 1, len(result.Queries["q"]))
 
 	// query should return correct name
 	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
@@ -1015,7 +1009,7 @@ func TestConditionalUpsertExample0JSON(t *testing.T) {
 	require.True(t, len(mr.keys) == 0)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 
 	// query should return the wrong name
 	q1 := `
@@ -1048,7 +1042,7 @@ func TestConditionalUpsertExample0JSON(t *testing.T) {
 	require.Equal(t, []string{"1-name"}, mr.preds)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.Q))
+	require.Equal(t, 1, len(result.Queries["q"]))
 	// query should return correct name
 	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
@@ -1110,7 +1104,7 @@ upsert {
 	require.Equal(t, []string{"1-color"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.Q))
+	require.Equal(t, 2, len(result.Queries["q"]))
 	q2 := `
 {
   q(func: eq(works_for, "%s")) {
@@ -1151,8 +1145,8 @@ upsert {
 	require.NoError(t, err)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.User1))
-	require.Equal(t, 2, len(result.User2))
+	require.Equal(t, 2, len(result.Queries["user1"]))
+	require.Equal(t, 2, len(result.Queries["user2"]))
 
 	// The following mutation should have no effect on the state of the database
 	m4 := `
@@ -1250,8 +1244,8 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 1, len(result.User1))
-	require.Equal(t, 1, len(result.User2))
+	require.Equal(t, 1, len(result.Queries["user1"]))
+	require.Equal(t, 1, len(result.Queries["user2"]))
 
 	res, _, err = queryWithTs(fmt.Sprintf(q1, "company1"), "application/graphql+-", "", 0)
 	require.NoError(t, err)
@@ -1599,7 +1593,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 3, len(result.Q))
+	require.Equal(t, 3, len(result.Queries["q"]))
 
 	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
@@ -1889,7 +1883,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 3, len(result.Q))
+	require.Equal(t, 3, len(result.Queries["q"]))
 
 	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	expectedRes := `
@@ -1937,7 +1931,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 }
 
 func TestUpsertBulkUpdateBranch(t *testing.T) {
@@ -1986,7 +1980,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 3, len(result.Q))
+	require.Equal(t, 3, len(result.Queries["q"]))
 
 	q2 := `
 {
@@ -2022,7 +2016,7 @@ upsert {
 	require.NoError(t, err)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 3, len(result.Q))
+	require.Equal(t, 3, len(result.Queries["q"]))
 
 	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
 	require.NoError(t, err)
@@ -2119,7 +2113,7 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 }
 
 func TestEmptyRequest(t *testing.T) {
@@ -2170,65 +2164,8 @@ upsert {
 	require.NoError(t, err)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 	require.Equal(t, []string{"1-email", "1-name", "1-works_for"}, mr.preds)
-}
-
-func TestInvalidAliasCode(t *testing.T) {
-	m1 := `
-  upsert {
-    mutation {
-      set {
-        _:user <age> "45" .
-      }
-    }
-
-    query {
-      code(func: eq(age, 34)) @filter(ge(name, "user")) {
-        uid
-      }
-    }
-  }`
-	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
-	require.Contains(t, "query alias [code] not allowed", err.Error())
-}
-
-func TestInvalidAliasMessage(t *testing.T) {
-	m1 := `
-  upsert {
-    mutation {
-      set {
-        _:user <age> "45" .
-      }
-    }
-
-    query {
-      message(func: eq(age, 34)) @filter(ge(name, "user")) {
-        uid
-      }
-    }
-  }`
-	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
-	require.Contains(t, "query alias [message] not allowed", err.Error())
-}
-
-func TestInvalidAliasUids(t *testing.T) {
-	m1 := `
-  upsert {
-    mutation {
-      set {
-        _:user <age> "45" .
-      }
-    }
-
-    query {
-      uids(func: eq(age, 34)) @filter(ge(name, "user")) {
-        uid
-      }
-    }
-  }`
-	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
-	require.Contains(t, "query alias [uids] not allowed", err.Error())
 }
 
 func TestMultipleMutation(t *testing.T) {
@@ -2263,7 +2200,7 @@ upsert {
 	require.Equal(t, []string{"1-email", "1-name"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 0, len(result.Q))
+	require.Equal(t, 0, len(result.Queries["q"]))
 
 	q1 := `
 {
@@ -2616,7 +2553,7 @@ func TestJsonOldAndNewAPI(t *testing.T) {
 	require.Equal(t, []string{"1-color", "1-works_with"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.Q))
+	require.Equal(t, 2, len(result.Queries["q"]))
 	q2 := `
   {
     q(func: eq(works_for, "%s")) {
@@ -2695,7 +2632,7 @@ func TestJsonNewAPI(t *testing.T) {
 	require.Equal(t, []string{"1-color", "1-works_with"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.Q))
+	require.Equal(t, 2, len(result.Queries["q"]))
 	q2 := `
   {
     q(func: eq(works_for, "%s")) {
@@ -2765,7 +2702,7 @@ func TestUpsertMultiValueJson(t *testing.T) {
 	require.Equal(t, []string{"1-color"}, mr.preds)
 	result := QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.Q))
+	require.Equal(t, 2, len(result.Queries["q"]))
 	q2 := `
 {
   q(func: eq(works_for, "%s")) {
@@ -2809,8 +2746,8 @@ func TestUpsertMultiValueJson(t *testing.T) {
 	require.NoError(t, err)
 	result = QueryResult{}
 	require.NoError(t, json.Unmarshal(mr.data, &result))
-	require.Equal(t, 2, len(result.User1))
-	require.Equal(t, 2, len(result.User2))
+	require.Equal(t, 2, len(result.Queries["user1"]))
+	require.Equal(t, 2, len(result.Queries["user2"]))
 }
 
 // This test may fail sometimes because ACL token

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1068,11 +1068,6 @@ func validateKeys(nq *api.NQuad) error {
 // are longer than the limit (2^16).
 func validateQuery(queries []*gql.GraphQuery) error {
 	for _, q := range queries {
-		// These are used in the response of a mutation in HTTP API.
-		if a := strings.ToLower(q.Alias); a == "code" || a == "message" || a == "uids" {
-			return errors.Errorf("query alias [%v] not allowed", a)
-		}
-
 		if err := validatePredName(q.Attr); err != nil {
 			return err
 		}


### PR DESCRIPTION
Right now the results of the upsert query are attached to the final
response at the same level as other field (e.g "message", "code") which
introduces the restriction that the names of these fields cannot be used
to name queries.

This PR gets rid of this restriction by attaching the response to the
queries in the "queries" field. This eliminates the need to check for
certain keywords in the query.

Fixes #4361

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4375)
<!-- Reviewable:end -->
