### PR TITLE
Change getT queries to accept the name of the ID field as argument

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -609,7 +609,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 		input       string
 		output      string
 		description string
-		err         error
 	}{
 		{
 			`
@@ -622,7 +621,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			`,
 			`{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
 			"alice doesn't have access to <age>",
-			nil,
 		},
 		{
 			`
@@ -635,7 +633,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			`,
 			`{}`,
 			`alice doesn't have access to <age> so "has(age)" is unauthorized`,
-			nil,
 		},
 		{
 			`
@@ -652,7 +649,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			`,
 			`{"me1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],"me2":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
 			`me1, me2 will have same results, can't order by <age> since it is unauthorized`,
-			nil,
 		},
 		{
 			`
@@ -664,7 +660,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			`,
 			`{}`,
 			`can't groupby <age> since <age> is unauthorized`,
-			nil,
 		},
 		{
 			`
@@ -677,7 +672,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			`,
 			`{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
 			`filter won't work because <nickname> is unauthorized`,
-			nil,
 		},
 	}
 
@@ -685,7 +679,8 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.description, func(t *testing.T) {
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)
-			require.True(t, (string(resp.Json) == tc.output && err == tc.err))
+			require.Nil(t, err)
+			require.Equal(t, tc.output, string(resp.Json))
 		})
 	}
 }

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -657,7 +657,7 @@ func requirePost(
 
 	params := &GraphQLParams{
 		Query: `query getPost($id: ID!, $getAuthor: Boolean!)  {
-			getPost(id: $id) {
+			getPost(postID: $id) {
 				postID
 				title
 				text

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -354,7 +354,7 @@ func deepFilter(t *testing.T) {
 func manyQueries(t *testing.T) {
 	posts := allPosts(t)
 
-	getPattern := `getPost(id: "%s") {
+	getPattern := `getPost(postID: "%s") {
 		postID
 		title
 		text
@@ -502,7 +502,7 @@ func queryOrderAtRoot(t *testing.T) {
 func queriesWithError(t *testing.T) {
 	posts := allPosts(t)
 
-	getPattern := `getPost(id: "%s") {
+	getPattern := `getPost(postID: "%s") {
 		postID
 		title
 		text

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -901,8 +901,9 @@ func addGetQuery(schema *ast.Schema, defn *ast.Definition) {
 	// If the defn, only specified one of ID/XID field, they they are mandatory. If it specified
 	// both, then they are optional.
 	if hasIDField {
+		fields := getIDField(defn)
 		qry.Arguments = append(qry.Arguments, &ast.ArgumentDefinition{
-			Name: "id",
+			Name: fields[0].Name,
 			Type: &ast.Type{
 				NamedType: idTypeFor(defn),
 				NonNull:   !hasXIDField,

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -259,7 +259,7 @@ input UpdatePostInput {
 #######################
 
 type Query {
-	getPost(id: ID!): Post
+	getPost(postID: ID!): Post
 	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	getAuthor(id: ID, name: String): Author
 	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -233,7 +233,7 @@ input UpdatePostInput {
 type Query {
 	getAuthor(id: ID!): Author
 	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getPost(id: ID!): Post
+	getPost(postID: ID!): Post
 	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -302,7 +302,7 @@ input UpdatePostInput {
 #######################
 
 type Query {
-	getPost(id: ID!): Post
+	getPost(postID: ID!): Post
 	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 }
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -470,6 +470,7 @@ func (f *field) XIDArg() string {
 }
 
 func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
+	idField := f.Type().IDField()
 	xidArgName := ""
 	// This method is only called for Get queries. These queries can accept one of the
 	// combinations as input.
@@ -478,7 +479,7 @@ func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
 	// 3. ID and XID fields
 	// Therefore, the non ID field is an XID field.
 	for _, arg := range f.field.Arguments {
-		if arg.Name != IDArgName {
+		if arg.Name != idField.Name() {
 			xidArgName = arg.Name
 		}
 	}
@@ -493,12 +494,12 @@ func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
 		xid = &xidArgVal
 	}
 
-	idArg := f.ArgValue(IDArgName)
-	if idArg == nil && xid == nil {
+	if idField == nil && xid == nil {
 		// This means that both were optional and were not supplied, lets return here.
 		return
 	}
 
+	idArg := f.ArgValue(idField.Name())
 	if idArg != nil {
 		id, ok := idArg.(string)
 		var ierr error


### PR DESCRIPTION
Now we accept the name of the ID field as argument instead of the hardcoded `id`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4564)
<!-- Reviewable:end -->
