### PR TITLE
Split posting lists recursively.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1218,7 +1218,7 @@ func (out *rollupOutput) recursiveSplit() {
 			if shouldSplit(part) {
 				needsSplit = true
 			}
-		} 
+		}
 
 		if !needsSplit {
 			return

--- a/posting/list.go
+++ b/posting/list.go
@@ -879,7 +879,7 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		// Check if the list (or any of it's parts if it's been previously split) have
 		// become too big. Split the list if that is the case.
 		out.newMinTs = maxCommitTs
-		out.splitUpList()
+		out.recursiveSplit()
 		out.removeEmptySplits()
 	} else {
 		out.plist.Splits = nil
@@ -1205,6 +1205,26 @@ func (l *List) readListPart(startUid uint64) (*pb.PostingList, error) {
 // shouldSplit returns true if the given plist should be split in two.
 func shouldSplit(plist *pb.PostingList) bool {
 	return plist.Size() >= maxListSize && len(plist.Pack.Blocks) > 1
+}
+
+func (out *rollupOutput) recursiveSplit() {
+	// Call splitUpList. Otherwise the map of startUids to parts won't be initialized.
+	out.splitUpList()
+
+	// Keep calling splitUpList until all the parts cannot be further split.
+	for {
+		needsSplit := false
+		for _, part := range out.parts {
+			if shouldSplit(part) {
+				needsSplit = true
+			}
+		} 
+
+		if !needsSplit {
+			return
+		}
+		out.splitUpList()
+	}
 }
 
 // splitUpList checks the list and splits it in smaller parts if needed.


### PR DESCRIPTION
Currently, split posting lists are split in one go. This means that the
resulting splits will be added to the list even if they are still too
big. This change recursively splits the parts of the lists until all of
them are smaller than the threshold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4867)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-83bc6c49be-47477.surge.sh)
<!-- Dgraph:end -->