### PR TITLE
Fix Dart client URL

### DIFF
--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -483,7 +483,7 @@ These third-party clients are contributed by the community and are not officiall
 
 ### Dart
 
-- https://github.com/katutz/dgraph
+- https://github.com/marceloneppel/dgraph
 
 ### Elixir
 


### PR DESCRIPTION
I fixed the Dart client URL to the new one. Now the client is compatible with Dgraph 1.1.x.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4828)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-780fe312d5-45599.surge.sh)
<!-- Dgraph:end -->