### PR TITLE
tests: Fix flaky bulk loader systest.

### DIFF
--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -243,7 +243,7 @@ StopServers
 
 popd >/dev/null
 
-INFO "verifing schema is same before export and after bulk import"
+INFO "verifying schema is same before export and after bulk import"
 diff -b dir1/schema.out dir2/schema.out || FATAL "schema incorrect"
 INFO "schema is correct"
 

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -212,7 +212,7 @@ EOF
 
 function StopServers
 {
-  INFO "stoping containers"
+  INFO "stopping containers"
   DockerCompose -f $DOCKER_CONF down
 }
 

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -11,6 +11,10 @@ INFO()  { echo "$ME: $@";     }
 ERROR() { echo >&2 "$ME: $@"; }
 FATAL() { ERROR "$@"; exit 1; }
 
+function DockerCompose {
+    docker-compose -p dgraph "$@"
+}
+
 set -e
 
 INFO "rebuilding dgraph"
@@ -45,7 +49,7 @@ function ErrorExit
 function StartZero
 {
   INFO "starting zero container"
-  docker-compose -f $DOCKER_CONF up --force-recreate --detach zero1
+  DockerCompose -f $DOCKER_CONF up --force-recreate --detach zero1
   TIMEOUT=10
   while [[ $TIMEOUT > 0 ]]; do
     if docker logs zero1 2>&1 | grep -q 'CID set'; then
@@ -63,11 +67,11 @@ function StartAlpha
   local p_dir=$1
 
   INFO "starting alpha container"
-  docker-compose -f $DOCKER_CONF up --force-recreate --no-start alpha1
+  DockerCompose -f $DOCKER_CONF up --force-recreate --no-start alpha1
   if [[ $p_dir ]]; then
     docker cp $p_dir alpha1:/data/alpha1/
   fi
-  docker-compose -f $DOCKER_CONF up --detach alpha1
+  DockerCompose -f $DOCKER_CONF up --detach alpha1
 
   TIMEOUT=10
   while [[ $TIMEOUT > 0 ]]; do
@@ -84,7 +88,7 @@ function StartAlpha
 function ResetCluster
 {
     INFO "restarting cluster with only one zero and alpha"
-    docker-compose -f $DOCKER_CONF down
+    DockerCompose -f $DOCKER_CONF down
     StartZero
     StartAlpha
 }
@@ -209,7 +213,7 @@ EOF
 function StopServers
 {
   INFO "stoping containers"
-  docker-compose -f $DOCKER_CONF down
+  DockerCompose -f $DOCKER_CONF down
 }
 
 function Cleanup

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -102,6 +102,10 @@ predicate_with_default_type:default  .
 predicate_with_index_no_uid_count:string @index(exact) .
 ' &>/dev/null
 
+  # Wait for background indexing to finish.
+  # TODO: Use better way of waiting once it's available.
+  sleep 5
+
   curl -H "Content-Type: application/rdf" localhost:$HTTP_PORT/mutate?commitNow=true -X POST -d $'
 {
   set {


### PR DESCRIPTION
This fixes flaky tests with the following changes:

* Use the same "dgraph" Docker Compose project as the other tests.
* Wait for background indexing to finish (introduced in #4819).

test-bulk-schema.sh was creating its Dgraph cluster using its own Docker Compose project, which doesn't work nicely with the other custom cluster tests which all utilize the same "dgraph" project name. Using the same name allows Docker Compose to cleanly recreate or delete containers. This change makes test-bulk-schema.sh use the same "dgraph" project.

Because Dgraph re-indexes in the background, the test must wait for the update to finish to properly compare the schema before and after. Otherwise, this error in the test can happen:

```
test-bulk-schema.sh: verifying schema is same before export and after bulk import
[00:23:41][./dgraph/cmd/bulk/systest/test-bulk-schema.sh] [Test Error Output]
test-bulk-schema.sh: schema incorrect
test-bulk-schema.sh: *** unexpected error ***
[00:23:41][./dgraph/cmd/bulk/systest/test-bulk-schema.sh] [Test Output]
7a8
>       "index": true, 
8a10,12
>       "tokenizer": [
>         "exact"
>       ], 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4953)
<!-- Reviewable:end -->
