### PR TITLE
Fix bug in exporting types with reverse predicates.

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -333,7 +333,15 @@ func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 func fieldToString(update *pb.SchemaUpdate) string {
 	var builder strings.Builder
 	x.Check2(builder.WriteString("\t"))
-	x.Check2(builder.WriteString(update.Predicate))
+	// Write < > brackets in reverse predicates or Dgraph won't be able to
+	// parse the exported schema.
+	if strings.HasPrefix(update.Predicate, "~") {
+		x.Check2(builder.WriteString("<"))
+		x.Check2(builder.WriteString(update.Predicate))
+		x.Check2(builder.WriteString(">"))
+	} else {
+		x.Check2(builder.WriteString(update.Predicate))
+	}
 	x.Check2(builder.WriteString("\n"))
 	return builder.String()
 }

--- a/worker/export.go
+++ b/worker/export.go
@@ -333,8 +333,8 @@ func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 func fieldToString(update *pb.SchemaUpdate) string {
 	var builder strings.Builder
 	x.Check2(builder.WriteString("\t"))
-	// Write < > brackets in reverse predicates or Dgraph won't be able to
-	// parse the exported schema.
+	// While exporting type definitions, "<" and ">" brackets must be written around
+	// the name of everse predicates or Dgraph won't be able to parse the exported schema.
 	if strings.HasPrefix(update.Predicate, "~") {
 		x.Check2(builder.WriteString("<"))
 		x.Check2(builder.WriteString(update.Predicate))

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -58,6 +58,9 @@ var personType = &pb.TypeUpdate{
 			Predicate: "friend",
 		},
 		{
+			Predicate: "~friend",
+		},
+		{
 			Predicate: "friend_not_served",
 		},
 	},
@@ -189,6 +192,8 @@ func checkExportSchema(t *testing.T, schemaFileList []string) {
 	require.Equal(t, "uid", types.TypeID(result.Preds[1].ValueType).Name())
 
 	require.Equal(t, 1, len(result.Types))
+	t.Logf("result %+v", result.Types)
+	t.Logf("person type %+v", personType)
 	require.True(t, proto.Equal(result.Types[0], personType))
 }
 

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -192,8 +192,6 @@ func checkExportSchema(t *testing.T, schemaFileList []string) {
 	require.Equal(t, "uid", types.TypeID(result.Preds[1].ValueType).Name())
 
 	require.Equal(t, 1, len(result.Types))
-	t.Logf("result %+v", result.Types)
-	t.Logf("person type %+v", personType)
 	require.True(t, proto.Equal(result.Types[0], personType))
 }
 


### PR DESCRIPTION
< > brackets are needed around the type name. They were missing.

Fixes #4856

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4857)
<!-- Reviewable:end -->
