### PR TITLE
Add types in all examples in docs.

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -356,6 +356,7 @@ dob := time.Date(1980, 01, 01, 23, 0, 0, 0, time.UTC)
 p := Person{
     Uid:     "_:alice",
 	Name:    "Alice",
+	DType: []string{"Person"},
 	Age:     26,
 	Married: true,
 	Location: loc{
@@ -540,7 +541,11 @@ predicate `name` is the name of an account. It's indexed so that we can look up
 accounts based on their name.
 
 ```sh
-$ curl -X POST localhost:8080/alter -d 'name: string @index(term) .'
+$ curl -X POST localhost:8080/alter -d \
+'name: string @index(term) .
+type Person {
+   name
+}'
 ```
 
 If all goes well, the response should be `{"code":"Success","message":"Done"}`.
@@ -549,6 +554,7 @@ Other operations can be performed via the `/alter` endpoint as well. A specific
 predicate or the entire database can be dropped.
 
 To drop the predicate `name`:
+
 ```sh
 $ curl -X POST localhost:8080/alter -d '{"drop_attr": "name"}'
 ```
@@ -655,7 +661,9 @@ are:
 
 ```
 <0x1> <balance> "110" .
+<0x1> <dgraph.type> "Balance" .
 <0x2> <balance> "60" .
+<0x2> <dgraph.type> "Balance" .
 ```
 
 Note that we have to refer to the Alice and Bob nodes by UID in the RDF format.
@@ -671,7 +679,9 @@ $ curl -H "Content-Type: application/rdf" -X POST localhost:8080/mutate?startTs=
 {
   set {
     <0x1> <balance> "110" .
+    <0x1> <dgraph.type> "Balance" .
     <0x2> <balance> "60" .
+    <0x2> <dgraph.type> "Balance" .
   }
 }
 ' | jq

--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -121,6 +121,7 @@ $ curl localhost:8080/alter -d '
 $ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -d '{
   set {
     _:dgraph <name> "Dgraph" .
+    _:dgraph <dgraph.type> "Software" .
     _:dgraph <url> "https://github.com/dgraph-io/dgraph" .
     _:dgraph <description> "Fast, Transactional, Distributed Graph Database." .
   }
@@ -131,6 +132,7 @@ $ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -
 $ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -d '{
   set {
     _:badger <name> "Badger" .
+    _:badger <dgraph.type> "Software" .
     _:badger <url> "https://github.com/dgraph-io/badger" .
     _:badger <description> "Embeddable, persistent and fast key-value (KV) database written in pure Go." .
   }
@@ -869,6 +871,7 @@ Before (in Dgraph v1.0)
 curl -H 'X-Dgraph-CommitNow: true' localhost:8080/mutate -d '{
   set {
     _:n <name> "Alice" .
+    _:n <dgraph.type> "Person" .
   }
 }'
 ```
@@ -879,6 +882,7 @@ Now (in Dgraph v1.1):
 curl -H 'Content-Type: application/rdf' localhost:8080/mutate?commitNow=true -d '{
   set {
     _:n <name> "Alice" .
+    _:n <dgraph.type> "Person" .
   }
 }'
 ```

--- a/wiki/content/mutations/index.md
+++ b/wiki/content/mutations/index.md
@@ -26,6 +26,7 @@ Meaning that the graph node identified by `subject` is linked to `object` with d
 For example, the triple
 ```
 <0x01> <name> "Alice" .
+<0x01> <dgraph.type> "Person" .
 ```
 Represents that graph node with ID `0x01` has a `name` with string value `"Alice"`.  While triple
 ```
@@ -46,10 +47,15 @@ Blank nodes in mutations, written `_:identifier`, identify nodes within a mutati
     _:class <student> _:x .
     _:class <student> _:y .
     _:class <name> "awesome class" .
+    _:class <dgraph.type> "Class" .
     _:x <name> "Alice" .
+    _:x <dgraph.type> "Person" .
+    _:x <dgraph.type> "Student" .
     _:x <planet> "Mars" .
     _:x <friend> _:y .
     _:y <name> "Bob" .
+    _:y <dgraph.type> "Person" .
+    _:y <dgraph.type> "Student" .
  }
 }
 ```
@@ -72,10 +78,15 @@ The graph has thus been updated as if it had stored the triples
 <0x6bc818dc89e78754> <student> <0xc3bcc578868b719d> .
 <0x6bc818dc89e78754> <student> <0xb294fb8464357b0a> .
 <0x6bc818dc89e78754> <name> "awesome class" .
+<0x6bc818dc89e78754> <dgraph.type> "Class" .
 <0xc3bcc578868b719d> <name> "Alice" .
+<0xc3bcc578868b719d> <dgraph.type> "Person" .
+<0xc3bcc578868b719d> <dgraph.type> "Student" .
 <0xc3bcc578868b719d> <planet> "Mars" .
 <0xc3bcc578868b719d> <friend> <0xb294fb8464357b0a> .
 <0xb294fb8464357b0a> <name> "Bob" .
+<0xb294fb8464357b0a> <dgraph.type> "Person" .
+<0xb294fb8464357b0a> <dgraph.type> "Student" .
 ```
 The blank node labels `_:class`, `_:x` and `_:y` do not identify the nodes after the mutation, and can be safely reused to identify new nodes in later mutations.
 
@@ -85,6 +96,8 @@ A later mutation can update the data for existing UIDs.  For example, the follow
  set {
     <0x6bc818dc89e78754> <student> _:x .
     _:x <name> "Chris" .
+    _:x <dgraph.type> "Person" .
+    _:x <dgraph.type> "Student" .
  }
 }
 ```
@@ -111,6 +124,7 @@ Dgraph's input language, RDF, also supports triples of the form `<a_fixed_identi
 
 ```
 _:userA <http://schema.org/type> <http://schema.org/Person> .
+_:userA <dgraph.type> "Person" .
 _:userA <http://schema.org/name> "FirstName LastName" .
 <https://www.themoviedb.org/person/32-robin-wright> <http://schema.org/type> <http://schema.org/Person> .
 <https://www.themoviedb.org/person/32-robin-wright> <http://schema.org/name> "Robin Wright" .
@@ -120,6 +134,7 @@ As Dgraph doesn't natively support such external IDs as node identifiers.  Inste
 
 ```
 <0x123> <xid> "http://schema.org/Person" .
+<0x123> <dgraph.type> "ExternalType" .
 ```
 
 While Robin Wright might get UID `0x321` and triples
@@ -128,6 +143,7 @@ While Robin Wright might get UID `0x321` and triples
 <0x321> <xid> "https://www.themoviedb.org/person/32-robin-wright" .
 <0x321> <http://schema.org/type> <0x123> .
 <0x321> <http://schema.org/name> "Robin Wright" .
+<0x321> <dgraph.type> "Person" .
 ```
 
 An appropriate schema might be as follows.
@@ -179,6 +195,7 @@ Set the type first of all.
 {
   set {
     _:blank <xid> "http://schema.org/Person" .
+    _:blank <dgraph.type> "ExternalType" .
   }
 }
 ```
@@ -199,6 +216,7 @@ Now you can create a new person and attach its type using the upsert block.
            uid(Person) <xid> "https://www.themoviedb.org/person/32-robin-wright" .
            uid(Person) <http://schema.org/type> uid(Type) .
            uid(Person) <http://schema.org/name> "Robin Wright" .
+           uid(Person) <dgraph.type> "Person" .
           }
       }
     }
@@ -221,6 +239,7 @@ You can also delete a person and detach the relation between Type and Person Nod
            uid(Person) <xid> "https://www.themoviedb.org/person/32-robin-wright" .
            uid(Person) <http://schema.org/type> uid(Type) .
            uid(Person) <http://schema.org/name> "Robin Wright" .
+           uid(Person) <dgraph.type> "Person" .
           }
       }
     }
@@ -248,6 +267,7 @@ RDF N-Quad allows specifying a language for string values and an RDF type.  Lang
 <0x01> <name> "Adelaide"@en .
 <0x01> <name> "Аделаида"@ru .
 <0x01> <name> "Adélaïde"@fr .
+<0x01> <dgraph.type> "Person" .
 ```
 See also [how language strings are handled in queries]({{< relref "query-language/index.md#language-support" >}}).
 
@@ -301,6 +321,7 @@ For example, if the store contained
 ```
 <0xf11168064b01135b> <name> "Lewis Carrol"
 <0xf11168064b01135b> <died> "1998"
+<0xf11168064b01135b> <dgraph.type> "Person" .
 ```
 
 Then delete mutation
@@ -374,6 +395,7 @@ curl -H "Content-Type: application/rdf" -X POST localhost:8080/mutate?commitNow=
 {
   set {
     _:alice <name> "Alice" .
+    _:alice <dgraph.type> "Person" .
   }
 }'
 ```
@@ -424,13 +446,15 @@ For example:
 ```json
 {
   "name": "diggy",
-  "food": "pizza"
+  "food": "pizza",
+  "dgraph.type": "Mascot"
 }
 ```
 Will be converted into the RDFs:
 ```
 _:blank-0 <name> "diggy" .
 _:blank-0 <food> "pizza" .
+_:blank-0 <dgraph.type> "Mascot" .
 ```
 
 The result of the mutation would also contain a map, which would have the uid assigned corresponding
@@ -440,7 +464,8 @@ to the key `blank-0`. You could specify your own key like
 {
   "uid": "_:diggy",
   "name": "diggy",
-  "food": "pizza"
+  "food": "pizza",
+  "dgraph.type": "Mascot"
 }
 ```
 
@@ -459,13 +484,15 @@ For example, the JSON mutation
   "rating@en": "tastes good",
   "rating@es": "sabe bien",
   "rating@fr": "c'est bon",
-  "rating@it": "è buono"
+  "rating@it": "è buono",
+  "dgraph.type": "Food"
 }
 ```
 
 is equivalent to the following RDF:
 ```
 _:blank-0 <food> "taco" .
+_:blank-0 <dgraph.type> "Food" .
 _:blank-0 <rating> "tastes good"@en .
 _:blank-0 <rating> "sabe bien"@es .
 _:blank-0 <rating> "c'est bon"@fr .
@@ -501,12 +528,14 @@ For example:
   "uid": "0x467ba0",
   "food": "taco",
   "rating": "tastes good",
+  "dgraph.type": "Food"
 }
 ```
 Will be converted into the RDFs:
 ```
 <0x467ba0> <food> "taco" .
 <0x467ba0> <rating> "tastes good" .
+<0x467ba0> <dgraph.type> "Food" .
 ```
 
 ### Edges between nodes
@@ -544,7 +573,9 @@ node.
   }
 }
 ```
+
 Will be converted to:
+
 ```
 _:alice <name> "Alice" .
 _:alice <friend> _:bob .
@@ -638,17 +669,21 @@ used to show facets in query results. E.g.
 {
   "name": "Carol",
   "name|initial": "C",
+  "dgraph.type": "Person",
   "friend": {
     "name": "Daryl",
-    "friend|close": "yes"
+    "friend|close": "yes",
+    "dgraph.type": "Person"
   }
 }
 ```
 Produces the following RDFs:
 ```
 _:blank-0 <name> "Carol" (initial=C) .
+_:blank-0 <dgraph.type> "Person" .
 _:blank-0 <friend> _:blank-1 (close=yes) .
 _:blank-1 <name> "Daryl" .
+_:blank-1 <dgraph.type> "Person" .
 ```
 
 ### Creating a list with JSON and interacting with
@@ -1235,6 +1270,7 @@ upsert {
   mutation @if(eq(len(u1), 0) AND eq(len(u2), 0) AND eq(len(u3), 0)) {
     set {
       _:user <name> "user" .
+      _:user <dgraph.type> "Person" .
       _:user <email> "user_email1@company1.io" .
       _:user <email> "user_email2@company1.io" .
     }
@@ -1258,6 +1294,7 @@ upsert {
   mutation @if(eq(len(u1), 1) AND eq(len(u2), 1) AND eq(len(u3), 0)) {
     set {
       _:user <name> "user" .
+      _:user <dgraph.type> "Person" .
       _:user <email> "user_email1@company1.io" .
       _:user <email> "user_email2@company1.io" .
     }
@@ -1346,15 +1383,18 @@ curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow
       "set": [
         {
           "uid": "_:user",
-          "name": "user"
+          "name": "user",
+          "dgraph.type": "Person"
         },
         {
           "uid": "_:user",
-          "email": "user_email1@company1.io"
+          "email": "user_email1@company1.io",
+          "dgraph.type": "Person"
         },
         {
           "uid": "_:user",
-          "email": "user_email2@company1.io"
+          "email": "user_email2@company1.io",
+          "dgraph.type": "Person"
         }
       ]
     },
@@ -1363,7 +1403,8 @@ curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow
       "set": [
         {
           "uid": "uid(u1)",
-          "email": "user_email2@company1.io"
+          "email": "user_email2@company1.io",
+          "dgraph.type": "Person"
         }
       ]
     },
@@ -1372,7 +1413,8 @@ curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow
       "set": [
         {
           "uid": "uid(u2)",
-          "email": "user_email1@company1.io"
+          "email": "user_email1@company1.io",
+          "dgraph.type": "Person"
         }
       ]
     },
@@ -1381,15 +1423,18 @@ curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow
       "set": [
         {
           "uid": "_:user",
-          "name": "user"
+          "name": "user",
+          "dgraph.type": "Person"
         },
         {
           "uid": "_:user",
-          "email": "user_email1@company1.io"
+          "email": "user_email1@company1.io",
+          "dgraph.type": "Person"
         },
         {
           "uid": "_:user",
-          "email": "user_email2@company1.io"
+          "email": "user_email2@company1.io",
+          "dgraph.type": "Person"
         }
       ],
       "delete": [

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -758,6 +758,7 @@ Here is how you would add a `Point`.
   set {
     <_:0xeb1dde9c> <loc> "{'type':'Point','coordinates':[-122.4220186,37.772318]}"^^<geo:geojson> .
     <_:0xeb1dde9c> <name> "Hamon Tower" .
+    <_:0xeb1dde9c> <dgraph.type> "Location" .
   }
 }
 ```
@@ -769,6 +770,7 @@ Here is how you would associate a `Polygon` with a node. Adding a `MultiPolygon`
   set {
     <_:0xf76c276b> <loc> "{'type':'Polygon','coordinates':[[[-122.409869,37.7785442],[-122.4097444,37.7786443],[-122.4097544,37.7786521],[-122.4096334,37.7787494],[-122.4096233,37.7787416],[-122.4094004,37.7789207],[-122.4095818,37.7790617],[-122.4097883,37.7792189],[-122.4102599,37.7788413],[-122.409869,37.7785442]],[[-122.4097357,37.7787848],[-122.4098499,37.778693],[-122.4099025,37.7787339],[-122.4097882,37.7788257],[-122.4097357,37.7787848]]]}"^^<geo:geojson> .
     <_:0xf76c276b> <name> "Best Western Americana Hotel" .
+    <_:0xf76c276b> <dgraph.type> "Location" .
   }
 }
 ```
@@ -2142,6 +2144,7 @@ Mutation:
   set {
     _:a <公司> "Dgraph Labs Inc"@en .
     _:b <公司> "夏新科技有限责任公司"@zh .
+    _:a <dgraph.type> "Company" .
   }
 }
 ```
@@ -2582,14 +2585,18 @@ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -XP
 
     # -- Facets on scalar predicates
     _:alice <name> "Alice" .
+    _:alice <dgraph.type> "Person" .
     _:alice <mobile> "040123456" (since=2006-01-02T15:04:05) .
     _:alice <car> "MA0123" (since=2006-02-02T13:01:09, first=true) .
 
     _:bob <name> "Bob" .
+    _:bob <dgraph.type> "Person" .
     _:bob <car> "MA0134" (since=2006-02-02T13:01:09) .
 
     _:charlie <name> "Charlie" .
+    _:charlie <dgraph.type> "Person" .
     _:dave <name> "Dave" .
+    _:dave <dgraph.type> "Person" .
 
 
     # -- Facets on UID predicates
@@ -2600,8 +2607,11 @@ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -XP
 
     # -- Facets for variable propagation
     _:movie1 <name> "Movie 1" .
+    _:movie1 <dgraph.type> "Movie" .
     _:movie2 <name> "Movie 2" .
+    _:movie2 <dgraph.type> "Movie" .
     _:movie3 <name> "Movie 3" .
+    _:movie3 <dgraph.type> "Movie" .
 
     _:alice <rated> _:movie1 (rating=3) .
     _:alice <rated> _:movie2 (rating=2) .
@@ -2672,8 +2682,11 @@ Example:
 {
   set {
     _:person1 <name> "Daniel" (वंश="स्पेनी", ancestry="Español") .
+    _:person1 <dgraph.type> "Person" .
     _:person2 <name> "Raj" (वंश="हिंदी", ancestry="हिंदी") .
+    _:person2 <dgraph.type> "Person" .
     _:person3 <name> "Zhang Wei" (वंश="चीनी", ancestry="中文") .
+    _:person3 <dgraph.type> "Person" .
   }
 }
 ```
@@ -2956,9 +2969,13 @@ curl -H "Content-Type: application/rdf" localhost:8080/mutate?commitNow=true -XP
     _:c <friend> _:d (weight=0.3) .
     _:a <friend> _:d (weight=1) .
     _:a <name> "Alice" .
+    _:a <dgraph.type> "Person" .
     _:b <name> "Bob" .
+    _:b <dgraph.type> "Person" .
     _:c <name> "Tom" .
+    _:c <dgraph.type> "Person" .
     _:d <name> "Mallory" .
+    _:d <dgraph.type> "Person" .
   }
 }' | python -m json.tool | less
 ```
@@ -3429,9 +3446,13 @@ name: string @index(rune) .
 {
   set{
     _:ad <name> "Adam" .
+    _:ad <dgraph.type> "Person" .
     _:aa <name> "Aaron" .
+    _:aa <dgraph.type> "Person" .
     _:am <name> "Amy" .
+    _:am <dgraph.type> "Person" .
     _:ro <name> "Ronald" .
+    _:ro <dgraph.type> "Person" .
   }
 }
 ```


### PR DESCRIPTION
Sometimes users get confused by Dgraph's new behavior related to Types. And I often notice that the cause of this is other examples in the documentation that aren't exemplifying with types. So I had to add them to avoid future confusion like that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4382)
<!-- Reviewable:end -->
