### PR TITLE
contrib: Update jepsen test runner tool.

### DIFF
--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -50,6 +50,7 @@ type jepsenTest struct {
 	timeLimit         int
 	concurrency       string
 	rebalanceInterval string
+	nemesisInterval   string
 	localBinary       string
 	nodes             string
 	skew              string
@@ -110,6 +111,8 @@ var (
 		"Number of concurrent workers per test. \"6n\" means 6 workers per node.")
 	rebalanceInterval = pflag.String("rebalance-interval", "10h",
 		"Interval of Dgraph's tablet rebalancing.")
+	nemesisInterval = pflag.String("nemesis-interval", "10",
+		"Roughly how long to wait (in seconds) between nemesis operations.")
 	localBinary = pflag.StringP("local-binary", "b", "/gobin/dgraph",
 		"Path to Dgraph binary within the Jepsen control node.")
 	nodes     = pflag.String("nodes", "n1,n2,n3,n4,n5", "Nodes to run on.")
@@ -224,6 +227,7 @@ func runJepsenTest(test *jepsenTest) int {
 		"--time-limit", strconv.Itoa(test.timeLimit),
 		"--concurrency", test.concurrency,
 		"--rebalance-interval", test.rebalanceInterval,
+		"--nemesis-interval", test.nemesisInterval,
 		"--local-binary", test.localBinary,
 		"--nodes", test.nodes,
 		"--test-count", strconv.Itoa(test.testCount),
@@ -340,6 +344,9 @@ func main() {
 		log.Fatal("skew-clock nemesis specified but --jepsen.skew wasn't set.")
 	}
 
+	if *doDown {
+		jepsenDown()
+	}
 	if *doUp {
 		jepsenUp()
 	}
@@ -366,6 +373,7 @@ func main() {
 				timeLimit:         *timeLimit,
 				concurrency:       *concurrency,
 				rebalanceInterval: *rebalanceInterval,
+				nemesisInterval:   *nemesisInterval,
 				localBinary:       *localBinary,
 				nodes:             *nodes,
 				skew:              *skew,
@@ -373,9 +381,5 @@ func main() {
 			})
 			tcEnd(status)
 		}
-	}
-
-	if *doDown {
-		jepsenDown()
 	}
 }


### PR DESCRIPTION
* If `--down` flag is present, tear down Jepsen before the test runs (not after).
* Add `--nemesis-interval` flag to set the interval between nemesis operations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4495)
<!-- Reviewable:end -->
