### PR TITLE
graphql: Add test to query GQL Endpoint with TLS.

### DIFF
--- a/tlstest/certrequireandverify/certrequireandverify_test.go
+++ b/tlstest/certrequireandverify/certrequireandverify_test.go
@@ -86,7 +86,7 @@ func TestGQLAdminHealthWithClientCert(t *testing.T) {
 		Transport: &transport,
 	}
 
-	healthCheckQuery := []byte(`{"query":"query {\n  health {\n    message\n    status\n  }\n}"}`)
+	healthCheckQuery := []byte(`{"query":"query {\n health {\n message\n status\n }\n}"}`)
 	gqlAdminEndpoint := "https://localhost:8180/admin"
 	req, err := http.NewRequest("POST", gqlAdminEndpoint, bytes.NewBuffer(healthCheckQuery))
 	require.NoError(t, err, "Failed to create request : %v", err)
@@ -119,7 +119,7 @@ func TestGQLAdminHealthWithoutClientCert(t *testing.T) {
 		Transport: &transport,
 	}
 
-	healthCheckQuery := []byte(`{"query":"query {\n  health {\n    message\n    status\n  }\n}"}`)
+	healthCheckQuery := []byte(`{"query":"query {\n health {\n message\n status\n }\n}"}`)
 	gqlAdminEndpoint := "https://localhost:8180/admin"
 	req, err := http.NewRequest("POST", gqlAdminEndpoint, bytes.NewBuffer(healthCheckQuery))
 	require.NoError(t, err, "Failed to create request : %v", err)

--- a/tlstest/certrequireandverify/certrequireandverify_test.go
+++ b/tlstest/certrequireandverify/certrequireandverify_test.go
@@ -1,8 +1,14 @@
 package certrequireandverify
 
 import (
+	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
@@ -56,4 +62,41 @@ func TestCurlAccessWithClientCert(t *testing.T) {
 	testutil.VerifyCurlCmd(t, curlArgs, &testutil.CurlFailureConfig{
 		ShouldFail: false,
 	})
+}
+
+func TestGQLAdminHealthWithClientCert(t *testing.T) {
+	// Read the root cert file.
+	caCert, err := ioutil.ReadFile("../tls/ca.crt")
+	require.NoError(t, err, "Unable to read root cert file : %v", err)
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caCert)
+
+	// Load the client cert file.
+	clientCert, err := tls.LoadX509KeyPair("../tls/client.acl.crt", "../tls/client.acl.key")
+	require.NoError(t, err, "Unable to read client cert file : %v", err)
+	tlsConfig := tls.Config{
+		RootCAs:      pool,
+		Certificates: []tls.Certificate{clientCert},
+	}
+	transport := http.Transport{
+		TLSClientConfig: &tlsConfig,
+	}
+	client := http.Client{
+		Timeout:   time.Second * 10,
+		Transport: &transport,
+	}
+
+	healthCheckQuery := []byte(`{"query":"query {\n  health {\n    message\n    status\n  }\n}"}`)
+	gqlAdminEndpoint := "https://localhost:8180/admin"
+	req, err := http.NewRequest("POST", gqlAdminEndpoint, bytes.NewBuffer(healthCheckQuery))
+	require.NoError(t, err, "Failed to create request : %v", err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err, "Https request failed: %v", err)
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err, "Error while reading http response: %v", err)
+	require.Contains(t, string(body), "Dgraph connection established")
 }

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUIREANDVERIFY
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --tls_dir /dgraph-tls --tls_client_auth REQUIREANDVERIFY --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1


### PR DESCRIPTION
Test that HTTPS/TLS options work with Graphql endpoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4769)
<!-- Reviewable:end -->
