### PR TITLE
Extend ACL tests

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1951,7 +1951,7 @@ func TestAllowUIDAccess(t *testing.T) {
 }
 
 func TestAddNewPredicate(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
 
 	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
@@ -1977,6 +1977,7 @@ func TestAddNewPredicate(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 	addToGroup(t, accessJwt, userid, "guardians")
+	time.Sleep(6 * time.Second)
 
 	// Alice is a guardian now, it can create new predicate.
 	err = userClient.Alter(ctx, &api.Operation{
@@ -1986,7 +1987,7 @@ func TestAddNewPredicate(t *testing.T) {
 }
 
 func TestCrossGroupPermission(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
 
 	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
@@ -2047,6 +2048,7 @@ func TestCrossGroupPermission(t *testing.T) {
 			addToGroup(t, accessJwt, "user"+userIdx, "reader")
 		}
 	}
+	time.Sleep(6 * time.Second)
 
 	// operations
 	dgQuery := func(client *dgo.Dgraph, shouldFail bool, user string) {
@@ -2076,7 +2078,6 @@ func TestCrossGroupPermission(t *testing.T) {
 	}
 	dgAlter := func(client *dgo.Dgraph, shouldFail bool, user string) {
 		err := client.Alter(ctx, &api.Operation{Schema: `newpred: string @index(exact) .`})
-
 		require.True(t, (err != nil) == shouldFail,
 			"Alter test failed for: "+user+", shouldFail: "+strconv.FormatBool(shouldFail))
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -38,18 +37,9 @@ var (
 	dgraphEndpoint = testutil.SockAddr
 )
 
-func checkOutput(t *testing.T, cmd *exec.Cmd, shouldFail bool) string {
-	out, err := cmd.CombinedOutput()
-	if (!shouldFail && err != nil) || (shouldFail && err == nil) {
-		t.Errorf("Error output from command:%v", string(out))
-		t.Fatal(err)
-	}
-
-	return string(out)
-}
-
 func createUser(t *testing.T, accessToken, username, password string) []byte {
-	addUser := `mutation addUser($name: String!, $pass: String!) {
+	addUser := `
+	mutation addUser($name: String!, $pass: String!) {
 		addUser(input: [{name: $name, password: $pass}]) {
 			user {
 				name
@@ -69,7 +59,8 @@ func createUser(t *testing.T, accessToken, username, password string) []byte {
 }
 
 func getCurrentUser(t *testing.T, accessToken string) []byte {
-	query := `query {
+	query := `
+	query {
 		getCurrentUser {
 			name
 		}
@@ -97,7 +88,8 @@ func checkUserCount(t *testing.T, resp []byte, expected int) {
 
 func deleteUser(t *testing.T, accessToken, username string) {
 	// TODO - Verify that only one uid got deleted once numUids are returned as part of the payload.
-	delUser := `mutation deleteUser($name: String!) {
+	delUser := `
+	mutation deleteUser($name: String!) {
 		deleteUser(filter: {name: {eq: $name}}) {
 			msg
 		}
@@ -115,7 +107,8 @@ func deleteUser(t *testing.T, accessToken, username string) {
 
 func deleteGroup(t *testing.T, accessToken, name string) {
 	// TODO - Verify that only one uid got deleted once numUids are returned as part of the payload.
-	delGroup := `mutation deleteUser($name: String!) {
+	delGroup := `
+	mutation deleteUser($name: String!) {
 		deleteGroup(filter: {name: {eq: $name}}) {
 			msg
 		}
@@ -145,7 +138,8 @@ func TestPasswordReturn(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-	query := `query {
+	query := `
+	query {
 		getCurrentUser {
 			name
 			password
@@ -234,22 +228,11 @@ func resetUser(t *testing.T) {
 func TestReservedPredicates(t *testing.T) {
 	// This test uses the groot account to ensure that reserved predicates
 	// cannot be altered even if the permissions allow it.
-	ctx := context.Background()
-
 	dg1, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
 	alterReservedPredicates(t, dg1)
-
-	dg2, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	if err != nil {
-		t.Fatalf("Error while getting a dgraph client: %v", err)
-	}
-	if err := dg2.Login(ctx, x.GrootId, "password"); err != nil {
-		t.Fatalf("unable to login using the groot account:%v", err)
-	}
-	alterReservedPredicates(t, dg2)
 }
 
 func TestAuthorization(t *testing.T) {
@@ -443,7 +426,8 @@ func createAccountAndData(t *testing.T, dg *dgo.Dgraph) {
 }
 
 func createGroup(t *testing.T, accessToken, name string) []byte {
-	addGroup := `mutation addGroup($name: String!) {
+	addGroup := `
+	mutation addGroup($name: String!) {
 		addGroup(input: [{name: $name}]) {
 			group {
 				name
@@ -463,7 +447,8 @@ func createGroup(t *testing.T, accessToken, name string) []byte {
 
 func createGroupWithRules(t *testing.T, accessJwt, name string, rules []rule) *group {
 	queryParams := testutil.GraphQLParams{
-		Query: `mutation addGroup($name: String!, $rules: [RuleRef]){
+		Query: `
+		mutation addGroup($name: String!, $rules: [RuleRef]){
 			addGroup(input: [
 				{
 					name: $name
@@ -505,8 +490,8 @@ func createGroupWithRules(t *testing.T, accessJwt, name string, rules []rule) *g
 func updateGroup(t *testing.T, accessJwt, name string, setRules []rule,
 	removeRules []string) *group {
 	queryParams := testutil.GraphQLParams{
-		Query: `mutation updateGroup($name: String!, $set: SetGroupPatch, 
-$remove: RemoveGroupPatch){
+		Query: `
+		mutation updateGroup($name: String!, $set: SetGroupPatch, $remove: RemoveGroupPatch){
 			updateGroup(input: {
 				filter: {
 					name: {
@@ -1715,7 +1700,7 @@ func TestWrongPermission(t *testing.T) {
 		CommitNow: true,
 	})
 
-	require.Error(t, err, "Setting permission to 9 shouldn't have returned error")
+	require.Error(t, err, "Setting permission to 9 should have returned error")
 	require.Contains(t, err.Error(), "Value for this predicate should be between 0 and 7")
 
 	ruleMutation = `
@@ -1731,7 +1716,7 @@ func TestWrongPermission(t *testing.T) {
 		CommitNow: true,
 	})
 
-	require.Error(t, err, "Setting permission to -1 shouldn't have returned error")
+	require.Error(t, err, "Setting permission to -1 should have returned error")
 	require.Contains(t, err.Error(), "Value for this predicate should be between 0 and 7")
 }
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2027,6 +2027,7 @@ func TestCrossGroupPermission(t *testing.T) {
 		UserID:   "groot",
 		Passwd:   "password",
 	})
+	require.NoError(t, err)
 
 	// create 8 users.
 	for i := 0; i < 8; i++ {

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1895,7 +1895,7 @@ func TestAddUpdateGroupWithDuplicateRules(t *testing.T) {
 }
 
 func TestAllowUIDAccess(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
@@ -1950,8 +1950,8 @@ func TestAllowUIDAccess(t *testing.T) {
 	testutil.CompareJSON(t, `{"me":[{"name":"100th User", "uid": "0x64"}]}`, string(resp.GetJson()))
 }
 
-func TestAddNewPreidcate(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+func TestAddNewPredicate(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)
@@ -1978,9 +1978,6 @@ func TestAddNewPreidcate(t *testing.T) {
 	require.NoError(t, err, "login failed")
 	addToGroup(t, accessJwt, userid, "guardians")
 
-	// wait for acl cache to be refresh.
-	time.Sleep(6 * time.Second)
-
 	// Alice is a guardian now, it can create new predicate.
 	err = userClient.Alter(ctx, &api.Operation{
 		Schema: `newpred: string .`,
@@ -1989,7 +1986,7 @@ func TestAddNewPreidcate(t *testing.T) {
 }
 
 func TestCrossGroupPermission(t *testing.T) {
-	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
 	require.NoError(t, err)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -149,7 +149,7 @@ func TestPasswordReturn(t *testing.T) {
 
 	l := makeRequest(t, accessJwt, testutil.GraphQLParams{Query: query})
 	require.Equal(t, string(l), `{"errors":[{"message":"Cannot query field \"password\"`+
-		` on type \"User\".","locations":[{"line":4,"column":4}]}]}`)
+		` on type \"User\".","locations":[{"line":5,"column":4}]}]}`)
 }
 
 func TestGetCurrentUser(t *testing.T) {
@@ -2019,6 +2019,14 @@ func TestCrossGroupPermission(t *testing.T) {
 	addRulesToGroup(t, accessJwt, "reader", []rule{{Predicate: "newpred", Permission: 4}})
 	addRulesToGroup(t, accessJwt, "writer", []rule{{Predicate: "newpred", Permission: 2}})
 	addRulesToGroup(t, accessJwt, "alterer", []rule{{Predicate: "newpred", Permission: 1}})
+	// Wait for acl cache to be refreshed
+	time.Sleep(6 * time.Second)
+
+	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint: adminEndpoint,
+		UserID:   "groot",
+		Passwd:   "password",
+	})
 
 	// create 8 users.
 	for i := 0; i < 8; i++ {

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2006,6 +2006,7 @@ func TestCrossGroupPermission(t *testing.T) {
 		UserID:   "groot",
 		Passwd:   "password",
 	})
+	require.NoError(t, err)
 
 	// TODO(@Animesh): I am Running all the operations with the same accessJwt
 	// but access token will expire after 3s. Find an idomatic way to run these.


### PR DESCRIPTION
Added test for -:
    * Different groups having different permissions for a predicate and users belong to more than 1 such group.
    * New predicate creation. Users can't create new predicate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5083)
<!-- Reviewable:end -->
