### PR TITLE
contrib: add fluentd log parser configuration and k8s manifest

### DIFF
--- a/contrib/config/monitoring/fluentd/fluent-docker.conf
+++ b/contrib/config/monitoring/fluentd/fluent-docker.conf
@@ -1,0 +1,51 @@
+<source>
+    @id fluentd-containers.log
+    @type tail
+    path /var/lib/docker/containers/*/*.log
+    pos_file /var/log/containers.log.pos
+
+    tag dgraph.*
+    read_from_head true
+
+    <parse>
+        @type json
+        keep_time_key true
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+    </parse>
+</source>
+
+<filter dgraph.**>
+    @type parser
+    key_name log
+
+    <parse>
+        @type regexp
+        expression /^(?<severity>[IWECF])(?<time>\d{4} \d{2}:\d{2}:\d{2}\.\d{6}) +(?<thread>\d+) (?<src_file>[^:]+):(?<src_line>\d+)\] (?<message>(?:.|\n)*)$/
+        time_format %m%d %H:%M:%S.%L
+    </parse>
+
+    reserve_data true
+</filter>
+
+<filter dgraph.**>
+    @type record_transformer
+    enable_ruby true
+
+    <record>
+        severity ${ if (record["severity"] == "E") then "Error" elsif (record["severity"] == "W") then "Warning" elsif (record["severity"] == "I") then "Info" elsif (record["severity"] == "D") then "Debug" else record["severity"] end}
+        tag ${tag}
+    </record>
+</filter>
+
+<match dgraph.**>
+    @type rewrite_tag_filter
+    <rule>
+        key tag
+        pattern /^dgraph.var.lib.docker.containers.(\w{32})/
+        tag raw.docker.$1
+    </rule>
+</match>
+
+<match *.*>
+  @type stdout
+</match>

--- a/contrib/config/monitoring/fluentd/fluentd-config.yaml
+++ b/contrib/config/monitoring/fluentd/fluentd-config.yaml
@@ -1,0 +1,58 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: fluentd-config
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  containers.input.conf: |-
+    <source>
+      @id fluentd-containers.log
+      @type tail
+      path /var/log/containers/*.log
+      pos_file /var/log/containers.log.pos
+
+      tag dgraph.*
+      read_from_head true
+
+      <parse>
+        @type json
+        keep_time_key true
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+    </source>
+
+    <filter dgraph.**>
+      @type parser
+      key_name log
+
+      <parse>
+        @type regexp
+        expression /^(?<severity>[IWECF])(?<time>\d{4} \d{2}:\d{2}:\d{2}\.\d{6}) +(?<thread>\d+) (?<src_file>[^:]+):(?<src_line>\d+)\] (?<message>(?:.|\n)*)$/
+        time_format %m%d %H:%M:%S.%L
+      </parse>
+
+      reserve_data true
+    </filter>
+
+    <filter dgraph.**>
+      @type record_transformer
+      enable_ruby true
+
+      <record>
+        severity ${ if (record["severity"] == "E") then "Error" elsif (record["severity"] == "W") then "Warning" elsif (record["severity"] == "I") then "Info" elsif (record["severity"] == "D") then "Debug" else record["severity"] end}
+        tag ${tag}
+      </record>
+    </filter>
+
+    <match dgraph.**>
+      @type route
+      remove_tag_prefix dgraph.var.log.containers
+      add_tag_prefix raw.kubernetes
+    </match>
+
+    # Add your log injector and management pipeline here.
+    <match raw.kubernetes.**>
+      @type stdout
+    </match>

--- a/contrib/config/monitoring/fluentd/fluentd-config.yaml
+++ b/contrib/config/monitoring/fluentd/fluentd-config.yaml
@@ -1,8 +1,8 @@
-kind: ConfigMap
 apiVersion: v1
+kind: ConfigMap
 metadata:
-  name: fluentd-config
-  namespace: kube-system
+  name: fluentd-config-dgraph-io
+  namespace: default
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
 data:
@@ -10,15 +10,16 @@ data:
     <source>
       @id fluentd-containers.log
       @type tail
-      path /var/log/containers/*.log
+      path /var/log/containers/dgraph*.log
       pos_file /var/log/containers.log.pos
 
       tag dgraph.*
       read_from_head true
 
       <parse>
-        @type json
-        keep_time_key true
+        @type regexp
+
+        expression /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
         time_format %Y-%m-%dT%H:%M:%S.%NZ
       </parse>
     </source>
@@ -46,13 +47,16 @@ data:
       </record>
     </filter>
 
-    <match dgraph.**>
-      @type route
-      remove_tag_prefix dgraph.var.log.containers
-      add_tag_prefix raw.kubernetes
-    </match>
-
     # Add your log injector and management pipeline here.
-    <match raw.kubernetes.**>
-      @type stdout
+    <match dgraph.**>
+      @type elasticsearch
+
+      logstash_format true
+      include_tag_key true
+
+      host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
+      port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
+      scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+      user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
+      password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
     </match>

--- a/contrib/config/monitoring/fluentd/fluentd.yaml
+++ b/contrib/config/monitoring/fluentd/fluentd.yaml
@@ -1,0 +1,113 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-dgraph-io
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd-dgraph-io
+  namespace: default
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd-dgraph-io
+roleRef:
+  kind: ClusterRole
+  name: fluentd-dgraph-io
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd-dgraph-io
+  namespace: default
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-elasticsearch
+  namespace: default
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  selector:
+    matchLabels:
+      name: fluentd-elasticsearch
+  template:
+    metadata:
+      labels:
+        name: fluentd-elasticsearch
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccount: fluentd-dgraph-io
+      serviceAccountName: fluentd-dgraph-io
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      initContainers:
+      - name: config-fluentd
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c"]
+        args:
+        - cp /fluentd/etcsrc/containers.input.conf /fluentd/etc/fluent.conf
+        volumeMounts:
+        - name: config-path
+          mountPath: /fluentd/etc
+        - name: config-source
+          mountPath: /fluentd/etcsrc
+      containers:
+      - name: fluentd-elasticsearch
+        image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch
+        env:
+          - name:  FLUENT_ELASTICSEARCH_HOST
+            value: "<HOST>"
+          - name:  FLUENT_ELASTICSEARCH_PORT
+            value: "<PORT>"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "https"
+          - name: FLUENT_ELASTICSEARCH_USER
+            value: <USER>
+          - name: FLUENT_ELASTICSEARCH_PASSWORD
+            value: <PASSWORD>
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: config-path
+          mountPath: /fluentd/etc
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: config-source
+        configMap:
+          name: fluentd-config-dgraph-io
+      - name: config-path
+        emptyDir: {}


### PR DESCRIPTION
* Fixes #4381 
* Add fluentd configuration to parse structured dgraph logs on k8s

Here is a sample from kibana dashboard for fluentd parsed logs.

![screenshot-test-cluster-6197617514 k4a bonsaisearch net-2019 12 20-19_37_19](https://user-images.githubusercontent.com/21292343/71260495-04f22780-2361-11ea-8caa-65e48ffbc0bc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4455)
<!-- Reviewable:end -->
