### PR TITLE
Doc - TLS - small fixes

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1582,7 +1582,7 @@ Ratel UI (and any other JavaScript clients built on top of `dgraph-js-http`)
 connect to Dgraph servers via HTTP, when TLS is enabled servers begin to expect
 HTTPS requests only. Therefore some adjustments need to be made.
 
-If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN`:
+If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN` (default):
 
 1. Change the connection URL from `http://` to `https://` (e.g. `https://127.0.0.1:8080`).
 2. Install / make trusted the certificate of the Dgraph certificate authority `ca.crt`. Refer to the documentation of your OS / browser for instructions

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1585,8 +1585,8 @@ HTTPS requests only. Therefore some adjustments need to be made.
 If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN`:
 
 1. Change the connection URL from `http://` to `https://` (e.g. `https://127.0.0.1:8080`).
-2. Install / make trusted the certificate of the Dgraph certificate authority `ca.crt`. Refer to the documentation of your OS / browser for instructions.
-(E.g. on Mac OS this means adding `ca.crt` to the KeyChain and making it trusted
+2. Install / make trusted the certificate of the Dgraph certificate authority `ca.crt`. Refer to the documentation of your OS / browser for instructions
+(e.g. on Mac OS this means adding `ca.crt` to the KeyChain and making it trusted
 for `Secure Socket Layer`).
 
 For `REQUIREANY` and `REQUIREANDVERIFY` you need to follow the steps above and

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1592,7 +1592,7 @@ for `Secure Socket Layer`).
 For `REQUIREANY` and `REQUIREANDVERIFY` you need to follow the steps above and
 also need to install client certificate on your OS / browser:
 
-1. Generate a client certificate: `dgraph -c MyLaptop`.
+1. Generate a client certificate: `dgraph cert -c MyLaptop`.
 2. Convert it to a `.p12` file:
 `openssl pkcs12 -export -out MyLaptopCert.p12 -in tls/client.MyLaptop.crt -inkey tls/client.MyLaptop.key`. Use any password you like for export.
 3. Install the generated `MyLaptopCert.p12` file on the client system

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1582,8 +1582,8 @@ Ratel UI (and any other JavaScript clients built on top of `dgraph-js-http`)
 connect to Dgraph servers via HTTP, when TLS is enabled servers begin to expect
 HTTPS requests only. Therefore some adjustments need to be made.
 
-If the `--tls_client_auth` option is set to `REQUEST` (default) or
-`VERIFYIFGIVEN`:
+If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN`:
+
 1. Change the connection URL from `http://` to `https://` (e.g. `https://127.0.0.1:8080`).
 2. Install / make trusted the certificate of the Dgraph certificate authority `ca.crt`. Refer to the documentation of your OS / browser for instructions.
 (E.g. on Mac OS this means adding `ca.crt` to the KeyChain and making it trusted


### PR DESCRIPTION
- `request` is not anymore the default value
- a command was missing the `cert` part - now fixed
- fixes style of a numbered list by adding an empty line

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4764)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f74dacc23d-44001.surge.sh)
<!-- Dgraph:end -->