### PR TITLE
Alpha Close: Wait for indexing to complete

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -176,9 +176,6 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	defer stopIndexing(closer)
 
 	buildIndexesHelper := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) error {
-		// in case background indexing is running, we should call it here again.
-		defer stopIndexing(closer)
-
 		wrtCtx := schema.GetWriteContext(context.Background())
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {
 			return err
@@ -197,6 +194,9 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	wg.Add(1)
 	defer wg.Done()
 	buildIndexes := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) {
+		// In case background indexing is running, we should call it here again.
+		defer stopIndexing(closer)
+
 		// We should only start building indexes once this function has returned.
 		// This is in order to ensure that we do not call DropPrefix for one predicate
 		// and write indexes for another predicate simultaneously. because that could


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.

<!-- First, describe here details about it. -->
The background reindexing starts indexing in the background but we do not wait for the indexing to complete while shutting down alpha. This PR fixes that issue by waiting for the background indexing to complete before we shutdown alpha. 

The issue can be easily seen by adding a long sleep in the background indexing and trying to shutdown alpha. It can be seen that Alpha doesn't wait for the indexing to complete while shutting down.

### GitHub Issue or Jira number.
<!-- Add here. -->
Partially fixes https://github.com/dgraph-io/dgraph/issues/3873
See also https://github.com/dgraph-io/dgraph/issues/3873#issuecomment-610947133

<!-- Add here. e.g. "It breaks/affects Ratel UI behavior." -->

### Affected releases.

v20.03

### Changelog tags.

<!-- removed, added, fixed, ... -->
N/A
<!-- Add here. -->

### Please indicate if this is a breaking change.

<!-- Add here. -->
No
### Please indicate if this is an enterprise feature.

<!-- Add here. -->
No
### Please indicate if documentation needs to be updated.

<!-- If yes indicate the documentation issue number. Add here. -->
<!--or create one and add the number here -->
No
### Please indicate if end to end testing is needed.
No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5137)
<!-- Reviewable:end -->
