### PR TITLE
Fix point-in-time Prometheus metrics.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -791,8 +791,6 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode)
 
 	span.Annotatef(nil, "Request received: %v", req)
 	if isQuery {
-		v := x.TagValueStatusOK
-		ctx, _ = tag.New(ctx, tag.Upsert(x.KeyStatus, v))
 		ostats.Record(ctx, x.PendingQueries.M(1), x.NumQueries.M(1))
 		defer func() {
 			measurements = append(measurements, x.PendingQueries.M(-1))
@@ -803,6 +801,9 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode)
 	}
 
 	defer func() {
+		// Tag "ok" or "error" status after measurements since the accumulative
+		// metrics don't need the status key. The status is useful for the
+		// request latency metrics.
 		v := x.TagValueStatusOK
 		if rerr != nil {
 			v = x.TagValueStatusError

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -802,8 +802,6 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode)
 		ostats.Record(ctx, x.NumMutations.M(1))
 	}
 
-	isGraphQL, _ := ctx.Value(isGraphQL).(bool)
-
 	defer func() {
 		v := x.TagValueStatusOK
 		if rerr != nil {

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -105,6 +105,8 @@ var (
 		20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500,
 		650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
 
+	// Use this tag for the metric view if it needs status or method granularity.
+	// Metrics would be viewed separately for different tag values.
 	allTagKeys = []tag.Key{
 		KeyStatus, KeyMethod,
 	}
@@ -152,14 +154,14 @@ var (
 			Measure:     PendingQueries,
 			Description: PendingQueries.Description(),
 			Aggregation: view.Sum(),
-			TagKeys:     allTagKeys,
+			TagKeys:     nil,
 		},
 		{
 			Name:        PendingProposals.Name(),
 			Measure:     PendingProposals,
 			Description: PendingProposals.Description(),
 			Aggregation: view.LastValue(),
-			TagKeys:     allTagKeys,
+			TagKeys:     nil,
 		},
 		{
 			Name:        MemoryInUse.Name(),
@@ -187,14 +189,14 @@ var (
 			Measure:     ActiveMutations,
 			Description: ActiveMutations.Description(),
 			Aggregation: view.Sum(),
-			TagKeys:     allTagKeys,
+			TagKeys:     nil,
 		},
 		{
 			Name:        AlphaHealth.Name(),
 			Measure:     AlphaHealth,
 			Description: AlphaHealth.Description(),
 			Aggregation: view.LastValue(),
-			TagKeys:     allTagKeys,
+			TagKeys:     nil,
 		},
 	}
 )

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -151,14 +151,14 @@ var (
 			Name:        PendingQueries.Name(),
 			Measure:     PendingQueries,
 			Description: PendingQueries.Description(),
-			Aggregation: view.LastValue(),
+			Aggregation: view.Sum(),
 			TagKeys:     allTagKeys,
 		},
 		{
 			Name:        PendingProposals.Name(),
 			Measure:     PendingProposals,
 			Description: PendingProposals.Description(),
-			Aggregation: view.LastValue(),
+			Aggregation: view.Sum(),
 			TagKeys:     allTagKeys,
 		},
 		{
@@ -186,7 +186,7 @@ var (
 			Name:        ActiveMutations.Name(),
 			Measure:     ActiveMutations,
 			Description: ActiveMutations.Description(),
-			Aggregation: view.LastValue(),
+			Aggregation: view.Sum(),
 			TagKeys:     allTagKeys,
 		},
 		{

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -158,7 +158,7 @@ var (
 			Name:        PendingProposals.Name(),
 			Measure:     PendingProposals,
 			Description: PendingProposals.Description(),
-			Aggregation: view.Sum(),
+			Aggregation: view.LastValue(),
 			TagKeys:     allTagKeys,
 		},
 		{


### PR DESCRIPTION
Fixes #4532.

The metrics for pending queries, active mutations, and pending proposals would report only "1" or "-1" because the metrics view was set to LastValue. This change fixes this by changing the view to a Sum so measurements of "1" and "-1" would accumulate the metrics as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4948)
<!-- Reviewable:end -->
