### PR TITLE
Docs: add script flags to docs / systemd

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -23,13 +23,29 @@ docker run -it dgraph/dgraph:latest dgraph
 #### Automatic download
 
 Running
+
 ```sh
 curl https://get.dgraph.io -sSf | bash
 
 # Test that it worked fine, by running:
 dgraph
 ```
+
 would install the `dgraph` binary into your system.
+
+Other instalation options:
+
+> Add `-s --` before the flags.
+
+`--y`: Automatically agree to the terms of the Dgraph Community License.
+
+`--systemd`: Automatically create Dgraph's installation as Systemd services.
+
+>Installing Dgraph and requesting the automatic creation of systemd service. e.g:
+
+```sh
+curl https://get.dgraph.io -sSf | bash -s -- --systemd
+```
 
 #### Manual download [optional]
 


### PR DESCRIPTION
It documents flags for installation script.

It was tested in CentOS 8 and Ubuntu 18.04*

To request the systemd installation.
```
curl https://get.dgraph.io -sSf | bash -s -- --systemd
```
To request the systemd installation and accept the licence.
```
curl https://get.dgraph.io -sSf | bash -s -- -y --systemd
```

closes #4509

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4710)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-dc918602bc-42580.surge.sh)
<!-- Dgraph:end -->