### PR TITLE
contrib: Use go1.14.1 for release builds.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -23,7 +23,7 @@ mkdir $GOPATH
 PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
-GOVERSION="1.13.5"
+GOVERSION="1.14.1"
 
 # Turn off go modules by default. Only enable go modules when needed.
 export GO111MODULE=off


### PR DESCRIPTION
Starting with v20.03, Dgraph builds will be built using go1.14.1.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/4984)
<!-- Reviewable:end -->
