### PR TITLE
Fix Nquad value conversion in live loader.

### DIFF
--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -301,7 +301,11 @@ func (l *loader) conflictKeysForNQuad(nq *api.NQuad) ([]uint64, error) {
 			Tid:   types.TypeID(de.GetValueType()),
 			Value: de.GetValue(),
 		}
-
+		// If the value type is not already set according to the schema, we set it to string and
+		// then convert it to the type as declared in the schema.
+		if storageVal.Tid != pred.ValueType {
+			storageVal.Tid = types.StringID
+		}
 		schemaVal, err := types.Convert(storageVal, types.TypeID(pred.ValueType))
 		if err != nil {
 			errs = append(errs, err.Error())

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -301,7 +301,7 @@ func (l *loader) conflictKeysForNQuad(nq *api.NQuad) ([]uint64, error) {
 			Tid:   types.TypeID(de.GetValueType()),
 			Value: de.GetValue(),
 		}
-		// If the value type is not already set according to the schema, we set it to string and
+		// If the value type is not already set according to the schema, set it to string and
 		// then convert it to the type as declared in the schema.
 		if storageVal.Tid != pred.ValueType {
 			storageVal.Tid = types.StringID


### PR DESCRIPTION
Type conversion was failing when loading the 1 million dataset because the N-Quads doesn't have value type associated with it. Fixes #4468 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4793)
<!-- Reviewable:end -->
