### PR TITLE
Check for erors when writing to buffers in x.go

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -182,17 +182,17 @@ func (gqlErr *GqlError) Error() string {
 		return ""
 	}
 
-	buf.WriteString(gqlErr.Message)
+	Check2(buf.WriteString(gqlErr.Message))
 
 	if len(gqlErr.Locations) > 0 {
-		buf.WriteString(" (Locations: [")
+		Check2(buf.WriteString(" (Locations: ["))
 		for i, loc := range gqlErr.Locations {
 			if i > 0 {
-				buf.WriteString(", ")
+				Check2(buf.WriteString(", "))
 			}
-			buf.WriteString(fmt.Sprintf("{Line: %v, Column: %v}", loc.Line, loc.Column))
+			Check2(buf.WriteString(fmt.Sprintf("{Line: %v, Column: %v}", loc.Line, loc.Column)))
 		}
-		buf.WriteString("])")
+		Check2(buf.WriteString("])"))
 	}
 
 	return buf.String()
@@ -202,9 +202,9 @@ func (errList GqlErrorList) Error() string {
 	var buf bytes.Buffer
 	for i, gqlErr := range errList {
 		if i > 0 {
-			buf.WriteByte('\n')
+			Check(buf.WriteByte('\n'))
 		}
-		buf.WriteString(gqlErr.Error())
+		Check2(buf.WriteString(gqlErr.Error()))
 	}
 	return buf.String()
 }


### PR DESCRIPTION
Writing to the buffers in the affected functions will most likely not
cause an error so using Check2 should be safe to use to verify the
errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4636)
<!-- Reviewable:end -->
