### PR TITLE
Reduce memory usage of bulkloader

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -176,8 +176,8 @@ func newMapIterator(mePool chan *pb.MapEntry, filename string) *mapIterator {
 	return &mapIterator{mePool: mePool, fd: fd, reader: bufio.NewReaderSize(gzReader, 16<<10)}
 }
 
-func (r *reducer) encodeAndWrite(
-	writer *badger.StreamWriter, entryCh chan []*pb.MapEntry, recycleCh chan []*pb.MapEntry, closer *y.Closer) {
+func (r *reducer) encodeAndWrite(writer *badger.StreamWriter, entryCh chan []*pb.MapEntry,
+	recycleCh chan []*pb.MapEntry, closer *y.Closer) {
 	defer closer.Done()
 
 	var listSize int
@@ -240,7 +240,7 @@ func (r *reducer) encodeAndWrite(
 		}
 	}
 	kvb.finish = true
-	listSize += r.toList(nil, list, kvb)
+	r.toList(nil, list, kvb)
 	if len(list.Kv) > 0 {
 		for _, kv := range list.Kv {
 			setStreamId(kv)

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -67,8 +67,8 @@ func (r *reducer) run() error {
 		go func(shardId int, db *badger.DB) {
 			defer thr.Done(nil)
 
-			//Use a chan as mapEntries pool for mapIterator to read mapoutput. Fixed size is ok because mapEntries will
-			// be reused. Not use sync.Pool because it's slower.
+			//Use a chan as mapEntries pool for mapIterator to read mapoutput. Fixed size is ok,
+			// because mapEntries will be reused. Not use sync.Pool because it's slower.
 			const poolSize = 2e6
 			mePool := make(chan *pb.MapEntry, poolSize)
 			for i := 0; i < poolSize; i++ {


### PR DESCRIPTION
I used bulkloader to initial my cluster, but It was killed due to OOM. The dataset only has one predicate: dgraph.type, so I set reducer to 1, but the reduce stage still occupied 100G memory.
I located the problem at the reduce.go source file: all mapEntries with the same key must in one batch to produce postinglist. And in my dataset,  postinglists can be very large. That leads to a long time to produce a batch and a very large batch size. So I make a little change to improve bulkloader.
The idea is that use a struct named kvBuilder to store inbuilding kv, So a batch doesn't have to include all all mapEntries with the same key, therefore saves memory from holding massive duplicate keys. This small change brings two benefits: first, process won't be block by a large batch, therefore speeds up bulkloader; second, memory usage will be reduced.
By this method, memory usage of the reduce stage cut down to 7G, and achieved 1.33x speedup.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4529)
<!-- Reviewable:end -->
