### PR TITLE
Disallow reverse predicates in pred argument for dgraph directive on fields

### DIFF
--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -583,10 +583,13 @@ invalid_schemas:
     input: |
       type X {
         f1: String! @dgraph(pred:"~movie")
+        f2: String! @dgraph(pred:"<~movie>")
       }
     errlist: [
       {"message": "Type X; Field f1: reverse pred argument for @dgraph directive is not supported.",
-      "locations":[{"line":2, "column":16}]}
+      "locations":[{"line":2, "column":16}]},
+      {"message": "Type X; Field f2: reverse pred argument for @dgraph directive is not supported.",
+      "locations":[{"line":3, "column":16}]}
     ]
 
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -578,6 +578,17 @@ invalid_schemas:
       "locations":[{"line":1, "column":9}]}
     ]
 
+  -
+    name: "Dgraph directive with reverse pred argument on field produces an error"
+    input: |
+      type X {
+        f1: String! @dgraph(pred:"~movie")
+      }
+    errlist: [
+      {"message": "Type X; Field f1: reverse pred argument for @dgraph directive is not supported.",
+      "locations":[{"line":2, "column":16}]}
+    ]
+
 
 valid_schemas:
   -

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -443,7 +443,7 @@ func dgraphDirectiveValidation(sch *ast.Schema, typ *ast.Definition, field *ast.
 			typ.Name, field.Name,
 		)
 	}
-	if strings.HasPrefix(predArg.Value.Raw, "~") {
+	if strings.HasPrefix(predArg.Value.Raw, "~") || strings.HasPrefix(predArg.Value.Raw, "<~") {
 		return gqlerror.ErrorPosf(
 			dir.Position,
 			"Type %s; Field %s: reverse pred argument for @dgraph directive is not supported.",

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -443,6 +443,13 @@ func dgraphDirectiveValidation(sch *ast.Schema, typ *ast.Definition, field *ast.
 			typ.Name, field.Name,
 		)
 	}
+	if strings.HasPrefix(predArg.Value.Raw, "~") {
+		return gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s: reverse pred argument for @dgraph directive is not supported.",
+			typ.Name, field.Name,
+		)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This change disallows supporting `~pred` as pred argument for `@dgraph` directive as we don't completely support it yet. It would be supported in a future release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4598)
<!-- Reviewable:end -->
