### PR TITLE
dgraph-ha: handle SIGTERM for alpha init container

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -252,6 +252,7 @@ spec:
       #       - bash
       #       - "-c"
       #       - |
+      #         trap "exit" SIGINT SIGTERM
       #         echo "Write to /dgraph/doneinit when ready."
       #         until [ -f /dgraph/doneinit ]; do sleep 2; done
       #     volumeMounts:


### PR DESCRIPTION
Previously, if the alpha init container is used and the pod is killed before data is loaded
 it would take 5 minutes (grace period) to delete the pod.
After the change, the pod is killed quickly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4415)
<!-- Reviewable:end -->
