### PR TITLE
docs: Set default version to v1.2.0.

### DIFF
--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -20,8 +20,9 @@ HOST=https://docs.dgraph.io
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 VERSIONS_ARRAY=(
-	'v1.1.1'
+	'v1.2.0'
 	'master'
+	'v1.1.1'
 	'v1.1.0'
 	'v1.0.18'
 	'v1.0.17'


### PR DESCRIPTION
Set `v1.2.0` as the default in the docs build script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4683)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b646255605-42117.surge.sh)
<!-- Dgraph:end -->