### PR TITLE
Accept --timeout in test.sh.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -162,7 +162,7 @@ function RunCustomClusterTests {
 #
 
 ARGS=$(getopt -n$ME -o"hucCfFvn" \
-              -l"help,unit,cluster,cluster-only,full,systest-only,oss,verbose,no-cache,short" -- "$@") \
+              -l"help,unit,cluster,cluster-only,full,systest-only,oss,verbose,no-cache,short,timeout:" -- "$@") \
     || exit 1
 eval set -- "$ARGS"
 while true; do
@@ -177,6 +177,7 @@ while true; do
         -n|--no-cache)     GO_TEST_OPTS+=( "-count=1" )    ;;
            --oss)          GO_TEST_OPTS+=( "-tags=oss" )   ;;
            --short)        GO_TEST_OPTS+=( "-short=true" ) ;;
+        -t|--timeout)      GO_TEST_OPTS+=( "-timeout=$2" ) ;;
         --)                shift; break                    ;;
     esac
     shift


### PR DESCRIPTION
Tests are currently failing on my laptop, and the default test timeout is 1 minute. This makes things more bearable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5028)
<!-- Reviewable:end -->
