### PR TITLE
release/v1.0.14: Preserve UIDs for bulk loader.

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -59,6 +59,7 @@ type options struct {
 	HttpAddr         string
 	IgnoreErrors     bool
 	CustomTokenizers string
+	NewUids          bool
 
 	MapShards    int
 	ReduceShards int

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -184,11 +185,11 @@ func (m *mapper) addMapEntry(key []byte, p *pb.Posting, shard int) {
 }
 
 func (m *mapper) processNQuad(nq gql.NQuad) {
-	sid := m.lookupUid(nq.GetSubject())
+	sid := m.uid(nq.GetSubject())
 	var oid uint64
 	var de *pb.DirectedEdge
 	if nq.GetObjectValue() == nil {
-		oid = m.lookupUid(nq.GetObjectId())
+		oid = m.uid(nq.GetObjectId())
 		de = nq.CreateUidEdge(sid, oid)
 	} else {
 		var err error
@@ -213,6 +214,15 @@ func (m *mapper) processNQuad(nq gql.NQuad) {
 		pp := m.createPredicatePosting(nq.Predicate)
 		m.addMapEntry(key, pp, shard)
 	}
+}
+
+func (m *mapper) uid(xid string) uint64 {
+	if uid, err := strconv.ParseUint(xid, 0, 64); err == nil {
+		m.xids.BumpTo(uid)
+		return uid
+	}
+
+	return m.lookupUid(xid)
 }
 
 func (m *mapper) lookupUid(xid string) uint64 {

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -217,9 +217,11 @@ func (m *mapper) processNQuad(nq gql.NQuad) {
 }
 
 func (m *mapper) uid(xid string) uint64 {
-	if uid, err := strconv.ParseUint(xid, 0, 64); err == nil {
-		m.xids.BumpTo(uid)
-		return uid
+	if !m.opt.NewUids {
+		if uid, err := strconv.ParseUint(xid, 0, 64); err == nil {
+			m.xids.BumpTo(uid)
+			return uid
+		}
 	}
 
 	return m.lookupUid(xid)

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -91,6 +91,8 @@ func init() {
 			"more parallelism, but increases memory usage.")
 	flag.String("custom_tokenizers", "",
 		"Comma separated list of tokenizer plugins")
+	flag.Bool("new_uids", false,
+		"Ignore UIDs in load files and assign new ones.")
 }
 
 func run() {
@@ -114,6 +116,7 @@ func run() {
 		MapShards:        Bulk.Conf.GetInt("map_shards"),
 		ReduceShards:     Bulk.Conf.GetInt("reduce_shards"),
 		CustomTokenizers: Bulk.Conf.GetString("custom_tokenizers"),
+		NewUids:          Bulk.Conf.GetBool("new_uids"),
 	}
 
 	x.PrintVersion()


### PR DESCRIPTION
This is a feature for the **v1.0.14** release to allow bulk loader to keep UIDs in the format `<0xabc123>` in the loaded dataset. This mostly follows b77971ad70be8a2043546dd72eb75da9c44ff75c along with the necessary changes in xidmap.go for (*XidMap).BumpTo.

Fixes:

- DGRAPH-1215

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5139)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->