### PR TITLE
Use x.Check2 instead of discarding the error messages.

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgryski/go-groupvarint"
 )
 
@@ -68,7 +69,7 @@ func (e *Encoder) packBlock() {
 		}
 
 		data := groupvarint.Encode4(buf, tmpUids)
-		_, _ = out.Write(data)
+		x.Check2(out.Write(data))
 
 		// e.uids has ended and we have padded tmpUids with 0s
 		if len(e.uids) <= 4 {

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -455,9 +455,9 @@ func main() {
 	}
 	doc += fmt.Sprintf("%s", yml)
 	if opts.OutFile == "-" {
-		_, _ = fmt.Printf("%s", doc)
+		x.Check2(fmt.Printf("%s", doc))
 	} else {
-		_, _ = fmt.Fprintf(os.Stderr, "Writing file: %s\n", opts.OutFile)
+		x.Check2(fmt.Fprintf(os.Stderr, "Writing file: %s\n", opts.OutFile))
 		err = ioutil.WriteFile(opts.OutFile, []byte(doc), 0644)
 		if err != nil {
 			fatal(errors.Errorf("unable to write file: %v", err))

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -265,17 +265,17 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 
 	var out bytes.Buffer
 	writeEntry := func(key string, js []byte) {
-		_, _ = out.WriteRune('"')
-		_, _ = out.WriteString(key)
-		_, _ = out.WriteRune('"')
-		_, _ = out.WriteRune(':')
-		_, _ = out.Write(js)
+		x.Check2(out.WriteRune('"'))
+		x.Check2(out.WriteString(key))
+		x.Check2(out.WriteRune('"'))
+		x.Check2(out.WriteRune(':'))
+		x.Check2(out.Write(js))
 	}
-	_, _ = out.WriteRune('{')
+	x.Check2(out.WriteRune('{'))
 	writeEntry("data", resp.Json)
-	_, _ = out.WriteRune(',')
+	x.Check2(out.WriteRune(','))
 	writeEntry("extensions", js)
-	_, _ = out.WriteRune('}')
+	x.Check2(out.WriteRune('}'))
 
 	if _, err := writeResponse(w, r, out.Bytes()); err != nil {
 		// If client crashes before server could write response, writeResponse will error out,

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -249,7 +249,7 @@ func (m *mapper) lookupUid(xid string) uint64 {
 	// Also, checked that sb goes on the stack whereas sb.String() goes on
 	// heap. Note that the calls to the strings.Builder.* are inlined.
 	sb := strings.Builder{}
-	_, _ = sb.WriteString(xid)
+	x.Check2(sb.WriteString(xid))
 	uid, isNew := m.xids.AssignUid(sb.String())
 	if !m.opt.StoreXids || !isNew {
 		return uid

--- a/worker/export.go
+++ b/worker/export.go
@@ -278,35 +278,35 @@ func (e *exporter) toRDF() (*bpb.KVList, error) {
 func toSchema(attr string, update *pb.SchemaUpdate) (*bpb.KVList, error) {
 	// bytes.Buffer never returns error for any of the writes. So, we don't need to check them.
 	var buf bytes.Buffer
-	_, _ = buf.WriteRune('<')
-	_, _ = buf.WriteString(attr)
-	_, _ = buf.WriteRune('>')
-	_, _ = buf.WriteRune(':')
+	x.Check2(buf.WriteRune('<'))
+	x.Check2(buf.WriteString(attr))
+	x.Check2(buf.WriteRune('>'))
+	x.Check2(buf.WriteRune(':'))
 	if update.GetList() {
-		_, _ = buf.WriteRune('[')
+		x.Check2(buf.WriteRune('['))
 	}
-	_, _ = buf.WriteString(types.TypeID(update.GetValueType()).Name())
+	x.Check2(buf.WriteString(types.TypeID(update.GetValueType()).Name()))
 	if update.GetList() {
-		_, _ = buf.WriteRune(']')
+		x.Check2(buf.WriteRune(']'))
 	}
 	switch {
 	case update.GetDirective() == pb.SchemaUpdate_REVERSE:
-		_, _ = buf.WriteString(" @reverse")
+		x.Check2(buf.WriteString(" @reverse"))
 	case update.GetDirective() == pb.SchemaUpdate_INDEX && len(update.GetTokenizer()) > 0:
-		_, _ = buf.WriteString(" @index(")
-		_, _ = buf.WriteString(strings.Join(update.GetTokenizer(), ","))
-		_, _ = buf.WriteRune(')')
+		x.Check2(buf.WriteString(" @index("))
+		x.Check2(buf.WriteString(strings.Join(update.GetTokenizer(), ",")))
+		x.Check2(buf.WriteRune(')'))
 	}
 	if update.GetCount() {
-		_, _ = buf.WriteString(" @count")
+		x.Check2(buf.WriteString(" @count"))
 	}
 	if update.GetLang() {
-		_, _ = buf.WriteString(" @lang")
+		x.Check2(buf.WriteString(" @lang"))
 	}
 	if update.GetUpsert() {
-		_, _ = buf.WriteString(" @upsert")
+		x.Check2(buf.WriteString(" @upsert"))
 	}
-	_, _ = buf.WriteString(" . \n")
+	x.Check2(buf.WriteString(" . \n"))
 	kv := &bpb.KV{
 		Value:   buf.Bytes(),
 		Version: 2, // Schema value
@@ -316,12 +316,12 @@ func toSchema(attr string, update *pb.SchemaUpdate) (*bpb.KVList, error) {
 
 func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 	var buf bytes.Buffer
-	_, _ = buf.WriteString(fmt.Sprintf("type %s {\n", attr))
+	x.Check2(buf.WriteString(fmt.Sprintf("type %s {\n", attr)))
 	for _, field := range update.Fields {
-		_, _ = buf.WriteString(fieldToString(field))
+		x.Check2(buf.WriteString(fieldToString(field)))
 	}
 
-	_, _ = buf.WriteString("}\n")
+	x.Check2(buf.WriteString("}\n"))
 
 	kv := &bpb.KV{
 		Value:   buf.Bytes(),
@@ -332,9 +332,9 @@ func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 
 func fieldToString(update *pb.SchemaUpdate) string {
 	var builder strings.Builder
-	_, _ = builder.WriteString("\t")
-	_, _ = builder.WriteString(update.Predicate)
-	_, _ = builder.WriteString("\n")
+	x.Check2(builder.WriteString("\t"))
+	x.Check2(builder.WriteString(update.Predicate))
+	x.Check2(builder.WriteString("\n"))
 	return builder.String()
 }
 


### PR DESCRIPTION
When writing to newly created buffer or string builder, it's very
unlikely that Dgraph will see an error so it's safe to use x.Check2
instead of discarding the error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4523)
<!-- Reviewable:end -->
