### PR TITLE
Split lists in the bulk loader.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -806,6 +806,11 @@ func (l *List) Rollup() ([]*bpb.KV, error) {
 		}
 		kvs = append(kvs, kv)
 	}
+	// Sort the KVs by their key so that the main part of the list is at the
+	// start of the list and all other parts appear in the order of their start UID.
+	sort.Slice(kvs, func(i, j int) bool {
+		return bytes.Compare(kvs[i].Key, kvs[j].Key) <= 0
+	})
 
 	return kvs, nil
 }


### PR DESCRIPTION
The equivalent of PR #4875 for the 1.2 branch. The original change
cannot be cherry-picked because there are other changes to the bulk
loader that are not included in this branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4967)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0f406885e2-49168.surge.sh)
<!-- Dgraph:end -->