### PR TITLE
Do not use type keys during tablet size calculation.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1023,6 +1023,12 @@ func (n *node) rollupLists(readTs uint64) error {
 			return
 		}
 		pk, err := x.Parse(key)
+
+		// Type keys should not count for tablet size calculations.
+		if pk.IsType() {
+			return
+		}
+
 		if err != nil {
 			glog.Errorf("Error while parsing key %s: %v", hex.Dump(key), err)
 			return


### PR DESCRIPTION
Currently, the keys used for storing types are used during the tablet
size calculation. This leads to an Alpha instructing Zero to delete the
tablet for this predicate. This is incorrect since type and predicate
names are not equivalent and types do not have an corresponding tablet.

The bug is mostly harmless but it could lead to issues if a type has the
same name as a predicate.

Fixes #4473

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4517)
<!-- Reviewable:end -->
