### PR TITLE
Check uid list is empty when filling shortest path vars.

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1572,8 +1572,10 @@ func (sg *SubGraph) recursiveFillVars(doneVars map[string]varValue) error {
 // fillShortestPathVars reads value of the uid variable from mp map and fills it into From and To
 // parameters.
 func (sg *SubGraph) fillShortestPathVars(mp map[string]varValue) error {
-	// The uidVar.Uids can be nil if the variable didn't return any uids. This would mean
-	// sg.Params.From or sg.Params.To is 0 and the query would return an empty result.
+	// The uidVar.Uids can be nil or have an empty uid list if the variable didn't
+	// return any uids. This would mean sg.Params.From or sg.Params.To is 0 and the
+	// query would return an empty result.
+
 	if sg.Params.ShortestPathArgs.From != nil && len(sg.Params.ShortestPathArgs.From.NeedsVar) > 0 {
 		fromVar := sg.Params.ShortestPathArgs.From.NeedsVar[0].Name
 		uidVar, ok := mp[fromVar]
@@ -1581,7 +1583,7 @@ func (sg *SubGraph) fillShortestPathVars(mp map[string]varValue) error {
 			return errors.Errorf("value of from var(%s) should have already been populated",
 				fromVar)
 		}
-		if uidVar.Uids != nil {
+		if uidVar.Uids != nil && len(uidVar.Uids.Uids) > 0 {
 			if len(uidVar.Uids.Uids) > 1 {
 				return errors.Errorf("from variable(%s) should only expand to 1 uid", fromVar)
 			}
@@ -1596,7 +1598,7 @@ func (sg *SubGraph) fillShortestPathVars(mp map[string]varValue) error {
 			return errors.Errorf("value of to var(%s) should have already been populated",
 				toVar)
 		}
-		if uidVar.Uids != nil {
+		if uidVar.Uids != nil && len(uidVar.Uids.Uids) > 0 {
 			if len(uidVar.Uids.Uids) > 1 {
 				return errors.Errorf("to variable(%s) should only expand to 1 uid", toVar)
 			}


### PR DESCRIPTION
### Description.

When filling the shortest path vars, the code checks the object is nil but 
it doesn't check whether the uid list inside is empty, leading to out of bounds
errors.

### GitHub Issue or Jira number.

https://dgraph.atlassian.net/browse/DGRAPH-1222

### Affected releases.

20.03.1

### Changelog tags.

fixed

### Please indicate if this is a breaking change.

No

### Please indicate if this is an enterprise feature.

No

### Please indicate if documentation needs to be updated.

No

### Please indicate if end to end testing is needed.

No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5141)
<!-- Reviewable:end -->
