### PR TITLE
release.sh: Update Go version for release builds.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -23,7 +23,7 @@ mkdir $GOPATH
 PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
-GOVERSION="1.12.7"
+GOVERSION="1.13.5"
 
 # Turn off go modules by default. Only enable go modules when needed.
 export GO111MODULE=off


### PR DESCRIPTION
Use the latest Go release version (go 1.13.5) for Dgraph release binaries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4427)
<!-- Reviewable:end -->
