### PR TITLE
Indicate dev environment in Sentry events

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -162,6 +162,7 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 }
 
 func run() {
+	glog.Infof("Dev version ? %v", x.DevVersion() )
 	x.InitSentry(enc.EeBuild)
 	defer x.FlushSentry()
 	x.ConfigureSentryScope("zero")

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -162,7 +162,6 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 }
 
 func run() {
-	glog.Infof("Dev version ? %v", x.DevVersion())
 	x.InitSentry(enc.EeBuild)
 	defer x.FlushSentry()
 	x.ConfigureSentryScope("zero")

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -162,7 +162,7 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 }
 
 func run() {
-	glog.Infof("Dev version ? %v", x.DevVersion() )
+	glog.Infof("Dev version ? %v", x.DevVersion())
 	x.InitSentry(enc.EeBuild)
 	defer x.FlushSentry()
 	x.ConfigureSentryScope("zero")

--- a/x/error.go
+++ b/x/error.go
@@ -75,6 +75,13 @@ func Check2(_ interface{}, err error) {
 	Check(err)
 }
 
+// Panic on error.
+func Panic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
 // Ignore function is used to ignore errors deliberately, while keeping the
 // linter happy.
 func Ignore(_ error) {

--- a/x/init.go
+++ b/x/init.go
@@ -105,7 +105,8 @@ func Version() string {
 }
 
 // pattern for  dev version = min. 7 hex digits of commit-hash.
-var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`) 
+var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`)
+
 // DevVersion returns true if the version string contains the above pattern
 // e.g.
 //  1. v2.0.0-rc1-127-gd20a768b3 => dev version

--- a/x/init.go
+++ b/x/init.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -101,6 +102,13 @@ func PrintVersion() {
 // Version returns a string containing the dgraphVersion.
 func Version() string {
 	return dgraphVersion
+}
+
+// DevVersion returns true if the version string contains a git commit hash.
+func DevVersion() (matched bool) {
+	pattern := `-g[[:xdigit:]]{7,}` // -g followed by a commit-hash of min. 7 hex digits.
+	matched, _ = regexp.MatchString(pattern, dgraphVersion)
+	return
 }
 
 // ExecutableChecksum returns a byte slice containing the SHA256 checksum of the executable.

--- a/x/init.go
+++ b/x/init.go
@@ -105,13 +105,12 @@ func Version() string {
 }
 
 // DevVersion returns true if the version string contains a git commit hash.
-// e.g. 
+// e.g.
 //  1. v2.0.0-rc1-127-gd20a768b3 => Dev version
 //  2. v2.0.0 => prod version
 func DevVersion() (matched bool) {
 	pattern := `-g[[:xdigit:]]{7,}` // -g followed by a commit-hash of min. 7 hex digits.
-	matched, _ = regexp.MatchString(pattern, dgraphVersion)
-	return
+	return (regexp.MustCompile(pattern).MatchString(dgraphVersion)
 }
 
 // ExecutableChecksum returns a byte slice containing the SHA256 checksum of the executable.

--- a/x/init.go
+++ b/x/init.go
@@ -104,8 +104,9 @@ func Version() string {
 	return dgraphVersion
 }
 
-var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`) // -g followed by a commit-hash of min. 7 hex digits.
-// DevVersion returns true if the version string contains a git commit hash.
+// pattern for  dev version = min. 7 hex digits of commit-hash.
+var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`) 
+// DevVersion returns true if the version string contains the above pattern
 // e.g.
 //  1. v2.0.0-rc1-127-gd20a768b3 => dev version
 //  2. v2.0.0 => prod version

--- a/x/init.go
+++ b/x/init.go
@@ -104,13 +104,13 @@ func Version() string {
 	return dgraphVersion
 }
 
+var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`) // -g followed by a commit-hash of min. 7 hex digits.
 // DevVersion returns true if the version string contains a git commit hash.
 // e.g.
-//  1. v2.0.0-rc1-127-gd20a768b3 => Dev version
+//  1. v2.0.0-rc1-127-gd20a768b3 => dev version
 //  2. v2.0.0 => prod version
 func DevVersion() (matched bool) {
-	pattern := `-g[[:xdigit:]]{7,}` // -g followed by a commit-hash of min. 7 hex digits.
-	return (regexp.MustCompile(pattern).MatchString(dgraphVersion))
+	return (versionRe.MatchString(dgraphVersion))
 }
 
 // ExecutableChecksum returns a byte slice containing the SHA256 checksum of the executable.

--- a/x/init.go
+++ b/x/init.go
@@ -105,6 +105,9 @@ func Version() string {
 }
 
 // DevVersion returns true if the version string contains a git commit hash.
+// e.g. 
+//  1. v2.0.0-rc1-127-gd20a768b3 => Dev version
+//  2. v2.0.0 => prod version
 func DevVersion() (matched bool) {
 	pattern := `-g[[:xdigit:]]{7,}` // -g followed by a commit-hash of min. 7 hex digits.
 	matched, _ = regexp.MatchString(pattern, dgraphVersion)

--- a/x/init.go
+++ b/x/init.go
@@ -110,7 +110,7 @@ func Version() string {
 //  2. v2.0.0 => prod version
 func DevVersion() (matched bool) {
 	pattern := `-g[[:xdigit:]]{7,}` // -g followed by a commit-hash of min. 7 hex digits.
-	return (regexp.MustCompile(pattern).MatchString(dgraphVersion)
+	return (regexp.MustCompile(pattern).MatchString(dgraphVersion))
 }
 
 // ExecutableChecksum returns a byte slice containing the SHA256 checksum of the executable.

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -30,10 +30,14 @@ var env string
 
 // InitSentry initializes the sentry machinery.
 func InitSentry(ee bool) {
+	env = "dev"
+	if !DevVersion() {
+		env = ""
+	}
 	if ee {
-		env = "enterprise"
+		env += "-enterprise"
 	} else {
-		env = "oss"
+		env = "-oss"
 	}
 	initSentry()
 }

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -31,12 +31,12 @@ var env string
 // InitSentry initializes the sentry machinery.
 func InitSentry(ee bool) {
 	if DevVersion() {
-		env = "dev"
+		env = "dev-"
 	}
 	if ee {
-		env += "-enterprise"
+		env += "enterprise"
 	} else {
-		env += "-oss"
+		env += "oss"
 	}
 	initSentry()
 }

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -30,9 +30,8 @@ var env string
 
 // InitSentry initializes the sentry machinery.
 func InitSentry(ee bool) {
-	env = "dev"
-	if !DevVersion() {
-		env = ""
+	if DevVersion() {
+		env = "dev"
 	}
 	if ee {
 		env += "-enterprise"

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -30,6 +30,7 @@ var env string
 
 // InitSentry initializes the sentry machinery.
 func InitSentry(ee bool) {
+	env = "prod-"
 	if DevVersion() {
 		env = "dev-"
 	}

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -37,7 +37,7 @@ func InitSentry(ee bool) {
 	if ee {
 		env += "-enterprise"
 	} else {
-		env = "-oss"
+		env += "-oss"
 	}
 	initSentry()
 }
@@ -66,14 +66,6 @@ func ConfigureSentryScope(subcmd string) {
 		scope.SetTag("dgraph", subcmd)
 		scope.SetLevel(sentry.LevelFatal)
 	})
-}
-
-// Panic sends the error report to Sentry and then panics.
-func Panic(err error) {
-	if err != nil {
-		CaptureSentryException(err)
-		panic(err)
-	}
 }
 
 // CaptureSentryException sends the error report to Sentry.

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -125,3 +125,21 @@ func TestGqlError(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionString(t *testing.T) {	
+	dgraphVersion = "v1.2.2-rc1-g1234567"
+	require.True(t,DevVersion())
+
+	dgraphVersion = "v20.03-1-beta-Mar20-g12345678"
+	require.True(t,DevVersion())
+
+	dgraphVersion = "v20.03"
+	require.False(t,DevVersion())
+
+	// less than 7 hex digits in commit-hash
+	dgraphVersion = "v1.2.2-rc1-g123456"
+	require.False(t,DevVersion())
+
+}
+
+

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -126,20 +126,18 @@ func TestGqlError(t *testing.T) {
 	}
 }
 
-func TestVersionString(t *testing.T) {	
+func TestVersionString(t *testing.T) {
 	dgraphVersion = "v1.2.2-rc1-g1234567"
-	require.True(t,DevVersion())
+	require.True(t, DevVersion())
 
 	dgraphVersion = "v20.03-1-beta-Mar20-g12345678"
-	require.True(t,DevVersion())
+	require.True(t, DevVersion())
 
 	dgraphVersion = "v20.03"
-	require.False(t,DevVersion())
+	require.False(t, DevVersion())
 
 	// less than 7 hex digits in commit-hash
 	dgraphVersion = "v1.2.2-rc1-g123456"
-	require.False(t,DevVersion())
+	require.False(t, DevVersion())
 
 }
-
-


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.

<!-- First, describe here details about it. -->
Check for git commit hash in the version string to infer dev environment for Sentry. We now have 4 possible sentry enviroments:
1. prod-enterprise
2. prod-oss
3. dev-enterprise
4. dev-oss
 
### GitHub Issue or Jira number.

<!-- Add here. -->
https://dgraph.atlassian.net/browse/DGRAPH-1164 

### Other components or 3rd party tools affected (or regression areas).

<!-- Add here. e.g. "It breaks/affects Ratel UI behavior." -->

### Affected releases.

<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

<!-- Add here. -->
20.07

### Changelog tags.

<!-- removed, added, fixed, ... -->

<!-- Add here. -->

### Please indicate if this is a breaking change.

<!-- Add here. -->

### Please indicate if this is an enterprise feature.

<!-- Add here. -->

### Please indicate if documentation needs to be updated.

<!-- If yes indicate the documentation issue number. Add here. -->
<!--or create one and add the number here -->

### Please indicate if end to end testing is needed.

<!-- if yes indicate the testing issue number -->
<!--or create one and add the number here -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5051)
<!-- Reviewable:end -->
