### PR TITLE
Add support for sorting on multiple facets

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -73,8 +73,9 @@ type GraphQuery struct {
 	FacetsFilter     *FilterTree
 	GroupbyAttrs     []GroupByAttr
 	FacetVar         map[string]string
-	FacetOrder       []string
-	FacetDesc        []bool
+	FacetOrder       []*FacetOrder
+	// FacetOrder       []string
+	// FacetDesc        []bool
 
 	// Internal fields below.
 	// If gq.fragment is nonempty, then it is a fragment reference / spread.
@@ -108,6 +109,12 @@ type GroupByAttr struct {
 	Attr  string
 	Alias string
 	Langs []string
+}
+
+// FacetOrder stores ordering for single facet key.
+type FacetOrder struct {
+	Key       string
+	OrderDesc bool
 }
 
 // pair denotes the key value pair that is part of the GraphQL query root in parenthesis.
@@ -1905,8 +1912,9 @@ type facetRes struct {
 	f          *pb.FacetParams
 	ft         *FilterTree
 	vmap       map[string]string
-	facetOrder []string
-	orderdesc  []bool
+	facetOrder []*FacetOrder
+	// facetOrder []string
+	// orderdesc  []bool
 }
 
 func parseFacets(it *lex.ItemIterator) (res facetRes, err error) {
@@ -2006,15 +2014,18 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 
 	facetVar := make(map[string]string)
 	var facets pb.FacetParams
-	var orderdesc []bool
-	var orderkey []string
+	// var orderdesc []bool
+	// var orderkey []string
+	var facetOrder []*FacetOrder
 
 	if _, ok := tryParseItemType(it, itemRightRound); ok {
 		// @facets() just parses to an empty set of facets.
-		res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
+		// res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
+		res.f, res.vmap, res.facetOrder = &facets, facetVar, facetOrder
 		return res, true, nil
 	}
 
+	facetOrderMap := make(map[string]struct{})
 	for {
 		// We've just consumed a leftRound or a comma.
 
@@ -2041,12 +2052,16 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 				Alias: facetItem.alias,
 			})
 			if facetItem.ordered {
-				// if orderkey != "" {
-				// 	return res, false,
-				// 		facetItemIt.Errorf("Invalid use of orderasc/orderdesc in facets")
-				// }
-				orderdesc = append(orderdesc, facetItem.orderdesc)
-				orderkey = append(orderkey, facetItem.name)
+				if _, ok := facetOrderMap[facetItem.name]; ok {
+					// return duplicate error.
+					return res, false,
+						it.Errorf("Sorting by facet: [%s] can only be done once", facetItem.name)
+				}
+				facetOrderMap[facetItem.name] = struct{}{}
+
+				// orderdesc = append(orderdesc, facetItem.orderdesc)
+				// orderkey = append(orderkey, facetItem.name)
+				facetOrder = append(facetOrder, &FacetOrder{Key: facetItem.name, OrderDesc: facetItem.orderdesc})
 			}
 		}
 
@@ -2066,7 +2081,7 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 			}
 			out = append(out, facets.Param[flen-1])
 			facets.Param = out
-			res.f, res.vmap, res.facetOrder, res.orderdesc = &facets, facetVar, orderkey, orderdesc
+			res.f, res.vmap, res.facetOrder = &facets, facetVar, facetOrder
 			return res, true, nil
 		}
 		if item, ok := tryParseItemType(it, itemComma); !ok {
@@ -2403,12 +2418,13 @@ func parseDirective(it *lex.ItemIterator, curp *GraphQuery) error {
 			curp.FacetVar = res.vmap
 			// if len(res.facetOrder) > 0 {
 			// fmt.Println("############### ", res.facetOrder[0], res.orderdesc[0])
-			curp.FacetOrder = res.facetOrder
-			curp.FacetDesc = res.orderdesc
+			// curp.FacetOrder = res.facetOrder
+			// curp.FacetDesc = res.orderdesc
 			// } else {
 			// 	curp.FacetOrder = ""
 			// 	curp.FacetDesc = false
 			// }
+			curp.FacetOrder = res.facetOrder
 			if curp.Facets != nil {
 				return item.Errorf("Only one facets allowed")
 			}

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -111,8 +111,8 @@ type GroupByAttr struct {
 
 // FacetOrder stores ordering for single facet key.
 type FacetOrder struct {
-	Key       string
-	OrderDesc bool
+	Key  string
+	Desc bool // true if ordering should be decending by this facet.
 }
 
 // pair denotes the key value pair that is part of the GraphQL query root in parenthesis.
@@ -2051,7 +2051,7 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 				}
 				facetsOrderKeys[facetItem.name] = struct{}{}
 				facetsOrder = append(facetsOrder,
-					&FacetOrder{Key: facetItem.name, OrderDesc: facetItem.orderdesc})
+					&FacetOrder{Key: facetItem.name, Desc: facetItem.orderdesc})
 			}
 		}
 

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3407,8 +3407,46 @@ func TestParseFacets(t *testing.T) {
 	require.Equal(t, []string{"friends"}, childAttrs(res.Query[0]))
 	require.NotNil(t, res.Query[0].Children[0].Facets)
 	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
-	require.Equal(t, "closeness", res.Query[0].Children[0].FacetOrder)
-	require.True(t, res.Query[0].Children[0].FacetDesc)
+	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
+	require.True(t, res.Query[0].Children[0].FacetsOrder[0].OrderDesc)
+}
+
+func TestParseOrderbyMultipleFacets(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(orderdesc: closeness, orderasc: since) {
+				name
+			}
+		}
+	}
+`
+	res, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+	require.NotNil(t, res.Query[0])
+	require.Equal(t, []string{"friends"}, childAttrs(res.Query[0]))
+	require.NotNil(t, res.Query[0].Children[0].Facets)
+	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
+	require.Equal(t, len(res.Query[0].Children[0].FacetsOrder), 2)
+	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
+	require.True(t, res.Query[0].Children[0].FacetsOrder[0].OrderDesc)
+	require.Equal(t, "since", res.Query[0].Children[0].FacetsOrder[1].Key)
+	require.False(t, res.Query[0].Children[0].FacetsOrder[1].OrderDesc)
+}
+
+func TestParseOrderbySameFacetsMultipleTimes(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(orderdesc: closeness, orderasc: closeness) {
+				name
+			}
+		}
+	}
+`
+	_, err := Parse(Request{Str: query})
+	require.Contains(t, err.Error(),
+		"Sorting by facet: [closeness] can only be done once")
 }
 
 func TestParseOrderbyFacet(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3408,7 +3408,7 @@ func TestParseFacets(t *testing.T) {
 	require.NotNil(t, res.Query[0].Children[0].Facets)
 	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
 	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
-	require.True(t, res.Query[0].Children[0].FacetsOrder[0].OrderDesc)
+	require.True(t, res.Query[0].Children[0].FacetsOrder[0].Desc)
 }
 
 func TestParseOrderbyMultipleFacets(t *testing.T) {
@@ -3429,9 +3429,41 @@ func TestParseOrderbyMultipleFacets(t *testing.T) {
 	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
 	require.Equal(t, 2, len(res.Query[0].Children[0].FacetsOrder))
 	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
-	require.True(t, res.Query[0].Children[0].FacetsOrder[0].OrderDesc)
+	require.True(t, res.Query[0].Children[0].FacetsOrder[0].Desc)
 	require.Equal(t, "since", res.Query[0].Children[0].FacetsOrder[1].Key)
-	require.False(t, res.Query[0].Children[0].FacetsOrder[1].OrderDesc)
+	require.False(t, res.Query[0].Children[0].FacetsOrder[1].Desc)
+}
+
+func TestParseOrderbyMultipleFacetsWithAlias(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(0x1)) {
+			friends @facets(orderdesc: closeness, orderasc: since, score, location:from) {
+				name
+			}
+		}
+	}
+`
+	res, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+	require.NotNil(t, res.Query[0])
+	require.Equal(t, []string{"friends"}, childAttrs(res.Query[0]))
+	require.NotNil(t, res.Query[0].Children[0].Facets)
+	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
+	require.Equal(t, 2, len(res.Query[0].Children[0].FacetsOrder))
+	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
+	require.True(t, res.Query[0].Children[0].FacetsOrder[0].Desc)
+	require.Equal(t, "since", res.Query[0].Children[0].FacetsOrder[1].Key)
+	require.False(t, res.Query[0].Children[0].FacetsOrder[1].Desc)
+	require.Equal(t, 4, len(res.Query[0].Children[0].Facets.Param))
+	require.Nil(t, res.Query[0].Children[0].FacetsFilter)
+	require.Empty(t, res.Query[0].Children[0].FacetVar)
+	for _, param := range res.Query[0].Children[0].Facets.Param {
+		if param.Key == "from" {
+			require.Equal(t, "location", param.Alias)
+			break
+		}
+	}
 }
 
 func TestParseOrderbySameFacetsMultipleTimes(t *testing.T) {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -3427,7 +3427,7 @@ func TestParseOrderbyMultipleFacets(t *testing.T) {
 	require.Equal(t, []string{"friends"}, childAttrs(res.Query[0]))
 	require.NotNil(t, res.Query[0].Children[0].Facets)
 	require.Equal(t, []string{"name"}, childAttrs(res.Query[0].Children[0]))
-	require.Equal(t, len(res.Query[0].Children[0].FacetsOrder), 2)
+	require.Equal(t, 2, len(res.Query[0].Children[0].FacetsOrder))
 	require.Equal(t, "closeness", res.Query[0].Children[0].FacetsOrder[0].Key)
 	require.True(t, res.Query[0].Children[0].FacetsOrder[0].OrderDesc)
 	require.Equal(t, "since", res.Query[0].Children[0].FacetsOrder[1].Key)

--- a/query/query.go
+++ b/query/query.go
@@ -127,10 +127,10 @@ type params struct {
 	// Facet tells us about the requested facets and their aliases.
 	Facet *pb.FacetParams
 	// FacetOrder has the name of the facet by which the results should be sorted.
-	FacetOrder string
+	FacetOrder []string
 	// FacetOrderDesc is true if the facets should be order in descending order. If it's
 	// false, the facets will be ordered in ascending order.
-	FacetOrderDesc bool
+	FacetOrderDesc []bool
 
 	// Var is the name of the variable defined in this SubGraph
 	// (e.g. in "x as name", this would be x).
@@ -514,24 +514,29 @@ func treeCopy(gq *gql.GraphQuery, sg *SubGraph) error {
 		attrsSeen[key] = struct{}{}
 
 		args := params{
-			Alias:          gchild.Alias,
-			Cascade:        gchild.Cascade || sg.Params.Cascade,
-			Expand:         gchild.Expand,
-			Facet:          gchild.Facets,
-			FacetOrder:     gchild.FacetOrder,
-			FacetOrderDesc: gchild.FacetDesc,
-			FacetVar:       gchild.FacetVar,
-			GetUid:         sg.Params.GetUid,
-			IgnoreReflex:   sg.Params.IgnoreReflex,
-			Langs:          gchild.Langs,
-			NeedsVar:       append(gchild.NeedsVar[:0:0], gchild.NeedsVar...),
-			Normalize:      gchild.Normalize || sg.Params.Normalize,
-			Order:          gchild.Order,
-			Var:            gchild.Var,
-			GroupbyAttrs:   gchild.GroupbyAttrs,
-			IsGroupBy:      gchild.IsGroupby,
-			IsInternal:     gchild.IsInternal,
+			Alias:   gchild.Alias,
+			Cascade: gchild.Cascade || sg.Params.Cascade,
+			Expand:  gchild.Expand,
+			Facet:   gchild.Facets,
+			// FacetOrder:     gchild.FacetOrder,
+			// FacetOrderDesc: gchild.FacetDesc,
+			FacetVar:     gchild.FacetVar,
+			GetUid:       sg.Params.GetUid,
+			IgnoreReflex: sg.Params.IgnoreReflex,
+			Langs:        gchild.Langs,
+			NeedsVar:     append(gchild.NeedsVar[:0:0], gchild.NeedsVar...),
+			Normalize:    gchild.Normalize || sg.Params.Normalize,
+			Order:        gchild.Order,
+			Var:          gchild.Var,
+			GroupbyAttrs: gchild.GroupbyAttrs,
+			IsGroupBy:    gchild.IsGroupby,
+			IsInternal:   gchild.IsInternal,
 		}
+
+		// if len(gchild.FacetOrder) > 0 {
+		args.FacetOrder = gchild.FacetOrder
+		args.FacetOrderDesc = gchild.FacetDesc
+		// }
 
 		if gchild.IsCount {
 			if len(gchild.Children) != 0 {
@@ -2322,7 +2327,7 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 		return errors.Errorf("Facet matrix and UID matrix mismatch: %d vs %d",
 			len(sg.facetsMatrix), len(sg.uidMatrix))
 	}
-	orderby := sg.Params.FacetOrder
+	orderby := sg.Params.FacetOrder[0]
 	for i := 0; i < len(sg.uidMatrix); i++ {
 		ul := sg.uidMatrix[i]
 		fl := sg.facetsMatrix[i]
@@ -2356,7 +2361,7 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 			continue
 		}
 		if err := types.SortWithFacet(values, &uids, facetList,
-			[]bool{sg.Params.FacetOrderDesc}, ""); err != nil {
+			[]bool{sg.Params.FacetOrderDesc[0]}, ""); err != nil {
 			return err
 		}
 		sg.uidMatrix[i].Uids = uids

--- a/query/query.go
+++ b/query/query.go
@@ -2358,11 +2358,11 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				if !types.IsSortable(fVal.Tid) {
-					return errors.Errorf("Value of type: %s isn't sortable", fVal.Tid.Name())
+				// If type is not sortable, we are ignoring it.
+				if types.IsSortable(fVal.Tid) {
+					values[j][idx] = fVal
 				}
 
-				values[j][idx] = fVal
 				remainingFacets--
 				if remainingFacets == 0 {
 					break

--- a/query/query.go
+++ b/query/query.go
@@ -126,7 +126,7 @@ type params struct {
 
 	// Facet tells us about the requested facets and their aliases.
 	Facet *pb.FacetParams
-	// FacetsOrders keeps ordering for facets. Each entry stores name of the facet key and
+	// FacetsOrder keeps ordering for facets. Each entry stores name of the facet key and
 	// OrderDesc(will be true if results should be ordered by desc order of key) information for it.
 	FacetsOrder []*gql.FacetOrder
 
@@ -2360,7 +2360,7 @@ func (sg *SubGraph) sortAndPaginateUsingFacet(ctx context.Context) error {
 			}
 
 			for _, fo := range sg.Params.FacetsOrder {
-				if f, ok := facetsMap[fo.Key]; ok && f != nil /*TODO: confirm this*/ {
+				if f, ok := facetsMap[fo.Key]; ok && f != nil {
 					fVal, err := facets.ValFor(f)
 					if err != nil {
 						return err

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -1921,3 +1921,11 @@ func TestFacetsWithExpand(t *testing.T) {
 		}
 	}`, js)
 }
+
+// Tests for multiple facets sorting.
+
+// orderby more than once should be error on same facet.
+
+// orderby on non sortable facet should be error.
+
+// orderby should include facet in the result.

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -338,6 +338,21 @@ func TestOrderdescFacetsWithFilters(t *testing.T) {
 	`, js)
 }
 
+// func TestFacetsMultipleOrderby(t *testing.T) {
+// 	populateClusterWithFacets()
+// 	query := `
+// 		{
+// 			me(func: uid(1)) @cascade {
+// 				friend @facets(orderdesc: since) {
+// 					name
+// 				}
+// 			}
+// 		}
+// 	`
+// 	js := processQueryNoErr(t, query)
+// 	fmt.Println(js)
+// }
+
 func TestRetrieveFacetsAsVars(t *testing.T) {
 	populateClusterWithFacets()
 	// to see how friend @facets are positioned in output.
@@ -1924,8 +1939,10 @@ func TestFacetsWithExpand(t *testing.T) {
 
 // Tests for multiple facets sorting.
 
-// orderby more than once should be error on same facet.
+// orderby more than once should be error on same facet.(Done in parser_test.go)
 
 // orderby on non sortable facet should be error.
 
 // orderby should include facet in the result.
+
+// add tests for different types(float, string, int, datetime, bool)

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -90,9 +90,9 @@ func populateClusterWithFacets() error {
 	bossFacet := "(company = \"company1\")"
 	triples += fmt.Sprintf("<1> <boss> <34> %s .\n", bossFacet)
 
-	friendFacets7 := "(since=2006-01-02T15:04:05, fastfriend=true, score=100)"
+	friendFacets7 := "(since=2006-01-02T15:04:05, fastfriend=true, score=100, from=\"delhi\")"
 	friendFacets8 := "(since=2007-01-02T15:04:05, fastfriend=false, score=100)"
-	friendFacets9 := "(since=2008-01-02T15:04:05, fastfriend=true, score=200)"
+	friendFacets9 := "(since=2008-01-02T15:04:05, fastfriend=true, score=200, from=\"bengaluru\")"
 	triples += fmt.Sprintf("<33> <friend> <25> %s .\n", friendFacets7)
 	triples += fmt.Sprintf("<33> <friend> <31> %s .\n", friendFacets8)
 	triples += fmt.Sprintf("<33> <friend> <34> %s .\n", friendFacets9)
@@ -415,7 +415,7 @@ func TestFacetsMultipleOrderbyAllFacets(t *testing.T) {
 		{
 			me(func: uid(33)) {
 				name
-				friend @facets(fastfriend, orderdesc:score, orderasc:since) {
+				friend @facets(fastfriend, from, orderdesc:score, orderasc:since) {
 					name
 				}
 			}
@@ -444,10 +444,61 @@ func TestFacetsMultipleOrderbyAllFacets(t *testing.T) {
 							"1": true,
 							"2": false
 						},
+						"friend|from": {
+							"0": "bengaluru",
+							"1": "delhi"
+						},
 						"friend|score": {
 							"0": 200,
 							"1": 100,
 							"2": 100
+						},
+						"friend|since": {
+							"0": "2008-01-02T15:04:05Z",
+							"1": "2006-01-02T15:04:05Z",
+							"2": "2007-01-02T15:04:05Z"
+						}
+					}
+				]
+			}
+		}
+	`, js)
+}
+
+// This test tests multiple order by on facets where some facets in not present in all records.
+func TestFacetsMultipleOrderbyMissingFacets(t *testing.T) {
+	populateClusterWithFacets()
+	query := `
+		{
+			me(func: uid(33)) {
+				name
+				friend @facets(orderasc:from, orderdesc:since) {
+					name
+				}
+			}
+		}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+		{
+			"data": {
+				"me": [
+					{
+						"name": "Michale",
+						"friend": [
+							{
+								"name": "Roger"
+							},
+							{
+								"name": "Daryl Dixon"
+							},
+							{
+								"name": "Andrea"
+							}
+						],
+						"friend|from": {
+							"0": "bengaluru",
+							"1": "delhi"
 						},
 						"friend|since": {
 							"0": "2008-01-02T15:04:05Z",

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -17,7 +17,6 @@
 package query
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -475,8 +474,42 @@ func TestFacetsMultipleOrderbyNonsortableFacet(t *testing.T) {
 			}
 		}
 	`
-	_, err := processQuery(context.Background(), t, query)
-	require.Contains(t, err.Error(), "Value of type: bool isn't sortable")
+
+	js := processQueryNoErr(t, query)
+	// Since fastfriend is of bool type, it is not sortable.
+	// Hence result should be sorted by score.
+	require.JSONEq(t, `
+		{
+			"data": {
+			"me": [
+				{
+				"name": "Michale",
+				"friend": [
+					{
+					"name": "Daryl Dixon"
+					},
+					{
+					"name": "Andrea"
+					},
+					{
+					"name": "Roger"
+					}
+				],
+				"friend|fastfriend": {
+					"0": true,
+					"1": false,
+					"2": true
+				},
+				"friend|score": {
+					"0": 100,
+					"1": 100,
+					"2": 200
+				}
+				}
+			]
+			}
+		}
+	`, js)
 }
 
 func TestFacetsMultipleOrderbyAllFacets(t *testing.T) {

--- a/query/query_facets_test.go
+++ b/query/query_facets_test.go
@@ -97,6 +97,9 @@ func populateClusterWithFacets() error {
 	triples += fmt.Sprintf("<33> <friend> <31> %s .\n", friendFacets8)
 	triples += fmt.Sprintf("<33> <friend> <34> %s .\n", friendFacets9)
 
+	triples += fmt.Sprintf("<34> <friend> <31> %s .\n", friendFacets8)
+	triples += fmt.Sprintf("<34> <friend> <25> %s .\n", friendFacets9)
+
 	err := addTriplesToCluster(triples)
 
 	// Mark the setup as done so that the next tests do not have to perform it.
@@ -385,6 +388,73 @@ func TestFacetsMultipleOrderby(t *testing.T) {
 							"0": "2007-01-02T15:04:05Z",
 							"1": "2006-01-02T15:04:05Z",
 							"2": "2008-01-02T15:04:05Z"
+						}
+					}
+				]
+			}
+		}
+	`, js)
+}
+
+func TestFacetsMultipleOrderbyMultipleUIDs(t *testing.T) {
+	populateClusterWithFacets()
+	query := `
+		{
+			me(func: uid(33, 34)) {
+				name
+				friend @facets(orderdesc:since, orderasc:score) {
+					name
+				}
+			}
+		}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+		{
+			"data": {
+				"me": [
+					{
+						"name": "Michale",
+						"friend": [
+							{
+								"name": "Roger"
+							},
+							{
+								"name": "Andrea"
+							},
+							{
+								"name": "Daryl Dixon"
+							}
+						],
+						"friend|score": {
+							"0": 200,
+							"1": 100,
+							"2": 100
+						},
+						"friend|since": {
+							"0": "2008-01-02T15:04:05Z",
+							"1": "2007-01-02T15:04:05Z",
+							"2": "2006-01-02T15:04:05Z"
+						}
+					},
+					{
+						"name": "Roger",
+						"friend": [
+							{
+								"name": "Daryl Dixon"
+							},
+							{
+								"name": "Andrea"
+							}
+						],
+						"friend|score": {
+							"0": 200,
+							"1": 100
+						},
+						"friend|since": {
+							"0": "2008-01-02T15:04:05Z",
+							"1": "2007-01-02T15:04:05Z"
 						}
 					}
 				]

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -137,7 +137,8 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 					})
 				}
 			}
-			if len(sg.Params.Order) > 0 || len(sg.Params.FacetOrder) > 0 {
+			// TODO(Ashish): verify change here.
+			if len(sg.Params.Order) > 0 || len(sg.Params.FacetsOrder) > 0 {
 				// Can't use merge sort if the UIDs are not sorted.
 				sg.updateDestUids()
 			} else {

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -137,7 +137,6 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 					})
 				}
 			}
-			// TODO(Ashish): verify change here.
 			if len(sg.Params.Order) > 0 || len(sg.Params.FacetsOrder) > 0 {
 				// Can't use merge sort if the UIDs are not sorted.
 				sg.updateDestUids()

--- a/types/sort.go
+++ b/types/sort.go
@@ -91,12 +91,16 @@ func SortWithFacet(v [][]Val, ul *[]uint64, l []*pb.Facets, desc []bool, lang st
 		return nil
 	}
 
-	typ := v[0][0].Tid
-	switch typ {
-	case DateTimeID, IntID, FloatID, StringID, DefaultID:
-		// Don't do anything, we can sort values of this type.
-	default:
-		return errors.Errorf("Value of type: %s isn't sortable", typ.Name())
+	// TODO(Ashish): can we move this check to place where v is formed??
+	// TODO(Ashish): Here we can checking type for values in v[0] only. This might not return result
+	// as v[0] might have DefaultID type for some val while some v[x] can have some nonsortable type.
+	for _, val := range v[0] {
+		switch val.Tid {
+		case DateTimeID, IntID, FloatID, StringID, DefaultID:
+			// Don't do anything, we can sort values of this type.
+		default:
+			return errors.Errorf("Value of type: %s isn't sortable", val.Tid.Name())
+		}
 	}
 
 	var cl *collate.Collator

--- a/types/sort.go
+++ b/types/sort.go
@@ -92,8 +92,9 @@ func SortWithFacet(v [][]Val, ul *[]uint64, l []*pb.Facets, desc []bool, lang st
 	}
 
 	// TODO(Ashish): can we move this check to place where v is formed??
-	// TODO(Ashish): Here we can checking type for values in v[0] only. This might not return result
-	// as v[0] might have DefaultID type for some val while some v[x] can have some nonsortable type.
+	// TODO(Ashish): Here we are checking type for values in v[0] only. This might not return
+	// correct result as v[0] might have DefaultID type for some val while some v[x]
+	// can have some nonsortable type.
 	for _, val := range v[0] {
 		switch val.Tid {
 		case DateTimeID, IntID, FloatID, StringID, DefaultID:

--- a/types/sort.go
+++ b/types/sort.go
@@ -84,6 +84,16 @@ func (s byValue) Less(i, j int) bool {
 	return false
 }
 
+// IsSortable returns true, if tid is sortable. Otherwise it returns false.
+func IsSortable(tid TypeID) bool {
+	switch tid {
+	case DateTimeID, IntID, FloatID, StringID, DefaultID:
+		return true
+	}
+
+	return false
+}
+
 // SortWithFacet sorts the given array in-place and considers the given facets to calculate
 // the proper ordering.
 func SortWithFacet(v [][]Val, ul *[]uint64, l []*pb.Facets, desc []bool, lang string) error {
@@ -91,15 +101,8 @@ func SortWithFacet(v [][]Val, ul *[]uint64, l []*pb.Facets, desc []bool, lang st
 		return nil
 	}
 
-	// TODO(Ashish): can we move this check to place where v is formed??
-	// TODO(Ashish): Here we are checking type for values in v[0] only. This might not return
-	// correct result as v[0] might have DefaultID type for some val while some v[x]
-	// can have some nonsortable type.
 	for _, val := range v[0] {
-		switch val.Tid {
-		case DateTimeID, IntID, FloatID, StringID, DefaultID:
-			// Don't do anything, we can sort values of this type.
-		default:
+		if !IsSortable(val.Tid) {
 			return errors.Errorf("Value of type: %s isn't sortable", val.Tid.Name())
 		}
 	}

--- a/types/sort.go
+++ b/types/sort.go
@@ -89,9 +89,9 @@ func IsSortable(tid TypeID) bool {
 	switch tid {
 	case DateTimeID, IntID, FloatID, StringID, DefaultID:
 		return true
+	default:
+		return false
 	}
-
-	return false
 }
 
 // SortWithFacet sorts the given array in-place and considers the given facets to calculate


### PR DESCRIPTION
Fixes: https://github.com/dgraph-io/dgraph/issues/3638

Currently, we can specify ordering only on single facet while retrieving facets on uid predicates.
This PR adds support for specifying ordering on more than one facets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4579)
<!-- Reviewable:end -->
