### PR TITLE
Fix how interfaces and @hasInverse works

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -232,9 +232,7 @@ var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) *gq
 
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	var dirs ast.DirectiveList
-	for _, d := range src.Directives {
-		dirs = append(dirs, d)
-	}
+	dirs = append(dirs, src.Directives...)
 
 	// Lets leave out copying the arguments as types in input schemas are not supposed to contain
 	// them. We add arguments for filters and order statements later.

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -233,9 +233,7 @@ var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) *gq
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	var dirs ast.DirectiveList
 	for _, d := range src.Directives {
-		if d.Name != inverseDirective {
-			dirs = append(dirs, d)
-		}
+		dirs = append(dirs, d)
 	}
 
 	// Lets leave out copying the arguments as types in input schemas are not supposed to contain

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -302,9 +302,11 @@ func isInverse(sch *ast.Schema, expectedInvType, expectedInvField, typeName stri
 	// We might have copied this directive in from an interface we are implementing.
 	// If so, make the check for that interface.
 	parentInt := parentInterface(sch, sch.Types[expectedInvType], expectedInvField)
-	if parentInt != nil &&
-		parentInt.Fields.ForName(expectedInvField).Directives.ForName(inverseDirective) != nil {
-		expectedInvType = parentInt.Name
+	if parentInt != nil {
+		fld := parentInt.Fields.ForName(expectedInvField)
+		if fld.Directives != nil && fld.Directives.ForName(inverseDirective) != nil {
+			expectedInvType = parentInt.Name
+		}
 	}
 
 	invType := field.Type.Name()

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -251,23 +251,49 @@ func hasInverseValidation(sch *ast.Schema, typ *ast.Definition,
 
 	invDirective := invField.Directives.ForName(inverseDirective)
 	if invDirective == nil {
-		invField.Directives = append(invField.Directives, &ast.Directive{
-			Name: inverseDirective,
-			Arguments: []*ast.Argument{
-				{
-					Name: inverseArg,
-					Value: &ast.Value{
-						Raw:      field.Name,
-						Position: dir.Position,
-						Kind:     ast.EnumValue,
+		addDirective := func(fld *ast.FieldDefinition) {
+			fld.Directives = append(fld.Directives, &ast.Directive{
+				Name: inverseDirective,
+				Arguments: []*ast.Argument{
+					{
+						Name: inverseArg,
+						Value: &ast.Value{
+							Raw:      field.Name,
+							Position: dir.Position,
+							Kind:     ast.EnumValue,
+						},
 					},
 				},
-			},
-			Position: dir.Position,
-		})
+				Position: dir.Position,
+			})
+		}
+
+		addDirective(invField)
+
+		// If it was an interface, we also need to copy the @hasInverse directive
+		// to all implementing types
+		if invType.Kind == ast.Interface {
+			for _, t := range sch.Types {
+				if implements(t, invType) {
+					f := t.Fields.ForName(invFieldName)
+					if f != nil {
+						addDirective(f)
+					}
+				}
+			}
+		}
 	}
 
 	return nil
+}
+
+func implements(typ *ast.Definition, intfc *ast.Definition) bool {
+	for _, t := range typ.Interfaces {
+		if t == intfc.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func isInverse(sch *ast.Schema, expectedInvType, expectedInvField, typeName string,

--- a/graphql/schema/testdata/schemagen/input/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/input/hasInverse-with-interface-having-directive.graphql
@@ -1,0 +1,20 @@
+type Author {
+  id: ID!
+  name: String! @search(by: [hash])
+  posts: [Post] 
+}
+
+interface Post {
+  id: ID!
+  text: String @search(by: [fulltext])
+  datePublished: DateTime @search
+  author: Author! @hasInverse(field: posts)
+}
+
+type Question implements Post {
+  answered: Boolean 
+}
+
+type Answer implements Post {
+  markedUseful: Boolean
+}

--- a/graphql/schema/testdata/schemagen/input/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/input/hasInverse-with-type-having-directive.graphql
@@ -1,0 +1,20 @@
+type Author {
+  id: ID!
+  name: String! @search(by: [hash])
+  posts: [Post] @hasInverse(field: author)
+}
+
+interface Post {
+  id: ID!
+  text: String @search(by: [fulltext])
+  datePublished: DateTime @search
+  author: Author! 
+}
+
+type Question implements Post {
+  answered: Boolean 
+}
+
+type Answer implements Post {
+  markedUseful: Boolean
+}

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -1,0 +1,370 @@
+#######################
+# Input Schema
+#######################
+
+type Author {
+	id: ID!
+	name: String! @search(by: [hash])
+	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
+}
+
+interface Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+}
+
+type Question implements Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+	answered: Boolean
+}
+
+type Answer implements Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+	markedUseful: Boolean
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+type AddAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+type AddQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+}
+
+type DeleteAnswerPayload {
+	msg: String
+}
+
+type DeleteAuthorPayload {
+	msg: String
+}
+
+type DeletePostPayload {
+	msg: String
+}
+
+type DeleteQuestionPayload {
+	msg: String
+}
+
+type UpdateAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+type UpdateAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+type UpdatePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+}
+
+type UpdateQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AnswerOrderable {
+	text
+	datePublished
+}
+
+enum AuthorOrderable {
+	name
+}
+
+enum PostOrderable {
+	text
+	datePublished
+}
+
+enum QuestionOrderable {
+	text
+	datePublished
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddAnswerInput {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef!
+	markedUseful: Boolean
+}
+
+input AddAuthorInput {
+	name: String!
+	posts: [PostRef]
+}
+
+input AddQuestionInput {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef!
+	answered: Boolean
+}
+
+input AnswerFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: AnswerFilter
+	or: AnswerFilter
+	not: AnswerFilter
+}
+
+input AnswerOrder {
+	asc: AnswerOrderable
+	desc: AnswerOrderable
+	then: AnswerOrder
+}
+
+input AnswerPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	markedUseful: Boolean
+}
+
+input AnswerRef {
+	id: ID
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	markedUseful: Boolean
+}
+
+input AuthorFilter {
+	id: [ID!]
+	name: StringHashFilter
+	and: AuthorFilter
+	or: AuthorFilter
+	not: AuthorFilter
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
+}
+
+input AuthorPatch {
+	name: String
+	posts: [PostRef]
+}
+
+input AuthorRef {
+	id: ID
+	name: String
+	posts: [PostRef]
+}
+
+input PostFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: PostFilter
+	or: PostFilter
+	not: PostFilter
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
+}
+
+input PostPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+}
+
+input PostRef {
+	id: ID!
+}
+
+input QuestionFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: QuestionFilter
+	or: QuestionFilter
+	not: QuestionFilter
+}
+
+input QuestionOrder {
+	asc: QuestionOrderable
+	desc: QuestionOrderable
+	then: QuestionOrder
+}
+
+input QuestionPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	answered: Boolean
+}
+
+input QuestionRef {
+	id: ID
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	answered: Boolean
+}
+
+input UpdateAnswerInput {
+	filter: AnswerFilter!
+	set: AnswerPatch
+	remove: AnswerPatch
+}
+
+input UpdateAuthorInput {
+	filter: AuthorFilter!
+	set: AuthorPatch
+	remove: AuthorPatch
+}
+
+input UpdatePostInput {
+	filter: PostFilter!
+	set: PostPatch
+	remove: PostPatch
+}
+
+input UpdateQuestionInput {
+	filter: QuestionFilter!
+	set: QuestionPatch
+	remove: QuestionPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	getPost(id: ID!): Post
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	getQuestion(id: ID!): Question
+	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+	getAnswer(id: ID!): Answer
+	queryAnswer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
+	addQuestion(input: [AddQuestionInput!]!): AddQuestionPayload
+	updateQuestion(input: UpdateQuestionInput!): UpdateQuestionPayload
+	deleteQuestion(filter: QuestionFilter!): DeleteQuestionPayload
+	addAnswer(input: [AddAnswerInput!]!): AddAnswerPayload
+	updateAnswer(input: UpdateAnswerInput!): UpdateAnswerPayload
+	deleteAnswer(filter: AnswerFilter!): DeleteAnswerPayload
+}

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -1,0 +1,370 @@
+#######################
+# Input Schema
+#######################
+
+type Author {
+	id: ID!
+	name: String! @search(by: [hash])
+	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
+}
+
+interface Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+}
+
+type Question implements Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+	answered: Boolean
+}
+
+type Answer implements Post {
+	id: ID!
+	text: String @search(by: [fulltext])
+	datePublished: DateTime @search
+	author(filter: AuthorFilter): Author! @hasInverse(field: posts)
+	markedUseful: Boolean
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+type AddAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+type AddQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+}
+
+type DeleteAnswerPayload {
+	msg: String
+}
+
+type DeleteAuthorPayload {
+	msg: String
+}
+
+type DeletePostPayload {
+	msg: String
+}
+
+type DeleteQuestionPayload {
+	msg: String
+}
+
+type UpdateAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+type UpdateAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+type UpdatePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+}
+
+type UpdateQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AnswerOrderable {
+	text
+	datePublished
+}
+
+enum AuthorOrderable {
+	name
+}
+
+enum PostOrderable {
+	text
+	datePublished
+}
+
+enum QuestionOrderable {
+	text
+	datePublished
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddAnswerInput {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef!
+	markedUseful: Boolean
+}
+
+input AddAuthorInput {
+	name: String!
+	posts: [PostRef]
+}
+
+input AddQuestionInput {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef!
+	answered: Boolean
+}
+
+input AnswerFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: AnswerFilter
+	or: AnswerFilter
+	not: AnswerFilter
+}
+
+input AnswerOrder {
+	asc: AnswerOrderable
+	desc: AnswerOrderable
+	then: AnswerOrder
+}
+
+input AnswerPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	markedUseful: Boolean
+}
+
+input AnswerRef {
+	id: ID
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	markedUseful: Boolean
+}
+
+input AuthorFilter {
+	id: [ID!]
+	name: StringHashFilter
+	and: AuthorFilter
+	or: AuthorFilter
+	not: AuthorFilter
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
+}
+
+input AuthorPatch {
+	name: String
+	posts: [PostRef]
+}
+
+input AuthorRef {
+	id: ID
+	name: String
+	posts: [PostRef]
+}
+
+input PostFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: PostFilter
+	or: PostFilter
+	not: PostFilter
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
+}
+
+input PostPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+}
+
+input PostRef {
+	id: ID!
+}
+
+input QuestionFilter {
+	id: [ID!]
+	text: StringFullTextFilter
+	datePublished: DateTimeFilter
+	and: QuestionFilter
+	or: QuestionFilter
+	not: QuestionFilter
+}
+
+input QuestionOrder {
+	asc: QuestionOrderable
+	desc: QuestionOrderable
+	then: QuestionOrder
+}
+
+input QuestionPatch {
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	answered: Boolean
+}
+
+input QuestionRef {
+	id: ID
+	text: String
+	datePublished: DateTime
+	author: AuthorRef
+	answered: Boolean
+}
+
+input UpdateAnswerInput {
+	filter: AnswerFilter!
+	set: AnswerPatch
+	remove: AnswerPatch
+}
+
+input UpdateAuthorInput {
+	filter: AuthorFilter!
+	set: AuthorPatch
+	remove: AuthorPatch
+}
+
+input UpdatePostInput {
+	filter: PostFilter!
+	set: PostPatch
+	remove: PostPatch
+}
+
+input UpdateQuestionInput {
+	filter: QuestionFilter!
+	set: QuestionPatch
+	remove: QuestionPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	getPost(id: ID!): Post
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	getQuestion(id: ID!): Question
+	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+	getAnswer(id: ID!): Answer
+	queryAnswer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
+	addQuestion(input: [AddQuestionInput!]!): AddQuestionPayload
+	updateQuestion(input: UpdateQuestionInput!): UpdateQuestionPayload
+	deleteQuestion(filter: QuestionFilter!): DeleteQuestionPayload
+	addAnswer(input: [AddAnswerInput!]!): AddAnswerPayload
+	updateAnswer(input: UpdateAnswerInput!): UpdateAnswerPayload
+	deleteAnswer(filter: AnswerFilter!): DeleteAnswerPayload
+}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -832,15 +832,9 @@ func (m *mutation) IncludeInterfaceField(dgraphTypes []interface{}) bool {
 }
 
 func (t *astType) Field(name string) FieldDefinition {
-	typName := t.Name()
-	parentInt := parentInterface(t.inSchema, t.inSchema.Types[typName], name)
-	if parentInt != nil {
-		typName = parentInt.Name
-	}
-
 	return &fieldDefinition{
 		// this ForName lookup is a loop in the underlying schema :-(
-		fieldDef:        t.inSchema.Types[typName].Fields.ForName(name),
+		fieldDef:        t.inSchema.Types[t.Name()].Fields.ForName(name),
 		inSchema:        t.inSchema,
 		dgraphPredicate: t.dgraphPredicate,
 	}


### PR DESCRIPTION
There were some bugs in how @hasInverse and interfaces work.  The @hasInverse wasn't in all the right places so with a schema like

```
type Author {
  ...
  questions: [Question] @hasInverse(field: author)
}

interface Post {
  ...
  author: Author!
}

type Question implements Post { ... }
```

we'd incorrectly copy the `@hasInverse` to the Question, but when doing mutation rewriting look for it on the post, and thus not link up questions and authors correctly.

Although this error really came from both schema generation and runtime problems, I don't think that this needs rewriting or e2e tests at this point.  Really the rewriting and e2e tests show that if there is a has inverse directive, then the reverse references get setup properly.  So now we have a set of schema tests that show that the @hasInverse gets set up properly.  Would be good to rearrange the e2e tests to show this, but that's a bigger bit of work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4605)
<!-- Reviewable:end -->
