### PR TITLE
Allow Alter requests to wait a bit before rejecting them

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -109,7 +109,7 @@ func runJSONMutation(m string) error {
 func alterSchema(s string) error {
 	for {
 		_, _, err := runWithRetries("PUT", "", addr+"/alter", s)
-		if err != nil && strings.Contains(err.Error(), "is already being modified") {
+		if err != nil && strings.Contains(err.Error(), "errIndexingInProgress") {
 			time.Sleep(time.Second)
 			continue
 		} else if err != nil {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -88,7 +88,7 @@ var (
 )
 
 var (
-	errIndexingInProgress = errors.New("indexing is in progress. Please retry later")
+	errIndexingInProgress = errors.New("errIndexingInProgress: Please retry later")
 )
 
 // Server implements protos.DgraphServer

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -88,7 +88,7 @@ var (
 )
 
 var (
-	errIndexingInProgress = errors.New("schema is already being modified. Please retry")
+	errIndexingInProgress = errors.New("indexing is in progress. Please retry later")
 )
 
 // Server implements protos.DgraphServer
@@ -245,8 +245,16 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	}
 
 	// If a background task is already running, we should reject all the new alter requests.
-	if schema.State().IndexingInProgress() {
-		return nil, errIndexingInProgress
+	const numTries = 3
+	for i := 0; i < numTries; i++ {
+		if !schema.State().IndexingInProgress() {
+			break
+		} else if i == numTries-1 {
+			return nil, errIndexingInProgress
+		}
+		// Let's wait a bit to see if some really simple indexing tasks can finish before we reject
+		// this request.
+		time.Sleep(time.Second)
 	}
 
 	for _, update := range result.Preds {

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -111,7 +111,7 @@ func TestParallelIndexing(t *testing.T) {
 			balance_int: int @index(int) .
 			balance_str: string @index(fulltext, term, exact) .
 		`,
-	}); err != nil && !strings.Contains(err.Error(), "is already being modified") {
+	}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
 		t.Fatalf("error in adding indexes :: %v\n", err)
 	}
 
@@ -119,7 +119,7 @@ func TestParallelIndexing(t *testing.T) {
 	for {
 		if err := dg.Alter(context.Background(), &api.Operation{
 			Schema: `balance_float: float @index(float) .`,
-		}); err != nil && !strings.Contains(err.Error(), "is already being modified") {
+		}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
 			t.Fatalf("error in adding indexes :: %v\n", err)
 		} else if err == nil {
 			break


### PR DESCRIPTION
Adding a 3s delay allows simple background indexing tasks to finish, thereby reducing the chance of an Alter request failing. The 3s delay can later be increase to up to 10s -- Alter isn't the critical path. This helps with Jepsen test stability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4977)
<!-- Reviewable:end -->
