### PR TITLE
docs: adds missing release page in the toc

### DIFF
--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -64,3 +64,8 @@ title = "Dgraph Documentation"
   url = "/dgraph-compared-to-other-databases/"
   identifier = "dgraph-compared-to-other-databases"
   weight = 12
+[[menu.main]]
+  name = "Releases"
+  url = "/releases/"
+  identifier = "releases"
+  weight = 13

--- a/wiki/content/releases/index.md
+++ b/wiki/content/releases/index.md
@@ -11,12 +11,13 @@ You can watch the [Announce][] Discuss category to know about the latest release
 
  Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
 -----------------------|-----------------|------------|--------------------|------------
- v20.03.x              | Unreleased      | -          | -                  | -
+ v20.03.x              | [v20.03.0][]    | Yes        | March 2020         | March 2021
  v1.2.x                | [v1.2.2][]      | Yes        | January 2020       | January 2021
  v1.1.x                | [v1.1.1][]      | Yes        | January 2020       | January 2021
  v1.0.x                | [v1.0.18][]     | No         | December 2017      | March 2020
 
 
+[v20.03.0]: https://discuss.dgraph.io/t/dgraph-v20-03-0-release/6216
 [v1.2.2]: https://discuss.dgraph.io/t/dgraph-v1-2-2-release/6158
 [v1.1.1]: https://discuss.dgraph.io/t/dgraph-v1-1-1-release/5664
 [v1.0.18]: https://discuss.dgraph.io/t/dgraph-v1-0-18-release/5663


### PR DESCRIPTION
Somehow we have missed to backport the latest changes from master to this branch

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5091)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9bfc5f67ff-52247.surge.sh)
<!-- Dgraph:end -->