### PR TITLE
re-encrypt restore from encrypted backups

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -105,8 +105,8 @@ $ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
 	flag.StringVarP(&opt.zero, "zero", "z", "", "gRPC address for Dgraph zero. ex: localhost:5080")
 	flag.StringVarP(&opt.backupId, "backup_id", "", "", "The ID of the backup series to "+
 		"restore. If empty, it will restore the latest series.")
-	flag.StringVarP(&opt.keyfile, "keyfile", "k", "",
-		"Key file to decrypt the backup. The same key is also used to re-encrypt the restored data.")
+	flag.StringVarP(&opt.keyfile, "keyfile", "k", "", "Key file to decrypt the backup. "+
+		"The same key is also used to re-encrypt the restored data.")
 	_ = Restore.Cmd.MarkFlagRequired("postings")
 	_ = Restore.Cmd.MarkFlagRequired("location")
 }

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -106,7 +106,7 @@ $ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
 	flag.StringVarP(&opt.backupId, "backup_id", "", "", "The ID of the backup series to "+
 		"restore. If empty, it will restore the latest series.")
 	flag.StringVarP(&opt.keyfile, "keyfile", "k", "",
-		"Key file to decrypt the backup")
+		"Key file to decrypt the backup. The same key is also used to re-encrypt the restored data.")
 	_ = Restore.Cmd.MarkFlagRequired("postings")
 	_ = Restore.Cmd.MarkFlagRequired("location")
 }

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -272,7 +272,8 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	testutil.KeyFile = "../../../ee/enc/enc-key"
-	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore", "-k", testutil.KEYFILE}
+	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
+		"-k", testutil.KeyFile}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -271,7 +271,8 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	require.NoError(t, os.RemoveAll(restoreDir))
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
-	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore", "-k", "../../../ee/enc/enc-key"}
+	testutil.KEYFILE = "../../../ee/enc/enc-key"
+	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore", "-k", testutil.KEYFILE}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -271,7 +271,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	require.NoError(t, os.RemoveAll(restoreDir))
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
-	testutil.KEYFILE = "../../../ee/enc/enc-key"
+	testutil.KeyFile = "../../../ee/enc/enc-key"
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore", "-k", testutil.KEYFILE}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -34,7 +34,8 @@ var KEYFILE string
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
 		// TOOD(Ibrahim): Remove compression level once badger is updated.
-		WithReadOnly(true).WithZSTDCompressionLevel(1).WithEncryptionKey(enc.ReadEncryptionKeyFile(KEYFILE))
+		WithReadOnly(true).WithZSTDCompressionLevel(1).
+		WithEncryptionKey(enc.ReadEncryptionKeyFile(KEYFILE))
 	return badger.OpenManaged(opt)
 }
 

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -21,16 +21,20 @@ import (
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
+	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 )
 
+// KEYFILE is set to the path of the file containing the key. Used for testing purposes only.
+var KEYFILE string
+
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
 		// TOOD(Ibrahim): Remove compression level once badger is updated.
-		WithReadOnly(true).WithZSTDCompressionLevel(1)
+		WithReadOnly(true).WithZSTDCompressionLevel(1).WithEncryptionKey(enc.ReadEncryptionKeyFile(KEYFILE))
 	return badger.OpenManaged(opt)
 }
 

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -29,13 +29,13 @@ import (
 )
 
 // KEYFILE is set to the path of the file containing the key. Used for testing purposes only.
-var KEYFILE string
+var KeyFile string
 
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
 		// TOOD(Ibrahim): Remove compression level once badger is updated.
 		WithReadOnly(true).WithZSTDCompressionLevel(1).
-		WithEncryptionKey(enc.ReadEncryptionKeyFile(KEYFILE))
+		WithEncryptionKey(enc.ReadEncryptionKeyFile(KeyFile))
 	return badger.OpenManaged(opt)
 }
 

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -51,7 +51,8 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).
 				WithValueThreshold(1 << 10).
-				WithNumVersionsToKeep(math.MaxInt32))
+				WithNumVersionsToKeep(math.MaxInt32).
+				WithEncryptionKey(enc.ReadEncryptionKeyFile(keyfile)))
 			if err != nil {
 				return 0, err
 			}


### PR DESCRIPTION
As part of the encrypted backup/restore feature, currently, the restore tool restores the "p" dir unencrypted whether the backup is encrypted or not. 

This story allow restores to be encrypted with the same key file used to decrypt the backup. If backup was unencrypted, the restore will remain unencrypted.

Fixes DGRAPH-1223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5140)
<!-- Reviewable:end -->
