### PR TITLE
Add query/mutation logging in glog V=3.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -767,6 +767,9 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, er
 
 func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode) (
 	resp *api.Response, rerr error) {
+	if glog.V(3) {
+		glog.Infof("Got a query: %+v", req)
+	}
 	isGraphQL, _ := ctx.Value(IsGraphql).(bool)
 	if isGraphQL {
 		atomic.AddUint64(&numGraphQL, 1)


### PR DESCRIPTION
Closes #4944.

By setting `-v=3` or `--vmodule=server=3`, then query/mutation logs will appear in the Alpha log.

Example:

Query (has `query:` field)
```
I0324 15:41:27.464042    9642 server.go:771] Got a query: query:"{ q(func: has(counter.val)) { uid, val: counter.val }}"
```

Mutation (has `mutations:` field)
```
I0324 15:41:27.474000    9642 server.go:771] Got a query: start_ts:20006 mutations:<set_nquads:"<0x1> <counter.val> \"11\"^^<xs:int> ." commit_now:true > commit_now:true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5024)
<!-- Reviewable:end -->
