### PR TITLE
Rename Load and ListManifests functions.

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -221,7 +221,7 @@ func runRestoreCmd() error {
 
 func runLsbackupCmd() error {
 	fmt.Println("Listing backups from:", opt.location)
-	manifests, err := worker.ListManifests(opt.location)
+	manifests, err := worker.ListBackupManifests(opt.location)
 	if err != nil {
 		return errors.Wrapf(err, "while listing manifests")
 	}

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -173,9 +173,9 @@ type predicateSet map[string]struct{}
 // are passed as arguments.
 type loadFn func(reader io.Reader, groupId int, preds predicateSet) (uint64, error)
 
-// Load will scan location l for backup files in the given backup series and load them
+// LoadBackup will scan location l for backup files in the given backup series and load them
 // sequentially. Returns the maximum Since value on success, otherwise an error.
-func Load(location, backupId string, fn loadFn) LoadResult {
+func LoadBackup(location, backupId string, fn loadFn) LoadResult {
 	uri, err := url.Parse(location)
 	if err != nil {
 		return LoadResult{0, 0, err}
@@ -190,8 +190,8 @@ func Load(location, backupId string, fn loadFn) LoadResult {
 	return h.Load(uri, backupId, fn)
 }
 
-// ListManifests scans location l for backup files and returns the list of manifests.
-func ListManifests(l string) (map[string]*Manifest, error) {
+// ListBackupManifests scans location l for backup files and returns the list of manifests.
+func ListBackupManifests(l string) (map[string]*Manifest, error) {
 	uri, err := url.Parse(l)
 	if err != nil {
 		return nil, err

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -42,7 +42,7 @@ func RunRestore(pdir, location, backupId string) LoadResult {
 
 	// Scan location for backup files and load them. Each file represents a node group,
 	// and we create a new p dir for each.
-	return Load(location, backupId,
+	return LoadBackup(location, backupId,
 		func(r io.Reader, groupId int, preds predicateSet) (uint64, error) {
 
 			dir := filepath.Join(pdir, fmt.Sprintf("p%d", groupId))


### PR DESCRIPTION
These functions are related to backups but now that the code is in the
worker package that is not obvious. Rename these two methods for better
readability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4904)
<!-- Reviewable:end -->
