### PR TITLE
Doc - Improve ACL section

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -308,7 +308,7 @@ dgraph acl mod -a localhost:9080 -g dev -p name -m 7
 
 ### Retrieve Users and Groups Information 
 
-The following examples show how to retrive information about users and groups.
+The following examples show how to retrieve information about users and groups.
 
 #### Using the Command Line
 

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -245,7 +245,7 @@ A typical workflow is the following:
 4. Assign the user to the group
 5. Assign predicate permissions to the group
 
-#### Using the command line
+#### Using the Command Line
 
 1. Reset the root password. The example below uses the dgraph endpoint `localhost:9080`
 as a demo, make sure to choose the correct IP and port for your environment:
@@ -306,11 +306,11 @@ a predicate, the default behavior is to block all (`READ`, `WRITE` and `MODIFY`)
 dgraph acl mod -a localhost:9080 -g dev -p name -m 7
 ```
 
-### Retrieve Users and Groups information 
+### Retrieve Users and Groups Information 
 
 The following examples show how to retrive information about users and groups.
 
-#### Using the command line
+#### Using the Command Line
 
 1. Check information about a user
 ```bash

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -342,7 +342,7 @@ Users: alice
 ACL  : {friend  7}
 ACL  : {name  7}
 ```
-3. Run ACL commands as another guardian (Member of `guardians` group)
+3. Run ACL commands as another guardian (member of `guardians` group). 
 You can also run ACL commands with other users. Say we have a user `alice` which is member
 of `guardians` group and its password is `simple_alice`. We can run ACL commands as shown below.
 ```bash

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -353,8 +353,11 @@ Above command will show information about user `groot`.
 ### Access Data Using a Client
 
 Now that the ACL data are set, to access the data protected by ACL rules, we need to
-first log in through a user. A sample code using the dgo client can be found
-[here](https://github.com/dgraph-io/dgraph/blob/master/tlstest/acl/acl_over_tls_test.go).
+first log in through a user. This is tyically done via the client's `.login(USER_ID, USER_PASSWORD)` method.
+
+A sample code using the dgo client can be found
+[here](https://github.com/dgraph-io/dgraph/blob/master/tlstest/acl/acl_over_tls_test.go). An example using
+dgraph4j can be found [here](https://github.com/dgraph-io/dgraph4j/blob/master/src/test/java/io/dgraph/AclTest.java).
 
 ### Access Data Using Curl
 

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -234,8 +234,18 @@ If you are using docker-compose, a sample cluster can be set up by:
 
 ### Set up ACL Rules
 
-Now that your cluster is running with the ACL feature turned on, let's set up the ACL
-rules. A typical workflow is the following:
+Now that your cluster is running with the ACL feature turned on, you can set up the ACL
+rules. This can be done using the web UI Ratel or from the command line.
+
+A typical workflow is the following:
+
+1. Reset the root password
+2. Create a regular user
+3. Create a group
+4. Assign the user to the group
+5. Assign predicate permissions to the group
+
+#### Using the command line
 
 1. Reset the root password. The example below uses the dgraph endpoint `localhost:9080`
 as a demo, make sure to choose the correct IP and port for your environment:
@@ -295,7 +305,14 @@ a predicate, the default behavior is to block all (`READ`, `WRITE` and `MODIFY`)
 ```bash
 dgraph acl mod -a localhost:9080 -g dev -p name -m 7
 ```
-6. Check information about a user
+
+### Retrieve Users and Groups information 
+
+The following examples show how to retrive information about users and groups.
+
+#### Using the command line
+
+1. Check information about a user
 ```bash
 dgraph acl info -a localhost:9080 -u alice
 ```
@@ -308,7 +325,7 @@ UID   : 0x3
 Group : dev
 Group : sre
 ```
-7. Check information about a group
+2. Check information about a group
 ```bash
 dgraph acl info -a localhost:9080 -g dev
 ```
@@ -325,14 +342,14 @@ Users: alice
 ACL  : {friend  7}
 ACL  : {name  7}
 ```
-
-8. Run ACL commands as another guardian (Member of `guardians` group)
+3. Run ACL commands as another guardian (Member of `guardians` group)
 You can also run ACL commands with other users. Say we have a user `alice` which is member
 of `guardians` group and its password is `simple_alice`. We can run ACL commands as shown below.
 ```bash
 dgraph acl info -a localhost:9180 -u groot -w alice -x simple_alice
 ```
 Above command will show information about user `groot`.
+
 ### Access Data Using a Client
 
 Now that the ACL data are set, to access the data protected by ACL rules, we need to


### PR DESCRIPTION
- Current documentation includes examples on how to set up the ACL rules via the command line, but it does not mention that the same operations can be done via the web ui as well. This is now cited (high level only)
- The steps of the typical workflow of how to set up ACL rules are now first listed. Then each step is described in details later
 - A new section "Retrieve Users and Groups information" is created and the corresponding examples are moved from "Set up ACL Rules" into this new section
- Wrong indentation of section "Access Data Using a Client" is fixed
- `.login` method is cited and an example with dgraph4j is linked

Details on how to set up acl rules and retrieve information via ratel are not added in this PR - but can be easily added in a later PR (e.g. creating a sub-section "Using Ratel", similar to the new sub-section "Using the command line")

Addition examples of the `.login` method via other official clients can be added in a second PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4763)
<!-- Reviewable:end -->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f790d0323d-44233.surge.sh)
<!-- Dgraph:end -->