### PR TITLE
Remove posting pool and minor performance improvement.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -22,7 +22,6 @@ import (
 	"log"
 	"math"
 	"sort"
-	"sync"
 
 	"github.com/dgryski/go-farm"
 
@@ -285,8 +284,7 @@ func NewPosting(t *pb.DirectedEdge) *pb.Posting {
 		postingType = pb.Posting_REF
 	}
 
-	p := postingPool.Get().(*pb.Posting)
-	*p = pb.Posting{
+	p := &pb.Posting{
 		Uid:         t.ValueId,
 		Value:       t.Value,
 		ValType:     t.ValueType,
@@ -404,26 +402,6 @@ func (l *List) addMutation(ctx context.Context, txn *Txn, t *pb.DirectedEdge) er
 	l.Lock()
 	defer l.Unlock()
 	return l.addMutationInternal(ctx, txn, t)
-}
-
-var postingPool = &sync.Pool{
-	New: func() interface{} {
-		return &pb.Posting{}
-	},
-}
-
-func (l *List) release() {
-	fromList := func(list *pb.PostingList) {
-		for _, p := range list.GetPostings() {
-			postingPool.Put(p)
-		}
-	}
-	fromList(l.plist)
-	for _, plist := range l.mutationMap {
-		fromList(plist)
-	}
-	l.plist = nil
-	l.mutationMap = nil
 }
 
 func (l *List) addMutationInternal(ctx context.Context, txn *Txn, t *pb.DirectedEdge) error {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -272,7 +272,6 @@ func (lc *LocalCache) UpdateDeltasAndDiscardLists() {
 func (lc *LocalCache) fillPreds(ctx *api.TxnContext, gid uint32) {
 	lc.RLock()
 	defer lc.RUnlock()
-	predKeys := make([]string, 0, len(lc.deltas))
 	for key := range lc.deltas {
 		pk, err := x.Parse([]byte(key))
 		x.Check(err)
@@ -282,7 +281,7 @@ func (lc *LocalCache) fillPreds(ctx *api.TxnContext, gid uint32) {
 		// Also send the group id that the predicate was being served by. This is useful when
 		// checking if Zero should allow a commit during a predicate move.
 		predKey := fmt.Sprintf("%d-%s", gid, pk.Attr)
-		predKeys = append(predKeys, predKey)
+		ctx.Preds = append(ctx.Preds, predKey)
 	}
-	x.Union(&ctx.Preds, predKeys)
+	ctx.Preds = x.Unique(ctx.Preds)
 }

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -43,6 +43,27 @@ const (
 	mb = 1 << 20
 )
 
+// syncMarks stores the watermark for synced RAFT proposals. Each RAFT proposal consists
+// of many individual mutations, which could be applied to many different posting lists.
+// Thus, each PL when being mutated would send an undone Mark, and each list would
+// accumulate all such pending marks. When the PL is synced to BadgerDB, it would
+// mark all the pending ones as done.
+// This ideally belongs to RAFT node struct (where committed watermark is being tracked),
+// but because the logic of mutations is
+// present here and to avoid a circular dependency, we've placed it here.
+// Note that there's one watermark for each RAFT node/group.
+// This watermark would be used for taking snapshots, to ensure that all the data and
+// index mutations have been syned to BadgerDB, before a snapshot is taken, and previous
+// RAFT entries discarded.
+func init() {
+	x.AddInit(func() {
+		pl := pb.PostingList{}
+		var err error
+		_, err = pl.Marshal()
+		x.Check(err)
+	})
+}
+
 func getMemUsage() int {
 	if runtime.GOOS != "linux" {
 		pid := os.Getpid()

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -272,6 +272,7 @@ func (lc *LocalCache) UpdateDeltasAndDiscardLists() {
 func (lc *LocalCache) fillPreds(ctx *api.TxnContext, gid uint32) {
 	lc.RLock()
 	defer lc.RUnlock()
+	predKeys := make([]string, 0, len(lc.deltas))
 	for key := range lc.deltas {
 		pk, err := x.Parse([]byte(key))
 		x.Check(err)
@@ -281,8 +282,7 @@ func (lc *LocalCache) fillPreds(ctx *api.TxnContext, gid uint32) {
 		// Also send the group id that the predicate was being served by. This is useful when
 		// checking if Zero should allow a commit during a predicate move.
 		predKey := fmt.Sprintf("%d-%s", gid, pk.Attr)
-		if !x.HasString(ctx.Preds, predKey) {
-			ctx.Preds = append(ctx.Preds, predKey)
-		}
+		predKeys = append(predKeys, predKey)
 	}
+	x.Union(&ctx.Preds, predKeys)
 }

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -43,27 +43,6 @@ const (
 	mb = 1 << 20
 )
 
-// syncMarks stores the watermark for synced RAFT proposals. Each RAFT proposal consists
-// of many individual mutations, which could be applied to many different posting lists.
-// Thus, each PL when being mutated would send an undone Mark, and each list would
-// accumulate all such pending marks. When the PL is synced to BadgerDB, it would
-// mark all the pending ones as done.
-// This ideally belongs to RAFT node struct (where committed watermark is being tracked),
-// but because the logic of mutations is
-// present here and to avoid a circular dependency, we've placed it here.
-// Note that there's one watermark for each RAFT node/group.
-// This watermark would be used for taking snapshots, to ensure that all the data and
-// index mutations have been syned to BadgerDB, before a snapshot is taken, and previous
-// RAFT entries discarded.
-func init() {
-	x.AddInit(func() {
-		pl := pb.PostingList{}
-		var err error
-		_, err = pl.Marshal()
-		x.Check(err)
-	})
-}
-
 func getMemUsage() int {
 	if runtime.GOOS != "linux" {
 		pid := os.Getpid()

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -58,17 +58,18 @@ func (txn *Txn) addConflictKey(conflictKey uint64) {
 func (txn *Txn) FillContext(ctx *api.TxnContext, gid uint32) {
 	txn.Lock()
 	ctx.StartTs = txn.StartTs
+
+	keys := make([]string, 0, len(txn.conflicts))
 	for key := range txn.conflicts {
 		// We don'txn need to send the whole conflict key to Zero. Solving #2338
 		// should be done by sending a list of mutating predicates to Zero,
 		// along with the keys to be used for conflict detection.
 		fps := strconv.FormatUint(key, 36)
-		if !x.HasString(ctx.Keys, fps) {
-			ctx.Keys = append(ctx.Keys, fps)
-		}
+		keys = append(keys, fps)
 	}
-	txn.Unlock()
+	x.Union(&ctx.Keys, keys)
 
+	txn.Unlock()
 	txn.Update()
 	txn.cache.fillPreds(ctx, gid)
 }

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -59,15 +59,14 @@ func (txn *Txn) FillContext(ctx *api.TxnContext, gid uint32) {
 	txn.Lock()
 	ctx.StartTs = txn.StartTs
 
-	keys := make([]string, 0, len(txn.conflicts))
 	for key := range txn.conflicts {
 		// We don'txn need to send the whole conflict key to Zero. Solving #2338
 		// should be done by sending a list of mutating predicates to Zero,
 		// along with the keys to be used for conflict detection.
 		fps := strconv.FormatUint(key, 36)
-		keys = append(keys, fps)
+		ctx.Keys = append(ctx.Keys, fps)
 	}
-	x.Union(&ctx.Keys, keys)
+	ctx.Keys = x.Unique(ctx.Keys)
 
 	txn.Unlock()
 	txn.Update()

--- a/x/x.go
+++ b/x/x.go
@@ -291,15 +291,18 @@ func HasString(a []string, b string) bool {
 
 // Unique takes an array and returns it with no duplicate entries.
 func Unique(a []string) []string {
+	if len(a) < 2 {
+		return a
+	}
+
 	sort.Strings(a)
-	previous := ""
-	idx := 0
+	idx := 1
 	for _, val := range a {
-		if previous == "" || previous != val {
-			a[idx] = val
-			previous = val
-			idx++
+		if a[idx-1] == val {
+			continue
 		}
+		a[idx] = val
+		idx++
 	}
 	return a[:idx]
 }

--- a/x/x.go
+++ b/x/x.go
@@ -289,20 +289,19 @@ func HasString(a []string, b string) bool {
 	return false
 }
 
-// Union takes two array and returns their union with no duplicate entries.
-func Union(a *[]string, b []string) {
+// Unique takes an array and return it with no duplicate entries.
+func Unique(a []string) []string {
 	keys := make(map[string]struct{})
-	for _, val := range *a {
-		keys[val] = struct{}{}
-	}
-	for _, val := range b {
+	for _, val := range a {
 		keys[val] = struct{}{}
 	}
 
-	*a = make([]string, 0, len(keys))
+	a = a[:0]
 	for key := range keys {
-		*a = append(*a, key)
+		a = append(a, key)
 	}
+
+	return a
 }
 
 // ReadLine reads a single line from a buffered reader. The line is read into the

--- a/x/x.go
+++ b/x/x.go
@@ -289,7 +289,7 @@ func HasString(a []string, b string) bool {
 	return false
 }
 
-// Unique takes an array and return it with no duplicate entries.
+// Unique takes an array and returns it with no duplicate entries.
 func Unique(a []string) []string {
 	keys := make(map[string]struct{})
 	for _, val := range a {

--- a/x/x.go
+++ b/x/x.go
@@ -289,6 +289,22 @@ func HasString(a []string, b string) bool {
 	return false
 }
 
+// Union takes two array and returns their union with no duplicate entries.
+func Union(a *[]string, b []string) {
+	keys := make(map[string]struct{})
+	for _, val := range *a {
+		keys[val] = struct{}{}
+	}
+	for _, val := range b {
+		keys[val] = struct{}{}
+	}
+
+	*a = make([]string, 0, len(keys))
+	for key := range keys {
+		*a = append(*a, key)
+	}
+}
+
 // ReadLine reads a single line from a buffered reader. The line is read into the
 // passed in buffer to minimize allocations. This is the preferred
 // method for loading long lines which could be longer than the buffer

--- a/x/x.go
+++ b/x/x.go
@@ -291,17 +291,17 @@ func HasString(a []string, b string) bool {
 
 // Unique takes an array and returns it with no duplicate entries.
 func Unique(a []string) []string {
-	keys := make(map[string]struct{})
+	sort.Strings(a)
+	previous := ""
+	idx := 0
 	for _, val := range a {
-		keys[val] = struct{}{}
+		if previous == "" || previous != val {
+			a[idx] = val
+			previous = val
+			idx++
+		}
 	}
-
-	a = a[:0]
-	for key := range keys {
-		a = append(a, key)
-	}
-
-	return a
+	return a[:idx]
 }
 
 // ReadLine reads a single line from a buffered reader. The line is read into the


### PR DESCRIPTION
Initially, Sync pool was added to improve performance. But it was difficult to figure out when to release it since multiple thread had access to the object. So, sync pool release was removed in commit 29c2addf but sync pool was still used which taking memory and time while creating an object from sync pool. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4408)
<!-- Reviewable:end -->
