### PR TITLE
Update helm chart to work with latest Kubernetes.

### DIFF
--- a/contrib/config/kubernetes/helm/README.md
+++ b/contrib/config/kubernetes/helm/README.md
@@ -12,7 +12,7 @@ The above command will  install the latest available dgraph docker image. In ord
 $ helm install --name my-release ./ --set image.tag=XXX
 ```
 
-By default zero and alpha services are exposed only within the kubernetes cluster as kubernets service type "ClusterIP". In order to expose the alpha service to internet you can use kubernetes service type "LoadBalancer":
+By default zero and alpha services are exposed only within the kubernetes cluster as kubernetes service type "ClusterIP". In order to expose the alpha service publicly you can use kubernetes service type "LoadBalancer":
 
 ```bash
 $ helm install --name my-release ./ --set alpha.service.type="LoadBalancer"

--- a/contrib/config/kubernetes/helm/templates/alpha-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/alpha-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "dgraph.alpha.fullname" . }}"

--- a/contrib/config/kubernetes/helm/templates/ratel-deployment.yaml
+++ b/contrib/config/kubernetes/helm/templates/ratel-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "dgraph.ratel.fullname" . }}

--- a/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "dgraph.zero.fullname" . }}"


### PR DESCRIPTION
As of Kubernetes v1.16.0, the apiVersions apps/v1beta2, extensions/v1beta1 and apps/v1beta1 are deprecated.

When trying to install the current Helm chart on Kubernetes v1.16.0+, this error happens:

```
$ helm install my-release .
Error: unable to build kubernetes objects from release manifest: [unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1", unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta2", unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta1"]
```

This change uses the stable apps/v1 apiVersion as the recommended replacement documented in the [v1.16 release notes](https://kubernetes.io/blog/2019/09/18/kubernetes-1-16-release-announcement/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4393)
<!-- Reviewable:end -->
