### PR TITLE
Set version when rollup is called with no splits.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -946,10 +946,10 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		}
 	}
 
+	out.newMinTs = maxCommitTs
 	if split {
 		// Check if the list (or any of it's parts if it's been previously split) have
 		// become too big. Split the list if that is the case.
-		out.newMinTs = maxCommitTs
 		out.recursiveSplit()
 		out.removeEmptySplits()
 	} else {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4945)
<!-- Reviewable:end -->
