### PR TITLE
Support disk based reindexing

### DIFF
--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -11,16 +11,16 @@ func TestReindexLangTerm(t *testing.T) {
 	require.NoError(t, alterSchema(`name: string @lang .`))
 
 	m1 := `{
-      set {
-        _:u1 <name> "Ab Bc"@en .
-        _:u2 <name> "Bc Cd"@en .
-        _:u3 <name> "Cd Da"@fr .
-      }
-    }`
+    set {
+      _:u1 <name> "Ab Bc"@en .
+      _:u2 <name> "Bc Cd"@en .
+      _:u3 <name> "Cd Da"@fr .
+    }
+  }`
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	// perform reindexing
+	// perform re-indexing
 	require.NoError(t, alterSchema(`name: string @lang @index(term) .`))
 
 	q1 := `{
@@ -38,365 +38,365 @@ func TestReindexData(t *testing.T) {
 	require.NoError(t, alterSchema(`name: string @lang .`))
 
 	m1 := `{
-      set {
-        <10000> <name>	"Vidar Flataukan"@en	.
-        <10001> <name>	"starring"@en	.
-        <10002> <name>	"cinematography"@en	.
-        <10003> <name>	"directed_by"@en	.
-        <10004> <name>	"edited_by"@en	.
-        <10005> <name>	"festivals"@en	.
-        <10006> <name>	"genre"@en	.
-        <10007> <name>	"Movies"@en	.
-        <10008> <name>	"music"@en	.
-        <10009> <name>	"produced_by"@en	.
-        <10010> <name>	"production_companies"@en	.
-        <10011> <name>	"written_by"@en	.
-        <10012> <name>	"Films edited"@en	.
-        <10013> <name>	"Apple movie trailer ID"@en	.
-        <10014> <name>	"Films art directed"@en	.
-        <10015> <name>	"Films casting directed"@en	.
-        <10016> <name>	"Portrayed in films (dubbed)"@en	.
-        <10017> <name>	"Portrayed in films"@en	.
-        <10018> <name>	"Cinematography"@en	.
-        <10019> <name>	"Films In Collection"@en	.
-        <10020> <name>	"Films"@en	.
-        <10021> <name>	"Companies performing this role or service"@en	.
-        <10022> <name>	"Costume design by"@en	.
-        <10023> <name>	"Costume Design for Film"@en	.
-        <10024> <name>	"Country of origin"@en	.
-        <10025> <name>	"Crewmember"@en	.
-        <10026> <name>	"Film crew role"@en	.
-        <10027> <name>	"Film"@en	.
-        <10028> <name>	"Films crewed"@en	.
-        <10029> <name>	"Film release region"@en	.
-        <10030> <name>	"Film"@en	.
-        <10031> <name>	"Note"@en	.
-        <10032> <name>	"Runtime"@en	.
-        <10033> <name>	"Film cut"@en	.
-        <10034> <name>	"Films distributed in this medium"@en	.
-        <10035> <name>	"Films distributed"@en	.
-        <10036> <name>	"Distributors"@en	.
-        <10037> <name>	"Dubbing performances"@en	.
-        <10038> <name>	"Edited by"@en	.
-        <10039> <name>	"Estimated budget"@en	.
-        <10040> <name>	"Executive produced by"@en	.
-        <10041> <name>	"Fandango ID"@en	.
-        <10042> <name>	"Notable filming locations"@en	.
-        <10043> <name>	"Featured in film"@en	.
-        <10044> <name>	"Performed by"@en	.
-        <10045> <name>	"Featured Song"@en	.
-        <10046> <name>	"Date founded"@en	.
-        <10047> <name>	"Closing date"@en	.
-        <10048> <name>	"Festival"@en	.
-        <10049> <name>	"Films"@en	.
-        <10050> <name>	"Opening date"@en	.
-        <10051> <name>	"Venues"@en	.
-        <10052> <name>	"Festivals with this focus"@en	.
-        <10053> <name>	"Focus"@en	.
-        <10054> <name>	"Individual festivals"@en	.
-        <10055> <name>	"Location"@en	.
-        <10056> <name>	"Festivals sponsored"@en	.
-        <10057> <name>	"Sponsoring organization"@en	.
-        <10058> <name>	"Festival"@en	.
-        <10059> <name>	"From"@en	.
-        <10060> <name>	"Sponsor"@en	.
-        <10061> <name>	"To"@en	.
-        <10062> <name>	"Art direction by"@en	.
-        <10063> <name>	"Casting director"@en	.
-        <10064> <name>	"Film Collections"@en	.
-        <10065> <name>	"Film company"@en	.
-        <10066> <name>	"Film cut"@en	.
-        <10067> <name>	"Film"@en	.
-        <10068> <name>	"Role/service"@en	.
-        <10069> <name>	"Distributor"@en	.
-        <10070> <name>	"Film cut"@en	.
-        <10071> <name>	"Film distribution medium"@en	.
-        <10072> <name>	"Film"@en	.
-        <10073> <name>	"Region"@en	.
-        <10074> <name>	"Year"@en	.
-        <10075> <name>	"Film festivals"@en	.
-        <10076> <name>	"Film format"@en	.
-        <10077> <name>	"Filming"@en	.
-        <10078> <name>	"Production design by"@en	.
-        <10079> <name>	"Film Series"@en	.
-        <10080> <name>	"Set Decoration by"@en	.
-        <10081> <name>	"Film Format"@en	.
-        <10082> <name>	"Genres"@en	.
-        <10083> <name>	"Gross revenue"@en	.
-        <10084> <name>	"Initial release date"@en	.
-        <10085> <name>	"Films with this crew job"@en	.
-        <10086> <name>	"Languages"@en	.
-        <10087> <name>	"Featured In Films"@en	.
-        <10088> <name>	"Featured Locations"@en	.
-        <10089> <name>	"Metacritic film ID"@en	.
-        <10090> <name>	"Music by"@en	.
-        <10091> <name>	"Netflix ID"@en	.
-        <10092> <name>	"NY Times ID"@en	.
-        <10093> <name>	"Other crew"@en	.
-        <10094> <name>	"Other film companies"@en	.
-        <10095> <name>	"Personal appearances"@en	.
-        <10096> <name>	"Post-production"@en	.
-        <10097> <name>	"Pre-production"@en	.
-        <10098> <name>	"Prequel"@en	.
-        <10099> <name>	"Primary language"@en	.
-        <10100> <name>	"Produced by"@en	.
-        <10101> <name>	"Production companies"@en	.
-        <10102> <name>	"Films production designed"@en	.
-        <10103> <name>	"Rated"@en	.
-        <10104> <name>	"Film regional debut venue"@en	.
-        <10105> <name>	"Film release distribution medium"@en	.
-        <10106> <name>	"Film release region"@en	.
-        <10107> <name>	"Film"@en	.
-        <10108> <name>	"Release Date"@en	.
-        <10109> <name>	"Release date(s)"@en	.
-        <10110> <name>	"Rotten Tomatoes ID"@en	.
-        <10111> <name>	"Runtime"@en	.
-        <10112> <name>	"Sequel"@en	.
-        <10113> <name>	"Films In Series"@en	.
-        <10114> <name>	"Film sets designed"@en	.
-        <10115> <name>	"Films"@en	.
-        <10116> <name>	"Film songs"@en	.
-        <10117> <name>	"Composition"@en	.
-        <10118> <name>	"Film"@en	.
-        <10119> <name>	"Performers"@en	.
-        <10120> <name>	"Songs"@en	.
-        <10121> <name>	"Soundtrack"@en	.
-        <10122> <name>	"Performances"@en	.
-        <10123> <name>	"Story by"@en	.
-        <10124> <name>	"Film Story Credits"@en	.
-        <10125> <name>	"Films On This Subject"@en	.
-        <10126> <name>	"Subjects"@en	.
-        <10127> <name>	"Tagline"@en	.
-        <10128> <name>	"Trailer Addict ID"@en	.
-        <10129> <name>	"Trailers"@en	.
-        <10130> <name>	"Screenplay by"@en	.
-        <10131> <name>	"Film music credits"@en	.
-        <10132> <name>	"Actor"@en	.
-        <10133> <name>	"Character note"@en	.
-        <10134> <name>	"Character"@en	.
-        <10135> <name>	"Film"@en	.
-        <10136> <name>	"Special Performance Type"@en	.
-        <10137> <name>	"Film"@en	.
-        <10138> <name>	"Person"@en	.
-        <10139> <name>	"Film appearances"@en	.
-        <10140> <name>	"Type of Appearance"@en	.
-        <10141> <name>	"Films appeared in"@en	.
-        <10142> <name>	"Films Executive Produced"@en	.
-        <10143> <name>	"Films Produced"@en	.
-        <10144> <name>	"Films"@en	.
-        <10145> <name>	"Special Film Performance"@en	.
-        <10146> <name>	"Film writing credits"@en	.
-        <10147> <name>	"What Price Goofy"@en	.
-        <10148> <name>	"Vlasta Zehrova"@en	.
-        <10149> <name>	"General Orlov"@en	.
-        <10150> <name>	"Corinne Dufour"@en	.
-        <10151> <name>	"Sunshine and Gold"@en	.
-        <10152> <name>	"Moon Over Tao"@en	.
-        <10153> <name>	"Pasquale Marino"@en	.
-        <10154> <name>	"Matteo Capelli"@en	.
-        <10155> <name>	"Michal Hejný"@en	.
-        <10156> <name>	"Karioka"@en	.
-        <10157> <name>	"Yossi Eini"@en	.
-        <10158> <name>	"Viktor Gordeyev"@en	.
-        <10159> <name>	"Roos Van Vlaenderen"@en	.
-        <10160> <name>	"General Georgi Koskov"@en	.
-        <10161> <name>	"Do kalle-shagh"@en	.
-        <10162> <name>	"Moataz El Tony"@en	.
-        <10163> <name>	"Dirty Dreamer"@en	.
-        <10164> <name>	"Karl Sturm"@en	.
-        <10165> <name>	"Michael Ehninger"@en	.
-        <10166> <name>	"Killer of Small Fishes"@en	.
-        <10167> <name>	"Jean-Pierre Dougnac"@en	.
-        <10168> <name>	"Yes We Can!"@en	.
-        <10169> <name>	"Jaroslaw Dunaj"@en	.
-        <10170> <name>	"William O'Farrell"@en	.
-        <10171> <name>	"Melodies, Melodies..."@en	.
-        <10172> <name>	"Jerzy Sagan"@en	.
-        <10173> <name>	"Only the Valiant"@en	.
-        <10174> <name>	"Socarrat"@en	.
-        <10175> <name>	"Yuet-Ming Yiu"@en	.
-        <10176> <name>	"Georg Wratsch"@en	.
-        <10177> <name>	"Zivorad Zika Pavlovic"@en	.
-        <10178> <name>	"Shinsuke Akagi"@en	.
-        <10179> <name>	"The Donkey Who Drank the Moon"@en	.
-        <10180> <name>	"Tanemaku tabibito: Minori no cha"@en	.
-        <10181> <name>	"The Crossing"@en	.
-        <10182> <name>	"Samvel Muzhikyan"@en	.
-        <10183> <name>	"Breaking the Wall"@en	.
-        <10184> <name>	"Tommaso Blu"@en	.
-        <10185> <name>	"Mário Viegas"@en	.
-        <10186> <name>	"Carl Struve"@en	.
-        <10187> <name>	"Pine Tree"@en	.
-        <10188> <name>	"Lost Youth"@en	.
-        <10189> <name>	"Pasi"@en	.
-        <10190> <name>	"Grigori Kirillov"@en	.
-        <10191> <name>	"Valentina Kutsenko"@en	.
-        <10192> <name>	"Fleeing by Night"@en	.
-        <10193> <name>	"Salwa Nakkara"@en	.
-        <10194> <name>	"Li Wei Chang"@en	.
-        <10195> <name>	"Plenty O'Toole"@en	.
-        <10196> <name>	"Thomás Tristonho"@en	.
-        <10197> <name>	"Sjamsuddin Jusuf"@en	.
-        <10198> <name>	"Tit for Tat"@en	.
-        <10199> <name>	"Svetlana Korkoshko"@en	.
-        <10200> <name>	"Badiaa Masabny"@en	.
-        <10201> <name>	"Edith Toreg"@en	.
-        <10202> <name>	"Casey Alexander"@en	.
-        <10203> <name>	"Xie Yuan"@en	.
-        <10204> <name>	"Feliks Rybicki"@en	.
-        <10205> <name>	"Early Rain"@en	.
-        <10206> <name>	"The Virgin Star"@en	.
-        <10207> <name>	"When the Cloud Scatters Away"@en	.
-        <10208> <name>	"Helen Ward"@en	.
-        <10209> <name>	"Yoo Se-Hung"@en	.
-        <10210> <name>	"Dancing with Father"@en	.
-        <10211> <name>	"Joana Nin"@en	.
-        <10212> <name>	"A Tearstained Crown"@en	.
-        <10213> <name>	"Yael Reuveny"@en	.
-        <10214> <name>	"Merrick"@en	.
-        <10215> <name>	"Teuda Bara"@en	.
-        <10216> <name>	"Chris Ayers"@en	.
-        <10217> <name>	"Trust, at least trust"@en	.
-        <10218> <name>	"Rerberg and Tarkovsky - Reverse Side of \"Stalker\""@en	.
-        <10219> <name>	"Stefan Forss"@en	.
-        <10220> <name>	"Myeongdong vs Nampodong"@en	.
-        <10221> <name>	"A Daughter of a Condemned Criminal"@en	.
-        <10222> <name>	"Alone Crying Star"@en	.
-        <10223> <name>	"Though the Heavens May Fall"@en	.
-        <10224> <name>	"Friendship of Hope"@en	.
-        <10225> <name>	"Hedpoh Chernyim"@en	.
-        <10226> <name>	"Cheng-Peng Kao"@en	.
-        <10227> <name>	"Yin Hang"@en	.
-        <10228> <name>	"脱走遊戯"@ja	.
-        <10229> <name>	"まむしと青大将"@ja	.
-        <10230> <name>	"網走番外地 吹雪の斗争"@ja	.
-        <10231> <name>	"結婚って、幸せですか THE MOVIE"@ja	.
-        <10232> <name>	"スープ〜生まれ変わりの物語〜"@ja	.
-        <10233> <name>	"ドミニク・グリーン"@ja	.
-        <10234> <name>	"コント55号 世紀の大弱点"@ja	.
-        <10152> <name>	"タオの月"@ja	.
-        <10178> <name>	"赤木伸輔"@ja	.
-        <10180> <name>	"種まく旅人～みのりの茶～"@ja	.
-        <10235> <name>	"Лев Любецкий"@ru	.
-        <10236> <name>	"Смерть Таирова"@ru	.
-        <10237> <name>	"Михаль Рейно"@ru	.
-        <10238> <name>	"Фрэнк Бёрнс"@ru	.
-        <10239> <name>	"Ловец Макинтайр"@ru	.
-        <10240> <name>	"Хавьер Перес Гробет"@ru	.
-        <10241> <name>	"Джулио Пампильоне"@ru	.
-        <10242> <name>	"Теодора Ремундова"@ru	.
-        <10243> <name>	"Дин Каримович Махаматдинов"@ru	.
-        <10158> <name>	"Виктор Владимирович Гордеев"@ru	.
-        <10244> <name>	"Ирина Ивановна Поплавская"@ru	.
-        <10202> <name>	"Кэйси Александр"@ru	.
-        <10245> <name>	"Артём Витальевич Цыпин"@ru	.
-        <10246> <name>	"بياعة الجرايد"@ar	.
-        <10247> <name>	"شفيقة القبطية"@ar	.
-        <10156> <name>	"كاريوكا"@ar	.
-        <10200> <name>	"بديعة مصابنى"@ar	.
-        <10248> <name>	"手機裡的眼淚"@zh-Hant	.
-        <10249> <name>	"먼동이 틀 때"@ko	.
-        <10250> <name>	"사랑과 헤이세이의 색남"@ko	.
-        <10251> <name>	"9. Altın Koza Film Festivali"@tr	.
-        <10252> <name>	"아쉬칸 카티비"@ko	.
-        <10253> <name>	"Charles Kawalsky"@fr	.
-        <10254> <name>	"박철호"@ko	.
-        <10255> <name>	"Ruggero Cara"@ca	.
-        <10240> <name>	"Xavier Pérez Grobet"@es-419	.
-        <10240> <name>	"Xavier Pérez Grobet"@fr	.
-        <10240> <name>	"Xavier Pérez Grobet"@sl	.
-        <10256> <name>	"최옥희"@ko	.
-        <10257> <name>	"George Wang"@de	.
-        <10257> <name>	"George Wang"@es-419	.
-        <10257> <name>	"王玨"@zh	.
-        <10257> <name>	"王玨"@zh-Hant	.
-        <10258> <name>	"Danie miłości"@pl	.
-        <10258> <name>	"Joyful Reunion"@ro	.
-        <10258> <name>	"飲食男女：好遠又好近"@zh-Hant	.
-        <10259> <name>	"Kim Kristensen"@da	.
-        <10259> <name>	"Kim Kristensen"@nl	.
-        <10260> <name>	"Ecaterina Teodoroiu"@ro	.
-        <10261> <name>	"써가"@ko	.
-        <10262> <name>	"12. Altın Koza Film Festivali"@tr	.
-        <10263> <name>	"5. Altın Koza Film Festivali"@tr	.
-        <10264> <name>	"선택"@ko	.
-        <10265> <name>	"ناصر مهدی‌پور"@fa	.
-        <10266> <name>	"Rita Elmgren"@sv	.
-        <10267> <name>	"Intruso"@pt-PT	.
-        <10268> <name>	"서장원"@ko	.
-        <10150> <name>	"Corinne Dufour"@fr	.
-        <10159> <name>	"Roos Van Vlaenderen"@fr	.
-        <10159> <name>	"Roos Van Vlaenderen"@pl	.
-        <10159> <name>	"Roos Van Vlaenderen"@ro	.
-        <10159> <name>	"Roos Van Vlaenderen"@tr	.
-        <10160> <name>	"General Koskov"@sv	.
-        <10269> <name>	"Karolina Kaiser"@hu	.
-        <10270> <name>	"朱芷瑩"@zh-Hant	.
-        <10271> <name>	"Sune Spangberg"@ro	.
-        <10271> <name>	"Sune Spångberg"@sv	.
-        <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt	.
-        <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt-BR	.
-        <10273> <name>	"Irja Elstelä"@fi	.
-        <10171> <name>	"Melodii, melodii"@ro	.
-        <10172> <name>	"Jerzy Sagan"@pl	.
-        <10173> <name>	"La carga de los valientes"@es	.
-        <10177> <name>	"Живорад Жика Павловић"@sr	.
-        <10181> <name>	"La Traversée"@fr	.
-        <10181> <name>	"La traversée"@tr	.
-        <10182> <name>	"Samvel Muzhikyan"@de	.
-        <10182> <name>	"Samvel Muzhikyan"@pl	.
-        <10183> <name>	"성벽을 뚫고"@ko	.
-        <10185> <name>	"Mário Viegas"@pt	.
-        <10187> <name>	"일송정 푸른 솔은"@ko	.
-        <10188> <name>	"잃어버린 청춘"@ko	.
-        <10189> <name>	"파시"@ko	.
-        <10192> <name>	"야분"@ko	.
-        <10193> <name>	"Salwa Nakkara"@fr	.
-        <10193> <name>	"Salwa Nakkara"@nl	.
-        <10193> <name>	"Salwa Nakkara"@ro	.
-        <10274> <name>	"애국자의 아들"@ko	.
-        <10275> <name>	"Inês de Portugal"@pt-PT	.
-        <10202> <name>	"Casey Alexander"@de	.
-        <10203> <name>	"謝園"@zh-Hant	.
-        <10204> <name>	"Feliks Rybicki"@pl	.
-        <10205> <name>	"초우"@ko	.
-        <10206> <name>	"처녀 별"@ko	.
-        <10207> <name>	"구름이 흩어질 때"@ko	.
-        <10210> <name>	"아빠와 함께 춤을"@ko	.
-        <10211> <name>	"Joana Nin"@pt	.
-        <10212> <name>	"눈물젖은 왕관"@ko	.
-        <10213> <name>	"Yael Reuveny"@sl	.
-        <10276> <name>	"이별의 종착역"@ko	.
-        <10277> <name>	"아내를 빼앗긴 사나이"@ko	.
-        <10278> <name>	"울지 않으련다"@ko	.
-        <10215> <name>	"Teuda Bara"@pt	.
-        <10215> <name>	"Teuda Bara"@ro	.
-        <10215> <name>	"Teuda Bara"@tr	.
-        <10217> <name>	"없어도 의리만은"@ko	.
-        <10218> <name>	"Rerberg i Tarkowski. Odwrotna strona Stalkera"@pl	.
-        <10219> <name>	"Stefan Forss"@fi	.
-        <10220> <name>	"명동 사나이와 남포동 사나이"@ko	.
-        <10221> <name>	"사형수의 딸"@ko	.
-        <10222> <name>	"홀로 우는 별"@ko	.
-        <10279> <name>	"내 청춘에 한은 없다"@ko	.
-        <10223> <name>	"하늘이 무너져도"@ko	.
-        <10224> <name>	"내일 있는 우정"@ko	.
-        <10280> <name>	"젊은 그들"@ko	.
-        <10225> <name>	"เห็ดเผาะ เชิญยิ้ม"@th	.
-        <10281> <name>	"젊은 설계도"@ko	.
-        <10226> <name>	"高振鵬"@zh-Hant	.
-        <10282> <name>	"젊은 아들의 마지막 노래"@ko	.
-        <10227> <name>	"尹航"@zh-Hant	.
-        <10283> <name>	"Mahmood Sammakbashi"@de	.
-        <10284> <name>	"Gárdonyi Lajos"@hu	.
-        <10285> <name>	"아들의 심판"@ko	.
-        <10286> <name>	"목숨걸고 왔수다"@ko	.
-        <10287> <name>	"항구의 일야"@ko	.
-        <10288> <name>	"남포동 출신"@ko	.
-        <10289> <name>	"체스트"@ko	.
-        <10289> <name>	"Це не я, це — він"@uk	.
-      }
-    }`
+    set {
+      <10000> <name>	"Vidar Flataukan"@en	.
+      <10001> <name>	"starring"@en	.
+      <10002> <name>	"cinematography"@en	.
+      <10003> <name>	"directed_by"@en	.
+      <10004> <name>	"edited_by"@en	.
+      <10005> <name>	"festivals"@en	.
+      <10006> <name>	"genre"@en	.
+      <10007> <name>	"Movies"@en	.
+      <10008> <name>	"music"@en	.
+      <10009> <name>	"produced_by"@en	.
+      <10010> <name>	"production_companies"@en	.
+      <10011> <name>	"written_by"@en	.
+      <10012> <name>	"Films edited"@en	.
+      <10013> <name>	"Apple movie trailer ID"@en	.
+      <10014> <name>	"Films art directed"@en	.
+      <10015> <name>	"Films casting directed"@en	.
+      <10016> <name>	"Portrayed in films (dubbed)"@en	.
+      <10017> <name>	"Portrayed in films"@en	.
+      <10018> <name>	"Cinematography"@en	.
+      <10019> <name>	"Films In Collection"@en	.
+      <10020> <name>	"Films"@en	.
+      <10021> <name>	"Companies performing this role or service"@en	.
+      <10022> <name>	"Costume design by"@en	.
+      <10023> <name>	"Costume Design for Film"@en	.
+      <10024> <name>	"Country of origin"@en	.
+      <10025> <name>	"Crewmember"@en	.
+      <10026> <name>	"Film crew role"@en	.
+      <10027> <name>	"Film"@en	.
+      <10028> <name>	"Films crewed"@en	.
+      <10029> <name>	"Film release region"@en	.
+      <10030> <name>	"Film"@en	.
+      <10031> <name>	"Note"@en	.
+      <10032> <name>	"Runtime"@en	.
+      <10033> <name>	"Film cut"@en	.
+      <10034> <name>	"Films distributed in this medium"@en	.
+      <10035> <name>	"Films distributed"@en	.
+      <10036> <name>	"Distributors"@en	.
+      <10037> <name>	"Dubbing performances"@en	.
+      <10038> <name>	"Edited by"@en	.
+      <10039> <name>	"Estimated budget"@en	.
+      <10040> <name>	"Executive produced by"@en	.
+      <10041> <name>	"Fandango ID"@en	.
+      <10042> <name>	"Notable filming locations"@en	.
+      <10043> <name>	"Featured in film"@en	.
+      <10044> <name>	"Performed by"@en	.
+      <10045> <name>	"Featured Song"@en	.
+      <10046> <name>	"Date founded"@en	.
+      <10047> <name>	"Closing date"@en	.
+      <10048> <name>	"Festival"@en	.
+      <10049> <name>	"Films"@en	.
+      <10050> <name>	"Opening date"@en	.
+      <10051> <name>	"Venues"@en	.
+      <10052> <name>	"Festivals with this focus"@en	.
+      <10053> <name>	"Focus"@en	.
+      <10054> <name>	"Individual festivals"@en	.
+      <10055> <name>	"Location"@en	.
+      <10056> <name>	"Festivals sponsored"@en	.
+      <10057> <name>	"Sponsoring organization"@en	.
+      <10058> <name>	"Festival"@en	.
+      <10059> <name>	"From"@en	.
+      <10060> <name>	"Sponsor"@en	.
+      <10061> <name>	"To"@en	.
+      <10062> <name>	"Art direction by"@en	.
+      <10063> <name>	"Casting director"@en	.
+      <10064> <name>	"Film Collections"@en	.
+      <10065> <name>	"Film company"@en	.
+      <10066> <name>	"Film cut"@en	.
+      <10067> <name>	"Film"@en	.
+      <10068> <name>	"Role/service"@en	.
+      <10069> <name>	"Distributor"@en	.
+      <10070> <name>	"Film cut"@en	.
+      <10071> <name>	"Film distribution medium"@en	.
+      <10072> <name>	"Film"@en	.
+      <10073> <name>	"Region"@en	.
+      <10074> <name>	"Year"@en	.
+      <10075> <name>	"Film festivals"@en	.
+      <10076> <name>	"Film format"@en	.
+      <10077> <name>	"Filming"@en	.
+      <10078> <name>	"Production design by"@en	.
+      <10079> <name>	"Film Series"@en	.
+      <10080> <name>	"Set Decoration by"@en	.
+      <10081> <name>	"Film Format"@en	.
+      <10082> <name>	"Genres"@en	.
+      <10083> <name>	"Gross revenue"@en	.
+      <10084> <name>	"Initial release date"@en	.
+      <10085> <name>	"Films with this crew job"@en	.
+      <10086> <name>	"Languages"@en	.
+      <10087> <name>	"Featured In Films"@en	.
+      <10088> <name>	"Featured Locations"@en	.
+      <10089> <name>	"Metacritic film ID"@en	.
+      <10090> <name>	"Music by"@en	.
+      <10091> <name>	"Netflix ID"@en	.
+      <10092> <name>	"NY Times ID"@en	.
+      <10093> <name>	"Other crew"@en	.
+      <10094> <name>	"Other film companies"@en	.
+      <10095> <name>	"Personal appearances"@en	.
+      <10096> <name>	"Post-production"@en	.
+      <10097> <name>	"Pre-production"@en	.
+      <10098> <name>	"Prequel"@en	.
+      <10099> <name>	"Primary language"@en	.
+      <10100> <name>	"Produced by"@en	.
+      <10101> <name>	"Production companies"@en	.
+      <10102> <name>	"Films production designed"@en	.
+      <10103> <name>	"Rated"@en	.
+      <10104> <name>	"Film regional debut venue"@en	.
+      <10105> <name>	"Film release distribution medium"@en	.
+      <10106> <name>	"Film release region"@en	.
+      <10107> <name>	"Film"@en	.
+      <10108> <name>	"Release Date"@en	.
+      <10109> <name>	"Release date(s)"@en	.
+      <10110> <name>	"Rotten Tomatoes ID"@en	.
+      <10111> <name>	"Runtime"@en	.
+      <10112> <name>	"Sequel"@en	.
+      <10113> <name>	"Films In Series"@en	.
+      <10114> <name>	"Film sets designed"@en	.
+      <10115> <name>	"Films"@en	.
+      <10116> <name>	"Film songs"@en	.
+      <10117> <name>	"Composition"@en	.
+      <10118> <name>	"Film"@en	.
+      <10119> <name>	"Performers"@en	.
+      <10120> <name>	"Songs"@en	.
+      <10121> <name>	"Soundtrack"@en	.
+      <10122> <name>	"Performances"@en	.
+      <10123> <name>	"Story by"@en	.
+      <10124> <name>	"Film Story Credits"@en	.
+      <10125> <name>	"Films On This Subject"@en	.
+      <10126> <name>	"Subjects"@en	.
+      <10127> <name>	"Tagline"@en	.
+      <10128> <name>	"Trailer Addict ID"@en	.
+      <10129> <name>	"Trailers"@en	.
+      <10130> <name>	"Screenplay by"@en	.
+      <10131> <name>	"Film music credits"@en	.
+      <10132> <name>	"Actor"@en	.
+      <10133> <name>	"Character note"@en	.
+      <10134> <name>	"Character"@en	.
+      <10135> <name>	"Film"@en	.
+      <10136> <name>	"Special Performance Type"@en	.
+      <10137> <name>	"Film"@en	.
+      <10138> <name>	"Person"@en	.
+      <10139> <name>	"Film appearances"@en	.
+      <10140> <name>	"Type of Appearance"@en	.
+      <10141> <name>	"Films appeared in"@en	.
+      <10142> <name>	"Films Executive Produced"@en	.
+      <10143> <name>	"Films Produced"@en	.
+      <10144> <name>	"Films"@en	.
+      <10145> <name>	"Special Film Performance"@en	.
+      <10146> <name>	"Film writing credits"@en	.
+      <10147> <name>	"What Price Goofy"@en	.
+      <10148> <name>	"Vlasta Zehrova"@en	.
+      <10149> <name>	"General Orlov"@en	.
+      <10150> <name>	"Corinne Dufour"@en	.
+      <10151> <name>	"Sunshine and Gold"@en	.
+      <10152> <name>	"Moon Over Tao"@en	.
+      <10153> <name>	"Pasquale Marino"@en	.
+      <10154> <name>	"Matteo Capelli"@en	.
+      <10155> <name>	"Michal Hejný"@en	.
+      <10156> <name>	"Karioka"@en	.
+      <10157> <name>	"Yossi Eini"@en	.
+      <10158> <name>	"Viktor Gordeyev"@en	.
+      <10159> <name>	"Roos Van Vlaenderen"@en	.
+      <10160> <name>	"General Georgi Koskov"@en	.
+      <10161> <name>	"Do kalle-shagh"@en	.
+      <10162> <name>	"Moataz El Tony"@en	.
+      <10163> <name>	"Dirty Dreamer"@en	.
+      <10164> <name>	"Karl Sturm"@en	.
+      <10165> <name>	"Michael Ehninger"@en	.
+      <10166> <name>	"Killer of Small Fishes"@en	.
+      <10167> <name>	"Jean-Pierre Dougnac"@en	.
+      <10168> <name>	"Yes We Can!"@en	.
+      <10169> <name>	"Jaroslaw Dunaj"@en	.
+      <10170> <name>	"William O'Farrell"@en	.
+      <10171> <name>	"Melodies, Melodies..."@en	.
+      <10172> <name>	"Jerzy Sagan"@en	.
+      <10173> <name>	"Only the Valiant"@en	.
+      <10174> <name>	"Socarrat"@en	.
+      <10175> <name>	"Yuet-Ming Yiu"@en	.
+      <10176> <name>	"Georg Wratsch"@en	.
+      <10177> <name>	"Zivorad Zika Pavlovic"@en	.
+      <10178> <name>	"Shinsuke Akagi"@en	.
+      <10179> <name>	"The Donkey Who Drank the Moon"@en	.
+      <10180> <name>	"Tanemaku tabibito: Minori no cha"@en	.
+      <10181> <name>	"The Crossing"@en	.
+      <10182> <name>	"Samvel Muzhikyan"@en	.
+      <10183> <name>	"Breaking the Wall"@en	.
+      <10184> <name>	"Tommaso Blu"@en	.
+      <10185> <name>	"Mário Viegas"@en	.
+      <10186> <name>	"Carl Struve"@en	.
+      <10187> <name>	"Pine Tree"@en	.
+      <10188> <name>	"Lost Youth"@en	.
+      <10189> <name>	"Pasi"@en	.
+      <10190> <name>	"Grigori Kirillov"@en	.
+      <10191> <name>	"Valentina Kutsenko"@en	.
+      <10192> <name>	"Fleeing by Night"@en	.
+      <10193> <name>	"Salwa Nakkara"@en	.
+      <10194> <name>	"Li Wei Chang"@en	.
+      <10195> <name>	"Plenty O'Toole"@en	.
+      <10196> <name>	"Thomás Tristonho"@en	.
+      <10197> <name>	"Sjamsuddin Jusuf"@en	.
+      <10198> <name>	"Tit for Tat"@en	.
+      <10199> <name>	"Svetlana Korkoshko"@en	.
+      <10200> <name>	"Badiaa Masabny"@en	.
+      <10201> <name>	"Edith Toreg"@en	.
+      <10202> <name>	"Casey Alexander"@en	.
+      <10203> <name>	"Xie Yuan"@en	.
+      <10204> <name>	"Feliks Rybicki"@en	.
+      <10205> <name>	"Early Rain"@en	.
+      <10206> <name>	"The Virgin Star"@en	.
+      <10207> <name>	"When the Cloud Scatters Away"@en	.
+      <10208> <name>	"Helen Ward"@en	.
+      <10209> <name>	"Yoo Se-Hung"@en	.
+      <10210> <name>	"Dancing with Father"@en	.
+      <10211> <name>	"Joana Nin"@en	.
+      <10212> <name>	"A Tearstained Crown"@en	.
+      <10213> <name>	"Yael Reuveny"@en	.
+      <10214> <name>	"Merrick"@en	.
+      <10215> <name>	"Teuda Bara"@en	.
+      <10216> <name>	"Chris Ayers"@en	.
+      <10217> <name>	"Trust, at least trust"@en	.
+      <10218> <name>	"Rerberg and Tarkovsky - Reverse Side of \"Stalker\""@en	.
+      <10219> <name>	"Stefan Forss"@en	.
+      <10220> <name>	"Myeongdong vs Nampodong"@en	.
+      <10221> <name>	"A Daughter of a Condemned Criminal"@en	.
+      <10222> <name>	"Alone Crying Star"@en	.
+      <10223> <name>	"Though the Heavens May Fall"@en	.
+      <10224> <name>	"Friendship of Hope"@en	.
+      <10225> <name>	"Hedpoh Chernyim"@en	.
+      <10226> <name>	"Cheng-Peng Kao"@en	.
+      <10227> <name>	"Yin Hang"@en	.
+      <10228> <name>	"脱走遊戯"@ja	.
+      <10229> <name>	"まむしと青大将"@ja	.
+      <10230> <name>	"網走番外地 吹雪の斗争"@ja	.
+      <10231> <name>	"結婚って、幸せですか THE MOVIE"@ja	.
+      <10232> <name>	"スープ〜生まれ変わりの物語〜"@ja	.
+      <10233> <name>	"ドミニク・グリーン"@ja	.
+      <10234> <name>	"コント55号 世紀の大弱点"@ja	.
+      <10152> <name>	"タオの月"@ja	.
+      <10178> <name>	"赤木伸輔"@ja	.
+      <10180> <name>	"種まく旅人～みのりの茶～"@ja	.
+      <10235> <name>	"Лев Любецкий"@ru	.
+      <10236> <name>	"Смерть Таирова"@ru	.
+      <10237> <name>	"Михаль Рейно"@ru	.
+      <10238> <name>	"Фрэнк Бёрнс"@ru	.
+      <10239> <name>	"Ловец Макинтайр"@ru	.
+      <10240> <name>	"Хавьер Перес Гробет"@ru	.
+      <10241> <name>	"Джулио Пампильоне"@ru	.
+      <10242> <name>	"Теодора Ремундова"@ru	.
+      <10243> <name>	"Дин Каримович Махаматдинов"@ru	.
+      <10158> <name>	"Виктор Владимирович Гордеев"@ru	.
+      <10244> <name>	"Ирина Ивановна Поплавская"@ru	.
+      <10202> <name>	"Кэйси Александр"@ru	.
+      <10245> <name>	"Артём Витальевич Цыпин"@ru	.
+      <10246> <name>	"بياعة الجرايد"@ar	.
+      <10247> <name>	"شفيقة القبطية"@ar	.
+      <10156> <name>	"كاريوكا"@ar	.
+      <10200> <name>	"بديعة مصابنى"@ar	.
+      <10248> <name>	"手機裡的眼淚"@zh-Hant	.
+      <10249> <name>	"먼동이 틀 때"@ko	.
+      <10250> <name>	"사랑과 헤이세이의 색남"@ko	.
+      <10251> <name>	"9. Altın Koza Film Festivali"@tr	.
+      <10252> <name>	"아쉬칸 카티비"@ko	.
+      <10253> <name>	"Charles Kawalsky"@fr	.
+      <10254> <name>	"박철호"@ko	.
+      <10255> <name>	"Ruggero Cara"@ca	.
+      <10240> <name>	"Xavier Pérez Grobet"@es-419	.
+      <10240> <name>	"Xavier Pérez Grobet"@fr	.
+      <10240> <name>	"Xavier Pérez Grobet"@sl	.
+      <10256> <name>	"최옥희"@ko	.
+      <10257> <name>	"George Wang"@de	.
+      <10257> <name>	"George Wang"@es-419	.
+      <10257> <name>	"王玨"@zh	.
+      <10257> <name>	"王玨"@zh-Hant	.
+      <10258> <name>	"Danie miłości"@pl	.
+      <10258> <name>	"Joyful Reunion"@ro	.
+      <10258> <name>	"飲食男女：好遠又好近"@zh-Hant	.
+      <10259> <name>	"Kim Kristensen"@da	.
+      <10259> <name>	"Kim Kristensen"@nl	.
+      <10260> <name>	"Ecaterina Teodoroiu"@ro	.
+      <10261> <name>	"써가"@ko	.
+      <10262> <name>	"12. Altın Koza Film Festivali"@tr	.
+      <10263> <name>	"5. Altın Koza Film Festivali"@tr	.
+      <10264> <name>	"선택"@ko	.
+      <10265> <name>	"ناصر مهدی‌پور"@fa	.
+      <10266> <name>	"Rita Elmgren"@sv	.
+      <10267> <name>	"Intruso"@pt-PT	.
+      <10268> <name>	"서장원"@ko	.
+      <10150> <name>	"Corinne Dufour"@fr	.
+      <10159> <name>	"Roos Van Vlaenderen"@fr	.
+      <10159> <name>	"Roos Van Vlaenderen"@pl	.
+      <10159> <name>	"Roos Van Vlaenderen"@ro	.
+      <10159> <name>	"Roos Van Vlaenderen"@tr	.
+      <10160> <name>	"General Koskov"@sv	.
+      <10269> <name>	"Karolina Kaiser"@hu	.
+      <10270> <name>	"朱芷瑩"@zh-Hant	.
+      <10271> <name>	"Sune Spangberg"@ro	.
+      <10271> <name>	"Sune Spångberg"@sv	.
+      <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt	.
+      <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt-BR	.
+      <10273> <name>	"Irja Elstelä"@fi	.
+      <10171> <name>	"Melodii, melodii"@ro	.
+      <10172> <name>	"Jerzy Sagan"@pl	.
+      <10173> <name>	"La carga de los valientes"@es	.
+      <10177> <name>	"Живорад Жика Павловић"@sr	.
+      <10181> <name>	"La Traversée"@fr	.
+      <10181> <name>	"La traversée"@tr	.
+      <10182> <name>	"Samvel Muzhikyan"@de	.
+      <10182> <name>	"Samvel Muzhikyan"@pl	.
+      <10183> <name>	"성벽을 뚫고"@ko	.
+      <10185> <name>	"Mário Viegas"@pt	.
+      <10187> <name>	"일송정 푸른 솔은"@ko	.
+      <10188> <name>	"잃어버린 청춘"@ko	.
+      <10189> <name>	"파시"@ko	.
+      <10192> <name>	"야분"@ko	.
+      <10193> <name>	"Salwa Nakkara"@fr	.
+      <10193> <name>	"Salwa Nakkara"@nl	.
+      <10193> <name>	"Salwa Nakkara"@ro	.
+      <10274> <name>	"애국자의 아들"@ko	.
+      <10275> <name>	"Inês de Portugal"@pt-PT	.
+      <10202> <name>	"Casey Alexander"@de	.
+      <10203> <name>	"謝園"@zh-Hant	.
+      <10204> <name>	"Feliks Rybicki"@pl	.
+      <10205> <name>	"초우"@ko	.
+      <10206> <name>	"처녀 별"@ko	.
+      <10207> <name>	"구름이 흩어질 때"@ko	.
+      <10210> <name>	"아빠와 함께 춤을"@ko	.
+      <10211> <name>	"Joana Nin"@pt	.
+      <10212> <name>	"눈물젖은 왕관"@ko	.
+      <10213> <name>	"Yael Reuveny"@sl	.
+      <10276> <name>	"이별의 종착역"@ko	.
+      <10277> <name>	"아내를 빼앗긴 사나이"@ko	.
+      <10278> <name>	"울지 않으련다"@ko	.
+      <10215> <name>	"Teuda Bara"@pt	.
+      <10215> <name>	"Teuda Bara"@ro	.
+      <10215> <name>	"Teuda Bara"@tr	.
+      <10217> <name>	"없어도 의리만은"@ko	.
+      <10218> <name>	"Rerberg i Tarkowski. Odwrotna strona Stalkera"@pl	.
+      <10219> <name>	"Stefan Forss"@fi	.
+      <10220> <name>	"명동 사나이와 남포동 사나이"@ko	.
+      <10221> <name>	"사형수의 딸"@ko	.
+      <10222> <name>	"홀로 우는 별"@ko	.
+      <10279> <name>	"내 청춘에 한은 없다"@ko	.
+      <10223> <name>	"하늘이 무너져도"@ko	.
+      <10224> <name>	"내일 있는 우정"@ko	.
+      <10280> <name>	"젊은 그들"@ko	.
+      <10225> <name>	"เห็ดเผาะ เชิญยิ้ม"@th	.
+      <10281> <name>	"젊은 설계도"@ko	.
+      <10226> <name>	"高振鵬"@zh-Hant	.
+      <10282> <name>	"젊은 아들의 마지막 노래"@ko	.
+      <10227> <name>	"尹航"@zh-Hant	.
+      <10283> <name>	"Mahmood Sammakbashi"@de	.
+      <10284> <name>	"Gárdonyi Lajos"@hu	.
+      <10285> <name>	"아들의 심판"@ko	.
+      <10286> <name>	"목숨걸고 왔수다"@ko	.
+      <10287> <name>	"항구의 일야"@ko	.
+      <10288> <name>	"남포동 출신"@ko	.
+      <10289> <name>	"체스트"@ko	.
+      <10289> <name>	"Це не я, це — він"@uk	.
+    }
+  }`
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package alpha
 
 import (
@@ -6,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReindexLangTerm(t *testing.T) {
+func TestReindexTerm(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`name: string @lang .`))
 
@@ -34,368 +50,16 @@ func TestReindexLangTerm(t *testing.T) {
 	require.Contains(t, res, `{"name@en":"Bc Cd"}`)
 }
 
-func TestReindexData(t *testing.T) {
+func TestReindexLang(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`name: string @lang .`))
 
 	m1 := `{
     set {
-      <10000> <name>	"Vidar Flataukan"@en	.
-      <10001> <name>	"starring"@en	.
-      <10002> <name>	"cinematography"@en	.
-      <10003> <name>	"directed_by"@en	.
-      <10004> <name>	"edited_by"@en	.
-      <10005> <name>	"festivals"@en	.
-      <10006> <name>	"genre"@en	.
-      <10007> <name>	"Movies"@en	.
-      <10008> <name>	"music"@en	.
-      <10009> <name>	"produced_by"@en	.
-      <10010> <name>	"production_companies"@en	.
-      <10011> <name>	"written_by"@en	.
-      <10012> <name>	"Films edited"@en	.
-      <10013> <name>	"Apple movie trailer ID"@en	.
-      <10014> <name>	"Films art directed"@en	.
-      <10015> <name>	"Films casting directed"@en	.
-      <10016> <name>	"Portrayed in films (dubbed)"@en	.
-      <10017> <name>	"Portrayed in films"@en	.
-      <10018> <name>	"Cinematography"@en	.
-      <10019> <name>	"Films In Collection"@en	.
-      <10020> <name>	"Films"@en	.
-      <10021> <name>	"Companies performing this role or service"@en	.
-      <10022> <name>	"Costume design by"@en	.
-      <10023> <name>	"Costume Design for Film"@en	.
-      <10024> <name>	"Country of origin"@en	.
-      <10025> <name>	"Crewmember"@en	.
-      <10026> <name>	"Film crew role"@en	.
-      <10027> <name>	"Film"@en	.
-      <10028> <name>	"Films crewed"@en	.
-      <10029> <name>	"Film release region"@en	.
-      <10030> <name>	"Film"@en	.
-      <10031> <name>	"Note"@en	.
-      <10032> <name>	"Runtime"@en	.
-      <10033> <name>	"Film cut"@en	.
-      <10034> <name>	"Films distributed in this medium"@en	.
-      <10035> <name>	"Films distributed"@en	.
-      <10036> <name>	"Distributors"@en	.
-      <10037> <name>	"Dubbing performances"@en	.
-      <10038> <name>	"Edited by"@en	.
-      <10039> <name>	"Estimated budget"@en	.
-      <10040> <name>	"Executive produced by"@en	.
-      <10041> <name>	"Fandango ID"@en	.
-      <10042> <name>	"Notable filming locations"@en	.
-      <10043> <name>	"Featured in film"@en	.
-      <10044> <name>	"Performed by"@en	.
-      <10045> <name>	"Featured Song"@en	.
-      <10046> <name>	"Date founded"@en	.
-      <10047> <name>	"Closing date"@en	.
-      <10048> <name>	"Festival"@en	.
-      <10049> <name>	"Films"@en	.
-      <10050> <name>	"Opening date"@en	.
-      <10051> <name>	"Venues"@en	.
-      <10052> <name>	"Festivals with this focus"@en	.
-      <10053> <name>	"Focus"@en	.
-      <10054> <name>	"Individual festivals"@en	.
-      <10055> <name>	"Location"@en	.
-      <10056> <name>	"Festivals sponsored"@en	.
-      <10057> <name>	"Sponsoring organization"@en	.
-      <10058> <name>	"Festival"@en	.
-      <10059> <name>	"From"@en	.
-      <10060> <name>	"Sponsor"@en	.
-      <10061> <name>	"To"@en	.
-      <10062> <name>	"Art direction by"@en	.
-      <10063> <name>	"Casting director"@en	.
-      <10064> <name>	"Film Collections"@en	.
-      <10065> <name>	"Film company"@en	.
-      <10066> <name>	"Film cut"@en	.
-      <10067> <name>	"Film"@en	.
-      <10068> <name>	"Role/service"@en	.
-      <10069> <name>	"Distributor"@en	.
-      <10070> <name>	"Film cut"@en	.
-      <10071> <name>	"Film distribution medium"@en	.
-      <10072> <name>	"Film"@en	.
-      <10073> <name>	"Region"@en	.
-      <10074> <name>	"Year"@en	.
-      <10075> <name>	"Film festivals"@en	.
-      <10076> <name>	"Film format"@en	.
-      <10077> <name>	"Filming"@en	.
-      <10078> <name>	"Production design by"@en	.
-      <10079> <name>	"Film Series"@en	.
-      <10080> <name>	"Set Decoration by"@en	.
-      <10081> <name>	"Film Format"@en	.
-      <10082> <name>	"Genres"@en	.
-      <10083> <name>	"Gross revenue"@en	.
-      <10084> <name>	"Initial release date"@en	.
-      <10085> <name>	"Films with this crew job"@en	.
-      <10086> <name>	"Languages"@en	.
-      <10087> <name>	"Featured In Films"@en	.
-      <10088> <name>	"Featured Locations"@en	.
-      <10089> <name>	"Metacritic film ID"@en	.
-      <10090> <name>	"Music by"@en	.
-      <10091> <name>	"Netflix ID"@en	.
-      <10092> <name>	"NY Times ID"@en	.
-      <10093> <name>	"Other crew"@en	.
-      <10094> <name>	"Other film companies"@en	.
-      <10095> <name>	"Personal appearances"@en	.
-      <10096> <name>	"Post-production"@en	.
-      <10097> <name>	"Pre-production"@en	.
-      <10098> <name>	"Prequel"@en	.
-      <10099> <name>	"Primary language"@en	.
-      <10100> <name>	"Produced by"@en	.
-      <10101> <name>	"Production companies"@en	.
-      <10102> <name>	"Films production designed"@en	.
-      <10103> <name>	"Rated"@en	.
-      <10104> <name>	"Film regional debut venue"@en	.
-      <10105> <name>	"Film release distribution medium"@en	.
-      <10106> <name>	"Film release region"@en	.
-      <10107> <name>	"Film"@en	.
-      <10108> <name>	"Release Date"@en	.
-      <10109> <name>	"Release date(s)"@en	.
-      <10110> <name>	"Rotten Tomatoes ID"@en	.
       <10111> <name>	"Runtime"@en	.
-      <10112> <name>	"Sequel"@en	.
-      <10113> <name>	"Films In Series"@en	.
-      <10114> <name>	"Film sets designed"@en	.
-      <10115> <name>	"Films"@en	.
-      <10116> <name>	"Film songs"@en	.
-      <10117> <name>	"Composition"@en	.
-      <10118> <name>	"Film"@en	.
-      <10119> <name>	"Performers"@en	.
-      <10120> <name>	"Songs"@en	.
-      <10121> <name>	"Soundtrack"@en	.
-      <10122> <name>	"Performances"@en	.
-      <10123> <name>	"Story by"@en	.
-      <10124> <name>	"Film Story Credits"@en	.
-      <10125> <name>	"Films On This Subject"@en	.
-      <10126> <name>	"Subjects"@en	.
-      <10127> <name>	"Tagline"@en	.
-      <10128> <name>	"Trailer Addict ID"@en	.
-      <10129> <name>	"Trailers"@en	.
-      <10130> <name>	"Screenplay by"@en	.
-      <10131> <name>	"Film music credits"@en	.
-      <10132> <name>	"Actor"@en	.
-      <10133> <name>	"Character note"@en	.
-      <10134> <name>	"Character"@en	.
-      <10135> <name>	"Film"@en	.
-      <10136> <name>	"Special Performance Type"@en	.
-      <10137> <name>	"Film"@en	.
-      <10138> <name>	"Person"@en	.
-      <10139> <name>	"Film appearances"@en	.
-      <10140> <name>	"Type of Appearance"@en	.
-      <10141> <name>	"Films appeared in"@en	.
-      <10142> <name>	"Films Executive Produced"@en	.
-      <10143> <name>	"Films Produced"@en	.
-      <10144> <name>	"Films"@en	.
-      <10145> <name>	"Special Film Performance"@en	.
-      <10146> <name>	"Film writing credits"@en	.
-      <10147> <name>	"What Price Goofy"@en	.
-      <10148> <name>	"Vlasta Zehrova"@en	.
-      <10149> <name>	"General Orlov"@en	.
-      <10150> <name>	"Corinne Dufour"@en	.
-      <10151> <name>	"Sunshine and Gold"@en	.
-      <10152> <name>	"Moon Over Tao"@en	.
-      <10153> <name>	"Pasquale Marino"@en	.
-      <10154> <name>	"Matteo Capelli"@en	.
-      <10155> <name>	"Michal Hejný"@en	.
-      <10156> <name>	"Karioka"@en	.
-      <10157> <name>	"Yossi Eini"@en	.
-      <10158> <name>	"Viktor Gordeyev"@en	.
-      <10159> <name>	"Roos Van Vlaenderen"@en	.
-      <10160> <name>	"General Georgi Koskov"@en	.
-      <10161> <name>	"Do kalle-shagh"@en	.
-      <10162> <name>	"Moataz El Tony"@en	.
-      <10163> <name>	"Dirty Dreamer"@en	.
-      <10164> <name>	"Karl Sturm"@en	.
-      <10165> <name>	"Michael Ehninger"@en	.
-      <10166> <name>	"Killer of Small Fishes"@en	.
-      <10167> <name>	"Jean-Pierre Dougnac"@en	.
-      <10168> <name>	"Yes We Can!"@en	.
-      <10169> <name>	"Jaroslaw Dunaj"@en	.
-      <10170> <name>	"William O'Farrell"@en	.
-      <10171> <name>	"Melodies, Melodies..."@en	.
-      <10172> <name>	"Jerzy Sagan"@en	.
-      <10173> <name>	"Only the Valiant"@en	.
-      <10174> <name>	"Socarrat"@en	.
-      <10175> <name>	"Yuet-Ming Yiu"@en	.
-      <10176> <name>	"Georg Wratsch"@en	.
-      <10177> <name>	"Zivorad Zika Pavlovic"@en	.
-      <10178> <name>	"Shinsuke Akagi"@en	.
-      <10179> <name>	"The Donkey Who Drank the Moon"@en	.
-      <10180> <name>	"Tanemaku tabibito: Minori no cha"@en	.
-      <10181> <name>	"The Crossing"@en	.
-      <10182> <name>	"Samvel Muzhikyan"@en	.
-      <10183> <name>	"Breaking the Wall"@en	.
-      <10184> <name>	"Tommaso Blu"@en	.
-      <10185> <name>	"Mário Viegas"@en	.
-      <10186> <name>	"Carl Struve"@en	.
-      <10187> <name>	"Pine Tree"@en	.
-      <10188> <name>	"Lost Youth"@en	.
-      <10189> <name>	"Pasi"@en	.
-      <10190> <name>	"Grigori Kirillov"@en	.
-      <10191> <name>	"Valentina Kutsenko"@en	.
-      <10192> <name>	"Fleeing by Night"@en	.
-      <10193> <name>	"Salwa Nakkara"@en	.
-      <10194> <name>	"Li Wei Chang"@en	.
-      <10195> <name>	"Plenty O'Toole"@en	.
-      <10196> <name>	"Thomás Tristonho"@en	.
-      <10197> <name>	"Sjamsuddin Jusuf"@en	.
-      <10198> <name>	"Tit for Tat"@en	.
-      <10199> <name>	"Svetlana Korkoshko"@en	.
-      <10200> <name>	"Badiaa Masabny"@en	.
-      <10201> <name>	"Edith Toreg"@en	.
-      <10202> <name>	"Casey Alexander"@en	.
-      <10203> <name>	"Xie Yuan"@en	.
-      <10204> <name>	"Feliks Rybicki"@en	.
-      <10205> <name>	"Early Rain"@en	.
-      <10206> <name>	"The Virgin Star"@en	.
-      <10207> <name>	"When the Cloud Scatters Away"@en	.
-      <10208> <name>	"Helen Ward"@en	.
-      <10209> <name>	"Yoo Se-Hung"@en	.
-      <10210> <name>	"Dancing with Father"@en	.
-      <10211> <name>	"Joana Nin"@en	.
-      <10212> <name>	"A Tearstained Crown"@en	.
-      <10213> <name>	"Yael Reuveny"@en	.
-      <10214> <name>	"Merrick"@en	.
-      <10215> <name>	"Teuda Bara"@en	.
-      <10216> <name>	"Chris Ayers"@en	.
-      <10217> <name>	"Trust, at least trust"@en	.
-      <10218> <name>	"Rerberg and Tarkovsky - Reverse Side of \"Stalker\""@en	.
-      <10219> <name>	"Stefan Forss"@en	.
-      <10220> <name>	"Myeongdong vs Nampodong"@en	.
-      <10221> <name>	"A Daughter of a Condemned Criminal"@en	.
-      <10222> <name>	"Alone Crying Star"@en	.
-      <10223> <name>	"Though the Heavens May Fall"@en	.
-      <10224> <name>	"Friendship of Hope"@en	.
-      <10225> <name>	"Hedpoh Chernyim"@en	.
-      <10226> <name>	"Cheng-Peng Kao"@en	.
-      <10227> <name>	"Yin Hang"@en	.
-      <10228> <name>	"脱走遊戯"@ja	.
-      <10229> <name>	"まむしと青大将"@ja	.
-      <10230> <name>	"網走番外地 吹雪の斗争"@ja	.
-      <10231> <name>	"結婚って、幸せですか THE MOVIE"@ja	.
-      <10232> <name>	"スープ〜生まれ変わりの物語〜"@ja	.
-      <10233> <name>	"ドミニク・グリーン"@ja	.
-      <10234> <name>	"コント55号 世紀の大弱点"@ja	.
-      <10152> <name>	"タオの月"@ja	.
-      <10178> <name>	"赤木伸輔"@ja	.
-      <10180> <name>	"種まく旅人～みのりの茶～"@ja	.
-      <10235> <name>	"Лев Любецкий"@ru	.
-      <10236> <name>	"Смерть Таирова"@ru	.
-      <10237> <name>	"Михаль Рейно"@ru	.
-      <10238> <name>	"Фрэнк Бёрнс"@ru	.
-      <10239> <name>	"Ловец Макинтайр"@ru	.
+      <10032> <name>	"Runtime"@en	.
       <10240> <name>	"Хавьер Перес Гробет"@ru	.
-      <10241> <name>	"Джулио Пампильоне"@ru	.
-      <10242> <name>	"Теодора Ремундова"@ru	.
-      <10243> <name>	"Дин Каримович Махаматдинов"@ru	.
-      <10158> <name>	"Виктор Владимирович Гордеев"@ru	.
-      <10244> <name>	"Ирина Ивановна Поплавская"@ru	.
-      <10202> <name>	"Кэйси Александр"@ru	.
-      <10245> <name>	"Артём Витальевич Цыпин"@ru	.
-      <10246> <name>	"بياعة الجرايد"@ar	.
-      <10247> <name>	"شفيقة القبطية"@ar	.
-      <10156> <name>	"كاريوكا"@ar	.
-      <10200> <name>	"بديعة مصابنى"@ar	.
-      <10248> <name>	"手機裡的眼淚"@zh-Hant	.
-      <10249> <name>	"먼동이 틀 때"@ko	.
-      <10250> <name>	"사랑과 헤이세이의 색남"@ko	.
-      <10251> <name>	"9. Altın Koza Film Festivali"@tr	.
-      <10252> <name>	"아쉬칸 카티비"@ko	.
-      <10253> <name>	"Charles Kawalsky"@fr	.
-      <10254> <name>	"박철호"@ko	.
-      <10255> <name>	"Ruggero Cara"@ca	.
-      <10240> <name>	"Xavier Pérez Grobet"@es-419	.
-      <10240> <name>	"Xavier Pérez Grobet"@fr	.
-      <10240> <name>	"Xavier Pérez Grobet"@sl	.
-      <10256> <name>	"최옥희"@ko	.
-      <10257> <name>	"George Wang"@de	.
-      <10257> <name>	"George Wang"@es-419	.
-      <10257> <name>	"王玨"@zh	.
-      <10257> <name>	"王玨"@zh-Hant	.
-      <10258> <name>	"Danie miłości"@pl	.
-      <10258> <name>	"Joyful Reunion"@ro	.
-      <10258> <name>	"飲食男女：好遠又好近"@zh-Hant	.
-      <10259> <name>	"Kim Kristensen"@da	.
-      <10259> <name>	"Kim Kristensen"@nl	.
-      <10260> <name>	"Ecaterina Teodoroiu"@ro	.
-      <10261> <name>	"써가"@ko	.
-      <10262> <name>	"12. Altın Koza Film Festivali"@tr	.
-      <10263> <name>	"5. Altın Koza Film Festivali"@tr	.
-      <10264> <name>	"선택"@ko	.
-      <10265> <name>	"ناصر مهدی‌پور"@fa	.
-      <10266> <name>	"Rita Elmgren"@sv	.
-      <10267> <name>	"Intruso"@pt-PT	.
-      <10268> <name>	"서장원"@ko	.
-      <10150> <name>	"Corinne Dufour"@fr	.
-      <10159> <name>	"Roos Van Vlaenderen"@fr	.
-      <10159> <name>	"Roos Van Vlaenderen"@pl	.
-      <10159> <name>	"Roos Van Vlaenderen"@ro	.
-      <10159> <name>	"Roos Van Vlaenderen"@tr	.
-      <10160> <name>	"General Koskov"@sv	.
-      <10269> <name>	"Karolina Kaiser"@hu	.
-      <10270> <name>	"朱芷瑩"@zh-Hant	.
-      <10271> <name>	"Sune Spangberg"@ro	.
-      <10271> <name>	"Sune Spångberg"@sv	.
-      <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt	.
-      <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt-BR	.
-      <10273> <name>	"Irja Elstelä"@fi	.
-      <10171> <name>	"Melodii, melodii"@ro	.
-      <10172> <name>	"Jerzy Sagan"@pl	.
-      <10173> <name>	"La carga de los valientes"@es	.
-      <10177> <name>	"Живорад Жика Павловић"@sr	.
-      <10181> <name>	"La Traversée"@fr	.
-      <10181> <name>	"La traversée"@tr	.
-      <10182> <name>	"Samvel Muzhikyan"@de	.
-      <10182> <name>	"Samvel Muzhikyan"@pl	.
-      <10183> <name>	"성벽을 뚫고"@ko	.
-      <10185> <name>	"Mário Viegas"@pt	.
-      <10187> <name>	"일송정 푸른 솔은"@ko	.
-      <10188> <name>	"잃어버린 청춘"@ko	.
-      <10189> <name>	"파시"@ko	.
-      <10192> <name>	"야분"@ko	.
-      <10193> <name>	"Salwa Nakkara"@fr	.
-      <10193> <name>	"Salwa Nakkara"@nl	.
-      <10193> <name>	"Salwa Nakkara"@ro	.
-      <10274> <name>	"애국자의 아들"@ko	.
-      <10275> <name>	"Inês de Portugal"@pt-PT	.
-      <10202> <name>	"Casey Alexander"@de	.
-      <10203> <name>	"謝園"@zh-Hant	.
-      <10204> <name>	"Feliks Rybicki"@pl	.
-      <10205> <name>	"초우"@ko	.
-      <10206> <name>	"처녀 별"@ko	.
-      <10207> <name>	"구름이 흩어질 때"@ko	.
-      <10210> <name>	"아빠와 함께 춤을"@ko	.
-      <10211> <name>	"Joana Nin"@pt	.
-      <10212> <name>	"눈물젖은 왕관"@ko	.
-      <10213> <name>	"Yael Reuveny"@sl	.
-      <10276> <name>	"이별의 종착역"@ko	.
-      <10277> <name>	"아내를 빼앗긴 사나이"@ko	.
-      <10278> <name>	"울지 않으련다"@ko	.
-      <10215> <name>	"Teuda Bara"@pt	.
-      <10215> <name>	"Teuda Bara"@ro	.
-      <10215> <name>	"Teuda Bara"@tr	.
-      <10217> <name>	"없어도 의리만은"@ko	.
-      <10218> <name>	"Rerberg i Tarkowski. Odwrotna strona Stalkera"@pl	.
-      <10219> <name>	"Stefan Forss"@fi	.
-      <10220> <name>	"명동 사나이와 남포동 사나이"@ko	.
-      <10221> <name>	"사형수의 딸"@ko	.
-      <10222> <name>	"홀로 우는 별"@ko	.
-      <10279> <name>	"내 청춘에 한은 없다"@ko	.
-      <10223> <name>	"하늘이 무너져도"@ko	.
-      <10224> <name>	"내일 있는 우정"@ko	.
-      <10280> <name>	"젊은 그들"@ko	.
-      <10225> <name>	"เห็ดเผาะ เชิญยิ้ม"@th	.
-      <10281> <name>	"젊은 설계도"@ko	.
-      <10226> <name>	"高振鵬"@zh-Hant	.
-      <10282> <name>	"젊은 아들의 마지막 노래"@ko	.
-      <10227> <name>	"尹航"@zh-Hant	.
-      <10283> <name>	"Mahmood Sammakbashi"@de	.
-      <10284> <name>	"Gárdonyi Lajos"@hu	.
-      <10285> <name>	"아들의 심판"@ko	.
-      <10286> <name>	"목숨걸고 왔수다"@ko	.
-      <10287> <name>	"항구의 일야"@ko	.
-      <10288> <name>	"남포동 출신"@ko	.
-      <10289> <name>	"체스트"@ko	.
-      <10289> <name>	"Це не я, це — він"@uk	.
+      <10231> <name>	"結婚って、幸せですか THE MOVIE"@ja	.
     }
   }`
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -405,10 +405,50 @@ func TestReindexData(t *testing.T) {
 
 	q1 := `{
     q(func: eq(name@en, "Runtime")) {
+      uid
       name@en
     }
   }`
 	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"data":{"q":[{"name@en":"Runtime"},{"name@en":"Runtime"}]}}`, res)
+	require.JSONEq(t, `{
+    "data": {
+      "q": [
+        {
+          "uid": "0x2730",
+          "name@en": "Runtime"
+        },
+        {
+          "uid": "0x277f",
+          "name@en": "Runtime"
+        }
+      ]
+    }
+  }`, res)
+
+	// adding another triplet
+	m2 := `{ set { <10400> <name>	"Runtime"@en	. }}`
+	_, err = mutationWithTs(m2, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+    "data": {
+      "q": [
+        {
+          "uid": "0x2730",
+          "name@en": "Runtime"
+        },
+        {
+          "uid": "0x277f",
+          "name@en": "Runtime"
+        },
+        {
+          "uid": "0x28a0",
+          "name@en": "Runtime"
+        }
+      ]
+    }
+  }`, res)
 }

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -1,0 +1,414 @@
+package alpha
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReindexLangTerm(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`name: string @lang .`))
+
+	m1 := `{
+      set {
+        _:u1 <name> "Ab Bc"@en .
+        _:u2 <name> "Bc Cd"@en .
+        _:u3 <name> "Cd Da"@fr .
+      }
+    }`
+	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	// perform reindexing
+	require.NoError(t, alterSchema(`name: string @lang @index(term) .`))
+
+	q1 := `{
+      q(func: anyofterms(name@en, "bc")) {
+        name@en
+      }
+    }`
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data":{"q":[{"name@en":"Ab Bc"},{"name@en":"Bc Cd"}]}}`, res)
+}
+
+func TestReindexData(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`name: string @lang .`))
+
+	m1 := `{
+      set {
+        <10000> <name>	"Vidar Flataukan"@en	.
+        <10001> <name>	"starring"@en	.
+        <10002> <name>	"cinematography"@en	.
+        <10003> <name>	"directed_by"@en	.
+        <10004> <name>	"edited_by"@en	.
+        <10005> <name>	"festivals"@en	.
+        <10006> <name>	"genre"@en	.
+        <10007> <name>	"Movies"@en	.
+        <10008> <name>	"music"@en	.
+        <10009> <name>	"produced_by"@en	.
+        <10010> <name>	"production_companies"@en	.
+        <10011> <name>	"written_by"@en	.
+        <10012> <name>	"Films edited"@en	.
+        <10013> <name>	"Apple movie trailer ID"@en	.
+        <10014> <name>	"Films art directed"@en	.
+        <10015> <name>	"Films casting directed"@en	.
+        <10016> <name>	"Portrayed in films (dubbed)"@en	.
+        <10017> <name>	"Portrayed in films"@en	.
+        <10018> <name>	"Cinematography"@en	.
+        <10019> <name>	"Films In Collection"@en	.
+        <10020> <name>	"Films"@en	.
+        <10021> <name>	"Companies performing this role or service"@en	.
+        <10022> <name>	"Costume design by"@en	.
+        <10023> <name>	"Costume Design for Film"@en	.
+        <10024> <name>	"Country of origin"@en	.
+        <10025> <name>	"Crewmember"@en	.
+        <10026> <name>	"Film crew role"@en	.
+        <10027> <name>	"Film"@en	.
+        <10028> <name>	"Films crewed"@en	.
+        <10029> <name>	"Film release region"@en	.
+        <10030> <name>	"Film"@en	.
+        <10031> <name>	"Note"@en	.
+        <10032> <name>	"Runtime"@en	.
+        <10033> <name>	"Film cut"@en	.
+        <10034> <name>	"Films distributed in this medium"@en	.
+        <10035> <name>	"Films distributed"@en	.
+        <10036> <name>	"Distributors"@en	.
+        <10037> <name>	"Dubbing performances"@en	.
+        <10038> <name>	"Edited by"@en	.
+        <10039> <name>	"Estimated budget"@en	.
+        <10040> <name>	"Executive produced by"@en	.
+        <10041> <name>	"Fandango ID"@en	.
+        <10042> <name>	"Notable filming locations"@en	.
+        <10043> <name>	"Featured in film"@en	.
+        <10044> <name>	"Performed by"@en	.
+        <10045> <name>	"Featured Song"@en	.
+        <10046> <name>	"Date founded"@en	.
+        <10047> <name>	"Closing date"@en	.
+        <10048> <name>	"Festival"@en	.
+        <10049> <name>	"Films"@en	.
+        <10050> <name>	"Opening date"@en	.
+        <10051> <name>	"Venues"@en	.
+        <10052> <name>	"Festivals with this focus"@en	.
+        <10053> <name>	"Focus"@en	.
+        <10054> <name>	"Individual festivals"@en	.
+        <10055> <name>	"Location"@en	.
+        <10056> <name>	"Festivals sponsored"@en	.
+        <10057> <name>	"Sponsoring organization"@en	.
+        <10058> <name>	"Festival"@en	.
+        <10059> <name>	"From"@en	.
+        <10060> <name>	"Sponsor"@en	.
+        <10061> <name>	"To"@en	.
+        <10062> <name>	"Art direction by"@en	.
+        <10063> <name>	"Casting director"@en	.
+        <10064> <name>	"Film Collections"@en	.
+        <10065> <name>	"Film company"@en	.
+        <10066> <name>	"Film cut"@en	.
+        <10067> <name>	"Film"@en	.
+        <10068> <name>	"Role/service"@en	.
+        <10069> <name>	"Distributor"@en	.
+        <10070> <name>	"Film cut"@en	.
+        <10071> <name>	"Film distribution medium"@en	.
+        <10072> <name>	"Film"@en	.
+        <10073> <name>	"Region"@en	.
+        <10074> <name>	"Year"@en	.
+        <10075> <name>	"Film festivals"@en	.
+        <10076> <name>	"Film format"@en	.
+        <10077> <name>	"Filming"@en	.
+        <10078> <name>	"Production design by"@en	.
+        <10079> <name>	"Film Series"@en	.
+        <10080> <name>	"Set Decoration by"@en	.
+        <10081> <name>	"Film Format"@en	.
+        <10082> <name>	"Genres"@en	.
+        <10083> <name>	"Gross revenue"@en	.
+        <10084> <name>	"Initial release date"@en	.
+        <10085> <name>	"Films with this crew job"@en	.
+        <10086> <name>	"Languages"@en	.
+        <10087> <name>	"Featured In Films"@en	.
+        <10088> <name>	"Featured Locations"@en	.
+        <10089> <name>	"Metacritic film ID"@en	.
+        <10090> <name>	"Music by"@en	.
+        <10091> <name>	"Netflix ID"@en	.
+        <10092> <name>	"NY Times ID"@en	.
+        <10093> <name>	"Other crew"@en	.
+        <10094> <name>	"Other film companies"@en	.
+        <10095> <name>	"Personal appearances"@en	.
+        <10096> <name>	"Post-production"@en	.
+        <10097> <name>	"Pre-production"@en	.
+        <10098> <name>	"Prequel"@en	.
+        <10099> <name>	"Primary language"@en	.
+        <10100> <name>	"Produced by"@en	.
+        <10101> <name>	"Production companies"@en	.
+        <10102> <name>	"Films production designed"@en	.
+        <10103> <name>	"Rated"@en	.
+        <10104> <name>	"Film regional debut venue"@en	.
+        <10105> <name>	"Film release distribution medium"@en	.
+        <10106> <name>	"Film release region"@en	.
+        <10107> <name>	"Film"@en	.
+        <10108> <name>	"Release Date"@en	.
+        <10109> <name>	"Release date(s)"@en	.
+        <10110> <name>	"Rotten Tomatoes ID"@en	.
+        <10111> <name>	"Runtime"@en	.
+        <10112> <name>	"Sequel"@en	.
+        <10113> <name>	"Films In Series"@en	.
+        <10114> <name>	"Film sets designed"@en	.
+        <10115> <name>	"Films"@en	.
+        <10116> <name>	"Film songs"@en	.
+        <10117> <name>	"Composition"@en	.
+        <10118> <name>	"Film"@en	.
+        <10119> <name>	"Performers"@en	.
+        <10120> <name>	"Songs"@en	.
+        <10121> <name>	"Soundtrack"@en	.
+        <10122> <name>	"Performances"@en	.
+        <10123> <name>	"Story by"@en	.
+        <10124> <name>	"Film Story Credits"@en	.
+        <10125> <name>	"Films On This Subject"@en	.
+        <10126> <name>	"Subjects"@en	.
+        <10127> <name>	"Tagline"@en	.
+        <10128> <name>	"Trailer Addict ID"@en	.
+        <10129> <name>	"Trailers"@en	.
+        <10130> <name>	"Screenplay by"@en	.
+        <10131> <name>	"Film music credits"@en	.
+        <10132> <name>	"Actor"@en	.
+        <10133> <name>	"Character note"@en	.
+        <10134> <name>	"Character"@en	.
+        <10135> <name>	"Film"@en	.
+        <10136> <name>	"Special Performance Type"@en	.
+        <10137> <name>	"Film"@en	.
+        <10138> <name>	"Person"@en	.
+        <10139> <name>	"Film appearances"@en	.
+        <10140> <name>	"Type of Appearance"@en	.
+        <10141> <name>	"Films appeared in"@en	.
+        <10142> <name>	"Films Executive Produced"@en	.
+        <10143> <name>	"Films Produced"@en	.
+        <10144> <name>	"Films"@en	.
+        <10145> <name>	"Special Film Performance"@en	.
+        <10146> <name>	"Film writing credits"@en	.
+        <10147> <name>	"What Price Goofy"@en	.
+        <10148> <name>	"Vlasta Zehrova"@en	.
+        <10149> <name>	"General Orlov"@en	.
+        <10150> <name>	"Corinne Dufour"@en	.
+        <10151> <name>	"Sunshine and Gold"@en	.
+        <10152> <name>	"Moon Over Tao"@en	.
+        <10153> <name>	"Pasquale Marino"@en	.
+        <10154> <name>	"Matteo Capelli"@en	.
+        <10155> <name>	"Michal Hejný"@en	.
+        <10156> <name>	"Karioka"@en	.
+        <10157> <name>	"Yossi Eini"@en	.
+        <10158> <name>	"Viktor Gordeyev"@en	.
+        <10159> <name>	"Roos Van Vlaenderen"@en	.
+        <10160> <name>	"General Georgi Koskov"@en	.
+        <10161> <name>	"Do kalle-shagh"@en	.
+        <10162> <name>	"Moataz El Tony"@en	.
+        <10163> <name>	"Dirty Dreamer"@en	.
+        <10164> <name>	"Karl Sturm"@en	.
+        <10165> <name>	"Michael Ehninger"@en	.
+        <10166> <name>	"Killer of Small Fishes"@en	.
+        <10167> <name>	"Jean-Pierre Dougnac"@en	.
+        <10168> <name>	"Yes We Can!"@en	.
+        <10169> <name>	"Jaroslaw Dunaj"@en	.
+        <10170> <name>	"William O'Farrell"@en	.
+        <10171> <name>	"Melodies, Melodies..."@en	.
+        <10172> <name>	"Jerzy Sagan"@en	.
+        <10173> <name>	"Only the Valiant"@en	.
+        <10174> <name>	"Socarrat"@en	.
+        <10175> <name>	"Yuet-Ming Yiu"@en	.
+        <10176> <name>	"Georg Wratsch"@en	.
+        <10177> <name>	"Zivorad Zika Pavlovic"@en	.
+        <10178> <name>	"Shinsuke Akagi"@en	.
+        <10179> <name>	"The Donkey Who Drank the Moon"@en	.
+        <10180> <name>	"Tanemaku tabibito: Minori no cha"@en	.
+        <10181> <name>	"The Crossing"@en	.
+        <10182> <name>	"Samvel Muzhikyan"@en	.
+        <10183> <name>	"Breaking the Wall"@en	.
+        <10184> <name>	"Tommaso Blu"@en	.
+        <10185> <name>	"Mário Viegas"@en	.
+        <10186> <name>	"Carl Struve"@en	.
+        <10187> <name>	"Pine Tree"@en	.
+        <10188> <name>	"Lost Youth"@en	.
+        <10189> <name>	"Pasi"@en	.
+        <10190> <name>	"Grigori Kirillov"@en	.
+        <10191> <name>	"Valentina Kutsenko"@en	.
+        <10192> <name>	"Fleeing by Night"@en	.
+        <10193> <name>	"Salwa Nakkara"@en	.
+        <10194> <name>	"Li Wei Chang"@en	.
+        <10195> <name>	"Plenty O'Toole"@en	.
+        <10196> <name>	"Thomás Tristonho"@en	.
+        <10197> <name>	"Sjamsuddin Jusuf"@en	.
+        <10198> <name>	"Tit for Tat"@en	.
+        <10199> <name>	"Svetlana Korkoshko"@en	.
+        <10200> <name>	"Badiaa Masabny"@en	.
+        <10201> <name>	"Edith Toreg"@en	.
+        <10202> <name>	"Casey Alexander"@en	.
+        <10203> <name>	"Xie Yuan"@en	.
+        <10204> <name>	"Feliks Rybicki"@en	.
+        <10205> <name>	"Early Rain"@en	.
+        <10206> <name>	"The Virgin Star"@en	.
+        <10207> <name>	"When the Cloud Scatters Away"@en	.
+        <10208> <name>	"Helen Ward"@en	.
+        <10209> <name>	"Yoo Se-Hung"@en	.
+        <10210> <name>	"Dancing with Father"@en	.
+        <10211> <name>	"Joana Nin"@en	.
+        <10212> <name>	"A Tearstained Crown"@en	.
+        <10213> <name>	"Yael Reuveny"@en	.
+        <10214> <name>	"Merrick"@en	.
+        <10215> <name>	"Teuda Bara"@en	.
+        <10216> <name>	"Chris Ayers"@en	.
+        <10217> <name>	"Trust, at least trust"@en	.
+        <10218> <name>	"Rerberg and Tarkovsky - Reverse Side of \"Stalker\""@en	.
+        <10219> <name>	"Stefan Forss"@en	.
+        <10220> <name>	"Myeongdong vs Nampodong"@en	.
+        <10221> <name>	"A Daughter of a Condemned Criminal"@en	.
+        <10222> <name>	"Alone Crying Star"@en	.
+        <10223> <name>	"Though the Heavens May Fall"@en	.
+        <10224> <name>	"Friendship of Hope"@en	.
+        <10225> <name>	"Hedpoh Chernyim"@en	.
+        <10226> <name>	"Cheng-Peng Kao"@en	.
+        <10227> <name>	"Yin Hang"@en	.
+        <10228> <name>	"脱走遊戯"@ja	.
+        <10229> <name>	"まむしと青大将"@ja	.
+        <10230> <name>	"網走番外地 吹雪の斗争"@ja	.
+        <10231> <name>	"結婚って、幸せですか THE MOVIE"@ja	.
+        <10232> <name>	"スープ〜生まれ変わりの物語〜"@ja	.
+        <10233> <name>	"ドミニク・グリーン"@ja	.
+        <10234> <name>	"コント55号 世紀の大弱点"@ja	.
+        <10152> <name>	"タオの月"@ja	.
+        <10178> <name>	"赤木伸輔"@ja	.
+        <10180> <name>	"種まく旅人～みのりの茶～"@ja	.
+        <10235> <name>	"Лев Любецкий"@ru	.
+        <10236> <name>	"Смерть Таирова"@ru	.
+        <10237> <name>	"Михаль Рейно"@ru	.
+        <10238> <name>	"Фрэнк Бёрнс"@ru	.
+        <10239> <name>	"Ловец Макинтайр"@ru	.
+        <10240> <name>	"Хавьер Перес Гробет"@ru	.
+        <10241> <name>	"Джулио Пампильоне"@ru	.
+        <10242> <name>	"Теодора Ремундова"@ru	.
+        <10243> <name>	"Дин Каримович Махаматдинов"@ru	.
+        <10158> <name>	"Виктор Владимирович Гордеев"@ru	.
+        <10244> <name>	"Ирина Ивановна Поплавская"@ru	.
+        <10202> <name>	"Кэйси Александр"@ru	.
+        <10245> <name>	"Артём Витальевич Цыпин"@ru	.
+        <10246> <name>	"بياعة الجرايد"@ar	.
+        <10247> <name>	"شفيقة القبطية"@ar	.
+        <10156> <name>	"كاريوكا"@ar	.
+        <10200> <name>	"بديعة مصابنى"@ar	.
+        <10248> <name>	"手機裡的眼淚"@zh-Hant	.
+        <10249> <name>	"먼동이 틀 때"@ko	.
+        <10250> <name>	"사랑과 헤이세이의 색남"@ko	.
+        <10251> <name>	"9. Altın Koza Film Festivali"@tr	.
+        <10252> <name>	"아쉬칸 카티비"@ko	.
+        <10253> <name>	"Charles Kawalsky"@fr	.
+        <10254> <name>	"박철호"@ko	.
+        <10255> <name>	"Ruggero Cara"@ca	.
+        <10240> <name>	"Xavier Pérez Grobet"@es-419	.
+        <10240> <name>	"Xavier Pérez Grobet"@fr	.
+        <10240> <name>	"Xavier Pérez Grobet"@sl	.
+        <10256> <name>	"최옥희"@ko	.
+        <10257> <name>	"George Wang"@de	.
+        <10257> <name>	"George Wang"@es-419	.
+        <10257> <name>	"王玨"@zh	.
+        <10257> <name>	"王玨"@zh-Hant	.
+        <10258> <name>	"Danie miłości"@pl	.
+        <10258> <name>	"Joyful Reunion"@ro	.
+        <10258> <name>	"飲食男女：好遠又好近"@zh-Hant	.
+        <10259> <name>	"Kim Kristensen"@da	.
+        <10259> <name>	"Kim Kristensen"@nl	.
+        <10260> <name>	"Ecaterina Teodoroiu"@ro	.
+        <10261> <name>	"써가"@ko	.
+        <10262> <name>	"12. Altın Koza Film Festivali"@tr	.
+        <10263> <name>	"5. Altın Koza Film Festivali"@tr	.
+        <10264> <name>	"선택"@ko	.
+        <10265> <name>	"ناصر مهدی‌پور"@fa	.
+        <10266> <name>	"Rita Elmgren"@sv	.
+        <10267> <name>	"Intruso"@pt-PT	.
+        <10268> <name>	"서장원"@ko	.
+        <10150> <name>	"Corinne Dufour"@fr	.
+        <10159> <name>	"Roos Van Vlaenderen"@fr	.
+        <10159> <name>	"Roos Van Vlaenderen"@pl	.
+        <10159> <name>	"Roos Van Vlaenderen"@ro	.
+        <10159> <name>	"Roos Van Vlaenderen"@tr	.
+        <10160> <name>	"General Koskov"@sv	.
+        <10269> <name>	"Karolina Kaiser"@hu	.
+        <10270> <name>	"朱芷瑩"@zh-Hant	.
+        <10271> <name>	"Sune Spangberg"@ro	.
+        <10271> <name>	"Sune Spångberg"@sv	.
+        <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt	.
+        <10272> <name>	"Utena a garota revolucionaria : Uma aventura Mágica"@pt-BR	.
+        <10273> <name>	"Irja Elstelä"@fi	.
+        <10171> <name>	"Melodii, melodii"@ro	.
+        <10172> <name>	"Jerzy Sagan"@pl	.
+        <10173> <name>	"La carga de los valientes"@es	.
+        <10177> <name>	"Живорад Жика Павловић"@sr	.
+        <10181> <name>	"La Traversée"@fr	.
+        <10181> <name>	"La traversée"@tr	.
+        <10182> <name>	"Samvel Muzhikyan"@de	.
+        <10182> <name>	"Samvel Muzhikyan"@pl	.
+        <10183> <name>	"성벽을 뚫고"@ko	.
+        <10185> <name>	"Mário Viegas"@pt	.
+        <10187> <name>	"일송정 푸른 솔은"@ko	.
+        <10188> <name>	"잃어버린 청춘"@ko	.
+        <10189> <name>	"파시"@ko	.
+        <10192> <name>	"야분"@ko	.
+        <10193> <name>	"Salwa Nakkara"@fr	.
+        <10193> <name>	"Salwa Nakkara"@nl	.
+        <10193> <name>	"Salwa Nakkara"@ro	.
+        <10274> <name>	"애국자의 아들"@ko	.
+        <10275> <name>	"Inês de Portugal"@pt-PT	.
+        <10202> <name>	"Casey Alexander"@de	.
+        <10203> <name>	"謝園"@zh-Hant	.
+        <10204> <name>	"Feliks Rybicki"@pl	.
+        <10205> <name>	"초우"@ko	.
+        <10206> <name>	"처녀 별"@ko	.
+        <10207> <name>	"구름이 흩어질 때"@ko	.
+        <10210> <name>	"아빠와 함께 춤을"@ko	.
+        <10211> <name>	"Joana Nin"@pt	.
+        <10212> <name>	"눈물젖은 왕관"@ko	.
+        <10213> <name>	"Yael Reuveny"@sl	.
+        <10276> <name>	"이별의 종착역"@ko	.
+        <10277> <name>	"아내를 빼앗긴 사나이"@ko	.
+        <10278> <name>	"울지 않으련다"@ko	.
+        <10215> <name>	"Teuda Bara"@pt	.
+        <10215> <name>	"Teuda Bara"@ro	.
+        <10215> <name>	"Teuda Bara"@tr	.
+        <10217> <name>	"없어도 의리만은"@ko	.
+        <10218> <name>	"Rerberg i Tarkowski. Odwrotna strona Stalkera"@pl	.
+        <10219> <name>	"Stefan Forss"@fi	.
+        <10220> <name>	"명동 사나이와 남포동 사나이"@ko	.
+        <10221> <name>	"사형수의 딸"@ko	.
+        <10222> <name>	"홀로 우는 별"@ko	.
+        <10279> <name>	"내 청춘에 한은 없다"@ko	.
+        <10223> <name>	"하늘이 무너져도"@ko	.
+        <10224> <name>	"내일 있는 우정"@ko	.
+        <10280> <name>	"젊은 그들"@ko	.
+        <10225> <name>	"เห็ดเผาะ เชิญยิ้ม"@th	.
+        <10281> <name>	"젊은 설계도"@ko	.
+        <10226> <name>	"高振鵬"@zh-Hant	.
+        <10282> <name>	"젊은 아들의 마지막 노래"@ko	.
+        <10227> <name>	"尹航"@zh-Hant	.
+        <10283> <name>	"Mahmood Sammakbashi"@de	.
+        <10284> <name>	"Gárdonyi Lajos"@hu	.
+        <10285> <name>	"아들의 심판"@ko	.
+        <10286> <name>	"목숨걸고 왔수다"@ko	.
+        <10287> <name>	"항구의 일야"@ko	.
+        <10288> <name>	"남포동 출신"@ko	.
+        <10289> <name>	"체스트"@ko	.
+        <10289> <name>	"Це не я, це — він"@uk	.
+      }
+    }`
+	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+
+	// reindex
+	require.NoError(t, alterSchema(`name: string @lang @index(exact) .`))
+
+	q1 := `{
+    q(func: eq(name@en, "Runtime")) {
+      name@en
+    }
+  }`
+	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"data":{"q":[{"name@en":"Runtime"},{"name@en":"Runtime"}]}}`, res)
+}

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -30,7 +30,8 @@ func TestReindexLangTerm(t *testing.T) {
     }`
 	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"data":{"q":[{"name@en":"Ab Bc"},{"name@en":"Bc Cd"}]}}`, res)
+	require.Contains(t, res, `{"name@en":"Ab Bc"}`)
+	require.Contains(t, res, `{"name@en":"Bc Cd"}`)
 }
 
 func TestReindexData(t *testing.T) {

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -24,30 +24,30 @@ import (
 
 func TestReindexTerm(t *testing.T) {
 	require.NoError(t, dropAll())
-	require.NoError(t, alterSchema(`name: string @lang .`))
+	require.NoError(t, alterSchema(`name: string .`))
 
 	m1 := `{
     set {
-      _:u1 <name> "Ab Bc"@en .
-      _:u2 <name> "Bc Cd"@en .
-      _:u3 <name> "Cd Da"@fr .
+      _:u1 <name> "Ab Bc" .
+      _:u2 <name> "Bc Cd" .
+      _:u3 <name> "Cd Da" .
     }
   }`
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
 	// perform re-indexing
-	require.NoError(t, alterSchema(`name: string @lang @index(term) .`))
+	require.NoError(t, alterSchema(`name: string @index(term) .`))
 
 	q1 := `{
-      q(func: anyofterms(name@en, "bc")) {
-        name@en
+      q(func: anyofterms(name, "bc")) {
+        name
       }
     }`
 	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
 	require.NoError(t, err)
-	require.Contains(t, res, `{"name@en":"Ab Bc"}`)
-	require.Contains(t, res, `{"name@en":"Bc Cd"}`)
+	require.Contains(t, res, `{"name":"Ab Bc"}`)
+	require.Contains(t, res, `{"name":"Bc Cd"}`)
 }
 
 func TestReindexLang(t *testing.T) {

--- a/posting/index.go
+++ b/posting/index.go
@@ -530,7 +530,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	defer indexDB.Close()
 
 	indexWriter := NewTxnWriter(indexDB)
-	// TODO: need to call defer Flush
+	// Set it to 1 in case there are no keys found for an index and NewStreamAt is called with ts>0.
 	var counter uint64 = 1
 
 	glog.V(1).Infof(
@@ -579,6 +579,8 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		return nil, nil
 	}
 	stream.Send = func(kvList *bpb.KVList) error {
+		// The work of adding the index edges to the transaction is done by r.fn
+		// so this function doesn't have any work to do.
 		return nil
 	}
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -522,7 +522,8 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		WithNumVersionsToKeep(math.MaxInt64).
 		WithCompression(options.None).
 		WithEventLogging(false).
-		WithLogRotatesToFlush(10)
+		WithLogRotatesToFlush(10).
+		WithMaxCacheSize(50)
 	indexDB, err := badger.OpenManaged(dbOpts)
 	if err != nil {
 		return errors.Wrap(err, "error opening temp badger for reindexing")
@@ -578,7 +579,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 		return nil, nil
 	}
-	stream.Send = func(kvList *bpb.KVList) error {
+	stream.Send = func(*bpb.KVList) error {
 		// The work of adding the index edges to the transaction is done by r.fn
 		// so this function doesn't have any work to do.
 		return nil
@@ -639,7 +640,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 		return nil, nil
 	}
-	indexStream.Send = func(kvList *bpb.KVList) error {
+	indexStream.Send = func(*bpb.KVList) error {
 		return nil
 	}
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -650,6 +650,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 		return nil
 	}
+
 	if err := tmpStream.Orchestrate(ctx); err != nil {
 		return err
 	}

--- a/posting/index.go
+++ b/posting/index.go
@@ -515,7 +515,9 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 	// We write the index in a temporary badger first and then,
 	// merge entries before writing them to p directory.
-	os.Mkdir(tmpDir, os.ModePerm)
+	if err := os.Mkdir(tmpDir, os.ModePerm); err != nil {
+		return errors.Wrap(err, "error creating in temp dir for reindexing")
+	}
 	indexDir, err := ioutil.TempDir(tmpDir, "")
 	if err != nil {
 		return errors.Wrap(err, "error creating temp dir for reindexing")
@@ -526,7 +528,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	dbOpts := badger.DefaultOptions(indexDir).
 		WithSyncWrites(false).
 		WithNumVersionsToKeep(math.MaxInt64).
-		WithCompression(options.None).
+		WithCompression(options.Snappy).
 		WithEventLogging(false).
 		WithLogRotatesToFlush(10).
 		WithMaxCacheSize(50)

--- a/posting/index.go
+++ b/posting/index.go
@@ -598,7 +598,11 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	}
 	glog.V(1).Infof("Rebuilding index for predicate %s: building temp index took: %v\n",
 		r.attr, time.Since(start))
-	indexDB.Flatten(5)
+
+	// flatten the LSM tree to optimize reads
+	if err := indexDB.Flatten(5); err != nil {
+		return err
+	}
 
 	// Now we write all the created posting lists to disk.
 	glog.V(1).Infof("Rebuilding index for predicate %s: writing index to badger", r.attr)

--- a/posting/index.go
+++ b/posting/index.go
@@ -551,7 +551,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	// could be replaced with WriteBatch in the code
 	// Todo(Aman): Replace TxnWriter with WriteBatch. While we do that we should ensure that
 	// WriteBatch has a mechanism for throttling. Also, find other places where TxnWriter
-	// could be replaced with WriteBatch in the code. 
+	// could be replaced with WriteBatch in the code.
 	tmpWriter := NewTxnWriter(tmpDB)
 	stream := pstore.NewStreamAt(r.startTs)
 	stream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (1/2):", r.attr)

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -1,3 +1,21 @@
+// +build systest
+
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package main
 
 import (

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -1,0 +1,9265 @@
+package main
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+var tc = []struct {
+	query string
+	resp  string
+}{
+	{
+		query: `{
+		  caro(func: allofterms(name@en, "Marc Caro")) {
+			  name@en
+			  director.film {
+			    name@en
+			  }
+		  }
+		}`,
+		resp: `{
+			"caro": [
+				{
+					"name@en": "Marc Caro",
+					"director.film": [
+						{
+							"name@en": "Delicatessen"
+						},
+						{
+							"name@en": "The City of Lost Children"
+						}
+					]
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			coactors(func:allofterms(name@en, "Jane Campion")) @cascade {
+				JC_films as director.film {      # JC_films = all Jane Campion's films
+					starting_movie: name@en
+					starring {
+						JC_actors as performance.actor {      # JC_actors = all actors in all JC films
+							actor : name@en
+							actor.film {
+								performance.film @filter(not uid(JC_films)) {
+									film_together : name@en
+									starring {
+										# find a coactor who has been in some JC film
+										performance.actor @filter(uid(JC_actors)) {
+											coactor_name: name@en
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}`,
+		resp: `{
+			"coactors": [
+				{
+					"director.film": [
+						{
+							"starting_movie": "Bright Star",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Ben Whishaw",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Cloud Atlas",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "I'm Not There",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cloud Atlas",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Perfume: The Story of a Murderer",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Skyfall",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The International",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cloud Atlas",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cloud Atlas",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Layer Cake",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cloud Atlas",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Zero Theorem",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "In the Heart of the Sea",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Abbie Cornish",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "A Good Year",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sucker Punch",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Elizabeth: The Golden Age",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Horseplay",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Marking Time",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Everything Goes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Legend of the Guardians: The Owls of Ga'Hoole",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Thomas Brodie-Sangster",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Station Jim",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Thomas Brodie-Sangster"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Love Actually",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Thomas Brodie-Sangster"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Miracle of the Cards",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Thomas Brodie-Sangster"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hitler: The Rise of Evil",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Thomas Brodie-Sangster"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Jonathan Aris",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Not Only But Always",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jonathan Aris"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sightseers",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jonathan Aris"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Jackal",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jonathan Aris"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Claudie Blakley",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Pride & Prejudice",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Claudie Blakley"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Roger Ashton-Griffiths",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "You Will Meet a Tall Dark Stranger",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Madness of King George",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Pirates",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Swept from the Sea",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Napoleon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Grace of Monaco",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Brothers Grimm",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Cook, the Thief, His Wife & Her Lover",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red Faction: Origins",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Gangs of New York",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Young Sherlock Holmes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Vincent Franklin",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Confetti",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Vincent Franklin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Paul Schneider",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Away We Go",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Schneider"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Goodbye to All That",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Schneider"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Elizabethtown",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Schneider"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Olly Alexander",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Great Expectations",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Olly Alexander"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Kerry Fox",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Mister Pip",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kerry Fox"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Burning Man",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kerry Fox"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Last Tattoo",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kerry Fox"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Samuel Barnett",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Mrs Henderson Presents",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Samuel Barnett"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The History Boys",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Samuel Barnett"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"starting_movie": "In the Cut",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Arthur J. Nascarella",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Kate & Leopold",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Groomsmen",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bringing Out the Dead",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Theo Kogan"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cop Land",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Running Scared",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "New Jersey Drive",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Ref",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Mark Ruffalo",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "My Life Without Me",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Eternal Sunshine of the Spotless Mind",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Dentist",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Collateral",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Date Night",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Now You See Me",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sympathy for Delicious",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Shutter Island",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Zodiac",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "All the King's Men",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Ride with the Devil",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Rumor Has It",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Julius LeFlore",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Police Academy: Mission to Moscow",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Julius LeFlore"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Michael Ienna",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Little Fish",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michael Ienna"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Vinny Vella",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Casino",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Vinny Vella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Coffee and Cigarettes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Vinny Vella"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Lou Martini Jr.",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Godfather",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Lou Martini Jr."
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Michelle DiBenedetti",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Hitch",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michelle DiBenedetti"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Theo Kogan",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Bringing Out the Dead",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Theo Kogan"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Kevin Bacon",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "My One and Only",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Apollo 13",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sleepers",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "National Lampoon's Animal House",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Taking Chance",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Tremors",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hollow Man",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Footloose",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Few Good Men",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Queens Logic",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men: First Class",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Frost/Nixon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Murder in the First",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Diner",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mystic River",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Flatliners",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Beyond All Boundaries",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kevin Bacon"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Dana Lubotsky",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Mona Lisa Smile",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Dana Lubotsky"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Babe",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Dana Lubotsky"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Jennifer Jason Leigh",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Girls of the White Orchid",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Love Letter",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Skipped Parts",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Hudsucker Proxy",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Flesh and Blood",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sister, Sister",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Backdraft",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Man Who Wasn't There",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Road to Perdition",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Last Exit to Brooklyn",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Fast Times at Ridgemont High",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Georgia",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Thanks of a Grateful Nation",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Thousand Acres",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Jennifer Jason Leigh"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Meg Ryan",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "When Harry Met Sally...",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Innerspace",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Armed and Dangerous",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Promised Land",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "City of Angels",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Top Gun",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Restoration",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "I.Q.",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Deal",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Kate & Leopold",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Michelle Hurst",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "All Good Things",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michelle Hurst"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Smoke",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michelle Hurst"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"starting_movie": "Holy Smoke!",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Tim Robertson",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Jenny Kissed Me",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Tim Robertson"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Chant of Jimmie Blacksmith",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Tim Robertson"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Julie Hamilton",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "In the Company of Actors",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Justine Clarke"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Julie Hamilton"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Kerry Walker",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Singer and the Dancer",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kerry Walker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Paul Goddard",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Babe",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Goddard"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hildegarde",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Goddard"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Matrix",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Goddard"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Leslie Dayman",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Oscar and Lucinda",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Leslie Dayman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Pam Grier",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "First to Die",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Fortress 2: Re-Entry",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Adventures of Pluto Nash",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Class of 1999",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Larry Crowne",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Jackie Brown",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Package",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Arena",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mars Attacks!",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Greased Lightning",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Above the Law",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Drum",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Pam Grier"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Harvey Keitel",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Wrong Turn at Tahoe",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "From Dusk till Dawn",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bad Timing",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Blue Collar",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "National Treasure: Book of Secrets",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Taking Sides",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Duellists",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Grey Zone",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red Dragon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Inglourious Basterds",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Moonrise Kingdom",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Taxi Driver",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cop Land",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Alice Doesn't Live Here Anymore",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Blue in the Face",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Smoke",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michelle Hurst"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Who's That Knocking at My Door",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "National Treasure",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Grand Budapest Hotel",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Pulp Fiction",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mean Streets",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Thelma & Louise",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Last Temptation of Christ",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Reservoir Dogs",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bugsy",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bad Lieutenant",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Kate Winslet",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "War Game",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Life of David Gale",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Holiday",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Movie 43",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Iris",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Enigma",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "All the King's Men",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Pride",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Flushed Away",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Reader",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Christmas Carol: The Movie",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "War Game",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Carnage",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Titanic",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Heavenly Creatures",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sense and Sensibility",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Kid in King Arthur's Court",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Contagion",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Revolutionary Road",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Eternal Sunshine of the Spotless Mind",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mark Ruffalo"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Little Children",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Quills",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hamlet",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Labor Day",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Nalini Krishan",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Star Wars Episode II: Attack of the Clones",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nalini Krishan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"starting_movie": "The Water Diary",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Alice Englert",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Beautiful Creatures",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Alice Englert"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Ginger and Rosa",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Alice Englert"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Justine Clarke",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "In the Company of Actors",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Justine Clarke"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Julie Hamilton"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mad Max Beyond Thunderdome",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Justine Clarke"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Russell Dykstra",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Garage Days",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Oranges and Sunshine",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Clubland",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Lantana",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Ned Kelly",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Clayton Jacobson"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Clayton Jacobson",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Ned Kelly",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Clayton Jacobson"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Chris Haywood",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Nun and the Bandit",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Salvation",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Lonely Hearts",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Oscar and Lucinda",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Leslie Dayman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Exile",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Emerald City",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Island",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Man from Snowy River",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sweet Talker",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Burke & Wills",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Jindabyne",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Death Cheaters",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Molokai: The Story of Father Damien",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Alex",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Lust and Revenge",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Bit Part",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"starting_movie": "The Portrait of a Lady",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Shelley Winters",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Tenant",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Odds Against Tomorrow",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Poor Pretty Eddie",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Rudolph and Frosty's Christmas in July",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Silence of the Hams",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Jury Duty",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Lolita",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Winters"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Mary-Louise Parker",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Mr. Wonderful",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red Dragon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Fried Green Tomatoes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bullets over Broadway",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Client",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Boys on the Side",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red 2",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Christian Bale",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Mary, Mother of Jesus",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Out of the Furnace",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Henry V",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "I'm Not There",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mio in the Land of Faraway",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Treasure Island",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Public Enemies",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Velvet Goldmine",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Little Women",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Newsies",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Midsummer Night's Dream",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "3:10 to Yuma",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Empire of the Sun",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "I'm Not There",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ben Whishaw"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The New World",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Knight of Cups",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "John Gielgud",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Leave All Fair",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Scarlet and the Black",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Prospero's Books",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hamlet",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kate Winslet"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Murder by Decree",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Elizabeth",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Chimes at Midnight",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Priest of Love",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Richard III",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Julius Caesar",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Gielgud"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Martin Donovan",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Heaven",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Martin Donovan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Unthinkable",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Martin Donovan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Living Out Loud",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Martin Donovan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Reluctant Fundamentalist",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Martin Donovan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Nicole Kidman",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Trespass",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hemingway & Gellhorn",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "BMX Bandits",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Malice",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cold Mountain",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Railway Man",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Invasion",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Emerald City",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Far and Away",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Golden Compass",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Just Go With It",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Batman Forever",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Grace of Monaco",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Hours",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "To Die For",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Eyes Wide Shut",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Happy Feet",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Days of Thunder",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Peacemaker",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Bit Part",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Valentina Cervi",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Tulse Luper Suitcases",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Valentina Cervi"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hotel",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Valentina Cervi"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Shelley Duvall",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Annie Hall",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "RocketMan",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Suburban Commando",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Frankenweenie (1984)",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Time Bandits",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Home Fries",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Roxanne",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Underneath",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Shining Forwards and Backwards",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Shining",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Tale of the Mummy",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Shelley Duvall"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Roger Ashton-Griffiths",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "You Will Meet a Tall Dark Stranger",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Madness of King George",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Pirates",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Swept from the Sea",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Napoleon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Grace of Monaco",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Nicole Kidman"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Brothers Grimm",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Cook, the Thief, His Wife & Her Lover",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red Faction: Origins",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Gangs of New York",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Young Sherlock Holmes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Roger Ashton-Griffiths"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "John Malkovich",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "In the Line of Fire",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Hitchhiker's Guide to the Galaxy",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Beowulf",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Empire of the Sun",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Christian Bale"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Transformers: Dark of the Moon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Heart of Darkness",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Afterwards",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mary Reilly",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red 2",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Burn After Reading",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Changeling",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Penguins of Madagascar",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mary Reilly",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hotel",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Valentina Cervi"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Dangerous Liaisons",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "John Malkovich"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Richard E. Grant",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Doctor Who: The Curse of Fatal Death",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Penelope",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "L.A. Story",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Foster",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Twelfth Night: Or What You Will",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Warlock",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hildegarde",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Paul Goddard"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Nutcracker in 3D",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Age of Innocence",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bram Stoker's Dracula",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Little Vampire",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Corpse Bride",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Richard E. Grant"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Viggo Mortensen",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Ruby Cairo",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Perfect Murder",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hidalgo",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Lord of the Rings: The Return of the King",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Crimson Tide",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Young Americans",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Road",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Young Guns II",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "On the Road",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Psycho",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Lord of the Rings: The Two Towers",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Bruce Allpress"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "G.I. Jane",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Lord of the Rings: The Fellowship of the Ring",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Carlito's Way",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Leatherface: The Texas Chainsaw Massacre III",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Last Voyage of Demeter",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Barbara Hershey",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Natural",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Tin Men",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Falling Down",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Lantana",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Russell Dykstra"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Beaches",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Right Stuff",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Entity",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Baby Maker",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Last Temptation of Christ",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Hannah and Her Sisters",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"starting_movie": "The Piano",
+							"starring": [
+								{
+									"performance.actor": [
+										{
+											"actor": "Ian Mune",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Lord of the Rings: The Fellowship of the Ring",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Spooked",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Two Little Boys",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Nutcase",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Harvey Keitel",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Wrong Turn at Tahoe",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "From Dusk till Dawn",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bad Timing",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Blue Collar",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "National Treasure: Book of Secrets",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Taking Sides",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Duellists",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Grey Zone",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Red Dragon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Mary-Louise Parker"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Inglourious Basterds",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Moonrise Kingdom",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Taxi Driver",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Cop Land",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Alice Doesn't Live Here Anymore",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Blue in the Face",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Smoke",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michelle Hurst"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Who's That Knocking at My Door",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "National Treasure",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Grand Budapest Hotel",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Pulp Fiction",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Mean Streets",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Thelma & Louise",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Last Temptation of Christ",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Barbara Hershey"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Reservoir Dogs",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bugsy",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bad Lieutenant",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Harvey Keitel"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Sam Neill",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Jurassic Park",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "One Against the Wind",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "A Long Way Down",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Sleeping Dogs",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Adventurer: The Curse of the Midas Box",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Merlin",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "For Love Alone",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Wimbledon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Restoration",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Meg Ryan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Evil Angels",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "My Brilliant Career",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Framed",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Magic Pudding",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Under the Mountain",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Little Fish",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Michael Ienna"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "La Révolution française",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Plenty",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Jurassic Park III",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Fever",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Molokai: The Story of Father Damien",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Chris Haywood"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Jungle Book",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Event Horizon",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Legend of the Guardians: The Owls of Ga'Hoole",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Abbie Cornish"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Hunt for Red October",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Yes",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Sam Neill"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Kerry Walker",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Singer and the Dancer",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Kerry Walker"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Anna Paquin",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Courageous Heart of Irena Sendler",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men: Days of Future Past",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Buffalo Soldiers",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men 2",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Amistad",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Almost Famous",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men 2",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Romantics",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Finding Forrester",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Scream 4",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "X-Men: The Last Stand",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Anna Paquin"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Holly Hunter",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Harlan County War",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Broadcast News",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Positively True Adventures of the Alleged Texas Cheerleader-Murdering Mom",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Big White",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Always",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "O Brother, Where Art Thou?",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Timecode",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Once Around",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Blood Simple",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Living Out Loud",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Martin Donovan"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Raising Arizona",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Moonlight Mile",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Copycat",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Holly Hunter"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Cliff Curtis",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "Blow",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Six Days Seven Nights",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Spooked",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Ian Mune"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Deep Rising",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Whale Rider",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Bringing Out the Dead",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Theo Kogan"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Arthur J. Nascarella"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Collateral Damage",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Crossing Over",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Cliff Curtis"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"performance.actor": [
+										{
+											"actor": "Bruce Allpress",
+											"actor.film": [
+												{
+													"performance.film": [
+														{
+															"film_together": "The Scarecrow",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Bruce Allpress"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "Ozzie",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Bruce Allpress"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													"performance.film": [
+														{
+															"film_together": "The Lord of the Rings: The Two Towers",
+															"starring": [
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Bruce Allpress"
+																		}
+																	]
+																},
+																{
+																	"performance.actor": [
+																		{
+																			"coactor_name": "Viggo Mortensen"
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			PJ as var(func:allofterms(name@en, "Peter Jackson")) @normalize @cascade {
+				F as director.film
+			}
+
+			peterJ(func: uid(PJ)) @normalize @cascade {
+				name : name@en
+				actor.film {
+					performance.film @filter(uid(F)) {
+						film_name: name@en
+					}
+					performance.character {
+						character: name@en
+					}
+				}
+			}
+		}`,
+		resp: `{
+			"peterJ": [
+				{
+					"character": "Derek",
+					"film_name": "Bad Taste",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Mercenary On Boat",
+					"film_name": "The Lord of the Rings: The Return of the King",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Undertaker's Assistant",
+					"film_name": "Dead Alive",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Bum Outside Theater",
+					"film_name": "Heavenly Creatures",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Robert",
+					"film_name": "Bad Taste",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Rohirrim Warrior",
+					"film_name": "The Lord of the Rings: The Two Towers",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Albert Dreary",
+					"film_name": "The Lord of the Rings: The Fellowship of the Ring",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Gunner #1",
+					"film_name": "King Kong",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Prospector #4",
+					"film_name": "The Valley",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Man with Piercings",
+					"film_name": "The Frighteners",
+					"name": "Peter Jackson"
+				},
+				{
+					"character": "Man at Pharmacy",
+					"film_name": "The Lovely Bones",
+					"name": "Peter Jackson"
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			var(func: allofterms(name@en, "Taraji Henson")) {
+				actor.film {
+					F as performance.film {
+						G as genre
+					}
+				}
+			}
+
+			Taraji_films_by_genre(func: uid(G)) {
+				genre_name : name@en
+				films : ~genre @filter(uid(F)) {
+					film_name : name@en
+				}
+			}
+		}`,
+		resp: `{
+			"Taraji_films_by_genre": [
+				{
+					"genre_name": "Chase Movie",
+					"films": [
+						{
+							"film_name": "Date Night"
+						}
+					]
+				},
+				{
+					"genre_name": "Black comedy",
+					"films": [
+						{
+							"film_name": "Smokin' Aces"
+						}
+					]
+				},
+				{
+					"genre_name": "Television film",
+					"films": [
+						{
+							"film_name": "Satan's School for Girls"
+						}
+					]
+				},
+				{
+					"genre_name": "Romantic comedy",
+					"films": [
+						{
+							"film_name": "Date Night"
+						},
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						},
+						{
+							"film_name": "Larry Crowne"
+						}
+					]
+				},
+				{
+					"genre_name": "Musical comedy",
+					"films": [
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						}
+					]
+				},
+				{
+					"genre_name": "Musical Drama",
+					"films": [
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						}
+					]
+				},
+				{
+					"genre_name": "Drama",
+					"films": [
+						{
+							"film_name": "The Good Doctor"
+						},
+						{
+							"film_name": "The Curious Case of Benjamin Button"
+						},
+						{
+							"film_name": "Smokin' Aces"
+						},
+						{
+							"film_name": "The Family That Preys"
+						},
+						{
+							"film_name": "Satan's School for Girls"
+						},
+						{
+							"film_name": "Not Easily Broken"
+						},
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						},
+						{
+							"film_name": "Larry Crowne"
+						}
+					]
+				},
+				{
+					"genre_name": "Comedy-drama",
+					"films": [
+						{
+							"film_name": "The Family That Preys"
+						},
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						}
+					]
+				},
+				{
+					"genre_name": "Cult film",
+					"films": [
+						{
+							"film_name": "Satan's School for Girls"
+						}
+					]
+				},
+				{
+					"genre_name": "Crime Fiction",
+					"films": [
+						{
+							"film_name": "Smokin' Aces"
+						},
+						{
+							"film_name": "Date Night"
+						},
+						{
+							"film_name": "Satan's School for Girls"
+						}
+					]
+				},
+				{
+					"genre_name": "Comedy",
+					"films": [
+						{
+							"film_name": "Smokin' Aces"
+						},
+						{
+							"film_name": "Date Night"
+						},
+						{
+							"film_name": "The Family That Preys"
+						},
+						{
+							"film_name": "Not Easily Broken"
+						},
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						},
+						{
+							"film_name": "Larry Crowne"
+						}
+					]
+				},
+				{
+					"genre_name": "Romance Film",
+					"films": [
+						{
+							"film_name": "The Curious Case of Benjamin Button"
+						},
+						{
+							"film_name": "Date Night"
+						},
+						{
+							"film_name": "The Family That Preys"
+						},
+						{
+							"film_name": "Not Easily Broken"
+						},
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						},
+						{
+							"film_name": "Larry Crowne"
+						}
+					]
+				},
+				{
+					"genre_name": "Action Thriller",
+					"films": [
+						{
+							"film_name": "Smokin' Aces"
+						}
+					]
+				},
+				{
+					"genre_name": "Adventure Film",
+					"films": [
+						{
+							"film_name": "The Curious Case of Benjamin Button"
+						}
+					]
+				},
+				{
+					"genre_name": "Action Comedy",
+					"films": [
+						{
+							"film_name": "Date Night"
+						}
+					]
+				},
+				{
+					"genre_name": "Film adaptation",
+					"films": [
+						{
+							"film_name": "Not Easily Broken"
+						}
+					]
+				},
+				{
+					"genre_name": "Action/Adventure",
+					"films": [
+						{
+							"film_name": "Date Night"
+						}
+					]
+				},
+				{
+					"genre_name": "Mystery",
+					"films": [
+						{
+							"film_name": "Satan's School for Girls"
+						}
+					]
+				},
+				{
+					"genre_name": "Action Film",
+					"films": [
+						{
+							"film_name": "Smokin' Aces"
+						},
+						{
+							"film_name": "Date Night"
+						}
+					]
+				},
+				{
+					"genre_name": "Horror",
+					"films": [
+						{
+							"film_name": "Satan's School for Girls"
+						}
+					]
+				},
+				{
+					"genre_name": "Thriller",
+					"films": [
+						{
+							"film_name": "The Good Doctor"
+						},
+						{
+							"film_name": "Smokin' Aces"
+						},
+						{
+							"film_name": "Date Night"
+						}
+					]
+				},
+				{
+					"genre_name": "Backstage Musical",
+					"films": [
+						{
+							"film_name": "I Can Do Bad All by Myself"
+						}
+					]
+				},
+				{
+					"genre_name": "Family Drama",
+					"films": [
+						{
+							"film_name": "The Family That Preys"
+						}
+					]
+				},
+				{
+					"genre_name": "Screwball comedy",
+					"films": [
+						{
+							"film_name": "Date Night"
+						}
+					]
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			q(func: allofterms(name@en, "Ang Lee")) {
+				director.film {
+					name@en
+					num_actors as count(starring)
+				}
+				most_actors : max(val(num_actors))
+			}
+		}`,
+		resp: `{
+			"q": [
+				{
+					"director.film": [
+						{
+							"name@en": "Ride with the Devil",
+							"count(starring)": 10
+						},
+						{
+							"name@en": "Crouching Tiger, Hidden Dragon",
+							"count(starring)": 31
+						},
+						{
+							"name@en": "Taking Woodstock",
+							"count(starring)": 130
+						},
+						{
+							"name@en": "The Ice Storm",
+							"count(starring)": 45
+						},
+						{
+							"name@en": "Eat Drink Man Woman",
+							"count(starring)": 16
+						},
+						{
+							"name@en": "Life of Pi",
+							"count(starring)": 42
+						},
+						{
+							"name@en": "Lust, Caution",
+							"count(starring)": 16
+						},
+						{
+							"name@en": "The Wedding Banquet",
+							"count(starring)": 15
+						},
+						{
+							"name@en": "The Hire: Chosen",
+							"count(starring)": 1
+						},
+						{
+							"name@en": "Brokeback Mountain",
+							"count(starring)": 54
+						},
+						{
+							"name@en": "Sense and Sensibility",
+							"count(starring)": 15
+						},
+						{
+							"name@en": "Hulk",
+							"count(starring)": 15
+						}
+					],
+					"most_actors": 130
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			ID as var(func: allofterms(name@en, "Steven Spielberg")) {
+			}
+
+			avs(func: uid(ID)) @normalize {
+				name : name@en
+			}
+		}`,
+		resp: `{
+			"avs": [
+				{
+					"name": "Steven Spielberg"
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			ID as var(func: allofterms(name@en, "Steven")) {
+				director.film {
+					num_actors as count(starring)
+				}
+				average as avg(val(num_actors))
+			}
+
+			avs(func: uid(ID), orderdesc: val(average)) @filter(ge(val(average), 40)) @normalize {
+				name : name@en
+				average_actors : val(average)
+				num_films : count(director.film)
+			}
+		}`,
+		resp: `{
+			"avs": [
+				{
+					"name": "Steven Spielberg",
+					"average_actors": 51.733333,
+					"num_films": 30
+				},
+				{
+					"name": "Steven Zaillian",
+					"average_actors": 40,
+					"num_films": 3
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			var(func:allofterms(name@en, "Jean-Pierre Jeunet")) {
+				name@en
+				films as director.film {
+					stars as count(starring)
+					directors as count(~director.film)
+					ratio as math(stars / directors)
+				}
+			}
+
+			best_ratio(func: uid(films), orderdesc: val(ratio)){
+				name@en
+				stars_per_director : val(ratio)
+				num_stars : val(stars)
+			}
+		}`,
+		resp: `{
+			"best_ratio": [
+				{
+					"name@en": "A Very Long Engagement",
+					"stars_per_director": 78,
+					"num_stars": 78
+				},
+				{
+					"name@en": "Micmacs",
+					"stars_per_director": 72,
+					"num_stars": 72
+				},
+				{
+					"name@en": "Amélie",
+					"stars_per_director": 68,
+					"num_stars": 68
+				},
+				{
+					"name@en": "The City of Lost Children",
+					"stars_per_director": 43,
+					"num_stars": 87
+				},
+				{
+					"name@en": "The Young and Prodigious Spivet",
+					"stars_per_director": 15,
+					"num_stars": 15
+				},
+				{
+					"name@en": "Alien: Resurrection",
+					"stars_per_director": 15,
+					"num_stars": 15
+				},
+				{
+					"name@en": "Delicatessen",
+					"stars_per_director": 8,
+					"num_stars": 17
+				},
+				{
+					"name@en": "Things I Like, Things I Don't Like",
+					"stars_per_director": 2,
+					"num_stars": 2
+				}
+			]
+		}`,
+	},
+	{
+		query: `{
+			var(func:allofterms(name@en, "Steven Spielberg")) {
+				director.film @groupby(genre) {
+					a as count(uid)
+				}
+			}
+
+			byGenre(func: uid(a), orderdesc: val(a)) {
+				name@en
+				num_movies : val(a)
+			}
+		}`,
+		resp: `{
+			"byGenre": [
+				{
+					"name@en": "Drama",
+					"num_movies": 19
+				},
+				{
+					"name@en": "Adventure Film",
+					"num_movies": 14
+				},
+				{
+					"name@en": "Action Film",
+					"num_movies": 11
+				},
+				{
+					"name@en": "Thriller",
+					"num_movies": 10
+				},
+				{
+					"name@en": "Science Fiction",
+					"num_movies": 8
+				},
+				{
+					"name@en": "War film",
+					"num_movies": 6
+				},
+				{
+					"name@en": "Comedy",
+					"num_movies": 5
+				},
+				{
+					"name@en": "Family",
+					"num_movies": 4
+				},
+				{
+					"name@en": "Historical fiction",
+					"num_movies": 4
+				},
+				{
+					"name@en": "Mystery",
+					"num_movies": 4
+				},
+				{
+					"name@en": "Biographical film",
+					"num_movies": 4
+				},
+				{
+					"name@en": "Fantasy",
+					"num_movies": 4
+				},
+				{
+					"name@en": "Costume Adventure",
+					"num_movies": 3
+				},
+				{
+					"name@en": "Action/Adventure",
+					"num_movies": 3
+				},
+				{
+					"name@en": "Horror",
+					"num_movies": 3
+				},
+				{
+					"name@en": "Adventure Comedy",
+					"num_movies": 3
+				},
+				{
+					"name@en": "Film adaptation",
+					"num_movies": 3
+				},
+				{
+					"name@en": "Crime Fiction",
+					"num_movies": 2
+				},
+				{
+					"name@en": "Romance Film",
+					"num_movies": 2
+				},
+				{
+					"name@en": "Future noir",
+					"num_movies": 2
+				},
+				{
+					"name@en": "Epic film",
+					"num_movies": 2
+				},
+				{
+					"name@en": "Chase Movie",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Disaster Film",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Dystopia",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Doomsday film",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Adventure",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Children's Fantasy",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Action Comedy",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Comedy-drama",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Political drama",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Coming of age",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Airplanes and airports",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Road movie",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Fantasy Adventure",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Childhood Drama",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Screwball comedy",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Children's/Family",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Crime",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Animation",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Historical period drama",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Romantic comedy",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Suspense",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Alien Film",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Political thriller",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Film noir",
+					"num_movies": 1
+				},
+				{
+					"name@en": "Mystery film",
+					"num_movies": 1
+				}
+			]
+		}`,
+	},
+}
+
+func Test1Million(t *testing.T) {
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	if err != nil {
+		log.Fatalf("Error while getting a dgraph client: %v", err)
+	}
+
+	for _, tt := range tc {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		resp, err := dg.NewTxn().Query(ctx, tt.query)
+		cancel()
+
+		if ctx.Err() == context.DeadlineExceeded {
+			t.Fatal("aborting test due to query timeout")
+		}
+		require.NoError(t, err)
+
+		testutil.CompareJSON(t, tt.resp, string(resp.Json))
+	}
+}

--- a/systest/1million/docker-compose.yml
+++ b/systest/1million/docker-compose.yml
@@ -1,0 +1,78 @@
+# Auto-generated with: [./compose -a 3 -z 1 -r 1 -d data -w]
+#
+version: "3.5"
+services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+    - 8180:8180
+    - 9180:9180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=1 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+  alpha2:
+    image: dgraph/dgraph:latest
+    container_name: alpha2
+    working_dir: /data/alpha2
+    depends_on:
+    - alpha1
+    labels:
+      cluster: test
+    ports:
+    - 8182:8182
+    - 9182:9182
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 102 --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+  alpha3:
+    image: dgraph/dgraph:latest
+    container_name: alpha3
+    working_dir: /data/alpha3
+    depends_on:
+    - alpha2
+    labels:
+      cluster: test
+    ports:
+    - 8183:8183
+    - 9183:9183
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 103 --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=3 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+    - 5180:5180
+    - 6180:6180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=1 --logtostderr
+      -v=2 --bindall
+volumes:
+  data:

--- a/systest/1million/test-reindex.sh
+++ b/systest/1million/test-reindex.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-readonly ME=${0##*/}
 readonly SRCDIR=$(dirname $0)
 
 BENCHMARKS_REPO="$(pwd)/benchmarks"
@@ -21,9 +20,12 @@ Info "cloning benchmarks repo"
 BENCHMARKS_URL=https://github.com/dgraph-io/benchmarks/blob/master/data
 rm -rf $BENCHMARKS_REPO
 mkdir -p $BENCHMARKS_REPO/data
-wget -O $BENCHMARKS_REPO/data/1million.schema $BENCHMARKS_URL/1million.schema?raw=true
-wget -O $BENCHMARKS_REPO/data/1million-noindex.schema $BENCHMARKS_URL/1million-noindex.schema?raw=true
-wget -O $BENCHMARKS_REPO/data/1million.rdf.gz $BENCHMARKS_URL/1million.rdf.gz?raw=true
+wget -O $NO_INDEX_SCHEMA_FILE $BENCHMARKS_URL/1million-noindex.schema?raw=true
+wget -O $SCHEMA_FILE $BENCHMARKS_URL/1million.schema?raw=true
+wget -O $DATA_FILE $BENCHMARKS_URL/1million.rdf.gz?raw=true
+
+Info "entering directory $SRCDIR"
+cd $SRCDIR
 
 Info "bringing down zero and alpha and data volumes"
 DockerCompose down -v

--- a/systest/1million/test-reindex.sh
+++ b/systest/1million/test-reindex.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -e
+readonly ME=${0##*/}
+readonly SRCDIR=$(dirname $0)
+
+BENCHMARKS_REPO="$(pwd)/benchmarks"
+NO_INDEX_SCHEMA_FILE="$BENCHMARKS_REPO/data/1million-noindex.schema"
+SCHEMA_FILE="$BENCHMARKS_REPO/data/1million.schema"
+DATA_FILE="$BENCHMARKS_REPO/data/1million.rdf.gz"
+
+function Info {
+    echo -e "INFO: $*"
+}
+
+function DockerCompose {
+    docker-compose -p dgraph "$@"
+}
+
+Info "cloning benchmarks repo"
+BENCHMARKS_URL=https://github.com/dgraph-io/benchmarks/blob/master/data
+rm -rf $BENCHMARKS_REPO
+mkdir -p $BENCHMARKS_REPO/data
+wget -O $BENCHMARKS_REPO/data/1million.schema $BENCHMARKS_URL/1million.schema?raw=true
+wget -O $BENCHMARKS_REPO/data/1million-noindex.schema $BENCHMARKS_URL/1million-noindex.schema?raw=true
+wget -O $BENCHMARKS_REPO/data/1million.rdf.gz $BENCHMARKS_URL/1million.rdf.gz?raw=true
+
+Info "bringing down zero and alpha and data volumes"
+DockerCompose down -v
+
+Info "bringing up zero container"
+DockerCompose up -d --remove-orphans --force-recreate zero1
+
+Info "waiting for zero to become leader"
+DockerCompose logs -f zero1 | grep -q -m1 "I've become the leader"
+
+Info "bulk loading data set"
+DockerCompose run -v $BENCHMARKS_REPO:$BENCHMARKS_REPO --name bulk_load zero1 \
+    bash -s <<EOF
+        mkdir -p /data/alpha1
+        mkdir -p /data/alpha2
+        mkdir -p /data/alpha3
+        /gobin/dgraph bulk --schema=$NO_INDEX_SCHEMA_FILE --files=$DATA_FILE \
+                            --format=rdf --zero=zero1:5180 --out=/data/zero1/bulk \
+                            --reduce_shards 3 --map_shards 9
+        mv /data/zero1/bulk/0/p /data/alpha1
+        mv /data/zero1/bulk/1/p /data/alpha2
+        mv /data/zero1/bulk/2/p /data/alpha3
+EOF
+
+Info "bringing up alpha container"
+DockerCompose up -d --force-recreate alpha1 alpha2 alpha3
+
+Info "waiting for alpha to be ready"
+DockerCompose logs -f alpha1 | grep -q -m1 "Server is ready"
+# after the server prints the log "Server is ready", it may be still loading data from badger
+Info "sleeping for 5 seconds for the server to be ready"
+sleep 5
+
+Info "building indexes"
+curl localhost:8180/alter --data-binary @$SCHEMA_FILE
+
+if [[ ! -z "$TEAMCITY_VERSION" ]]; then
+    # Make TeamCity aware of Go tests
+    export GOFLAGS="-json"
+fi
+
+Info "running regression queries"
+go test -v || FOUND_DIFFS=1
+
+Info "bringing down zero and alpha and data volumes"
+DockerCompose down -v
+
+if [[ $FOUND_DIFFS -eq 0 ]]; then
+    Info "no diffs found in query results"
+else
+    Info "found some diffs in query results"
+fi
+
+rm -rf $BENCHMARKS_REPO
+exit $FOUND_DIFFS

--- a/systest/1million/test-reindex.sh
+++ b/systest/1million/test-reindex.sh
@@ -66,7 +66,7 @@ if [[ ! -z "$TEAMCITY_VERSION" ]]; then
 fi
 
 Info "running regression queries"
-go test -v || FOUND_DIFFS=1
+go test -v -tags systest || FOUND_DIFFS=1
 
 Info "bringing down zero and alpha and data volumes"
 DockerCompose down -v

--- a/test.sh
+++ b/test.sh
@@ -253,6 +253,9 @@ if [[ :${TEST_SET}: == *:systest:* ]]; then
 
     Info "Running large load test"
     RunCmd ./systest/21million/test-21million.sh || TestFailed
+
+    Info "Running rebuilding index test"
+    RunCmd ./systest/1million/test-reindex.sh || TestFailed
 fi
 
 Info "Stopping cluster"


### PR DESCRIPTION
While re-indexing a predicate, we now write the temp data on disk instead of keeping it in memory. This allows us to recreate index for large datasets.

On 21 million dataset, we get following results:

|        | Disk Based | Memory Based |
|-------------------|------------|--------------|
| Adding Exact Index |  0m45.964s |  0m47.661s |
| Adding Hash Index |  0m50.706s |  0m48.044s    |
| Adding FullText Index | 1m6.489s  |  2m14.316s |
| Adding Term Index | 1m16.898s  |  3m5.429s    |

On 18 GB p directory, we get following results:

|        | Disk Based | Memory Based |
|-------------------|------------|--------------|
| Adding Exact Index | 23m45.145s |  |
| Adding Hash Index | 26m51.485s | |
| Adding FullText Index | 22m56.642s | |
| Adding Term Index | 22m49.796s | |
| Adding Count Index | 7m34.345s | |

### Todo
  * [x] Add test when same index key is written multiple times to tmp badger
  * [x] Add logs printing progress report
  * [x] Calculation of reduction in memory usage
  * [x] Calculation of increase in re-indexing time
  * [x] Performance optimization
           * Use Batch Writer for writing data to temp badger
           * Use batching to write to temp badger
  * [x] Avoid using tmpfs for temp badger
  * [x] Systest using 1million dataset
  * [x] More Optimizations
           * Use managed badger and incremental version
  * [x] Benchmarks
           * With and without compressions (without compression is faster)
           * With and without Flatten (without flatten is faster)
           * On 15 GB p directory
           * On 21 million dataset

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4440)
<!-- Reviewable:end -->
