### PR TITLE
Replaced s2 contains point methods with go-geom

### DIFF
--- a/types/geofilter.go
+++ b/types/geofilter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
+	"github.com/twpayne/go-geom/xy"
 )
 
 // QueryType indicates the type of geo query.
@@ -311,12 +312,13 @@ func (q GeoQueryData) contains(g geom.T) bool {
 	x.AssertTruef(q.pt != nil || len(q.loops) > 0, "At least a point or loop should be defined.")
 	switch v := g.(type) {
 	case *geom.Polygon:
+		if q.pt != nil {
+			return polygonContainsCoord(v, q.pt)
+		}
+
 		s2loop, err := loopFromPolygon(v)
 		if err != nil {
 			return false
-		}
-		if q.pt != nil {
-			return s2loop.ContainsPoint(*q.pt)
 		}
 
 		// Input could be a multipolygon, in which q.loops would have more than 1 loop. Each loop
@@ -329,16 +331,13 @@ func (q GeoQueryData) contains(g geom.T) bool {
 		return true
 	case *geom.MultiPolygon:
 		if q.pt != nil {
-			for i := 0; i < v.NumPolygons(); i++ {
-				p := v.Polygon(i)
-				s2loop, err := loopFromPolygon(p)
-				if err != nil {
-					return false
-				}
-				if s2loop.ContainsPoint(*q.pt) {
+			for j := 0; j < v.NumPolygons(); j++ {
+				if polygonContainsCoord(v.Polygon(j), q.pt) {
 					return true
 				}
 			}
+
+			return false
 		}
 
 		if len(q.loops) > 0 {
@@ -356,6 +355,19 @@ func (q GeoQueryData) contains(g geom.T) bool {
 		// We will only consider polygons for contains queries.
 		return false
 	}
+}
+
+func polygonContainsCoord(v *geom.Polygon, pt *s2.Point) bool {
+	for i := 0; i < v.NumLinearRings(); i++ {
+		r := v.LinearRing(i)
+		ll := s2.LatLngFromPoint(*pt)
+		p := []float64{ll.Lng.Degrees(), ll.Lat.Degrees()}
+		if xy.IsPointInRing(r.Layout(), p, r.FlatCoords()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // returns true if the geometry represented by uid/attr intersects the given loop or point

--- a/types/geofilter_test.go
+++ b/types/geofilter_test.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"encoding/binary"
+	"math/rand"
 	"strings"
 	"testing"
 
@@ -407,4 +408,23 @@ func TestMatchesFilterNearPoint(t *testing.T) {
 		{{-122, 37}, {-123, 37}, {-123, 38}, {-122, 38}, {-122, 37}},
 	})
 	require.True(t, qd.MatchesFilter(poly))
+}
+
+func BenchmarkMatchesFilterContainsPoint(b *testing.B) {
+	us, _ := loadPolygon("testdata/us.json")
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		p := geom.NewPoint(geom.XY).MustSetCoords(geom.Coord{
+			(rand.Float64() * 360) - 180,
+			(rand.Float64() * 180) - 90})
+
+		d, _ := wkb.Marshal(p, binary.LittleEndian)
+		src := ValueForType(GeoID)
+		src.Value = []byte(d)
+		gd, _ := Convert(src, StringID)
+		gb := gd.Value.(string)
+		_, qd, _ := queryTokens(QueryTypeContains, gb, 0.0)
+		qd.contains(us)
+	}
 }


### PR DESCRIPTION
Leads to significantly higher performance.

```
goos: linux
goarch: amd64
BenchmarkMatchesFilterContainsPoint-8               3902            312904 ns/op
BenchmarkMatchesFilterContainsPoint_Before-8          31          35054224 ns/op
PASS
ok      command-line-arguments  2.636s
```

From my testing while working on a project of my own I found that while using s2 types is very fast, converting to them is very slow, so if you're converting each time it's much faster to just use the go-geom types directly. This PR just changes this for contains point queries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5023)
<!-- Reviewable:end -->
