### PR TITLE
Allow uid access

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -671,7 +671,7 @@ func parsePredsFromQuery(gqls []*gql.GraphQuery) []string {
 		if gq.Func != nil {
 			predsMap[gq.Func.Attr] = struct{}{}
 		}
-		if len(gq.Attr) > 0 {
+		if len(gq.Attr) > 0 && gq.Attr != "uid" {
 			predsMap[gq.Attr] = struct{}{}
 		}
 		for _, ord := range gq.Order {

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1078,29 +1078,6 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			testutil.CompareJSON(t, tc.output, string(resp.Json))
 		})
 	}
-
-	require.NoError(t, testutil.AssignUids(101))
-	mutation = &api.Mutation{
-		SetNquads: []byte(`
-			<100> <name> "100th User" .
-			<100> <age> "100" .
-		`),
-		CommitNow: true,
-	}
-	_, err = dg.NewTxn().Mutate(ctx, mutation)
-	require.NoError(t, err)
-	uidQuery := `
-	{
-		me(func: uid(100)) {
-			uid
-			name
-			age
-		}
-	}
-	`
-	resp, err := userClient.NewReadOnlyTxn().Query(ctx, uidQuery)
-	require.Nil(t, err)
-	testutil.CompareJSON(t, `{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson()))
 }
 
 func TestNewACLPredicates(t *testing.T) {
@@ -1895,4 +1872,61 @@ func TestAddUpdateGroupWithDuplicateRules(t *testing.T) {
 
 	// cleanup
 	deleteGroup(t, grootJwt, groupName)
+}
+
+func TestAllowUIDAccess(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	require.NoError(t, err)
+
+	testutil.DropAll(t, dg)
+	op := api.Operation{Schema: `
+		name	 : string @index(exact) .
+	`}
+	require.NoError(t, dg.Alter(ctx, &op))
+	require.NoError(t, testutil.WaitForAlter(ctx, dg, op.Schema))
+
+	resetUser(t)
+	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint: adminEndpoint,
+		UserID:   "groot",
+		Passwd:   "password",
+	})
+	require.NoError(t, err, "login failed")
+	createGroup(t, accessJwt, devGroup)
+	addToGroup(t, accessJwt, userid, devGroup)
+
+	require.NoError(t, testutil.AssignUids(101))
+	mutation := &api.Mutation{
+		SetNquads: []byte(`
+			<100> <name> "100th User" .
+		`),
+		CommitNow: true,
+	}
+	_, err = dg.NewTxn().Mutate(ctx, mutation)
+	require.NoError(t, err)
+
+	// give read access of <name> to alice
+	addRulesToGroup(t, accessJwt, devGroup, []rule{{"name", Read.Code}})
+
+	userClient, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+	time.Sleep(6 * time.Second)
+
+	err = userClient.Login(ctx, userid, userpassword)
+	require.NoError(t, err)
+
+	uidQuery := `
+	{
+		me(func: uid(100)) {
+			uid
+			name
+		}
+	}
+	`
+
+	resp, err := userClient.NewReadOnlyTxn().Query(ctx, uidQuery)
+	require.Nil(t, err)
+	testutil.CompareJSON(t, `{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson()))
 }

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1078,6 +1078,29 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 			testutil.CompareJSON(t, tc.output, string(resp.Json))
 		})
 	}
+
+	require.NoError(t, testutil.AssignUids(101))
+	mutation = &api.Mutation{
+		SetNquads: []byte(`
+			<100> <name> "100th User" .
+			<100> <age> "100" .
+		`),
+		CommitNow: true,
+	}
+	_, err = dg.NewTxn().Mutate(ctx, mutation)
+	require.NoError(t, err)
+	uidQuery := `
+	{
+		me(func: uid(100)) {
+			uid
+			name
+			age
+		}
+	}
+	`
+	resp, err := userClient.NewReadOnlyTxn().Query(ctx, uidQuery)
+	require.Nil(t, err)
+	testutil.CompareJSON(t, `{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson()))
 }
 
 func TestNewACLPredicates(t *testing.T) {


### PR DESCRIPTION
Internal ref:
* DGRAPH-1101
---
`uid` in query was being blocked during authorization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4924)
<!-- Reviewable:end -->
