### PR TITLE
Allow uid access

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -778,6 +778,9 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	}
 
 	if len(blockedPreds) != 0 {
+		if _, ok := blockedPreds["uid"]; ok {
+			delete(blockedPreds, "uid")
+		}
 		parsedReq.Query = removePredsFromQuery(parsedReq.Query, blockedPreds)
 	}
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -677,7 +677,7 @@ func parsePredsFromQuery(gqls []*gql.GraphQuery) []string {
 		if gq.Func != nil {
 			predsMap[gq.Func.Attr] = struct{}{}
 		}
-		if len(gq.Attr) > 0 {
+		if len(gq.Attr) > 0 && gq.Attr != "uid" {
 			predsMap[gq.Attr] = struct{}{}
 		}
 		for _, ord := range gq.Order {
@@ -778,9 +778,6 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result) error {
 	}
 
 	if len(blockedPreds) != 0 {
-		if _, ok := blockedPreds["uid"]; ok {
-			delete(blockedPreds, "uid")
-		}
 		parsedReq.Query = removePredsFromQuery(parsedReq.Query, blockedPreds)
 	}
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -684,7 +684,7 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 		})
 	}
 
-	testutil.AssignUids(101)
+	require.NoError(t, testutil.AssignUids(101))
 	mutation = &api.Mutation{
 		SetNquads: []byte(`
 			<100> <name> "100th User" .

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -683,4 +683,16 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			require.Equal(t, tc.output, string(resp.Json))
 		})
 	}
+
+	uidQuery := `
+	{
+		me(func: has(name)) {
+			uid
+			name
+		}
+	}
+	`
+	resp, err := userClient.NewReadOnlyTxn().Query(ctx, uidQuery)
+	require.Nil(t, err)
+	require.Contains(t, string(resp.Json), "uid")
 }

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -680,19 +680,30 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)
 			require.Nil(t, err)
-			require.Equal(t, tc.output, string(resp.Json))
+			testutil.CompareJSON(t, tc.output, string(resp.Json))
 		})
 	}
 
+	testutil.AssignUids(101)
+	mutation = &api.Mutation{
+		SetNquads: []byte(`
+			<100> <name> "100th User" .
+			<100> <age> "100" .
+		`),
+		CommitNow: true,
+	}
+	_, err = dg.NewTxn().Mutate(ctx, mutation)
+	require.NoError(t, err)
 	uidQuery := `
 	{
-		me(func: has(name)) {
+		me(func: uid(100)) {
 			uid
 			name
+			age
 		}
 	}
 	`
 	resp, err := userClient.NewReadOnlyTxn().Query(ctx, uidQuery)
 	require.Nil(t, err)
-	require.Contains(t, string(resp.Json), "uid")
+	testutil.CompareJSON(t, `{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson()))
 }


### PR DESCRIPTION
Internal ref:
- DGRAPH-1101

---

`uid` in query was being blocked during authorization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4922)
<!-- Reviewable:end -->
