### PR TITLE
Optimize computing reverse reindexing

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -173,6 +173,30 @@ func (txn *Txn) addReverseMutationHelper(ctx context.Context, plist *List,
 
 func (txn *Txn) addReverseMutation(ctx context.Context, t *pb.DirectedEdge) error {
 	key := x.ReverseKey(t.Attr, t.ValueId)
+	plist, err := txn.GetFromDelta(key)
+	if err != nil {
+		return err
+	}
+	x.AssertTrue(plist != nil)
+
+	// We must create a copy here.
+	edge := &pb.DirectedEdge{
+		Entity:  t.ValueId,
+		ValueId: t.Entity,
+		Attr:    t.Attr,
+		Op:      t.Op,
+		Facets:  t.Facets,
+	}
+	if err := plist.addMutation(ctx, txn, edge); err != nil {
+		return err
+	}
+
+	ostats.Record(ctx, x.NumEdges.M(1))
+	return nil
+}
+
+func (txn *Txn) addReverseAndCountMutation(ctx context.Context, t *pb.DirectedEdge) error {
+	key := x.ReverseKey(t.Attr, t.ValueId)
 	hasCountIndex := schema.State().HasCount(t.Attr)
 
 	var getFn func(key []byte) (*List, error)
@@ -231,7 +255,7 @@ func (l *List) handleDeleteAll(ctx context.Context, edge *pb.DirectedEdge,
 		case isReversed:
 			// Delete reverse edge for each posting.
 			delEdge.ValueId = p.Uid
-			return txn.addReverseMutation(ctx, delEdge)
+			return txn.addReverseAndCountMutation(ctx, delEdge)
 		case isIndexed:
 			// Delete index edge of each posting.
 			val := types.Val{
@@ -282,7 +306,6 @@ func (txn *Txn) addCountMutation(ctx context.Context, t *pb.DirectedEdge, count 
 	}
 	ostats.Record(ctx, x.NumEdges.M(1))
 	return nil
-
 }
 
 func (txn *Txn) updateCount(ctx context.Context, params countParams) error {
@@ -291,9 +314,11 @@ func (txn *Txn) updateCount(ctx context.Context, params countParams) error {
 		Attr:    params.attr,
 		Op:      pb.DirectedEdge_DEL,
 	}
-	if err := txn.addCountMutation(ctx, &edge, uint32(params.countBefore),
-		params.reverse); err != nil {
-		return err
+	if params.countBefore > 0 {
+		if err := txn.addCountMutation(ctx, &edge, uint32(params.countBefore),
+			params.reverse); err != nil {
+			return err
+		}
 	}
 
 	if params.countAfter > 0 {
@@ -431,7 +456,7 @@ func (l *List) AddMutationWithIndex(ctx context.Context, edge *pb.DirectedEdge,
 	// Add reverse mutation irrespective of hasMutated, server crash can happen after
 	// mutation is synced and before reverse edge is synced
 	if (pstore != nil) && (edge.ValueId != 0) && schema.State().IsReversed(edge.Attr) {
-		if err := txn.addReverseMutation(ctx, edge); err != nil {
+		if err := txn.addReverseAndCountMutation(ctx, edge); err != nil {
 			return err
 		}
 	}
@@ -533,13 +558,11 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	dbOpts := badger.DefaultOptions(tmpIndexDir).
 		WithSyncWrites(false).
 		WithNumVersionsToKeep(math.MaxInt64).
+		WithLogger(&x.ToGlog{}).
 		WithCompression(options.None).
 		WithEventLogging(false).
 		WithLogRotatesToFlush(10).
 		WithMaxCacheSize(50) // TODO(Aman): Disable cache altogether
-
-	// TODO(Ibrahim): Remove this once badger is updated.
-	dbOpts.ZSTDCompressionLevel = 1
 
 	tmpDB, err := badger.OpenManaged(dbOpts)
 	if err != nil {
@@ -558,9 +581,6 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	// Todo(Aman): Replace TxnWriter with WriteBatch. While we do that we should ensure that
 	// WriteBatch has a mechanism for throttling. Also, find other places where TxnWriter
 	// could be replaced with WriteBatch in the code
-	// Todo(Aman): Replace TxnWriter with WriteBatch. While we do that we should ensure that
-	// WriteBatch has a mechanism for throttling. Also, find other places where TxnWriter
-	// could be replaced with WriteBatch in the code.
 	tmpWriter := NewTxnWriter(tmpDB)
 	stream := pstore.NewStreamAt(r.startTs)
 	stream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (1/2):", r.attr)
@@ -583,6 +603,9 @@ func (r *rebuilder) Run(ctx context.Context) error {
 			return nil, errors.Wrapf(err, "error reading posting list from disk")
 		}
 
+		// We are using different transactions in each call to KeyToList function. This could
+		// be a problem for computing reverse count indexes if deltas for same key are added
+		// in different transactions. Such a case doesn't occur for now.
 		txn := NewTxn(r.startTs)
 		if err := r.fn(pk.Uid, l, txn); err != nil {
 			return nil, err
@@ -1002,6 +1025,8 @@ func rebuildReverseEdges(ctx context.Context, rb *IndexRebuild) error {
 			edge.Label = pp.Label
 
 			for {
+				// we only need to build reverse index here.
+				// We will update the reverse count index separately.
 				err := txn.addReverseMutation(ctx, &edge)
 				switch err {
 				case ErrRetry:


### PR DESCRIPTION
We used to compute reverse count indexes twice while reindexing.
First, while computing reverse edges, and then later while explicitly
computing reverse count index. Now, we use a different function
while reindexing reverse edges and do not compute the reverse
count indexes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4755)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-1e92791bfd-44296.surge.sh)
<!-- Dgraph:end -->