### PR TITLE
Revert k8s ha yaml - Removing liveness and readiness probes

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -16,7 +16,7 @@ metadata:
     app: dgraph-zero
     monitor: zero-dgraph-io
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 5080
     targetPort: 5080
@@ -35,7 +35,7 @@ metadata:
     app: dgraph-alpha
     monitor: alpha-dgraph-io
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 8080
     targetPort: 8080
@@ -56,7 +56,7 @@ metadata:
   labels:
     app: dgraph-alpha
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 8080
     targetPort: 8080
@@ -71,7 +71,7 @@ metadata:
   labels:
     app: dgraph-ratel
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 8000
     targetPort: 8000

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -171,24 +171,6 @@ spec:
             else
               exec dgraph zero --my=$(hostname -f):5080 --peer dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080 --idx $idx --replicas 3
             fi
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: 6080
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
-        readinessProbe:
-          httpGet:
-            path: /state
-            port: 6080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
       terminationGracePeriodSeconds: 60
       volumes:
       - name: datadir
@@ -306,24 +288,6 @@ spec:
           - |
             set -ex
             dgraph alpha --my=$(hostname -f):7080 --lru_mb 2048 --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080
-        livenessProbe:
-          httpGet:
-            path: /health?live=1
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
-        readinessProbe:
-          httpGet:
-            path: /health
-            port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
-          timeoutSeconds: 5
-          failureThreshold: 6
-          successThreshold: 1
       terminationGracePeriodSeconds: 600
       volumes:
       - name: datadir


### PR DESCRIPTION
Fixes #4627

- Removing liveness and readiness probes until the issue is fixed
- Replaced ClusterIP to LoadBalancer for services

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4631)
<!-- Reviewable:end -->
<!-- Dgraph:start -->
---
Docs Preview: [<img src="https://docs.dgraph.io/images/dgraph.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://dgraph-94ede5ef47-40848.surge.sh/)
<!-- Dgraph:end -->