### PR TITLE
Support ACL operations using the admin GraphQL API

### DIFF
--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -80,7 +80,7 @@ func runGzipWithRetry(contentType, url string, buf io.Reader, gzReq, gzResp bool
 		resp, err = client.Do(req)
 		if err != nil && strings.Contains(err.Error(), "Token is expired") {
 			grootAccessJwt, grootRefreshJwt, err = testutil.HttpLogin(&testutil.LoginParams{
-				Endpoint:   addr + "/login",
+				Endpoint:   addr + "/admin",
 				RefreshJwt: grootRefreshJwt,
 			})
 
@@ -270,7 +270,7 @@ func runWithRetries(method, contentType, url string, body string) (
 	qr, respBody, err := runRequest(req)
 	if err != nil && strings.Contains(err.Error(), "Token is expired") {
 		grootAccessJwt, grootRefreshJwt, err = testutil.HttpLogin(&testutil.LoginParams{
-			Endpoint:   addr + "/login",
+			Endpoint:   addr + "/admin",
 			RefreshJwt: grootRefreshJwt,
 		})
 		if err != nil {

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1665,7 +1665,7 @@ func TestMain(m *testing.M) {
 	if _, err := zc.AssignUids(context.Background(), &pb.Num{Val: 1e6}); err != nil {
 		log.Fatal(err)
 	}
-	grootAccessJwt, grootRefreshJwt = testutil.GrootHttpLogin(addr + "/login")
+	grootAccessJwt, grootRefreshJwt = testutil.GrootHttpLogin(addr + "/admin")
 
 	r := m.Run()
 	os.Exit(r)

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var loginEndpoint = "http://" + testutil.SockAddrHttp + "/login"
+var adminEndpoint = "http://" + testutil.SockAddrHttp + "/admin"
 
 func TestCurlAuthorization(t *testing.T) {
 	if testing.Short() {
@@ -38,7 +38,7 @@ func TestCurlAuthorization(t *testing.T) {
 
 	// test query through curl
 	accessJwt, refreshJwt, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   userid,
 		Passwd:   userpassword,
 	})
@@ -97,7 +97,7 @@ func TestCurlAuthorization(t *testing.T) {
 	})
 	// login again using the refreshJwt
 	accessJwt, refreshJwt, err = testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint:   loginEndpoint,
+		Endpoint:   adminEndpoint,
 		RefreshJwt: refreshJwt,
 	})
 	require.NoError(t, err, fmt.Sprintf("login through refresh token failed: %v", err))
@@ -112,7 +112,7 @@ func TestCurlAuthorization(t *testing.T) {
 	})
 	// refresh the jwts again
 	accessJwt, refreshJwt, err = testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint:   loginEndpoint,
+		Endpoint:   adminEndpoint,
 		RefreshJwt: refreshJwt,
 	})
 	require.NoError(t, err, fmt.Sprintf("login through refresh token failed: %v", err))
@@ -135,7 +135,7 @@ func TestCurlAuthorization(t *testing.T) {
 	time.Sleep(6 * time.Second)
 	// refresh the jwts again
 	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint:   loginEndpoint,
+		Endpoint:   adminEndpoint,
 		RefreshJwt: refreshJwt,
 	})
 	require.NoError(t, err, fmt.Sprintf("login through refresh token failed: %v", err))

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -105,7 +105,7 @@ func deleteUser(t *testing.T, accessToken, username string) {
 
 func TestCreateAndDeleteUsers(t *testing.T) {
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -132,7 +132,7 @@ func TestCreateAndDeleteUsers(t *testing.T) {
 
 func resetUser(t *testing.T) {
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -504,7 +504,7 @@ func addRulesToGroup(t *testing.T, accessToken, group string, rules []rule) {
 
 func createGroupAndAcls(t *testing.T, group string, addUserToGroup bool) {
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -617,7 +617,7 @@ func TestUnauthorizedDeletion(t *testing.T) {
 	resetUser(t)
 
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -715,7 +715,7 @@ func TestGuardianAccess(t *testing.T) {
 
 func addNewUserToGroup(t *testing.T, userName, password, groupName string) {
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -757,7 +757,7 @@ func removeUserFromGroup(t *testing.T, userName, groupName string) []byte {
 	}
 
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -782,7 +782,7 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 
 	resetUser(t)
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -1034,7 +1034,7 @@ func TestNegativePermissionDeleteRule(t *testing.T) {
 		string(resp.GetJson()))
 
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})
@@ -1122,7 +1122,7 @@ func TestNonExistentGroup(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
-		Endpoint: loginEndpoint,
+		Endpoint: adminEndpoint,
 		UserID:   "groot",
 		Passwd:   "password",
 	})

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -92,15 +92,6 @@ const (
 		format: String
 	}
 
-	input BackupInput {
-		destination: String!
-		accessKey: String
-		secretKey: String
-		sessionToken: String
-		anonymous: Boolean
-		forceFull: Boolean
-	}
-
 	type Response {
 		code: String
 		message: String
@@ -130,161 +121,13 @@ const (
 		response: Response
 	}
 
-	type BackupPayload {
-		response: Response
-	}
-
-	type User {
-		name: String! @id @dgraph(pred: "dgraph.xid")
-		# TODO - Update this to actual secret after password PR is merged here.
-		password: String! @dgraph(pred: "dgraph.password")
-		groups: [Group] @dgraph(pred: "dgraph.user.group")
-	}
-
-	type Group {
-		name: String! @id @dgraph(pred: "dgraph.xid")
-		users: [User] @dgraph(pred: "~dgraph.user.group")
-		rules: [Rule] @dgraph(pred: "dgraph.acl.rule")
-	}
-
-	type Rule {
-		id: ID!
-		predicate: String! @dgraph(pred: "dgraph.rule.predicate")
-		# TODO - Change permission to enum type once we figure out how to map enum strings to Int
-		# while storing it in Dgraph.
-		# We also need validation in Dgraph on ther permitted value of permission to be between [0,7]
-		# If we change permission to be an ENUM and only allow ACL mutations through the GraphQL API
-		# then we don't need this validation in Dgrpah.
-		permission: Int! @dgraph(pred: "dgraph.rule.permission")
-	}
-
-	input StringHashFilter {
-		eq: String
-	}
-
-	enum UserOrderable {
-		name
-	}
-
-	enum GroupOrderable {
-		name
-	}
-
-	input AddUserInput {
-		name: String!
-		password: String!
-		groups: [GroupRef]
-	}
-
-	input AddGroupInput {
-		name: String!
-		rules: [RuleRef]
-	}
-
-	input UserRef {
-		name: String!
-	}
-
-	input GroupRef {
-		name: String!
-	}
-
-	input RuleRef {
-		id: ID
-		predicate: String
-		permission: Int
-	}
-
-	input UserFilter {
-		name: StringHashFilter
-		and: UserFilter
-		or: UserFilter
-		not: UserFilter
-	}
-
-	input UserOrder {
-		asc: UserOrderable
-		desc: UserOrderable
-		then: UserOrder
-	}
-
-	input GroupOrder {
-		asc: GroupOrderable
-		desc: GroupOrderable
-		then: GroupOrder
-	}
-
-	input UserPatch {
-		password: String
-		groups: [GroupRef]
-	}
-
-	input UpdateUserInput {
-		filter: UserFilter!
-		set: UserPatch
-		remove: UserPatch
-	}
-
-	input GroupFilter {
-		name: StringHashFilter
-		and: UserFilter
-		or: UserFilter
-		not: UserFilter
-	}
-
-	input GroupPatch {
-		rules: [RuleRef]
-	}
-
-	input UpdateGroupInput {
-		filter: GroupFilter!
-		set: GroupPatch
-		remove: GroupPatch
-	}
-
-	type AddUserPayload {
-		user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-	}
-
-	type AddGroupPayload {
-		group(filter: GroupFilter, order: GroupOrder, first: Int, offset: Int): [Group]
-	}
-
-	enum Permission {
-		NOTHING     # (000)
-		ALTER       # (001)
-		WRITE       # (010)
-		ALTERWRITE  # (011)
-		READ        # (100)
-		READALTER   # (101)
-		READWRITE   # (110)
-		ALL         # (111)
-	}
-
-	type DeleteUserPayload {
-		msg: String
-	}
-
-	type DeleteGroupPayload {
-		msg: String
-	}
+	` + adminTypes + `
 
 	type Query {
 		getGQLSchema: GQLSchema
 		health: Health
 
-		# ACL related endpoints
-		# TODO - The endpoints below work fine for members of guardians group but they should only
-		# return a subset of the data for other users. Test that and add validation in the server
-		# for them.
-		getUser(name: String!): User
-		getGroup(name: String!): Group
-
-		# TODO - This needs a custom handler. Implement this later.
-		# getCurrentUser: User
-
-		queryUser(filter: UserFilter): [User]
-		queryGroup(filter: GroupFilter): [Group]
+		` + adminQueries + `
 	}
 
 	type Mutation {
@@ -293,26 +136,8 @@ const (
 		draining(input: DrainingInput!): DrainingPayload
 		shutdown: ShutdownPayload
 		config(input: ConfigInput!): ConfigPayload
-		backup(input: BackupInput!) : BackupPayload
 
-		# ACL related endpoints.
-		# 1. If user and group don't exist both are created and linked.
-		# 2. If user doesn't exist but group does, then user is created and both are linked.
-		# 3. If user exists and group doesn't exist, then two errors are returned i.e. User exists
-		# and group doesn't exist.
-		# 4. If user and group exists, then error that user exists.
-		addUser(input: [AddUserInput]): AddUserPayload
-		addGroup(input: [AddGroupInput]): AddGroupPayload
-
-		# update user allows updating a user's password or updating their groups. If the group
-		# doesn't exist, then it is created, otherwise linked to the user. If the user filter
-		# doesn't return anything then nothing happens.
-		updateUser(input: UpdateUserInput!): AddUserPayload
-		# update group only allows adding rules to a group.
-		updateGroup(input: UpdateGroupInput!): AddGroupPayload
-
-		deleteGroup(filter: GroupFilter!): DeleteGroupPayload
-		deleteUser(filter: UserFilter!): DeleteUserPayload
+		` + adminMutations + `
 	}
  `
 )

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -178,9 +178,6 @@ const (
 
 	input AddGroupInput {
 		name: String!
-		# Can't add users to a group in addGroup because users are a reverse edge from a group and
-		# we don't allow mutations along the reverse edge.
-		# users: [UserRef]
 		rules: [RuleRef]
 	}
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -358,6 +358,17 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 				backup,
 				resolve.StdMutationCompletion(m.ResponseName()))
 		}).
+		WithMutationResolver("login", func(m schema.Mutation) resolve.MutationResolver {
+			login := &loginResolver{}
+
+			// login implements the mutation rewriter, executor and query executor hence its passed
+			// thrice here.
+			return resolve.NewMutationResolver(
+				login,
+				login,
+				login,
+				resolve.StdQueryCompletion())
+		}).
 		WithSchemaIntrospection()
 
 	return rf

--- a/graphql/admin/endpoints.go
+++ b/graphql/admin/endpoints.go
@@ -1,0 +1,25 @@
+// +build oss
+
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+const adminTypes = ``
+
+const adminMutations = ``
+
+const adminQueries = ``

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -32,6 +32,21 @@ const adminTypes = `
 		response: Response
 	}
 
+	input LoginInput {
+		userId: String
+		password: String
+		refreshToken: String
+	}
+
+	type LoginResponse {
+		accessJwt: String
+		refreshJwt: String
+	}
+
+	type LoginPayload {
+		response: LoginResponse
+	}
+
 	type User {
 		name: String! @id @dgraph(pred: "dgraph.xid")
 		# TODO - Update this to actual secret after password PR is merged here.
@@ -159,6 +174,7 @@ const adminTypes = `
 const adminMutations = `
 	backup(input: BackupInput!) : BackupPayload
 
+	login(input: LoginInput!): LoginPayload
 	# ACL related endpoints.
 	# 1. If user and group don't exist both are created and linked.
 	# 2. If user doesn't exist but group does, then user is created and both are linked.

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -39,8 +39,8 @@ const adminTypes = `
 	}
 
 	type LoginResponse {
-		accessJwt: String
-		refreshJwt: String
+		accessJWT: String
+		refreshJWT: String
 	}
 
 	type LoginPayload {

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -1,0 +1,193 @@
+// +build !oss
+
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+const adminTypes = `
+	input BackupInput {
+		destination: String!
+		accessKey: String
+		secretKey: String
+		sessionToken: String
+		anonymous: Boolean
+		forceFull: Boolean
+	}
+
+	type BackupPayload {
+		response: Response
+	}
+
+	type User {
+		name: String! @id @dgraph(pred: "dgraph.xid")
+		# TODO - Update this to actual secret after password PR is merged here.
+		password: String! @dgraph(pred: "dgraph.password")
+		groups: [Group] @dgraph(pred: "dgraph.user.group")
+	}
+
+	type Group {
+		name: String! @id @dgraph(pred: "dgraph.xid")
+		users: [User] @dgraph(pred: "~dgraph.user.group")
+		rules: [Rule] @dgraph(pred: "dgraph.acl.rule")
+	}
+
+	type Rule {
+		id: ID!
+		predicate: String! @dgraph(pred: "dgraph.rule.predicate")
+		# TODO - Change permission to enum type once we figure out how to map enum strings to Int
+		# while storing it in Dgraph.
+		# We also need validation in Dgraph on ther permitted value of permission to be between [0,7]
+		# If we change permission to be an ENUM and only allow ACL mutations through the GraphQL API
+		# then we don't need this validation in Dgrpah.
+		permission: Int! @dgraph(pred: "dgraph.rule.permission")
+	}
+
+	input StringHashFilter {
+		eq: String
+	}
+
+	enum UserOrderable {
+		name
+	}
+
+	enum GroupOrderable {
+		name
+	}
+
+	input AddUserInput {
+		name: String!
+		password: String!
+		groups: [GroupRef]
+	}
+
+	input AddGroupInput {
+		name: String!
+		rules: [RuleRef]
+	}
+
+	input UserRef {
+		name: String!
+	}
+
+	input GroupRef {
+		name: String!
+	}
+
+	input RuleRef {
+		id: ID
+		predicate: String
+		permission: Int
+	}
+
+	input UserFilter {
+		name: StringHashFilter
+		and: UserFilter
+		or: UserFilter
+		not: UserFilter
+	}
+
+	input UserOrder {
+		asc: UserOrderable
+		desc: UserOrderable
+		then: UserOrder
+	}
+
+	input GroupOrder {
+		asc: GroupOrderable
+		desc: GroupOrderable
+		then: GroupOrder
+	}
+
+	input UserPatch {
+		password: String
+		groups: [GroupRef]
+	}
+
+	input UpdateUserInput {
+		filter: UserFilter!
+		set: UserPatch
+		remove: UserPatch
+	}
+
+	input GroupFilter {
+		name: StringHashFilter
+		and: UserFilter
+		or: UserFilter
+		not: UserFilter
+	}
+
+	input GroupPatch {
+		rules: [RuleRef]
+	}
+
+	input UpdateGroupInput {
+		filter: GroupFilter!
+		set: GroupPatch
+		remove: GroupPatch
+	}
+
+	type AddUserPayload {
+		user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	}
+
+	type AddGroupPayload {
+		group(filter: GroupFilter, order: GroupOrder, first: Int, offset: Int): [Group]
+	}
+
+	type DeleteUserPayload {
+		msg: String
+	}
+
+	type DeleteGroupPayload {
+		msg: String
+	}`
+
+const adminMutations = `
+	backup(input: BackupInput!) : BackupPayload
+
+	# ACL related endpoints.
+	# 1. If user and group don't exist both are created and linked.
+	# 2. If user doesn't exist but group does, then user is created and both are linked.
+	# 3. If user exists and group doesn't exist, then two errors are returned i.e. User exists
+	# and group doesn't exist.
+	# 4. If user and group exists, then error that user exists.
+	addUser(input: [AddUserInput]): AddUserPayload
+	addGroup(input: [AddGroupInput]): AddGroupPayload
+
+	# update user allows updating a user's password or updating their groups. If the group
+	# doesn't exist, then it is created, otherwise linked to the user. If the user filter
+	# doesn't return anything then nothing happens.
+	updateUser(input: UpdateUserInput!): AddUserPayload
+	# update group only allows adding rules to a group.
+	updateGroup(input: UpdateGroupInput!): AddGroupPayload
+
+	deleteGroup(filter: GroupFilter!): DeleteGroupPayload
+	deleteUser(filter: UserFilter!): DeleteUserPayload`
+
+const adminQueries = `
+	# ACL related endpoints
+	# TODO - The endpoints below work fine for members of guardians group but they should only
+	# return a subset of the data for other users. Test that and add validation in the server
+	# for them.
+	getUser(name: String!): User
+	getGroup(name: String!): Group
+
+	# TODO - This needs a custom handler. Implement this later.
+	# getCurrentUser: User
+
+	queryUser(filter: UserFilter): [User]
+	queryGroup(filter: GroupFilter): [Group]`

--- a/graphql/admin/login.go
+++ b/graphql/admin/login.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+
+	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
+	"github.com/dgraph-io/dgraph/edgraph"
+	"github.com/dgraph-io/dgraph/gql"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
+)
+
+type loginResolver struct {
+	mutation   schema.Mutation
+	accessJwt  string
+	refreshJwt string
+}
+
+type loginInput struct {
+	UserId       string
+	Password     string
+	RefreshToken string
+}
+
+func (lr *loginResolver) Rewrite(
+	m schema.Mutation) (*gql.GraphQuery, []*dgoapi.Mutation, error) {
+	glog.Info("Got login request")
+
+	lr.mutation = m
+	input, err := getLoginInput(m)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// TODO - Fix this context to log the IP as it does in the other request.
+	resp, err := (&edgraph.Server{}).Login(context.Background(), &dgoapi.LoginRequest{
+		Userid:       input.UserId,
+		Password:     input.Password,
+		RefreshToken: input.RefreshToken,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	jwt := &dgoapi.Jwt{}
+	if err := jwt.Unmarshal(resp.GetJson()); err != nil {
+		return nil, nil, err
+	}
+	lr.accessJwt = jwt.AccessJwt
+	lr.refreshJwt = jwt.RefreshJwt
+	return nil, nil, nil
+}
+
+func (lr *loginResolver) FromMutationResult(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	result map[string]interface{}) (*gql.GraphQuery, error) {
+
+	return nil, nil
+}
+
+func (lr *loginResolver) Mutate(
+	ctx context.Context,
+	query *gql.GraphQuery,
+	mutations []*dgoapi.Mutation) (map[string]string, map[string]interface{}, error) {
+
+	return nil, nil, nil
+}
+
+func (lr *loginResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
+	var buf bytes.Buffer
+
+	x.Check2(buf.WriteString(`{ "`))
+	x.Check2(buf.WriteString(lr.mutation.SelectionSet()[0].ResponseName() + `": [{`))
+
+	for i, sel := range lr.mutation.SelectionSet()[0].SelectionSet() {
+		var val string
+		switch sel.Name() {
+		case "accessJwt":
+			val = lr.accessJwt
+		case "refreshJwt":
+			val = lr.refreshJwt
+		}
+		if i != 0 {
+			x.Check2(buf.WriteString(","))
+		}
+		x.Check2(buf.WriteString(`"`))
+		x.Check2(buf.WriteString(sel.ResponseName()))
+		x.Check2(buf.WriteString(`":`))
+		x.Check2(buf.WriteString(`"` + val + `"`))
+	}
+	x.Check2(buf.WriteString("}]}"))
+
+	return buf.Bytes(), nil
+}
+
+func getLoginInput(m schema.Mutation) (*loginInput, error) {
+	inputArg := m.ArgValue(schema.InputArgName)
+	inputByts, err := json.Marshal(inputArg)
+	if err != nil {
+		return nil, schema.GQLWrapf(err, "couldn't get input argument")
+	}
+
+	var input loginInput
+	err = json.Unmarshal(inputByts, &input)
+	return &input, schema.GQLWrapf(err, "couldn't get input argument")
+}

--- a/graphql/admin/login.go
+++ b/graphql/admin/login.go
@@ -94,9 +94,9 @@ func (lr *loginResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]by
 	for i, sel := range lr.mutation.SelectionSet()[0].SelectionSet() {
 		var val string
 		switch sel.Name() {
-		case "accessJwt":
+		case "accessJWT":
 			val = lr.accessJwt
-		case "refreshJwt":
+		case "refreshJWT":
 			val = lr.refreshJwt
 		}
 		if i != 0 {


### PR DESCRIPTION
This PR supports all the operations currently supported by the ACL tool using the admin API available at `/admin`. The current tests in `acl_test.go` have also been modified to use the new API. The `dgraph acl` tool would be removed as part of another PR.

Some more testing is required for the API to test the behavior when users who are not part of the guardian group use it. I'll do that as part of a separate change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4760)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-893de2d0a0-43788.surge.sh)
<!-- Dgraph:end -->