### PR TITLE
Authenticate only once before authroization

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1613,8 +1613,7 @@ func TestUpsertWithValueVar(t *testing.T) {
 	require.NoError(t, alterSchema(`amount: int .`))
 	res, err := mutationWithTs(`{ set { _:p <amount> "0" . } }`, "application/rdf", false, true, 0)
 	require.NoError(t, err)
-	b, _ := json.MarshalIndent(res, "", "  ")
-	fmt.Printf("%s\n", b)
+	_, _ = json.MarshalIndent(res, "", "  ")
 
 	const (
 		// this upsert block increments the value of the counter by one

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -69,3 +69,7 @@ func authorizeGroot(ctx context.Context) error {
 	// always allow access
 	return nil
 }
+
+func authenticateAndUpdateContext(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -805,7 +805,7 @@ func authorizeGroot(ctx context.Context) error {
 	doAuthorizeGroot := func() error {
 		userId, ok := ctx.Value(userId).(string)
 		if !ok {
-			errors.New("Inappropriate value of userId in context: expected type string")
+			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
 
 		if userId == x.GrootId {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -522,11 +522,11 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	doAuthorizeAlter := func() error {
 		userId, ok := ctx.Value(userId).(string)
 		if !ok {
-			errors.New("Inappropriate value of userId in context: expected type string")
+			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
 		groupIds, ok := ctx.Value(groups).([]string)
 		if !ok {
-			errors.New("Inappropriate value of groups in context: expected type []srting")
+			return errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
 
 		if x.IsGuardian(groupIds) {
@@ -629,11 +629,11 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	doAuthorizeMutation := func() error {
 		userId, ok := ctx.Value(userId).(string)
 		if !ok {
-			errors.New("Inappropriate value of userId in context: expected type string")
+			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
 		groupIds, ok := ctx.Value(groups).([]string)
 		if !ok {
-			errors.New("Inappropriate value of groups in context: expected type []srting")
+			return errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
 
 		if x.IsGuardian(groupIds) {
@@ -756,11 +756,11 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	doAuthorizeQuery := func() (map[string]struct{}, error) {
 		userId, ok := ctx.Value(userId).(string)
 		if !ok {
-			errors.New("Inappropriate value of userId in context: expected type string")
+			return nil, errors.New("Inappropriate value of userId in context: expected type string")
 		}
 		groupIds, ok := ctx.Value(groups).([]string)
 		if !ok {
-			errors.New("Inappropriate value of groups in context: expected type []srting")
+			return nil, errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
 
 		if x.IsGuardian(groupIds) {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -38,6 +38,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var errTypAssertString = errors.New(
+	"Inappropriate value of userId in context: expected type string")
+
+var errTypAssertStringSlice = errors.New(
+	"Inappropriate value of groups in context: expected type []string")
+
 type userContextKey int
 
 const (
@@ -522,11 +528,11 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	doAuthorizeAlter := func() error {
 		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
-			return errors.New("Inappropriate value of userId in context: expected type string")
+			return errTypAssertString
 		}
 		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
-			return errors.New("Inappropriate value of groups in context: expected type []srting")
+			return errTypAssertStringSlice
 		}
 
 		if x.IsGuardian(groupIds) {
@@ -629,11 +635,11 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	doAuthorizeMutation := func() error {
 		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
-			return errors.New("Inappropriate value of userId in context: expected type string")
+			return errTypAssertString
 		}
 		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
-			return errors.New("Inappropriate value of groups in context: expected type []srting")
+			return errTypAssertStringSlice
 		}
 
 		if x.IsGuardian(groupIds) {
@@ -756,11 +762,11 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	doAuthorizeQuery := func() (map[string]struct{}, error) {
 		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
-			return nil, errors.New("Inappropriate value of userId in context: expected type string")
+			return nil, errTypAssertString
 		}
 		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
-			return nil, errors.New("Inappropriate value of groups in context: expected type []srting")
+			return nil, errTypAssertStringSlice
 		}
 
 		if x.IsGuardian(groupIds) {
@@ -805,7 +811,7 @@ func authorizeGroot(ctx context.Context) error {
 	doAuthorizeGroot := func() error {
 		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
-			return errors.New("Inappropriate value of userId in context: expected type string")
+			return errTypAssertString
 		}
 
 		if userId == x.GrootId {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -41,8 +41,8 @@ import (
 type userContextKey int
 
 const (
-	userId userContextKey = iota
-	groups
+	userIdKey userContextKey = iota
+	groupsKey
 )
 
 // Login handles login requests from clients.
@@ -520,11 +520,11 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 	// doAuthorizeAlter checks if alter of all the predicates are allowed
 	// as a byproduct, it also sets the userId, groups variables
 	doAuthorizeAlter := func() error {
-		userId, ok := ctx.Value(userId).(string)
+		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
 			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
-		groupIds, ok := ctx.Value(groups).([]string)
+		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
 			return errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
@@ -627,11 +627,11 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	// doAuthorizeMutation checks if modification of all the predicates are allowed
 	// as a byproduct, it also sets the userId and groups
 	doAuthorizeMutation := func() error {
-		userId, ok := ctx.Value(userId).(string)
+		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
 			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
-		groupIds, ok := ctx.Value(groups).([]string)
+		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
 			return errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
@@ -754,11 +754,11 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	preds := parsePredsFromQuery(parsedReq.Query)
 
 	doAuthorizeQuery := func() (map[string]struct{}, error) {
-		userId, ok := ctx.Value(userId).(string)
+		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
 			return nil, errors.New("Inappropriate value of userId in context: expected type string")
 		}
-		groupIds, ok := ctx.Value(groups).([]string)
+		groupIds, ok := ctx.Value(groupsKey).([]string)
 		if !ok {
 			return nil, errors.New("Inappropriate value of groups in context: expected type []srting")
 		}
@@ -803,7 +803,7 @@ func authorizeGroot(ctx context.Context) error {
 
 	// doAuthorizeState checks if the user is authorized to perform this API request
 	doAuthorizeGroot := func() error {
-		userId, ok := ctx.Value(userId).(string)
+		userId, ok := ctx.Value(userIdKey).(string)
 		if !ok {
 			return errors.New("Inappropriate value of userId in context: expected type string")
 		}
@@ -901,8 +901,8 @@ func authenticateAndUpdateContext(ctx context.Context) (context.Context, error) 
 		return ctx, status.Error(codes.Unauthenticated, err.Error())
 	}
 
-	newCtx := context.WithValue(ctx, userId, userData[0])
-	newCtx = context.WithValue(newCtx, groups, userData[1:])
+	newCtx := context.WithValue(ctx, userIdKey, userData[0])
+	newCtx = context.WithValue(newCtx, groupsKey, userData[1:])
 
 	return newCtx, nil
 }

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -788,6 +788,7 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode)
 	if doAuth == NeedAuthorize {
 		ctx, rerr = authenticateAndUpdateContext(ctx)
 		if rerr != nil {
+			glog.V(1).Info(rerr.Error())
 			return
 		}
 		if rerr = authorizeRequest(ctx, qc); rerr != nil {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -778,8 +778,8 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, authorize int) (
 	}
 
 	if authorize == NeedAuthorize {
-		ctx, err := authenticateAndUpdateContext(ctx)
-		if err != nil {
+		ctx, rerr = authenticateAndUpdateContext(ctx)
+		if rerr != nil {
 			return
 		}
 		if rerr = authorizeRequest(ctx, qc); rerr != nil {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -773,6 +773,13 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, authorize int) (
 	}
 
 	if authorize == NeedAuthorize {
+		userData, err := extractUserAndGroups(ctx)
+		if err != nil {
+			return nil, status.Error(codes.Unauthenticated, err.Error())
+		}
+		ctx = context.WithValue(ctx, "userId", userData[0])
+		ctx = context.WithValue(ctx, "groupIds", userData[1:])
+
 		if rerr = authorizeRequest(ctx, qc); rerr != nil {
 			return
 		}


### PR DESCRIPTION
Right now we do authentication and authorization together in all the authorization functions. Ideally it should be done only once. 
Now authentication will be done only once before authorization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4630)
<!-- Reviewable:end -->
