### PR TITLE
Fix protobuf regeneration.

### DIFF
--- a/protos/Makefile
+++ b/protos/Makefile
@@ -31,8 +31,8 @@ clean:
 check:
 	@./depcheck.sh && \
 		(echo "Upgrading proto libraries before regenerating." ; \
-		go get -u github.com/golang/protobuf/protoc-gen-go ; \
-		go get -u github.com/gogo/protobuf/protoc-gen-gofast)
+		GO111MODULE=off go get -u github.com/golang/protobuf/protoc-gen-go ; \
+		GO111MODULE=off go get -u github.com/gogo/protobuf/protoc-gen-gofast)
 
 .PHONY: regenerate
 regenerate: check clean


### PR DESCRIPTION
Commit c9b83927d3855d8542f1549befd140cc7b051738 breaks proto generation.
It seems like the protobuf is using the gogo library, which is not being
correctly sourced in the Makefile (because it's no longer in
$GOPATH/src).

Turning gomodules off when updating gogo and protoc fixes the issue for
now.

Fixes #5047

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5048)
<!-- Reviewable:end -->
