### PR TITLE
support @deprecated

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -25,6 +25,7 @@
           "Author.dob":"2000-01-01",
           "Author.posts":[]
         }
+
 -
   name: "Add multiple mutation with variables"
   gqlmutation: |
@@ -918,3 +919,28 @@
           }
         ]
       cond: "@if(eq(len(State2), 1))"
+
+-
+  name: "deprecated fields can be mutated"
+  gqlmutation: |
+    mutation addCategory($cat: AddCategoryInput!) {
+      addCategory(input: [$cat]) {
+        category {
+          name
+          iAmDeprecated
+        }
+      }
+    }
+  gqlvariables: |
+    { "cat":
+      { "name": "A Category",
+        "iAmDeprecated": "but I can be written to"
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid": "_:Category1",
+          "dgraph.type": ["Category"],
+          "Category.name": "A Category",
+          "Category.iAmDeprecated": "but I can be written to"
+        }

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1121,7 +1121,7 @@
   dgquery: |-
     query {
       queryCategory(func: type(Category)) {
-        iAmDeprecated : Post.iAmDeprecated
+        iAmDeprecated : Category.iAmDeprecated
         dgraph.uid : uid
       }
     }

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1110,3 +1110,18 @@
       }
     }
 
+-
+  name: "deprecated fields can be queried"
+  gqlquery: |
+    query {
+      queryCategory {
+        iAmDeprecated
+      }
+    }
+  dgquery: |-
+    query {
+      queryCategory(func: type(Category)) {
+        iAmDeprecated : Post.iAmDeprecated
+        dgraph.uid : uid
+      }
+    }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -37,13 +37,14 @@ type Post {
         isPublished: Boolean @search
         postType: PostType @search
         author: Author!
-        category: Category @hasInverse(field: posts)
+        category: Category @hasInverse(field: posts)   
 }
 
 type Category {
         id: ID
         name: String
         posts: [Post]
+        iAmDeprecated: String @deprecated(reason: "because")
 }
 
 enum PostType {

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -37,7 +37,7 @@ type Post {
         isPublished: Boolean @search
         postType: PostType @search
         author: Author!
-        category: Category @hasInverse(field: posts)   
+        category: Category @hasInverse(field: posts)
 }
 
 type Category {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -39,6 +39,8 @@ const (
 	dgraphPredArg   = "pred"
 	idDirective     = "id"
 
+	deprecatedDirective = "deprecated"
+
 	Typename = "__typename"
 
 	// schemaExtras is everything that gets added to an input schema to make it
@@ -225,6 +227,13 @@ var directiveValidators = map[string]directiveValidator{
 	searchDirective:  searchValidation,
 	dgraphDirective:  dgraphDirectiveValidation,
 	idDirective:      idValidation,
+	deprecatedDirective: func(
+		sch *ast.Schema,
+		typ *ast.Definition,
+		field *ast.FieldDefinition,
+		dir *ast.Directive) *gqlerror.Error {
+		return nil
+	},
 }
 
 var defnValidations, typeValidations []func(defn *ast.Definition) *gqlerror.Error

--- a/graphql/schema/schemagen_test.yml
+++ b/graphql/schema/schemagen_test.yml
@@ -379,8 +379,8 @@ schemas:
       }
     output: |
       type A {
-        A.p: string
-        A.q: string
+        A.p
+        A.q
       }
       A.p: string .
       A.q: string .

--- a/graphql/schema/schemagen_test.yml
+++ b/graphql/schema/schemagen_test.yml
@@ -368,3 +368,19 @@ schemas:
         B.correct: bool
       }
       B.correct: bool @index(bool) .
+
+  -
+    name: "deprecated fields get included in Dgraph schema"
+    input: |
+      type A {
+        id: ID!
+        p: String @deprecated
+        q: String @deprecated(reason: "just because it is")
+      }
+    output: |
+      type A {
+        A.p: string
+        A.q: string
+      }
+      A.p: string .
+      A.q: string .

--- a/graphql/schema/testdata/introspection/input/enum_withdeprecated.txt
+++ b/graphql/schema/testdata/introspection/input/enum_withdeprecated.txt
@@ -1,0 +1,10 @@
+{
+    __type(name: "TestDeprecatedEnum") {
+        name
+        enumValues(includeDeprecated: true) {
+            name
+            isDeprecated
+            deprecationReason
+        }
+    }
+}

--- a/graphql/schema/testdata/introspection/input/enum_withoutdeprecated.txt
+++ b/graphql/schema/testdata/introspection/input/enum_withoutdeprecated.txt
@@ -1,0 +1,10 @@
+{
+    __type(name: "TestDeprecatedEnum") {
+        name
+        enumValues(includeDeprecated: false) {
+            name
+            isDeprecated
+            deprecationReason
+        }
+    }
+}

--- a/graphql/schema/testdata/introspection/input/type_withdeprecated.txt
+++ b/graphql/schema/testdata/introspection/input/type_withdeprecated.txt
@@ -1,0 +1,10 @@
+{
+    __type(name: "TestDeprecatedObject") {
+        name
+        fields(includeDeprecated: true) {
+            name
+            isDeprecated
+            deprecationReason
+        }
+    }
+}

--- a/graphql/schema/testdata/introspection/input/type_withoutdeprecated.txt
+++ b/graphql/schema/testdata/introspection/input/type_withoutdeprecated.txt
@@ -1,0 +1,10 @@
+{
+    __type(name: "TestDeprecatedObject") {
+        name
+        fields(includeDeprecated: false) {
+            name
+            isDeprecated
+            deprecationReason
+        }
+    }
+}

--- a/graphql/schema/testdata/introspection/output/enum_withdeprecated.json
+++ b/graphql/schema/testdata/introspection/output/enum_withdeprecated.json
@@ -1,0 +1,22 @@
+{
+    "__type": {
+        "name": "TestDeprecatedEnum",
+        "enumValues": [
+            {
+                "deprecationReason": null,
+                "isDeprecated": true,
+                "name": "dep"
+            },
+            {
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "notDep"
+            },
+            {
+                "deprecationReason": "because",
+                "isDeprecated": true,
+                "name": "depReason"
+            }
+        ]
+    }
+}

--- a/graphql/schema/testdata/introspection/output/enum_withoutdeprecated.json
+++ b/graphql/schema/testdata/introspection/output/enum_withoutdeprecated.json
@@ -1,0 +1,12 @@
+{
+    "__type": {
+        "name": "TestDeprecatedEnum",
+        "enumValues": [
+            {
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "notDep"
+            }
+        ]
+    }
+}

--- a/graphql/schema/testdata/introspection/output/type_withdeprecated.json
+++ b/graphql/schema/testdata/introspection/output/type_withdeprecated.json
@@ -1,0 +1,22 @@
+{
+    "__type": {
+        "name": "TestDeprecatedObject",
+        "fields": [
+            {
+                "deprecationReason": null,
+                "isDeprecated": true,
+                "name": "dep"
+            },
+            {
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "notDep"
+            },
+            {
+                "deprecationReason": "because",
+                "isDeprecated": true,
+                "name": "depReason"
+            }
+        ]
+    }
+}

--- a/graphql/schema/testdata/introspection/output/type_withoutdeprecated.json
+++ b/graphql/schema/testdata/introspection/output/type_withoutdeprecated.json
@@ -1,0 +1,12 @@
+{
+    "__type": {
+        "name": "TestDeprecatedObject",
+        "fields": [
+            {
+                "deprecationReason": null,
+                "isDeprecated": false,
+                "name": "notDep"
+            }
+        ]
+    }
+}

--- a/graphql/schema/testdata/schemagen/input/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/input/deprecated.graphql
@@ -1,0 +1,6 @@
+type Atype {
+    iamDeprecated: String @deprecated
+    soAmI: String! @deprecated(reason: "because")
+}
+
+

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -1,0 +1,138 @@
+#######################
+# Input Schema
+#######################
+
+type Atype {
+	iamDeprecated: String @deprecated
+	soAmI: String! @deprecated(reason: "because")
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAtypePayload {
+	atype(order: AtypeOrder, first: Int, offset: Int): [Atype]
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AtypeOrderable {
+	iamDeprecated
+	soAmI
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddAtypeInput {
+	iamDeprecated: String
+	soAmI: String!
+}
+
+input AtypeOrder {
+	asc: AtypeOrderable
+	desc: AtypeOrderable
+	then: AtypeOrder
+}
+
+input AtypeRef {
+	iamDeprecated: String
+	soAmI: String
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	queryAtype(order: AtypeOrder, first: Int, offset: Int): [Atype]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAtype(input: [AddAtypeInput!]!): AddAtypePayload
+}


### PR DESCRIPTION
@deprecated is required by GraphQL spec ... there's nothing we have to do to support it other than allow it to pass through.  It's the client tools that should react to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4685)
<!-- Reviewable:end -->
  
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-2843bc9934-42173.surge.sh)
<!-- Dgraph:end -->