### PR TITLE
log level for invalid keys in calculating tablet sizes (#5071)

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1170,12 +1170,12 @@ func (n *node) calculateTabletSizes() {
 	for _, tinfo := range tableInfos {
 		left, err := x.Parse(tinfo.Left)
 		if err != nil {
-			glog.V(2).Infof("Unable to parse key: %v", err)
+			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
 		right, err := x.Parse(tinfo.Right)
 		if err != nil {
-			glog.V(2).Infof("Unable to parse key: %v", err)
+			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
 		if left.Attr != right.Attr {
@@ -1197,6 +1197,7 @@ func (n *node) calculateTabletSizes() {
 		total += int64(tinfo.EstimatedSz)
 	}
 	if len(tablets) == 0 {
+		glog.V(2).Infof("No tablets found.")
 		return
 	}
 	// Update Zero with the tablet sizes. If Zero sees a tablet which does not belong to


### PR DESCRIPTION
(cherry-picked from commit 558b646a5b978f07f0c4f10f5c0ee75c4ae5633e)

<!-- Please, fill up the PR details. -->
<!-- If you are a Dgraph engineer, please add this param at the end of your URL query `&template=DgraphPR.md` -->
<!-- e.g: https://github.com/dgraph-io/dgraph/compare/$YOURBRANCH?expand=1&template=DgraphPR.md -->

### Dear contributor, what does this PR do?

<!-- First, describe here details about it. -->

### Motivation

<!-- Besides the motivation itself, if applicable, you should add references. e.g public conversations (URL) in the community. This helps reviewers with context. You should also advocate for the PR if needed. You can ping Daniel, Karthic, Michel or Santo if you need help. -->

### Components affected by this PR <!-- (Optional) -->

<!-- Please, take a minute to think about what or who this PR affects. Does it need help for doing documentation? Does it affect third parties (Open Source or not) applications? Make it clear so we can track and fix it. -->
<!-- e.g. "It breaks/affects Ratel UI behavior." or You are working on documentation. Check if any links will be broken with your changes. -->

### Does this PR break backwards compatibility?  <!-- (Optional) -->

<!-- Yes/no, and details if needed. -->

### Fixes <!-- (Optional) -->

<!-- Add here an issue that this PR will close. -->

### More <!-- (Optional) -->

<!-- Add here TODOS, testing results, additional notes, consolidated discussion points, personal signs and etc. -->

<!-- You can always ping us (Daniel, Karthic, Micheldiz or Santo in Slack or via DM at http://discuss.dgraph.io/) if you need help about filling those sections. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5072)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-2b7b3f2135-51605.surge.sh)
<!-- Dgraph:end -->