### PR TITLE
Get most tests working on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /installs
 /coverage.out
 /dgraph-bulk-loader
+/osx-docker-gopath
 
 # fuzzing output
 gql/gql-fuzz.zip

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -32,7 +32,7 @@ function restartCluster {
       -v dgraph_gocache:/root/.cache/go-build \
       -v `pwd`/..:/app \
       -w /app/dgraph \
-      golang:1.13 \
+      golang:1.14 \
       go build -o /app/osx-docker-gopath/bin/dgraph
   fi
 

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -16,19 +16,28 @@ function restartCluster {
   basedir=$(dirname "${BASH_SOURCE[0]}")/../..
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
+
+  docker_compose_gopath="${GOPATH:-$(go env GOPATH)}"
+  make install
+
   if [[ "$OSTYPE" == "darwin"* ]]; then
     if !(AVAILABLE_RAM=$(cat ~/Library/Group\ Containers/group.com.docker/settings.json | grep memoryMiB | grep -oe "[0-9]\+") && test $AVAILABLE_RAM -ge 6144); then
       echo -e "\e[33mWarning: You may not have allocated enough memory for Docker on Mac. Please increase the allocated RAM to at least 6GB with a 4GB swap. See https://docs.docker.com/docker-for-mac/#resources \e[0m"
     fi
+    docker_compose_gopath=`pwd`/../osx-docker-gopath
 
-    # TODO: read the go version from a constant
-    # TODO: linux can also compile dgraph using this command without a major performance penalty (since gocache is in a volume).
-    docker run -it --rm -v dgraph_gopath:/go -v dgraph_gocache:/root/.cache/go-build -v `pwd`/..:/app -w /app/dgraph golang:1.13 go build && mv -f dgraph $(go env GOPATH)/bin/dgraph
-  else
-    make install
+    # FIXME: read the go version from a constant
+    docker run -it --rm \
+      -v dgraph_gopath:/go \
+      -v dgraph_gocache:/root/.cache/go-build \
+      -v `pwd`/..:/app \
+      -w /app/dgraph \
+      golang:1.13 \
+      go build -o /app/osx-docker-gopath/bin/dgraph
   fi
+
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
-  GOPATH="${GOPATH:-$(go env GOPATH)}" docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
+  GOPATH=$docker_compose_gopath docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans --detach || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6180 || exit 1

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -17,7 +17,13 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    docker run -it --rm -v dgraph_gopath:/go -v dgraph_gocache:/root/.cache/go-build -v `pwd`/..:/app -w /app/dgraph golang:1.14 go build && mv -f dgraph $(go env GOPATH)/bin/dgraph
+    if !(AVAILABLE_RAM=$(cat ~/Library/Group\ Containers/group.com.docker/settings.json | grep memoryMiB | grep -oe "[0-9]\+") && test $AVAILABLE_RAM -ge 6144); then
+      echo -e "\e[33mWarning: You may not have allocated enough memory for Docker on Mac. Please increase the allocated RAM to at least 6GB with a 4GB swap. See https://docs.docker.com/docker-for-mac/#resources \e[0m"
+    fi
+
+    # TODO: read the go version from a constant
+    # TODO: linux can also compile dgraph using this command without a major performance penalty (since gocache is in a volume).
+    docker run -it --rm -v dgraph_gopath:/go -v dgraph_gocache:/root/.cache/go-build -v `pwd`/..:/app -w /app/dgraph golang:1.13 go build && mv -f dgraph $(go env GOPATH)/bin/dgraph
   else
     make install
   fi

--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -17,7 +17,7 @@ function restartCluster {
   pushd $basedir/dgraph >/dev/null
   echo "Rebuilding dgraph ..."
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    (env GOOS=linux GOARCH=amd64 go build) && mv -f dgraph $(go env GOPATH)/bin/dgraph
+    docker run -it --rm -v dgraph_gopath:/go -v dgraph_gocache:/root/.cache/go-build -v `pwd`/..:/app -w /app/dgraph golang:1.14 go build && mv -f dgraph $(go env GOPATH)/bin/dgraph
   else
     make install
   fi

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -100,7 +100,7 @@ func TestLiveLoadJSONFileEmpty(t *testing.T) {
 
 	pipeline := [][]string{
 		{"echo", "[]"},
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", "/dev/stdin",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -112,7 +112,7 @@ func TestLiveLoadJSONFile(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -127,7 +127,7 @@ func TestLiveLoadJSONCompressedStream(t *testing.T) {
 
 	pipeline := [][]string{
 		{"gzip", "-c", testDataDir + "/family.json"},
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", "/dev/stdin",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -148,7 +148,7 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 	fileList := strings.Join(files, ",")
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", fileList,
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -119,7 +119,7 @@ func TestLiveLoadJsonUidKeep(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -133,7 +133,7 @@ func TestLiveLoadJsonUidDiscard(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live", "--new_uids",
+		{testutil.DgraphBinaryPath(), "live", "--new_uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -147,7 +147,7 @@ func TestLiveLoadRdfUidKeep(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		{testutil.DgraphBinaryPath(), "live",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.rdf",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -161,7 +161,7 @@ func TestLiveLoadRdfUidDiscard(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{os.ExpandEnv("$GOPATH/bin/dgraph"), "live", "--new_uids",
+		{testutil.DgraphBinaryPath(), "live", "--new_uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.rdf",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}

--- a/systest/bulk_live_fixture_test.go
+++ b/systest/bulk_live_fixture_test.go
@@ -134,7 +134,7 @@ func (s *suite) setup(schemaFile, rdfFile string) {
 			s.t.Fatalf("Couldn't start zero in Dgraph cluster: %v\n", err)
 		}
 
-		bulkCmd := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"), "bulk",
+		bulkCmd := exec.Command(testutil.DgraphBinaryPath(), "bulk",
 			"-f", rdfFile,
 			"-s", schemaFile,
 			"--http", "localhost:"+strconv.Itoa(freePort(0)),
@@ -156,7 +156,7 @@ func (s *suite) setup(schemaFile, rdfFile string) {
 	}
 
 	if !s.opts.skipLiveLoader {
-		liveCmd := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+		liveCmd := exec.Command(testutil.DgraphBinaryPath(), "live",
 			"--files", rdfFile,
 			"--schema", schemaFile,
 			"--alpha", testutil.SockAddr,

--- a/systest/cluster_setup_test.go
+++ b/systest/cluster_setup_test.go
@@ -67,7 +67,7 @@ func NewDgraphCluster(dir string) *DgraphCluster {
 }
 
 func (d *DgraphCluster) StartZeroOnly() error {
-	d.zero = exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+	d.zero = exec.Command(testutil.DgraphBinaryPath(),
 		"zero",
 		"-w=wz",
 		"-o", strconv.Itoa(d.zeroPortOffset),
@@ -87,7 +87,7 @@ func (d *DgraphCluster) StartZeroOnly() error {
 }
 
 func (d *DgraphCluster) StartAlphaOnly() error {
-	d.dgraph = exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+	d.dgraph = exec.Command(testutil.DgraphBinaryPath(),
 		"alpha",
 		"--lru_mb=4096",
 		"--zero", ":"+d.zeroPort,
@@ -130,7 +130,7 @@ type Node struct {
 
 func (d *DgraphCluster) AddNode(dir string) (Node, error) {
 	o := strconv.Itoa(freePort(x.PortInternal))
-	dgraph := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"),
+	dgraph := exec.Command(testutil.DgraphBinaryPath(),
 		"alpha",
 		"--lru_mb=4096",
 		"--zero", ":"+d.zeroPort,

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -40,7 +40,7 @@ func TestLoaderXidmap(t *testing.T) {
 
 	data, err := filepath.Abs("testdata/first.rdf.gz")
 	require.NoError(t, err)
-	liveCmd := exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+	liveCmd := exec.Command(testutil.DgraphBinaryPath(), "live",
 		"--files", data,
 		"--alpha", testutil.SockAddr,
 		"--zero", testutil.SockAddrZero,
@@ -52,7 +52,7 @@ func TestLoaderXidmap(t *testing.T) {
 	// Load another file, live should reuse the xidmap.
 	data, err = filepath.Abs("testdata/second.rdf.gz")
 	require.NoError(t, err)
-	liveCmd = exec.Command(os.ExpandEnv("$GOPATH/bin/dgraph"), "live",
+	liveCmd = exec.Command(testutil.DgraphBinaryPath(), "live",
 		"--files", data,
 		"--alpha", testutil.SockAddr,
 		"--zero", testutil.SockAddrZero,

--- a/testutil/exec.go
+++ b/testutil/exec.go
@@ -18,6 +18,7 @@ package testutil
 
 import (
 	"fmt"
+	"go/build"
 	"io"
 	"os"
 	"os/exec"
@@ -114,4 +115,14 @@ func pipelineInternal(cmds [][]string, opts []CmdOpts) error {
 	}
 
 	return err
+}
+
+func DgraphBinaryPath() string {
+	gopath := os.Getenv("GOPATH")
+
+	if gopath == "" {
+		gopath = build.Default.GOPATH
+	}
+
+	return os.ExpandEnv(gopath + "/bin/dgraph")
 }


### PR DESCRIPTION
### Description.

This PR gets most tests working on OSX.

* Apparently, if GOOS is set to linux (for cross compiling), then CGO_ENABLED is set to false as OSX's libc is not compatible with ubuntu's libc, which causes many things to fail. In this PR, OSX's compile for docker happens within a docker run command (which we should also use for linux eventually)
* Docker for Mac allocates 2GB for the linux subsystem, which is not enough for dgraph's tests (and things silently fail). test.sh now spits out a warning if you are running Docker for Mac with too little RAM (< 6GB)
* Some tests (like `load-json/load_test.go`), work by calling out to the dgraph binary. Thus we also need the dgraph binary compiled for the correct environment on the machine. This PR also introduces `testutil.DgraphBinaryPath()` which finds the dgraph binary using the default GOPATH if the GOPATH is unset

<!-- First, describe here details about it. -->

### GitHub Issue or Jira number.

### Other components or 3rd party tools affected (or regression areas).

### Affected releases.

### Changelog tags.

### Please indicate if this is a breaking change.

No

### Please indicate if this is an enterprise feature.

No

### Please indicate if documentation needs to be updated.

No

### Please indicate if end to end testing is needed.

No, it's updates to test.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5055)
<!-- Reviewable:end -->
