### PR TITLE
docs: Clarify untagged value full-text documentation.

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -182,11 +182,23 @@ For example:
 - `name@*` => Look for all the values of this predicate and return them along with their language. For example, if there are two values with languages en and hi, this query will return two keys named "name@en" and "name@hi".
 
 
-{{% notice "note" %}}In functions, language lists (including the `@*` notation) are not allowed. Untagged predicates, Single language tags, and `.` notation work as described above.
+{{% notice "note" %}}
+
+In functions, language lists (including the `@*` notation) are not allowed.
+Untagged predicates, Single language tags, and `.` notation work as described
+above.
 
 ---
 
-In [full-text search functions]({{< relref "#full-text-search" >}}) (`alloftext`, `anyoftext`), when no language is specified (untagged or `@.`), the default (English) full-text tokenizer is used.{{% /notice %}}
+In [full-text search functions]({{< relref "#full-text-search" >}})
+(`alloftext`, `anyoftext`), when no language is specified (untagged or `@.`),
+the default (English) full-text tokenizer is used. This does not mean that
+the value with the `en` tag will be searched when querying the untagged value,
+but that untagged values will be treated as English text. If you don't want that
+to be the case, use the appropriate tag for the desired language, both for
+mutating and querying the value.
+
+{{% /notice %}}
 
 
 Query Example: Some of Bollywood director and actor Farhan Akhtar's movies have a name stored in Russian as well as Hindi and English, others do not.


### PR DESCRIPTION
In #4634, a user thought untagged values and the value with the
English tag were treated as the same value. This is not the case so this
PR changes the documentation to clarify this situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4802)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-627e1d481a-44903.surge.sh)
<!-- Dgraph:end -->