### PR TITLE
Stricter checks in x.Parse

### DIFF
--- a/x/keys.go
+++ b/x/keys.go
@@ -506,7 +506,7 @@ func Parse(key []byte) (ParsedKey, error) {
 		}
 
 		if len(k) != 16 {
-			return p, errors.Errorf("StartUid length < 8 for key: %q, parsed key: %+v", key, p)
+			return p, errors.Errorf("StartUid length != 8 for key: %q, parsed key: %+v", key, p)
 		}
 
 		k = k[8:]
@@ -536,7 +536,7 @@ func Parse(key []byte) (ParsedKey, error) {
 		}
 
 		if len(k) != 12 {
-			return p, errors.Errorf("StartUid length < 8 for key: %q, parsed key: %+v", key, p)
+			return p, errors.Errorf("StartUid length != 8 for key: %q, parsed key: %+v", key, p)
 		}
 
 		k = k[4:]

--- a/x/keys.go
+++ b/x/keys.go
@@ -505,7 +505,7 @@ func Parse(key []byte) (ParsedKey, error) {
 			break
 		}
 
-		if len(k) < 16 {
+		if len(k) != 16 {
 			return p, errors.Errorf("StartUid length < 8 for key: %q, parsed key: %+v", key, p)
 		}
 
@@ -535,7 +535,7 @@ func Parse(key []byte) (ParsedKey, error) {
 			break
 		}
 
-		if len(k) < 12 {
+		if len(k) != 12 {
 			return p, errors.Errorf("StartUid length < 8 for key: %q, parsed key: %+v", key, p)
 		}
 

--- a/x/keys_test.go
+++ b/x/keys_test.go
@@ -208,3 +208,27 @@ func TestTypeKey(t *testing.T) {
 		require.Equal(t, sattr, pk.Attr)
 	}
 }
+
+func TestBadStartUid(t *testing.T) {
+	testKey := func(key []byte) {
+		key, err := GetSplitKey(key, 10)
+		require.NoError(t, err)
+		_, err = Parse(key)
+		require.NoError(t, err)
+		key = append(key, 0)
+		_, err = Parse(key)
+		require.Error(t, err)
+	}
+
+	key := DataKey("aa", 1)
+	testKey(key)
+
+	key = ReverseKey("aa", 1)
+	testKey(key)
+
+	key = CountKey("aa", 0, false)
+	testKey(key)
+
+	key = CountKey("aa", 0, true)
+	testKey(key)
+}


### PR DESCRIPTION
For data, count, and reverse keys, if there's a startuid appended at
the end of the key, there should be exactly eight remaining bytes.

More bytes mean that the key is malformed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4583)
<!-- Reviewable:end -->
