### PR TITLE
Ignore type mutation if type is already present

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -309,6 +309,20 @@ func createSchema(attr string, typ types.TypeID, hint pb.Metadata_HintType) erro
 
 func runTypeMutation(ctx context.Context, update *pb.TypeUpdate) error {
 	current := *update
+	old, exists := schema.State().GetType(update.TypeName)
+	if exists {
+		curBytes, err := current.Marshal()
+		if err != nil {
+			return err
+		}
+		oldBytes, err := old.Marshal()
+		if err != nil {
+			return err
+		}
+		if bytes.Equal(curBytes, oldBytes) {
+			return nil
+		}
+	}
 	schema.State().SetType(update.TypeName, current)
 	return updateType(update.TypeName, *update)
 }


### PR DESCRIPTION
As of now when we get a `type` mutation, we don't check if it is already there. We apply the mutation. This change would ignore the mutation if the `type` is already present.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5119)
<!-- Reviewable:end -->
