### PR TITLE
docs: Document turning off encryption and changing encryption key.

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -650,27 +650,38 @@ dd if=/dev/random bs=1 count=32 of=enc_key_file
 
 ### Turn on Encryption
 
-Here is an example that starts one zero server and one alpha server with the encryption feature turned on:
+Here is an example that starts one Zero server and one Alpha server with the encryption feature turned on:
 
 ```bash
 dgraph zero --my=localhost:5080 --replicas 1 --idx 1
 dgraph alpha --encryption_key_file "./enc_key_file" --my=localhost:7080 --lru_mb=1024 --zero=localhost:5080
 ```
 
-If multiple alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` option to
-each of the alphas.
+If multiple Alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` option to
+each of the Alphas.
+
+Once an Alpha has encryption enabled, the encryption key must be provided in order to start the Alpha server.
+If the Alpha server restarts, the `--encryption_key_file` option must be set along with the key in order to
+restart successfully.
 
 ### Turn off Encryption
 
-Once a database has encryption enabled, the encryption key must be provided in order to open the database.
+If you wish to turn off encryption from an existing Alpha, then you can export your data and import it
+into a new Dgraph instance without encryption enabled.
 
-If you wish to turn off encryption from an existing database, then you can export your data that you can then
-import into a new Dgraph instance without encryption enabled.
+### Change Encryption Key
 
-### Rotate Encryption Key
+The master encryption key set by the `--encryption_key_file` option does not change automatically. The master
+encryption key encrypts underlying *data keys* which are changed on a regular basis automatically (more info
+about this is covered on the encryption-at-rest [blog][encblog] post).
 
-You can rotate the master encryption key by using the `badger rotate` command on both p and w directories for
-each Alpha. You'll need both the current key and the new key in two different files. Specify the directory you
+[encblog]: https://dgraph.io/blog/post/encryption-at-rest-dgraph-badger#one-key-to-rule-them-all-many-keys-to-find-them
+
+Changing the existing key to a new one is called key rotation. You can rotate the master encryption key by
+using the `badger rotate` command on both p and w directories for each Alpha. To maintain availability in HA
+cluster configurations, you can do this rotate the key one Alpha at a time in a rolling manner.
+
+You'll need both the current key and the new key in two different files. Specify the directory you
 rotate ("p" or "w") for the `--dir` flag, the old key for the `--old-key-path` flag, and the new key with the
 `--new-key-path` flag.
 

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -660,6 +660,27 @@ dgraph alpha --encryption_key_file "./enc_key_file" --my=localhost:7080 --lru_mb
 If multiple alpha nodes are part of the cluster, you will need to pass the `--encryption_key_file` option to
 each of the alphas.
 
+### Turn off Encryption
+
+Once a database has encryption enabled, the encryption key must be provided in order to open the database.
+
+If you wish to turn off encryption from an existing database, then you can export your data that you can then
+import into a new Dgraph instance without encryption enabled.
+
+### Rotate Encryption Key
+
+You can rotate the master encryption key by using the `badger rotate` command on both p and w directories for
+each Alpha. You'll need both the current key and the new key in two different files. Specify the directory you
+rotate ("p" or "w") for the `--dir` flag, the old key for the `--old-key-path` flag, and the new key with the
+`--new-key-path` flag.
+
+```
+badger rotate --dir p --old-key-path enc_key_file --new-key-path new_enc_key_file
+badger rotate --dir w --old-key-path enc_key_file --new-key-path new_enc_key_file
+```
+
+Then, you can start Alpha with the `new_enc_key_file` key file to use the new key.
+
 ### Bulk loader with Encryption
 
 Even before Dgraph cluster starts, we can load data using bulk loader with encryption feature turned on.


### PR DESCRIPTION
* Add section called "Turn off Encryption". Turning off encryption involves creating a new instance. There's currently no way to turn off encryption on an instance once it's been turned on.
* Add section called "Change Encryption Key". This involves using the `badger rotate` tool for both the p and w directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5037)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6f0f36e2d7-51554.surge.sh)
<!-- Dgraph:end -->