### PR TITLE
contrib: Move run.sh script in standalone image.

### DIFF
--- a/contrib/standalone/Dockerfile
+++ b/contrib/standalone/Dockerfile
@@ -8,6 +8,6 @@ EXPOSE 8080
 # gRPC API port
 EXPOSE 9080
 
-ADD run.sh .
-RUN chmod +x run.sh
-CMD ["./run.sh"]
+ADD run.sh /run.sh
+RUN chmod +x /run.sh
+CMD ["/run.sh"]


### PR DESCRIPTION

This allows the user to run the standalone image while bind-mounting the data
directories to somewhere on the host. e.g.,

```
docker run -v /mnt/dgraph:/dgraph dgraph/standalone
```

Before this change, the user would get this error when trying to use a mount for /dgraph, since `/dgraph/run.sh` doesn't exist in the mountpoint:

```
$ docker run -v /mnt/dgraph:/dgraph dgraph/standalone    
docker: Error response from daemon: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"./run.sh\": stat ./run.sh: no such file or directory": unknown.
ERRO[0001] error waiting for container: context canceled 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4800)
<!-- Reviewable:end -->
