### PR TITLE
Doc - improve encryption section

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -402,12 +402,11 @@ To enable encryption, we need to pass a file that stores the data encryption key
 `--encryption_key_file`. The key size must be 16, 24, or 32 bytes long, and the key size determines
 the corresponding block size for AES encryption ,i.e. AES-128, AES-192, and AES-256, respectively.
 
-Here is an example encryption key file of size 16 bytes:
-
-*enc_key_file*
+You can use the following command to create the encryption key file (modify _count_ acccording
+to your specific needs):
 
 ```
-123456789012345
+dd if=/dev/random bs=1 count=32 of=enc_key_file
 ```
 
 ### Turn on Encryption
@@ -418,6 +417,9 @@ Here is an example that starts one zero server and one alpha server with the enc
 dgraph zero --my=localhost:5080 --replicas 1 --idx 1
 dgraph alpha --encryption_key_file "./enc_key_file" --my=localhost:7080 --lru_mb=1024 --zero=localhost:5080
 ```
+
+If multiple alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` otpion to
+all the alphas.
 
 ### Bulk loader with Encryption
 

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -402,8 +402,8 @@ To enable encryption, we need to pass a file that stores the data encryption key
 `--encryption_key_file`. The key size must be 16, 24, or 32 bytes long, and the key size determines
 the corresponding block size for AES encryption ,i.e. AES-128, AES-192, and AES-256, respectively.
 
-You can use the following command to create the encryption key file (modify _count_ acccording
-to your specific needs):
+You can use the following command to create the encryption key file (set _count_ equals to the
+desired key size):
 
 ```
 dd if=/dev/random bs=1 count=32 of=enc_key_file
@@ -418,8 +418,8 @@ dgraph zero --my=localhost:5080 --replicas 1 --idx 1
 dgraph alpha --encryption_key_file "./enc_key_file" --my=localhost:7080 --lru_mb=1024 --zero=localhost:5080
 ```
 
-If multiple alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` otpion to
-all the alphas.
+If multiple alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` option to
+each of the alphas.
 
 ### Bulk loader with Encryption
 


### PR DESCRIPTION
- add method to easily generate a random string of the correct size 
- document what to do in case of alpha nodes > 1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4745)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-bf095e07ad-43368.surge.sh)
<!-- Dgraph:end -->