### PR TITLE
[Optimization] Tunes badger for raftwal

### DIFF
--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -523,6 +523,7 @@ func (w *DiskStorage) allEntries(lo, hi, maxSize uint64) (es []raftpb.Entry, rer
 		}
 
 		iopt := badger.DefaultIteratorOptions
+		iopt.PrefetchValues = false
 		iopt.Prefix = w.entryPrefix()
 		itr := txn.NewIterator(iopt)
 		defer itr.Close()

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -522,6 +522,11 @@ func (w *DiskStorage) allEntries(lo, hi, maxSize uint64) (es []raftpb.Entry, rer
 			})
 		}
 
+		// We are opening badger in LSM only mode. In that mode the values are
+		// colocated with the keys. Hence, there is no need to prefetch values.
+		// Also, if Prefetch is set to true, then it causes latency issue with
+		// random spikes inbetween.
+
 		iopt := badger.DefaultIteratorOptions
 		iopt.PrefetchValues = false
 		iopt.Prefix = w.entryPrefix()


### PR DESCRIPTION
We observed that when running dgraph at scale, things started to get slow. The throughput in diskless mode went from 8k to less than 1k within minutes for continous mutations.  We noticed that most(80%) of time was being taken while PreFetch() in badger for raft-wal. This PR fixes that. Now the throughput stabalizes around 7k expect for when compaction happens. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4472)
<!-- Reviewable:end -->
