### PR TITLE
Remove unauthorized predicates from query

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -523,8 +523,6 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 
 		if x.IsGuardian(groupIds) {
 			// Members of guardian group are allowed to alter anything.
-			// TODO(Animesh): Check if this could possibly lead to
-			// altering ACL predicates.
 			return nil
 		}
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -789,7 +789,9 @@ func authorizeState(ctx context.Context) error {
 	return doAuthorizeState()
 }
 
-func removePredsFromQuery(gqls []*gql.GraphQuery, unAuthPreds map[string]struct{}) []*gql.GraphQuery {
+func removePredsFromQuery(gqls []*gql.GraphQuery,
+	unAuthPreds map[string]struct{}) []*gql.GraphQuery {
+
 	filter := gqls[:0]
 	for _, gq := range gqls {
 		if gq.Func != nil && len(gq.Func.Attr) > 0 {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -481,7 +481,8 @@ func authorizePreds(userId string, groupIds, preds []string,
 }
 
 // authorizeAlter parses the Schema in the operation and authorizes the operation
-// using the aclCachePtr
+// using the aclCachePtr. It will return error if any one of the predicates specified in alter
+// are not authorized.
 func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	if len(worker.Config.HmacSecret) == 0 {
 		// the user has not turned on the acl feature
@@ -601,7 +602,8 @@ func isAclPredMutation(nquads []*api.NQuad) bool {
 	return false
 }
 
-// authorizeMutation authorizes the mutation using the aclCachePtr
+// authorizeMutation authorizes the mutation using the aclCachePtr. It will return permission
+// denied error if any one of the predicates in mutation(set or delete) is unauthorized.
 func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	if len(worker.Config.HmacSecret) == 0 {
 		// the user has not turned on the acl feature
@@ -700,7 +702,6 @@ func parsePredsFromQuery(gqls []*gql.GraphQuery) []string {
 
 func parsePredsFromFilter(f *gql.FilterTree) []string {
 	preds := make([]string, 0)
-
 	if f == nil {
 		return preds
 	}
@@ -731,7 +732,8 @@ func logAccess(log *accessEntry) {
 	glog.V(1).Infof(log.String())
 }
 
-//authorizeQuery authorizes the query using the aclCachePtr
+//authorizeQuery authorizes the query using the aclCachePtr. It will silently drop all
+// unauthorized predicates from query.
 func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	if len(worker.Config.HmacSecret) == 0 {
 		// the user has not turned on the acl feature

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -536,7 +536,8 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 		if len(blockedPreds) > 0 {
 			var msg strings.Builder
 			for key := range blockedPreds {
-				_, _ = msg.WriteString(key + " ")
+				x.Check2(msg.WriteString(key))
+				x.Check2(msg.WriteString(""))
 			}
 			return status.Errorf(codes.PermissionDenied,
 				"unauthorized to alter following predicates: %s\n", msg.String())
@@ -642,7 +643,8 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 		if len(blockedPreds) > 0 {
 			var msg strings.Builder
 			for key := range blockedPreds {
-				_, _ = msg.WriteString(key + " ")
+				x.Check2(msg.WriteString(key))
+				x.Check2(msg.WriteString(" "))
 			}
 			return status.Errorf(codes.PermissionDenied,
 				"unauthorized to mutate following predicates: %s\n", msg.String())
@@ -670,32 +672,25 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 func parsePredsFromQuery(gqls []*gql.GraphQuery) []string {
 	predsMap := make(map[string]struct{})
 	for _, gq := range gqls {
-
 		if gq.Func != nil {
 			predsMap[gq.Func.Attr] = struct{}{}
 		}
-
 		if len(gq.Attr) > 0 {
 			predsMap[gq.Attr] = struct{}{}
 		}
-
 		for _, ord := range gq.Order {
 			predsMap[ord.Attr] = struct{}{}
 		}
-
 		for _, spec := range gq.GroupbyAttrs {
 			predsMap[spec.Attr] = struct{}{}
 		}
-
 		for _, pred := range parsePredsFromFilter(gq.Filter) {
 			predsMap[pred] = struct{}{}
 		}
-
 		for _, childPred := range parsePredsFromQuery(gq.Children) {
 			predsMap[childPred] = struct{}{}
 		}
 	}
-
 	preds := make([]string, 0, len(predsMap))
 	for pred := range predsMap {
 		preds = append(preds, pred)
@@ -709,15 +704,12 @@ func parsePredsFromFilter(f *gql.FilterTree) []string {
 	if f == nil {
 		return preds
 	}
-
 	if f.Func != nil && len(f.Func.Attr) > 0 {
 		preds = append(preds, f.Func.Attr)
 	}
-
 	for _, ch := range f.Child {
 		preds = append(preds, parsePredsFromFilter(ch)...)
 	}
-
 	return preds
 }
 
@@ -830,7 +822,6 @@ func removePredsFromQuery(gqls []*gql.GraphQuery,
 				continue
 			}
 		}
-
 		if len(gq.Attr) > 0 {
 			if _, ok := blockedPreds[gq.Attr]; ok {
 				continue
@@ -842,7 +833,6 @@ func removePredsFromQuery(gqls []*gql.GraphQuery,
 				continue
 			}
 		}
-
 		gq.Filter = removeFilters(gq.Filter, blockedPreds)
 		gq.GroupbyAttrs = removeGroupBy(gq.GroupbyAttrs, blockedPreds)
 		gq.Children = removePredsFromQuery(gq.Children, blockedPreds)
@@ -856,7 +846,6 @@ func removeFilters(f *gql.FilterTree, blockedPreds map[string]struct{}) *gql.Fil
 	if f == nil {
 		return nil
 	}
-
 	if f.Func != nil && len(f.Func.Attr) > 0 {
 		if _, ok := blockedPreds[f.Func.Attr]; ok {
 			return nil
@@ -870,11 +859,9 @@ func removeFilters(f *gql.FilterTree, blockedPreds map[string]struct{}) *gql.Fil
 			filteredChildren = append(filteredChildren, child)
 		}
 	}
-
 	if len(filteredChildren) != len(f.Child) && (f.Op == "AND" || f.Op == "NOT") {
 		return nil
 	}
-
 	f.Child = filteredChildren
 	return f
 }
@@ -883,14 +870,11 @@ func removeGroupBy(groupAttrs []gql.GroupByAttr,
 	blockedPreds map[string]struct{}) []gql.GroupByAttr {
 
 	filteredAttrs := groupAttrs[:0]
-
 	for _, gAttr := range groupAttrs {
 		if _, ok := blockedPreds[gAttr.Attr]; ok {
 			continue
 		}
-
 		filteredAttrs = append(filteredAttrs, gAttr)
 	}
-
 	return filteredAttrs
 }

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -44,15 +44,15 @@ func TestCurlAuthorization(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-	// No ACL rules are specified, so everything should fail.
+	// No ACL rules are specified, so query should return empty response,
+	// alter and mutate should fail.
 	queryArgs := func(jwt string) []string {
 		return []string{"-H", fmt.Sprintf("X-Dgraph-AccessToken:%s", jwt),
 			"-H", "Content-Type: application/graphql+-",
 			"-d", query, curlQueryEndpoint}
 	}
 	testutil.VerifyCurlCmd(t, queryArgs(accessJwt), &testutil.CurlFailureConfig{
-		ShouldFail:   true,
-		DgraphErrMsg: "PermissionDenied",
+		ShouldFail: false,
 	})
 
 	mutateArgs := func(jwt string) []string {
@@ -116,11 +116,10 @@ func TestCurlAuthorization(t *testing.T) {
 		RefreshJwt: refreshJwt,
 	})
 	require.NoError(t, err, fmt.Sprintf("login through refresh token failed: %v", err))
-	// verify that with an ACL rule defined, all the operations should be denied when the acsess JWT
-	// does not have the required permissions
+	// verify that with an ACL rule defined, all the operations except query should
+	// does not have the required permissions be denied when the acsess JWT
 	testutil.VerifyCurlCmd(t, queryArgs(accessJwt), &testutil.CurlFailureConfig{
-		ShouldFail:   true,
-		DgraphErrMsg: "PermissionDenied",
+		ShouldFail: false,
 	})
 	testutil.VerifyCurlCmd(t, mutateArgs(accessJwt), &testutil.CurlFailureConfig{
 		ShouldFail:   true,

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -651,7 +651,7 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			}
 			`,
 			`{"me1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],"me2":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
-			`me1, me2 will have same resul, can't order by <age> since it is unauthorized`,
+			`me1, me2 will have same results, can't order by <age> since it is unauthorized`,
 			nil,
 		},
 		{

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -135,9 +135,9 @@ func testAuthorization(t *testing.T, dg *dgo.Dgraph) {
 		t.Fatalf("unable to login using the account %v", userid)
 	}
 
-	// initially the query, mutate and alter operations should all fail
-	// when there are no rules defined on the predicates
-	queryPredicateWithUserAccount(t, dg, true)
+	// initially the query should return empty result, mutate and alter
+	// operations should all fail when there are no rules defined on the predicates
+	queryPredicateWithUserAccount(t, dg, false)
 	mutatePredicateWithUserAccount(t, dg, true)
 	alterPredicateWithUserAccount(t, dg, true)
 	createGroupAndAcls(t, unusedGroup, false)
@@ -145,8 +145,9 @@ func testAuthorization(t *testing.T, dg *dgo.Dgraph) {
 	glog.Infof("Sleeping for 6 seconds for acl caches to be refreshed")
 	time.Sleep(6 * time.Second)
 
-	// now all these operations should fail since there are rules defined on the unusedGroup
-	queryPredicateWithUserAccount(t, dg, true)
+	// now all these operations except query should fail since
+	// there are rules defined on the unusedGroup
+	queryPredicateWithUserAccount(t, dg, false)
 	mutatePredicateWithUserAccount(t, dg, true)
 	alterPredicateWithUserAccount(t, dg, true)
 	// create the dev group and add the user to it
@@ -219,7 +220,6 @@ func queryPredicateWithUserAccount(t *testing.T, dg *dgo.Dgraph, shouldFail bool
 	ctx := context.Background()
 	txn := dg.NewTxn()
 	_, err := txn.Query(ctx, query)
-
 	if shouldFail {
 		require.Error(t, err, "the query should have failed")
 	} else {
@@ -380,8 +380,9 @@ func TestPredicatePermission(t *testing.T) {
 	// Schema query is allowed to all logged in users.
 	querySchemaWithUserAccount(t, dg, false)
 
-	// The operations should be blocked when no rule is defined.
-	queryPredicateWithUserAccount(t, dg, true)
+	// The query should return emptry response, alter and mutation
+	// should be blocked when no rule is defined.
+	queryPredicateWithUserAccount(t, dg, false)
 	mutatePredicateWithUserAccount(t, dg, true)
 	alterPredicateWithUserAccount(t, dg, true)
 	createGroupAndAcls(t, unusedGroup, false)
@@ -389,9 +390,9 @@ func TestPredicatePermission(t *testing.T) {
 	// Wait for 6 seconds to ensure the new acl have reached all acl caches.
 	glog.Infof("Sleeping for 6 seconds for acl caches to be refreshed")
 	time.Sleep(6 * time.Second)
-	// The operations should all fail when there is a rule defined, but the current user
-	// is not allowed.
-	queryPredicateWithUserAccount(t, dg, true)
+	// The operations except query should fail when there is a rule defined, but the
+	// current user is not allowed.
+	queryPredicateWithUserAccount(t, dg, false)
 	mutatePredicateWithUserAccount(t, dg, true)
 	alterPredicateWithUserAccount(t, dg, true)
 	// Schema queries should still succeed since they are not tied to specific predicates.

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -459,6 +459,10 @@ func regExpVariableFilter(f *Function, idx int) error {
 }
 
 func substituteVariablesFilter(f *FilterTree, vmap varMap) error {
+	if f == nil {
+		return nil
+	}
+
 	if f.Func != nil {
 		if err := substituteVar(f.Func.Attr, &f.Func.Attr, vmap); err != nil {
 			return err

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -297,7 +297,7 @@ func verifyOutput(t *testing.T, bytes []byte, failureConfig *CurlFailureConfig) 
 					failureConfig.DgraphErrMsg, errorEntry.Message))
 		}
 	} else {
-		require.True(t, len(output.Data) > 0,
+		require.True(t, output.Data != nil,
 			fmt.Sprintf("no data entry found in the output:%+v", output))
 	}
 }


### PR DESCRIPTION
All unauthorized predicates will be silently dropped from `query` and `mutation` without warning/error.
Unchanged behaviors:
 - `mutation` of ACL predicates is still not allowed.
 - `alter` will still give `permission denied` error if user doesn't have alter permission on any one of the predicate
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4479)
<!-- Reviewable:end -->
