### PR TITLE
Remove changes in tests for background indexing PR

### DIFF
--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -87,7 +87,6 @@ func (exp *Experiment) verify() {
 	require.NoError(exp.t, dg.Alter(ctx, &api.Operation{DropAll: true}), "drop all failed")
 	require.NoError(exp.t, dg.Alter(ctx, &api.Operation{Schema: exp.schema}),
 		"schema change failed")
-	require.NoError(exp.t, testutil.WaitForAlter(ctx, dg, exp.schema))
 
 	_, err = dg.NewTxn().Mutate(ctx,
 		&api.Mutation{Set: exp.nqs, CommitNow: true})

--- a/contrib/integration/acctupsert/main.go
+++ b/contrib/integration/acctupsert/main.go
@@ -92,9 +92,6 @@ func setup(c *dgo.Dgraph) {
 		`,
 	}
 	x.Check(c.Alter(ctx, op))
-	if err := testutil.WaitForAlter(ctx, c, op.Schema); err != nil {
-		x.Check(err)
-	}
 }
 
 func doUpserts(c *dgo.Dgraph) {

--- a/contrib/integration/testtxn/main_test.go
+++ b/contrib/integration/testtxn/main_test.go
@@ -371,9 +371,6 @@ func TestIgnoreIndexConflict(t *testing.T) {
 	if err := s.dg.Alter(context.Background(), op); err != nil {
 		log.Fatal(err)
 	}
-	if err := testutil.WaitForAlter(context.Background(), s.dg, op.Schema); err != nil {
-		log.Fatal(err)
-	}
 
 	txn := s.dg.NewTxn()
 	mu := &api.Mutation{}
@@ -425,9 +422,6 @@ func TestReadIndexKeySameTxn(t *testing.T) {
 	op = &api.Operation{}
 	op.Schema = `name: string @index(exact) .`
 	if err := s.dg.Alter(context.Background(), op); err != nil {
-		log.Fatal(err)
-	}
-	if err := testutil.WaitForAlter(context.Background(), s.dg, op.Schema); err != nil {
 		log.Fatal(err)
 	}
 
@@ -940,5 +934,4 @@ func TestTxnDiscardBeforeCommit(t *testing.T) {
 func alterSchema(dg *dgo.Dgraph, schema string) {
 	op := api.Operation{Schema: schema}
 	x.Check(dg.Alter(ctxb, &op))
-	x.Check(testutil.WaitForAlter(ctxb, dg, schema))
 }

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -57,7 +57,7 @@ func runGzipWithRetry(contentType, url string, buf io.Reader, gzReq, gzResp bool
 	*http.Response, error) {
 
 	client := &http.Client{}
-	numRetries := 3
+	numRetries := 2
 
 	var resp *http.Response
 	var err error

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -206,35 +206,35 @@ func checkSchema(t *testing.T, query, key string) {
 func TestBgIndexSchemaReverse(t *testing.T) {
 	require.NoError(t, dropAll())
 	q1 := `schema(pred: [value]) {}`
-	require.NoError(t, alterSchema(`value: [uid] .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] .`))
 	checkSchema(t, q1, "list")
-	require.NoError(t, alterSchema(`value: [uid] @count @reverse .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] @count @reverse .`))
 	checkSchema(t, q1, "reverse")
 }
 
 func TestBgIndexSchemaTokenizers(t *testing.T) {
 	require.NoError(t, dropAll())
 	q1 := `schema(pred: [value]) {}`
-	require.NoError(t, alterSchema(`value: string @index(fulltext, hash) .`))
+	require.NoError(t, alterSchemaInBackground(`value: string @index(fulltext, hash) .`))
 	checkSchema(t, q1, "fulltext")
-	require.NoError(t, alterSchema(`value: string @index(term, hash) @upsert .`))
+	require.NoError(t, alterSchemaInBackground(`value: string @index(term, hash) @upsert .`))
 	checkSchema(t, q1, "term")
 }
 
 func TestBgIndexSchemaCount(t *testing.T) {
 	require.NoError(t, dropAll())
 	q1 := `schema(pred: [value]) {}`
-	require.NoError(t, alterSchema(`value: [uid] @count .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] @count .`))
 	checkSchema(t, q1, "count")
-	require.NoError(t, alterSchema(`value: [uid] @reverse .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] @reverse .`))
 	checkSchema(t, q1, "reverse")
 }
 
 func TestBgIndexSchemaReverseAndCount(t *testing.T) {
 	require.NoError(t, dropAll())
 	q1 := `schema(pred: [value]) {}`
-	require.NoError(t, alterSchema(`value: [uid] @reverse .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] @reverse .`))
 	checkSchema(t, q1, "reverse")
-	require.NoError(t, alterSchema(`value: [uid] @count .`))
+	require.NoError(t, alterSchemaInBackground(`value: [uid] @count .`))
 	checkSchema(t, q1, "count")
 }

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -278,12 +278,11 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	m.Types = result.Types
 	_, err = query.ApplyMutations(ctx, m)
 
-	// wait for indexing to complete.
+	// wait for indexing to complete or context to be canceled.
 	for !op.RunInBackground {
-		if !schema.State().IndexingInProgress() {
+		if !schema.State().IndexingInProgress() || ctx.Err() != nil {
 			break
 		}
-
 		time.Sleep(time.Second * 2)
 	}
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -239,6 +239,11 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		return empty, err
 	}
 
+	// If a background task is already running, we should reject all the new alter requests.
+	if schema.State().IndexingInProgress() {
+		return nil, errIndexingInProgress
+	}
+
 	result, err := schema.Parse(op.Schema)
 	if err != nil {
 		return empty, err

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1885,7 +1885,6 @@ func TestAllowUIDAccess(t *testing.T) {
 		name	 : string @index(exact) .
 	`}
 	require.NoError(t, dg.Alter(ctx, &op))
-	require.NoError(t, testutil.WaitForAlter(ctx, dg, op.Schema))
 
 	resetUser(t)
 	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -35,10 +35,6 @@ func setSchema(schema string) {
 	if err != nil {
 		panic(fmt.Sprintf("Could not alter schema. Got error %v", err.Error()))
 	}
-
-	if err := testutil.WaitForAlter(context.Background(), client, schema); err != nil {
-		panic(err)
-	}
 }
 
 func dropPredicate(pred string) {

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -9269,15 +9269,6 @@ func Test1Million(t *testing.T) {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
 
-	schemaFile := os.Getenv("SCHEMA_FILE")
-	data, err := ioutil.ReadFile(schemaFile)
-	if err != nil {
-		t.Fatalf("Error in reading the schema: %v", err)
-	}
-	if err := testutil.WaitForAlter(context.Background(), dg, string(data)); err != nil {
-		t.Fatalf("Error in waiting for alter to complete: %v", err)
-	}
-
 	for _, tt := range tc {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 		resp, err := dg.NewTxn().Query(ctx, tt.query)

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -20,8 +20,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 

--- a/systest/1million/test-reindex.sh
+++ b/systest/1million/test-reindex.sh
@@ -68,7 +68,6 @@ if [[ ! -z "$TEAMCITY_VERSION" ]]; then
 fi
 
 Info "running regression queries"
-export SCHEMA_FILE
 go test -v -tags systest || FOUND_DIFFS=1
 
 Info "bringing down zero and alpha and data volumes"

--- a/systest/bgindex/common_test.go
+++ b/systest/bgindex/common_test.go
@@ -42,7 +42,7 @@ func printStats(counter *uint64, quit <-chan struct{}, wg *sync.WaitGroup) {
 }
 
 // blocks until query returns no error.
-func checkSchemaUpdate(query string, dg *dgo.Dgraph) {
+func waitForSchemaUpdate(query string, dg *dgo.Dgraph) {
 	for {
 		time.Sleep(2 * time.Second)
 		_, err := dg.NewReadOnlyTxn().Query(context.Background(), query)

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -163,7 +163,7 @@ func TestCountIndex(t *testing.T) {
 		go runLoop()
 	}
 	go printStats(&counter, quit, &swg)
-	checkSchemaUpdate(`{ q(func: eq(count(value), "3")) {uid}}`, dg)
+	waitForSchemaUpdate(`{ q(func: eq(count(value), "3")) {uid}}`, dg)
 	close(quit)
 	swg.Wait()
 	fmt.Println("mutations done")

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -132,8 +132,7 @@ func TestParallelIndexing(t *testing.T) {
 	}
 
 	fmt.Println("waiting for float indexing to complete")
-	s := `balance_float: float @index(float) .`
-	testutil.WaitForAlter(context.Background(), dg, s)
+	waitForSchemaUpdate(`{ q(func: eq(balance_float, "2.0")) {uid}}`, dg)
 
 	// balance should be same as uid.
 	checkBalance := func(b int, pred string) error {

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -154,7 +154,7 @@ func TestReverseIndex(t *testing.T) {
 		go runLoop()
 	}
 	go printStats(&counter, quit, &swg)
-	checkSchemaUpdate(`{ q(func: uid(0x01)) { ~balance { uid }}}`, dg)
+	waitForSchemaUpdate(`{ q(func: uid(0x01)) { ~balance { uid }}}`, dg)
 	close(quit)
 	swg.Wait()
 	fmt.Println("mutations done")

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -154,7 +154,7 @@ func TestStringIndex(t *testing.T) {
 		go runLoop()
 	}
 	go printStats(&counter, quit, &swg)
-	checkSchemaUpdate(`{ q(func: anyoftext(balance, "example")) {uid}}`, dg)
+	waitForSchemaUpdate(`{ q(func: anyoftext(balance, "example")) {uid}}`, dg)
 	close(quit)
 	swg.Wait()
 	fmt.Println("mutations done")

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -175,7 +175,6 @@ func NQuadMutationTest(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `xid: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	assigned, err := txn.Mutate(ctx, &api.Mutation{
@@ -252,7 +251,6 @@ func DeleteAllReverseIndex(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: "link: [uid] @reverse ."}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	assignedIds, err := c.NewTxn().Mutate(ctx, &api.Mutation{
 		CommitNow: true,
 		SetNquads: []byte("_:a <link> _:b ."),
@@ -301,7 +299,6 @@ func NormalizeEdgeCasesTest(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: "xid: string @index(exact) ."}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	_, err := c.NewTxn().Mutate(ctx, &api.Mutation{
 		CommitNow: true,
@@ -380,7 +377,6 @@ func FacetOrderTest(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -454,7 +450,6 @@ func LangAndSortBugTest(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: "name: string @index(exact) @lang ."}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -550,7 +545,6 @@ func SchemaAfterDeleteNode(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: "married: bool ."}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	assigned, err := txn.Mutate(ctx, &api.Mutation{
@@ -605,7 +599,6 @@ func FullTextEqual(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: "text: string @index(fulltext) ."}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	texts := []string{"bat man", "aqua man", "bat cave", "bat", "man", "aqua", "cave"}
 	var rdfs bytes.Buffer
@@ -675,7 +668,6 @@ func ScalarToList(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `pred: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	uids, err := c.NewTxn().Mutate(ctx, &api.Mutation{
 		SetNquads: []byte(`_:blank <pred> "first" .`),
@@ -697,7 +689,6 @@ func ScalarToList(t *testing.T, c *dgo.Dgraph) {
 
 	op = &api.Operation{Schema: `pred: [string] @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	resp, err = c.NewTxn().Query(ctx, q)
 	require.NoError(t, err)
 	require.Equal(t, `{"me":[{"pred":["first"]}]}`, string(resp.Json))
@@ -765,7 +756,6 @@ func ListToScalar(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `pred: [string] @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	err := c.Alter(ctx, &api.Operation{Schema: `pred: string @index(exact) .`})
 	require.Error(t, err)
@@ -774,7 +764,6 @@ func ListToScalar(t *testing.T, c *dgo.Dgraph) {
 	require.NoError(t, c.Alter(ctx, &api.Operation{DropAttr: `pred`}))
 	op = &api.Operation{Schema: `pred: string @index(exact) .`}
 	err = c.Alter(ctx, op)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	require.NoError(t, err)
 }
 
@@ -831,7 +820,6 @@ func EmptyNamesWithExact(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 	op := &api.Operation{Schema: `name: string @index(exact) @lang .`}
 	err := c.Alter(ctx, op)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	require.NoError(t, err)
 
 	_, err = c.NewTxn().Mutate(ctx, &api.Mutation{
@@ -866,7 +854,6 @@ func EmptyRoomsWithTermIndex(t *testing.T, c *dgo.Dgraph) {
 	`
 	ctx := context.Background()
 	err := c.Alter(ctx, op)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	require.NoError(t, err)
 
 	_, err = c.NewTxn().Mutate(ctx, &api.Mutation{
@@ -1052,7 +1039,6 @@ func HasWithDash(t *testing.T, c *dgo.Dgraph) {
 		Schema: `name: string @index(hash) .`,
 	}
 	check(t, (c.Alter(ctx, op)))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -1092,7 +1078,6 @@ func ListGeoFilterTest(t *testing.T, c *dgo.Dgraph) {
 		`,
 	}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
@@ -1141,7 +1126,6 @@ func ListRegexFilterTest(t *testing.T, c *dgo.Dgraph) {
 		`,
 	}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
@@ -1190,7 +1174,6 @@ func RegexQueryWithVars(t *testing.T, c *dgo.Dgraph) {
 		`,
 	}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
@@ -1235,7 +1218,6 @@ func GraphQLVarChild(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
@@ -1337,7 +1319,6 @@ func MathGe(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
@@ -1477,7 +1458,6 @@ func HasReverseEdge(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `follow: [uid] @reverse .`}
 	check(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	txn := c.NewTxn()
 	defer txn.Discard(ctx)
 
@@ -1583,7 +1563,6 @@ func DropData(t *testing.T, c *dgo.Dgraph) {
 		`,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -1679,7 +1658,6 @@ func ReverseCountIndex(t *testing.T, c *dgo.Dgraph) {
 
 	ctx := context.Background()
 	err := c.Alter(ctx, op)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	require.NoError(t, err)
 
 	mu := &api.Mutation{
@@ -1779,7 +1757,6 @@ func TypePredicateCheck(t *testing.T, c *dgo.Dgraph) {
 	}`
 	ctx = context.Background()
 	err = c.Alter(ctx, op)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 	require.NoError(t, err)
 }
 
@@ -1888,7 +1865,6 @@ func OverwriteUidPredicates(t *testing.T, c *dgo.Dgraph) {
 	}
 	err := c.Alter(ctx, op)
 	require.NoError(t, err)
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err = txn.Mutate(context.Background(), &api.Mutation{

--- a/systest/plugin_test.go
+++ b/systest/plugin_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/tok"
 )
 
 func TestPlugins(t *testing.T) {
@@ -81,7 +80,6 @@ func TestPlugins(t *testing.T) {
 		check(t, cluster.client.Alter(ctx, &api.Operation{
 			Schema: initialSchema,
 		}))
-		check(t, testutil.WaitForAlter(ctx, cluster.client, initialSchema))
 
 		txn := cluster.client.NewTxn()
 		_, err = txn.Mutate(ctx, &api.Mutation{SetJson: []byte(setJSON)})
@@ -94,11 +92,6 @@ func TestPlugins(t *testing.T) {
 			check(t, err)
 			testutil.CompareJSON(t, test.wantResult, string(reply.GetJson()))
 		}
-	}
-
-	// Need to do this so that schema.Parse in testutil.WaitForAlter doesn't complain.
-	for _, soFile := range soFiles {
-		tok.LoadCustomTokenizer(soFile)
 	}
 
 	suite(

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -72,7 +72,6 @@ func MultipleBlockEval(t *testing.T, c *dgo.Dgraph) {
     `,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -237,7 +236,6 @@ func UnmatchedVarEval(t *testing.T, c *dgo.Dgraph) {
     `,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -324,7 +322,6 @@ func SchemaQueryTest(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -371,7 +368,6 @@ func SchemaQueryTestPredicate1(t *testing.T, c *dgo.Dgraph) {
     `,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -435,7 +431,6 @@ func SchemaQueryTestPredicate2(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -473,7 +468,6 @@ func SchemaQueryTestPredicate3(t *testing.T, c *dgo.Dgraph) {
     `,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -513,7 +507,6 @@ func SchemaQueryTestHTTP(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(exact) .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -585,7 +578,6 @@ func FuzzyMatch(t *testing.T, c *dgo.Dgraph) {
     `,
 	}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -726,7 +718,6 @@ func QueryHashIndex(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(hash) @lang .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -837,7 +828,6 @@ func RegexpToggleTrigramIndex(t *testing.T, c *dgo.Dgraph) {
 
 	op := &api.Operation{Schema: `name: string @index(term) @lang .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	txn := c.NewTxn()
 	_, err := txn.Mutate(ctx, &api.Mutation{
@@ -880,7 +870,6 @@ func RegexpToggleTrigramIndex(t *testing.T, c *dgo.Dgraph) {
 
 	op = &api.Operation{Schema: `name: string @index(trigram) @lang .`}
 	require.NoError(t, c.Alter(ctx, op))
-	require.NoError(t, testutil.WaitForAlter(ctx, c, op.Schema))
 
 	t.Log("testing with trigram index")
 	for _, tc := range tests {

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -332,10 +332,8 @@ func verifyOutput(t *testing.T, bytes []byte, failureConfig *CurlFailureConfig) 
 // the result against the expected output.
 // VerifyCurlCmd executes the curl command with the given arguments and verifies
 // the result against the expected output.
-func VerifyCurlCmd(t *testing.T, args []string,
-	failureConfig *CurlFailureConfig) {
+func VerifyCurlCmd(t *testing.T, args []string, failureConfig *CurlFailureConfig) {
 	queryCmd := exec.Command("curl", args...)
-
 	output, err := queryCmd.Output()
 	if len(failureConfig.CurlErrMsg) > 0 {
 		// the curl command should have returned an non-zero code

--- a/wiki/content/clients/index.md
+++ b/wiki/content/clients/index.md
@@ -572,11 +572,6 @@ type Person {
 
 If all goes well, the response should be `{"code":"Success","message":"Done"}`.
 
-We build indexes in the background so that mutations and queries are not blocked.
-In such a case, the new schema may not be reflected right away. You could poll the
-schema to check whether indexing has been completed. New alter requests will be
-rejected until the background indexing task is finished.
-
 Other operations can be performed via the `/alter` endpoint as well. A specific
 predicate or the entire database can be dropped.
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2140,7 +2140,8 @@ Reverse edges are also computed if specified by a schema mutation.
 
 ### Indexes in Background
 
-Starting Dgraph version `20.3.0`, indexes are computed in the background,
+Indexes may take long time to compute depdending upon the size of the data.
+Starting Dgraph version `20.3.0`, indexes can be computed in the background,
 and thus indexing may still be running after an Alter operation returns.
 This requires that you wait for indexing to complete before running queries
 that require newly created indices. Such queries will fail with an error
@@ -2176,13 +2177,37 @@ Background indexing task may fail if an unexpected error occurs while computing
 the indexes. You should retry the Alter operation in order to update the schema,
 or sync the schema across all the alphas.
 
-You can find examples here in order to wait for indexing to complete:
-
-- [dgraph4j](https://github.com/dgraph-io/dgraph4j/pull/135)
-- [dgo](https://github.com/dgraph-io/dgo/pull/117)
-- [pydgraph](https://github.com/dgraph-io/pydgraph/pull/120)
-
 We also plan to add a simpler API soon to check the status of background indexing.
+See this [PR](https://github.com/dgraph-io/dgraph/pull/4961) for more details.
+
+#### HTTP API
+
+You can specify the flag `run_in_background` to `true` to run
+index computation in the background.
+
+```sh
+curl localhost:8080/alter?run_in_background=true -XPOST -d $'
+    name: string @index(fulltext, term) .
+    age: int @index(int) @upsert .
+    friend: [uid] @count @reverse .
+' | python -m json.tool | less
+```
+
+#### Grpc API
+
+You can set `RunInBackground` field to `true` of the `api.Operation
+struct before passing it to the `Alter` function.
+
+```go
+op := &api.Operation{}
+op.Schema = `
+  name: string @index(fulltext, term) .
+  age: int @index(int) @upsert .
+  friend: [uid] @count @reverse .
+`
+op.RunInBackground = true
+err = dg.Alter(context.Background(), op)
+```
 
 
 ### Predicate name rules
@@ -2697,7 +2722,6 @@ curl localhost:8080/alter -XPOST -d $'
     name: string @index(exact, term) .
     rated: [uid] @reverse @count .
 ' | python -m json.tool | less
-
 ```
 
 ```sh

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2141,7 +2141,7 @@ Reverse edges are also computed if specified by a schema mutation.
 ### Indexes in Background
 
 Indexes may take long time to compute depdending upon the size of the data.
-Starting Dgraph version `20.3.0`, indexes can be computed in the background,
+Starting Dgraph version `20.03.0`, indexes can be computed in the background,
 and thus indexing may still be running after an Alter operation returns.
 This requires that you wait for indexing to complete before running queries
 that require newly created indices. Such queries will fail with an error

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -145,6 +145,10 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	// block here and wait for indexing to be finished.
 	gr.Node.waitForTask(opIndexing)
 
+	// There is a race condition in stopTask and waitForTask.
+	// We wait here for stopTask to finish.
+	time.Sleep(time.Millisecond)
+
 	// done is used to ensure that we only stop the indexing task once.
 	var done uint32
 	stopIndexing := func(closer *y.Closer) {


### PR DESCRIPTION
Because we wait for index computation to finish before we return in an Alter, we do not need to wait for alter in the tests.

**TODO**
  * [x] ratel test when alter is cancelled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5003)
<!-- Reviewable:end -->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-daa6494f03-50477.surge.sh)
<!-- Dgraph:end -->