### PR TITLE
GraphQL Admin API: Support Backup operation

### DIFF
--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -21,16 +21,10 @@ package alpha
 import (
 	"context"
 	"net/http"
-	"net/url"
-	"time"
 
-	"github.com/dgraph-io/dgraph/ee/backup"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 func init() {
@@ -54,115 +48,17 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 
 	req := pb.BackupRequest{
 		Destination:  destination,
-		UnixTs:       time.Now().UTC().Format("20060102.150405.000"),
 		AccessKey:    accessKey,
 		SecretKey:    secretKey,
 		SessionToken: sessionToken,
 		Anonymous:    anonymous,
 	}
 
-	if err := processBackupRequest(context.Background(), req, forceFull); err != nil {
+	if err := worker.ProcessBackupRequest(context.Background(), req, forceFull); err != nil {
 		x.SetStatus(w, err.Error(), "Backup failed.")
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	x.Check2(w.Write([]byte(`{"code": "Success", "message": "Backup completed."}`)))
-}
-
-func processBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
-	if !worker.EnterpriseEnabled() {
-		return errors.Errorf("You must enable enterprise features first. "+
-			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.",
-			"Backup failed.")
-	}
-
-	if req.Destination == "" {
-		return errors.Errorf("You must specify a 'destination' value")
-	}
-
-	if err := x.HealthCheck(); err != nil {
-		glog.Errorf("Backup canceled, not ready to accept requests: %s", err)
-		return err
-	}
-
-	ts, err := worker.Timestamps(ctx, &pb.Num{ReadOnly: true})
-	if err != nil {
-		glog.Errorf("Unable to retrieve readonly timestamp for backup: %s", err)
-		return err
-	}
-
-	req.ReadTs = ts.ReadOnly
-	req.UnixTs = time.Now().UTC().Format("20060102.150405.000")
-
-	// Read the manifests to get the right timestamp from which to start the backup.
-	uri, err := url.Parse(req.Destination)
-	if err != nil {
-		return err
-	}
-	handler, err := backup.NewUriHandler(uri, backup.GetCredentialsFromRequest(&req))
-	if err != nil {
-		return err
-	}
-	latestManifest, err := handler.GetLatestManifest(uri)
-	if err != nil {
-		return err
-	}
-	req.SinceTs = latestManifest.Since
-	if forceFull {
-		req.SinceTs = 0
-	}
-
-	// Update the membership state to get the latest mapping of groups to predicates.
-	if err := worker.UpdateMembershipState(ctx); err != nil {
-		return err
-	}
-
-	// Get the current membership state and parse it for easier processing.
-	state := worker.GetMembershipState()
-	var groups []uint32
-	predMap := make(map[uint32][]string)
-	for gid, group := range state.Groups {
-		groups = append(groups, gid)
-		predMap[gid] = make([]string, 0)
-		for pred := range group.Tablets {
-			predMap[gid] = append(predMap[gid], pred)
-		}
-	}
-
-	glog.Infof("Created backup request: %s. Groups=%v\n", &req, groups)
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	errCh := make(chan error, len(state.Groups))
-	for _, gid := range groups {
-		req := req
-		req.GroupId = gid
-		req.Predicates = predMap[gid]
-		go func(req *pb.BackupRequest) {
-			_, err := worker.BackupGroup(ctx, req)
-			errCh <- err
-		}(&req)
-	}
-
-	for range groups {
-		if err := <-errCh; err != nil {
-			glog.Errorf("Error received during backup: %v", err)
-			return err
-		}
-	}
-
-	m := backup.Manifest{Since: req.ReadTs, Groups: predMap}
-	if req.SinceTs == 0 {
-		m.Type = "full"
-		m.BackupId = x.GetRandomName(1)
-		m.BackupNum = 1
-	} else {
-		m.Type = "incremental"
-		m.BackupId = latestManifest.BackupId
-		m.BackupNum = latestManifest.BackupNum + 1
-	}
-
-	bp := &backup.Processor{Request: &req}
-	return bp.CompleteBackup(ctx, &m)
 }

--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -54,7 +54,7 @@ func backupHandler(w http.ResponseWriter, r *http.Request) {
 		Anonymous:    anonymous,
 	}
 
-	if err := worker.ProcessBackupRequest(context.Background(), req, forceFull); err != nil {
+	if err := worker.ProcessBackupRequest(context.Background(), &req, forceFull); err != nil {
 		x.SetStatus(w, err.Error(), "Backup failed.")
 		return
 	}

--- a/ee/backup/backup.go
+++ b/ee/backup/backup.go
@@ -297,3 +297,4 @@ func writeKVList(list *bpb.KVList, w io.Writer) error {
 	_, err = w.Write(buf)
 	return err
 }
+

--- a/ee/backup/backup.go
+++ b/ee/backup/backup.go
@@ -297,4 +297,3 @@ func writeKVList(list *bpb.KVList, w io.Writer) error {
 	_, err = w.Write(buf)
 	return err
 }
-

--- a/ee/backup/tests/minio-large/backup_test.go
+++ b/ee/backup/tests/minio-large/backup_test.go
@@ -207,8 +207,7 @@ func copyToLocalFs(t *testing.T) {
 	for object := range objectCh1 {
 		require.NoError(t, object.Err)
 		dstDir := backupDir + "/" + object.Key
-		err := os.MkdirAll(dstDir, os.ModePerm)
-		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(dstDir, os.ModePerm))
 
 		// Get all the files in that folder and
 		lsCh2 := make(chan struct{})

--- a/ee/backup/tests/minio-large/backup_test.go
+++ b/ee/backup/tests/minio-large/backup_test.go
@@ -207,7 +207,8 @@ func copyToLocalFs(t *testing.T) {
 	for object := range objectCh1 {
 		require.NoError(t, object.Err)
 		dstDir := backupDir + "/" + object.Key
-		os.MkdirAll(dstDir, os.ModePerm)
+		err := os.MkdirAll(dstDir, os.ModePerm)
+		require.NoError(t, err)
 
 		// Get all the files in that folder and
 		lsCh2 := make(chan struct{})
@@ -215,7 +216,8 @@ func copyToLocalFs(t *testing.T) {
 		for object := range objectCh2 {
 			require.NoError(t, object.Err)
 			dstFile := backupDir + "/" + object.Key
-			mc.FGetObject(bucketName, object.Key, dstFile, minio.GetObjectOptions{})
+			err := mc.FGetObject(bucketName, object.Key, dstFile, minio.GetObjectOptions{})
+			require.NoError(t, err)
 		}
 		close(lsCh2)
 	}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -54,7 +54,7 @@ const (
 	graphqlAdminSchema = `
 	type GQLSchema @dgraph(type: "dgraph.graphql") {
 		id: ID!
-		schema: String!  @dgraph(type: "dgraph.graphql.schema") 
+		schema: String!  @dgraph(type: "dgraph.graphql.schema")
 		generatedSchema: String!
 	}
 
@@ -85,6 +85,20 @@ const (
 		schema: String!
 	}
 
+	input BackupInput {
+		destination: String!
+		accessKey: String
+		secretKey: String
+		sessionToken: String
+		anonymous: Boolean
+		forceFull: Boolean
+	}
+
+	type BackupPayload {
+		code: String
+		message: String
+	}
+
 	type Query {
 		getGQLSchema: GQLSchema
 		health: Health
@@ -92,6 +106,7 @@ const (
 
 	type Mutation {
 		updateGQLSchema(input: UpdateGQLSchemaInput!) : UpdateGQLSchemaPayload
+		backup(input: BackupInput!) : BackupPayload
 	}
  `
 )
@@ -256,6 +271,15 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 				func(ctx context.Context, query schema.Query) *resolve.Resolved {
 					return &resolve.Resolved{Err: errors.Errorf(errMsgServerNotReady)}
 				})
+		}).
+		WithMutationResolver("backup", func(m schema.Mutation) resolve.MutationResolver {
+			backup := &backupResolver{}
+
+			return resolve.NewMutationResolver(
+				backup,
+				backup,
+				backup,
+				resolve.StdQueryCompletion())
 		}).
 		WithSchemaIntrospection()
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -279,6 +279,8 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 		WithMutationResolver("backup", func(m schema.Mutation) resolve.MutationResolver {
 			backup := &backupResolver{}
 
+			// backup implements the mutation rewriter, executor and query executor hence its passed
+			// thrice here.
 			return resolve.NewMutationResolver(
 				backup,
 				backup,

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -94,9 +94,13 @@ const (
 		forceFull: Boolean
 	}
 
-	type BackupPayload {
+	type Response {
 		code: String
 		message: String
+	}
+
+	type BackupPayload {
+		response: Response
 	}
 
 	type Query {
@@ -279,7 +283,7 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 				backup,
 				backup,
 				backup,
-				resolve.StdQueryCompletion())
+				resolve.StdMutationCompletion(m.ResponseName()))
 		}).
 		WithSchemaIntrospection()
 

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -24,14 +24,12 @@ import (
 	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/worker"
 	"github.com/golang/glog"
 )
 
-type backupResolver struct {
-	// admin *adminServer
-
-	// mutation schema.Mutation
-}
+type backupResolver struct{}
 
 type backupInput struct {
 	Destination  string
@@ -53,8 +51,15 @@ func (br *backupResolver) Rewrite(
 	}
 	fmt.Printf("input: %+v\n", input)
 
-	// Return error if request fails here.
-	return nil, nil, nil
+	err = worker.ProcessBackupRequest(context.Background(), pb.BackupRequest{
+		Destination:  input.Destination,
+		AccessKey:    input.AccessKey,
+		SecretKey:    input.SecretKey,
+		SessionToken: input.SessionToken,
+		Anonymous:    input.Anonymous,
+	}, input.ForceFull)
+
+	return nil, nil, err
 }
 
 func (br *backupResolver) FromMutationResult(

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -53,7 +53,7 @@ func (br *backupResolver) Rewrite(
 		return nil, nil, err
 	}
 
-	err = worker.ProcessBackupRequest(context.Background(), pb.BackupRequest{
+	err = worker.ProcessBackupRequest(context.Background(), &pb.BackupRequest{
 		Destination:  input.Destination,
 		AccessKey:    input.AccessKey,
 		SecretKey:    input.SecretKey,

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
+	"github.com/dgraph-io/dgraph/gql"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/golang/glog"
+)
+
+type backupResolver struct {
+	// admin *adminServer
+
+	// mutation schema.Mutation
+}
+
+type backupInput struct {
+	Destination  string
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+	Anonymous    bool
+	ForceFull    bool
+}
+
+func (br *backupResolver) Rewrite(
+	m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+
+	glog.Info("Got backup request")
+
+	input, err := getBackupInput(m)
+	if err != nil {
+		return nil, nil, err
+	}
+	fmt.Printf("input: %+v\n", input)
+
+	// Return error if request fails here.
+	return nil, nil, nil
+}
+
+func (br *backupResolver) FromMutationResult(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	result map[string]interface{}) (*gql.GraphQuery, error) {
+
+	return nil, nil
+}
+
+func (br *backupResolver) Mutate(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string]interface{}, error) {
+
+	return nil, nil, nil
+}
+
+func (br *backupResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
+	return nil, nil
+}
+
+func getBackupInput(m schema.Mutation) (*backupInput, error) {
+	inputArg := m.ArgValue(schema.InputArgName)
+	inputByts, err := json.Marshal(inputArg)
+	if err != nil {
+		return nil, schema.GQLWrapf(err, "couldn't get input argument")
+	}
+
+	var input backupInput
+	err = json.Unmarshal(inputByts, &input)
+	return &input, schema.GQLWrapf(err, "couldn't get input argument")
+}

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -32,7 +32,7 @@ func (w *grpcWorker) Backup(ctx context.Context, req *pb.BackupRequest) (*pb.Sta
 	return nil, x.ErrNotSupported
 }
 
-func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
+func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull bool) error {
 	glog.Warningf("Backup failed: %v", x.ErrNotSupported)
 	return x.ErrNotSupported
 }

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -31,3 +31,8 @@ func (w *grpcWorker) Backup(ctx context.Context, req *pb.BackupRequest) (*pb.Sta
 	glog.Warningf("Backup failed: %v", x.ErrNotSupported)
 	return nil, x.ErrNotSupported
 }
+
+func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
+	glog.Warningf("Backup failed: %v", x.ErrNotSupported)
+	return x.ErrNotSupported
+}

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -77,12 +77,12 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 
 func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull bool) error {
 	if !EnterpriseEnabled() {
-		return errors.New("You must enable enterprise features first. " +
+		return errors.New("you must enable enterprise features first. " +
 			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.")
 	}
 
 	if req.Destination == "" {
-		return errors.Errorf("You must specify a 'destination' value")
+		return errors.Errorf("you must specify a 'destination' value")
 	}
 
 	if err := x.HealthCheck(); err != nil {

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -76,9 +76,8 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 
 func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull bool) error {
 	if !EnterpriseEnabled() {
-		return errors.Errorf("You must enable enterprise features first. "+
-			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.",
-			"Backup failed.")
+		return errors.New("You must enable enterprise features first. " +
+			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.")
 	}
 
 	if req.Destination == "" {

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -133,7 +133,7 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull 
 		}
 	}
 
-	glog.Infof("Created backup request: %s. Groups=%v\n", &req, groups)
+	glog.Infof("Created backup request: %s. Groups=%v\n", req, groups)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -139,13 +140,13 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull 
 
 	errCh := make(chan error, len(state.Groups))
 	for _, gid := range groups {
-		req := req
-		req.GroupId = gid
-		req.Predicates = predMap[gid]
+		br := proto.Clone(req).(*pb.BackupRequest)
+		br.GroupId = gid
+		br.Predicates = predMap[gid]
 		go func(req *pb.BackupRequest) {
 			_, err := BackupGroup(ctx, req)
 			errCh <- err
-		}(req)
+		}(br)
 	}
 
 	for range groups {

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -74,7 +74,7 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 	return res, nil
 }
 
-func ProcessRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
+func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
 	if !EnterpriseEnabled() {
 		return errors.Errorf("You must enable enterprise features first. "+
 			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.",

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -74,7 +74,7 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 	return res, nil
 }
 
-func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
+func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull bool) error {
 	if !EnterpriseEnabled() {
 		return errors.Errorf("You must enable enterprise features first. "+
 			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.",
@@ -104,7 +104,7 @@ func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull b
 	if err != nil {
 		return err
 	}
-	handler, err := backup.NewUriHandler(uri, backup.GetCredentialsFromRequest(&req))
+	handler, err := backup.NewUriHandler(uri, backup.GetCredentialsFromRequest(req))
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull b
 		go func(req *pb.BackupRequest) {
 			_, err := BackupGroup(ctx, req)
 			errCh <- err
-		}(&req)
+		}(req)
 	}
 
 	for range groups {
@@ -167,6 +167,6 @@ func ProcessBackupRequest(ctx context.Context, req pb.BackupRequest, forceFull b
 		m.BackupNum = latestManifest.BackupNum + 1
 	}
 
-	bp := &backup.Processor{Request: &req}
+	bp := &backup.Processor{Request: req}
 	return bp.CompleteBackup(ctx, &m)
 }

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -14,10 +14,13 @@ package worker
 
 import (
 	"context"
+	"net/url"
+	"time"
 
 	"github.com/dgraph-io/dgraph/ee/backup"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -69,4 +72,101 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 	}
 
 	return res, nil
+}
+
+func ProcessRequest(ctx context.Context, req pb.BackupRequest, forceFull bool) error {
+	if !EnterpriseEnabled() {
+		return errors.Errorf("You must enable enterprise features first. "+
+			"Supply the appropriate license file to Dgraph Zero using the HTTP endpoint.",
+			"Backup failed.")
+	}
+
+	if req.Destination == "" {
+		return errors.Errorf("You must specify a 'destination' value")
+	}
+
+	if err := x.HealthCheck(); err != nil {
+		glog.Errorf("Backup canceled, not ready to accept requests: %s", err)
+		return err
+	}
+
+	ts, err := Timestamps(ctx, &pb.Num{ReadOnly: true})
+	if err != nil {
+		glog.Errorf("Unable to retrieve readonly timestamp for backup: %s", err)
+		return err
+	}
+
+	req.ReadTs = ts.ReadOnly
+	req.UnixTs = time.Now().UTC().Format("20060102.150405.000")
+
+	// Read the manifests to get the right timestamp from which to start the backup.
+	uri, err := url.Parse(req.Destination)
+	if err != nil {
+		return err
+	}
+	handler, err := backup.NewUriHandler(uri, backup.GetCredentialsFromRequest(&req))
+	if err != nil {
+		return err
+	}
+	latestManifest, err := handler.GetLatestManifest(uri)
+	if err != nil {
+		return err
+	}
+	req.SinceTs = latestManifest.Since
+	if forceFull {
+		req.SinceTs = 0
+	}
+
+	// Update the membership state to get the latest mapping of groups to predicates.
+	if err := UpdateMembershipState(ctx); err != nil {
+		return err
+	}
+
+	// Get the current membership state and parse it for easier processing.
+	state := GetMembershipState()
+	var groups []uint32
+	predMap := make(map[uint32][]string)
+	for gid, group := range state.Groups {
+		groups = append(groups, gid)
+		predMap[gid] = make([]string, 0)
+		for pred := range group.Tablets {
+			predMap[gid] = append(predMap[gid], pred)
+		}
+	}
+
+	glog.Infof("Created backup request: %s. Groups=%v\n", &req, groups)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	errCh := make(chan error, len(state.Groups))
+	for _, gid := range groups {
+		req := req
+		req.GroupId = gid
+		req.Predicates = predMap[gid]
+		go func(req *pb.BackupRequest) {
+			_, err := BackupGroup(ctx, req)
+			errCh <- err
+		}(&req)
+	}
+
+	for range groups {
+		if err := <-errCh; err != nil {
+			glog.Errorf("Error received during backup: %v", err)
+			return err
+		}
+	}
+
+	m := backup.Manifest{Since: req.ReadTs, Groups: predMap}
+	if req.SinceTs == 0 {
+		m.Type = "full"
+		m.BackupId = x.GetRandomName(1)
+		m.BackupNum = 1
+	} else {
+		m.Type = "incremental"
+		m.BackupId = latestManifest.BackupId
+		m.BackupNum = latestManifest.BackupNum + 1
+	}
+
+	bp := &backup.Processor{Request: &req}
+	return bp.CompleteBackup(ctx, &m)
 }


### PR DESCRIPTION
This PR adds support for doing backups using the GraphQL Admin API. A backup can be initiated with the following mutation
```
mutation {
  backup(input: {destination: "/tmp", accessKey: "xxx", secretKey: "xxx", 
    sessionToken: "xxx", anonymous: true, forceFull: true}) {
    
    response {
      code
      message
    }
  }
}
```

The options for the backup are the same as those that we have in the HTTP API. Common code for backup has been moved to `worker.ProcessBackupRequest` so that it can be called from both `/admin/backup` and from the graphql admin package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4706)
<!-- Reviewable:end -->
