### PR TITLE
contrib: Use xgo to use Cgo in cross-compiled release builds.

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -118,44 +118,42 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  env GOOS=windows GOARCH=amd64 go get -v -d .
-  env GOOS=windows GOARCH=amd64 GO111MODULE=on go build -v -o dgraph-windows-amd64.exe -ldflags \
+  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
-  mv dgraph-windows-amd64.exe $TMP/windows/dgraph.exe
+  mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=windows GOARCH=amd64 go get -v -d .
-  env GOOS=windows GOARCH=amd64 GO111MODULE=on go build -v -o badger-windows-amd64.exe .
-  mv badger-windows-amd64.exe $TMP/windows/badger.exe
+  #env GOOS=windows GOARCH=amd64 go get -v -d .
+  #env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 GO111MODULE=on go build -v -o badger-windows-amd64.exe .
+  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 .
+  mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  env GOOS=windows GOARCH=amd64 go get -v -d .
-  env GOOS=windows GOARCH=amd64 go build -v -o ratel-windows-amd64.exe -ldflags "-X $ratel_release=$release_version" .
-  mv ratel-windows-amd64.exe $TMP/windows/dgraph-ratel.exe
+  #env GOOS=windows GOARCH=amd64 go get -v -d .
+  #env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v -o ratel-windows-amd64.exe -ldflags "-X $ratel_release=$release_version" .
+  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
+  mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  env GOOS=darwin GOARCH=amd64 go get -v -d .
-  env GOOS=darwin GOARCH=amd64 GO111MODULE=on go build -v -o dgraph-darwin-amd64 -ldflags \
-      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags \
+  "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
-  mv dgraph-darwin-amd64 $TMP/darwin/dgraph
+  mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=darwin GOARCH=amd64 go get -v -d .
-  env GOOS=darwin GOARCH=amd64 GO111MODULE=on go build -v -o badger-darwin-amd64 .
-  mv badger-darwin-amd64 $TMP/darwin/badger
+  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 .
+  mv badger-darwin-10.9-amd64 $TMP/darwin/badger
 popd
 
 pushd $basedir/ratel
-  env GOOS=darwin GOARCH=amd64 go get -v -d .
-  env GOOS=darwin GOARCH=amd64 go build -v -o ratel-darwin-amd64 -v -ldflags "-X $ratel_release=$release_version" .
-  mv ratel-darwin-amd64 $TMP/darwin/dgraph-ratel
+  env CGO_ENABLED=1 xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
+  mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
 popd
 
 # Build Linux.

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -24,8 +24,6 @@ PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
 GOVERSION="1.14.1"
-# Build new image if upgrading Go version.
-XGO_IMAGE="danielmai/xgo-1.14.1"
 
 # Turn off go modules by default. Only enable go modules when needed.
 export GO111MODULE=off
@@ -75,6 +73,7 @@ go get -u github.com/dgraph-io/dgo
 go get -u github.com/dgraph-io/badger
 go get -u github.com/golang/protobuf/protoc-gen-go
 go get -u github.com/gogo/protobuf/protoc-gen-gofast
+go get -u github.com/techknowlogick/xgo
 
 pushd $GOPATH/src/google.golang.org/grpc
   git checkout v1.13.0
@@ -120,43 +119,43 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  xgo -image="$XGO_IMAGE" --targets=windows/amd64 -ldflags \
+  xgo -go="$GO_VERSION" --targets=windows/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  xgo -image="$XGO_IMAGE" --targets=windows/amd64 .
+  xgo -go="$GO_VERSION" --targets=windows/amd64 .
   mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  xgo -image="$XGO_IMAGE" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="$GO_VERSION" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 -ldflags \
+  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 -ldflags \
   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 .
+  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 .
   mv badger-darwin-10.9-amd64 $TMP/darwin/badger
 popd
 
 pushd $basedir/ratel
-  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
 popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-  xgo -image="$XGO_IMAGE" --targets=linux/amd64 -ldflags \
+  xgo -go="$GO_VERSION" --targets=linux/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
@@ -164,13 +163,13 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -image="$XGO_IMAGE" --targets=linux/amd64 .
+  xgo -go="$GO_VERSION" --targets=linux/amd64 .
   strip -x badger-linux-amd64
   mv badger-linux-amd64 $TMP/linux/badger
 popd
 
 pushd $basedir/ratel
-  xgo -image="$XGO_IMAGE" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="$GO_VERSION" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
   strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -73,7 +73,7 @@ go get -u github.com/dgraph-io/dgo
 go get -u github.com/dgraph-io/badger
 go get -u github.com/golang/protobuf/protoc-gen-go
 go get -u github.com/gogo/protobuf/protoc-gen-gofast
-go get -u github.com/techknowlogick/xgo
+go get -u src.techknowlogick.com/xgo
 
 pushd $GOPATH/src/google.golang.org/grpc
   git checkout v1.13.0
@@ -119,43 +119,43 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  xgo -go="$GO_VERSION" --targets=windows/amd64 -ldflags \
+  xgo -go="go-$GOVERSION" --targets=windows/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  xgo -go="$GO_VERSION" --targets=windows/amd64 .
+  xgo -go="go-$GOVERSION" --targets=windows/amd64 .
   mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  xgo -go="$GO_VERSION" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="go-$GOVERSION" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 -ldflags \
+  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 -ldflags \
   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 .
+  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 .
   mv badger-darwin-10.9-amd64 $TMP/darwin/badger
 popd
 
 pushd $basedir/ratel
-  xgo -go="$GO_VERSION" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
 popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-  xgo -go="$GO_VERSION" --targets=linux/amd64 -ldflags \
+  xgo -go="go-$GOVERSION" --targets=linux/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
@@ -163,13 +163,13 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -go="$GO_VERSION" --targets=linux/amd64 .
+  xgo -go="go-$GOVERSION" --targets=linux/amd64 .
   strip -x badger-linux-amd64
   mv badger-linux-amd64 $TMP/linux/badger
 popd
 
 pushd $basedir/ratel
-  xgo -go="$GO_VERSION" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go="go-$GOVERSION" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
   strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -118,25 +118,25 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 -ldflags \
+  xgo -go=$GOVERSION --targets=windows/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 .
+  xgo -go=$GOVERSION --targets=windows/amd64 .
   mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go=$GOVERSION --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags \
+  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags \
   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -125,15 +125,11 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  #env GOOS=windows GOARCH=amd64 go get -v -d .
-  #env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 GO111MODULE=on go build -v -o badger-windows-amd64.exe .
   env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 .
   mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  #env GOOS=windows GOARCH=amd64 go get -v -d .
-  #env CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -v -o ratel-windows-amd64.exe -ldflags "-X $ratel_release=$release_version" .
   env CGO_ENABLED=1 GO111MODULE=on xgo -go=$GOVERSION --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
@@ -158,8 +154,7 @@ popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-  env GOOS=linux GOARCH=amd64 go get -v -d .
-  env GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -o dgraph-linux-amd64 -ldflags \
+  xgo -go=$GOVERSION --targets=linux/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
@@ -167,15 +162,13 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  env GOOS=linux GOARCH=amd64 go get -v -d .
-  env GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -o badger-linux-amd64 .
+  xgo -go=$GOVERSION --targets=linux/amd64 .
   strip -x badger-linux-amd64
   mv badger-linux-amd64 $TMP/linux/badger
 popd
 
 pushd $basedir/ratel
-  env GOOS=linux GOARCH=amd64 go get -v -d .
-  env GOOS=linux GOARCH=amd64 go build -v -o ratel-linux-amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go=$GOVERSION --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
   strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -24,6 +24,8 @@ PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
 GOVERSION="1.14.1"
+# Build new image if upgrading Go version.
+XGO_IMAGE="danielmai/xgo-1.14.1"
 
 # Turn off go modules by default. Only enable go modules when needed.
 export GO111MODULE=off
@@ -118,43 +120,43 @@ popd
 
 # Build Windows.
 pushd $basedir/dgraph/dgraph
-  xgo -go=$GOVERSION --targets=windows/amd64 -ldflags \
+  xgo -image="$XGO_IMAGE" --targets=windows/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/windows
   mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
 popd
 
 pushd $basedir/badger/badger
-  xgo -go=$GOVERSION --targets=windows/amd64 .
+  xgo -image="$XGO_IMAGE" --targets=windows/amd64 .
   mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
 popd
 
 pushd $basedir/ratel
-  xgo -go=$GOVERSION --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -image="$XGO_IMAGE" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
 popd
 
 # Build Darwin.
 pushd $basedir/dgraph/dgraph
-  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags \
+  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 -ldflags \
   "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   mkdir $TMP/darwin
   mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 .
+  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 .
   mv badger-darwin-10.9-amd64 $TMP/darwin/badger
 popd
 
 pushd $basedir/ratel
-  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -image="$XGO_IMAGE" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
 popd
 
 # Build Linux.
 pushd $basedir/dgraph/dgraph
-  xgo -go=$GOVERSION --targets=linux/amd64 -ldflags \
+  xgo -image="$XGO_IMAGE" --targets=linux/amd64 -ldflags \
       "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
   strip -x dgraph-linux-amd64
   mkdir $TMP/linux
@@ -162,13 +164,13 @@ pushd $basedir/dgraph/dgraph
 popd
 
 pushd $basedir/badger/badger
-  xgo -go=$GOVERSION --targets=linux/amd64 .
+  xgo -image="$XGO_IMAGE" --targets=linux/amd64 .
   strip -x badger-linux-amd64
   mv badger-linux-amd64 $TMP/linux/badger
 popd
 
 pushd $basedir/ratel
-  xgo -go=$GOVERSION --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -image="$XGO_IMAGE" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
   strip -x ratel-linux-amd64
   mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
 popd

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -148,7 +148,7 @@ pushd $basedir/badger/badger
 popd
 
 pushd $basedir/ratel
-  env CGO_ENABLED=1 xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
+  xgo -go=$GOVERSION --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
   mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
 popd
 


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->
<!-- If you are a Dgraph engineer, please add this param at the end of your URL query `&template=DgraphPR.md` -->
<!-- e.g: https://github.com/dgraph-io/dgraph/compare/$YOURBRANCH?expand=1&template=DgraphPR.md -->

### What does this PR do?

This updates the release.sh script to use xgo for Linux, Windows, and Darwin builds. 


<!-- First, describe here details about it. -->

### Motivation

This is to fix the panics related to Badger compression which only uses Zstd when Cgo is enabled. See #4995.

<!-- Besides the motivation itself, if applicable, you should add references. e.g public conversations (URL) in the community. This helps reviewers with context. You should also advocate for the PR if needed. You can ping Daniel, Karthic, Michel or Santo if you need help. -->

### Components affected by this PR <!-- (Optional) -->

Darwin and Windows release builds moving forward (v20.03.0 were already built with this change). Linux builds are working fine.

<!-- Please, take a minute to think about what or who this PR affects. Does it need help for doing documentation? Does it affect third parties (Open Source or not) applications? Make it clear so we can track and fix it. -->
<!-- e.g. "It breaks/affects Ratel UI behavior." or You are working on documentation. Check if any links will be broken with your changes. -->

### Does this PR break backwards compatibility?  <!-- (Optional) -->

No.

<!-- Yes/no, and details if needed. -->

### Fixes <!-- (Optional) -->
Fixes #4995
<!-- Add here an issue that this PR will close. -->

### More <!-- (Optional) -->

<!-- Add here TODOS, testing results, additional notes, consolidated discussion points, personal signs and etc. -->

<!-- You can always ping us (Daniel, Karthic, Micheldiz or Santo in Slack or via DM at http://discuss.dgraph.io/) if you need help about filling those sections. -->
This uses https://github.com/techknowlogick/xgo/, which is a maintained fork of https://github.com/karalabe/xgo.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5120)
<!-- Reviewable:end -->
