### PR TITLE
ACL: Allow users to query data for their groups 

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -60,7 +60,7 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 	return nil
 }
 
-func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
+func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) error {
 	// always allow access
 	return nil
 }

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -920,8 +920,7 @@ func addUserFilterToFilter(filter *gql.FilterTree, userId string,
 		return nil
 	}
 
-	if filter.Func != nil && gql.IsInequalityFn(filter.Func.Name) &&
-		filter.Func.Attr == "dgraph.type" {
+	if filter.Func != nil && filter.Func.Name == "type" {
 
 		// type function supports only one argument
 		if len(filter.Func.Args) != 1 {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -790,6 +790,8 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 			for _, pred := range x.AllACLPredicates() {
 				delete(blockedPreds, pred)
 			}
+			// In query context ~predicate and predicate are considered different.
+			delete(blockedPreds, "~dgraph.user.group")
 		}
 		parsedReq.Query = removePredsFromQuery(parsedReq.Query, blockedPreds)
 	}
@@ -830,57 +832,24 @@ func authorizeGroot(ctx context.Context) error {
 // addUserFilterToQuery applies makes sure that a user can access only its own
 // acl info by applying filter of userid and groupid to acl predicates
 func addUserFilterToQuery(gq *gql.GraphQuery, userId string, groupIds []string) {
-	parentFilter := func(newFilter, filter *gql.FilterTree) *gql.FilterTree {
-		if filter == nil {
-			return newFilter
-		}
-		parentFilter := &gql.FilterTree{
-			Op:    "AND",
-			Child: []*gql.FilterTree{filter, newFilter},
-		}
-		return parentFilter
-	}
-
-	userFilter := func(userId string) *gql.FilterTree {
-		return &gql.FilterTree{
-			Func: &gql.Function{
-				Attr: "dgraph.xid",
-				Name: "eq",
-				Args: []gql.Arg{{Value: userId}},
-			},
-		}
-	}
-
-	groupFilter := func(groupIds []string) *gql.FilterTree {
-		child := &gql.FilterTree{
-			Func: &gql.Function{
-				Attr: "dgraph.xid",
-				Name: "eq",
-			},
-		}
-		for _, gid := range groupIds {
-			child.Func.Args = append(child.Func.Args,
-				gql.Arg{Value: gid})
-		}
-		return &gql.FilterTree{
-			Op:    "OR",
-			Child: []*gql.FilterTree{child},
-		}
-	}
-
 	if gq.Func != nil && gq.Func.Name == "type" {
-		for _, arg := range gq.Func.Args {
-			// The case where value of some varialble v (say) is "Group" and a
-			// query comes like `eq(dgraph.type, val(v))`, will be ingored here.
-			if arg.Value == "User" {
-				newFilter := userFilter(userId)
-				gq.Filter = parentFilter(newFilter, gq.Filter)
-			} else if arg.Value == "Group" {
-				newFilter := groupFilter(groupIds)
-				gq.Filter = parentFilter(newFilter, gq.Filter)
-			}
+		// type function only supports one argument
+		if len(gq.Func.Args) != 1 {
+			return
+		}
+		arg := gq.Func.Args[0]
+		// The case where value of some varialble v (say) is "Group" and a
+		// query comes like `eq(dgraph.type, val(v))`, will be ingored here.
+		if arg.Value == "User" {
+			newFilter := userFilter(userId)
+			gq.Filter = parentFilter(newFilter, gq.Filter)
+		} else if arg.Value == "Group" {
+			newFilter := groupFilter(groupIds)
+			gq.Filter = parentFilter(newFilter, gq.Filter)
 		}
 	}
+
+	gq.Filter = addUserFilterToFilter(gq.Filter, userId, groupIds)
 
 	switch gq.Attr {
 	case "dgraph.user.group":
@@ -894,6 +863,88 @@ func addUserFilterToQuery(gq *gql.GraphQuery, userId string, groupIds []string) 
 	for _, ch := range gq.Children {
 		addUserFilterToQuery(ch, userId, groupIds)
 	}
+}
+
+func parentFilter(newFilter, filter *gql.FilterTree) *gql.FilterTree {
+	if filter == nil {
+		return newFilter
+	}
+	parentFilter := &gql.FilterTree{
+		Op:    "AND",
+		Child: []*gql.FilterTree{filter, newFilter},
+	}
+	return parentFilter
+}
+
+func userFilter(userId string) *gql.FilterTree {
+	return &gql.FilterTree{
+		Func: &gql.Function{
+			Attr: "dgraph.xid",
+			Name: "eq",
+			Args: []gql.Arg{{Value: userId}},
+		},
+	}
+}
+
+func groupFilter(groupIds []string) *gql.FilterTree {
+	filter := &gql.FilterTree{
+		Func: &gql.Function{
+			Attr: "dgraph.xid",
+			Name: "eq",
+		},
+	}
+	for _, gid := range groupIds {
+		filter.Func.Args = append(filter.Func.Args,
+			gql.Arg{Value: gid})
+	}
+
+	return filter
+}
+
+/*
+ addUserFilterToFilter makes sure that user can't misue filters to access other user's info.
+ If the *filter* have type(Group) or type(User) functions, it generate a *newFilter* with function
+ like eq(dgraph.xid, userId) or eq(dgraph.xid, groupId...) and return a filter of the form
+
+		&gql.FilterTree{
+			Op: "AND",
+			Child: []gql.FilterTree{
+				{filter, newFilter}
+			}
+		}
+*/
+func addUserFilterToFilter(filter *gql.FilterTree, userId string,
+	groupIds []string) *gql.FilterTree {
+
+	if filter == nil {
+		return nil
+	}
+
+	if filter.Func != nil && gql.IsInequalityFn(filter.Func.Name) &&
+		filter.Func.Attr == "dgraph.type" {
+
+		// type function supports only one argument
+		if len(filter.Func.Args) != 1 {
+			return nil
+		}
+		arg := filter.Func.Args[0]
+		var newFilter *gql.FilterTree
+		switch arg.Value {
+		case "User":
+			newFilter = userFilter(userId)
+		case "Group":
+			newFilter = groupFilter(groupIds)
+		}
+
+		// If filter have function, it can't have children.
+		return parentFilter(newFilter, filter)
+	}
+
+	for idx, child := range filter.Child {
+		filter.Child[idx] = addUserFilterToFilter(child, userId, groupIds)
+	}
+
+	return filter
 }
 
 // removePredsFromQuery removes all the predicates in blockedPreds

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -846,7 +846,7 @@ func addUserFilterToQuery(gq *gql.GraphQuery, userId string, groupIds []string) 
 			Func: &gql.Function{
 				Attr: "dgraph.xid",
 				Name: "eq",
-				Args: []gql.Arg{gql.Arg{Value: userId}},
+				Args: []gql.Arg{{Value: userId}},
 			},
 		}
 	}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -993,7 +993,7 @@ func parseRequest(qc *queryContext) error {
 }
 
 func authorizeRequest(ctx context.Context, qc *queryContext) error {
-	if err := authorizeQuery(ctx, &qc.gqlRes); err != nil {
+	if err := authorizeQuery(ctx, &qc.gqlRes, qc.graphql); err != nil {
 		return err
 	}
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1154,6 +1154,9 @@ func TestQueryUserInfo(t *testing.T) {
 					predicate
 					permission
 				}
+				users {
+					name
+				}
 			}
 		}
 	}
@@ -1182,6 +1185,11 @@ func TestQueryUserInfo(t *testing.T) {
 					  "predicate": "nickname",
 					  "permission": 2
 					}
+				  ],
+				  "users": [
+					  {
+						  "name": "alice"
+					  }
 				  ]
 				}
 			  ]
@@ -1215,4 +1223,25 @@ func TestQueryUserInfo(t *testing.T) {
 	require.NoError(t, err, "Error while querying ACL")
 
 	testutil.CompareJSON(t, `{"me":[]}`, string(resp.GetJson()))
+
+	gqlQuery = `
+	query {
+		getGroup(name: "guardians") {
+			name
+			rules {
+				predicate
+				permission
+			}
+			users {
+				name
+			}
+		}
+	}
+	`
+
+	params = testutil.GraphQLParams{
+		Query: gqlQuery,
+	}
+	b = makeRequest(t, accessJwt, params)
+	testutil.CompareJSON(t, `{"data": {"getGroup": null}}`, string(b))
 }

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1613,7 +1613,7 @@ func getValueArg(val string) (string, error) {
 }
 
 func validFuncName(name string) bool {
-	if isGeoFunc(name) || isInequalityFn(name) {
+	if isGeoFunc(name) || IsInequalityFn(name) {
 		return true
 	}
 
@@ -1714,7 +1714,7 @@ L:
 						return nil,
 							itemInFunc.Errorf("Multiple variables not allowed in len function")
 					}
-					if !isInequalityFn(function.Name) {
+					if !IsInequalityFn(function.Name) {
 						return nil,
 							itemInFunc.Errorf("len function only allowed inside inequality" +
 								" function")
@@ -1763,7 +1763,7 @@ L:
 				case isGeoFunc(function.Name):
 					err = parseGeoArgs(it, function)
 
-				case isInequalityFn(function.Name):
+				case IsInequalityFn(function.Name):
 					err = parseIneqArgs(it, function)
 
 				default:
@@ -3225,7 +3225,7 @@ func isGeoFunc(name string) bool {
 	return name == "near" || name == "contains" || name == "within" || name == "intersects"
 }
 
-func isInequalityFn(name string) bool {
+func IsInequalityFn(name string) bool {
 	switch name {
 	case "eq", "le", "ge", "gt", "lt":
 		return true

--- a/x/keys.go
+++ b/x/keys.go
@@ -595,8 +595,16 @@ func IsAclPredicate(pred string) bool {
 // ReservedPredicates returns the complete list of reserved predicates that needs to
 // be expanded when * is given as a predicate.
 func ReservedPredicates() []string {
-	var preds []string
+	preds := make([]string, 0, len(reservedPredicateMap))
 	for pred := range reservedPredicateMap {
+		preds = append(preds, pred)
+	}
+	return preds
+}
+
+func AllACLPredicates() []string {
+	preds := make([]string, 0, len(aclPredicateMap))
+	for pred := range aclPredicateMap {
 		preds = append(preds, pred)
 	}
 	return preds


### PR DESCRIPTION
This PR enables users to query their groups, username, permissions. Earlier only `guardians` could do any of that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4774)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-3ca6b81c59-44352.surge.sh)
<!-- Dgraph:end -->