### PR TITLE
Ignore errors from writing to buffers.

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -68,7 +68,7 @@ func (e *Encoder) packBlock() {
 		}
 
 		data := groupvarint.Encode4(buf, tmpUids)
-		out.Write(data)
+		_, _ = out.Write(data)
 
 		// e.uids has ended and we have padded tmpUids with 0s
 		if len(e.uids) <= 4 {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -265,17 +265,17 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 
 	var out bytes.Buffer
 	writeEntry := func(key string, js []byte) {
-		out.WriteRune('"')
-		out.WriteString(key)
-		out.WriteRune('"')
-		out.WriteRune(':')
-		out.Write(js)
+		_, _ = out.WriteRune('"')
+		_, _ = out.WriteString(key)
+		_, _ = out.WriteRune('"')
+		_, _ = out.WriteRune(':')
+		_, _ = out.Write(js)
 	}
-	out.WriteRune('{')
+	_, _ = out.WriteRune('{')
 	writeEntry("data", resp.Json)
-	out.WriteRune(',')
+	_, _ = out.WriteRune(',')
 	writeEntry("extensions", js)
-	out.WriteRune('}')
+	_, _ = out.WriteRune('}')
 
 	if _, err := writeResponse(w, r, out.Bytes()); err != nil {
 		// If client crashes before server could write response, writeResponse will error out,

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -249,7 +249,7 @@ func (m *mapper) lookupUid(xid string) uint64 {
 	// Also, checked that sb goes on the stack whereas sb.String() goes on
 	// heap. Note that the calls to the strings.Builder.* are inlined.
 	sb := strings.Builder{}
-	sb.WriteString(xid)
+	_, _ = sb.WriteString(xid)
 	uid, isNew := m.xids.AssignUid(sb.String())
 	if !m.opt.StoreXids || !isNew {
 		return uid

--- a/worker/export.go
+++ b/worker/export.go
@@ -278,34 +278,34 @@ func (e *exporter) toRDF() (*bpb.KVList, error) {
 func toSchema(attr string, update pb.SchemaUpdate) (*bpb.KVList, error) {
 	// bytes.Buffer never returns error for any of the writes. So, we don't need to check them.
 	var buf bytes.Buffer
-	buf.WriteRune('<')
-	buf.WriteString(attr)
-	buf.WriteRune('>')
-	buf.WriteByte(':')
+	_, _ = buf.WriteRune('<')
+	_, _ = buf.WriteString(attr)
+	_, _ = buf.WriteRune('>')
+	_, _ = buf.WriteRune(':')
 	if update.List {
-		buf.WriteRune('[')
+		_, _ = buf.WriteRune('[')
 	}
-	buf.WriteString(types.TypeID(update.ValueType).Name())
+	_, _ = buf.WriteString(types.TypeID(update.ValueType).Name())
 	if update.List {
-		buf.WriteRune(']')
+		_, _ = buf.WriteRune(']')
 	}
 	if update.Directive == pb.SchemaUpdate_REVERSE {
-		buf.WriteString(" @reverse")
+		_, _ = buf.WriteString(" @reverse")
 	} else if update.Directive == pb.SchemaUpdate_INDEX && len(update.Tokenizer) > 0 {
-		buf.WriteString(" @index(")
-		buf.WriteString(strings.Join(update.Tokenizer, ","))
-		buf.WriteByte(')')
+		_, _ = buf.WriteString(" @index(")
+		_, _ = buf.WriteString(strings.Join(update.Tokenizer, ","))
+		_, _ = buf.WriteRune(')')
 	}
 	if update.Count {
-		buf.WriteString(" @count")
+		_, _ = buf.WriteString(" @count")
 	}
 	if update.Lang {
-		buf.WriteString(" @lang")
+		_, _ = buf.WriteString(" @lang")
 	}
 	if update.Upsert {
-		buf.WriteString(" @upsert")
+		_, _ = buf.WriteString(" @upsert")
 	}
-	buf.WriteString(" . \n")
+	_, _ = buf.WriteString(" . \n")
 	kv := &bpb.KV{
 		Value:   buf.Bytes(),
 		Version: 2, // Schema value
@@ -331,9 +331,9 @@ func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 
 func fieldToString(update *pb.SchemaUpdate) string {
 	var builder strings.Builder
-	builder.WriteString("\t")
-	builder.WriteString(update.Predicate)
-	builder.WriteString("\n")
+	_, _ = builder.WriteString("\t")
+	_, _ = builder.WriteString(update.Predicate)
+	_, _ = builder.WriteString("\n")
 	return builder.String()
 }
 


### PR DESCRIPTION
It's very unlikely that these statements will ever cause an error so
it's safe to ignore them. This PR changes the statements to clear the
corresponsing warning in DeepSource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4426)
<!-- Reviewable:end -->
