### PR TITLE
Fix Levenshtein distance calculation with match function.

### DIFF
--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -597,7 +597,7 @@ func FuzzyMatch(t *testing.T, c *dgo.Dgraph) {
 		in, out, failure string
 	}{
 		{
-			in:  `{q(func:match(term, drive, 8)) {term}}`,
+			in:  `{q(func:match(term, drive, 0)) {term}}`,
 			out: `{"q":[{"term":"drive"}]}`,
 		},
 		{
@@ -658,12 +658,19 @@ func FuzzyMatch(t *testing.T, c *dgo.Dgraph) {
 		{
 			in: `{q(func:match(term, "carigeway", 8)) {term}}`,
 			out: `{"q":[
-        {"term": "dual carriageway"}
+        {"term": "highway"},
+        {"term": "motorway"},
+        {"term": "dual carriageway"},
+        {"term": "pathway"},
+        {"term": "parkway"}
       ]}`,
 		},
 		{
-			in:  `{q(func:match(term, "carigeway", 4)) {term}}`,
-			out: `{"q":[]}`,
+			in: `{q(func:match(term, "carigeway", 4)) {term}}`,
+			out: `{"q":[
+        {"term": "highway"},
+        {"term": "parkway"}
+      ]}`,
 		},
 		{
 			in: `{q(func:match(term, "dualway", 8)) {term}}`,

--- a/worker/match.go
+++ b/worker/match.go
@@ -32,7 +32,7 @@ import (
 // This implemention is optimized to use O(min(m,n)) space and is based on the
 // optimized C version found here:
 // http://en.wikibooks.org/wiki/Algorithm_implementation/Strings/Levenshtein_distance#C
-func levenshteinDistance(s, t string, max int) int {
+func levenshteinDistance(s, t string) int {
 	if len(s) > len(t) {
 		s, t = t, s
 	}
@@ -43,7 +43,6 @@ func levenshteinDistance(s, t string, max int) int {
 		column[y] = y
 	}
 
-	var minIdx int
 	for x := 1; x <= len(r2); x++ {
 		column[0] = x
 
@@ -75,7 +74,7 @@ func matchFuzzy(query, val string, max int) bool {
 	if val == "" {
 		return false
 	}
-	return levenshteinDistance(val, query, max) <= max
+	return levenshteinDistance(val, query) <= max
 }
 
 // uidsForMatch collects a list of uids that "might" match a fuzzy term based on the ngram

--- a/worker/match.go
+++ b/worker/match.go
@@ -56,12 +56,6 @@ func levenshteinDistance(s, t string, max int) int {
 			column[y] = min(column[y]+1, column[y-1]+1, lastDiag+cost)
 			lastDiag = oldDiag
 		}
-		if minIdx < len(r1) && column[minIdx] > column[minIdx+1] {
-			minIdx++
-		}
-		if column[minIdx] > max {
-			return column[minIdx]
-		}
 	}
 	return column[len(r1)]
 }

--- a/worker/match_test.go
+++ b/worker/match_test.go
@@ -7,13 +7,15 @@ import (
 )
 
 func TestDistance(t *testing.T) {
-	require.Equal(t, 0, levenshteinDistance("detour", "detour", 2))
-	require.Equal(t, 1, levenshteinDistance("detour", "det.our", 2))
-	require.Equal(t, 2, levenshteinDistance("detour", "det..our", 2))
-	require.Equal(t, 4, levenshteinDistance("detour", "..det..our", 2))
-	require.Equal(t, 2, levenshteinDistance("detour", "detour..", 2))
-	require.Equal(t, 3, levenshteinDistance("detour", "detour...", 2))
-	require.Equal(t, 3, levenshteinDistance("detour", "...detour", 2))
-	require.Equal(t, 3, levenshteinDistance("detour", "..detour.", 2))
-	require.Equal(t, 1, levenshteinDistance("detour", "detoar", 2))
+	require.Equal(t, 0, levenshteinDistance("detour", "detour"))
+	require.Equal(t, 1, levenshteinDistance("detour", "det.our"))
+	require.Equal(t, 2, levenshteinDistance("detour", "det..our"))
+	require.Equal(t, 4, levenshteinDistance("detour", "..det..our"))
+	require.Equal(t, 2, levenshteinDistance("detour", "detour.."))
+	require.Equal(t, 3, levenshteinDistance("detour", "detour..."))
+	require.Equal(t, 3, levenshteinDistance("detour", "...detour"))
+	require.Equal(t, 3, levenshteinDistance("detour", "..detour."))
+	require.Equal(t, 1, levenshteinDistance("detour", "detoar"))
+	require.Equal(t, 6, levenshteinDistance("detour", "DETOUR"))
+
 }

--- a/worker/match_test.go
+++ b/worker/match_test.go
@@ -17,5 +17,6 @@ func TestDistance(t *testing.T) {
 	require.Equal(t, 3, levenshteinDistance("detour", "..detour."))
 	require.Equal(t, 1, levenshteinDistance("detour", "detoar"))
 	require.Equal(t, 6, levenshteinDistance("detour", "DETOUR"))
+	require.Equal(t, 6, levenshteinDistance("detour", "DETOUR"))
 
 }

--- a/worker/match_test.go
+++ b/worker/match_test.go
@@ -10,9 +10,10 @@ func TestDistance(t *testing.T) {
 	require.Equal(t, 0, levenshteinDistance("detour", "detour", 2))
 	require.Equal(t, 1, levenshteinDistance("detour", "det.our", 2))
 	require.Equal(t, 2, levenshteinDistance("detour", "det..our", 2))
-	require.Equal(t, 3, levenshteinDistance("detour", "..det..our", 2))
+	require.Equal(t, 4, levenshteinDistance("detour", "..det..our", 2))
 	require.Equal(t, 2, levenshteinDistance("detour", "detour..", 2))
 	require.Equal(t, 3, levenshteinDistance("detour", "detour...", 2))
 	require.Equal(t, 3, levenshteinDistance("detour", "...detour", 2))
 	require.Equal(t, 3, levenshteinDistance("detour", "..detour.", 2))
+	require.Equal(t, 1, levenshteinDistance("detour", "detoar", 2))
 }

--- a/worker/match_test.go
+++ b/worker/match_test.go
@@ -17,6 +17,4 @@ func TestDistance(t *testing.T) {
 	require.Equal(t, 3, levenshteinDistance("detour", "..detour."))
 	require.Equal(t, 1, levenshteinDistance("detour", "detoar"))
 	require.Equal(t, 6, levenshteinDistance("detour", "DETOUR"))
-	require.Equal(t, 6, levenshteinDistance("detour", "DETOUR"))
-
 }


### PR DESCRIPTION
Fixes #4494.

We try to be smart about calculating the Levenshtein distance by short-circuiting the calculation based on the `max`-allowed distance, but that ends up returning incorrect distances.

* Remove `max` argument
* Fix and update tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4545)
<!-- Reviewable:end -->
