### PR TITLE
Escape MySQL column names

### DIFF
--- a/dgraph/cmd/migrate/dump.go
+++ b/dgraph/cmd/migrate/dump.go
@@ -91,7 +91,12 @@ func (m *dumpMeta) dumpTable(table string) error {
 	tableGuide := m.tableGuides[table]
 	tableInfo := m.tableInfos[table]
 
-	query := fmt.Sprintf(`select %s from %s`, strings.Join(tableInfo.columnNames, ","), table)
+	escapedColNames := make([]string, len(tableInfo.columnNames))
+	for _, c := range tableInfo.columnNames {
+		escapedColNames = append(escapedColNames, fmt.Sprintf("`"+"%s"+"`", c))
+	}
+
+	query := fmt.Sprintf(`select %s from %s`, strings.Join(escapedColNames, ","), table)
 	rows, err := m.sqlPool.Query(query)
 	if err != nil {
 		return err
@@ -135,7 +140,12 @@ func (m *dumpMeta) dumpTableConstraints(table string) error {
 	tableGuide := m.tableGuides[table]
 	tableInfo := m.tableInfos[table]
 
-	query := fmt.Sprintf(`select %s from %s`, strings.Join(tableInfo.columnNames, ","), table)
+	escapedColNames := make([]string, len(tableInfo.columnNames))
+	for _, c := range tableInfo.columnNames {
+		escapedColNames = append(escapedColNames, fmt.Sprintf("`"+"%s"+"`", c))
+	}
+
+	query := fmt.Sprintf(`select %s from %s`, strings.Join(escapedColNames, ","), table)
 	rows, err := m.sqlPool.Query(query)
 	if err != nil {
 		return err

--- a/dgraph/cmd/migrate/dump.go
+++ b/dgraph/cmd/migrate/dump.go
@@ -91,7 +91,7 @@ func (m *dumpMeta) dumpTable(table string) error {
 	tableGuide := m.tableGuides[table]
 	tableInfo := m.tableInfos[table]
 
-	escapedColNames := make([]string, len(tableInfo.columnNames))
+	var escapedColNames []string
 	for _, c := range tableInfo.columnNames {
 		escapedColNames = append(escapedColNames, fmt.Sprintf("`"+"%s"+"`", c))
 	}
@@ -140,7 +140,7 @@ func (m *dumpMeta) dumpTableConstraints(table string) error {
 	tableGuide := m.tableGuides[table]
 	tableInfo := m.tableInfos[table]
 
-	escapedColNames := make([]string, len(tableInfo.columnNames))
+	var escapedColNames []string
 	for _, c := range tableInfo.columnNames {
 		escapedColNames = append(escapedColNames, fmt.Sprintf("`"+"%s"+"`", c))
 	}


### PR DESCRIPTION
This change wraps all the column names with backticks so that MySQL won't complain when a table has columns that are also reserved keywords in MySQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4673)
<!-- Reviewable:end -->
