### PR TITLE
graphql: duplicate /health in GraphQL /admin

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -289,7 +289,7 @@ func healthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		ctx := attachAccessJwt(context.Background(), r)
+		ctx := x.AttachAccessJwt(context.Background(), r)
 		var resp *api.Response
 		if resp, err = (&edgraph.Server{}).Health(ctx, true); err != nil {
 			x.SetStatus(w, x.Error, err.Error())
@@ -335,7 +335,7 @@ func stateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	ctx := context.Background()
-	ctx = attachAccessJwt(ctx, r)
+	ctx = x.AttachAccessJwt(ctx, r)
 
 	var aResp *api.Response
 	if aResp, err = (&edgraph.Server{}).State(ctx); err != nil {

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -443,7 +443,7 @@ func makeRequest(t *testing.T, accessToken string, params testutil.GraphQLParams
 
 	req, err := http.NewRequest(http.MethodPost, adminUrl, bytes.NewBuffer(b))
 	require.NoError(t, err)
-	req.Header.Set("accessJwt", accessToken)
+	req.Header.Set("X-Dgraph-AccessToken", accessToken)
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -54,7 +54,7 @@ const (
 		generatedSchema: String!
 	}
 	  
-	"""Node state is the state of an individual node int he Dgraph cluster """
+	"""Node state is the state of an individual node in the Dgraph cluster """
 	type NodeState {
 		"""node type : either 'alpha' or 'zero'"""
 		instance: String

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -47,11 +47,6 @@ const (
 		"(Please let us know : https://github.com/dgraph-io/dgraph/issues)"
 
 	// GraphQL schema for /admin endpoint.
-	//
-	// Eventually we should generate this from just the types definition.
-	// But for now, that would add too much into the schema, so this is
-	// hand crafted to be one of our schemas so we can pass it into the
-	// pipeline.
 	graphqlAdminSchema = `
 	type GQLSchema @dgraph(type: "dgraph.graphql") {
 		id: ID!
@@ -59,18 +54,17 @@ const (
 		generatedSchema: String!
 	}
 
-	type Health {
-		message: String!
-		status: HealthStatus!
+	"""Node state is the state of an individual node int he Dgraph cluster """
+	type NodeState {
+		"""node type : either 'alpha' or 'zero'"""
+		instance: String
+		address: String
+		"""node health status : either 'healthy' or 'unhealthy'"""
+		status: String
+		group: Int
+		uptime: Int
+		lastEcho: Int
 	}
-
-	enum HealthStatus {
-		ErrNoConnection
-		NoGraphQLSchema
-		Healthy
-	}
-
-	scalar DateTime
 
 	directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 
@@ -134,7 +128,7 @@ const (
 
 	type Query {
 		getGQLSchema: GQLSchema
-		health: Health
+		health: [NodeState]
 	}
 
 	type Mutation {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -53,7 +53,7 @@ const (
 		schema: String!  @dgraph(type: "dgraph.graphql.schema")
 		generatedSchema: String!
 	}
-
+	  
 	"""Node state is the state of an individual node int he Dgraph cluster """
 	type NodeState {
 		"""node type : either 'alpha' or 'zero'"""
@@ -151,7 +151,6 @@ type gqlSchema struct {
 type adminServer struct {
 	rf       resolve.ResolverFactory
 	resolver *resolve.RequestResolver
-	status   healthStatus
 
 	// The mutex that locks schema update operations
 	mux sync.Mutex
@@ -207,7 +206,6 @@ func newAdminResolver(
 	server := &adminServer{
 		rf:                rf,
 		resolver:          resolve.New(adminSchema, rf),
-		status:            errNoConnection,
 		gqlServer:         gqlServer,
 		fns:               fns,
 		withIntrospection: withIntrospection,
@@ -269,7 +267,6 @@ func newAdminResolver(
 		defer server.mux.Unlock()
 
 		server.schema = newSchema
-		server.status = healthy
 		server.resetSchema(gqlSchema)
 	}, 1, closer)
 
@@ -282,14 +279,12 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 	rf := resolverFactoryWithErrorMsg(errResolverNotFound).
 		WithQueryResolver("health",
 			func(q schema.Query) resolve.QueryResolver {
-				health := &healthResolver{
-					status: errNoConnection,
-				}
+				health := &healthResolver{}
 
 				return resolve.NewQueryResolver(
 					health,
 					health,
-					resolve.StdQueryCompletion())
+					resolve.AliasQueryCompletion())
 			}).
 		WithMutationResolver("updateGQLSchema", func(m schema.Mutation) resolve.MutationResolver {
 			return resolve.MutationResolverFunc(
@@ -364,26 +359,28 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 }
 
 func (as *adminServer) initServer() {
-	var waitFor time.Duration
+	// It takes a few seconds for the Dgraph cluster to be up and running.
+	// Before that, trying to read the GraphQL schema will result in error:
+	// "Please retry again, server is not ready to accept requests."
+	// 5 seconds is a pretty reliable wait for a fresh instance to read the
+	// schema on a first try.
+	waitFor := 5 * time.Second
+
+	// Nothing else should be able to lock before here.  The admin resolvers aren't yet
+	// set up (they all just error), so we will obtain the lock here without contention.
+	// We then setup the admin resolvers and they must wait until we are done before the
+	// first admin calls will go through.
+	as.mux.Lock()
+	defer as.mux.Unlock()
+
+	as.addConnectedAdminResolvers()
 	for {
 		<-time.After(waitFor)
-		waitFor = 10 * time.Second
-
-		// Nothing else should be able to lock before here.  The admin resolvers aren't yet
-		// set up (they all just error), so we will obtain the lock here without contention.
-		// We then setup the admin resolvers and they must wait until we are done before the
-		// first admin calls will go through.
-		as.mux.Lock()
-		defer as.mux.Unlock()
-
-		as.addConnectedAdminResolvers()
-
-		as.status = noGraphQLSchema
 
 		sch, err := getCurrentGraphQLSchema(as.resolver)
 		if err != nil {
 			glog.Infof("Error reading GraphQL schema: %s.", err)
-			break
+			continue
 		} else if sch == nil {
 			glog.Infof("No GraphQL schema in Dgraph; serving empty GraphQL API")
 			break
@@ -405,7 +402,6 @@ func (as *adminServer) initServer() {
 		glog.Infof("Successfully loaded GraphQL schema.  Serving GraphQL API.")
 
 		as.schema = *sch
-		as.status = healthy
 		as.resetSchema(generatedSchema)
 
 		break
@@ -424,32 +420,21 @@ func (as *adminServer) addConnectedAdminResolvers() {
 	as.fns.Qe = qryExec
 	as.fns.Me = mutExec
 
-	as.rf.WithQueryResolver("health",
-		func(q schema.Query) resolve.QueryResolver {
-			health := &healthResolver{
-				status: as.status,
+	as.rf.WithMutationResolver("updateGQLSchema",
+		func(m schema.Mutation) resolve.MutationResolver {
+			updResolver := &updateSchemaResolver{
+				admin:                as,
+				baseAddRewriter:      addRw,
+				baseMutationRewriter: updRw,
+				baseMutationExecutor: mutExec,
 			}
 
-			return resolve.NewQueryResolver(
-				health,
-				health,
-				resolve.StdQueryCompletion())
+			return resolve.NewMutationResolver(
+				updResolver,
+				updResolver,
+				updResolver,
+				resolve.StdMutationCompletion(m.Name()))
 		}).
-		WithMutationResolver("updateGQLSchema",
-			func(m schema.Mutation) resolve.MutationResolver {
-				updResolver := &updateSchemaResolver{
-					admin:                as,
-					baseAddRewriter:      addRw,
-					baseMutationRewriter: updRw,
-					baseMutationExecutor: mutExec,
-				}
-
-				return resolve.NewMutationResolver(
-					updResolver,
-					updResolver,
-					updResolver,
-					resolve.StdMutationCompletion(m.Name()))
-			}).
 		WithQueryResolver("getGQLSchema",
 			func(q schema.Query) resolve.QueryResolver {
 				getResolver := &getSchemaResolver{
@@ -506,8 +491,6 @@ func (as *adminServer) resetSchema(gqlSchema schema.Schema) {
 	}
 
 	as.gqlServer.ServeGQL(resolve.New(gqlSchema, resolverFactory))
-
-	as.status = healthy
 }
 
 func writeResponse(m schema.Mutation, code, message string) []byte {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -62,6 +62,7 @@ const (
 		"""node health status : either 'healthy' or 'unhealthy'"""
 		status: String
 		group: Int
+		version: String
 		uptime: Int
 		lastEcho: Int
 	}

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -19,7 +19,6 @@ package common
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -272,8 +271,7 @@ func health(t *testing.T) {
 	require.NoError(t, err)
 
 	var health []pb.HealthInfo
-	url := fmt.Sprintf("%s/health?all", adminDgraphURL)
-	resp, err := http.Get(url)
+	resp, err := http.Get(adminDgraphHealthURL)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	healthRes, err := ioutil.ReadAll(resp.Body)

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -183,8 +183,9 @@ func admin(t *testing.T) {
 
 	client := dgo.NewDgraphClient(api.NewDgraphClient(d))
 
-	err = checkGraphQLHealth(graphqlAdminTestAdminURL, []string{"NoGraphQLSchema"})
+	hasSchema, err := hasCurrentGraphQLSchema(graphqlAdminTestAdminURL)
 	require.NoError(t, err)
+	require.False(t, hasSchema)
 
 	schemaIsInInitialState(t, client)
 	addGQLSchema(t, client)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -42,6 +42,7 @@ const (
 	graphqlAdminURL = "http://localhost:8180/admin"
 	alphagRPC       = "localhost:9180"
 
+	adminDgraphURL           = "http://localhost:8280"
 	graphqlAdminTestURL      = "http://localhost:8280/graphql"
 	graphqlAdminTestAdminURL = "http://localhost:8280/admin"
 	alphaAdminTestgRPC       = "localhost:9280"
@@ -187,6 +188,7 @@ func BootstrapServer(schema, data []byte) {
 func RunAll(t *testing.T) {
 	// admin tests
 	t.Run("admin", admin)
+	t.Run("health", health)
 
 	// schema tests
 	t.Run("graphql descriptions", graphQLDescriptions)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -42,7 +42,7 @@ const (
 	graphqlAdminURL = "http://localhost:8180/admin"
 	alphagRPC       = "localhost:9180"
 
-	adminDgraphURL           = "http://localhost:8280"
+	adminDgraphHealthURL     = "http://localhost:8280/health?all"
 	graphqlAdminTestURL      = "http://localhost:8280/graphql"
 	graphqlAdminTestAdminURL = "http://localhost:8280/admin"
 	alphaAdminTestgRPC       = "localhost:9280"

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -148,13 +148,13 @@ type director struct {
 }
 
 func BootstrapServer(schema, data []byte) {
-	err := checkGraphQLLayerStarted(graphqlAdminURL)
+	err := checkGraphQLStarted(graphqlAdminURL)
 	if err != nil {
 		panic(fmt.Sprintf("Waited for GraphQL test server to become available, but it never did.\n"+
 			"Got last error %+v", err.Error()))
 	}
 
-	err = checkGraphQLLayerStarted(graphqlAdminTestAdminURL)
+	err = checkGraphQLStarted(graphqlAdminTestAdminURL)
 	if err != nil {
 		panic(fmt.Sprintf("Waited for GraphQL AdminTest server to become available, "+
 			"but it never did.\n Got last error: %+v", err.Error()))
@@ -174,11 +174,6 @@ func BootstrapServer(schema, data []byte) {
 	}
 
 	err = populateGraphQLData(client, data)
-	if err != nil {
-		panic(err)
-	}
-
-	err = checkGraphQLHealth(graphqlAdminURL, []string{"Healthy"})
 	if err != nil {
 		panic(err)
 	}
@@ -578,20 +573,18 @@ func allCountriesAdded() ([]*country, error) {
 	return result.Data.QueryCountry, nil
 }
 
-func checkGraphQLLayerStarted(url string) error {
+func checkGraphQLStarted(url string) error {
 	var err error
 	retries := 6
 	sleep := 10 * time.Second
 
-	// Because of how the test containers are brought up, there's no guarantee
-	// that the GraphQL layer is running by now.  So we
+	// Because of how GraphQL starts (it needs to read the schema from Dgraph),
+	// there's no guarantee that GraphQL is available by now.  So we
 	// need to try and connect and potentially retry a few times.
 	for retries > 0 {
 		retries--
 
-		// In local dev, we might already have an instance Healthy.  In CI,
-		// we expect the GraphQL layer to be waiting for a first schema.
-		err = checkGraphQLHealth(url, []string{"NoGraphQLSchema", "Healthy"})
+		_, err = hasCurrentGraphQLSchema(url)
 		if err == nil {
 			return nil
 		}
@@ -600,52 +593,47 @@ func checkGraphQLLayerStarted(url string) error {
 	return err
 }
 
-func checkGraphQLHealth(url string, status []string) error {
-	health := &GraphQLParams{
-		Query: `query {
-			health {
-				message
-				status
-			}
-		}`,
+func hasCurrentGraphQLSchema(url string) (bool, error) {
+
+	schemaQry := &GraphQLParams{
+		Query: `query { getGQLSchema { id } }`,
 	}
-	req, err := health.createGQLPost(url)
+	req, err := schemaQry.createGQLPost(url)
 	if err != nil {
-		return errors.Wrap(err, "while creating gql post")
+		return false, errors.Wrap(err, "while creating gql post")
 	}
 
-	resp, err := runGQLRequest(req)
+	res, err := runGQLRequest(req)
 	if err != nil {
-		return errors.Wrap(err, "error running GraphQL query")
+		return false, errors.Wrap(err, "error running GraphQL query")
 	}
 
-	var healthResult struct {
-		Data struct {
-			Health struct {
-				Message string
-				Status  string
-			}
-		}
-		Errors x.GqlErrorList
-	}
-
-	err = json.Unmarshal(resp, &healthResult)
+	var result *GraphQLResponse
+	err = json.Unmarshal(res, &result)
 	if err != nil {
-		return errors.Wrap(err, "error trying to unmarshal GraphQL query result")
+		return false, errors.Wrap(err, "error unmarshalling result")
 	}
 
-	if len(healthResult.Errors) > 0 {
-		return healthResult.Errors
+	if len(result.Errors) > 0 {
+		return false, result.Errors
 	}
 
-	for _, s := range status {
-		if healthResult.Data.Health.Status == s {
-			return nil
+	var sch struct {
+		GetGQLSchema struct {
+			ID string
 		}
 	}
 
-	return errors.Errorf("GraphQL server was not at right health: found %s",
-		healthResult.Data.Health.Status)
+	err = json.Unmarshal(result.Data, &sch)
+	if err != nil {
+		return false, errors.Wrap(err, "error trying to unmarshal GraphQL query result")
+	}
+
+	if sch.GetGQLSchema.ID == "" {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func addSchema(url string, schema string) error {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -258,6 +258,12 @@ func StdQueryCompletion() CompletionFunc {
 	return removeObjectCompletion(completeDgraphResult)
 }
 
+// AliasQueryCompletion is the completion steps that get run for admin queries
+// those don't have the alias built in like Dgraph queries.
+func AliasQueryCompletion() CompletionFunc {
+	return removeObjectCompletion(injectAliasCompletion(completeResult))
+}
+
 // StdMutationCompletion is the completion steps that get run for add and update mutations
 func StdMutationCompletion(name string) CompletionFunc {
 	return addPathCompletion(name, addRootFieldCompletion(name, completeDgraphResult))
@@ -485,6 +491,56 @@ func addPathCompletion(name string, cf CompletionFunc) CompletionFunc {
 
 		return res, resErrs
 	})
+}
+
+// injectAliasCompletion takes a result with names as per the type names and swaps those for
+// any aliases specified in the query before apply cf.
+func injectAliasCompletion(cf CompletionFunc) CompletionFunc {
+	return CompletionFunc(func(
+		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
+
+		var val interface{}
+		if err := json.Unmarshal(result, &val); err != nil {
+			return nil, schema.GQLWrapLocationf(err, field.Location(), "unable to complete result")
+		}
+
+		var aliased interface{}
+		var resErr error
+		switch val := val.(type) {
+		case []interface{}:
+			aliased, resErr = aliasList(field, val)
+		case map[string]interface{}:
+			aliased, resErr = aliasObject([]schema.Field{field}, val)
+		case interface{}:
+			aliased, resErr = aliasValue(field, val)
+		}
+
+		res, err := json.Marshal(aliased)
+
+		return cf(ctx, field, res, schema.AppendGQLErrs(err, resErr))
+	})
+}
+
+// completeResult takes a result like {"res":{"a":...,"b":...}} and does the standard
+// object completion.  This is different to doing completion from Dgraph, because that requires
+// handling {"res":[{...}]} even if we expect a single value
+func completeResult(ctx context.Context, field schema.Field, result []byte, e error) (
+	[]byte, error) {
+
+	var val interface{}
+	if err := json.Unmarshal(result, &val); err != nil {
+		return nil, schema.GQLWrapLocationf(err, field.Location(), "unable to complete result")
+	}
+
+	path := make([]interface{}, 0, maxPathLength(field))
+
+	switch val := val.(type) {
+	case []interface{}:
+		return completeList(path, field, val)
+	case map[string]interface{}:
+		return completeObject(path, field.Type(), []schema.Field{field}, val)
+	}
+	return completeValue(path, field, val)
 }
 
 // Once a result has been returned from Dgraph, that result needs to be worked
@@ -968,4 +1024,47 @@ func maxPathLength(f schema.Field) int {
 	}
 
 	return 1 + childMax
+}
+
+// TODO: Include this behavior into the standard algorithm above.
+// That is, allow the completion algorithms to be like a walk through the
+// result structure and then we can apply different behaviors as each point.
+// That should eliminate unpacking and packing the result multiple times and
+// allow the result processing to be really flexible.
+func aliasValue(field schema.Field, val interface{}) (interface{}, error) {
+	switch val := val.(type) {
+	case map[string]interface{}:
+		return aliasObject(field.SelectionSet(), val)
+	case []interface{}:
+		return aliasList(field, val)
+	default:
+		return val, nil
+	}
+}
+
+func aliasList(field schema.Field, values []interface{}) ([]interface{}, error) {
+	var errs error
+	var result []interface{}
+	for _, b := range values {
+		r, err := aliasValue(field, b)
+		errs = schema.AppendGQLErrs(errs, err)
+		result = append(result, r)
+	}
+	return result, errs
+}
+
+func aliasObject(
+	fields []schema.Field,
+	res map[string]interface{}) (interface{}, error) {
+
+	var errs error
+	result := make(map[string]interface{})
+
+	for _, f := range fields {
+		r, err := aliasValue(f, res[f.Name()])
+		result[f.ResponseName()] = r
+		errs = schema.AppendGQLErrs(errs, err)
+	}
+
+	return result, errs
 }

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/golang/glog"
 	"go.opencensus.io/trace"
-	"google.golang.org/grpc/metadata"
 
 	"github.com/dgraph-io/dgraph/graphql/api"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -100,11 +99,7 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var res *schema.Response
 	gqlReq, err := getRequest(ctx, r)
 
-	if accessJwt := r.Header.Get("accessJwt"); accessJwt != "" {
-		md := metadata.New(nil)
-		md.Append("accessJwt", accessJwt)
-		ctx = metadata.NewIncomingContext(ctx, md)
-	}
+	ctx = x.AttachAccessJwt(ctx, r)
 
 	if err != nil {
 		res = schema.ErrorResponse(err)

--- a/x/x.go
+++ b/x/x.go
@@ -49,6 +49,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
 
@@ -321,6 +322,20 @@ func ParseRequest(w http.ResponseWriter, r *http.Request, data interface{}) bool
 		return false
 	}
 	return true
+}
+
+// AttachAccessJwt adds any incoming JWT header data into the grpc context metadata
+func AttachAccessJwt(ctx context.Context, r *http.Request) context.Context {
+	if accessJwt := r.Header.Get("X-Dgraph-AccessToken"); accessJwt != "" {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			md = metadata.New(nil)
+		}
+
+		md.Append("accessJwt", accessJwt)
+		ctx = metadata.NewIncomingContext(ctx, md)
+	}
+	return ctx
 }
 
 // Min returns the minimum of the two given numbers.


### PR DESCRIPTION
Note that the intention here is to keep /health, not replace it.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4768)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-637cc4aecd-44262.surge.sh)
<!-- Dgraph:end -->