### PR TITLE
Revert "Disable splits in release 1.2 (#4672)"

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1176,8 +1176,7 @@ func (l *List) readListPart(startUid uint64) (*pb.PostingList, error) {
 
 // shouldSplit returns true if the given plist should be split in two.
 func shouldSplit(plist *pb.PostingList) bool {
-	return false
-	// return plist.Size() >= maxListSize && len(plist.Pack.Blocks) > 1
+	return plist.Size() >= maxListSize && len(plist.Pack.Blocks) > 1
 }
 
 // splitUpList checks the list and splits it in smaller parts if needed.


### PR DESCRIPTION
This reverts commit c1a7a2c29567fd2ab12462c60b5bf902fc3354b9.

This was accidentally pused to master. I was planning to leave it as is since it looked like
splits were causing Jepsen bank test failures. However, it doesn't look like the splits are 
responsible for this (the p directory of a failed test did not contain any split lists).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4680)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-fd54ba8b39-41909.surge.sh)
<!-- Dgraph:end -->