### PR TITLE
Disable @* language queries when the predicate does not support langs.

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -839,7 +839,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst *fastJsonNode) error {
 			// add value for count(uid) nodes if any.
 			_ = handleCountUIDNodes(pc, dst, len(ul.Uids))
 		default:
-			if pc.Params.Alias == "" && len(pc.Params.Langs) > 0 {
+			if pc.Params.Alias == "" && len(pc.Params.Langs) > 0 && pc.Params.Langs[0] != "*" {
 				fieldName += "@"
 				fieldName += strings.Join(pc.Params.Langs, ":")
 			}
@@ -876,7 +876,7 @@ func (sg *SubGraph) preTraverse(uid uint64, dst *fastJsonNode) error {
 					}
 					fieldNameWithTag := fieldName
 					lang := pc.LangTags[idx].Lang[i]
-					if lang != "" {
+					if lang != "" && lang != "*" {
 						fieldNameWithTag += "@" + lang
 					}
 					encodeAsList := pc.List && len(lang) == 0

--- a/query/query.go
+++ b/query/query.go
@@ -857,8 +857,8 @@ func createTaskQuery(sg *SubGraph) (*pb.Query, error) {
 	// If the lang is set to *, query all the languages.
 	if len(sg.Params.Langs) == 1 && sg.Params.Langs[0] == "*" {
 		sg.Params.ExpandAll = true
-		sg.Params.Langs = nil
 	}
+
 	// count is to limit how many results we want.
 	first := calculateFirstN(sg)
 

--- a/worker/task.go
+++ b/worker/task.go
@@ -915,6 +915,11 @@ func (qs *queryState) helpProcessTask(ctx context.Context, q *pb.Query, gid uint
 		return nil, errors.Errorf("Language tags can only be used with predicates of string type"+
 			" having @lang directive in schema. Got: [%v]", attr)
 	}
+	if len(q.Langs) == 1 && q.Langs[0] == "*" {
+		// Reset the Langs fields. The ExpandAll field is set to true already so there's no
+		// more need to store the star value in this field.
+		q.Langs = nil
+	}
 
 	typ, err := schema.State().TypeOf(attr)
 	if err != nil {


### PR DESCRIPTION
This changes makes "@." and "@*" behave the same way

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4881)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b943be8b6f-47260.surge.sh)
<!-- Dgraph:end -->