### PR TITLE
Fix flaky test

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -680,7 +680,7 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)
 			require.Nil(t, err)
-			require.Equal(t, tc.output, string(resp.Json))
+			testutil.CompareJSON(t, tc.output, string(resp.Json))
 		})
 	}
 }


### PR DESCRIPTION
Order of result in array is not always the same. `testutil.CompareJSON` takes care of that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4578)
<!-- Reviewable:end -->
