### PR TITLE
Fix telemetry in alphas.

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -31,19 +31,19 @@ import (
 
 // Telemetry holds information about the state of the zero and alpha server.
 type Telemetry struct {
-	Arch        string
-	Cid         string
-	ClusterSize int
-	DiskUsageMB int64
-	NumAlphas   int
-	NumGroups   int
-	NumTablets  int
-	NumZeros    int
-	OS          string
-	SinceHours  int
-	Version     string
-	NumQueries  uint64
-	NumGraphQL  uint64
+	Arch         string
+	Cid          string
+	ClusterSize  int
+	DiskUsageMB  int64
+	NumAlphas    int
+	NumGroups    int
+	NumTablets   int
+	NumZeros     int
+	OS           string
+	SinceHours   int
+	Version      string
+	NumGraphQLPM uint64
+	NumGraphQL   uint64
 }
 
 var url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"


### PR DESCRIPTION
- SinceHours now returns the uptime like zero does.
- NumQueries renamed to be more explicity this is the number of
GraphQL+- queries, not the total number of queries.
- Counters between queries and graphql queries were swapped incorrectly.

Fixes #4639.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4641)
<!-- Reviewable:end -->
