### PR TITLE
Skip split keys during backup.

### DIFF
--- a/worker/backup_processor.go
+++ b/worker/backup_processor.go
@@ -135,6 +135,12 @@ func (pr *BackupProcessor) WriteBackup(ctx context.Context) (*pb.Status, error) 
 			return false
 		}
 
+		// Do not choose keys that contain parts of a multi-part list. These keys
+		// will be accessed from the main list.
+		if parsedKey.HasStartUid {
+			return false
+		}
+
 		// Backup type keys in every group.
 		if parsedKey.IsType() {
 			return true

--- a/worker/task.go
+++ b/worker/task.go
@@ -2244,6 +2244,13 @@ loop:
 			return err
 		}
 
+		if pk.HasStartUid {
+			// The keys holding parts of a split key should not be accessed here because
+			// they have a different prefix. However, the check is being added to guard
+			// against future bugs.
+			continue
+		}
+
 		// The following optimization speeds up this iteration considerably, because it avoids
 		// the need to run ReadPostingList.
 		if item.UserMeta()&posting.BitEmptyPosting > 0 {


### PR DESCRIPTION
Just like in the case of an export, the split keys should be skipped.

Fixes #5008

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5009)
<!-- Reviewable:end -->
