### PR TITLE
Removed tracing and compression from raft badger

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -677,10 +677,12 @@ func (n *node) Run() {
 			n.SaveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
 			timer.Record("disk")
 			if rd.MustSync {
-				if err := n.Store.Sync(); err != nil {
-					glog.Errorf("Error while calling Store.Sync: %v", err)
-				}
-				timer.Record("sync")
+				go func() {
+					if err := n.Store.Sync(); err != nil {
+						glog.Errorf("Error while calling Store.Sync: %v", err)
+					}
+					timer.Record("sync")
+				}()
 			}
 			span.Annotatef(nil, "Saved to storage")
 

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -205,6 +205,8 @@ func run() {
 	x.Checkf(os.MkdirAll(opts.w, 0700), "Error while creating WAL dir.")
 	kvOpt := badger.LSMOnlyOptions(opts.w).WithSyncWrites(false).WithTruncate(true).
 		WithValueLogFileSize(64 << 20).WithMaxCacheSize(10 << 20)
+	kvOpt.Compression = 0
+	kvOpt.EventLogging = false
 	kv, err := badger.Open(kvOpt)
 	x.Checkf(err, "Error while opening WAL store")
 	defer kv.Close()

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -892,10 +892,12 @@ func (n *node) Run() {
 			n.SaveToStorage(rd.HardState, rd.Entries, rd.Snapshot)
 			timer.Record("disk")
 			if rd.MustSync {
-				if err := n.Store.Sync(); err != nil {
-					glog.Errorf("Error while calling Store.Sync: %+v", err)
-				}
-				timer.Record("sync")
+				go func() {
+					if err := n.Store.Sync(); err != nil {
+						glog.Errorf("Error while calling Store.Sync: %+v", err)
+					}
+					timer.Record("sync")
+				}()
 			}
 			if span != nil {
 				span.Annotatef(nil, "Saved %d entries. Snapshot, HardState empty? (%v, %v)",

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -157,6 +157,8 @@ func (s *ServerState) initStorage() {
 		opt.EncryptionKey = nil
 		glog.Infof("Opening write-ahead log BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
+		opt.EventLogging = false
+		opt.Compression = 0
 
 		s.WALstore, err = badger.Open(opt)
 		x.Checkf(err, "Error while creating badger KV WAL store")


### PR DESCRIPTION
We parallelized the raftwal must sync op. From benchmarks, we can see that it takes 1/5th of the time per proposal now. We have also removed tracing and compression from raftwal, which also helps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4553)
<!-- Reviewable:end -->
