### PR TITLE
track operations and cancel when needed

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -99,7 +99,7 @@ func (n *node) startRollUp() (context.Context, error) {
 	return ctx, nil
 }
 
-// startTask is used to check whether the an op is already going on.
+// startTask is used to check whether an op is already going on.
 // If rollup is going on, we cancel and wait for rollup to complete
 // before we return. If the same task is already going, we return error.
 func (n *node) startTask(id int) error {
@@ -149,7 +149,7 @@ func (n *node) stopTask(id int) {
 
 	// Signal that task is completed or cancelled.
 	op.done <- struct{}{}
-	glog.Infof("Operation complete with id: %d", id)
+	glog.Infof("Operation completed with id: %d", id)
 }
 
 // Now that we apply txn updates via Raft, waiting based on Txn timestamps is

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -127,6 +127,7 @@ func (n *node) startTask(id int) (*operation, error) {
 func (n *node) stopTask(op *operation) {
 	// Signal that task is completed or cancelled.
 	op.cancel()
+	// Needs to be done before we acquire the lock to avoid deadlock.
 	close(op.done)
 
 	n.opsLock.Lock()

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -139,12 +139,11 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	}
 
 	// Ensure that rollup is not running.
-	wrtCtx := schema.GetWriteContext(context.Background())
-	if tmpCtx, err := gr.Node.startTask(wrtCtx, opIndexing); err != nil {
+	tmpCtx, err := gr.Node.startTask(opIndexing)
+	if err != nil {
 		return err
-	} else {
-		wrtCtx = tmpCtx
 	}
+	wrtCtx := schema.GetWriteContext(tmpCtx)
 
 	buildIndexesHelper := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) error {
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -149,11 +149,10 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 		return err
 	}
 	defer stopIndexing()
+
 	// wrtCtx is used by the background tasks.
 	wrtCtx = schema.GetWriteContext(wrtCtx)
-
 	buildIndexesHelper := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) error {
-		defer stopIndexing()
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {
 			return err
 		}
@@ -171,6 +170,8 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	wg.Add(1)
 	defer wg.Done()
 	buildIndexes := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) {
+		defer stopIndexing()
+
 		// We should only start building indexes once this function has returned.
 		// This is in order to ensure that we do not call DropPrefix for one predicate
 		// and write indexes for another predicate simultaneously. because that could

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -154,7 +154,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 		// in case background indexing is running, we should call it here again.
 		defer stopIndexing(op)
 
-		wrtCtx := schema.GetWriteContext(op.ctx)
+		wrtCtx := schema.GetWriteContext(context.Background())
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {
 			return err
 		}

--- a/worker/proposal_test.go
+++ b/worker/proposal_test.go
@@ -80,7 +80,7 @@ func TestLimiterDeadlock(t *testing.T) {
 				"Total proposals: ", atomic.LoadInt64(&currentCount),
 				"Pending proposal: ", atomic.LoadInt64(&pending),
 				"Completed Proposals: ", atomic.LoadInt64(&completed),
-				"Aboted Proposals: ", atomic.LoadInt64(&aborted),
+				"Aborted Proposals: ", atomic.LoadInt64(&aborted),
 				"IOU: ", l.iou)
 		}
 	}()
@@ -109,7 +109,7 @@ func TestLimiterDeadlock(t *testing.T) {
 
 	// After trying all the proposals, (completed + aborted) should be equal to  tried proposal.
 	require.True(t, toTry == completed+aborted,
-		fmt.Sprintf("Tried: %d, Compteted: %d, Aboted: %d", toTry, completed, aborted))
+		fmt.Sprintf("Tried: %d, Compteted: %d, Aborted: %d", toTry, completed, aborted))
 }
 
 func BenchmarkRateLimiter(b *testing.B) {


### PR DESCRIPTION
we now track operations in the system such as rollup, indexing and snapshots. We cancel rollup whenever indexing or snapshot needs to be taken. We also do not allow multiple operations at the same time.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4916)
<!-- Reviewable:end -->
