### PR TITLE
Check response status when posting telemtry data.

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -98,7 +98,7 @@ func (s *Server) periodicallyPostTelemetry() {
 	glog.V(2).Infof("Starting telemetry data collection for zero...")
 	start := time.Now()
 
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(time.Minute * 10)
 	defer ticker.Stop()
 
 	var lastPostedAt time.Time

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -96,7 +96,7 @@ func PeriodicallyPostTelemetry() {
 	glog.V(2).Infof("Starting telemetry data collection for alpha...")
 
 	start := time.Now()
-	ticker := time.NewTicker(time.Minute)
+	ticker := time.NewTicker(time.Minute * 10)
 	defer ticker.Stop()
 
 	var lastPostedAt time.Time

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -47,7 +47,7 @@ type Telemetry struct {
 	NumGraphQL   uint64 `json:",omitempty"`
 }
 
-var url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
+const url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
 
 // NewZero returns a Telemetry struct that holds information about the state of zero server.
 func NewZero(ms *pb.MembershipState) *Telemetry {
@@ -92,12 +92,13 @@ func (t *Telemetry) Post() error {
 		return err
 	}
 
+	var requestURL string
 	if len(t.Version) > 0 {
-		url += "/pings"
+		requestURL = url + "/pings"
 	} else {
-		url += "/dev"
+		requestURL = url + "/dev"
 	}
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))
+	req, err := http.NewRequest("POST", requestURL, bytes.NewBuffer(data))
 	if err != nil {
 		return err
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -27,23 +27,24 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 // Telemetry holds information about the state of the zero and alpha server.
 type Telemetry struct {
-	Arch         string
-	Cid          string
-	ClusterSize  int
-	DiskUsageMB  int64
-	NumAlphas    int
-	NumGroups    int
-	NumTablets   int
-	NumZeros     int
-	OS           string
-	SinceHours   int
-	Version      string
-	NumGraphQLPM uint64
-	NumGraphQL   uint64
+	Arch         string `json:",omitempty"`
+	Cid          string `json:",omitempty"`
+	ClusterSize  int    `json:",omitempty"`
+	DiskUsageMB  int64  `json:",omitempty"`
+	NumAlphas    int    `json:",omitempty"`
+	NumGroups    int    `json:",omitempty"`
+	NumTablets   int    `json:",omitempty"`
+	NumZeros     int    `json:",omitempty"`
+	OS           string `json:",omitempty"`
+	SinceHours   int    `json:",omitempty"`
+	Version      string `json:",omitempty"`
+	NumGraphQLPM uint64 `json:",omitempty"`
+	NumGraphQL   uint64 `json:",omitempty"`
 }
 
 var url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
@@ -115,6 +116,9 @@ func (t *Telemetry) Post() error {
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode != 201 {
+		return errors.Errorf(string(body))
 	}
 	glog.V(2).Infof("Telemetry response status: %v", resp.Status)
 	glog.V(2).Infof("Telemetry response body: %s", body)


### PR DESCRIPTION
When posting telemetry data check the response status and on error return an appropriate error.
Also, updating the telemetry ticker from one minute to ten minute.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4726)
<!-- Reviewable:end -->
