### PR TITLE
[OPTIMIZATION] Various optimizations for facets filter queries

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -146,10 +146,8 @@ func valToBytes(v types.Val) ([]byte, error) {
 		// and hence we are using strconv.FormatInt() here. Since int64 and int are most common int
 		// types we are using FormatInt for those.
 		switch num := v.Value.(type) {
-		case int64:
+		case int64, int:
 			return []byte(strconv.FormatInt(num, 10)), nil
-		case int:
-			return []byte(strconv.FormatInt(int64(num), 10)), nil
 		default:
 			return []byte(fmt.Sprintf("%d", v.Value)), nil
 		}

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -130,9 +130,9 @@ func (fj *fastJsonNode) IsEmpty() bool {
 }
 
 var (
-	TrueBoolBytes    = []byte("true")
-	FalseBoolBytes   = []byte("false")
-	EmptyStringBytes = []byte(`""`)
+	boolTrueBytes    = []byte("true")
+	boolFalseBytes   = []byte("false")
+	emptyStringBytes = []byte(`""`)
 )
 
 func valToBytes(v types.Val) ([]byte, error) {
@@ -143,7 +143,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 		return []byte(fmt.Sprintf("%q", v.Value)), nil
 	case types.IntID:
 		switch v.Value.(type) {
-		case int64: // In types.Convert(), we always convert to int64.
+		case int64: // In types.Convert(), we always convert to int64 in types.Convert().
 			return []byte(strconv.Itoa(int(v.Value.(int64)))), nil
 		default:
 			return []byte(strconv.Itoa(v.Value.(int))), nil
@@ -152,14 +152,14 @@ func valToBytes(v types.Val) ([]byte, error) {
 		return []byte(fmt.Sprintf("%f", v.Value)), nil
 	case types.BoolID:
 		if v.Value.(bool) {
-			return TrueBoolBytes, nil
+			return boolTrueBytes, nil
 		}
-		return FalseBoolBytes, nil
+		return boolFalseBytes, nil
 	case types.DateTimeID:
 		// Return empty string instead of zero-time value string - issue#3166
 		t := v.Value.(time.Time)
 		if t.IsZero() {
-			return EmptyStringBytes, nil
+			return emptyStringBytes, nil
 		}
 		return t.MarshalJSON()
 	case types.GeoID:

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -146,8 +146,10 @@ func valToBytes(v types.Val) ([]byte, error) {
 		// and hence we are using strconv.FormatInt() here. Since int64 and int are most common int
 		// types we are using FormatInt for those.
 		switch num := v.Value.(type) {
-		case int64, int:
+		case int64:
 			return []byte(strconv.FormatInt(num, 10)), nil
+		case int:
+			return []byte(strconv.FormatInt(int64(num), 10)), nil
 		default:
 			return []byte(fmt.Sprintf("%d", v.Value)), nil
 		}

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -142,11 +142,11 @@ func valToBytes(v types.Val) ([]byte, error) {
 	case types.BinaryID:
 		return []byte(fmt.Sprintf("%q", v.Value)), nil
 	case types.IntID:
-		switch v.Value.(type) {
+		switch num := v.Value.(type) {
 		case int64: // In types.Convert(), we always convert to int64 in types.Convert().
-			return []byte(strconv.Itoa(int(v.Value.(int64)))), nil
+			return []byte(strconv.Itoa(int(num))), nil
 		default:
-			return []byte(strconv.Itoa(v.Value.(int))), nil
+			return []byte(strconv.Itoa(num.(int))), nil
 		}
 	case types.FloatID:
 		return []byte(fmt.Sprintf("%f", v.Value)), nil

--- a/query/query.go
+++ b/query/query.go
@@ -384,16 +384,16 @@ func isEmptyIneqFnWithVar(sg *SubGraph) bool {
 // is already set in api.Value
 func convertWithBestEffort(tv *pb.TaskValue, attr string) (types.Val, error) {
 	// value would be in binary format with appropriate type
-	v, _ := getValue(tv)
-	if !v.Tid.IsScalar() {
-		return v, errors.Errorf("Leaf predicate:'%v' must be a scalar.", attr)
+	tid := types.TypeID(tv.ValType)
+	if !tid.IsScalar() {
+		return types.Val{}, errors.Errorf("Leaf predicate:'%v' must be a scalar.", attr)
 	}
 
 	// creates appropriate type from binary format
-	sv, err := types.Convert(v, v.Tid)
+	sv, err := types.Convert(types.Val{Tid: types.BinaryID, Value: tv.Val}, tid)
 	if err != nil {
 		// This can happen when a mutation ingests corrupt data into the database.
-		return v, errors.Wrapf(err, "error interpreting appropriate type for %v", attr)
+		return types.Val{}, errors.Wrapf(err, "error interpreting appropriate type for %v", attr)
 	}
 	return sv, nil
 }

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -35,7 +35,7 @@ import (
 
 // Convert converts the value to given scalar type.
 func Convert(from Val, toID TypeID) (Val, error) {
-	var to Val = Val{Tid: toID}
+	to := Val{Tid: toID}
 
 	// sanity: we expect a value
 	data, ok := from.Value.([]byte)

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"strconv"
 	"time"
+	"unsafe"
 
 	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
@@ -34,14 +35,14 @@ import (
 
 // Convert converts the value to given scalar type.
 func Convert(from Val, toID TypeID) (Val, error) {
-	var to Val
+	var to Val = Val{Tid: toID}
 
 	// sanity: we expect a value
 	data, ok := from.Value.([]byte)
 	if !ok {
 		return to, errors.Errorf("Invalid data to convert to %s", toID.Name())
 	}
-	to = ValueForType(toID)
+
 	fromID := from.Tid
 	res := &to.Value
 
@@ -54,7 +55,7 @@ func Convert(from Val, toID TypeID) (Val, error) {
 			case BinaryID:
 				*res = data
 			case StringID, DefaultID:
-				*res = string(data)
+				*res = *(*string)(unsafe.Pointer(&data))
 			case IntID:
 				if len(data) < 8 {
 					return to, errors.Errorf("Invalid data for int64 %v", data)

--- a/types/conversion.go
+++ b/types/conversion.go
@@ -55,6 +55,7 @@ func Convert(from Val, toID TypeID) (Val, error) {
 			case BinaryID:
 				*res = data
 			case StringID, DefaultID:
+				// We never modify from Val, so this should be safe.
 				*res = *(*string)(unsafe.Pointer(&data))
 			case IntID:
 				if len(data) < 8 {

--- a/worker/task.go
+++ b/worker/task.go
@@ -1897,20 +1897,15 @@ func applyFacetsTree(postingFacets []*api.Facet, ftree *facetsTree) (bool, error
 		fnType, fname := parseFuncTypeHelper(fname)
 		switch fnType {
 		case compareAttrFn: // lt, gt, le, ge, eq
-			var err error
-			typId, err := facets.TypeIDFor(fc)
+			fVal, err := facets.ValFor(fc)
 			if err != nil {
 				return false, err
 			}
 
-			v, err := types.Convert(ftree.function.val, typId)
+			v, err := types.Convert(ftree.function.val, fVal.Tid)
 			if err != nil {
 				// ignore facet if not of appropriate type
 				return false, nil
-			}
-			fVal, err := facets.ValFor(fc)
-			if err != nil {
-				return false, err
 			}
 
 			return types.CompareVals(fname, fVal, v), nil
@@ -1928,7 +1923,7 @@ func applyFacetsTree(postingFacets []*api.Facet, ftree *facetsTree) (bool, error
 		return false, errors.Errorf("Fn %s not supported in facets filtering.", fname)
 	}
 
-	var res []bool
+	res := make([]bool, 0, 2)
 	for _, c := range ftree.children {
 		r, err := applyFacetsTree(postingFacets, c)
 		if err != nil {

--- a/worker/task.go
+++ b/worker/task.go
@@ -1989,12 +1989,15 @@ func filterOnStandardFn(fname string, fcTokens []string, argTokens []string) (bo
 }
 
 type facetsFunc struct {
-	name       string
-	key        string
-	args       []string
-	tokens     []string
-	val        types.Val
-	fnType     FuncType
+	name   string
+	key    string
+	args   []string
+	tokens []string
+	val    types.Val
+	fnType FuncType
+	// typesToVal stores converted vals of the function val for all common types. Converting
+	// function val to particular type val(check applyFacetsTree()) consumes significant amount of
+	// time. This maps helps in doing conversion only once(check preprocessFilter()).
 	typesToVal map[types.TypeID]types.Val
 }
 type facetsTree struct {


### PR DESCRIPTION
This PR tries to optimize queries with facets filter. It has following changes:

- Improving `applyFacetsTree` function by avoiding some multiple call to `parseFuncTypeHelper` and
conversion calls to `ftree.function.val`
- Minor optimizations in `types.Convert`
- Minor optimizations in `valToBytes`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4923)
<!-- Reviewable:end -->
