### PR TITLE
docs: Clarify match function usage.

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -364,7 +364,7 @@ Index Required: `trigram`
 Matches predicate values by calculating the [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) to the string,
 also known as _fuzzy matching_. The distance parameter must be greater than zero (0). Using a greater distance value can yield more but less accurate results.
 
-Query Example: At root, fuzzy match nodes similar to `Stephen`, with a distance value of 8.
+Query Example: At root, fuzzy match nodes similar to `Stephen`, with a distance value of less than or equal to 8.
 
 {{< runnable >}}
 {


### PR DESCRIPTION
Clarify that match(predicate, string, distance) returns matches for <= distance according to the following:

https://github.com/dgraph-io/dgraph/blob/36da9d1cb4aa8476e317c9e2e1d8c0af516f7c31/worker/match.go#L78-L85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4396)
<!-- Reviewable:end -->
