### PR TITLE
contrib: Add Restart option to systemd files

### DIFF
--- a/contrib/systemd/centos/dgraph-alpha.service
+++ b/contrib/systemd/centos/dgraph-alpha.service
@@ -8,6 +8,7 @@ Requires=dgraph-zero.service
 Type=simple
 WorkingDirectory=/var/lib/dgraph
 ExecStart=/usr/bin/bash -c 'dgraph alpha --lru_mb 2048 -p /var/lib/dgraph/p -w /var/lib/dgraph/w'
+Restart=on-failure
 StandardOutput=journal
 StandardError=journal
 User=dgraph

--- a/contrib/systemd/centos/dgraph-ui.service
+++ b/contrib/systemd/centos/dgraph-ui.service
@@ -6,6 +6,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/bin/bash -c 'dgraph-ratel'
+Restart=on-failure
 StandardOutput=journal
 StandardError=journal
 User=dgraph

--- a/contrib/systemd/centos/dgraph-zero.service
+++ b/contrib/systemd/centos/dgraph-zero.service
@@ -7,6 +7,7 @@ After=network.target
 Type=simple
 WorkingDirectory=/var/lib/dgraph
 ExecStart=/usr/bin/bash -c 'dgraph zero --wal /var/lib/dgraph/zw'
+Restart=on-failure
 StandardOutput=journal
 StandardError=journal
 User=dgraph


### PR DESCRIPTION
From https://www.freedesktop.org/software/systemd/man/systemd.service.html#Options:

> Setting this to on-failure is the recommended choice for long-running services, in order to increase reliability by attempting automatic recovery from errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4645)
<!-- Reviewable:end -->
