### PR TITLE
Change the name of the ID field in TFilter input to actual field name

### DIFF
--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -149,7 +149,7 @@ func deepMutationErrors(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			updateCountryParams := &GraphQLParams{
 				Query: `mutation updateCountry($id: ID!, $set: PatchCountry!) {
-					updateCountry(input: {filter: {ids: [$id]}, set: $set}) {
+					updateCountry(input: {filter: {id: [$id]}, set: $set}) {
 						country { id }
 					}
 				}`,

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -324,7 +324,7 @@ func deepMutationsTest(t *testing.T, executeRequest requestExecutor) {
 		Query: `mutation updateAuthor($id: ID!, $set: PatchAuthor!, $remove: PatchAuthor!) {
 			updateAuthor(
 				input: {
-					filter: {ids: [$id]},
+					filter: {id: [$id]},
 					set: $set,
 					remove: $remove
 				}
@@ -518,7 +518,7 @@ func deepXIDTest(t *testing.T, executeRequest requestExecutor) {
 
 			updateCountry(
 				input: {
-					filter: {ids: [$id]},
+					filter: {id: [$id]},
 					set: $set,
 					remove: $remove
 				}
@@ -700,7 +700,7 @@ func updateMutationByIds(t *testing.T) {
 
 	t.Run("update Country", func(t *testing.T) {
 		filter := map[string]interface{}{
-			"ids": []string{newCountry.ID, anotherCountry.ID},
+			"id": []string{newCountry.ID, anotherCountry.ID},
 		}
 		newName := "updated name"
 		updateCountry(t, filter, newName, true)
@@ -771,7 +771,7 @@ func updateDelete(t *testing.T) {
 	newPost := addPost(t, newAuthor.ID, newCountry.ID, postExecutor)
 
 	filter := map[string]interface{}{
-		"ids": []string{newPost.PostID},
+		"postID": []string{newPost.PostID},
 	}
 	delPatch := map[string]interface{}{
 		"text":        "This post is just a test.",
@@ -874,11 +874,11 @@ func filterInUpdate(t *testing.T) {
 					"eq": "Testland",
 				},
 				"and": map[string]interface{}{
-					"ids": []string{countries[0].ID, countries[1].ID},
+					"id": []string{countries[0].ID, countries[1].ID},
 				},
 			},
 			FilterCountries: map[string]interface{}{
-				"ids": []string{countries[1].ID},
+				"id": []string{countries[1].ID},
 			},
 			Expected:  1,
 			Countries: []*country{&countries[0], &countries[1]},
@@ -886,10 +886,10 @@ func filterInUpdate(t *testing.T) {
 
 		"ID Filter": {
 			Filter: map[string]interface{}{
-				"ids": []string{countries[2].ID},
+				"id": []string{countries[2].ID},
 			},
 			FilterCountries: map[string]interface{}{
-				"ids": []string{countries[2].ID, countries[3].ID},
+				"id": []string{countries[2].ID, countries[3].ID},
 			},
 			Expected:  1,
 			Countries: []*country{&countries[2], &countries[3]},
@@ -945,7 +945,7 @@ func deleteMutationWithMultipleIds(t *testing.T) {
 	anotherCountry := addCountry(t, postExecutor)
 	t.Run("delete Country", func(t *testing.T) {
 		deleteCountryExpected := `{"deleteCountry" : { "msg": "Deleted" } }`
-		filter := map[string]interface{}{"ids": []string{country.ID, anotherCountry.ID}}
+		filter := map[string]interface{}{"id": []string{country.ID, anotherCountry.ID}}
 		deleteCountry(t, filter, deleteCountryExpected, nil)
 	})
 
@@ -960,7 +960,7 @@ func deleteMutationWithSingleID(t *testing.T) {
 	anotherCountry := addCountry(t, postExecutor)
 	t.Run("delete Country", func(t *testing.T) {
 		deleteCountryExpected := `{"deleteCountry" : { "msg": "Deleted" } }`
-		filter := map[string]interface{}{"ids": []string{newCountry.ID}}
+		filter := map[string]interface{}{"id": []string{newCountry.ID}}
 		deleteCountry(t, filter, deleteCountryExpected, nil)
 	})
 
@@ -977,7 +977,7 @@ func deleteMutationByName(t *testing.T) {
 	anotherCountry := addCountry(t, postExecutor)
 	anotherCountry.Name = "New country"
 	filter := map[string]interface{}{
-		"ids": []string{anotherCountry.ID},
+		"id": []string{anotherCountry.ID},
 	}
 	updateCountry(t, filter, anotherCountry.Name, true)
 
@@ -1032,7 +1032,7 @@ func deleteAuthor(
 		}`,
 		Variables: map[string]interface{}{
 			"filter": map[string]interface{}{
-				"ids": []string{authorID},
+				"id": []string{authorID},
 			},
 		},
 	}
@@ -1057,7 +1057,7 @@ func deletePost(
 			deletePost(filter: $filter) { msg }
 		}`,
 		Variables: map[string]interface{}{"filter": map[string]interface{}{
-			"ids": []string{postID},
+			"postID": []string{postID},
 		}},
 	}
 
@@ -1086,7 +1086,7 @@ func deleteWrongID(t *testing.T) {
 		&x.GqlError{Message: `input: couldn't complete deleteCountry because ` +
 			fmt.Sprintf(`input: Node with id %s is not of type Country`, newAuthor.ID)}}
 
-	filter := map[string]interface{}{"ids": []string{newAuthor.ID}}
+	filter := map[string]interface{}{"id": []string{newAuthor.ID}}
 	deleteCountry(t, filter, expectedData, expectedErrors)
 
 	cleanUp(t, []*country{newCountry}, []*author{newAuthor}, []*post{})
@@ -1114,7 +1114,7 @@ func manyMutations(t *testing.T) {
 		}`,
 		Variables: map[string]interface{}{
 			"name1": "Testland1", "filter": map[string]interface{}{
-				"ids": []string{newCountry.ID}}, "name2": "Testland2"},
+				"id": []string{newCountry.ID}}, "name2": "Testland2"},
 	}
 	multiMutationExpected := `{
 		"add1": { "country": { "id": "_UID_", "name": "Testland1" } },
@@ -1337,7 +1337,7 @@ func cleanUp(t *testing.T, countries []*country, authors []*author, posts []*pos
 		}
 
 		for _, country := range countries {
-			filter := map[string]interface{}{"ids": []string{country.ID}}
+			filter := map[string]interface{}{"id": []string{country.ID}}
 			deleteCountry(t, filter, `{"deleteCountry" : { "msg": "Deleted" } }`, nil)
 		}
 	})
@@ -1477,7 +1477,7 @@ func updateCharacter(t *testing.T, id string) {
 		}`,
 		Variables: map[string]interface{}{"character": map[string]interface{}{
 			"filter": map[string]interface{}{
-				"ids": []string{id},
+				"id": []string{id},
 			},
 			"set": map[string]interface{}{
 				"name": "Han Solo",
@@ -1672,13 +1672,13 @@ func cleanupStarwars(t *testing.T, starshipID, humanID, droidID string) {
 	}`,
 		Variables: map[string]interface{}{
 			"starshipFilter": map[string]interface{}{
-				"ids": []string{starshipID},
+				"id": []string{starshipID},
 			},
 			"humanFilter": map[string]interface{}{
-				"ids": []string{humanID},
+				"id": []string{humanID},
 			},
 			"droidFilter": map[string]interface{}{
-				"ids": []string{droidID},
+				"id": []string{droidID},
 			},
 		},
 	}

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -405,7 +405,7 @@ func queryOrderAtRoot(t *testing.T) {
 	}
 
 	filter := map[string]interface{}{
-		"ids": []string{answers[0].PostID, answers[1].PostID},
+		"postID": []string{answers[0].PostID, answers[1].PostID},
 	}
 
 	orderLikesDesc := map[string]interface{}{
@@ -946,7 +946,7 @@ func queryByMultipleIds(t *testing.T) {
 			}
 		}`,
 		Variables: map[string]interface{}{"filter": map[string]interface{}{
-			"ids": ids,
+			"postID": ids,
 		}},
 	}
 
@@ -1220,7 +1220,7 @@ func queryByMultipleInvalidIds(t *testing.T) {
 			}
 		}`,
 		Variables: map[string]interface{}{"filter": map[string]interface{}{
-			"ids": []string{"foo", "bar"},
+			"postID": []string{"foo", "bar"},
 		}},
 	}
 	// Since the ids are invalid and can't be converted to uint64, the query sent to Dgraph should

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -122,7 +122,7 @@
     }
   explanation: "A reference must be a valid UID"
   error:
-    { "message": 
+    { "message":
       "failed to rewrite mutation payload because ID argument (HI!) was not able to be parsed" }
 
 -
@@ -131,7 +131,7 @@
     mutation addPost($post: PostInput!) {
       addPost(input: $post) {
         post {
-          postId
+          postID
         }
       }
     }
@@ -279,11 +279,11 @@
       }
     }
   gqlvariables: |
-    { "author": 
+    { "author":
       { "name": "A.N. Author",
         "dob": "2000-01-01",
         "posts": [
-          { 
+          {
             "title": "New post",
             "text": "A really new post"
           }
@@ -320,11 +320,11 @@
       }
     }
   gqlvariables: |
-    { "author": 
+    { "author":
       { "name": "A.N. Author",
         "dob": "2000-01-01",
         "posts": [
-          { 
+          {
             "title": "New post",
             "text": "A really new post"
           },
@@ -379,7 +379,7 @@
       }
     }
   gqlvariables: |
-    { "author": 
+    { "author":
       { "name": "A.N. Author",
         "dob": "2000-01-01",
         "posts": [
@@ -388,7 +388,7 @@
             "title": "Old post",
             "text": "A really old post"
           },
-          { 
+          {
             "postID": "0x456"
           }
         ]
@@ -437,11 +437,11 @@
       }
     }
   gqlvariables: |
-    { "author": 
+    { "author":
       { "name": "A.N. Author",
         "dob": "2000-01-01",
         "posts": [
-          { 
+          {
             "postID": null,
             "title": "New post",
             "text": "A really new post"
@@ -479,11 +479,11 @@
       }
     }
   gqlvariables: |
-    { "author": 
+    { "author":
       { "name": "A.N. Author",
         "dob": "2000-01-01",
         "posts": [
-          { 
+          {
             "title": "Exciting post",
             "text": "A really good post",
             "category": {
@@ -512,8 +512,8 @@
                 "uid": "_:Category3",
                 "dgraph.type": [ "Category" ],
                 "Category.name": "New Category",
-                "Category.posts": [ 
-                  { "uid": "_:Post2" } 
+                "Category.posts": [
+                  { "uid": "_:Post2" }
                 ]
               }
             }
@@ -549,7 +549,7 @@
     }
   dgmutations:
     - setjson: |
-        { 
+        {
           "uid": "_:Country1",
           "dgraph.type": ["Country"],
           "Country.name": "Dgraph Land",
@@ -565,7 +565,7 @@
         }
       cond: "@if(eq(len(State2), 0))"
     - setjson: |
-        { 
+        {
           "uid": "_:Country1",
           "dgraph.type": ["Country"],
           "Country.name": "Dgraph Land",
@@ -607,7 +607,7 @@
     }
   dgmutations:
     - setjson: |
-        { 
+        {
           "uid": "_:Country1",
           "dgraph.type": ["Country"],
           "Country.name": "Dgraph Land",

--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -2,7 +2,9 @@
   name: "Only id filter"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {
-      deleteAuthor(filter: $filter)
+      deleteAuthor(filter: $filter) {
+        msg
+      }
     }
   gqlvariables: |
     { "filter":
@@ -23,7 +25,9 @@
   name: "Multiple filters including id"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {
-      deleteAuthor(filter: $filter)
+      deleteAuthor(filter: $filter) {
+        msg
+      }
     }
   gqlvariables: |
     { "filter":
@@ -47,7 +51,9 @@
   name: "Multiple non-id filters"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {
-      deleteAuthor(filter: $filter)
+      deleteAuthor(filter: $filter) {
+        msg
+      }
     }
   gqlvariables: |
     { "filter":

--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -6,7 +6,7 @@
     }
   gqlvariables: |
     { "filter":
-      { "ids": ["0x1", "0x2"] }
+      { "id": ["0x1", "0x2"] }
     }
   explanation: "The correct mutation and query should be built using variable and filters."
   dgmutations:
@@ -28,7 +28,7 @@
   gqlvariables: |
     { "filter":
       {
-        "ids": ["0x1", "0x2"],
+        "id": ["0x1", "0x2"],
         "name": { "eq": "A.N. Author" }
       }
     }

--- a/graphql/resolve/mutation_query_test.yaml
+++ b/graphql/resolve/mutation_query_test.yaml
@@ -125,7 +125,9 @@ ADD_UPDATE_MUTATION:
             title
             author {
               name
-              posts(filter: { title: { anyofterms: "GraphQL" } })
+              posts(filter: { title: { anyofterms: "GraphQL" } }) {
+                title
+              }
             }
           }
         }
@@ -137,7 +139,10 @@ ADD_UPDATE_MUTATION:
           title : Post.title
           author : Post.author {
             name : Author.name
-            posts : Author.posts @filter(anyofterms(Post.title, "GraphQL"))
+            posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) {
+              title : Post.title
+              dgraph.uid : uid
+            }
             dgraph.uid : uid
           }
           dgraph.uid : uid
@@ -157,7 +162,9 @@ ADD_UPDATE_MUTATION:
             title
             author @include(if: $include) {
               name
-              posts(filter: { title: { anyofterms: "GraphQL" } })
+              posts(filter: { title: { anyofterms: "GraphQL" } }) {
+                title
+              }
             }
           }
         }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -419,7 +419,7 @@ func rewriteUpsertQueryFromMutation(m schema.Mutation) *gql.GraphQuery {
 	})
 
 	// TODO - Cache this instead of this being a loop to find the IDField.
-	if ids := idFilter(m, m.MutatedType().IDField().Name()); ids != nil {
+	if ids := idFilter(m, m.MutatedType().IDField()); ids != nil {
 		addUIDFunc(dgQuery, ids)
 	} else {
 		addTypeFunc(dgQuery, m.MutatedType().DgraphName())

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -418,7 +418,8 @@ func rewriteUpsertQueryFromMutation(m schema.Mutation) *gql.GraphQuery {
 		Attr: "uid",
 	})
 
-	if ids := idFilter(m); ids != nil {
+	// TODO - Cache this instead of this being a loop to find the IDField.
+	if ids := idFilter(m, m.MutatedType().IDField().Name()); ids != nil {
 		addUIDFunc(dgQuery, ids)
 	} else {
 		addTypeFunc(dgQuery, m.MutatedType().DgraphName())

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -132,7 +132,8 @@ func TestMutationQueryRewriting(t *testing.T) {
 			assigned: map[string]string{"Post1": "0x4"},
 		},
 		"Update Post ": {
-			mut:      `updatePost(input: {filter: {ids:  ["0x4"]}, set: {text: "Updated text"} }) `,
+			mut: `updatePost(input: {filter: {postID
+				:  ["0x4"]}, set: {text: "Updated text"} }) `,
 			rewriter: NewUpdateRewriter(),
 			result: map[string]interface{}{
 				"updatePost": []interface{}{map[string]interface{}{"uid": "0x4"}}},

--- a/graphql/resolve/query_test.go
+++ b/graphql/resolve/query_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/graphql/test"
 	"github.com/stretchr/testify/require"
+	_ "github.com/vektah/gqlparser/validator/rules" // make gql validator init() all rules
 	"gopkg.in/yaml.v2"
 )
 
@@ -60,7 +61,6 @@ func TestQueryRewriting(t *testing.T) {
 			gqlQuery := test.GetQuery(t, op)
 
 			dgQuery, err := testRewriter.Rewrite(gqlQuery)
-
 			require.Nil(t, err)
 			require.Equal(t, tcase.DGQuery, dgraph.AsString(dgQuery))
 		})

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -824,10 +824,10 @@
     }
 
 -
-  name: "Filter with ids uses uid func at root."
+  name: "Filter with id uses uid func at root."
   gqlquery: |
     query {
-      queryAuthor(filter: { ids: ["0x1", "0x2"], and: { name: { eq: "A. N. Author" } }}) {
+      queryAuthor(filter: { id: ["0x1", "0x2"], and: { name: { eq: "A. N. Author" } }}) {
         name
       }
     }
@@ -840,10 +840,10 @@
     }
 
 -
-  name: "Filter with ids inside and argument doesn't use uid func at root."
+  name: "Filter with id inside and argument doesn't use uid func at root."
   gqlquery: |
     query {
-      queryAuthor(filter: { name: { eq: "A. N. Author" }, and: { ids: ["0x1", "0x2"] }}) {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, and: { id: ["0x1", "0x2"] }}) {
         name
       }
     }
@@ -856,10 +856,10 @@
     }
 
 -
-  name: "Filter with ids and not translates correctly.."
+  name: "Filter with id and not translates correctly.."
   gqlquery: |
     query {
-      queryAuthor(filter: { not: { ids: ["0x1", "0x2"] }}) {
+      queryAuthor(filter: { not: { id: ["0x1", "0x2"] }}) {
         name
       }
     }
@@ -872,12 +872,12 @@
     }
 
 -
-  name: "Deep filter with ids"
+  name: "Deep filter with id"
   gqlquery: |
     query {
       queryAuthor {
         name
-        posts(filter: { ids: ["0x1", "0x2"], and: { title: { anyofterms: "GraphQL" } }}) {
+        posts(filter: { postID: ["0x1", "0x2"], and: { title: { anyofterms: "GraphQL" } }}) {
           title
         }
       }
@@ -895,12 +895,12 @@
     }
 
 -
-  name: "Deep filter with ids in not key"
+  name: "Deep filter with id in not key"
   gqlquery: |
     query {
       queryAuthor {
         name
-        posts(filter: { title: { anyofterms: "GraphQL" }, not: { ids: ["0x1", "0x2"] } }) {
+        posts(filter: { title: { anyofterms: "GraphQL" }, not: { postID: ["0x1", "0x2"] } }) {
           title
         }
       }
@@ -921,7 +921,7 @@
   name: "Pagination and Order at root node with UID."
   gqlquery: |
     query {
-      queryAuthor(filter: { ids: ["0x1", "0x2"] }, order: {asc: name}, first: 0, offset: 1 ) {
+      queryAuthor(filter: { id: ["0x1", "0x2"] }, order: {asc: name}, first: 0, offset: 1 ) {
         name
       }
     }
@@ -937,7 +937,7 @@
   name: "Order at root node with UID."
   gqlquery: |
     query {
-      queryAuthor(filter: { ids: ["0x1", "0x2"] }, order: {asc: name}) {
+      queryAuthor(filter: { id: ["0x1", "0x2"] }, order: {asc: name}) {
         name
       }
     }
@@ -983,10 +983,10 @@
 
 
 -
-  name: "Filter with no valid ids construct the right query with type func at root."
+  name: "Filter with no valid id construct the right query with type func at root."
   gqlquery: |
     query {
-      queryAuthor(filter: { ids: ["alice", "bob"], and: { name: { eq: "A. N. Author" } }}) {
+      queryAuthor(filter: { id: ["alice", "bob"], and: { name: { eq: "A. N. Author" } }}) {
         name
       }
     }
@@ -999,10 +999,10 @@
     }
 
 -
-  name: "Filter with ids only includes valid ids in dgquery."
+  name: "Filter with id only includes valid id in dgquery."
   gqlquery: |
     query {
-      queryAuthor(filter: { ids: ["0x1", "bob"], and: { name: { eq: "A. N. Author" } }}) {
+      queryAuthor(filter: { id: ["0x1", "bob"], and: { name: { eq: "A. N. Author" } }}) {
         name
       }
     }
@@ -1082,7 +1082,7 @@
   name: "Query editor using code and uid"
   gqlquery: |
     query {
-      queryEditor(filter: { ids: ["0x1"], and: { code: { eq: "editor"}}}) {
+      queryEditor(filter: { id: ["0x1"], and: { code: { eq: "editor"}}}) {
         name
       }
     }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -3,7 +3,7 @@
 
 type Country {
         id: ID!
-        name: String! @search(by: [trigram])
+        name: String! @search(by: [trigram, exact])
         states: [State] @hasInverse(field: country)
 }
 

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -11,7 +11,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123", "0x124"]
+          "postID": ["0x123", "0x124"]
         },
         "set": {
           "text": "updated text"
@@ -45,7 +45,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123", "0x124"]
+          "postID": ["0x123", "0x124"]
         },
         "remove": {
           "text": "delete this text"
@@ -79,7 +79,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123", "0x124"]
+          "postID": ["0x123", "0x124"]
         },
         "remove": {
           "text": null
@@ -116,7 +116,7 @@
     { "patch":
       {
         "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": { "name": "Bob",
           "dob": "2000-01-01",
@@ -146,7 +146,7 @@
   name: "Update mutation for an interface"
   gqlmutation: |-
     mutation {
-      updateCharacter(input: {filter: { ids: ["0x123"] }, set: {name:"Bob"}}) {
+      updateCharacter(input: {filter: { id: ["0x123"] }, set: {name:"Bob"}}) {
         character {
           id
           name
@@ -249,7 +249,7 @@
     { "patch":
       { "filter": {
           "code": { "eq": "editor" },
-          "ids": [ "0x1", "0x2" ]
+          "id": [ "0x1", "0x2" ]
         },
         "set": {
           "name": "A.N. Editor"
@@ -283,7 +283,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
           "posts": [ { "postID": "0x456" } ]
@@ -293,10 +293,10 @@
   dgmutations:
     - setjson: |
         { "uid" : "uid(x)",
-          "Author.posts": [ 
-            { 
-              "uid": "0x456", 
-              "Post.author": { "uid": "uid(x)" } 
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "uid(x)" }
             }
           ]
         }
@@ -324,7 +324,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "remove": {
           "posts": [ { "postID": "0x456" } ]
@@ -334,10 +334,10 @@
   dgmutations:
     - deletejson: |
         { "uid" : "uid(x)",
-          "Author.posts": [ 
-            { 
-              "uid": "0x456", 
-              "Post.author": { "uid": "uid(x)" } 
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "uid(x)" }
             }
           ]
         }
@@ -365,7 +365,7 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
           "posts": [ { "postID": "0x456" } ]
@@ -378,20 +378,20 @@
   dgmutations:
     - setjson: |
         { "uid" : "uid(x)",
-          "Author.posts": [ 
-            { 
-              "uid": "0x456", 
-              "Post.author": { "uid": "uid(x)" } 
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "uid(x)" }
             }
           ]
         }
       cond: "@if(eq(len(Post2), 1) AND gt(len(x), 0))"
     - deletejson: |
         { "uid" : "uid(x)",
-          "Author.posts": [ 
-            { 
-              "uid": "0x789", 
-              "Post.author": { "uid": "uid(x)" } 
+          "Author.posts": [
+            {
+              "uid": "0x789",
+              "Post.author": { "uid": "uid(x)" }
             }
           ]
         }
@@ -422,11 +422,11 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
-          "posts": [ { 
-            "postID": "0x456",  
+          "posts": [ {
+            "postID": "0x456",
             "title": "A new title",
             "text": "Some edited text"
           } ]
@@ -437,10 +437,10 @@
   dgmutations:
     - setjson: |
         { "uid" : "uid(x)",
-          "Author.posts": [ 
-            { 
-              "uid": "0x456", 
-              "Post.author": { "uid": "uid(x)" } 
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "uid(x)" }
             }
           ]
         }
@@ -468,10 +468,10 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
-          "country": { 
+          "country": {
             "name": "New Country"
           }
         }
@@ -508,10 +508,10 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
-          "country": { 
+          "country": {
             "name": "New Country",
             "states": [ {
               "code": "dg",
@@ -579,10 +579,10 @@
   gqlvariables: |
     { "patch":
       { "filter": {
-          "ids": ["0x123"]
+          "id": ["0x123"]
         },
         "set": {
-          "country": { 
+          "country": {
             "name": "New Country",
             "states": [ {
               "code": "dg"

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -4,7 +4,7 @@
     mutation updatePost($patch: UpdatePostInput!) {
       updatePost(input: $patch) {
         post {
-          postId
+          postID
         }
       }
     }
@@ -38,7 +38,7 @@
     mutation updatePost($patch: UpdatePostInput!) {
       updatePost(input: $patch) {
         post {
-          postId
+          postID
         }
       }
     }
@@ -72,7 +72,7 @@
     mutation updatePost($patch: UpdatePostInput!) {
       updatePost(input: $patch) {
         post {
-          postId
+          postID
         }
       }
     }
@@ -173,7 +173,7 @@
     mutation updatePost($patch: UpdatePostInput!) {
       updatePost(input: $patch) {
         post {
-          postId
+          postID
         }
       }
     }

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -637,7 +637,7 @@ func addFilterType(schema *ast.Schema, defn *ast.Definition) {
 		if isID(fld) {
 			filter.Fields = append(filter.Fields,
 				&ast.FieldDefinition{
-					Name: "ids",
+					Name: fld.Name,
 					Type: ast.ListType(&ast.Type{
 						NamedType: IDType,
 						NonNull:   true,
@@ -663,7 +663,7 @@ func addFilterType(schema *ast.Schema, defn *ast.Definition) {
 
 	// Not filter makes sense even if the filter has only one field. And/Or would only make sense
 	// if the filter has more than one field or if it has one non-id field.
-	if (len(filter.Fields) == 1 && filter.Fields[0].Name != "ids") || len(filter.Fields) > 1 {
+	if (len(filter.Fields) == 1 && !isID(filter.Fields[0])) || len(filter.Fields) > 1 {
 		filter.Fields = append(filter.Fields,
 			&ast.FieldDefinition{Name: "and", Type: &ast.Type{NamedType: filterName}},
 			&ast.FieldDefinition{Name: "or", Type: &ast.Type{NamedType: filterName}},

--- a/graphql/schema/testdata/schemagen/input/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/input/field-with-id-directive.graphql
@@ -1,5 +1,5 @@
 type Post {
-    id: ID
+    postID: ID
     content: String!
     author: Author!
     genre: Genre

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -146,7 +146,7 @@ input PatchT {
 }
 
 input TFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: TFilter
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -3,7 +3,7 @@
 #######################
 
 type Post {
-	id: ID
+	postID: ID
 	content: String!
 	author(filter: AuthorFilter): Author!
 	genre(filter: GenreFilter): Genre
@@ -155,7 +155,7 @@ enum PostOrderable {
 #######################
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringHashFilter_StringRegExpFilter
 	and: AuthorFilter
 	or: AuthorFilter
@@ -214,7 +214,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	postID: [ID!]
 	not: PostFilter
 }
 
@@ -231,7 +231,7 @@ input PostOrder {
 }
 
 input PostRef {
-	id: ID
+	postID: ID
 	content: String
 	author: AuthorRef
 	genre: GenreRef

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -185,7 +185,7 @@ enum QuestionOrderable {
 #######################
 
 input AnswerFilter {
-	ids: [ID!]
+	id: [ID!]
 	text: StringFullTextFilter
 	datePublished: DateTimeFilter
 	and: AnswerFilter
@@ -215,7 +215,7 @@ input AnswerRef {
 }
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringHashFilter
 	and: AuthorFilter
 	or: AuthorFilter
@@ -268,7 +268,7 @@ input PatchQuestion {
 }
 
 input PostFilter {
-	ids: [ID!]
+	id: [ID!]
 	text: StringFullTextFilter
 	datePublished: DateTimeFilter
 	and: PostFilter
@@ -287,7 +287,7 @@ input PostRef {
 }
 
 input QuestionFilter {
-	ids: [ID!]
+	id: [ID!]
 	text: StringFullTextFilter
 	datePublished: DateTimeFilter
 	and: QuestionFilter

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -126,7 +126,7 @@ type UpdatePostPayload {
 #######################
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: AuthorFilter
 }
 
@@ -148,7 +148,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: PostFilter
 }
 

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -191,7 +191,7 @@ enum StarshipOrderable {
 #######################
 
 input CharacterFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringExactFilter
 	appearsIn: Episode_hash
 	and: CharacterFilter
@@ -210,7 +210,7 @@ input CharacterRef {
 }
 
 input DroidFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringExactFilter
 	appearsIn: Episode_hash
 	and: DroidFilter
@@ -244,7 +244,7 @@ input Episode_hash {
 }
 
 input HumanFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringExactFilter
 	appearsIn: Episode_hash
 	and: HumanFilter
@@ -302,7 +302,7 @@ input PatchStarship {
 }
 
 input StarshipFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringTermFilter
 	and: StarshipFilter
 	or: StarshipFilter

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -140,7 +140,7 @@ enum PostOrderable {
 #######################
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: AuthorFilter
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -141,7 +141,7 @@ enum PostOrderable {
 #######################
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringHashFilter
 	and: AuthorFilter
 	or: AuthorFilter
@@ -180,7 +180,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	postID: [ID!]
 	title: StringFullTextFilter_StringTermFilter
 	text: StringFullTextFilter_StringTermFilter
 	and: PostFilter

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -174,7 +174,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	postID: [ID!]
 	title: StringTermFilter
 	titleByEverything: StringFullTextFilter_StringHashFilter_StringTermFilter_StringRegExpFilter
 	text: StringFullTextFilter

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -128,7 +128,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: PostFilter
 }
 

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -117,7 +117,7 @@ enum MessageOrderable {
 #######################
 
 input MessageFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: MessageFilter
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -148,7 +148,7 @@ enum HumanOrderable {
 #######################
 
 input CharacterFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringExactFilter
 	and: CharacterFilter
 	or: CharacterFilter
@@ -172,7 +172,7 @@ input EmployeeOrder {
 }
 
 input HumanFilter {
-	ids: [ID!]
+	id: [ID!]
 	name: StringExactFilter
 	and: HumanFilter
 	or: HumanFilter

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -137,7 +137,7 @@ enum PostOrderable {
 #######################
 
 input AuthorFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: AuthorFilter
 }
 
@@ -167,7 +167,7 @@ input PatchPost {
 }
 
 input PostFilter {
-	ids: [ID!]
+	id: [ID!]
 	not: PostFilter
 }
 

--- a/graphql/test/test.go
+++ b/graphql/test/test.go
@@ -53,7 +53,11 @@ func LoadSchemaFromFile(t *testing.T, gqlFile string) schema.Schema {
 	gql, err := ioutil.ReadFile(gqlFile)
 	require.NoError(t, err, "Unable to read schema file")
 
-	handler, err := schema.NewHandler(string(gql))
+	return LoadSchemaFromString(t, string(gql))
+}
+
+func LoadSchemaFromString(t *testing.T, sch string) schema.Schema {
+	handler, err := schema.NewHandler(string(sch))
 	require.NoError(t, err, "input schema contained errors")
 
 	return LoadSchema(t, handler.GQLSchema())


### PR DESCRIPTION
This PR changes the name of the ID field in TypeFilter to actual field name instead of the generic `ids`. This is similar to the behavior of fields with `@id` directive.

@MichaelJCompton should we also do this for `getType` query function?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4556)
<!-- Reviewable:end -->
