### PR TITLE
Add comment clarifying comment in list.go

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1283,7 +1283,9 @@ func (out *rollupOutput) removeEmptySplits() {
 
 	if len(out.plist.Splits) == 1 {
 		// Only the first split remains. If it's also empty, remove it as well.
-		// This should mark the entire list for deletion.
+		// This should mark the entire list for deletion. Please note that the
+		// startUid of the first part is always one because a node can never have
+		// its uid set to zero.
 		if isPlistEmpty(out.parts[1]) {
 			out.plist.Splits = []uint64{}
 		}


### PR DESCRIPTION
The first part of a multi-part posting list is always one since nodes
cannot have their uid set to zero. Add a comment explaining this to
avoid confusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4559)
<!-- Reviewable:end -->
