### PR TITLE
Added support for xidmap in bulkloader

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -160,14 +160,14 @@ func readSchema(filename string) *schema.ParsedSchema {
 	return result
 }
 
-func (ld *loader) mapStage(opt *options) {
+func (ld *loader) mapStage() {
 	ld.prog.setPhase(mapPhase)
-	if len(opt.ClientDir) > 0 {
+	if len(ld.opt.ClientDir) > 0 {
 		var db *badger.DB
-		x.Check(os.MkdirAll(opt.ClientDir, 0700))
+		x.Check(os.MkdirAll(ld.opt.ClientDir, 0700))
 
 		var err error
-		db, err = badger.Open(badger.DefaultOptions(opt.ClientDir))
+		db, err = badger.Open(badger.DefaultOptions(ld.opt.ClientDir))
 		x.Checkf(err, "Error while creating badger KV posting store")
 		ld.xids = xidmap.New(ld.zero, db)
 	} else {

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -234,6 +234,8 @@ func (ld *loader) mapStage() {
 	}
 	x.Check(ld.xids.Flush())
 	ld.xids = nil
+	x.Check(db.Close())
+
 }
 
 func (ld *loader) reduceStage() {

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -162,17 +162,15 @@ func readSchema(filename string) *schema.ParsedSchema {
 
 func (ld *loader) mapStage() {
 	ld.prog.setPhase(mapPhase)
+	var db *badger.DB
 	if len(ld.opt.ClientDir) > 0 {
-		var db *badger.DB
 		x.Check(os.MkdirAll(ld.opt.ClientDir, 0700))
 
 		var err error
 		db, err = badger.Open(badger.DefaultOptions(ld.opt.ClientDir))
 		x.Checkf(err, "Error while creating badger KV posting store")
-		ld.xids = xidmap.New(ld.zero, db)
-	} else {
-		ld.xids = xidmap.New(ld.zero, nil)
 	}
+	ld.xids = xidmap.New(ld.zero, db)
 
 	files := x.FindDataFiles(ld.opt.DataFiles, []string{".rdf", ".rdf.gz", ".json", ".json.gz"})
 	if len(files) == 0 {

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -233,7 +233,9 @@ func (ld *loader) mapStage() {
 		ld.mappers[i] = nil
 	}
 	x.Check(ld.xids.Flush())
-	x.Check(db.Close())
+	if db != nil {
+		x.Check(db.Close())
+	}
 	ld.xids = nil
 }
 

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -233,9 +233,8 @@ func (ld *loader) mapStage() {
 		ld.mappers[i] = nil
 	}
 	x.Check(ld.xids.Flush())
-	ld.xids = nil
 	x.Check(db.Close())
-
+	ld.xids = nil
 }
 
 func (ld *loader) reduceStage() {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -81,6 +81,7 @@ func init() {
 	flag.Bool("version", false, "Prints the version of Dgraph Bulk Loader.")
 	flag.BoolP("store_xids", "x", false, "Generate an xid edge for each node.")
 	flag.StringP("zero", "z", "localhost:5080", "gRPC address for Dgraph zero")
+	flag.String("xidmap", "", "Directory to store xid to uid mapping")
 	// TODO: Potentially move http server to main.
 	flag.String("http", "localhost:8080",
 		"Address to serve http (pprof).")
@@ -129,6 +130,7 @@ func run() {
 		ReduceShards:     Bulk.Conf.GetInt("reduce_shards"),
 		CustomTokenizers: Bulk.Conf.GetString("custom_tokenizers"),
 		NewUids:          Bulk.Conf.GetBool("new_uids"),
+		ClientDir:        Bulk.Conf.GetString("xidmap"),
 
 		BadgerKeyFile:          Bulk.Conf.GetString("encryption_key_file"),
 		BadgerCompressionLevel: Bulk.Conf.GetInt("badger.compression_level"),
@@ -225,7 +227,7 @@ func run() {
 
 	loader := newLoader(&opt)
 	if !opt.SkipMapPhase {
-		loader.mapStage()
+		loader.mapStage(&opt)
 		mergeMapShardsIntoReduceShards(&opt)
 	}
 	loader.reduceStage()

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -227,7 +227,7 @@ func run() {
 
 	loader := newLoader(&opt)
 	if !opt.SkipMapPhase {
-		loader.mapStage(&opt)
+		loader.mapStage()
 		mergeMapShardsIntoReduceShards(&opt)
 	}
 	loader.reduceStage()


### PR DESCRIPTION
### Dear contributor, what does this PR do?
This PR adds `--xidmap` option to bulk-loader which stores explicit map between UIDs (Assigned by dgraph) and External IDs (passed by user). Documentation for `--xidmap` flag can be found [here](https://github.com/dgraph-io/dgraph/pull/5093)

<!-- First, describe here details about it. -->
### Motivation
This is a community-asked feature. Related discussion can be found in [Issue:4917](https://github.com/dgraph-io/dgraph/issues/4917)

<!-- Besides the motivation itself, if applicable, you should add references. e.g public conversations (URL) in the community. This helps reviewers with context. You should also advocate for the PR if needed. You can ping Daniel, Karthic, Michel or Santo if you need help. -->

### Components affected by this PR <!-- (Optional) -->
Bulk loader, documentation for this is being updated by [PR:5093](https://github.com/dgraph-io/dgraph/pull/5093)
<!-- Please, take a minute to think about what or who this PR affects. Does it need help for doing documentation? Does it affect third parties (Open Source or not) applications? Make it clear so we can track and fix it. -->
<!-- e.g. "It breaks/affects Ratel UI behavior." or You are working on documentation. Check if any links will be broken with your changes. -->

### Does this PR break backwards compatibility?  <!-- (Optional) -->
No
<!-- Yes/no, and details if needed. -->

### Testing <!-- (Optional) -->
Verified that `xid-uid` map stored using the flag is identical to the xid-uid mapping which happens in dgraph and can be checked via querying on `Ratel`. For this a small rdf file was bulk uploaded and queried to verify.

### Fixes <!-- (Optional) -->
[Issue:4917](https://github.com/dgraph-io/dgraph/issues/4917)
<!-- Add here an issue that this PR will close. -->

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5090)
<!-- Reviewable:end -->
