### PR TITLE
Include the total number of touched nodes in the query metrics.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -984,6 +984,11 @@ func processQuery(ctx context.Context, qc *queryContext) (*api.Response, error) 
 	resp.Metrics = &api.Metrics{
 		NumUids: er.Metrics,
 	}
+	var total uint64
+	for _, num := range resp.Metrics.NumUids {
+		total += num
+	}
+	resp.Metrics.NumUids["_total"] = total
 
 	return resp, err
 }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1545,4 +1545,5 @@ func TestNumUids(t *testing.T) {
 	metrics := processQueryForMetrics(t, query)
 	require.Equal(t, metrics.NumUids["friend"], uint64(10))
 	require.Equal(t, metrics.NumUids["name"], uint64(16))
+	require.Equal(t, metrics.NumUids["_total"], uint64(26))
 }


### PR DESCRIPTION
Total is stored under a key called "_total".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5073)
<!-- Reviewable:end -->
