### PR TITLE
Set ZSTD Compression Level to 1

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -107,6 +107,10 @@ func (r *reducer) createBadger(i int) *badger.DB {
 		WithTableLoadingMode(bo.MemoryMap).WithValueThreshold(1 << 10 /* 1 KB */).
 		WithLogger(nil).WithMaxCacheSize(1 << 20).
 		WithEncryptionKey(enc.ReadEncryptionKeyFile(r.opt.BadgerKeyFile))
+
+	// TOOD(Ibrahim): Remove this once badger is updated.
+	opt.ZSTDCompressionLevel = 1
+
 	db, err := badger.OpenManaged(opt)
 	x.Check(err)
 

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -765,6 +765,9 @@ func run() {
 		WithTableLoadingMode(options.MemoryMap).
 		WithReadOnly(opt.readOnly)
 
+	// TODO(Ibrahim): Remove this once badger is updated.
+	bopts.ZSTDCompressionLevel = 1
+
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)
 

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -332,8 +332,10 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph) *loader {
 		var err error
 		db, err = badger.Open(badger.DefaultOptions(opt.clientDir).
 			WithTableLoadingMode(bopt.MemoryMap).
-			WithSyncWrites(false))
+			// TODO(Ibrahim): Remove compression level once badger is updated.
+			WithSyncWrites(false).WithZSTDCompressionLevel(1))
 		x.Checkf(err, "Error while creating badger KV posting store")
+
 	}
 
 	// compression with zero server actually makes things worse

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -205,6 +205,10 @@ func run() {
 	x.Checkf(os.MkdirAll(opts.w, 0700), "Error while creating WAL dir.")
 	kvOpt := badger.LSMOnlyOptions(opts.w).WithSyncWrites(false).WithTruncate(true).
 		WithValueLogFileSize(64 << 20).WithMaxCacheSize(10 << 20)
+
+	// TOOD(Ibrahim): Remove this once badger is updated.
+	kvOpt.ZSTDCompressionLevel = 1
+
 	kv, err := badger.Open(kvOpt)
 	x.Checkf(err, "Error while opening WAL store")
 	defer kv.Close()

--- a/posting/index.go
+++ b/posting/index.go
@@ -532,6 +532,10 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		WithEventLogging(false).
 		WithLogRotatesToFlush(10).
 		WithMaxCacheSize(50) // TODO(Aman): Disable cache altogether
+
+	// TODO(Ibrahim): Remove this once badger is updated.
+	dbOpts.ZSTDCompressionLevel = 1
+
 	tmpDB, err := badger.OpenManaged(dbOpts)
 	if err != nil {
 		return errors.Wrap(err, "error opening temp badger for reindexing")

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -29,7 +29,8 @@ import (
 
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
-		WithReadOnly(true)
+		// TOOD(Ibrahim): Remove compression level once badger is updated.
+		WithReadOnly(true).WithZSTDCompressionLevel(1)
 	return badger.OpenManaged(opt)
 }
 

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -97,6 +97,8 @@ func (s *ServerState) runVlogGC(store *badger.DB) {
 func setBadgerOptions(opt badger.Options) badger.Options {
 	opt = opt.WithSyncWrites(false).WithTruncate(true).WithLogger(&x.ToGlog{}).
 		WithEncryptionKey(enc.ReadEncryptionKeyFile(Config.BadgerKeyFile))
+	// TODO(ibrahim): Remove this once badger is updated in dgraph.
+	opt.ZSTDCompressionLevel = 1
 
 	glog.Infof("Setting Badger table load option: %s", Config.BadgerTables)
 	switch Config.BadgerTables {
@@ -157,6 +159,9 @@ func (s *ServerState) initStorage() {
 		opt.EncryptionKey = nil
 		glog.Infof("Opening write-ahead log BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
+
+		// TODO(Ibrahim): Remove this once badger is updated.
+		opt.ZSTDCompressionLevel = 1
 
 		s.WALstore, err = badger.Open(opt)
 		x.Checkf(err, "Error while creating badger KV WAL store")


### PR DESCRIPTION
The default compression level in badger is `15` which is very slow. This PR changes the compression level from `15` to `1`.

Related to https://github.com/dgraph-io/badger/pull/1191
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4572)
<!-- Reviewable:end -->
