### PR TITLE
Ignore errors returned by stopTaks and startTask.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1579,7 +1579,7 @@ func (n *node) InitAndStartNode() {
 	go n.processTabletSizes()
 	go n.processApplyCh()
 	go n.BatchAndSendMessages()
-	// Ignoring the error since this method does not return an error and using x.Check would
+	// Ignoring the error since InitAndStartNode does not return an error and using x.Check would
 	// not be the right thing to do.
 	_, _ = n.startTask(opRollup)
 	go n.stopAllTasks()

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -114,7 +114,8 @@ func (n *node) startTask(id op) (*y.Closer, error) {
 		if id != opRollup {
 			time.Sleep(10 * time.Second) // Wait for 10s to start rollup operation.
 			// If any other operation is running, this would error out. So, ignore error.
-			n.startTask(opRollup)
+			// Ignoring the error since stop task runs in a goruotine.
+			_, _ = n.startTask(opRollup)
 		}
 	}
 
@@ -1578,7 +1579,9 @@ func (n *node) InitAndStartNode() {
 	go n.processTabletSizes()
 	go n.processApplyCh()
 	go n.BatchAndSendMessages()
-	n.startTask(opRollup)
+	// Ignoring the error since this method does not return an error and using x.Check would
+	// not be the right thing to do.
+	_, _ = n.startTask(opRollup)
 	go n.stopAllTasks()
 	go n.Run()
 }


### PR DESCRIPTION
The server can be recover from these errors and they cannot be reported
to the caller so they should be ignored instead.

Cannot x.Check for them since we don't want the errors to crash the
Alpha.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5100)
<!-- Reviewable:end -->
