### PR TITLE
Fix typo in export.go

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -334,7 +334,7 @@ func fieldToString(update *pb.SchemaUpdate) string {
 	var builder strings.Builder
 	x.Check2(builder.WriteString("\t"))
 	// While exporting type definitions, "<" and ">" brackets must be written around
-	// the name of everse predicates or Dgraph won't be able to parse the exported schema.
+	// the name of reverse predicates or Dgraph won't be able to parse the exported schema.
 	if strings.HasPrefix(update.Predicate, "~") {
 		x.Check2(builder.WriteString("<"))
 		x.Check2(builder.WriteString(update.Predicate))


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4955)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-247488f60a-49206.surge.sh)
<!-- Dgraph:end -->