### PR TITLE
Handle special characters in schema and type queries.

### DIFF
--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -1801,6 +1801,34 @@ func TestParseSchemaTypeMulti(t *testing.T) {
 	require.Equal(t, len(res.Schema.Fields), 0)
 }
 
+func TestParseSchemaSpecialChars(t *testing.T) {
+	query := `
+		schema (pred: [Person, <人物>]) {
+		}
+	`
+	res, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+	require.Equal(t, len(res.Schema.Predicates), 2)
+	require.Equal(t, len(res.Schema.Types), 0)
+	require.Equal(t, res.Schema.Predicates[0], "Person")
+	require.Equal(t, res.Schema.Predicates[1], "人物")
+	require.Equal(t, len(res.Schema.Fields), 0)
+}
+
+func TestParseSchemaTypeSpecialChars(t *testing.T) {
+	query := `
+		schema (type: [Person, <人物>]) {
+		}
+	`
+	res, err := Parse(Request{Str: query})
+	require.NoError(t, err)
+	require.Equal(t, len(res.Schema.Predicates), 0)
+	require.Equal(t, len(res.Schema.Types), 2)
+	require.Equal(t, res.Schema.Types[0], "Person")
+	require.Equal(t, res.Schema.Types[1], "人物")
+	require.Equal(t, len(res.Schema.Fields), 0)
+}
+
 func TestParseSchemaError(t *testing.T) {
 	query := `
 		schema () {

--- a/gql/state.go
+++ b/gql/state.go
@@ -253,6 +253,8 @@ func lexInsideSchema(l *lex.Lexer) lex.StateFn {
 			l.Emit(itemRightSquare)
 		case isSpace(r) || lex.IsEndOfLine(r):
 			l.Ignore()
+		case r == lsThan:
+			return lexIRIRef
 		case isNameBegin(r):
 			return lexArgName
 		case r == '#':


### PR DESCRIPTION
Special predicate names (i.e using Chinese characters) need to be
wrapped around "<" and ">" brackets but the lexer does not currently
support that. This PR adds support for that syntax.

Fixes #4933

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4937)
<!-- Reviewable:end -->
