### PR TITLE
contrib: Update path in systemd config README

### DIFF
--- a/contrib/systemd/centos/README.md
+++ b/contrib/systemd/centos/README.md
@@ -21,7 +21,7 @@ chown -R dgraph:dgraph /var/{lib,log}/dgraph
 ```
 
 Next, copy the `systemd` unit files, i.e. `dgraph-alpha.service`, `dgraph-zero.service`,
-and `dgraph-ui.service`, in this directory to `/usr/lib/systemd/system/`.
+and `dgraph-ui.service`, in this directory to `/etc/systemd/system/`.
 
 > **NOTE** These unit files expect that Dgraph is installed as `/usr/local/bin/dgraph`.
 


### PR DESCRIPTION
In a previous PR, we changed the path where to copy the service files from `/usr/lib/systemd/system/` to  `/etc/systemd/system/`
The `cp` commands where changed, but the text still referenced the old path. This is now fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4614)
<!-- Reviewable:end -->
