### PR TITLE
Docs - improves shutdown and upgrade sections

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2194,7 +2194,7 @@ Doing periodic exports is always a good idea. This is particularly useful if you
 
 - Start an [export]({{< relref "#export-database">}})
 - Ensure it is successful
-- Bring down the cluster
+- [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
 - Run Dgraph using new data directories.
 - Reload the data via [bulk loader]({{< relref "#bulk-loader" >}}).
 - If all looks good, you can delete the old directories (export serves as an insurance)

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2192,7 +2192,7 @@ Alternatively, you could:
 
 Doing periodic exports is always a good idea. This is particularly useful if you wish to upgrade Dgraph or reconfigure the sharding of a cluster. The following are the right steps safely export and restart.
 
-- Start an [export]({{< relref "#export">}})
+- Start an [export]({{< relref "#export-database">}})
 - Ensure it's successful
 - Bring down the cluster
 - Run Dgraph using new data directories.

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2160,6 +2160,8 @@ Currently, "rdf" and "json" are the only formats supported.
 
 A clean exit of a single Dgraph Alpha node is initiated by running the following command on that node.
 {{% notice "warning" %}}This won't work if called from outside the server where Dgraph is running.
+You can specify a list or range of whitelisted IP addresses from which shutdown or other admin operations
+can be initiated using the `--whitelist` flag on `dgraph alpha`.
 {{% /notice %}}
 
 ```graphql

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2208,6 +2208,10 @@ do a rolling restart of all your Alpha using the option `--mutations disallow` w
 At this point your application can still read from the old cluster and you can perform the steps 4. and 5. described above.
 When the new cluster (that uses the upgraded version of Dgraph) is up and running, you can point your application to it, and shutdown the old cluster.
 
+{{% notice "note" %}}
+If you are upgrading from v1.0, please make sure you follow the schema migration steps described in [this section](/howto/#schema-types-scalar-uid-and-list-uid).
+{{% /notice %}}
+
 ### Post Installation
 
 Now that Dgraph is up and running, to understand how to add and query data to Dgraph, follow [Query Language Spec](/query-language). Also, have a look at [Frequently asked questions](/faq).

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2192,14 +2192,21 @@ Alternatively, you could:
 
 Doing periodic exports is always a good idea. This is particularly useful if you wish to upgrade Dgraph or reconfigure the sharding of a cluster. The following are the right steps safely export and restart.
 
-- Start an [export]({{< relref "#export-database">}})
-- Ensure it is successful
-- [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
-- Run Dgraph using new data directories.
-- Reload the data via [bulk loader]({{< relref "#bulk-loader" >}}).
-- If all looks good, you can delete the old directories (export serves as an insurance)
+1. Start an [export]({{< relref "#export-database">}})
+2. Ensure it is successful
+3. [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
+4. Start a new Dgraph cluster using new data directories (this can be done by passing empty directories to the options `-p` and `-w` for Alphas and `-w` for Zeros)
+5. Reload the data via [bulk loader]({{< relref "#bulk-loader" >}}).
+6. If all looks good, you can delete the old directories (export serves as an insurance)
 
 These steps are necessary because Dgraph's underlying data format could have changed, and reloading the export avoids encoding incompatibilities.
+
+Blue-green deployment is a common approach to minimize downtime during the upgrade process. 
+This approach involves switching your application in read-only mode. To make sure that no mutations are executed during the maintenance window you can 
+do a rolling restart of all your Alpha using the option `--mutations disallow` when you restart the Alphas. This will ensure the cluster is in read-only mode.
+
+At this point your application can still read from the old cluster and you can perform the steps 4. and 5. described above.
+When the new cluster (that uses the upgraded version of Dgraph) is up and running, you can point your application to it, and shutdown the old cluster.
 
 ### Post Installation
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2188,20 +2188,20 @@ To drop all data, you could send a `DropAll` request via `/alter` endpoint.
 
 Alternatively, you could:
 
-* [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
-* delete (maybe do an export first) the `p` and `w` directories, then
-* restart Dgraph.
+* [Shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
+* Delete (maybe do an export first) the `p` and `w` directories, then
+* Restart Dgraph.
 
 ### Upgrade Database
 
-Doing periodic exports is always a good idea. This is particularly useful if you wish to upgrade Dgraph or reconfigure the sharding of a cluster. The following are the right steps safely export and restart.
+Doing periodic exports is always a good idea. This is particularly useful if you wish to upgrade Dgraph or reconfigure the sharding of a cluster. The following are the right steps to safely export and restart.
 
 1. Start an [export]({{< relref "#export-database">}})
 2. Ensure it is successful
-3. [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
+3. [Shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete
 4. Start a new Dgraph cluster using new data directories (this can be done by passing empty directories to the options `-p` and `-w` for Alphas and `-w` for Zeros)
-5. Reload the data via [bulk loader]({{< relref "#bulk-loader" >}}).
-6. If all looks good, you can delete the old directories (export serves as an insurance)
+5. Reload the data via [bulk loader]({{< relref "#bulk-loader" >}})
+6. Verify the correctness of the new Dgraph cluster. If all looks good, you can delete the old directories (export serves as an insurance)
 
 These steps are necessary because Dgraph's underlying data format could have changed, and reloading the export avoids encoding incompatibilities.
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2158,7 +2158,11 @@ Currently, "rdf" and "json" are the only formats supported.
 
 ### Shutdown Database
 
-A clean exit of a single Dgraph Alpha node is initiated by running the following command on that node.
+To shutdown a Dgraph cluster, shutdown all its Alpha and Zero nodes. This can be done in different ways,
+depending on how Dgraph was started (e.g. sending a `SIGTERM` to the processes, or using `systemctl stop service-name`
+if you are using systemd).
+
+A clean exit of a single Dgraph Alpha node can be initiated by running the following command on that node.
 {{% notice "warning" %}}This won't work if called from outside the server where Dgraph is running.
 You can specify a list or range of whitelisted IP addresses from which shutdown or other admin operations
 can be initiated using the `--whitelist` flag on `dgraph alpha`.

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2193,7 +2193,7 @@ Alternatively, you could:
 Doing periodic exports is always a good idea. This is particularly useful if you wish to upgrade Dgraph or reconfigure the sharding of a cluster. The following are the right steps safely export and restart.
 
 - Start an [export]({{< relref "#export-database">}})
-- Ensure it's successful
+- Ensure it is successful
 - Bring down the cluster
 - Run Dgraph using new data directories.
 - Reload the data via [bulk loader]({{< relref "#bulk-loader" >}}).

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2158,7 +2158,7 @@ Currently, "rdf" and "json" are the only formats supported.
 
 ### Shutdown Database
 
-A clean exit of a single Dgraph node is initiated by running the following command on that node.
+A clean exit of a single Dgraph Alpha node is initiated by running the following command on that node.
 {{% notice "warning" %}}This won't work if called from outside the server where Dgraph is running.
 {{% /notice %}}
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2206,7 +2206,7 @@ Doing periodic exports is always a good idea. This is particularly useful if you
 These steps are necessary because Dgraph's underlying data format could have changed, and reloading the export avoids encoding incompatibilities.
 
 Blue-green deployment is a common approach to minimize downtime during the upgrade process. 
-This approach involves switching your application in read-only mode. To make sure that no mutations are executed during the maintenance window you can 
+This approach involves switching your application to read-only mode. To make sure that no mutations are executed during the maintenance window you can 
 do a rolling restart of all your Alpha using the option `--mutations disallow` when you restart the Alphas. This will ensure the cluster is in read-only mode.
 
 At this point your application can still read from the old cluster and you can perform the steps 4. and 5. described above.

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2184,7 +2184,7 @@ To drop all data, you could send a `DropAll` request via `/alter` endpoint.
 
 Alternatively, you could:
 
-* [stop Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
+* [shutdown Dgraph]({{< relref "#shutdown-database" >}}) and wait for all writes to complete,
 * delete (maybe do an export first) the `p` and `w` directories, then
 * restart Dgraph.
 


### PR DESCRIPTION
Reference:
- https://github.com/dgraph-io/dgraph/issues/4839
- https://github.com/dgraph-io/dgraph/issues/4644

This PR:
- removes confusion on whether the shutdown mutation can be used with Zero as well
- clarifies more the upgrade process specifying what is meant for running dgraph in new directories
- adds link to the shutdown process in the upgrade section
- fixes broken link to export section in the upgrade section
- mentions the blue-green approach
- adds a notice regarding the needed schema upgrade step when upgrading from v1.0
- cite the general shutdown method (by stopping all nodes in the cluster, e.g. sending a SIGTERM, or using systemd). Info on how to shutdown in k8s or when using docker are not included in this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4863)
<!-- Reviewable:end -->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5ba1f97863-46348.surge.sh)
<!-- Dgraph:end -->