### PR TITLE
Cherry-pick "Throw errors returned by retrieveValuesAndFacets"

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -401,7 +401,11 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 
 			vals, fcs, err := retrieveValuesAndFacets(args, pl, facetsTree, listType)
 			switch {
-			case err == posting.ErrNoValue || len(vals) == 0:
+			case err == posting.ErrNoValue || (err == nil && len(vals) == 0):
+				// This branch is taken when the value does not exist in the pl or
+				// the number of values retreived is zero (there could still be facets).
+				// We add empty lists to the UidMatrix, FaceMatrix, ValueMatrix and
+				// LangMatrix so that all these data structure have predicatble layouts.
 				out.UidMatrix = append(out.UidMatrix, &pb.List{})
 				out.FacetMatrix = append(out.FacetMatrix, &pb.FacetsList{})
 				out.ValueMatrix = append(out.ValueMatrix,


### PR DESCRIPTION
The error was being ignored and an empty response was being written because the
condition in a case statement didn't exclude errors not equal to nil or ErrNoValue.

This caused reads below the rollup Ts to succeed with an empty response when
they should throw an error. The bug was triggered by running Jepsen tests with
incremental rollups enabled.

Fixes #4958

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4970)
<!-- Reviewable:end -->
