### PR TITLE
Remove size calculation from toList method in bulk loader.

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -407,7 +407,6 @@ func (r *reducer) toList(bufEntries [][]byte, list *bpb.KVList) []*countIndexEnt
 
 	var currentKey []byte
 	var uids []uint64
-	var size int
 	pl := new(pb.PostingList)
 
 	userMeta := []byte{posting.BitCompletePosting}
@@ -484,7 +483,6 @@ func (r *reducer) toList(bufEntries [][]byte, list *bpb.KVList) []*countIndexEnt
 			UserMeta: userMeta,
 			Version:  writeVersionTs,
 		}
-		size += kv.Size()
 		list.Kv = append(list.Kv, kv)
 
 		uids = uids[:0]


### PR DESCRIPTION
The total size of the key-value pairs is being calculated but it's not
being used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4869)
<!-- Reviewable:end -->
