### PR TITLE
Do not include empty nodes in the export output.

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -520,6 +520,12 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 
 	stream.Send = func(list *bpb.KVList) error {
 		for _, kv := range list.Kv {
+			// Skip nodes that have no data. Otherwise, the exported data could have
+			// formatting and/or syntax errors.
+			if len(kv.Value) == 0 {
+				continue
+			}
+
 			var writer *fileWriter
 			switch kv.Version {
 			case 1: // data

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -74,6 +74,11 @@ func addEdge(t *testing.T, edge *pb.DirectedEdge, l *posting.List) {
 	commitTransaction(t, edge, l)
 }
 
+func delEdge(t *testing.T, edge *pb.DirectedEdge, l *posting.List) {
+	edge.Op = pb.DirectedEdge_DEL
+	commitTransaction(t, edge, l)
+}
+
 func setClusterEdge(t *testing.T, dg *dgo.Dgraph, rdf string) {
 	mu := &api.Mutation{SetNquads: []byte(rdf), CommitNow: true}
 	err := testutil.RetryMutation(dg, mu)


### PR DESCRIPTION
Empty nodes are not included in the export output but the separator (a
comma in the case of JSON) is being appended. The fix is to skip over
empty values.

Added a deleted node to the exported graph to ensure that these type of
nodes are handled properly.

Fixes #3610

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4773)
<!-- Reviewable:end -->
