### PR TITLE
docs: Set v20.03.0 as latest docs.

### DIFF
--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -27,7 +27,7 @@ HUGO="${HUGO:-hugo}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 VERSIONS_ARRAY=(
-        'v20.03.0'
+	'v20.03.0'
 	'master'
 	'v1.2.2'
 	'v1.2.1'

--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -27,8 +27,9 @@ HUGO="${HUGO:-hugo}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 VERSIONS_ARRAY=(
-	'v1.2.2'
+        'v20.03.0'
 	'master'
+	'v1.2.2'
 	'v1.2.1'
 	'v1.2.0'
 	'v1.1.1'


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->
<!-- If you are a Dgraph engineer, please add this param at the end of your URL query `&template=DgraphPR.md` -->
<!-- e.g: https://github.com/dgraph-io/dgraph/compare/$YOURBRANCH?expand=1&template=DgraphPR.md -->

### Dear contributor, what does this PR do?

Set v20.03.0 as the latest docs for https://dgraph.io/docs.

<!-- First, describe here details about it. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5078)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e7c7d17e23-51867.surge.sh)
<!-- Dgraph:end -->