### PR TITLE
Add jaegerCollector helm chart option.

### DIFF
--- a/contrib/config/kubernetes/helm/Chart.yaml
+++ b/contrib/config/kubernetes/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dgraph
-version: 0.0.2
+version: 0.0.3
 appVersion: latest
 description: Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions, consistent replication and linearizable reads.
 keywords:

--- a/contrib/config/kubernetes/helm/README.md
+++ b/contrib/config/kubernetes/helm/README.md
@@ -94,3 +94,4 @@ The following table lists the configurable parameters of the dgraph chart and th
 | `ratel.securityContext.runAsUser`    | User ID for the ratel container                                     | `1001`                                              |
 | `ratel.livenessProbe`                | Ratel liveness probes                                               | `See values.yaml for defaults`                      |
 | `ratel.readinessProbe`               | Ratel readiness probes                                              | `See values.yaml for defaults`                      |
+| `jaegerCollector`                    | Address to set for `--jaeger.collector` flag for Zero and Alpha     | `""`                                                |

--- a/contrib/config/kubernetes/helm/templates/alpha-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/alpha-statefulset.yaml
@@ -100,7 +100,7 @@ spec:
          - "-c"
          - |
             set -ex
-            dgraph alpha --my=$(hostname -f):7080 --lru_mb {{ .Values.alpha.lru_mb }} --zero {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080
+            dgraph alpha --my=$(hostname -f):7080 --lru_mb {{ .Values.alpha.lru_mb }} --zero {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080{{- if .Values.jaegerCollector }} --jaeger.collector={{ .Values.jaegerCollector | quote }}{{- end }}
         resources:
 {{ toYaml .Values.alpha.resources | indent 10 }}
         {{- if .Values.alpha.livenessProbe.enabled }}

--- a/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
+++ b/contrib/config/kubernetes/helm/templates/zero-statefulset.yaml
@@ -102,9 +102,9 @@ spec:
              ordinal=${BASH_REMATCH[1]}
              idx=$(($ordinal + 1))
              if [[ $ordinal -eq 0 ]]; then
-               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}{{- if .Values.jaegerCollector }} --jaeger.collector={{ .Values.jaegerCollector | quote }}{{- end }}
              else
-               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}
+               exec dgraph zero --my=$(hostname -f):5080 --peer {{ template "dgraph.zero.fullname" . }}-0.{{ template "dgraph.zero.fullname" . }}-headless.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas {{ .Values.zero.shardReplicaCount }}{{- if .Values.jaegerCollector }} --jaeger.collector={{ .Values.jaegerCollector | quote }}{{- end }}
              fi 
         resources:
 {{ toYaml .Values.zero.resources | indent 10 }}

--- a/contrib/config/kubernetes/helm/values.yaml
+++ b/contrib/config/kubernetes/helm/values.yaml
@@ -285,3 +285,8 @@ ratel:
     timeoutSeconds: 5
     failureThreshold: 6
     successThreshold: 1
+
+# Configure trace collection to a Jaeger collector for Dgraph Zero and Dgraph Alpha.
+##
+# jaegerCollector: ""
+


### PR DESCRIPTION
Add a Helm chart option called `jaegerCollector` to set the Jaeger collector address for distributed tracing collection. This sets the `--jaeger.collector` flag for both Dgraph Zero and Dgraph Alpha instances.

* Update Helm chart README
* Update Dgraph Zero StatefulSet
* Update Dgraph Alpha StatefulSet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4489)
<!-- Reviewable:end -->
