### PR TITLE
graphql: Fix deleteGroup and deleteUser mutations.

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -229,12 +229,13 @@ func TestDeletePredicate(t *testing.T) {
 
 	output, err = runGraphqlQuery(`schema{}`)
 	require.NoError(t, err)
+
 	testutil.CompareJSON(t, `{"data":{"schema":[`+
 		`{"predicate":"age","type":"default"},`+
 		`{"predicate":"name","type":"string","index":true, "tokenizer":["term"]},`+
 		x.AclPredicates+","+x.GraphqlPredicates+","+
 		`{"predicate":"dgraph.type","type":"string","index":true, "tokenizer":["exact"],
-			"list":true}]}}`, output)
+			"list":true}],`+x.InitialTypes+`}}`, output)
 
 	output, err = runGraphqlQuery(q1)
 	require.NoError(t, err)
@@ -1065,7 +1066,7 @@ func TestListTypeSchemaChange(t *testing.T) {
 		x.AclPredicates+","+x.GraphqlPredicates+","+
 		`{"predicate":"occupations","type":"string"},`+
 		`{"predicate":"dgraph.type", "type":"string", "index":true, "tokenizer": ["exact"],
-			"list":true}]}}`, res)
+			"list":true}],`+x.InitialTypes+`}}`, res)
 }
 
 func TestDeleteAllSP2(t *testing.T) {
@@ -1312,7 +1313,7 @@ func TestDropAll(t *testing.T) {
 		`{"data":{"schema":[`+
 			x.AclPredicates+","+x.GraphqlPredicates+","+
 			`{"predicate":"dgraph.type", "type":"string", "index":true, "tokenizer":["exact"],
-				"list":true}]}}`, output)
+				"list":true}],`+x.InitialTypes+`}}`, output)
 
 	// Reinstate schema so that we can re-run the original query.
 	err = alterSchemaWithRetry(s)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1423,7 +1423,7 @@ func TestGroupDeleteShouldDeleteGroupFromUser(t *testing.T) {
 				}
 			]
 		}
-	}`, string(b))
+	}}`, string(b))
 }
 
 func TestWrongPermission(t *testing.T) {

--- a/ee/backup/tests/filesystem/backup_test.go
+++ b/ee/backup/tests/filesystem/backup_test.go
@@ -286,7 +286,7 @@ func runRestore(t *testing.T, backupLocation, lastDir string, commitTs uint64) m
 
 	restoredTypes, err := testutil.GetTypeNames(pdir, commitTs)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node"}, restoredTypes)
+	require.ElementsMatch(t, []string{"Node", "dgraph.graphql"}, restoredTypes)
 
 	return restored
 }

--- a/ee/backup/tests/minio/backup_test.go
+++ b/ee/backup/tests/minio/backup_test.go
@@ -293,7 +293,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	restoredTypes, err := testutil.GetTypeNames(pdir, commitTs)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node"}, restoredTypes)
+	require.ElementsMatch(t, []string{"Node", "dgraph.graphql"}, restoredTypes)
 
 	require.NoError(t, err)
 	t.Logf("--- Restored values: %+v\n", restored)

--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -158,3 +158,33 @@
         Category2 as Post.category
       }
     }
+
+-
+  name: "Delete mutation on a type with a field with reverse predicate"
+  gqlmutation: |
+    mutation deleteMovie($filter: MovieFilter!) {
+      deleteMovie(filter: $filter) {
+        msg
+      }
+    }
+  gqlvariables: |
+    { "filter":
+      { "id": ["0x1", "0x2"] }
+    }
+  explanation: "The correct mutation and query should be built using variable and filters."
+  dgmutations:
+    - deletejson: |
+        [
+          { "uid": "uid(x)" },
+          {
+            "uid": "uid(MovieDirector1)",
+            "directed.movies": [{ "uid": "uid(x)" }]
+          }
+        ]
+  dgquery: |-
+    query {
+      x as deleteMovie(func: uid(0x1, 0x2)) @filter(type(Movie)) {
+        uid
+        MovieDirector1 as ~directed.movies
+      }
+    }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -509,7 +509,12 @@ func (drw *deleteRewriter) Rewrite(m schema.Mutation) (
 	for _, fld := range m.MutatedType().Fields() {
 		invField := fld.Inverse()
 		if invField == nil {
-			continue
+			// This field be a reverse edge, in that case we need to delete the incoming connections
+			// to this node via its forward edges.
+			invField = fld.ForwardEdge()
+			if invField == nil {
+				continue
+			}
 		}
 		varName := varGen.next(fld.Type())
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -543,6 +543,7 @@ func dgraphDirectiveValidation(sch *ast.Schema, typ *ast.Definition, field *ast.
 					)
 				}
 				forwardFound = true
+				break
 			}
 		}
 		if !forwardFound {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -139,6 +139,8 @@ type FieldDefinition interface {
 	Type() Type
 	IsID() bool
 	Inverse() FieldDefinition
+	// TODO - It might be possible to get rid of ForwardEdge and just use Inverse() always.
+	ForwardEdge() FieldDefinition
 }
 
 type astType struct {
@@ -906,6 +908,53 @@ func (fd *fieldDefinition) Inverse() FieldDefinition {
 
 	// fld must exist if the schema passed our validation
 	fld := typ.Fields.ForName(invFieldArg.Value.Raw)
+
+	return &fieldDefinition{
+		fieldDef:        fld,
+		inSchema:        fd.inSchema,
+		dgraphPredicate: fd.dgraphPredicate}
+}
+
+// ForwardEdge gets the field definition for a forward edge if this field is a reverse edge
+// i.e. if it has a dgraph directive like
+// @dgraph(name: "~movies")
+func (fd *fieldDefinition) ForwardEdge() FieldDefinition {
+	dd := fd.fieldDef.Directives.ForName(dgraphDirective)
+	if dd == nil {
+		return nil
+	}
+
+	arg := dd.Arguments.ForName(dgraphPredArg)
+	if arg == nil {
+		return nil // really not possible
+	}
+	name := arg.Value.Raw
+
+	if !strings.HasPrefix(name, "~") && !strings.HasPrefix(name, "<~") {
+		return nil
+	}
+
+	fedge := strings.Trim(name, "<~>")
+	// typ must exist if the schema passed GQL validation
+	typ := fd.inSchema.Types[fd.Type().Name()]
+
+	var fld *ast.FieldDefinition
+	// Have to range through all the fields and find the correct forward edge. This would be
+	// expensive and should ideally be cached on schema update.
+	for _, field := range typ.Fields {
+		dir := field.Directives.ForName(dgraphDirective)
+		if dir == nil {
+			continue
+		}
+		predArg := dir.Arguments.ForName(dgraphPredArg)
+		if predArg == nil || predArg.Value.Raw == "" {
+			continue
+		}
+		if predArg.Value.Raw == fedge {
+			fld = field
+			break
+		}
+	}
 
 	return &fieldDefinition{
 		fieldDef:        fld,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -445,6 +445,7 @@ func InitialTypes() []*pb.TypeUpdate {
 				},
 			},
 		})
+
 	if x.WorkerConfig.AclEnabled {
 		// These type definitions are required for deleteUser and deleteGroup GraphQL API to work
 		// properly.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -435,15 +435,50 @@ func LoadTypesFromDb() error {
 // types to insert.
 func InitialTypes() []*pb.TypeUpdate {
 	var initialTypes []*pb.TypeUpdate
-	initialTypes = append(initialTypes, &pb.TypeUpdate{
-		TypeName: "dgraph.graphql",
-		Fields: []*pb.SchemaUpdate{
-			{
-				Predicate: "dgraph.graphql.schema",
-				ValueType: pb.Posting_STRING,
+	initialTypes = append(initialTypes,
+		&pb.TypeUpdate{
+			TypeName: "dgraph.graphql",
+			Fields: []*pb.SchemaUpdate{
+				{
+					Predicate: "dgraph.graphql.schema",
+					ValueType: pb.Posting_STRING,
+				},
+			},
+		})
+	if x.WorkerConfig.AclEnabled {
+		// These type definitions are required for deleteUser and deleteGroup GraphQL API to work
+		// properly.
+		initialTypes = append(initialTypes, &pb.TypeUpdate{
+			TypeName: "User",
+			Fields: []*pb.SchemaUpdate{
+				{
+					Predicate: "dgraph.xid",
+					ValueType: pb.Posting_STRING,
+				},
+				{
+					Predicate: "dgraph.password",
+					ValueType: pb.Posting_PASSWORD,
+				},
+				{
+					Predicate: "dgraph.user.group",
+					ValueType: pb.Posting_UID,
+				},
 			},
 		},
-	})
+			&pb.TypeUpdate{
+				TypeName: "Group",
+				Fields: []*pb.SchemaUpdate{
+					{
+						Predicate: "dgraph.xid",
+						ValueType: pb.Posting_STRING,
+					},
+					{
+						Predicate: "dgraph.acl.rule",
+						ValueType: pb.Posting_UID,
+					},
+				},
+			})
+	}
 
 	return initialTypes
 }

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -563,7 +563,7 @@ func SchemaAfterDeleteNode(t *testing.T, c *dgo.Dgraph) {
 		`{"predicate":"married","type":"bool"},`+
 		`{"predicate":"name","type":"default"},`+
 		`{"predicate":"dgraph.type","type":"string","index":true, "tokenizer":["exact"],
-			"list":true}]`),
+			"list":true}],`+x.InitialTypes),
 		string(resp.Json))
 
 	require.NoError(t, c.Alter(ctx, &api.Operation{DropAttr: "married"}))
@@ -585,7 +585,7 @@ func SchemaAfterDeleteNode(t *testing.T, c *dgo.Dgraph) {
 		`{"predicate":"friend","type":"uid","list":true},`+
 		`{"predicate":"name","type":"default"},`+
 		`{"predicate":"dgraph.type","type":"string","index":true, "tokenizer":["exact"],
-			"list":true}]`),
+			"list":true}],`+x.InitialTypes),
 		string(resp.Json))
 }
 

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -352,7 +352,7 @@ func SchemaQueryTest(t *testing.T, c *dgo.Dgraph) {
           "exact"
         ]
       }
-    ]
+    ],` + x.InitialTypes + `
   }`
 	testutil.CompareJSON(t, js, string(resp.Json))
 }
@@ -419,7 +419,7 @@ func SchemaQueryTestPredicate1(t *testing.T, c *dgo.Dgraph) {
       {
         "predicate": "age"
       }
-    ]
+    ],` + x.InitialTypes + `
   }`
 	testutil.CompareJSON(t, js, string(resp.Json))
 }
@@ -562,7 +562,7 @@ func SchemaQueryTestHTTP(t *testing.T, c *dgo.Dgraph) {
           "exact"
         ]
       }
-    ]
+    ],` + x.InitialTypes + `
   }`
 	testutil.CompareJSON(t, js, string(m["data"]))
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -178,6 +178,15 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 						s.Predicate)
 				}
 			}
+
+		}
+
+		// Propose initial types as well after a drop all as they would have been cleared.
+		initialTypes := schema.InitialTypes()
+		for _, t := range initialTypes {
+			if err := updateType(t.GetTypeName(), *t); err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/x/x.go
+++ b/x/x.go
@@ -118,6 +118,12 @@ const (
 {"predicate":"dgraph.rule.predicate","type":"string","index":true,"tokenizer":["exact"],"upsert":true},
 {"predicate":"dgraph.rule.permission","type":"int"}
 `
+
+	InitialTypes = `
+	"types": [{"fields": [{"name": "dgraph.graphql.schema"}],"name": "dgraph.graphql"},
+{"fields": [{"name": "dgraph.password"},{"name": "dgraph.xid"},{"name": "dgraph.user.group"}],"name": "User"},
+{"fields": [{"name": "dgraph.acl.rule"},{"name": "dgraph.xid"}],"name": "Group"}]`
+
 	// GroupIdFileName is the name of the file storing the ID of the group to which
 	// the data in a postings directory belongs. This ID is used to join the proper
 	// group the first time an Alpha comes up with data from a restored backup or a


### PR DESCRIPTION
deleteGroup should also delete the group from the user group lists that it belongs to. This was not happening before because we were not adding the delete mutation like we do for fields which have the `@hasInverse` directive. This happens now.

deleteUser should also delete the user from the groups that it belongs to. This was not happening because Dgraph didn't have the type info for `User` type and wasn't correctly deleting its edges. Now the type information is added to the list of initial types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4820)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-4bb7df26f6-45257.surge.sh)
<!-- Dgraph:end -->