### PR TITLE
Add zero.shardReplicaCount option in helm chart.

### DIFF
--- a/contrib/config/kubernetes/helm/Chart.yaml
+++ b/contrib/config/kubernetes/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.1
+version: 0.0.2
 appVersion: latest
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/contrib/config/kubernetes/helm/README.md
+++ b/contrib/config/kubernetes/helm/README.md
@@ -42,10 +42,11 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `image.tag`                          | Container image tag                                                 | `v1.0.13`                                           |
 | `image.pullPolicy`                   | Container pull policy                                               | `Always`                                            |
 | `zero.name`                          | Zero component name                                                 | `zero`                                              |
-| `zero.updateStrategy`                | Stratergy for upgrading zero nodes                                  | `RollingUpdate`                                     |
+| `zero.updateStrategy`                | Strategy for upgrading zero nodes                                   | `RollingUpdate`                                     |
 | `zero.rollingUpdatePartition`        | Partition update strategy                                           | `nil`                                               |
 | `zero.podManagementPolicy`           | Pod management policy for zero nodes                                | `OrderedReady`                                      |
 | `zero.replicaCount`                  | Number of zero nodes                                                | `3`                                                 |
+| `zero.shardReplicaCount`             | Max number of replicas per data shard                               | `5`                                                 |
 | `zero.terminationGracePeriodSeconds` | Zero server pod termination grace period                            | `60`                                                |
 | `zero.antiAffinity`                  | Zero anti-affinity policy                                           | `soft`                                              |
 | `zero.podAntiAffinitytopologyKey`    | Anti affinity topology key for zero nodes                           | `kubernetes.io/hostname`                            |
@@ -64,7 +65,7 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `zero.livenessProbe`                 | Zero liveness probes                                                | `See values.yaml for defaults`                      |
 | `zero.readinessProbe`                | Zero readiness probes                                               | `See values.yaml for defaults`                      |
 | `alpha.name`                         | Alpha component name                                                | `alpha`                                             |
-| `alpha.updateStrategy`               | Stratergy for upgrading alpha nodes                                 | `RollingUpdate`                                     |
+| `alpha.updateStrategy`               | Strategy for upgrading alpha nodes                                  | `RollingUpdate`                                     |
 | `alpha.rollingUpdatePartition`       | Partition update strategy                                           | `nil`                                               |
 | `alpha.podManagementPolicy`          | Pod management policy for alpha nodes                               | `OrderedReady`                                      |
 | `alpha.replicaCount`                 | Number of alpha nodes                                               | `3`                                                 |

--- a/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
@@ -102,9 +102,9 @@ spec:
              ordinal=${BASH_REMATCH[1]}
              idx=$(($ordinal + 1))
              if [[ $ordinal -eq 0 ]]; then
-               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
              else
-               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.replicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
              fi 
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}

--- a/contrib/config/kubernetes/helm/values.yaml
+++ b/contrib/config/kubernetes/helm/values.yaml
@@ -45,9 +45,14 @@ zero:
   ##
   podManagementPolicy: OrderedReady
 
-  ## Number of dgraph  zero pods
+  ## Number of dgraph zero pods
   ##
   replicaCount: 3
+
+  ## Max number of replicas per data shard.
+  ## i.e., the max number of Dgraph Alpha instances per group (shard).
+  ##
+  shardReplicaCount: 5
 
   ## zero server pod termination grace period
   ##


### PR DESCRIPTION
* Bump helm chart version to 0.0.2.
* New values.yaml option `zero.shardReplicaCount`. This sets Dgraph Zero's `--replicas` option.

```
$ helm template --set zero.shardReplicaCount=1 . | grep '\--replicas'
               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas 1
               exec dgraph zero --my=$(hostname -f):5080 --peer RELEASE-NAME-dgraph-zero-0.RELEASE-NAME-dgraph-zero-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 1
$ helm template --set zero.shardReplicaCount=3 . | grep '\--replicas'
               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas 3
               exec dgraph zero --my=$(hostname -f):5080 --peer RELEASE-NAME-dgraph-zero-0.RELEASE-NAME-dgraph-zero-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 3
$ helm template --set zero.shardReplicaCount=5 . | grep '\--replicas'
               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas 5
               exec dgraph zero --my=$(hostname -f):5080 --peer RELEASE-NAME-dgraph-zero-0.RELEASE-NAME-dgraph-zero-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 5
```

Fixes #4474.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4476)
<!-- Reviewable:end -->
