### PR TITLE
docs: Set v1.1.1 as latest docs.

### DIFF
--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -20,8 +20,10 @@ HOST=https://docs.dgraph.io
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 VERSIONS_ARRAY=(
-	'v1.1.0'
+	'v1.1.1'
 	'master'
+	'v1.1.0'
+	'v1.0.18'
 	'v1.0.17'
 	'v1.0.16'
 	'v1.0.15'


### PR DESCRIPTION
Sets v1.1.1 as the latest docs in the docs build script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4430)
<!-- Reviewable:end -->
