### PR TITLE
Shutdown executor goroutines (#5130)

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -888,6 +888,9 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 			}
 			n.Raft().Stop()
 			close(done)
+			if x.WorkerConfig.LudicrousMode {
+				n.ex.closer.SignalAndWait()
+			}
 			return
 		}
 	}


### PR DESCRIPTION
Once shutdown signal is sent, alpha used to ignore all the mutations present in the channel and shutdown. Now alpha will process all the mutation that are already there in the channel. Main go routine will wait for the channel to be drained completely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5150)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e5adf374e2-53585.surge.sh)
<!-- Dgraph:end -->