### PR TITLE
Fix typos in docs (#5062)

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2140,7 +2140,7 @@ Reverse edges are also computed if specified by a schema mutation.
 
 ### Indexes in Background
 
-Indexes may take long time to compute depdending upon the size of the data.
+Indexes may take long time to compute depending upon the size of the data.
 Starting Dgraph version `20.03.0`, indexes can be computed in the background,
 and thus indexing may still be running after an Alter operation returns.
 This requires that you wait for indexing to complete before running queries
@@ -2195,7 +2195,7 @@ curl localhost:8080/alter?runInBackground=true -XPOST -d $'
 
 #### Grpc API
 
-You can set `RunInBackground` field to `true` of the `api.Operation
+You can set `RunInBackground` field to `true` of the `api.Operation`
 struct before passing it to the `Alter` function.
 
 ```go


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5063)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-3fb5f5111b-51309.surge.sh)
<!-- Dgraph:end -->