### PR TITLE
Fix error when lexing language list.

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2474,7 +2474,7 @@ func parseDirective(it *lex.ItemIterator, curp *GraphQuery) error {
 func parseLanguageList(it *lex.ItemIterator) ([]string, error) {
 	item := it.Item()
 	var langs []string
-	for ; item.Typ == itemName || item.Typ == itemPeriod; item = it.Item() {
+	for ; item.Typ == itemName || item.Typ == itemPeriod || item.Typ == itemStar; item = it.Item() {
 		langs = append(langs, item.Val)
 		it.Next()
 		if it.Item().Typ == itemColon {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -2964,6 +2964,21 @@ func TestLangsInvalid9(t *testing.T) {
 		"The * symbol cannot be used as a valid language inside functions")
 }
 
+func TestLangsInvalid10(t *testing.T) {
+	query := `
+	query {
+		me(func: uid(1)) {
+			name@.:*
+		}
+	}
+	`
+
+	_, err := Parse(Request{Str: query})
+	require.Error(t, err)
+	require.Contains(t, err.Error(),
+		"If * is used, no other languages are allowed in the language list")
+}
+
 func TestLangsFilter(t *testing.T) {
 	query := `
 	query {

--- a/gql/state.go
+++ b/gql/state.go
@@ -63,6 +63,7 @@ const (
 	itemRightSquare
 	itemComma
 	itemMathOp
+	itemStar
 )
 
 // lexIdentifyBlock identifies whether it is an upsert block
@@ -445,6 +446,8 @@ func lexQuery(l *lex.Lexer) lex.StateFn {
 			return lexDirectiveOrLangList
 		case r == lsThan:
 			return lexIRIRef
+		case r == star:
+			l.Emit(itemStar)
 		default:
 			return l.Errorf("Unrecognized character in lexText: %#U", r)
 		}


### PR DESCRIPTION
A language list with the value "*:." is lexed correctly and an error
saying that if all the languages (the meaning of the character *) are
requested, the language list should only have one element.

But a language list with the value ".:*" fails with a lexing error. This
change changes the lexer so that the two lists fail with the same error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4784)
<!-- Reviewable:end -->
