### PR TITLE
Invoke "go tool pprof" instead of "pprof".

### DIFF
--- a/posting/size_test.go
+++ b/posting/size_test.go
@@ -179,7 +179,7 @@ func Test21MillionDataSetSize(t *testing.T) {
 	require.NoError(t, err)
 	calculatedSize := binary.BigEndian.Uint32(buf)
 	var pprofSize uint32
-	cmd := exec.Command("pprof", "-list", "PopulateList", "mem.out")
+	cmd := exec.Command("go", "tool", "pprof", "-list", "PopulateList", "mem.out")
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This change should eliminate the flakiness in this test in TeamCity
since not all agents have pprof installed directly but pprof can be
accessed via "go tool pprof".

Fixes #4536 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4536)
<!-- Reviewable:end -->
