### PR TITLE
contrib: update k8s liveness and readiness probes

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -169,6 +169,24 @@ spec:
             else
               exec dgraph zero --my=$(hostname -f):5080 --peer dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 3
             fi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 6080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /state
+            port: 6080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
       terminationGracePeriodSeconds: 60
       volumes:
       - name: datadir
@@ -285,6 +303,24 @@ spec:
           - |
             set -ex
             dgraph alpha --my=$(hostname -f):7080 --lru_mb 2048 --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080
+        livenessProbe:
+          httpGet:
+            path: /health?live=1
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+          successThreshold: 1
       terminationGracePeriodSeconds: 600
       volumes:
       - name: datadir

--- a/contrib/config/kubernetes/helm/values.yaml
+++ b/contrib/config/kubernetes/helm/values.yaml
@@ -111,7 +111,7 @@ zero:
   livenessProbe:
     enabled: false
     port: 6080
-    path: /state
+    path: /health
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5
@@ -215,7 +215,7 @@ alpha:
   livenessProbe:
     enabled: false
     port: 8080
-    path: /health
+    path: /health?live=1
     initialDelaySeconds: 30
     periodSeconds: 10
     timeoutSeconds: 5

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -276,13 +276,17 @@ func grpcPort() int {
 
 func healthCheck(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
-	if err := x.HealthCheck(); err != nil {
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, err = w.Write([]byte(err.Error()))
-		if err != nil {
-			glog.V(2).Infof("Error while writing health check response: %v", err)
+
+	_, ok := r.URL.Query()["live"]
+	if !ok {
+		if err := x.HealthCheck(); err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, err = w.Write([]byte(err.Error()))
+			if err != nil {
+				glog.V(2).Infof("Error while writing health check response: %v", err)
+			}
+			return
 		}
-		return
 	}
 
 	info := struct {

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -232,6 +232,13 @@ func (st *state) getState(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func (st *state) pingResponse(w http.ResponseWriter, r *http.Request) {
+	x.AddCorsHeaders(w)
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
+}
+
 func (st *state) serveHTTP(l net.Listener) {
 	srv := &http.Server{
 		ReadTimeout:  10 * time.Second,

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -236,7 +236,7 @@ func (st *state) pingResponse(w http.ResponseWriter, r *http.Request) {
 	x.AddCorsHeaders(w)
 
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("OK"))
 }
 
 func (st *state) serveHTTP(l net.Listener) {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -219,6 +219,7 @@ func run() {
 	st.serveGRPC(grpcListener, store)
 	st.serveHTTP(httpListener)
 
+	http.HandleFunc("/health", st.pingResponse)
 	http.HandleFunc("/state", st.getState)
 	http.HandleFunc("/removeNode", st.removeNode)
 	http.HandleFunc("/moveTablet", st.moveTablet)


### PR DESCRIPTION
* Fix liveness probe for dgraph alpha. Earlier there was a single endpoint for both liveness and readiness probes which can lead to some problems as described in #4383. This PR splits the single endpoint into two, one for readiness and one for liveness. The liveness probe does not take into consideration if the alpha is ready to take request, but ensure that the container is not in a frozen state and can serve some traffic.

The liveness probe can be triggered by providing a `live=1` GET parameter to the existing `/health` endpoint. The `/health` endpoint, however, corresponds to a readiness probe. This is similar to how cockroach DB handles these probes. 

* Add liveness probe to dgraph zero.
* Update k8s manifests to include both liveness and readiness probes.

This will require an update in the dgraph docker image `dgraph/dgraph`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4405)
<!-- Reviewable:end -->
