### PR TITLE
docs: improve TLS section by adding more examples

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1603,6 +1603,36 @@ enabled the browser will prompt you for a client certificate to use. Select the
 certificate you've just installed in the step above and queries/mutations will
 succeed.
 
+### Using Curl with Client authentication
+
+When TLS is enabled, `curl` requests to Dgraph will need some specific options to work.
+
+If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN` (default),
+use the option `--cacert`. For instance (for an export request):
+
+```
+curl --cacert ./tls/ca.crt https://localhost:8080/admin/export
+```
+
+If the `--tls_client_auth` option is set to  `REQUIREANY` or  `REQUIREANDVERIFY`,
+in addition to the `--cacert` option, also use the `--cert` and `--key` options.
+For instance (for an export request):
+
+``` 
+curl --cacert ./tls/ca.crt --cert ./tls/node.crt --key ./tls/node.key https://localhost:8080/admin/export
+```
+
+Refer to the `curl` documentation for further information on its TLS options.
+
+### Access Data Using a Client
+
+Some examples of connecting via a [Client](/clients) when TLS is in use can be found below:
+
+- [dgraph4j](https://github.com/dgraph-io/dgraph4j#creating-a-secure-client-using-tls)
+- [dgraph-js](https://github.com/dgraph-io/dgraph-js/tree/master/examples/tls)
+- [dgo](https://github.com/dgraph-io/dgraph/blob/master/tlstest/acl/acl_over_tls_test.go)
+- [pydgraph](https://github.com/dgraph-io/pydgraph/tree/master/examples/tls)
+
 ### Troubleshooting Ratel's Client authentication
 
 If you are getting errors in Ratel when server's TLS is enabled try opening


### PR DESCRIPTION
backport of https://github.com/dgraph-io/dgraph/pull/4911

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4913)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f6c6871ea5-47519.surge.sh)
<!-- Dgraph:end -->