### PR TITLE
Set correct posting list type while creating it in live loader.

### DIFF
--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -191,6 +191,7 @@ func getTypeVal(val *api.Value) (types.Val, error) {
 	}
 
 	p1.Value = p1.Value.([]byte)
+	p1.Tid = p.Tid
 	return p1, nil
 }
 
@@ -301,11 +302,7 @@ func (l *loader) conflictKeysForNQuad(nq *api.NQuad) ([]uint64, error) {
 			Tid:   types.TypeID(de.GetValueType()),
 			Value: de.GetValue(),
 		}
-		// If the value type is not already set according to the schema, set it to string and
-		// then convert it to the type as declared in the schema.
-		if storageVal.Tid != pred.ValueType {
-			storageVal.Tid = types.StringID
-		}
+
 		schemaVal, err := types.Convert(storageVal, types.TypeID(pred.ValueType))
 		if err != nil {
 			errs = append(errs, err.Error())


### PR DESCRIPTION
Posting list type was not properly set and hence it was panicking while generating tokens.
Tested this with the following data.
**Data File**
<_:blank> <ida> "991" .
<_:blank> <ida> "991"^^<xs:int> .
<10511170691297417216> <initial_release_date> "1957-01-01T00:00:00Z" .
<m.010rcp1x>    <initial_release_date>  "1971-06-12"^^<http://www.w3.org/2001/XMLSchema#date>

**Schema File**
<ida>: int @index(int) .
initial_release_date : datetime @index(year) .

The same code for converting the posting list is there in copyValue() in gql/mutation.go
Tested this patch in v20.03.0-beta.20200320 as well.