### PR TITLE
add option "-k" to debug tool for encryption support (#5113)

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
 	"github.com/dgraph-io/dgraph/codec"
+	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
@@ -55,6 +56,7 @@ type flagOptions struct {
 	readTs        uint64
 	sizeHistogram bool
 	noKeys        bool
+	badgerKeyFile string
 
 	// Options related to the WAL.
 	wdir           string
@@ -85,6 +87,8 @@ func init() {
 	flag.StringVarP(&opt.pdir, "postings", "p", "", "Directory where posting lists are stored.")
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
+	flag.StringVarP(&opt.badgerKeyFile, "encryption_key_file", "k", "",
+		"File where the encryption key is stored.")
 
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
@@ -763,7 +767,7 @@ func run() {
 	}
 	bopts := badger.DefaultOptions(dir).
 		WithTableLoadingMode(options.MemoryMap).
-		WithReadOnly(opt.readOnly)
+		WithReadOnly(opt.readOnly).WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.badgerKeyFile))
 
 	// TODO(Ibrahim): Remove this once badger is updated.
 	bopts.ZSTDCompressionLevel = 1


### PR DESCRIPTION
cherry-picked from commit f38073a49cccded36ef017b1d47c1e0a7ad05e5e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5146)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e84c74a0b6-53395.surge.sh)
<!-- Dgraph:end -->