### PR TITLE
graphql: Correctly validate ACL for GraphQL health query

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -65,7 +65,7 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 	return nil
 }
 
-func authorizeGroot(ctx context.Context) error {
+func authorizeGuardians(ctx context.Context) error {
 	// always allow access
 	return nil
 }

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -827,36 +827,6 @@ func authorizeGuardians(ctx context.Context) error {
 	return nil
 }
 
-// authorizeGroot authorizes the operation for Groot users.
-func authorizeGroot(ctx context.Context) error {
-	if len(worker.Config.HmacSecret) == 0 {
-		// the user has not turned on the acl feature
-		return nil
-	}
-
-	var userID string
-	// doAuthorizeState checks if the user is authorized to perform this API request
-	doAuthorizeGroot := func() error {
-		userData, err := extractUserAndGroups(ctx)
-		switch {
-		case err == errNoJwt:
-			return status.Error(codes.PermissionDenied, err.Error())
-		case err != nil:
-			return status.Error(codes.Unauthenticated, err.Error())
-		default:
-			userID = userData[0]
-			if userID == x.GrootId {
-				return nil
-			}
-			// Deny non groot users.
-			return status.Error(codes.PermissionDenied, fmt.Sprintf("User is '%v'. "+
-				"Only User '%v' is authorized.", userID, x.GrootId))
-		}
-	}
-
-	return doAuthorizeGroot()
-}
-
 /*
 	addUserFilterToQuery applies makes sure that a user can access only its own
 	acl info by applying filter of userid and groupid to acl predicates. A query like

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -694,7 +694,7 @@ func (s *Server) State(ctx context.Context) (*api.Response, error) {
 		return nil, ctx.Err()
 	}
 
-	if err := authorizeGroot(ctx); err != nil {
+	if err := authorizeGuardians(ctx); err != nil {
 		return nil, err
 	}
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -658,7 +658,7 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 
 	var healthAll []pb.HealthInfo
 	if all {
-		if err := authorizeGroot(ctx); err != nil {
+		if err := authorizeGuardians(ctx); err != nil {
 			return nil, err
 		}
 		pool := conn.GetPools().GetAll()

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1318,7 +1318,7 @@ func TestHealthForAcl(t *testing.T) {
 	require.NotNil(t, guardianResp.Data)
 	require.Nil(t, guardianResp.Errors)
 	require.NotNil(t, guardianResp.Data.Health)
-	require.Len(t, guardianResp.Data.Health, 6)
+	require.Len(t, guardianResp.Data.Health, 9)
 	for _, v := range guardianResp.Data.Health {
 		require.Contains(t, []string{"alpha", "zero"}, v.Instance)
 		require.NotNil(t, v.Address)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1583,6 +1583,7 @@ func TestHealthForAcl(t *testing.T) {
 	require.NotNil(t, guardianResp.Data)
 	require.Nil(t, guardianResp.Errors)
 	require.NotNil(t, guardianResp.Data.Health)
+	// we have 9 instances of alphas/zeros in teamcity environment
 	require.Len(t, guardianResp.Data.Health, 9)
 	for _, v := range guardianResp.Data.Health {
 		require.Contains(t, []string{"alpha", "zero"}, v.Instance)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1547,7 +1547,7 @@ func TestHealthForAcl(t *testing.T) {
 	testutil.CompareJSON(t, `{
 		"errors": [
 			{
-				"message": "Dgraph query failed because Error: rpc error: code = PermissionDenied desc = Only guardians are allowed access. User 'alice' is not a member of guardians group."
+				"message": "Dgraph query failed because Error: rpc error: code = PermissionDenied desc = Only guardians are allowed access. User '`+userid+`' is not a member of guardians group."
 			}
 		]
 	}`, string(b))

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1540,8 +1540,6 @@ func TestHealthForAcl(t *testing.T) {
 	require.NoError(t, err, "login failed")
 
 	b := makeRequest(t, accessJwt, params)
-	var nonGuardianResp map[string]interface{}
-	err = json.Unmarshal(b, &nonGuardianResp)
 
 	require.NoError(t, err, "health request failed")
 	testutil.CompareJSON(t, `{

--- a/graphql/admin/health.go
+++ b/graphql/admin/health.go
@@ -40,9 +40,9 @@ func (hr *healthResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]b
 	x.Check2(buf.WriteString(`{ "health":`))
 
 	var resp *api.Response
-	var respErr error
-	if resp, respErr = (&edgraph.Server{}).Health(ctx, true); respErr != nil {
-		respErr = errors.Errorf("%s: %s", x.Error, respErr.Error())
+	var err error
+	if resp, err = (&edgraph.Server{}).Health(ctx, true); err != nil {
+		err = errors.Errorf("%s: %s", x.Error, err.Error())
 		x.Check2(buf.Write([]byte(` null `)))
 	} else {
 		x.Check2(buf.Write(resp.GetJson()))
@@ -50,5 +50,5 @@ func (hr *healthResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]b
 
 	x.Check2(buf.WriteString(`}`))
 
-	return buf.Bytes(), respErr
+	return buf.Bytes(), err
 }

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -499,6 +499,10 @@ func injectAliasCompletion(cf CompletionFunc) CompletionFunc {
 	return CompletionFunc(func(
 		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
 
+		if len(result) == 0 {
+			return nil, schema.AsGQLErrors(err)
+		}
+
 		var val interface{}
 		if marshErr := json.Unmarshal(result, &val); marshErr != nil {
 			return nil,


### PR DESCRIPTION
This PR makes sure of following things:
- Only guardians are allowed to query health from graphql admin
- Errors are propagated properly to graphql output
- Fix panic when querying health from dgraph layer given nil response

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4807)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-bfdcfcedb3-45412.surge.sh)
<!-- Dgraph:end -->