### PR TITLE
Support comma separated list of zero addresses in alpha

### DIFF
--- a/contrib/integration/testtxn/main_test.go
+++ b/contrib/integration/testtxn/main_test.go
@@ -757,7 +757,7 @@ func TestCountIndexConcurrentTxns(t *testing.T) {
 	require.Error(t, err,
 		"the txn2 should be aborted due to concurrent update on the count index of	<0x01>")
 
-	// retry the mutatiton
+	// retry the mutation
 	txn3 := dg.NewTxn()
 	_, err = txn3.Mutate(ctxb, &mu)
 	x.Check(err)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -138,7 +138,7 @@ they form a Raft group and provide synchronous replication.
 	flag.String("my", "",
 		"IP_ADDRESS:PORT of this Dgraph Alpha, so other Dgraph Alphas can talk to this.")
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
-		"IP_ADDRESS:PORT of a Dgraph Zero.")
+		"Comma separated list of Dgraph zero addresses of the form IP_ADDRESS:PORT.")
 	flag.Uint64("idx", 0,
 		"Optional Raft ID that this Dgraph Alpha will use to join RAFT groups.")
 	flag.Int("max_retries", -1,
@@ -575,7 +575,7 @@ func run() {
 		NumPendingProposals: Alpha.Conf.GetInt("pending_proposals"),
 		Tracing:             Alpha.Conf.GetFloat64("trace"),
 		MyAddr:              Alpha.Conf.GetString("my"),
-		ZeroAddr:            Alpha.Conf.GetString("zero"),
+		ZeroAddr:            strings.Split(Alpha.Conf.GetString("zero"), ","),
 		RaftId:              cast.ToUint64(Alpha.Conf.GetString("idx")),
 		WhiteListedIPRanges: ips,
 		MaxRetries:          Alpha.Conf.GetInt("max_retries"),

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -105,7 +105,7 @@ func (r *reducer) run() error {
 func (r *reducer) createBadger(i int) *badger.DB {
 	if r.opt.BadgerKeyFile != "" {
 		// Need to set zero addr in WorkerConfig before checking the license.
-		x.WorkerConfig.ZeroAddr = r.opt.ZeroAddr
+		x.WorkerConfig.ZeroAddr = []string{r.opt.ZeroAddr}
 
 		if !worker.EnterpriseEnabled() {
 			// Crash since the enterprise license is not enabled..

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -87,8 +88,10 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	}
 
 	x.AssertTruef(len(x.WorkerConfig.ZeroAddr) > 0, "Providing dgraphzero address is mandatory.")
-	x.AssertTruef(x.WorkerConfig.ZeroAddr != x.WorkerConfig.MyAddr,
-		"Dgraph Zero address and Dgraph address (IP:Port) can't be the same.")
+	for _, zeroAddr := range x.WorkerConfig.ZeroAddr {
+		x.AssertTruef(zeroAddr != x.WorkerConfig.MyAddr,
+			"Dgraph Zero address and Dgraph address (IP:Port) can't be the same.")
+	}
 
 	if x.WorkerConfig.RaftId == 0 {
 		id, err := raftwal.RaftId(walStore)
@@ -113,6 +116,7 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	}
 	var connState *pb.ConnectionState
 	var err error
+
 	for { // Keep on retrying. See: https://github.com/dgraph-io/dgraph/issues/2289
 		pl := gr.connToZeroLeader()
 		if pl == nil {
@@ -646,14 +650,20 @@ func (g *groupi) connToZeroLeader() *conn.Pool {
 	// No leader found. Let's get the latest membership state from Zero.
 	delay := connBaseDelay
 	maxHalfDelay := time.Second
+	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for { // Keep on retrying. See: https://github.com/dgraph-io/dgraph/issues/2289
 		time.Sleep(delay)
 		if delay <= maxHalfDelay {
 			delay *= 2
 		}
+
+		zAddrList := x.WorkerConfig.ZeroAddr
+		// Pick a random zero address.
+		addr := zAddrList[randSrc.Intn(len(zAddrList))]
+
 		pl := g.AnyServer(0)
 		if pl == nil {
-			pl = conn.GetPools().Connect(x.WorkerConfig.ZeroAddr)
+			pl = conn.GetPools().Connect(addr)
 		}
 		if pl == nil {
 			glog.V(1).Infof("No healthy Zero server found. Retrying...")

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math/rand"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -90,7 +89,8 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	x.AssertTruef(len(x.WorkerConfig.ZeroAddr) > 0, "Providing dgraphzero address is mandatory.")
 	for _, zeroAddr := range x.WorkerConfig.ZeroAddr {
 		x.AssertTruef(zeroAddr != x.WorkerConfig.MyAddr,
-			"Dgraph Zero address and Dgraph address (IP:Port) can't be the same.")
+			"Dgraph Zero address %d and Dgraph address (IP:Port) %d can't be the same.",
+			zeroAddr, x.WorkerConfig.MyAddr)
 	}
 
 	if x.WorkerConfig.RaftId == 0 {
@@ -650,16 +650,15 @@ func (g *groupi) connToZeroLeader() *conn.Pool {
 	// No leader found. Let's get the latest membership state from Zero.
 	delay := connBaseDelay
 	maxHalfDelay := time.Second
-	randSrc := rand.New(rand.NewSource(time.Now().UnixNano()))
-	for { // Keep on retrying. See: https://github.com/dgraph-io/dgraph/issues/2289
+	for i := 0; ; i++ { // Keep on retrying. See: https://github.com/dgraph-io/dgraph/issues/2289
 		time.Sleep(delay)
 		if delay <= maxHalfDelay {
 			delay *= 2
 		}
 
 		zAddrList := x.WorkerConfig.ZeroAddr
-		// Pick a random zero address.
-		addr := zAddrList[randSrc.Intn(len(zAddrList))]
+		// Pick addresses in round robin manner.
+		addr := zAddrList[i%len(zAddrList)]
 
 		pl := g.AnyServer(0)
 		if pl == nil {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -89,7 +89,7 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 	x.AssertTruef(len(x.WorkerConfig.ZeroAddr) > 0, "Providing dgraphzero address is mandatory.")
 	for _, zeroAddr := range x.WorkerConfig.ZeroAddr {
 		x.AssertTruef(zeroAddr != x.WorkerConfig.MyAddr,
-			"Dgraph Zero address %d and Dgraph address (IP:Port) %d can't be the same.",
+			"Dgraph Zero address %s and Dgraph address (IP:Port) %s can't be the same.",
 			zeroAddr, x.WorkerConfig.MyAddr)
 	}
 

--- a/x/config.go
+++ b/x/config.go
@@ -53,8 +53,10 @@ type WorkerOptions struct {
 	Tracing float64
 	// MyAddr stores the address and port for this alpha.
 	MyAddr string
-	// ZeroAddr stores the address and port for the zero instance associated with this alpha.
-	ZeroAddr string
+	// ZeroAddr stores the list of address:port for the zero instances associated with this alpha.
+	// Alpha would be communicate via only one zero address from the list. All
+	// the other addresses serve as fallback.
+	ZeroAddr []string
 	// RaftId represents the id of this alpha instance for participating in the RAFT
 	// consensus protocol.
 	RaftId uint64

--- a/x/config.go
+++ b/x/config.go
@@ -54,7 +54,7 @@ type WorkerOptions struct {
 	// MyAddr stores the address and port for this alpha.
 	MyAddr string
 	// ZeroAddr stores the list of address:port for the zero instances associated with this alpha.
-	// Alpha would be communicate via only one zero address from the list. All
+	// Alpha would communicate via only one zero address from the list. All
 	// the other addresses serve as fallback.
 	ZeroAddr []string
 	// RaftId represents the id of this alpha instance for participating in the RAFT


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.
<!-- First, describe here details about it. -->
Currently, alpha supports specifying only a single zero instance address via the `--zero` flag in `dgraph alpha` command. This PR proposes supporting a comma-separated list of `zero` addresses in `dgraph alpha` so that any other address can be used from the list of zero addresses if one of them is unavailable.

One of the zero addresses will be randomly picked from the list and we'll try to establish a connection to it. If it fails, we'll pick the next zero address.

The `dgraph bulk/live` command accepts only a single zero address. The comma-separated list is only for `dgraph alpha` command.


### How to test this PR
1. Start 3 zero and an alpha instance.
2. Provide alpha with multiple `zero` addresses
3. Kill the zero instance alpha was connected to. Alpha would automatically rectify the failure and connect to another zero instance. 
4. Kill the running alpha instance
5. Try to start alpha again (ensure you have at least one zero running)
6. Alpha should be able to start (Without this PR, alpha wouldn't start at this point because the zero specified via `zero` flag is unavailable).


### GitHub Issue or Jira number.
<!-- Add here. -->
https://dgraph.atlassian.net/browse/DGRAPH-1132
https://github.com/dgraph-io/dgraph/issues/4949
### Other components or 3rd party tools affected (or regression areas).

<!-- Add here. e.g. "It breaks/affects Ratel UI behavior." -->

### Affected releases.
20.07
<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

<!-- Add here. -->

### Changelog tags.
<!-- removed, added, fixed, ... -->

<!-- Add here. -->
Support command separated list of zero addresses in alpha

### Please indicate if this is a breaking change.

<!-- Add here. -->
No
### Please indicate if this is an enterprise feature.

<!-- Add here. -->
No
### Please indicate if documentation needs to be updated.

<!-- If yes indicate the documentation issue number. Add here. -->
<!--or create one and add the number here -->
https://dgraph.atlassian.net/browse/DGRAPH-1203

### Please indicate if end to end testing is needed.
No
<!-- if yes indicate the testing issue number -->
<!--or create one and add the number here -->

Fixes https://github.com/dgraph-io/dgraph/issues/4949

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5116)
<!-- Reviewable:end -->
