### PR TITLE
Improving encryption at rest docs

### DIFF
--- a/wiki/content/_index.md
+++ b/wiki/content/_index.md
@@ -12,7 +12,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
 <section class="toc">
   <div class="container">
     <div class="row row-no-padding">
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -25,7 +24,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -38,7 +36,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -51,7 +48,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -64,7 +60,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -77,11 +72,10 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
-            <a href="/deploy">
+            <a href="{{< relref "deploy/index.md">}}">
               Deploy
             </a>
           </div>
@@ -90,7 +84,18 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
+      <div class="col-12 col-sm-6">
+        <div class="section-item">
+          <div class="section-name">
+            <a href="{{< relref "enterprise-features/index.md">}}">
+              Enterprise Features
+            </a>
+          </div>
+          <p class="section-desc">
+            Exclusive features like ACLs, binary backups, encryption at rest, and more
+          </p>
+        </div>
+      </div>
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
@@ -103,12 +108,12 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
           </p>
         </div>
       </div>
-
     </div>
   </div>
 </section>
 
 ## Contribute
+
 <section class="toc">
   <div class="container">
     <div class="row row-no-padding">
@@ -162,7 +167,6 @@ Dgraph is an open source, scalable, distributed, highly available and fast graph
     </div>
   </div>
 </section>
-
 
 ## Demo
 

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -27,6 +27,10 @@ enterprise features.
 
 ## Binary Backups
 
+{{% notice "note" %}}
+This feature was introduced in [v1.1.0](https://github.com/dgraph-io/dgraph/releases/tag/v1.1.0).
+{{% /notice %}}
+
 Binary backups are full backups of Dgraph that are backed up directly to cloud
 storage such as Amazon S3 or any Minio storage backend. Backups can also be
 saved to an on-premise network file system shared by all alpha instances. These
@@ -182,6 +186,10 @@ $ dgraph restore -p /var/db/dgraph -l /var/backups/dgraph -z localhost:5080
 ```
 
 ## Access Control Lists
+
+{{% notice "note" %}}
+This feature was introduced in [v1.1.0](https://github.com/dgraph-io/dgraph/releases/tag/v1.1.0).
+{{% /notice %}}
 
 Access Control List (ACL) provides access protection to your data stored in
 Dgraph. When the ACL feature is turned on, a client, e.g. dgo or dgraph4j, must
@@ -364,10 +372,18 @@ $ curl -X POST localhost:8080/login -d '{
 
 ## Encryption at Rest
 
-Encryption at rest refers to the encryption of data that is stored physically in any digital
-form. It ensures that sensitive data on disks is not readable by any user or application
-without a valid key that is required for decryption. Dgraph provides encryption at rest as an
-enterprise feature. If encryption is enabled, Dgraph uses AES (Advanced Encryption Standard)
+{{% notice "note" %}}
+This feature was introduced in [v1.1.1](https://github.com/dgraph-io/dgraph/releases/tag/v1.1.1).
+For migrating unencrypted data to a new Dgraph cluster with encryption enabled, you need to
+[export the database](https://docs.dgraph.io/deploy/#export-database) and [fast data load](https://docs.dgraph.io/deploy/#fast-data-loading),
+preferably using the [bulk loader](https://docs.dgraph.io/deploy/#bulk-loader).
+{{% /notice %}}
+
+Encryption at rest refers to the encryption of data that is stored physically in any
+digital form. It ensures that sensitive data on disks is not readable by any user
+or application without a valid key that is required for decryption. Dgraph provides
+encryption at rest as an enterprise feature. If encryption is enabled, Dgraph uses
+[Advanced Encryption Standard (AES)](https://en.wikipedia.org/wiki/Advanced_Encryption_Standard)
 algorithm to encrypt the data and secure it.
 
 ### Set up Encryption
@@ -376,9 +392,10 @@ To enable encryption, we need to pass a file that stores the data encryption key
 `--encryption_key_file`. The key size must be 16, 24, or 32 bytes long, and the key size determines
 the corresponding block size for AES encryption ,i.e. AES-128, AES-192, and AES-256, respectively.
 
-Here is an example encryption key file of size 16 bytes.
+Here is an example encryption key file of size 16 bytes:
 
 *enc_key_file*
+
 ```
 123456789012345
 ```


### PR DESCRIPTION
- Added instruction to migrate unencrypted data to a new Dgraph cluster
- Added the versions at which each enterprise features were introduced
- Added enterprise feature section in docs site homepage

We will have to iterate over this section once again after the implementation of badger's encryption key rotation in Dgraph.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4469)
<!-- Reviewable:end -->
