### PR TITLE
docs: Add /query options (read-only, best-effort) for HTTP API.

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -808,6 +808,40 @@ The result:
 }
 ```
 
+### Running read-only queries
+
+You can set the query parameter `ro=true` to `/query` to set it as a
+[read-only]({{< relref "#read-only-transactions" >}}) query.
+
+
+```sh
+$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?ro=true" -d $'
+{
+  balances(func: anyofterms(name, "Alice Bob")) {
+    uid
+    name
+    balance
+  }
+}
+```
+
+### Running best-effort queries
+
+You can set the query parameter `be=true` to `/query` to set it as a
+[best-effort]({{< relref "#read-only-transactions" >}}) query.
+
+
+```sh
+$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?be=true" -d $'
+{
+  balances(func: anyofterms(name, "Alice Bob")) {
+    uid
+    name
+    balance
+  }
+}
+```
+
 ### Compression via HTTP
 
 Dgraph supports gzip-compressed requests to and from Dgraph Alphas for `/query`, `/mutate`, and `/alter`.


### PR DESCRIPTION
Document the HTTP API `/query` options that are available via query parameters.

* Read-only queries: `/query?ro=true`
* Best-effort queries: `/query?be=true`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4670)
<!-- Reviewable:end -->
