### PR TITLE
Removes outputNode interface and use fastJsonNode type directly.

### DIFF
--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -91,6 +91,6 @@ func TestNormalizeJSONLimit(t *testing.T) {
 				types.ValueForType(types.StringID))
 		}
 	}
-	_, err := n.(*fastJsonNode).normalize()
+	_, err := n.normalize()
 	require.Error(t, err, "Couldn't evaluate @normalize directive - too many results")
 }


### PR DESCRIPTION
outputNode interface was used to support JSON or Protobuf encoding of results. But since we removed protobuf encoding, using fastJsonNode directly instead of calling it through interface speeds up the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4438)
<!-- Reviewable:end -->
