### PR TITLE
Add checks to verify expected number of list splits in list_test.go

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1176,10 +1176,7 @@ func (l *List) readListPart(startUid uint64) (*pb.PostingList, error) {
 
 // shouldSplit returns true if the given plist should be split in two.
 func shouldSplit(plist *pb.PostingList) bool {
-	// The split code has a bug, which is causing Jepsen test failures #4538. Turning off the splits
-	// for now, until we identify what the issue is and fix it.
-	return false
-	// return plist.Size() >= maxListSize && len(plist.Pack.Blocks) > 1
+	return plist.Size() >= maxListSize && len(plist.Pack.Blocks) > 1
 }
 
 // splitUpList checks the list and splits it in smaller parts if needed.

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -931,6 +931,7 @@ func createMultiPartList(t *testing.T, size int, addLabel bool) (*List, int) {
 	require.NoError(t, writePostingListToDisk(kvs))
 	ol, err = getNew(key, ps)
 	require.NoError(t, err)
+	require.True(t, len(ol.plist.Splits) > 0)
 
 	return ol, commits
 }
@@ -963,6 +964,7 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 		}
 		commits++
 	}
+	require.True(t, len(ol.plist.Splits) > 0)
 
 	// Delete all the previously inserted entries from the list.
 	baseStartTs := uint64(size) + 1
@@ -982,6 +984,7 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 		}
 		commits++
 	}
+	require.Equal(t, 0, len(ol.plist.Splits))
 
 	return ol, commits
 }
@@ -1000,7 +1003,6 @@ func writePostingListToDisk(kvs []*bpb.KV) error {
 func TestMultiPartListBasic(t *testing.T) {
 	size := int(1e5)
 	ol, commits := createMultiPartList(t, size, false)
-	t.Logf("List parts %v", len(ol.plist.Splits))
 	opt := ListOptions{ReadTs: uint64(size) + 1}
 	l, err := ol.Uids(opt)
 	require.NoError(t, err)
@@ -1014,7 +1016,6 @@ func TestMultiPartListBasic(t *testing.T) {
 func TestMultiPartListIterAfterUid(t *testing.T) {
 	size := int(1e5)
 	ol, _ := createMultiPartList(t, size, false)
-	t.Logf("List parts %v", len(ol.plist.Splits))
 
 	var visitedUids []uint64
 	ol.Iterate(uint64(size+1), 50000, func(p *pb.Posting) error {
@@ -1031,7 +1032,6 @@ func TestMultiPartListIterAfterUid(t *testing.T) {
 func TestMultiPartListWithPostings(t *testing.T) {
 	size := int(1e5)
 	ol, commits := createMultiPartList(t, size, true)
-	t.Logf("List parts %v", len(ol.plist.Splits))
 
 	var labels []string
 	err := ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
@@ -1051,7 +1051,6 @@ func TestMultiPartListWithPostings(t *testing.T) {
 func TestMultiPartListMarshal(t *testing.T) {
 	size := int(1e5)
 	ol, _ := createMultiPartList(t, size, false)
-	t.Logf("List parts %v", len(ol.plist.Splits))
 
 	kvs, err := ol.Rollup()
 	require.NoError(t, err)
@@ -1108,7 +1107,6 @@ func TestMultiPartListWriteToDisk(t *testing.T) {
 func TestMultiPartListDelete(t *testing.T) {
 	size := int(1e4)
 	ol, commits := createAndDeleteMultiPartList(t, size)
-	t.Logf("List parts %v", len(ol.plist.Splits))
 	require.Equal(t, size*2, commits)
 
 	counter := 0


### PR DESCRIPTION
This PR re-enalbles splits so it should only be merged once #4574 is merged.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4609)
<!-- Reviewable:end -->
