### PR TITLE
Make panic catcher test message clear

### DIFF
--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -39,6 +39,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+const (
+	panicMsg = "\n****\nThis test should trap this panic.\n" +
+		"It's working as expected if this message is logged with a stack trace.\n****\n"
+)
+
 type ErrorCase struct {
 	Name       string
 	GQLRequest string
@@ -259,12 +264,12 @@ func panicCatcher(t *testing.T) {
 type panicClient struct{}
 
 func (dg *panicClient) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
-	panic("bugz!!!")
+	panic(panicMsg)
 }
 
 func (dg *panicClient) Mutate(
 	ctx context.Context,
 	query *gql.GraphQuery,
 	mutations []*dgoapi.Mutation) (map[string]string, map[string]interface{}, error) {
-	panic("bugz!!!")
+	panic(panicMsg)
 }


### PR DESCRIPTION
We have a test that any panics caught by GraphQL processing are handled properly.  This changes the log message from the test to make it clear that it's expected.

Now the log message says

```
E0128 16:21:34.557535   42624 panics.go:33] panic: 
****
This test should trap this panic.
It's working as expected if this message is logged with a stack trace.
****
.
 trace: goroutine 2887 [running]:
runtime/debug.Stack(0x0, 0x0, 0x0)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/debug/stack.go:24 +0xa1
github.com/dgraph-io/dgraph/graphql/api.PanicHandler(0xc0003de2a0, 0x24, 0xc0002097a0)
	/Users/michael/go/src/github.com/dgraph-io/dgraph/graphql/api/panics.go:33 +0x66
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4686)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6112e8d8b1-41991.surge.sh)
<!-- Dgraph:end -->