### PR TITLE
Terraform modules for Kubernetes - AWS EKS

### DIFF
--- a/contrib/config/terraform/kubernetes/.gitignore
+++ b/contrib/config/terraform/kubernetes/.gitignore
@@ -1,0 +1,32 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+#
+# Kubeconfig
+kubeconfig

--- a/contrib/config/terraform/kubernetes/README.md
+++ b/contrib/config/terraform/kubernetes/README.md
@@ -1,0 +1,112 @@
+# Deploy Dgraph on AWS EKS using Terraform
+
+Dgraph is a horizontally scalable and distributed graph database, providing ACID transactions,
+consistent replication and linearizable reads. It's built from ground up to perform for a rich set
+of queries. Being a native graph database, it tightly controls how the data is arranged on disk to
+optimize for query performance and throughput, reducing disk seeks and network calls in a cluster.
+
+### Introduction
+
+The Terraform template creates the following resources towards setting up a Dgraph cluster on AWS EKS.
+
+- AWS VPC with 2 private subnets for hosting the EKS cluster, 2 public subnets to host the load balancers to expose the services and one NAT subnet to provision the NAT gateway required for the nodes/pods in the private subnet to communicate with the internet. Also sets up the NACL rules for secure inter subnet communication.
+- AWS EKS in the private subnets to host the Dgraph cluster.
+- The Dgraph cluster Kubernetes resources in either a standalone mode or a HA mode(refer to the variables available to tweak the provisioning of the Dgraph cluster below) on the EKS cluster.
+
+### Prerequisites
+
+- Terraform > 0.12.0
+- awscli >= 1.18.32
+
+## Steps to follow to get the Dgraph cluster on AWS EKS up and running:
+
+1. You must have an AWS account with privileges to create VPC, EKS and associated resources. Ensure awscli setup with the right credentials (One can also use AWS_PROFILE=\<profilename\> terraform \<command\> alternatively).
+
+2. [Download](https://terraform.io/downloads.html) and install Terraform.
+
+3. Create a `terraform.tfvars` file similar to that of `terraform.tfvars.example` and edit the variables inside accordingly.
+   You can override any variable present in [variables.tf](./variables.tf) by providing an explicit value in `terraform.tfvars` file.
+
+4. Execute the following commands:
+
+```sh
+$ terraform init
+$ terraform plan -target=module.aws
+$ terraform apply -target=module.aws
+# One can choose to not run the following commands if they intend to use [Helm charts](https://github.com/dgraph-io/charts) to provision their resources on the Kubernetes cluster.
+# If you want to manage the state of the Kubernetes resources using Terraform, run the following commands as well:
+$ terraform plan -target=module.dgraph
+$ terraform apply -target=module.dgraph
+```
+
+> Note: Both the modules cannot be applied in the same run owing to the way Terraform [evaluates](https://www.terraform.io/docs/providers/kubernetes/index.html#stacking-with-managed-kubernetes-cluster-resources) the provider blocks.
+
+The command `terraform apply -target=module.dgraph` would output the hostnames of the Load Balancers exposing the Alpha, Zero and Ratel services. 
+
+5. Use `terraform destroy -target=module.aws` to delete the setup and restore the previous state.
+
+
+
+The following table lists the configurable parameters of the template and their default values:
+
+| Parameter                 | Description                                                  | Default       |
+| ------------------------- | ------------------------------------------------------------ | ------------- |
+| `prefix`                  | The namespace prefix for all resources                       | dgraph        |
+| `cidr`                    | The CIDR of the VPC                                          | 10.20.0.0/16  |
+| `region`                  | The region to deploy the resources in                        | ap-south-1    |
+| `ha`                      | Enable or disable HA deployment of Dgraph                    | true          |
+| `ingress_whitelist_cidrs` | The CIDRs whitelisted at the service Load Balancer | ["0.0.0.0/0"] |
+| `only_whitelist_local_ip` | "Only whitelist the IP of the executioner at the service Load Balancers | true          |
+| `worker_nodes_count`      | The number of worker nodes to provision with the EKS cluster | 3             |
+| `instance_types`		          | The list of instance types to run as worker nodes | ["m5.large"] |
+| `namespace`               | The namespace to deploy the Dgraph pods to                   | dgraph        |
+| `zero_replicas`           | The number of Zero replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Zero pod | 3             |
+| `zero_persistence`        | If enabled mounts a persistent disk to the Zero pods         | true          |
+| `zero_storage_size_gb`       | The size of the persistent disk to attach to the Zero pods in GiB | 10            |
+| `alpha_replicas`          | The number of Alpha replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Alpha pod | 3             |
+| `alpha_initialize_data`   | If set, runs an init container to help with loading the data into Alpha | false         |
+| `alpha_persistence`       | If enabled, mounts a persistent disk to the Alpha pods        | true          |
+| `alpha_storage_size_gb`      | The size of the persistent disk to attach to the Alpha pods in GiB | 10            |
+| `alpha_lru_size_mb`               | The LRU cache to enable on Alpha pods in MiB                | 2048          |
+
+
+> NOTE: 
+>
+> 1. If `ha` is set to `false` the `worker_node_count` is overridden to `1`.
+>
+> 2. If `only_whitelist_local_ip` is set to`true`, the `ingress_whitelist_cidrs is overridden` to local IP of the executioner.
+>
+> 3. The `kubeconfig` file is created in the root directory of this repository.
+>
+> 4. One could use Helm to install the Kubernetes resources onto the cluster, in which case comment out the `dgraph` module in `main.tf`.
+>
+> 5. The number of `worker_nodes` needs to be more than the greater of replicas of Zero/Alpha when `ha` is enabled to ensure the topological scheduling based on hostnames works.
+> 
+> 6. The hostnames of the service Load Balancers are part of the output of the run. Please use the respective service ports in conjunction with the hostnames. TLS is not enabled.
+>
+> 7. When `alpha_initialize_data`is set to `true`, an init container is provisioned to help with loading the data as follows:
+>
+>    ```
+>          # Initializing the Alphas:
+>          #
+>          # You may want to initialize the Alphas with data before starting, e.g.
+>          # with data from the Dgraph Bulk Loader: https://docs.dgraph.io/deploy/#bulk-loader.
+>          # You can accomplish by uncommenting this initContainers config. This
+>          # starts a container with the same /dgraph volume used by Alpha and runs
+>          # before Alpha starts.
+>          #
+>          # You can copy your local p directory to the pod's /dgraph/p directory
+>          # with this command:
+>          #
+>          #    kubectl cp path/to/p dgraph-alpha-0:/dgraph/ -c init-alpha
+>          #    (repeat for each alpha pod)
+>          #
+>          # When you're finished initializing each Alpha data directory, you can signal
+>          # it to terminate successfully by creating a /dgraph/doneinit file:
+>          #
+>          #    kubectl exec dgraph-alpha-0 -c init-alpha touch /dgraph/doneinit
+>          #
+>          # Note that pod restarts cause re-execution of Init Containers. If persistance is 	  # enabled /dgraph is persisted across pod restarts, the Init Container will exit
+>          # automatically when /dgraph/doneinit is present and proceed with starting
+>          # the Alpha process.
+>    ```

--- a/contrib/config/terraform/kubernetes/main.tf
+++ b/contrib/config/terraform/kubernetes/main.tf
@@ -1,0 +1,47 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+data "http" "localip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
+locals {
+  whitelisted_cidrs = var.only_whitelist_local_ip ? ["${chomp(data.http.localip.body)}/32"] : var.ingress_whitelist_cidrs
+}
+
+module "aws" {
+  source = "./modules/aws"
+
+  prefix = var.prefix
+  cidr   = var.cidr
+  region = var.region
+
+  ha                      = var.ha
+  worker_nodes_count      = var.worker_nodes_count
+  instance_types          = var.instance_types
+  ingress_whitelist_cidrs = local.whitelisted_cidrs
+}
+
+module "dgraph" {
+  source = "./modules/dgraph"
+
+  prefix          = var.prefix
+  ha              = var.ha
+  namespace       = var.namespace
+  kubeconfig_path = module.aws.kubeconfig_path
+
+  zero_replicas        = var.zero_replicas
+  zero_persistence     = var.zero_persistence
+  zero_storage_size_gb = var.zero_storage_size_gb
+
+  alpha_initialize_data = var.alpha_initialize_data
+  alpha_replicas        = var.alpha_replicas
+  alpha_persistence     = var.alpha_persistence
+  alpha_storage_size_gb = var.alpha_storage_size_gb
+  alpha_lru_size_mb     = var.alpha_lru_size_mb
+  # The Kubernetes Service Terraform resource does not expose any attributes
+  zero_address = "${var.prefix}-dgraph-zero-0.${var.prefix}-dgraph-zero.${var.namespace}.svc.cluster.local"
+
+  ingress_whitelist_cidrs = local.whitelisted_cidrs
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/main.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+
+  cluster_name = var.prefix
+  cidr         = var.cidr
+  region       = var.region
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  cluster_name = var.prefix
+  ha           = var.ha
+  region       = var.region
+
+  vpc_id                  = module.vpc.vpc_id
+  cluster_subnet_ids      = module.vpc.cluster_subnet_ids
+  db_subnet_ids           = module.vpc.db_subnet_ids
+  worker_nodes_count      = var.worker_nodes_count
+  instance_types          = var.instance_types
+  ingress_whitelist_cidrs = var.ingress_whitelist_cidrs
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/data.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/data.tf
@@ -1,0 +1,3 @@
+data "aws_vpc" "vpc" {
+  id = "${var.vpc_id}"
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/eks-cluster.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/eks-cluster.tf
@@ -1,0 +1,75 @@
+resource "aws_iam_role" "cluster_role" {
+  name = "${var.cluster_name}-cluster-iam"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "aws_iam_role_policy_attachment" "eks_clusterpolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster_role.name
+}
+
+
+resource "aws_iam_role_policy_attachment" "eks_servicepolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.cluster_role.name
+}
+
+
+resource "aws_security_group" "cluster_sg" {
+  name        = "${var.cluster_name}-cluster-sg"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = data.aws_vpc.vpc.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-cluster-sg"
+  }
+}
+
+
+resource "aws_security_group_rule" "api_access_sgr" {
+  cidr_blocks       = ["0.0.0.0/0"]
+  description       = "Allow communication with the cluster API Server"
+  from_port         = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.cluster_sg.id
+  to_port           = 443
+  type              = "ingress"
+}
+
+
+resource "aws_eks_cluster" "eks" {
+  name     = var.cluster_name
+  role_arn = aws_iam_role.cluster_role.arn
+
+  vpc_config {
+    security_group_ids = [aws_security_group.cluster_sg.id]
+    subnet_ids         = var.cluster_subnet_ids
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_clusterpolicy,
+    aws_iam_role_policy_attachment.eks_servicepolicy,
+  ]
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/eks-worker-nodes.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/eks-worker-nodes.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role" "worker_role" {
+  name = "${var.cluster_name}-worker-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+
+resource "aws_iam_role_policy_attachment" "eks_worker_nodepolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.worker_role.name
+}
+
+
+resource "aws_iam_role_policy_attachment" "eks_cnipolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.worker_role.name
+}
+
+
+resource "aws_iam_role_policy_attachment" "container_readonlypolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.worker_role.name
+}
+
+
+resource "aws_eks_node_group" "nodegroup" {
+  cluster_name = aws_eks_cluster.eks.name
+
+  instance_types  = var.instance_types
+  node_group_name = "${var.cluster_name}-nodegroup"
+  node_role_arn   = aws_iam_role.worker_role.arn
+  subnet_ids      = var.db_subnet_ids
+
+  scaling_config {
+    desired_size = var.ha ? var.worker_nodes_count : 1
+    max_size     = var.ha ? var.worker_nodes_count : 1
+    min_size     = var.ha ? var.worker_nodes_count : 1
+  }
+
+  tags = map(
+    "Name", "${var.cluster_name}-nodegroup",
+    "kubernetes.io/cluster/${var.cluster_name}", "owned",
+  )
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks_worker_nodepolicy,
+    aws_iam_role_policy_attachment.eks_cnipolicy,
+    aws_iam_role_policy_attachment.container_readonlypolicy,
+  ]
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/outputs.tf
@@ -1,0 +1,62 @@
+locals {
+  kubeconfig_path = "${path.root}/kubeconfig"
+
+  config_map_aws_auth = <<CONFIGMAPAWSAUTH
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: aws-auth
+  namespace: kube-system
+data:
+  mapRoles: |
+    - rolearn: ${aws_iam_role.worker_role.arn}
+      username: system:node:{{EC2PrivateDNSName}}
+      groups:
+        - system:bootstrappers
+        - system:nodes
+CONFIGMAPAWSAUTH
+
+  kubeconfig = <<KUBECONFIG
+apiVersion: v1
+clusters:
+- cluster:
+    server: ${aws_eks_cluster.eks.endpoint}
+    certificate-authority-data: ${aws_eks_cluster.eks.certificate_authority.0.data}
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: aws
+  name: aws
+current-context: aws
+kind: Config
+preferences: {}
+users:
+- name: aws
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1alpha1
+      args:
+      - --region
+      - ${var.region}
+      - eks
+      - get-token
+      - --cluster-name
+      - ${var.cluster_name}
+      command: aws
+      env: null
+KUBECONFIG
+}
+
+
+resource "local_file" "kubeconfig" {
+  content  = local.kubeconfig
+  filename = local.kubeconfig_path
+
+  depends_on = [aws_eks_cluster.eks]
+}
+
+
+output "kubeconfig_path" {
+  value = local.kubeconfig_path
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = var.region
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/eks/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/eks/variables.tf
@@ -1,0 +1,50 @@
+variable "cluster_name" {
+  type        = string
+  default     = "dgraph"
+  description = "The name of the cluster"
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-south-1"
+  description = "AWS region to host your network"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "instance_types" {
+  type        = list
+  default     = ["m5.large"]
+  description = "The list of instance types to run as worker nodes"
+}
+
+variable "worker_nodes_count" {
+  type        = number
+  default     = 3
+  description = "The number of worker nodes to provision with the EKS cluster"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC to create the EKS cluster in"
+}
+
+variable "cluster_subnet_ids" {
+  type        = list
+  description = "The subnets earmarked to create the EKS cluster in"
+}
+
+variable "db_subnet_ids" {
+  type        = list
+  description = "The private subnet IDs"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The IPs whitelisted on the load balancer"
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/data.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/data.tf
@@ -1,0 +1,3 @@
+data "aws_availability_zones" "az" {
+  state = "available"
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/nacl-config.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/nacl-config.tf
@@ -1,0 +1,151 @@
+resource "aws_network_acl" "lb_nacl" {
+  vpc_id     = aws_vpc.vpc.id
+  subnet_ids = aws_subnet.lb_subnets.*.id
+
+
+  ingress {
+    from_port  = 1024
+    to_port    = 65535
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "tcp"
+    cidr_block = cidrsubnet(var.cidr, 1, 1)
+  }
+
+  ingress {
+    from_port  = 1024
+    to_port    = 65535
+    rule_no    = 101
+    action     = "allow"
+    protocol   = "udp"
+    cidr_block = cidrsubnet(var.cidr, 1, 1)
+  }
+
+  dynamic "ingress" {
+    for_each = var.ingress_ports
+    content {
+      from_port  = ingress.value
+      to_port    = ingress.value
+      rule_no    = 102 + ingress.key
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0"
+    }
+  }
+
+  egress {
+    from_port  = 0
+    to_port    = 0
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "-1"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  tags = map(
+    "Name", "${var.cluster_name}-lb-nacl",
+  )
+
+  depends_on = [aws_eip.nat_eip]
+}
+
+
+resource "aws_network_acl" "nat_nacl" {
+  vpc_id     = aws_vpc.vpc.id
+  subnet_ids = [aws_subnet.nat_subnet.id]
+
+  ingress {
+    from_port  = 0
+    to_port    = 65535
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "tcp"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    from_port  = 0
+    to_port    = 65535
+    rule_no    = 200
+    action     = "allow"
+    protocol   = "udp"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    from_port  = 0
+    to_port    = 0
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "-1"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  tags = map(
+    "Name", "${var.cluster_name}-nat-nacl",
+  )
+}
+
+
+resource "aws_network_acl" "db_nacl" {
+  vpc_id     = aws_vpc.vpc.id
+  subnet_ids = aws_subnet.db_subnets.*.id
+
+  ingress {
+    from_port  = 0
+    to_port    = 65535
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "tcp"
+    cidr_block = cidrsubnet(var.cidr, 1, 1)
+  }
+
+  ingress {
+    from_port  = 0
+    to_port    = 65535
+    rule_no    = 101
+    action     = "allow"
+    protocol   = "udp"
+    cidr_block = cidrsubnet(var.cidr, 1, 1)
+  }
+
+  ingress {
+    from_port  = 443
+    to_port    = 443
+    rule_no    = 102
+    action     = "allow"
+    protocol   = "tcp"
+    cidr_block = cidrsubnet(var.cidr, 2, 0)
+  }
+
+  ingress {
+    from_port  = 1024
+    to_port    = 65535
+    rule_no    = 103
+    action     = "allow"
+    protocol   = "tcp"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    from_port  = 1024
+    to_port    = 65535
+    rule_no    = 104
+    action     = "allow"
+    protocol   = "udp"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    from_port  = 0
+    to_port    = 0
+    rule_no    = 100
+    action     = "allow"
+    protocol   = "-1"
+    cidr_block = "0.0.0.0/0"
+  }
+
+  tags = map(
+    "Name", "${var.cluster_name}-db-nacl",
+  )
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.vpc.id
+}
+
+output "db_subnet_ids" {
+  value = aws_subnet.db_subnets.*.id
+}
+
+output "cluster_subnet_ids" {
+  value = concat(aws_subnet.db_subnets.*.id, aws_subnet.lb_subnets.*.id)
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = var.region
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/routes-config.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/routes-config.tf
@@ -1,0 +1,45 @@
+resource "aws_route_table" "route_public_subnets" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.ig.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-public-subnets-route-table"
+  }
+}
+
+resource "aws_route_table" "route_private_subnets" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_gw.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-private-subnets-route-table"
+  }
+}
+
+# ASSOCIATIONS
+##############
+
+resource "aws_route_table_association" "lb_subnet_route_association" {
+  count          = length(aws_subnet.lb_subnets)
+  subnet_id      = aws_subnet.lb_subnets[count.index].id
+  route_table_id = aws_route_table.route_public_subnets.id
+}
+
+resource "aws_route_table_association" "nat_subnet_route_association" {
+  subnet_id      = aws_subnet.nat_subnet.id
+  route_table_id = aws_route_table.route_public_subnets.id
+}
+
+resource "aws_route_table_association" "db_subnet_route_association" {
+  count          = length(aws_subnet.db_subnets)
+  subnet_id      = aws_subnet.db_subnets[count.index].id
+  route_table_id = aws_route_table.route_private_subnets.id
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/subnets-config.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/subnets-config.tf
@@ -1,0 +1,44 @@
+resource "aws_subnet" "lb_subnets" {
+  count = 2
+
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(cidrsubnet(var.cidr, 1, 0), 2, count.index)
+  availability_zone = data.aws_availability_zones.az.names[count.index]
+
+  map_public_ip_on_launch = true
+
+  tags = map(
+    "Name", "${var.cluster_name}-lb-az-${count.index}",
+    "kubernetes.io/cluster/${var.cluster_name}", "shared",
+    "kubernetes.io/role/elb", "1",
+  )
+}
+
+
+resource "aws_subnet" "nat_subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = cidrsubnet(cidrsubnet(var.cidr, 1, 0), 2, 2)
+  availability_zone       = data.aws_availability_zones.az.names[0]
+  map_public_ip_on_launch = false
+
+  tags = map(
+    "Name", "${var.cluster_name}-nat",
+  )
+}
+
+
+resource "aws_subnet" "db_subnets" {
+  count = 2
+
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = cidrsubnet(cidrsubnet(var.cidr, 1, 1), 1, count.index)
+  availability_zone = data.aws_availability_zones.az.names[count.index]
+
+  map_public_ip_on_launch = false
+
+  tags = map(
+    "Name", "${var.cluster_name}-db-az-${count.index}",
+    "kubernetes.io/cluster/${var.cluster_name}", "shared",
+    "kubernetes.io/role/internal-elb", "1",
+  )
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/variables.tf
@@ -1,0 +1,22 @@
+variable "cluster_name" {
+  type        = string
+  default     = "dgraph"
+  description = "The name of the VPC/EKS cluster. Will be used to prefix the applications"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region to host your network"
+}
+
+variable "cidr" {
+  type        = string
+  description = "The CIDR of the VPC"
+}
+
+variable "ingress_ports" {
+  type        = list
+  default     = [5080, 6080, 8000, 8080, 9080]
+  description = "The ingress ports opened at the LB NACL. The specific IP whitelists are applied at the security group level"
+}
+

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/versions.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/vpc-config.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/modules/vpc/vpc-config.tf
@@ -1,0 +1,39 @@
+resource "aws_vpc" "vpc" {
+  cidr_block           = var.cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  instance_tenancy     = "default"
+
+  tags = {
+    Name = var.cluster_name
+  }
+}
+
+resource "aws_internet_gateway" "ig" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.cluster_name}-internet-gateway"
+  }
+}
+
+
+resource "aws_vpc_dhcp_options" "dns_resolver" {
+  domain_name         = "ec2.internal"
+  domain_name_servers = ["AmazonProvidedDNS"]
+}
+
+resource "aws_vpc_dhcp_options_association" "dns_resolver" {
+  vpc_id          = aws_vpc.vpc.id
+  dhcp_options_id = aws_vpc_dhcp_options.dns_resolver.id
+}
+
+
+resource "aws_eip" "nat_eip" {
+  vpc = true
+}
+
+resource "aws_nat_gateway" "nat_gw" {
+  allocation_id = aws_eip.nat_eip.id
+  subnet_id     = aws_subnet.nat_subnet.id
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/outputs.tf
@@ -1,0 +1,3 @@
+output "kubeconfig_path" {
+  value = module.eks.kubeconfig_path
+}

--- a/contrib/config/terraform/kubernetes/modules/aws/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/aws/variables.tf
@@ -1,0 +1,41 @@
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "cidr" {
+  type        = string
+  default     = "10.20.0.0/16"
+  description = "The CIDR of the VPC"
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-south-1"
+  description = "The region to deploy the resources in"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The CIDRs whitelisted at the service load balancer"
+}
+
+variable "worker_nodes_count" {
+  type        = number
+  default     = 3
+  description = "The number of worker nodes to provision with the EKS cluster"
+}
+
+variable "instance_types" {
+  type        = list
+  default     = ["m5.large"]
+  description = "The list of instance types to run as worker nodes"
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/main.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/main.tf
@@ -1,0 +1,59 @@
+terraform {
+  required_version = ">= 0.12.0"
+}
+
+resource "kubernetes_namespace" "dgraph_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+module "zero" {
+  source = "./modules/zero"
+
+  prefix    = var.prefix
+  ha        = var.ha
+  namespace = var.namespace
+
+  replicas                = var.zero_replicas
+  persistence             = var.zero_persistence
+  storage_size_gb         = var.zero_storage_size_gb
+  ingress_whitelist_cidrs = var.ingress_whitelist_cidrs
+
+  namespace_resource = kubernetes_namespace.dgraph_namespace
+}
+
+module "alpha" {
+  source = "./modules/alpha"
+
+  prefix    = var.prefix
+  ha        = var.ha
+  namespace = var.namespace
+
+  initialize_data = var.alpha_initialize_data
+
+  # The Kubernetes Service Terraform resource does not expose any attributes
+  zero_address = var.zero_address
+
+  replicas        = var.alpha_replicas
+  persistence     = var.alpha_persistence
+  storage_size_gb = var.alpha_storage_size_gb
+
+  lru_size_mb = var.alpha_lru_size_mb
+
+  ingress_whitelist_cidrs = var.ingress_whitelist_cidrs
+
+  namespace_resource = kubernetes_namespace.dgraph_namespace
+}
+
+module "ratel" {
+  source = "./modules/ratel"
+
+  prefix    = var.prefix
+  namespace = var.namespace
+
+  ingress_whitelist_cidrs = var.ingress_whitelist_cidrs
+
+  namespace_resource = kubernetes_namespace.dgraph_namespace
+}
+

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/.gitignore
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/main.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/main.tf
@@ -1,0 +1,301 @@
+locals {
+  alpha_replicas        = var.ha ? var.replicas : 1
+  has_pod_anti_affinity = var.ha ? [1] : []
+  has_persistence       = var.persistence ? [1] : []
+  initialize_data       = var.initialize_data ? [1] : []
+}
+
+
+resource "kubernetes_service" "dgraph_alpha_public" {
+  metadata {
+    name      = "${var.prefix}-dgraph-alpha-public"
+    namespace = var.namespace
+
+    labels = {
+      app     = "${var.prefix}-dgraph-alpha"
+      monitor = "alpha-dgraph-io"
+    }
+  }
+
+  spec {
+    port {
+      name        = "alpha-grpc"
+      port        = var.grpc_port
+      target_port = var.grpc_port
+    }
+    port {
+      name        = "alpha-http"
+      port        = var.http_port
+      target_port = var.http_port
+    }
+
+    selector = {
+      app = "${var.prefix}-dgraph-alpha"
+    }
+
+    type = "LoadBalancer"
+
+    load_balancer_source_ranges = var.ingress_whitelist_cidrs
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_service" "dgraph_alpha_indexzero_public" {
+  metadata {
+    name      = "${var.prefix}-dgraph-alpha-0-public"
+    namespace = var.namespace
+
+    labels = {
+      app = "${var.prefix}-dgraph-alpha"
+    }
+  }
+
+  spec {
+    port {
+      name        = "alpha-http"
+      port        = var.http_port
+      target_port = var.http_port
+    }
+
+    selector = {
+      "statefulset.kubernetes.io/pod-name" = "${var.prefix}-dgraph-alpha-0"
+    }
+
+    type = "LoadBalancer"
+
+    load_balancer_source_ranges = var.ingress_whitelist_cidrs
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_service" "dgraph_alpha" {
+  metadata {
+    name      = "${var.prefix}-dgraph-alpha"
+    namespace = var.namespace
+
+    labels = {
+      app = "${var.prefix}-dgraph-alpha"
+    }
+  }
+
+  spec {
+    port {
+      name        = "alpha-grpc-int"
+      port        = var.grpc_int_port
+      target_port = var.grpc_int_port
+    }
+
+    selector = {
+      app = "${var.prefix}-dgraph-alpha"
+    }
+
+    type                        = "ClusterIP"
+    cluster_ip                  = "None"
+    publish_not_ready_addresses = true
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_config_map" "dgraph_alpha_command" {
+  metadata {
+    name      = "${var.prefix}-dgraph-alpha-cm"
+    namespace = var.namespace
+  }
+
+  data = {
+    "dgraph_alpha.sh"      = templatefile("${path.module}/templates/alpha.tpl", { prefix = var.prefix, namespace = var.namespace, replicas = local.alpha_replicas, lru = var.lru_size_mb, zero_address = var.zero_address })
+    "dgraph_init_alpha.sh" = file("${path.module}/templates/alpha_init.sh")
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_stateful_set" "dgraph_alpha" {
+  metadata {
+    name      = "${var.prefix}-dgraph-alpha"
+    namespace = var.namespace
+  }
+
+  spec {
+    update_strategy {
+      type = "RollingUpdate"
+    }
+
+    dynamic "volume_claim_template" {
+      for_each = local.has_persistence
+      content {
+        metadata {
+          name      = "datadir"
+          namespace = var.namespace
+
+          annotations = { "volume.alpha.kubernetes.io/storage-class" = "anything" }
+        }
+
+        spec {
+          access_modes = ["ReadWriteOnce"]
+
+          resources {
+            requests = {
+              storage = "${var.storage_size_gb}Gi"
+            }
+          }
+        }
+      }
+    }
+
+
+    service_name = "${var.prefix}-dgraph-alpha"
+
+    replicas = local.alpha_replicas
+
+    selector {
+      match_labels = {
+        app = "${var.prefix}-dgraph-alpha"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "${var.prefix}-dgraph-alpha"
+        }
+      }
+
+      spec {
+        dynamic "affinity" {
+          for_each = local.has_pod_anti_affinity
+          content {
+            pod_anti_affinity {
+              preferred_during_scheduling_ignored_during_execution {
+                weight = 100
+                pod_affinity_term {
+                  label_selector {
+                    match_expressions {
+                      key      = "kubernetes.io/hostname"
+                      operator = "In"
+                      values   = ["${var.prefix}-dgraph-alpha"]
+                    }
+                  }
+                  topology_key = "kubernetes.io/hostname"
+                }
+              }
+            }
+          }
+        }
+
+        termination_grace_period_seconds = var.termination_grace_period_seconds
+
+        volume {
+          name = "dgraph-alpha-command"
+
+          config_map {
+            name         = "${var.prefix}-dgraph-alpha-cm"
+            default_mode = "0755"
+          }
+        }
+
+        dynamic "init_container" {
+          for_each = local.initialize_data
+          content {
+            name = "init-alpha"
+
+            image             = "${var.image}:${var.image_version}"
+            image_pull_policy = var.image_pull_policy
+
+            command = var.init_command
+
+            volume_mount {
+              name       = "dgraph-alpha-command"
+              mount_path = "/cmd"
+            }
+
+            dynamic "volume_mount" {
+              for_each = local.has_persistence
+              content {
+                name       = "datadir"
+                mount_path = var.persistence_mount_path
+              }
+            }
+          }
+        }
+
+        container {
+          name = "alpha"
+
+          image             = "${var.image}:${var.image_version}"
+          image_pull_policy = var.image_pull_policy
+
+          env {
+            name  = "POD_NAMESPACE"
+            value = var.namespace
+          }
+
+          command = var.command
+
+          port {
+            name           = "alpha-grpc-int"
+            container_port = var.grpc_int_port
+          }
+
+          port {
+            name           = "alpha-http"
+            container_port = var.http_port
+          }
+
+          port {
+            name           = "alpha-grpc"
+            container_port = var.grpc_port
+          }
+
+          dynamic "volume_mount" {
+            for_each = local.has_persistence
+            content {
+              name       = "datadir"
+              mount_path = var.persistence_mount_path
+            }
+          }
+
+          volume_mount {
+            name       = "dgraph-alpha-command"
+            mount_path = "/cmd"
+          }
+
+          liveness_probe {
+            http_get {
+              path = var.liveness_probe_path
+              port = var.http_port
+            }
+
+            initial_delay_seconds = var.liveness_probe_initial_delay_seconds
+            timeout_seconds       = var.liveness_probe_timeout_seconds
+            period_seconds        = var.liveness_period_seconds
+            success_threshold     = var.liveness_probe_success_threshold
+            failure_threshold     = var.liveness_probe_failure_threshold
+          }
+
+          readiness_probe {
+            http_get {
+              path = var.readiness_probe_path
+              port = var.http_port
+            }
+
+            initial_delay_seconds = var.readiness_probe_initial_delay_seconds
+            timeout_seconds       = var.readiness_probe_timeout_seconds
+            period_seconds        = var.readiness_period_seconds
+            success_threshold     = var.readiness_probe_success_threshold
+            failure_threshold     = var.readiness_probe_failure_threshold
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [var.namespace_resource]
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/outputs.tf
@@ -1,0 +1,7 @@
+output "alpha_public_dns" {
+  value = kubernetes_service.dgraph_alpha_public.load_balancer_ingress[0].hostname
+}
+
+output "alpha_indexzero_public_dns" {
+  value = kubernetes_service.dgraph_alpha_indexzero_public.load_balancer_ingress[0].hostname
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/provider.tf
@@ -1,0 +1,3 @@
+provider "kubernetes" {
+  config_path = "${path.root}/kubeconfig"
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/templates/alpha.tpl
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/templates/alpha.tpl
@@ -1,0 +1,6 @@
+#//usr/bin/env bash
+
+set -ex
+
+# TODO: Use zero_port variable when kubernetes_service resource of Terraform supports outputs
+dgraph alpha --my=$(hostname -f):7080 --lru_mb ${lru} --zero ${zero_address}:5080

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/templates/alpha_init.sh
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/templates/alpha_init.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+trap "exit" SIGINT SIGTERM
+echo "Write to /dgraph/doneinit when ready."
+until [ -f /dgraph/doneinit ]; do sleep 2; done

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/alpha/variables.tf
@@ -1,0 +1,183 @@
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace to deploy the Dgraph pods to"
+}
+
+variable "initialize_data" {
+  type        = bool
+  default     = false
+  description = "If set, runs an init container to help with loading the data into Alpha"
+}
+
+variable "zero_address" {
+  type        = string
+  description = "The address of a Zero pod"
+}
+
+variable "persistence" {
+  type        = bool
+  default     = true
+  description = "If set to true, mounts a persistent disk to the Alpha pods"
+}
+
+variable "storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Alpha pods in GiB"
+}
+
+variable "replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Alpha replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Alpha pod"
+}
+
+variable "lru_size_mb" {
+  type        = number
+  default     = 1025
+  description = "The LRU cache size in MiB"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The IPs whitelisted on the load balancer"
+}
+
+variable "image" {
+  type        = string
+  default     = "dgraph/dgraph"
+  description = "The docker image to use to run Dgraph services"
+}
+
+variable "image_version" {
+  type        = string
+  default     = "latest"
+  description = "The version of the Dgraph docker image to run"
+}
+
+variable "image_pull_policy" {
+  type        = string
+  default     = "IfNotPresent"
+  description = "The default image pull policy to use while scheduling and running pods"
+}
+
+variable "http_port" {
+  type        = number
+  default     = 8080
+  description = "The HTTP port of Dgraph Alpha"
+}
+
+variable "grpc_port" {
+  type        = number
+  default     = 9080
+  description = "The external gRPC port exposed by Dgraph Alpha"
+}
+
+variable "grpc_int_port" {
+  type        = number
+  default     = 7080
+  description = "The internal gRPC port exposed Dgraph Alpha "
+}
+
+variable "command" {
+  type        = list
+  default     = ["bash", "/cmd/dgraph_alpha.sh"]
+  description = "The command to run to start the Dgraph Alpha service"
+}
+
+variable "init_command" {
+  type        = list
+  default     = ["bash", "/cmd/dgraph_init_alpha.sh"]
+  description = "The command to run to start the Dgraph Alpha init container"
+}
+
+variable "persistence_mount_path" {
+  type    = string
+  default = "/dgraph"
+}
+
+# Probes
+variable "liveness_probe_path" {
+  type    = string
+  default = "/health?live=1"
+}
+
+variable "liveness_probe_initial_delay_seconds" {
+  type    = number
+  default = 15
+}
+
+variable "liveness_probe_timeout_seconds" {
+  type    = number
+  default = 5
+}
+
+variable "liveness_period_seconds" {
+  type    = number
+  default = 10
+}
+
+variable "liveness_probe_success_threshold" {
+  type    = number
+  default = 1
+}
+
+variable "liveness_probe_failure_threshold" {
+  type    = number
+  default = 6
+}
+
+variable "readiness_probe_path" {
+  type    = string
+  default = "/health"
+}
+
+variable "readiness_probe_initial_delay_seconds" {
+  type    = number
+  default = 15
+}
+
+variable "readiness_probe_timeout_seconds" {
+  type    = number
+  default = 5
+}
+
+variable "readiness_period_seconds" {
+  type    = number
+  default = 10
+}
+
+variable "readiness_probe_success_threshold" {
+  type    = number
+  default = 1
+}
+
+variable "readiness_probe_failure_threshold" {
+  type    = number
+  default = 6
+}
+
+variable "termination_grace_period_seconds" {
+  type        = number
+  default     = 600
+  description = "The grace period to wait before sending SIGTERM to the Alpha pods"
+}
+
+variable "namespace_resource" {
+  type    = any
+  default = null
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/.gitignore
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/main.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/main.tf
@@ -1,0 +1,72 @@
+resource "kubernetes_service" "dgraph_ratel_public" {
+  metadata {
+    name      = "${var.prefix}-dgraph-ratel-public"
+    namespace = var.namespace
+
+    labels = {
+      app = "${var.prefix}-dgraph-ratel"
+    }
+  }
+
+  spec {
+    port {
+      name        = "ratel-http"
+      port        = var.http_port
+      target_port = var.http_port
+    }
+
+    selector = {
+      app = "${var.prefix}-dgraph-ratel"
+    }
+
+    type = "LoadBalancer"
+
+    load_balancer_source_ranges = var.ingress_whitelist_cidrs
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_deployment" "dgraph_ratel" {
+  metadata {
+    name      = "${var.prefix}-dgraph-ratel"
+    namespace = var.namespace
+    labels = {
+      "app" = "dgraph-ratel"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        app = "${var.prefix}-dgraph-ratel"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "${var.prefix}-dgraph-ratel"
+        }
+      }
+
+      spec {
+        container {
+          name = "ratel"
+
+          image             = "${var.image}:${var.image_version}"
+          image_pull_policy = var.image_pull_policy
+          command           = var.command
+
+          port {
+            name           = "dgraph-ratel"
+            container_port = var.http_port
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [var.namespace_resource]
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/outputs.tf
@@ -1,0 +1,3 @@
+output "ratel_public_dns" {
+  value = kubernetes_service.dgraph_ratel_public.load_balancer_ingress[0].hostname
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/provider.tf
@@ -1,0 +1,3 @@
+provider "kubernetes" {
+  config_path = "${path.root}/kubeconfig"
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/ratel/variables.tf
@@ -1,0 +1,52 @@
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace to deploy the Dgraph pods to"
+}
+
+variable "http_port" {
+  type        = number
+  default     = 8000
+  description = "The HTTP port exposed by Dgraph Ratel"
+}
+
+variable "image" {
+  type        = string
+  default     = "dgraph/dgraph"
+  description = "The docker image to use to run Dgraph services"
+}
+
+variable "image_version" {
+  type        = string
+  default     = "latest"
+  description = "The version of the Dgraph docker image to run"
+}
+
+variable "image_pull_policy" {
+  type        = string
+  default     = "IfNotPresent"
+  description = "The default image pull policy to use while scheduling and running pods"
+}
+
+variable command {
+  type        = list
+  default     = ["dgraph-ratel"]
+  description = "The command to run to start the Dgraph Ratel service"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The IPs whitelisted on the service load balancer"
+}
+
+variable "namespace_resource" {
+  type    = any
+  default = null
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/.gitignore
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/.gitignore
@@ -1,0 +1,29 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/main.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/main.tf
@@ -1,0 +1,238 @@
+locals {
+  zero_replicas         = var.ha ? var.replicas : 1
+  has_pod_anti_affinity = var.ha ? [1] : []
+  has_persistence       = var.persistence ? [1] : []
+}
+
+resource "kubernetes_service" "dgraph_zero_public" {
+  metadata {
+    name      = "${var.prefix}-dgraph-zero-public"
+    namespace = var.namespace
+
+    labels = {
+      app     = "${var.prefix}-dgraph-zero"
+      monitor = "zero-dgraph-io"
+    }
+  }
+
+  spec {
+    port {
+      name        = "zero-http"
+      port        = var.http_port
+      target_port = var.http_port
+    }
+
+    port {
+      name        = "zero-grpc"
+      port        = var.grpc_port
+      target_port = var.grpc_port
+    }
+
+    selector = {
+      app = "${var.prefix}-dgraph-zero"
+    }
+
+    type = "LoadBalancer"
+
+    load_balancer_source_ranges = var.ingress_whitelist_cidrs
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_service" "dgraph_zero" {
+  metadata {
+    name      = "${var.prefix}-dgraph-zero"
+    namespace = var.namespace
+
+    labels = {
+      app = "${var.prefix}-dgraph-zero"
+    }
+  }
+
+  spec {
+    port {
+      name        = "zero-grpc"
+      port        = var.grpc_port
+      target_port = var.grpc_port
+    }
+
+    selector = {
+      app = "${var.prefix}-dgraph-zero"
+    }
+
+    cluster_ip                  = "None"
+    type                        = "ClusterIP"
+    publish_not_ready_addresses = true
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_config_map" "dgraph_zero_command" {
+  metadata {
+    name      = "${var.prefix}-dgraph-zero-cm"
+    namespace = var.namespace
+  }
+
+  data = {
+    "dgraph_zero.sh" = var.ha ? templatefile("${path.module}/templates/zero-ha.tpl", { prefix = var.prefix, namespace = var.namespace, replicas = local.zero_replicas }) : templatefile("${path.module}/templates/zero.tpl", {})
+  }
+
+  depends_on = [var.namespace_resource]
+}
+
+
+resource "kubernetes_stateful_set" "dgraph_zero" {
+  metadata {
+    name      = "${var.prefix}-dgraph-zero"
+    namespace = var.namespace
+  }
+
+  spec {
+    update_strategy {
+      type = "RollingUpdate"
+    }
+
+    dynamic "volume_claim_template" {
+      for_each = local.has_persistence
+      content {
+        metadata {
+          name      = "datadir"
+          namespace = var.namespace
+
+          annotations = { "volume.alpha.kubernetes.io/storage-class" = "anything" }
+        }
+
+        spec {
+          access_modes = ["ReadWriteOnce"]
+
+          resources {
+            requests = {
+              storage = "${var.storage_size_gb}Gi"
+            }
+          }
+        }
+      }
+    }
+
+    service_name = "${var.prefix}-dgraph-zero"
+
+    replicas = local.zero_replicas
+
+    selector {
+      match_labels = {
+        app = "${var.prefix}-dgraph-zero"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "${var.prefix}-dgraph-zero"
+        }
+      }
+
+      spec {
+        dynamic "affinity" {
+          for_each = local.has_pod_anti_affinity
+          content {
+            pod_anti_affinity {
+              preferred_during_scheduling_ignored_during_execution {
+                weight = 100
+                pod_affinity_term {
+                  label_selector {
+                    match_expressions {
+                      key      = "kubernetes.io/hostname"
+                      operator = "In"
+                      values   = ["${var.prefix}-dgraph-zero"]
+                    }
+                  }
+                  topology_key = "kubernetes.io/hostname"
+                }
+              }
+            }
+          }
+        }
+
+        termination_grace_period_seconds = 60
+
+        volume {
+          name = "dgraph-zero-command"
+
+          config_map {
+            name         = "${var.prefix}-dgraph-zero-cm"
+            default_mode = "0755"
+          }
+        }
+
+        container {
+          name = "zero"
+
+          image             = "${var.image}:${var.image_version}"
+          image_pull_policy = var.image_pull_policy
+
+          env {
+            name  = "POD_NAMESPACE"
+            value = var.namespace
+          }
+
+          command = var.command
+
+          port {
+            name           = "zero-grpc"
+            container_port = var.grpc_port
+          }
+
+          port {
+            name           = "zero-http"
+            container_port = var.http_port
+          }
+
+          dynamic "volume_mount" {
+            for_each = local.has_persistence
+            content {
+              name       = "datadir"
+              mount_path = var.persistence_mount_path
+            }
+          }
+
+          volume_mount {
+            name       = "dgraph-zero-command"
+            mount_path = "/cmd"
+          }
+
+          liveness_probe {
+            http_get {
+              path = var.liveness_probe_path
+              port = var.http_port
+            }
+
+            initial_delay_seconds = var.liveness_probe_initial_delay_seconds
+            timeout_seconds       = var.liveness_probe_timeout_seconds
+            period_seconds        = var.liveness_period_seconds
+            success_threshold     = var.liveness_probe_success_threshold
+            failure_threshold     = var.liveness_probe_failure_threshold
+          }
+
+          readiness_probe {
+            http_get {
+              path = var.readiness_probe_path
+              port = var.http_port
+            }
+
+            initial_delay_seconds = var.readiness_probe_initial_delay_seconds
+            timeout_seconds       = var.readiness_probe_timeout_seconds
+            period_seconds        = var.readiness_period_seconds
+            success_threshold     = var.readiness_probe_success_threshold
+            failure_threshold     = var.readiness_probe_failure_threshold
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [var.namespace_resource]
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/outputs.tf
@@ -1,0 +1,3 @@
+output "zero_public_dns" {
+  value = kubernetes_service.dgraph_zero_public.load_balancer_ingress[0].hostname
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/provider.tf
@@ -1,0 +1,3 @@
+provider "kubernetes" {
+  config_path = "${path.root}/kubeconfig"
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/templates/zero-ha.tpl
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/templates/zero-ha.tpl
@@ -1,0 +1,12 @@
+set -ex
+
+[[ `hostname` =~ -([0-9]+)$ ]] || exit 1
+
+ordinal=$${BASH_REMATCH[1]}
+idx=$(($ordinal + 1))
+
+if [[ $ordinal -eq 0 ]]; then
+  exec dgraph zero --my=$(hostname -f):5080 --idx $idx --replicas ${replicas}
+else
+  exec dgraph zero --my=$(hostname -f):5080 --peer ${prefix}-dgraph-zero-0.${prefix}-dgraph-zero.${namespace}.svc.cluster.local:5080 --idx $idx --replicas ${replicas}
+fi

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/templates/zero.tpl
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/templates/zero.tpl
@@ -1,0 +1,3 @@
+set -ex
+
+exec dgraph zero --my=$(hostname -f):5080

--- a/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/modules/zero/variables.tf
@@ -1,0 +1,154 @@
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace to deploy the Dgraph pods to"
+}
+
+variable "persistence" {
+  type        = bool
+  default     = true
+  description = "If set to true, mounts a persistent disk to the Zero pods"
+}
+
+variable "storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Zero pods in GiB"
+}
+
+variable "replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Zero replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Zero pod"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The IPs whitelisted on the load balancer"
+}
+
+variable "image" {
+  type        = string
+  default     = "dgraph/dgraph"
+  description = "The docker image to use to run Dgraph services"
+}
+
+variable "image_version" {
+  type        = string
+  default     = "latest"
+  description = "The version of the Dgraph docker image to run"
+}
+
+variable "image_pull_policy" {
+  type        = string
+  default     = "IfNotPresent"
+  description = "The default image pull policy to use while scheduling and running pods"
+}
+
+variable "http_port" {
+  type        = number
+  default     = 6080
+  description = "The HTTP port exposed by the Dgraph Zero service"
+}
+
+variable "grpc_port" {
+  type        = number
+  default     = 5080
+  description = "the gRPC port exposed by the Dgraph Zero service"
+}
+
+variable "command" {
+  type        = list
+  default     = ["bash", "/cmd/dgraph_zero.sh"]
+  description = "The command to run to start the Dgraph Zero service"
+}
+
+variable "persistence_mount_path" {
+  type    = string
+  default = "/dgraph"
+}
+
+# Probes
+variable "liveness_probe_path" {
+  type    = string
+  default = "/health"
+}
+
+variable "liveness_probe_initial_delay_seconds" {
+  type    = number
+  default = 15
+}
+
+variable "liveness_probe_timeout_seconds" {
+  type    = number
+  default = 5
+}
+
+variable "liveness_period_seconds" {
+  type    = number
+  default = 10
+}
+
+variable "liveness_probe_success_threshold" {
+  type    = number
+  default = 1
+}
+
+variable "liveness_probe_failure_threshold" {
+  type    = number
+  default = 6
+}
+
+variable "readiness_probe_path" {
+  type    = string
+  default = "/state"
+}
+
+variable "readiness_probe_initial_delay_seconds" {
+  type    = number
+  default = 15
+}
+
+variable "readiness_probe_timeout_seconds" {
+  type    = number
+  default = 5
+}
+
+variable "readiness_period_seconds" {
+  type    = number
+  default = 10
+}
+
+variable "readiness_probe_success_threshold" {
+  type    = number
+  default = 1
+}
+
+variable "readiness_probe_failure_threshold" {
+  type    = number
+  default = 6
+}
+
+
+variable "termination_grace_period_seconds" {
+  type    = number
+  default = 60
+}
+
+variable "namespace_resource" {
+  type    = any
+  default = null
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/outputs.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/outputs.tf
@@ -1,0 +1,19 @@
+output "zero_public_dns" {
+  value       = module.zero.zero_public_dns
+  description = "The hostname of the Zero service LB"
+}
+
+output "alpha_public_dns" {
+  value       = module.alpha.alpha_public_dns
+  description = "The hostname of the Alpha service LB"
+}
+
+output "alpha_indexzero_public_dns" {
+  value       = module.alpha.alpha_indexzero_public_dns
+  description = "The hostname of the Alpha[0] pod"
+}
+
+output "ratel_public_dns" {
+  value       = module.ratel.ratel_public_dns
+  description = "The hostname of the Ratel service LB"
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/provider.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/provider.tf
@@ -1,0 +1,3 @@
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}

--- a/contrib/config/terraform/kubernetes/modules/dgraph/variables.tf
+++ b/contrib/config/terraform/kubernetes/modules/dgraph/variables.tf
@@ -1,0 +1,81 @@
+variable "kubeconfig_path" {
+  type        = string
+  description = "The path of the Kubeconfig file to use to provision resources on the cluster"
+}
+
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The CIDRs whitelisted at the service load balancer"
+}
+
+variable "namespace" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace to deploy the Dgraph pods to"
+}
+
+variable "zero_replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Zero replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Zero pod"
+}
+
+variable "zero_persistence" {
+  type        = bool
+  default     = true
+  description = "If enabled mounts a persistent disk to the Zero pods"
+}
+
+variable "zero_storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Zero pods in GiB"
+}
+
+variable "alpha_replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Alpha replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Alpha pod"
+}
+
+variable "alpha_initialize_data" {
+  type        = bool
+  default     = false
+  description = "If set, runs an init container to help with loading the data into Alpha"
+}
+
+variable "alpha_persistence" {
+  type        = bool
+  default     = true
+  description = "If enabled mounts a persistent disk to the Alpha pods"
+}
+
+variable "alpha_storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Alpha pods in GiB"
+}
+
+variable "alpha_lru_size_mb" {
+  type        = number
+  default     = 2048
+  description = "The LRU cache to enable on Alpha pods in MiB"
+}
+
+variable "zero_address" {
+  type        = string
+  description = "The address of the Zero pod for Alpha to register against"
+}

--- a/contrib/config/terraform/kubernetes/outputs.tf
+++ b/contrib/config/terraform/kubernetes/outputs.tf
@@ -1,0 +1,19 @@
+output "zero_public_dns" {
+  value       = module.dgraph.zero_public_dns
+  description = "The hostname of the Zero service LB"
+}
+
+output "alpha_public_dns" {
+  value       = module.dgraph.alpha_public_dns
+  description = "The hostname of the Alpha service LB"
+}
+
+output "alpha_indexzero_public_dns" {
+  value       = module.dgraph.alpha_indexzero_public_dns
+  description = "The hostname of the Alpha[0] service LB"
+}
+
+output "ratel_public_dns" {
+  value       = module.dgraph.ratel_public_dns
+  description = "The hostname of the Ratel service LB"
+}

--- a/contrib/config/terraform/kubernetes/terraform.tfvars.example
+++ b/contrib/config/terraform/kubernetes/terraform.tfvars.example
@@ -1,0 +1,31 @@
+## VPC/EKS
+##########
+prefix = "dgraph"
+cidr   = "10.20.0.0/16"
+region = "ap-south-1"
+
+# If ha is set to false the worker_node_count is overridden to 1
+ha                 = true
+worker_nodes_count = 3
+instance_types     = ["m5.large"]
+
+# If only_whitelist_local_ip is set to true, the ingress_whitelist_cidrs is overridden to local IP of the executioner
+ingress_whitelist_cidrs = ["0.0.0.0/0"]
+only_whitelist_local_ip = false
+
+
+## Dgraph
+#########
+namespace = "dgraph"
+
+# Zero
+zero_replicas        = 3
+zero_persistence     = true
+zero_storage_size_gb = 10
+
+# Alpha
+alpha_initialize_data = false
+alpha_replicas        = 3
+alpha_persistence     = true
+alpha_storage_size_gb = 10
+alpha_lru_size_mb     = 2048

--- a/contrib/config/terraform/kubernetes/variables.tf
+++ b/contrib/config/terraform/kubernetes/variables.tf
@@ -1,0 +1,111 @@
+## AWS/EKS
+##########
+
+variable "prefix" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace prefix for all resources"
+}
+
+variable "cidr" {
+  type        = string
+  default     = "10.20.0.0/16"
+  description = "The CIDR of the VPC"
+}
+
+variable "region" {
+  type        = string
+  default     = "ap-south-1"
+  description = "The region to deploy the resources in"
+}
+
+variable "ha" {
+  type        = bool
+  default     = true
+  description = "Enable or disable HA deployment of Dgraph"
+}
+
+variable "only_whitelist_local_ip" {
+  type        = bool
+  default     = true
+  description = "Only whitelist the IP of the executioner at the service Load Balancers"
+}
+
+variable "ingress_whitelist_cidrs" {
+  type        = list
+  default     = ["0.0.0.0/0"]
+  description = "The CIDRs whitelisted at the service Load Balancer"
+}
+
+variable "worker_nodes_count" {
+  type        = number
+  default     = 3
+  description = "The number of worker nodes to provision with the EKS cluster"
+}
+
+variable "instance_types" {
+  type        = list
+  default     = ["m5.large"]
+  description = "The list of instance types to run as worker nodes"
+}
+
+## Dgraph
+#########
+
+variable "namespace" {
+  type        = string
+  default     = "dgraph"
+  description = "The namespace to deploy the Dgraph pods to"
+}
+
+
+# Zero
+variable "zero_replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Zero replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Zero pod"
+}
+
+variable "zero_persistence" {
+  type        = bool
+  default     = true
+  description = "If enabled mounts a persistent disk to the Zero pods"
+}
+
+variable "zero_storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Zero pods in GiB"
+}
+
+
+# Alpha
+variable "alpha_replicas" {
+  type        = number
+  default     = 3
+  description = "The number of Alpha replicas to create. Overridden by the ha variable which when disabled leads to creation of only 1 Alpha pod"
+}
+
+variable "alpha_initialize_data" {
+  type        = bool
+  default     = false
+  description = "If set, runs an init container to help with loading the data into Alpha"
+}
+
+variable "alpha_persistence" {
+  type        = bool
+  default     = true
+  description = "If enabled mounts a persistent disk to the Alpha pods"
+}
+
+variable "alpha_storage_size_gb" {
+  type        = number
+  default     = 10
+  description = "The size of the persistent disk to attach to the Alpha pods in GiB"
+}
+
+variable "alpha_lru_size_mb" {
+  type        = number
+  default     = 2048
+  description = "The LRU cache to enable on Alpha pods in MiB"
+}


### PR DESCRIPTION
### Description.
Terraform modules to setup Dgraph on Kubernetes. Supports AWS EKS currently.

### GitHub Issue or Jira number.
1002

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5092)
<!-- Reviewable:end -->
