### PR TITLE
Optimize types.ParseTime and add benchmark test for it

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@
 #   - bash
 #   - curl
 #   - coreutils
-#   - gnu-getop
+#   - gnu-getopt
 #   - findutils
 #
 # Your $PATH must have all required packages in .bashrc:

--- a/types/conversion_test.go
+++ b/types/conversion_test.go
@@ -119,7 +119,7 @@ func TestConversionEdgeCases(t *testing.T) {
 			failure: "strconv.ParseBool"},
 		{in: Val{Tid: StringID, Value: []byte{}},
 			out:     Val{Tid: DateTimeID, Value: time.Time{}},
-			failure: `parsing time "" as "2006": cannot parse "" as "2006"`},
+			failure: `parsing time "" as "2006-01-02T15:04:05": cannot parse "" as "2006"`},
 
 		// From IntID to X
 		{in: Val{Tid: IntID, Value: []byte{}},
@@ -142,12 +142,12 @@ func TestConversionEdgeCases(t *testing.T) {
 		// From DateTimeID to X
 		{in: Val{Tid: DateTimeID, Value: []byte{}},
 			out:     Val{Tid: DateTimeID, Value: time.Time{}},
-			failure: "Time.UnmarshalBinary:"},
+			failure: "Time.UnmarshalBinary: no data"},
 		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
 			out: Val{Tid: DateTimeID, Value: time.Time{}}},
 		{in: Val{Tid: DateTimeID, Value: []byte{}},
 			out:     Val{Tid: BinaryID, Value: []byte{}},
-			failure: "Time.UnmarshalBinary"},
+			failure: "Time.UnmarshalBinary: no data"},
 		{in: Val{Tid: DateTimeID, Value: bs(time.Time{})},
 			out: Val{Tid: BinaryID, Value: bs(time.Time{})}},
 		{in: Val{Tid: DateTimeID, Value: []byte{}},

--- a/types/scalar_types_test.go
+++ b/types/scalar_types_test.go
@@ -23,6 +23,65 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var datesWithTz = []struct {
+	in  string
+	out time.Time
+}{
+	{in: "2018-10-28T04:00:10Z",
+		out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
+	{in: "2018-10-28T04:00:10-00:00",
+		out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
+	{in: "2018-05-30T09:30:10.5Z",
+		out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
+	{in: "2018-05-30T09:30:10.5-00:00",
+		out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
+	{in: "2018-05-30T09:30:10-06:00",
+		out: time.Date(2018, 5, 30, 9, 30, 10, 0, time.FixedZone("", -6*60*60))},
+	{in: "2018-05-28T14:41:57+30:00",
+		out: time.Date(2018, 5, 28, 14, 41, 57, 0, time.FixedZone("", 30*60*60))},
+}
+
+var datesWithoutTz = []struct {
+	in  string
+	out time.Time
+}{
+	{in: "2018-10-28T04:00:10",
+		out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
+	{in: "2018-05-30T09:30:10.5",
+		out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
+	{in: "2018",
+		out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+	{in: "2018-01",
+		out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+	{in: "2018-01-01",
+		out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
+}
+
+var invalidDates = []string{
+	"abcd",
+	"12345",
+	"123456",
+	"1234567",
+	"12345678",
+	"123456789",
+	"1234567891",
+	"11111111111111111Z",
+	"111111111111111:11",
+	"1111-11-11T11:11111111:1",
+	"1111-11-11T11:11:1111:11",
+	"18-10-28T04:00:10Z",
+	"318-10-28T04:00:10",
+	"2018-110-28T04:00:10",
+	"20181-4-28T25:00:10",
+	"2018-10-218T04:00:10",
+	"2018-14-28T25:00:10",
+	"2018-142-8T25:00:10",
+	"2018-05-33T09:65:10.5",
+	"201",
+	"2018-011",
+	"2018-01-011",
+}
+
 func TestTypeForName(t *testing.T) {
 	for name, tid := range typeNameMap {
 		typ, ok := TypeForName(name)
@@ -46,22 +105,7 @@ func TestValueForType(t *testing.T) {
 }
 
 func TestParseTimeWithoutTZ(t *testing.T) {
-	tests := []struct {
-		in  string
-		out time.Time
-	}{
-		{in: "2018-10-28T04:00:10",
-			out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
-		{in: "2018-05-30T09:30:10.5",
-			out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
-		{in: "2018",
-			out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{in: "2018-01",
-			out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-		{in: "2018-01-01",
-			out: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC)},
-	}
-	for _, tc := range tests {
+	for _, tc := range datesWithoutTz {
 		out, err := ParseTime(tc.in)
 		require.NoError(t, err)
 		require.EqualValues(t, tc.out, out)
@@ -75,26 +119,41 @@ func TestParseTimeWithTZ(t *testing.T) {
 	time.Local, err = time.LoadLocation("UTC")
 	require.NoError(t, err)
 
-	tests := []struct {
-		in  string
-		out time.Time
-	}{
-		{in: "2018-10-28T04:00:10Z",
-			out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
-		{in: "2018-10-28T04:00:10-00:00",
-			out: time.Date(2018, 10, 28, 4, 00, 10, 0, time.UTC)},
-		{in: "2018-05-30T09:30:10.5Z",
-			out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
-		{in: "2018-05-30T09:30:10.5-00:00",
-			out: time.Date(2018, 5, 30, 9, 30, 10, 500000000, time.UTC)},
-		{in: "2018-05-30T09:30:10-06:00",
-			out: time.Date(2018, 5, 30, 9, 30, 10, 0, time.FixedZone("", -6*60*60))},
-		{in: "2018-05-28T14:41:57+30:00",
-			out: time.Date(2018, 5, 28, 14, 41, 57, 0, time.FixedZone("", 30*60*60))},
-	}
-	for _, tc := range tests {
+	for _, tc := range datesWithTz {
 		out, err := ParseTime(tc.in)
 		require.NoError(t, err)
 		require.EqualValues(t, tc.out, out)
+	}
+}
+
+func TestParseTimeRejection(t *testing.T) {
+	var err error
+
+	// Set local time to UTC.
+	time.Local, err = time.LoadLocation("UTC")
+	require.NoError(t, err)
+
+	for _, invalidDate := range invalidDates {
+		_, err := ParseTime(invalidDate)
+		require.Error(t, err)
+	}
+}
+
+func BenchmarkParseTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, tc := range datesWithTz {
+			ParseTime(tc.in)
+		}
+		for _, tc := range datesWithoutTz {
+			ParseTime(tc.in)
+		}
+	}
+}
+
+func BenchmarkParseTimeRejections(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, invalidDate := range invalidDates {
+			ParseTime(invalidDate)
+		}
 	}
 }


### PR DESCRIPTION
benchmark                old ns/op     new ns/op     delta
BenchmarkParseTime-8     7103          4379          -38.35%

benchmark                old allocs     new allocs     delta
BenchmarkParseTime-8     39             16             -58.97%

benchmark                old bytes     new bytes     delta
BenchmarkParseTime-8     2144          896           -58.21%

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4693)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cf298c6467-43108.surge.sh)
<!-- Dgraph:end -->