### PR TITLE
graphql: @dgraph(pred: "...") with @search

### DIFF
--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -707,6 +707,41 @@ invalid_schemas:
       "locations":[{"line":1, "column":6}]},
     ]
 
+  -
+    name: "Conflicting GraphQL types for predicate"
+    input: |
+      type X {
+        f1: String! @dgraph(pred: "name")
+        f2: Y @dgraph(pred: "link")
+      }
+      type Y {
+        f1: Int @dgraph(pred: "name")
+        f2: X @dgraph(pred: "link")
+      }
+    errlist: [
+    {"message": "Type: Y; Field: f1 has its GraphQL Type: Int; which is different from a previous field with same dgraph predicate.",
+     "locations":[{"line":6, "column":3}]},
+    {"message": "Type: Y; Field: f2 has its GraphQL Type: X; which is different from a previous field with same dgraph predicate.",
+     "locations":[{"line":7, "column":3}]},
+    ]
+
+  -
+    name: "Conflicting dgraph types for predicate"
+    input: |
+      type X @secret(field: "f", pred: "pwd"){
+        f1: String @dgraph(pred: "name")
+      }
+      type Y {
+        f1: [String] @dgraph(pred: "name")
+        f2: String @dgraph(pred: "pwd")
+      }
+    errlist: [
+    {"message": "Type: Y; Field: f1 has its dgraph Type: [string]; which is different from a previous field with same dgraph predicate.",
+     "locations":[{"line":5, "column":3}]},
+    {"message": "Type: Y; Field: f2 has its dgraph Type: string; which is different from a previous field with same dgraph predicate.",
+     "locations":[{"line":6, "column":3}]},
+    ]
+
 
 
 valid_schemas:

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -708,40 +708,35 @@ invalid_schemas:
     ]
 
   -
-    name: "Conflicting GraphQL types for predicate"
+    name: "@dgraph predicate type validation"
     input: |
-      type X {
+      interface W @secret(field: "f", pred: "pwd") {
         f1: String! @dgraph(pred: "name")
-        f2: Y @dgraph(pred: "link")
+        f2: [Float] @dgraph(pred: "val")
+      }
+      type X implements W {
+        f3: Y @dgraph(pred: "link")
+        f4: String! @dgraph(pred: "f4") @id
       }
       type Y {
         f1: Int @dgraph(pred: "name")
-        f2: X @dgraph(pred: "link")
+        f2: Float @dgraph(pred: "val")
+        f3: X @dgraph(pred: "link")
+        f4: String @dgraph(pred: "f4")
+        f5: String @dgraph(pred: "pwd")
       }
     errlist: [
-    {"message": "Type: Y; Field: f1 has its GraphQL Type: Int; which is different from a previous field with same dgraph predicate.",
-     "locations":[{"line":6, "column":3}]},
-    {"message": "Type: Y; Field: f2 has its GraphQL Type: X; which is different from a previous field with same dgraph predicate.",
-     "locations":[{"line":7, "column":3}]},
+    {"message": "Type Y; Field f1: has type Int, which is different to type W; field f1, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":10, "column":3}]},
+    {"message": "Type Y; Field f2: has type Float, which is different to type W; field f2, which has the same @dgraph directive but type [Float]. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":11, "column":3}]},
+    {"message": "Type Y; Field f3: has type X, which is different to type X; field f3, which has the same @dgraph directive but type Y. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":12, "column":3}]},
+    {"message": "Type Y; Field f4: doesn't have @id directive, which conflicts with type X; field f4, which has the same @dgraph directive along with @id directive. Both these fields must either use @id directive, or use different Dgraph predicates.",
+     "locations":[{"line":13, "column":3}]},
+    {"message": "Type Y; Field f5: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
+     "locations":[{"line":14, "column":3}]},
     ]
-
-  -
-    name: "Conflicting dgraph types for predicate"
-    input: |
-      type X @secret(field: "f", pred: "pwd"){
-        f1: String @dgraph(pred: "name")
-      }
-      type Y {
-        f1: [String] @dgraph(pred: "name")
-        f2: String @dgraph(pred: "pwd")
-      }
-    errlist: [
-    {"message": "Type: Y; Field: f1 has its dgraph Type: [string]; which is different from a previous field with same dgraph predicate.",
-     "locations":[{"line":5, "column":3}]},
-    {"message": "Type: Y; Field: f2 has its dgraph Type: string; which is different from a previous field with same dgraph predicate.",
-     "locations":[{"line":6, "column":3}]},
-    ]
-
 
 
 valid_schemas:
@@ -844,4 +839,20 @@ valid_schemas:
       }
       type Y {
         f1: [X] @dgraph(pred: "f1")
+      }
+
+  -
+    name: "@dgraph predicate type validation gives no errors with non-null variations"
+    input: |
+      type X {
+        f1: String @dgraph(pred: "f1")
+        f2: [String] @dgraph(pred: "f2")
+        f3: [String!] @dgraph(pred: "f3")
+        f4: [String]! @dgraph(pred: "f4")
+      }
+      type Y {
+        f1: String! @dgraph(pred: "f1")
+        f2: [String!] @dgraph(pred: "f2")
+        f3: [String]! @dgraph(pred: "f3")
+        f4: [String!]! @dgraph(pred: "f4")
       }

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -705,6 +705,8 @@ invalid_schemas:
     errlist: [
       {"message": "Type X; has a secret directive and field of the same name f1",
       "locations":[{"line":1, "column":6}]},
+      {"message": "Type X; Field f1: has the @dgraph predicate, but that conflicts with type X @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
+       "locations":[{"line":2, "column":3}]},
     ]
 
   -
@@ -717,6 +719,7 @@ invalid_schemas:
       type X implements W {
         f3: Y @dgraph(pred: "link")
         f4: String! @dgraph(pred: "f4") @id
+        f6: String
       }
       type Y {
         f1: Int @dgraph(pred: "name")
@@ -724,18 +727,21 @@ invalid_schemas:
         f3: X @dgraph(pred: "link")
         f4: String @dgraph(pred: "f4")
         f5: String @dgraph(pred: "pwd")
+        f6: Int @dgraph(pred: "X.f6")
       }
     errlist: [
     {"message": "Type Y; Field f1: has type Int, which is different to type W; field f1, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
-     "locations":[{"line":10, "column":3}]},
-    {"message": "Type Y; Field f2: has type Float, which is different to type W; field f2, which has the same @dgraph directive but type [Float]. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
      "locations":[{"line":11, "column":3}]},
-    {"message": "Type Y; Field f3: has type X, which is different to type X; field f3, which has the same @dgraph directive but type Y. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+    {"message": "Type Y; Field f2: has type Float, which is different to type W; field f2, which has the same @dgraph directive but type [Float]. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
      "locations":[{"line":12, "column":3}]},
-    {"message": "Type Y; Field f4: doesn't have @id directive, which conflicts with type X; field f4, which has the same @dgraph directive along with @id directive. Both these fields must either use @id directive, or use different Dgraph predicates.",
+    {"message": "Type Y; Field f3: has type X, which is different to type X; field f3, which has the same @dgraph directive but type Y. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
      "locations":[{"line":13, "column":3}]},
-    {"message": "Type Y; Field f5: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
+    {"message": "Type Y; Field f4: doesn't have @id directive, which conflicts with type X; field f4, which has the same @dgraph directive along with @id directive. Both these fields must either use @id directive, or use different Dgraph predicates.",
      "locations":[{"line":14, "column":3}]},
+    {"message": "Type Y; Field f5: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
+     "locations":[{"line":15, "column":3}]},
+    {"message": "Type Y; Field f6: has type Int, which is different to type X; field f6, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":16, "column":3}]},
     ]
 
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -710,38 +710,48 @@ invalid_schemas:
     ]
 
   -
-    name: "@dgraph predicate type validation"
+    name: "@dgraph(pred: ...) validation"
     input: |
-      interface W @secret(field: "f", pred: "pwd") {
-        f1: String! @dgraph(pred: "name")
-        f2: [Float] @dgraph(pred: "val")
+      interface V {
+        f1: String @dgraph(pred: "ff1")
       }
-      type X implements W {
-        f3: Y @dgraph(pred: "link")
-        f4: String! @dgraph(pred: "f4") @id
-        f6: String
+      interface W @secret(field: "f", pred: "pwd") {
+        f2: String! @dgraph(pred: "name")
+        f3: [Float] @dgraph(pred: "val")
+        f4: String @dgraph(pred: "ff4")
+        f5: String @dgraph(pred: "ff1")
+      }
+      type X implements V & W {
+        f6: Y @dgraph(pred: "link")
+        f7: String! @dgraph(pred: "ff7") @id
+        f8: String
+        f9: String @dgraph(pred: "ff4")
       }
       type Y {
-        f1: Int @dgraph(pred: "name")
-        f2: Float @dgraph(pred: "val")
-        f3: X @dgraph(pred: "link")
-        f4: String @dgraph(pred: "f4")
-        f5: String @dgraph(pred: "pwd")
-        f6: Int @dgraph(pred: "X.f6")
+        f2: Int @dgraph(pred: "name")
+        f3: Float @dgraph(pred: "val")
+        f6: X @dgraph(pred: "link")
+        f7: String @dgraph(pred: "ff7")
+        f8: Int @dgraph(pred: "X.f8")
+        f10: String @dgraph(pred: "pwd")
       }
     errlist: [
-    {"message": "Type Y; Field f1: has type Int, which is different to type W; field f1, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
-     "locations":[{"line":11, "column":3}]},
-    {"message": "Type Y; Field f2: has type Float, which is different to type W; field f2, which has the same @dgraph directive but type [Float]. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
-     "locations":[{"line":12, "column":3}]},
-    {"message": "Type Y; Field f3: has type X, which is different to type X; field f3, which has the same @dgraph directive but type Y. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
-     "locations":[{"line":13, "column":3}]},
-    {"message": "Type Y; Field f4: doesn't have @id directive, which conflicts with type X; field f4, which has the same @dgraph directive along with @id directive. Both these fields must either use @id directive, or use different Dgraph predicates.",
+    {"message": "Type X; implements interfaces [V W], all of which have fields with @dgraph predicate: ff1. These fields must use different Dgraph predicates.",
+     "locations":[{"line":10, "column":6}]},
+    {"message": "Type X; Field f9: has the @dgraph directive, which conflicts with interface W; field f4, that this type implements. These fields must use different Dgraph predicates.",
      "locations":[{"line":14, "column":3}]},
-    {"message": "Type Y; Field f5: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
-     "locations":[{"line":15, "column":3}]},
-    {"message": "Type Y; Field f6: has type Int, which is different to type X; field f6, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
-     "locations":[{"line":16, "column":3}]},
+    {"message": "Type Y; Field f2: has type Int, which is different to type W; field f2, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":17, "column":3}]},
+    {"message": "Type Y; Field f3: has type Float, which is different to type W; field f3, which has the same @dgraph directive but type [Float]. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":18, "column":3}]},
+    {"message": "Type Y; Field f6: has type X, which is different to type X; field f6, which has the same @dgraph directive but type Y. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":19, "column":3}]},
+    {"message": "Type Y; Field f7: doesn't have @id directive, which conflicts with type X; field f7, which has the same @dgraph directive along with @id directive. Both these fields must either use @id directive, or use different Dgraph predicates.",
+     "locations":[{"line":20, "column":3}]},
+    {"message": "Type Y; Field f8: has type Int, which is different to type X; field f8, which has the same @dgraph directive but type String. These fields must have either the same GraphQL types, or use different Dgraph predicates.",
+     "locations":[{"line":21, "column":3}]},
+    {"message": "Type Y; Field f10: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
+     "locations":[{"line":22, "column":3}]},
     ]
 
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -705,8 +705,6 @@ invalid_schemas:
     errlist: [
       {"message": "Type X; has a secret directive and field of the same name f1",
       "locations":[{"line":1, "column":6}]},
-      {"message": "Type X; Field f1: has the @dgraph predicate, but that conflicts with type X @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
-       "locations":[{"line":2, "column":3}]},
     ]
 
   -
@@ -865,10 +863,12 @@ valid_schemas:
         f2: [String] @dgraph(pred: "f2")
         f3: [String!] @dgraph(pred: "f3")
         f4: [String]! @dgraph(pred: "f4")
+        f5: String
       }
       type Y {
         f1: String! @dgraph(pred: "f1")
         f2: [String!] @dgraph(pred: "f2")
         f3: [String]! @dgraph(pred: "f3")
         f4: [String!]! @dgraph(pred: "f4")
+        f5: String @dgraph(pred: "X.f5")
       }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -208,7 +208,8 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 			pwdField := getPasswordField(def)
 			if pwdField != nil {
 				fname := fieldName(pwdField, typName)
-				if parentInterfaceForPwdField(gqlSch, def, pwdField.Name) == nil {
+				if getDgraphDirPredArg(pwdField) != nil && parentInterfaceForPwdField(gqlSch, def,
+					pwdField.Name) == nil {
 					thisPred := pred{
 						name:       pwdField.Name,
 						parentName: def.Name,

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -97,17 +97,9 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 	}
 
 	checkExistingInterfaceFieldError := func(def *ast.Definition, existingPred, newPred pred) {
-		if def.Kind == ast.Interface {
-			for _, defName := range def.Types {
-				if existingPred.parentName == defName {
-					errs = append(errs, existingInterfaceFieldError(newPred, existingPred))
-				}
-			}
-		} else {
-			for _, defName := range def.Interfaces {
-				if existingPred.parentName == defName {
-					errs = append(errs, existingInterfaceFieldError(existingPred, newPred))
-				}
+		for _, defName := range def.Interfaces {
+			if existingPred.parentName == defName {
+				errs = append(errs, existingInterfaceFieldError(existingPred, newPred))
 			}
 		}
 	}
@@ -121,7 +113,7 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 			interfacePreds1 := interfacePreds[intr1]
 			for j := i + 1; j < len(interfaces); j++ {
 				intr2 := interfaces[j]
-				for fname, _ := range interfacePreds[intr2] {
+				for fname := range interfacePreds[intr2] {
 					if interfacePreds1[fname] {
 						if len(fieldsToReport[fname]) == 0 {
 							fieldsToReport[fname] = append(fieldsToReport[fname], intr1)
@@ -204,7 +196,9 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 								errs = append(errs, idError(thisPred, pred))
 							}
 						}
-						checkExistingInterfaceFieldError(def, pred, thisPred)
+						if def.Kind == ast.Object {
+							checkExistingInterfaceFieldError(def, pred, thisPred)
+						}
 					} else {
 						preds[fname] = thisPred
 					}
@@ -228,7 +222,9 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 						if thisPred.typ != pred.typ || !pred.isSecret {
 							errs = append(errs, secretError(thisPred, pred))
 						}
-						checkExistingInterfaceFieldError(def, pred, thisPred)
+						if def.Kind == ast.Object {
+							checkExistingInterfaceFieldError(def, pred, thisPred)
+						}
 					} else {
 						preds[fname] = thisPred
 					}

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -91,11 +91,10 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 				}
 
 				fname := fieldName(f, typName)
-				// No validation needed if this field doesn't have @dgraph(pred : ...). Also,
 				// this field could have originally been defined in an interface that this type
 				// implements. If we get a parent interface, that means this field gets validated
 				// during the validation of that interface. So, no need to validate this field here.
-				if fname != typName+"."+f.Name && parentInterface(gqlSch, def, f.Name) == nil {
+				if parentInterface(gqlSch, def, f.Name) == nil {
 
 					var prefix, suffix string
 					if f.Type.Elem != nil {
@@ -134,7 +133,7 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 			pwdField := getPasswordField(def)
 			if pwdField != nil {
 				fname := fieldName(pwdField, typName)
-				if fname != typName+"."+pwdField.Name && parentInterface(gqlSch, def,
+				if parentInterface(gqlSch, def,
 					pwdField.Name) == nil {
 					thisPred := pred{
 						name:       pwdField.Name,

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -169,19 +169,23 @@ func typeName(def *ast.Definition) string {
 }
 
 // fieldName returns the dgraph predicate corresponding to a field.
-// If the field had a dgraph directive, then it returns the value of the name field otherwise
+// If the field had a dgraph directive, then it returns the value of the pred arg otherwise
 // it returns typeName + "." + fieldName.
 func fieldName(def *ast.FieldDefinition, typName string) string {
-	name := typName + "." + def.Name
-	dir := def.Directives.ForName(dgraphDirective)
-	if dir == nil {
-		return name
-	}
-	predArg := dir.Arguments.ForName(dgraphPredArg)
+	predArg := getDgraphDirPredArg(def)
 	if predArg == nil {
-		return name
+		return typName + "." + def.Name
 	}
 	return predArg.Value.Raw
+}
+
+func getDgraphDirPredArg(def *ast.FieldDefinition) *ast.Argument {
+	dir := def.Directives.ForName(dgraphDirective)
+	if dir == nil {
+		return nil
+	}
+	predArg := dir.Arguments.ForName(dgraphPredArg)
+	return predArg
 }
 
 // genDgSchema generates Dgraph schema from a valid graphql schema.

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -402,7 +402,7 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) (string, gqlerror.Lis
 				indexStr := ""
 				if len(f.indexes) > 0 {
 					indexes := make([]string, 0)
-					for index, _ := range f.indexes {
+					for index := range f.indexes {
 						indexes = append(indexes, index)
 					}
 					sort.Strings(indexes)

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -320,7 +320,7 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 				}
 			}
 			if pwdField != nil {
-				parentInt := parentInterface(gqlSch, def, pwdField.Name)
+				parentInt := parentInterfaceForPwdField(gqlSch, def, pwdField.Name)
 				if parentInt != nil {
 					typName = typeName(parentInt)
 				}

--- a/graphql/schema/schemagen_test.yml
+++ b/graphql/schema/schemagen_test.yml
@@ -438,23 +438,33 @@ schemas:
   -
     name: "fields with same @dgraph(pred: ...) occur only once in schema"
     input: |
-      type A {
-        p: String @dgraph(pred: "name")
+      interface A {
+        p: String @dgraph(pred: "key")
       }
-      type B {
+      type B implements A {
         q: String @dgraph(pred: "name")
+      }
+      type C {
+        r: String @dgraph(pred: "name")
+        s: String @dgraph(pred: "key")
         name: String
       }
     output: |
       type A {
+        key
+      }
+      key: string .
+      type B {
+        key
         name
       }
       name: string .
-      type B {
+      type C {
         name
-        B.name
+        key
+        C.name
       }
-      B.name: string .
+      C.name: string .
 
   -
     name: "fields with same @dgraph(pred: ...) and different @search(by: [...]) have indexes

--- a/graphql/schema/schemagen_test.yml
+++ b/graphql/schema/schemagen_test.yml
@@ -466,11 +466,17 @@ schemas:
       type B {
         q: String @dgraph(pred: "name") @search(by: [trigram])
       }
+      type C {
+        q: String @dgraph(pred: "name") @search(by: [exact, term])
+      }
     output: |
       type A {
         name
       }
       name: string @index(exact, term, trigram) .
       type B {
+        name
+      }
+      type C {
         name
       }

--- a/graphql/schema/schemagen_test.yml
+++ b/graphql/schema/schemagen_test.yml
@@ -358,7 +358,7 @@ schemas:
       type A {
         A.id
       }
-      A.id: string @index(trigram, hash) @upsert .
+      A.id: string @index(hash, trigram) @upsert .
       type B {
         A.id
         B.correct
@@ -434,3 +434,43 @@ schemas:
       }
       A.p: string .
       A.q: string .
+
+  -
+    name: "fields with same @dgraph(pred: ...) occur only once in schema"
+    input: |
+      type A {
+        p: String @dgraph(pred: "name")
+      }
+      type B {
+        q: String @dgraph(pred: "name")
+        name: String
+      }
+    output: |
+      type A {
+        name
+      }
+      name: string .
+      type B {
+        name
+        B.name
+      }
+      B.name: string .
+
+  -
+    name: "fields with same @dgraph(pred: ...) and different @search(by: [...]) have indexes
+    combined"
+    input: |
+      type A {
+        p: String @dgraph(pred: "name") @search(by: [exact, term])
+      }
+      type B {
+        q: String @dgraph(pred: "name") @search(by: [trigram])
+      }
+    output: |
+      type A {
+        name
+      }
+      name: string @index(exact, term, trigram) .
+      type B {
+        name
+      }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -287,6 +287,22 @@ func parentInterface(sch *ast.Schema, typDef *ast.Definition, fieldName string) 
 	return nil
 }
 
+func parentInterfaceForPwdField(sch *ast.Schema, typDef *ast.Definition,
+	fieldName string) *ast.Definition {
+	if len(typDef.Interfaces) == 0 {
+		return nil
+	}
+
+	for _, iface := range typDef.Interfaces {
+		interfaceDef := sch.Types[iface]
+		pwdField := getPasswordField(interfaceDef)
+		if pwdField != nil && fieldName == pwdField.Name {
+			return interfaceDef
+		}
+	}
+	return nil
+}
+
 func convertPasswordDirective(dir *ast.Directive) *ast.FieldDefinition {
 	if dir.Name != "secret" {
 		return nil


### PR DESCRIPTION
We aren’t quite handling indexes correctly when the `@dgraph` predicate has a `@search`.

```graphql
type Country {
    ...
    name: String! @dgraph(pred: "name")
}

type Author {
    name: String! @dgraph(pred: "name") @search(by: [term])
    ...
}
```

This will write the predicate into the schema twice and only one will apply.  We should be smarter about this and do the following things:
* make sure we only write each predicate once.
* make sure all the predicate versions follow the below rules:
  1. all versions have the same dgraph type
  2. all versions either use @id, or none of them uses it
  3. all versions either use @secret, or none of them uses it
  4. a field from a type is not using the same predicate as another field in the interface that the type implements
  5. Two different interfaces, which are implemented by the same type, can't use same dgraph predicate for their fields
* set the indexes to the union of all the @search on the same pred name.

This PR takes care of all the above things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5019)
<!-- Reviewable:end -->
