### PR TITLE
log level for invalid keys in calculating tablet sizes

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1198,12 +1198,12 @@ func (n *node) calculateTabletSizes() {
 	for _, tinfo := range tableInfos {
 		left, err := x.Parse(tinfo.Left)
 		if err != nil {
-			glog.V(2).Infof("Unable to parse key: %v", err)
+			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
 		right, err := x.Parse(tinfo.Right)
 		if err != nil {
-			glog.V(2).Infof("Unable to parse key: %v", err)
+			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
 		if left.Attr != right.Attr {
@@ -1225,6 +1225,7 @@ func (n *node) calculateTabletSizes() {
 		total += int64(tinfo.EstimatedSz)
 	}
 	if len(tablets) == 0 {
+		glog.V(2).Infof("No tablets found.")
 		return
 	}
 	// Update Zero with the tablet sizes. If Zero sees a tablet which does not belong to


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.
Lower log level for invalid keys in calculating tablet sizes

<!-- First, describe here details about it. -->

### GitHub Issue or Jira number.

<!-- Add here. -->

https://dgraph.atlassian.net/browse/DGRAPH-1171

### Other components or 3rd party tools affected (or regression areas).

<!-- Add here. e.g. "It breaks/affects Ratel UI behavior." -->

### Affected releases.

<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

<!-- Add here. -->
v20.03

### Changelog tags.

<!-- removed, added, fixed, ... -->

<!-- Add here. -->

### Please indicate if this is a breaking change.

<!-- Add here. -->

### Please indicate if this is an enterprise feature.

<!-- Add here. -->

### Please indicate if documentation needs to be updated.

<!-- If yes indicate the documentation issue number. Add here. -->
<!--or create one and add the number here -->

### Please indicate if end to end testing is needed.

<!-- if yes indicate the testing issue number -->
<!--or create one and add the number here -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5071)
<!-- Reviewable:end -->
