### PR TITLE
Pass read timestamp to getNew.

### DIFF
--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -182,7 +182,7 @@ func TestTokensTable(t *testing.T) {
 	require.NoError(t, schema.ParseBytes([]byte(schemaVal), 1))
 
 	key := x.DataKey("name", 1)
-	l, err := getNew(key, ps)
+	l, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	edge := &pb.DirectedEdge{
@@ -236,7 +236,7 @@ func addEdgeToValue(t *testing.T, attr string, src uint64,
 		Entity: src,
 		Op:     pb.DirectedEdge_SET,
 	}
-	l, err := GetNoStore(x.DataKey(attr, src))
+	l, err := GetNoStore(x.DataKey(attr, src), startTs)
 	require.NoError(t, err)
 	// No index entries added here as we do not call AddMutationWithIndex.
 	addMutation(t, l, edge, Set, startTs, commitTs, false)
@@ -252,7 +252,7 @@ func addEdgeToUID(t *testing.T, attr string, src uint64,
 		Entity:  src,
 		Op:      pb.DirectedEdge_SET,
 	}
-	l, err := GetNoStore(x.DataKey(attr, src))
+	l, err := GetNoStore(x.DataKey(attr, src), startTs)
 	require.NoError(t, err)
 	// No index entries added here as we do not call AddMutationWithIndex.
 	addMutation(t, l, edge, Set, startTs, commitTs, false)
@@ -292,7 +292,7 @@ func TestRebuildTokIndex(t *testing.T) {
 			continue
 		}
 		idxKeys = append(idxKeys, string(key))
-		l, err := GetNoStore(key)
+		l, err := GetNoStore(key, 6)
 		require.NoError(t, err)
 		idxVals = append(idxVals, l)
 	}
@@ -355,7 +355,7 @@ func TestRebuildTokIndexWithDeletion(t *testing.T) {
 			continue
 		}
 		idxKeys = append(idxKeys, string(key))
-		l, err := GetNoStore(key)
+		l, err := GetNoStore(key, 7)
 		require.NoError(t, err)
 		idxVals = append(idxVals, l)
 	}

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -171,7 +171,7 @@ func checkValue(t *testing.T, ol *List, val string, readTs uint64) {
 // TODO(txn): Add tests after lru eviction
 func TestAddMutation_Value(t *testing.T) {
 	key := x.DataKey("value", 10)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	edge := &pb.DirectedEdge{
 		Value: []byte("oh hey there"),
@@ -194,7 +194,7 @@ func TestAddMutation_Value(t *testing.T) {
 
 func TestAddMutation_jchiu1(t *testing.T) {
 	key := x.DataKey("value", 12)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to cars and merge to BadgerDB.
@@ -241,7 +241,7 @@ func TestAddMutation_jchiu1(t *testing.T) {
 
 func TestAddMutation_DelSet(t *testing.T) {
 	key := x.DataKey("value", 1534)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// DO sp*, don't commit
@@ -267,7 +267,7 @@ func TestAddMutation_DelSet(t *testing.T) {
 
 func TestAddMutation_DelRead(t *testing.T) {
 	key := x.DataKey("value", 1543)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to newcars, and commit it
@@ -306,7 +306,7 @@ func TestAddMutation_DelRead(t *testing.T) {
 
 func TestAddMutation_jchiu2(t *testing.T) {
 	key := x.DataKey("value", 15)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Del a value cars and but don't merge.
@@ -330,7 +330,7 @@ func TestAddMutation_jchiu2(t *testing.T) {
 
 func TestAddMutation_jchiu2_Commit(t *testing.T) {
 	key := x.DataKey("value", 16)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Del a value cars and but don't merge.
@@ -357,7 +357,7 @@ func TestAddMutation_jchiu2_Commit(t *testing.T) {
 
 func TestAddMutation_jchiu3(t *testing.T) {
 	key := x.DataKey("value", 29)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to cars and merge to BadgerDB.
@@ -401,7 +401,7 @@ func TestAddMutation_jchiu3(t *testing.T) {
 
 func TestAddMutation_mrjn1(t *testing.T) {
 	key := x.DataKey("value", 21)
-	ol, err := GetNoStore(key)
+	ol, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set a value cars and merge.
@@ -454,7 +454,7 @@ func TestMillion(t *testing.T) {
 	maxListSize = math.MaxInt32
 
 	key := x.DataKey("bal", 1331)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	var commits int
 	N := int(1e6)
@@ -472,7 +472,7 @@ func TestMillion(t *testing.T) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		commits++
@@ -492,7 +492,7 @@ func TestMillion(t *testing.T) {
 func TestAddMutation_mrjn2(t *testing.T) {
 	ctx := context.Background()
 	key := x.DataKey("bal", 1001)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	var readTs uint64
 	for readTs = 1; readTs < 10; readTs++ {
@@ -570,7 +570,7 @@ func TestAddMutation_mrjn2(t *testing.T) {
 
 func TestAddMutation_gru(t *testing.T) {
 	key := x.DataKey("question.tag", 0x01)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	{
@@ -607,7 +607,7 @@ func TestAddMutation_gru(t *testing.T) {
 
 func TestAddMutation_gru2(t *testing.T) {
 	key := x.DataKey("question.tag", 0x100)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	{
@@ -659,7 +659,7 @@ func TestAddAndDelMutation(t *testing.T) {
 	// Ensure each test uses unique key since we don't clear the postings
 	// after each test
 	key := x.DataKey("dummy_key", 0x927)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	{
@@ -689,7 +689,7 @@ func TestAddAndDelMutation(t *testing.T) {
 
 func TestAfterUIDCount(t *testing.T) {
 	key := x.DataKey("value", 22)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	// Set value to cars and merge to BadgerDB.
 	edge := &pb.DirectedEdge{
@@ -763,7 +763,7 @@ func TestAfterUIDCount(t *testing.T) {
 
 func TestAfterUIDCount2(t *testing.T) {
 	key := x.DataKey("value", 23)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to cars and merge to BadgerDB.
@@ -793,7 +793,7 @@ func TestAfterUIDCount2(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	key := x.DataKey("value", 25)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to cars and merge to BadgerDB.
@@ -817,7 +817,7 @@ func TestDelete(t *testing.T) {
 
 func TestAfterUIDCountWithCommit(t *testing.T) {
 	key := x.DataKey("value", 26)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Set value to cars and merge to BadgerDB.
@@ -903,7 +903,7 @@ func createMultiPartList(t *testing.T, size int, addLabel bool) (*List, int) {
 	}()
 
 	key := x.DataKey(uuid.New().String(), 1331)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	commits := 0
 	for i := 1; i <= size; i++ {
@@ -921,7 +921,7 @@ func createMultiPartList(t *testing.T, size int, addLabel bool) (*List, int) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		commits++
@@ -933,7 +933,7 @@ func createMultiPartList(t *testing.T, size int, addLabel bool) (*List, int) {
 	}
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
+	ol, err = getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	require.True(t, len(ol.plist.Splits) > 0)
 
@@ -948,7 +948,7 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 	}()
 
 	key := x.DataKey(uuid.New().String(), 1331)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	commits := 0
 	for i := 1; i <= size; i++ {
@@ -963,7 +963,7 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		commits++
@@ -983,7 +983,7 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		commits++
@@ -1089,7 +1089,7 @@ func TestMultiPartListWriteToDisk(t *testing.T) {
 	require.Equal(t, len(kvs), len(originalList.plist.Splits)+1)
 
 	require.NoError(t, writePostingListToDisk(kvs))
-	newList, err := getNew(kvs[0].Key, ps)
+	newList, err := getNew(kvs[0].Key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	opt := ListOptions{ReadTs: uint64(size) + 1}
@@ -1140,7 +1140,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 
 	// Add entries to the maps.
 	key := x.DataKey(uuid.New().String(), 1331)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	for i := 1; i <= size; i++ {
 		edge := &pb.DirectedEdge{
@@ -1154,7 +1154,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 	}
@@ -1181,7 +1181,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 	}
@@ -1190,7 +1190,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	kvs, err := ol.Rollup()
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
+	ol, err = getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	for _, kv := range kvs {
 		require.Equal(t, baseStartTs+uint64(1+size/2), kv.Version)
@@ -1218,7 +1218,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup()
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps)
+			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 	}
@@ -1227,7 +1227,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	kvs, err = ol.Rollup()
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
+	ol, err = getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Verify all entries are once again in the list.
@@ -1280,7 +1280,7 @@ func TestRecursiveSplits(t *testing.T) {
 	// Create a list that should be split recursively.
 	size := int(1e5)
 	key := x.DataKey(uuid.New().String(), 1331)
-	ol, err := getNew(key, ps)
+	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	commits := 0
 	for i := 1; i <= size; i++ {
@@ -1302,7 +1302,7 @@ func TestRecursiveSplits(t *testing.T) {
 	kvs, err := ol.Rollup()
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps)
+	ol, err = getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	require.True(t, len(ol.plist.Splits) > 2)
 
@@ -1344,7 +1344,7 @@ func TestMain(m *testing.M) {
 
 func BenchmarkAddMutations(b *testing.B) {
 	key := x.DataKey("name", 1)
-	l, err := getNew(key, ps)
+	l, err := getNew(key, ps, math.MaxUint64)
 	if err != nil {
 		b.Error(err)
 	}

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"os/exec"
 	"runtime"
@@ -205,7 +206,7 @@ func (lc *LocalCache) SetIfAbsent(key string, updated *List) *List {
 
 func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) {
 	if lc == nil {
-		return getNew(key, pstore, lc.startTs)
+		return getNew(key, pstore, math.MaxUint64)
 	}
 	skey := string(key)
 	if pl := lc.getNoStore(skey); pl != nil {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -146,8 +146,8 @@ func Cleanup() {
 
 // GetNoStore returns the list stored in the key or creates a new one if it doesn't exist.
 // It does not store the list in any cache.
-func GetNoStore(key []byte) (rlist *List, err error) {
-	return getNew(key, pstore)
+func GetNoStore(key []byte, readTs uint64) (rlist *List, err error) {
+	return getNew(key, pstore, readTs)
 }
 
 // LocalCache stores a cache of posting lists and deltas.
@@ -205,7 +205,7 @@ func (lc *LocalCache) SetIfAbsent(key string, updated *List) *List {
 
 func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) {
 	if lc == nil {
-		return getNew(key, pstore)
+		return getNew(key, pstore, lc.startTs)
 	}
 	skey := string(key)
 	if pl := lc.getNoStore(skey); pl != nil {
@@ -215,7 +215,7 @@ func (lc *LocalCache) getInternal(key []byte, readFromDisk bool) (*List, error) 
 	var pl *List
 	if readFromDisk {
 		var err error
-		pl, err = getNew(key, pstore)
+		pl, err = getNew(key, pstore, lc.startTs)
 		if err != nil {
 			return nil, err
 		}

--- a/posting/lmap_test.go
+++ b/posting/lmap_test.go
@@ -17,6 +17,7 @@
 package posting
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 )
@@ -28,7 +29,7 @@ func BenchmarkGet(b *testing.B) {
 		for pb.Next() {
 			// i := uint64(rand.Int63())
 			_ = uint64(rand.Int63())
-			getNew(key, nil)
+			getNew(key, nil, math.MaxUint64)
 			// lmap.Get(i)
 		}
 	})
@@ -40,7 +41,7 @@ func BenchmarkGetLinear(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		k := uint64(i)
 		if _, ok := m[k]; !ok {
-			l, err := getNew(key, nil)
+			l, err := getNew(key, nil, math.MaxUint64)
 			if err != nil {
 				b.Error(err)
 			}

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -65,7 +65,7 @@ var (
 
 // rollUpKey takes the given key's posting lists, rolls it up and writes back to badger
 func (ir *incrRollupi) rollUpKey(writer *TxnWriter, key []byte) error {
-	l, err := GetNoStore(key)
+	l, err := GetNoStore(key, math.MaxUint64)
 	if err != nil {
 		return err
 	}
@@ -332,9 +332,8 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 	return l, nil
 }
 
-// TODO: We should only create a posting list with a specific readTs.
-func getNew(key []byte, pstore *badger.DB) (*List, error) {
-	txn := pstore.NewTransactionAt(math.MaxUint64, false)
+func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
+	txn := pstore.NewTransactionAt(readTs, false)
 	defer txn.Discard()
 
 	// When we do rollups, an older version would go to the top of the LSM tree, which can cause

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -17,6 +17,7 @@
 package posting
 
 import (
+	"math"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -31,7 +32,7 @@ func TestRollupTimestamp(t *testing.T) {
 	addEdgeToUID(t, "rollup", 1, 3, 3, 4)
 	addEdgeToUID(t, "rollup", 1, 4, 5, 6)
 
-	l, err := GetNoStore(key)
+	l, err := GetNoStore(key, math.MaxUint64)
 	require.NoError(t, err)
 
 	uidList, err := l.Uids(ListOptions{ReadTs: 7})
@@ -46,7 +47,7 @@ func TestRollupTimestamp(t *testing.T) {
 	}
 	addMutation(t, l, edge, Del, 9, 10, false)
 
-	nl, err := getNew(key, pstore)
+	nl, err := getNew(key, pstore, math.MaxUint64)
 	require.NoError(t, err)
 
 	uidList, err = nl.Uids(ListOptions{ReadTs: 11})
@@ -64,7 +65,7 @@ func TestPostingListRead(t *testing.T) {
 	key := x.DataKey("emptypl", 1)
 
 	assertLength := func(readTs, sz int) {
-		nl, err := getNew(key, pstore)
+		nl, err := getNew(key, pstore, math.MaxUint64)
 		require.NoError(t, err)
 		uidList, err := nl.Uids(ListOptions{ReadTs: uint64(readTs)})
 		require.NoError(t, err)

--- a/worker/match.go
+++ b/worker/match.go
@@ -84,7 +84,7 @@ func uidsForMatch(attr string, arg funcArgs) (*pb.List, error) {
 	opts := posting.ListOptions{ReadTs: arg.q.ReadTs}
 	uidsForNgram := func(ngram string) (*pb.List, error) {
 		key := x.IndexKey(attr, ngram)
-		pl, err := posting.GetNoStore(key)
+		pl, err := posting.GetNoStore(key, arg.q.ReadTs)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -545,7 +545,7 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 
 	key := x.IndexKey(order.Attr, token)
 	// Don't put the Index keys in memory.
-	pl, err := posting.GetNoStore(key)
+	pl, err := posting.GetNoStore(key, ts.GetReadTs())
 	if err != nil {
 		return err
 	}
@@ -741,7 +741,7 @@ func sortByValue(ctx context.Context, ts *pb.SortMessage, ul *pb.List,
 func fetchValue(uid uint64, attr string, langs []string, scalar types.TypeID,
 	readTs uint64) (types.Val, error) {
 	// Don't put the values in memory
-	pl, err := posting.GetNoStore(x.DataKey(attr, uid))
+	pl, err := posting.GetNoStore(x.DataKey(attr, uid), readTs)
 	if err != nil {
 		return types.Val{}, err
 	}

--- a/worker/task.go
+++ b/worker/task.go
@@ -1220,7 +1220,7 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 				switch lang {
 				case "":
 					if isList {
-						pl, err := posting.GetNoStore(x.DataKey(attr, uid))
+						pl, err := posting.GetNoStore(x.DataKey(attr, uid), arg.q.ReadTs)
 						if err != nil {
 							filterErr = err
 							return false
@@ -1234,7 +1234,8 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 						}
 						for _, sv := range svs {
 							dst, err := types.Convert(sv, typ)
-							if err == nil && types.CompareVals(arg.q.SrcFunc.Name, dst, arg.srcFn.eqTokens[row]) {
+							if err == nil && types.CompareVals(arg.q.SrcFunc.Name, dst,
+								arg.srcFn.eqTokens[row]) {
 								return true
 							}
 						}
@@ -1242,7 +1243,7 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 						return false
 					}
 
-					pl, err := posting.GetNoStore(x.DataKey(attr, uid))
+					pl, err := posting.GetNoStore(x.DataKey(attr, uid), arg.q.ReadTs)
 					if err != nil {
 						filterErr = err
 						return false
@@ -1258,7 +1259,7 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 					return err == nil &&
 						types.CompareVals(arg.q.SrcFunc.Name, dst, arg.srcFn.eqTokens[row])
 				case ".":
-					pl, err := posting.GetNoStore(x.DataKey(attr, uid))
+					pl, err := posting.GetNoStore(x.DataKey(attr, uid), arg.q.ReadTs)
 					if err != nil {
 						filterErr = err
 						return false

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -43,7 +43,7 @@ func uidsForRegex(attr string, arg funcArgs,
 
 	uidsForTrigram := func(trigram string) (*pb.List, error) {
 		key := x.IndexKey(attr, trigram)
-		pl, err := posting.GetNoStore(key)
+		pl, err := posting.GetNoStore(key, arg.q.ReadTs)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -91,7 +92,7 @@ func delClusterEdge(t *testing.T, dg *dgo.Dgraph, rdf string) {
 	require.NoError(t, err)
 }
 func getOrCreate(key []byte) *posting.List {
-	l, err := posting.GetNoStore(key)
+	l, err := posting.GetNoStore(key, math.MaxUint64)
 	x.Checkf(err, "While calling posting.Get")
 	return l
 }


### PR DESCRIPTION
Fixes the issue with ludicrous mode reading more up-to-date versions of the key than it should.

Ran the live loader and didn't see any errors in the live loader output or in the Dgraph logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5085)
<!-- Reviewable:end -->
