### PR TITLE
contrib: Update version name for Docker master tag.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -91,7 +91,7 @@ pushd $basedir/dgraph
   lastCommitSHA1=$(git rev-parse --short HEAD)
   gitBranch=$(git rev-parse --abbrev-ref HEAD)
   lastCommitTime=$(git log -1 --format=%ci)
-  release_version=$TAG
+  release_version=$(git describe --always --tags)
 popd
 
 # Regenerate protos. Should not be different from what's checked in.


### PR DESCRIPTION
Fixes #4934.

This changes the Dgraph version string for the Docker master branch builds from `master` to a commit-ish version string like `v1.2.1-8-g0a0d273a7`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4938)
<!-- Reviewable:end -->
