### PR TITLE
Disable multi-part list tests.

### DIFF
--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -22,7 +22,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"sort"
 	"strconv"
 	"testing"
 
@@ -999,243 +998,243 @@ func writePostingListToDisk(kvs []*bpb.KV) error {
 	return writer.Flush()
 }
 
-// Create a multi-part list and verify all the uids are there.
-func TestMultiPartListBasic(t *testing.T) {
-	size := int(1e5)
-	ol, commits := createMultiPartList(t, size, false)
-	opt := ListOptions{ReadTs: uint64(size) + 1}
-	l, err := ol.Uids(opt)
-	require.NoError(t, err)
-	require.Equal(t, commits, len(l.Uids), "List of Uids received: %+v", l.Uids)
-	for i, uid := range l.Uids {
-		require.Equal(t, uint64(i+1), uid)
-	}
-}
+// // Create a multi-part list and verify all the uids are there.
+// func TestMultiPartListBasic(t *testing.T) {
+// 	size := int(1e5)
+// 	ol, commits := createMultiPartList(t, size, false)
+// 	opt := ListOptions{ReadTs: uint64(size) + 1}
+// 	l, err := ol.Uids(opt)
+// 	require.NoError(t, err)
+// 	require.Equal(t, commits, len(l.Uids), "List of Uids received: %+v", l.Uids)
+// 	for i, uid := range l.Uids {
+// 		require.Equal(t, uint64(i+1), uid)
+// 	}
+// }
 
-// Verify that iteration works with an afterUid value greater than zero.
-func TestMultiPartListIterAfterUid(t *testing.T) {
-	size := int(1e5)
-	ol, _ := createMultiPartList(t, size, false)
+// // Verify that iteration works with an afterUid value greater than zero.
+// func TestMultiPartListIterAfterUid(t *testing.T) {
+// 	size := int(1e5)
+// 	ol, _ := createMultiPartList(t, size, false)
 
-	var visitedUids []uint64
-	ol.Iterate(uint64(size+1), 50000, func(p *pb.Posting) error {
-		visitedUids = append(visitedUids, p.Uid)
-		return nil
-	})
-	require.Equal(t, 50000, len(visitedUids))
-	for i, uid := range visitedUids {
-		require.Equal(t, uint64(50000+i+1), uid)
-	}
-}
+// 	var visitedUids []uint64
+// 	ol.Iterate(uint64(size+1), 50000, func(p *pb.Posting) error {
+// 		visitedUids = append(visitedUids, p.Uid)
+// 		return nil
+// 	})
+// 	require.Equal(t, 50000, len(visitedUids))
+// 	for i, uid := range visitedUids {
+// 		require.Equal(t, uint64(50000+i+1), uid)
+// 	}
+// }
 
-// Verify that postings can be retrieved in multi-part lists.
-func TestMultiPartListWithPostings(t *testing.T) {
-	size := int(1e5)
-	ol, commits := createMultiPartList(t, size, true)
+// // Verify that postings can be retrieved in multi-part lists.
+// func TestMultiPartListWithPostings(t *testing.T) {
+// 	size := int(1e5)
+// 	ol, commits := createMultiPartList(t, size, true)
 
-	var labels []string
-	err := ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
-		if len(p.Label) > 0 {
-			labels = append(labels, p.Label)
-		}
-		return nil
-	})
-	require.NoError(t, err)
-	require.Equal(t, commits, len(labels))
-	for i, label := range labels {
-		require.Equal(t, label, strconv.Itoa(int(i+1)))
-	}
-}
+// 	var labels []string
+// 	err := ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
+// 		if len(p.Label) > 0 {
+// 			labels = append(labels, p.Label)
+// 		}
+// 		return nil
+// 	})
+// 	require.NoError(t, err)
+// 	require.Equal(t, commits, len(labels))
+// 	for i, label := range labels {
+// 		require.Equal(t, label, strconv.Itoa(int(i+1)))
+// 	}
+// }
 
-// Verify marshaling of multi-part lists.
-func TestMultiPartListMarshal(t *testing.T) {
-	size := int(1e5)
-	ol, _ := createMultiPartList(t, size, false)
+// // Verify marshaling of multi-part lists.
+// func TestMultiPartListMarshal(t *testing.T) {
+// 	size := int(1e5)
+// 	ol, _ := createMultiPartList(t, size, false)
 
-	kvs, err := ol.Rollup()
-	require.NoError(t, err)
-	require.Equal(t, len(kvs), len(ol.plist.Splits)+1)
-	require.NoError(t, writePostingListToDisk(kvs))
+// 	kvs, err := ol.Rollup()
+// 	require.NoError(t, err)
+// 	require.Equal(t, len(kvs), len(ol.plist.Splits)+1)
+// 	require.NoError(t, writePostingListToDisk(kvs))
 
-	sort.Slice(kvs, func(i, j int) bool {
-		return string(kvs[i].Key) < string(kvs[j].Key)
-	})
+// 	sort.Slice(kvs, func(i, j int) bool {
+// 		return string(kvs[i].Key) < string(kvs[j].Key)
+// 	})
 
-	key := x.DataKey("multi-bal", 1331)
-	require.Equal(t, key, kvs[0].Key)
+// 	key := x.DataKey("multi-bal", 1331)
+// 	require.Equal(t, key, kvs[0].Key)
 
-	for i, startUid := range ol.plist.Splits {
-		partKey, err := x.GetSplitKey(key, startUid)
-		require.NoError(t, err)
-		require.Equal(t, partKey, kvs[i+1].Key)
-		part, err := ol.readListPart(startUid)
-		require.NoError(t, err)
-		data, err := part.Marshal()
-		require.NoError(t, err)
-		require.Equal(t, data, kvs[i+1].Value)
-		require.Equal(t, []byte{BitCompletePosting}, kvs[i+1].UserMeta)
-		require.Equal(t, ol.minTs, kvs[i+1].Version)
-	}
-}
+// 	for i, startUid := range ol.plist.Splits {
+// 		partKey, err := x.GetSplitKey(key, startUid)
+// 		require.NoError(t, err)
+// 		require.Equal(t, partKey, kvs[i+1].Key)
+// 		part, err := ol.readListPart(startUid)
+// 		require.NoError(t, err)
+// 		data, err := part.Marshal()
+// 		require.NoError(t, err)
+// 		require.Equal(t, data, kvs[i+1].Value)
+// 		require.Equal(t, []byte{BitCompletePosting}, kvs[i+1].UserMeta)
+// 		require.Equal(t, ol.minTs, kvs[i+1].Version)
+// 	}
+// }
 
-// Verify that writing a multi-part list to disk works correctly.
-func TestMultiPartListWriteToDisk(t *testing.T) {
-	size := int(1e5)
-	originalList, commits := createMultiPartList(t, size, false)
+// // Verify that writing a multi-part list to disk works correctly.
+// func TestMultiPartListWriteToDisk(t *testing.T) {
+// 	size := int(1e5)
+// 	originalList, commits := createMultiPartList(t, size, false)
 
-	kvs, err := originalList.Rollup()
-	require.NoError(t, err)
-	require.Equal(t, len(kvs), len(originalList.plist.Splits)+1)
+// 	kvs, err := originalList.Rollup()
+// 	require.NoError(t, err)
+// 	require.Equal(t, len(kvs), len(originalList.plist.Splits)+1)
 
-	require.NoError(t, writePostingListToDisk(kvs))
-	newList, err := getNew(kvs[0].Key, ps)
-	require.NoError(t, err)
+// 	require.NoError(t, writePostingListToDisk(kvs))
+// 	newList, err := getNew(kvs[0].Key, ps)
+// 	require.NoError(t, err)
 
-	opt := ListOptions{ReadTs: uint64(size) + 1}
-	originalUids, err := originalList.Uids(opt)
-	require.NoError(t, err)
-	newUids, err := newList.Uids(opt)
-	require.NoError(t, err)
-	require.Equal(t, commits, len(originalUids.Uids))
-	require.Equal(t, len(originalUids.Uids), len(newUids.Uids))
-	for i := range originalUids.Uids {
-		require.Equal(t, originalUids.Uids[i], newUids.Uids[i])
-	}
-}
+// 	opt := ListOptions{ReadTs: uint64(size) + 1}
+// 	originalUids, err := originalList.Uids(opt)
+// 	require.NoError(t, err)
+// 	newUids, err := newList.Uids(opt)
+// 	require.NoError(t, err)
+// 	require.Equal(t, commits, len(originalUids.Uids))
+// 	require.Equal(t, len(originalUids.Uids), len(newUids.Uids))
+// 	for i := range originalUids.Uids {
+// 		require.Equal(t, originalUids.Uids[i], newUids.Uids[i])
+// 	}
+// }
 
-// Verify that adding and deleting all the entries returns an empty list.
-func TestMultiPartListDelete(t *testing.T) {
-	size := int(1e4)
-	ol, commits := createAndDeleteMultiPartList(t, size)
-	require.Equal(t, size*2, commits)
+// // Verify that adding and deleting all the entries returns an empty list.
+// func TestMultiPartListDelete(t *testing.T) {
+// 	size := int(1e4)
+// 	ol, commits := createAndDeleteMultiPartList(t, size)
+// 	require.Equal(t, size*2, commits)
 
-	counter := 0
-	ol.Iterate(math.MaxUint64, 0, func(p *pb.Posting) error {
-		counter++
-		return nil
-	})
-	require.Equal(t, 0, counter)
+// 	counter := 0
+// 	ol.Iterate(math.MaxUint64, 0, func(p *pb.Posting) error {
+// 		counter++
+// 		return nil
+// 	})
+// 	require.Equal(t, 0, counter)
 
-	kvs, err := ol.Rollup()
-	require.NoError(t, err)
-	require.Equal(t, len(kvs), 1)
+// 	kvs, err := ol.Rollup()
+// 	require.NoError(t, err)
+// 	require.Equal(t, len(kvs), 1)
 
-	for _, kv := range kvs {
-		require.Equal(t, []byte{BitEmptyPosting}, kv.UserMeta)
-		require.Equal(t, ol.minTs, kv.Version)
-	}
-}
+// 	for _, kv := range kvs {
+// 		require.Equal(t, []byte{BitEmptyPosting}, kv.UserMeta)
+// 		require.Equal(t, ol.minTs, kv.Version)
+// 	}
+// }
 
-// Verify that the first part of a multi-part list is kept even when all its
-// entries have been deleted. Do this by creating a list, deleting the first
-// half, and ensuring iteration and mutation still work as expected.
-func TestMultiPartListDeleteAndAdd(t *testing.T) {
-	size := int(1e5)
-	// For testing, set the max list size to a lower threshold.
-	maxListSize = 5000
-	defer func() {
-		maxListSize = math.MaxInt32
-	}()
+// // Verify that the first part of a multi-part list is kept even when all its
+// // entries have been deleted. Do this by creating a list, deleting the first
+// // half, and ensuring iteration and mutation still work as expected.
+// func TestMultiPartListDeleteAndAdd(t *testing.T) {
+// 	size := int(1e5)
+// 	// For testing, set the max list size to a lower threshold.
+// 	maxListSize = 5000
+// 	defer func() {
+// 		maxListSize = math.MaxInt32
+// 	}()
 
-	// Add entries to the maps.
-	key := x.DataKey("del_add", 1331)
-	ol, err := getNew(key, ps)
-	require.NoError(t, err)
-	for i := 1; i <= size; i++ {
-		edge := &pb.DirectedEdge{
-			ValueId: uint64(i),
-		}
+// 	// Add entries to the maps.
+// 	key := x.DataKey("del_add", 1331)
+// 	ol, err := getNew(key, ps)
+// 	require.NoError(t, err)
+// 	for i := 1; i <= size; i++ {
+// 		edge := &pb.DirectedEdge{
+// 			ValueId: uint64(i),
+// 		}
 
-		txn := Txn{StartTs: uint64(i)}
-		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
-		if i%2000 == 0 {
-			kvs, err := ol.Rollup()
-			require.NoError(t, err)
-			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
-			require.NoError(t, err)
-		}
-	}
+// 		txn := Txn{StartTs: uint64(i)}
+// 		addMutationHelper(t, ol, edge, Set, &txn)
+// 		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+// 		if i%2000 == 0 {
+// 			kvs, err := ol.Rollup()
+// 			require.NoError(t, err)
+// 			require.NoError(t, writePostingListToDisk(kvs))
+// 			ol, err = getNew(key, ps)
+// 			require.NoError(t, err)
+// 		}
+// 	}
 
-	// Verify all entries are in the list.
-	opt := ListOptions{ReadTs: math.MaxUint64}
-	l, err := ol.Uids(opt)
-	require.NoError(t, err)
-	require.Equal(t, size, len(l.Uids), "List of Uids received: %+v", l.Uids)
-	for i, uid := range l.Uids {
-		require.Equal(t, uint64(i+1), uid)
-	}
+// 	// Verify all entries are in the list.
+// 	opt := ListOptions{ReadTs: math.MaxUint64}
+// 	l, err := ol.Uids(opt)
+// 	require.NoError(t, err)
+// 	require.Equal(t, size, len(l.Uids), "List of Uids received: %+v", l.Uids)
+// 	for i, uid := range l.Uids {
+// 		require.Equal(t, uint64(i+1), uid)
+// 	}
 
-	// Delete the first half of the previously inserted entries from the list.
-	baseStartTs := uint64(size) + 1
-	for i := 1; i <= 50000; i++ {
-		edge := &pb.DirectedEdge{
-			ValueId: uint64(i),
-		}
-		txn := Txn{StartTs: baseStartTs + uint64(i)}
-		addMutationHelper(t, ol, edge, Del, &txn)
-		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
-		if i%2000 == 0 {
-			kvs, err := ol.Rollup()
-			require.NoError(t, err)
-			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
-			require.NoError(t, err)
-		}
-	}
+// 	// Delete the first half of the previously inserted entries from the list.
+// 	baseStartTs := uint64(size) + 1
+// 	for i := 1; i <= 50000; i++ {
+// 		edge := &pb.DirectedEdge{
+// 			ValueId: uint64(i),
+// 		}
+// 		txn := Txn{StartTs: baseStartTs + uint64(i)}
+// 		addMutationHelper(t, ol, edge, Del, &txn)
+// 		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
+// 		if i%2000 == 0 {
+// 			kvs, err := ol.Rollup()
+// 			require.NoError(t, err)
+// 			require.NoError(t, writePostingListToDisk(kvs))
+// 			ol, err = getNew(key, ps)
+// 			require.NoError(t, err)
+// 		}
+// 	}
 
-	// Rollup list at the end of all the deletions.
-	kvs, err := ol.Rollup()
-	require.NoError(t, err)
-	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
-	require.NoError(t, err)
+// 	// Rollup list at the end of all the deletions.
+// 	kvs, err := ol.Rollup()
+// 	require.NoError(t, err)
+// 	require.NoError(t, writePostingListToDisk(kvs))
+// 	ol, err = getNew(key, ps)
+// 	require.NoError(t, err)
 
-	// Verify that the entries were actually deleted.
-	opt = ListOptions{ReadTs: math.MaxUint64}
-	l, err = ol.Uids(opt)
-	require.NoError(t, err)
-	require.Equal(t, 50000, len(l.Uids), "List of Uids received: %+v", l.Uids)
-	for i, uid := range l.Uids {
-		require.Equal(t, 50000+uint64(i+1), uid)
-	}
+// 	// Verify that the entries were actually deleted.
+// 	opt = ListOptions{ReadTs: math.MaxUint64}
+// 	l, err = ol.Uids(opt)
+// 	require.NoError(t, err)
+// 	require.Equal(t, 50000, len(l.Uids), "List of Uids received: %+v", l.Uids)
+// 	for i, uid := range l.Uids {
+// 		require.Equal(t, 50000+uint64(i+1), uid)
+// 	}
 
-	// Re-add the entries that were just deleted.
-	baseStartTs = uint64(2*size) + 1
-	for i := 1; i <= 50000; i++ {
-		edge := &pb.DirectedEdge{
-			ValueId: uint64(i),
-		}
-		txn := Txn{StartTs: baseStartTs + uint64(i)}
-		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
+// 	// Re-add the entries that were just deleted.
+// 	baseStartTs = uint64(2*size) + 1
+// 	for i := 1; i <= 50000; i++ {
+// 		edge := &pb.DirectedEdge{
+// 			ValueId: uint64(i),
+// 		}
+// 		txn := Txn{StartTs: baseStartTs + uint64(i)}
+// 		addMutationHelper(t, ol, edge, Set, &txn)
+// 		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
 
-		if i%2000 == 0 {
-			kvs, err := ol.Rollup()
-			require.NoError(t, err)
-			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
-			require.NoError(t, err)
-		}
-	}
+// 		if i%2000 == 0 {
+// 			kvs, err := ol.Rollup()
+// 			require.NoError(t, err)
+// 			require.NoError(t, writePostingListToDisk(kvs))
+// 			ol, err = getNew(key, ps)
+// 			require.NoError(t, err)
+// 		}
+// 	}
 
-	// Rollup list at the end of all the additions
-	kvs, err = ol.Rollup()
-	require.NoError(t, err)
-	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
-	require.NoError(t, err)
+// 	// Rollup list at the end of all the additions
+// 	kvs, err = ol.Rollup()
+// 	require.NoError(t, err)
+// 	require.NoError(t, writePostingListToDisk(kvs))
+// 	ol, err = getNew(key, ps)
+// 	require.NoError(t, err)
 
-	// Verify all entries are once again in the list.
-	opt = ListOptions{ReadTs: math.MaxUint64}
-	l, err = ol.Uids(opt)
-	require.NoError(t, err)
-	require.Equal(t, size, len(l.Uids), "List of Uids received: %+v", l.Uids)
-	for i, uid := range l.Uids {
-		require.Equal(t, uint64(i+1), uid)
-	}
-}
+// 	// Verify all entries are once again in the list.
+// 	opt = ListOptions{ReadTs: math.MaxUint64}
+// 	l, err = ol.Uids(opt)
+// 	require.NoError(t, err)
+// 	require.Equal(t, size, len(l.Uids), "List of Uids received: %+v", l.Uids)
+// 	for i, uid := range l.Uids {
+// 		require.Equal(t, uint64(i+1), uid)
+// 	}
+// }
 
 var ps *badger.DB
 


### PR DESCRIPTION
Splits are currently disables. This PR temporarily disables the tests.
They should be re-enabled once all the Jepsen tests are fixed and splits
are re-enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4684)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cf6e20d7bc-41936.surge.sh)
<!-- Dgraph:end -->