### PR TITLE
add option "-k" to debug tool for encryption

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -87,7 +87,8 @@ func init() {
 	flag.StringVarP(&opt.pdir, "postings", "p", "", "Directory where posting lists are stored.")
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
-	flag.StringVarP(&opt.badgerKeyFile, "encryption_key_file", "k", "", "File where the encryption key is stored.")
+	flag.StringVarP(&opt.badgerKeyFile, "encryption_key_file", "k", "",
+		"File where the encryption key is stored.")
 
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
 	"github.com/dgraph-io/dgraph/codec"
+	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
@@ -55,6 +56,7 @@ type flagOptions struct {
 	readTs        uint64
 	sizeHistogram bool
 	noKeys        bool
+	badgerKeyFile string
 
 	// Options related to the WAL.
 	wdir           string
@@ -85,6 +87,7 @@ func init() {
 	flag.StringVarP(&opt.pdir, "postings", "p", "", "Directory where posting lists are stored.")
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
+	flag.StringVarP(&opt.badgerKeyFile, "encryption_key_file", "k", "", "File where the encryption key is stored.")
 
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
@@ -763,7 +766,7 @@ func run() {
 	}
 	bopts := badger.DefaultOptions(dir).
 		WithTableLoadingMode(options.MemoryMap).
-		WithReadOnly(opt.readOnly)
+		WithReadOnly(opt.readOnly).WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.badgerKeyFile))
 
 	// TODO(Ibrahim): Remove this once badger is updated.
 	bopts.ZSTDCompressionLevel = 1


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.

<!-- First, describe here details about it. -->

Add a new option "-k" to debug tool for encryption
### GitHub Issue or Jira number.

<!-- Add here. -->
https://dgraph.atlassian.net/browse/DGRAPH-1200
### Other components or 3rd party tools affected (or regression areas).

<!-- Add here. e.g. "It breaks/affects Ratel UI behavior." -->

### Affected releases.

<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

<!-- Add here. -->
20.07
### Changelog tags.

<!-- removed, added, fixed, ... -->

<!-- Add here. -->
Added support for encryption in the debug tool.
### Please indicate if this is a breaking change.

<!-- Add here. -->
No.
### Please indicate if this is an enterprise feature.

<!-- Add here. -->
Yes.
### Please indicate if documentation needs to be updated.

<!-- If yes indicate the documentation issue number. Add here. -->
<!--or create one and add the number here -->
https://dgraph.atlassian.net/browse/DGRAPH-1202 

### Please indicate if end to end testing is needed.

<!-- if yes indicate the testing issue number -->
<!--or create one and add the number here -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5113)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9d09f7c447-52839.surge.sh)
<!-- Dgraph:end -->