### PR TITLE
Verify host when default and custom credentials are used.

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -98,7 +98,7 @@ func (creds *Credentials) hasCredentials() bool {
 	if creds == nil {
 		return false
 	}
-	return creds.accessKey != "" && creds.secretKey != ""
+	return creds.accessKey != "" || creds.secretKey != "" || creds.sessionToken != ""
 }
 
 func (creds *Credentials) isAnonymous() bool {

--- a/worker/s3_handler.go
+++ b/worker/s3_handler.go
@@ -73,22 +73,11 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 		var provider credentials.Provider
 		switch uri.Scheme {
 		case "s3":
-			// s3:///bucket/folder
-			if !strings.Contains(uri.Host, ".") {
-				uri.Host = defaultEndpointS3
-			}
-			if !s3utils.IsAmazonEndpoint(*uri) {
-				return nil, errors.Errorf("Invalid S3 endpoint %q", uri.Host)
-			}
 			// Access Key ID:     AWS_ACCESS_KEY_ID or AWS_ACCESS_KEY.
 			// Secret Access Key: AWS_SECRET_ACCESS_KEY or AWS_SECRET_KEY.
 			// Secret Token:      AWS_SESSION_TOKEN.
 			provider = &credentials.EnvAWS{}
-
 		default: // minio
-			if uri.Host == "" {
-				return nil, errors.Errorf("Minio handler requires a host")
-			}
 			// Access Key ID:     MINIO_ACCESS_KEY.
 			// Secret Access Key: MINIO_SECRET_KEY.
 			provider = &credentials.EnvMinio{}
@@ -101,6 +90,22 @@ func (h *s3Handler) setup(uri *url.URL) (*minio.Client, error) {
 		creds.AccessKeyID = h.creds.accessKey
 		creds.SecretAccessKey = h.creds.secretKey
 		creds.SessionToken = h.creds.sessionToken
+	}
+
+	// Verify URI and set default S3 host if needed.
+	switch uri.Scheme {
+	case "s3":
+		// s3:///bucket/folder
+		if !strings.Contains(uri.Host, ".") {
+			uri.Host = defaultEndpointS3
+		}
+		if !s3utils.IsAmazonEndpoint(*uri) {
+			return nil, errors.Errorf("Invalid S3 endpoint %q", uri.Host)
+		}
+	default: // minio
+		if uri.Host == "" {
+			return nil, errors.Errorf("Minio handler requires a host")
+		}
 	}
 
 	secure := uri.Query().Get("secure") != "false" // secure by default


### PR DESCRIPTION
Currently, the host is only checked when the default credentials are
used. This means using custom credentials will not work if there's no
host in the destination URI as the logic that handles this case is not
executed.

This PR changes the logic so that these checks are always executed,
regardless of the status of the credentials.

Fixes #4855 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4858)
<!-- Reviewable:end -->
