### PR TITLE
Cherry-pick "Do not include empty nodes in the export output" into 1.2 release

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -520,6 +520,12 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 
 	stream.Send = func(list *bpb.KVList) error {
 		for _, kv := range list.Kv {
+			// Skip nodes that have no data. Otherwise, the exported data could have
+			// formatting and/or syntax errors.
+			if len(kv.Value) == 0 {
+				continue
+			}
+
 			var writer *fileWriter
 			switch kv.Version {
 			case 1: // data

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -76,7 +76,10 @@ func populateGraphExport(t *testing.T) {
 		"<1> <friend_not_served> <5> <author0> .",
 		`<5> <name> "" .`,
 		`<6> <name> "Ding!\u0007Ding!\u0007Ding!\u0007" .`,
+		`<7> <name> "node_to_delete" .`,
 	}
+	// This triplet will be deleted to ensure deleted nodes do not affect the output of the export.
+	edgeToDelete := `<7> <name> "node_to_delete" .`
 	idMap := map[string]uint64{
 		"1": 1,
 		"2": 2,
@@ -84,10 +87,11 @@ func populateGraphExport(t *testing.T) {
 		"4": 4,
 		"5": 5,
 		"6": 6,
+		"7": 7,
 	}
 
 	l := &lex.Lexer{}
-	for _, edge := range rdfEdges {
+	processEdge := func(edge string, set bool) {
 		nq, err := chunker.ParseRDF(edge, l)
 		require.NoError(t, err)
 		rnq := gql.NQuad{NQuad: &nq}
@@ -95,8 +99,17 @@ func populateGraphExport(t *testing.T) {
 		require.NoError(t, err)
 		e, err := rnq.ToEdgeUsing(idMap)
 		require.NoError(t, err)
-		addEdge(t, e, getOrCreate(x.DataKey(e.Attr, e.Entity)))
+		if set {
+			addEdge(t, e, getOrCreate(x.DataKey(e.Attr, e.Entity)))
+		} else {
+			delEdge(t, e, getOrCreate(x.DataKey(e.Attr, e.Entity)))
+		}
 	}
+
+	for _, edge := range rdfEdges {
+		processEdge(edge, true)
+	}
+	processEdge(edgeToDelete, false)
 }
 
 func initTestExport(t *testing.T, schemaStr string) {

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -74,6 +74,11 @@ func addEdge(t *testing.T, edge *pb.DirectedEdge, l *posting.List) {
 	commitTransaction(t, edge, l)
 }
 
+func delEdge(t *testing.T, edge *pb.DirectedEdge, l *posting.List) {
+	edge.Op = pb.DirectedEdge_DEL
+	commitTransaction(t, edge, l)
+}
+
 func setClusterEdge(t *testing.T, dg *dgo.Dgraph, rdf string) {
 	mu := &api.Mutation{SetNquads: []byte(rdf), CommitNow: true}
 	err := testutil.RetryMutation(dg, mu)


### PR DESCRIPTION
Empty nodes are not included in the export output but the separator (a
comma in the case of JSON) is being appended. The fix is to skip over
empty values.

Added a deleted node to the exported graph to ensure that these type of
nodes are handled properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4896)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9d3e4686d9-47280.surge.sh)
<!-- Dgraph:end -->