### PR TITLE
contrib: Set whitelist config for /admin endpoint in standalone image.

### DIFF
--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -13,5 +13,7 @@ echo -e "\033[0;33m
 Warning: This standalone version is meant for quickstart purposes only.
          It is NOT RECOMMENDED for production environments.\033[0;0m"
 
+export DGRAPH_ALPHA_WHITELIST=0.0.0.0/0
+
 # TODO properly handle SIGTERM for all three processes.
 dgraph-ratel & dgraph zero & dgraph alpha --lru_mb $lru_mb


### PR DESCRIPTION
This PR updates the `dgraph/standalone` Docker image to have the `/admin` endpoint available from outside the container (e.g., when binding a host port to the container port with `docker run -p 8080:8080 ...`).

It's useful to have `/admin` available in the standalone image when running `/admin` commands, e.g., exports, GraphQL admin endpoint, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4576)
<!-- Reviewable:end -->
