### PR TITLE
Improve restore documentation.

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -198,7 +198,7 @@ Alpha.
 
 By default, Dgraph will look for a posting directory with the name `p`, so make
 sure to rename the directories after moving them. You can also use the `-p`
-option to specify a different path from the default.
+option of the `dgraph alpha` command to specify a different path from the default.
 
 #### Restore from Amazon S3
 ```sh

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -190,11 +190,11 @@ example, a backup for Alpha group 2 would have the name `.../r32-g2.backup`
 and would be loaded to posting directory `p2`.
 
 After running the restore command, the directories inside the `postings`
-directory are copied over to the machines/containers running the alphas and
-`dgraph alpha` is started to load the copied data. For example, in a database
-cluster with two Alpha groups and one replica each, `p1` is moved to the
-location of the first Alpha and `p2` is moved to the location of the second
-Alpha.
+directory need to be manually copied over to the machines/containers running the
+alphas before running the `dgraph alpha`. For example, in a database cluster
+with two Alpha groups and one replica each, `p1` needs to be moved to the
+location of the first Alpha and `p2` needs to be moved to the location of the
+second Alpha.
 
 By default, Dgraph will look for a posting directory with the name `p`, so make
 sure to rename the directories after moving them. You can also use the `-p`

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -191,10 +191,10 @@ and would be loaded to posting directory `p2`.
 
 After running the restore command, the directories inside the `postings`
 directory need to be manually copied over to the machines/containers running the
-alphas before running the `dgraph alpha`. For example, in a database cluster
-with two Alpha groups and one replica each, `p1` needs to be moved to the
-location of the first Alpha and `p2` needs to be moved to the location of the
-second Alpha.
+alphas before running the `dgraph alpha` command. For example, in a database
+cluster with two Alpha groups and one replica each, `p1` needs to be moved to
+the location of the first Alpha and `p2` needs to be moved to the location of
+the second Alpha.
 
 By default, Dgraph will look for a posting directory with the name `p`, so make
 sure to rename the directories after moving them. You can also use the `-p`

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -196,6 +196,10 @@ cluster with two Alpha groups and one replica each, `p1` is moved to the
 location of the first Alpha and `p2` is moved to the location of the second
 Alpha.
 
+By default, Dgraph will look for a posting directory with the name `p`, so make
+sure to rename the directories after moving them. You can also use the `-p`
+option to specify a different path from the default.
+
 #### Restore from Amazon S3
 ```sh
 $ dgraph restore -p /var/db/dgraph -l s3://s3.us-west-2.amazonaws.com/<bucketname>


### PR DESCRIPTION
Clarify that the posting directories have to be renamed for Alphas to
pick them up at the default location.

Fixes #4854

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4868)
<!-- Reviewable:end -->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-bc82d1e3b4-46650.surge.sh)
<!-- Dgraph:end -->