### PR TITLE
Cherry-pick "Backup schema keys in incremental backups" into release 20.03.

### DIFF
--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -289,11 +289,11 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	restored, err := testutil.GetPredicateValues(pdir, "movie", commitTs)
 	require.NoError(t, err)
 
-	restoredPreds, err := testutil.GetPredicateNames(pdir, commitTs)
+	restoredPreds, err := testutil.GetPredicateNames(pdir)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"dgraph.graphql.schema", "dgraph.type", "movie"}, restoredPreds)
 
-	restoredTypes, err := testutil.GetTypeNames(pdir, commitTs)
+	restoredTypes, err := testutil.GetTypeNames(pdir)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"Node", "dgraph.graphql"}, restoredTypes)
 

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -106,6 +106,12 @@ func TestBackupFilesystem(t *testing.T) {
 	_ = runBackup(t, 3, 1)
 	restored := runRestore(t, copyBackupDir, "", math.MaxUint64)
 
+	// Check the predicates and types in the schema are as expected.
+	// TODO: refactor tests so that minio and filesystem tests share most of their logic.
+	preds := []string{"dgraph.graphql.schema", "dgraph.type", "movie"}
+	types := []string{"Node", "dgraph.graphql"}
+	testutil.CheckSchema(t, preds, types)
+
 	checks := []struct {
 		blank, expected string
 	}{
@@ -130,10 +136,27 @@ func TestBackupFilesystem(t *testing.T) {
 	t.Logf("%+v", incr1)
 	require.NoError(t, err)
 
+	// Update schema and types to make sure updates to the schema are backed up.
+	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `
+		movie: string .
+		actor: string .
+		type Node {
+			movie
+		}
+		type NewNode {
+			actor
+		}`}))
+
 	// Perform first incremental backup.
 	_ = runBackup(t, 6, 2)
 	restored = runRestore(t, copyBackupDir, "", incr1.Txn.CommitTs)
 
+	// Check the predicates and types in the schema are as expected.
+	preds = append(preds, "actor")
+	types = append(types, "NewNode")
+	testutil.CheckSchema(t, preds, types)
+
+	// Perform some checks on the restored values.
 	checks = []struct {
 		blank, expected string
 	}{
@@ -157,6 +180,7 @@ func TestBackupFilesystem(t *testing.T) {
 	// Perform second incremental backup.
 	_ = runBackup(t, 9, 3)
 	restored = runRestore(t, copyBackupDir, "", incr2.Txn.CommitTs)
+	testutil.CheckSchema(t, preds, types)
 
 	checks = []struct {
 		blank, expected string
@@ -181,6 +205,7 @@ func TestBackupFilesystem(t *testing.T) {
 	// Perform second full backup.
 	dirs := runBackupInternal(t, true, 12, 4)
 	restored = runRestore(t, copyBackupDir, "", incr3.Txn.CommitTs)
+	testutil.CheckSchema(t, preds, types)
 
 	// Check all the values were restored to their most recent value.
 	checks = []struct {
@@ -279,15 +304,6 @@ func runRestore(t *testing.T, backupLocation, lastDir string, commitTs uint64) m
 	restored, err := testutil.GetPredicateValues(pdir, "movie", commitTs)
 	require.NoError(t, err)
 	t.Logf("--- Restored values: %+v\n", restored)
-
-	restoredPreds, err := testutil.GetPredicateNames(pdir, commitTs)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"dgraph.graphql.schema", "dgraph.type", "movie"}, restoredPreds)
-
-	restoredTypes, err := testutil.GetTypeNames(pdir, commitTs)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node", "dgraph.graphql"}, restoredTypes)
-
 	return restored
 }
 

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -112,6 +112,12 @@ func TestBackupMinio(t *testing.T) {
 	_ = runBackup(t, 3, 1)
 	restored := runRestore(t, "", math.MaxUint64)
 
+	// Check the predicates and types in the schema are as expected.
+	// TODO: refactor tests so that minio and filesystem tests share most of their logic.
+	preds := []string{"dgraph.graphql.schema", "dgraph.type", "movie"}
+	types := []string{"Node", "dgraph.graphql"}
+	testutil.CheckSchema(t, preds, types)
+
 	checks := []struct {
 		blank, expected string
 	}{
@@ -136,9 +142,25 @@ func TestBackupMinio(t *testing.T) {
 	t.Logf("%+v", incr1)
 	require.NoError(t, err)
 
+	// Update schema and types to make sure updates to the schema are backed up.
+	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `
+		movie: string .
+		actor: string .
+		type Node {
+			movie
+		}
+		type NewNode {
+			actor
+		}`}))
+
 	// Perform first incremental backup.
 	_ = runBackup(t, 6, 2)
 	restored = runRestore(t, "", incr1.Txn.CommitTs)
+
+	// Check the predicates and types in the schema are as expected.
+	preds = append(preds, "actor")
+	types = append(types, "NewNode")
+	testutil.CheckSchema(t, preds, types)
 
 	checks = []struct {
 		blank, expected string
@@ -163,6 +185,7 @@ func TestBackupMinio(t *testing.T) {
 	// Perform second incremental backup.
 	_ = runBackup(t, 9, 3)
 	restored = runRestore(t, "", incr2.Txn.CommitTs)
+	testutil.CheckSchema(t, preds, types)
 
 	checks = []struct {
 		blank, expected string
@@ -187,6 +210,7 @@ func TestBackupMinio(t *testing.T) {
 	// Perform second full backup.
 	dirs := runBackupInternal(t, true, 12, 4)
 	restored = runRestore(t, "", incr3.Txn.CommitTs)
+	testutil.CheckSchema(t, preds, types)
 
 	// Check all the values were restored to their most recent value.
 	checks = []struct {
@@ -286,18 +310,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	pdir := "./data/restore/p1"
 	restored, err := testutil.GetPredicateValues(pdir, "movie", commitTs)
 	require.NoError(t, err)
-
-	restoredPreds, err := testutil.GetPredicateNames(pdir, commitTs)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"dgraph.graphql.schema", "dgraph.type", "movie"}, restoredPreds)
-
-	restoredTypes, err := testutil.GetTypeNames(pdir, commitTs)
-	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node", "dgraph.graphql"}, restoredTypes)
-
-	require.NoError(t, err)
 	t.Logf("--- Restored values: %+v\n", restored)
-
 	return restored
 }
 

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -18,6 +18,7 @@ package testutil
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/badger/v2/options"
@@ -26,6 +27,8 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/stretchr/testify/require"
 )
 
 // KEYFILE is set to the path of the file containing the key. Used for testing purposes only.
@@ -134,11 +137,32 @@ func readSchema(pdir string, dType dataType) ([]string, error) {
 }
 
 // GetPredicateNames returns the list of all the predicates stored in the restored pdir.
-func GetPredicateNames(pdir string, readTs uint64) ([]string, error) {
+func GetPredicateNames(pdir string) ([]string, error) {
 	return readSchema(pdir, schemaPredicate)
 }
 
 // GetTypeNames returns the list of all the types stored in the restored pdir.
-func GetTypeNames(pdir string, readTs uint64) ([]string, error) {
+func GetTypeNames(pdir string) ([]string, error) {
 	return readSchema(pdir, schemaType)
+}
+
+// CheckSchema checks the names of the predicates and types in the schema against the given names.
+func CheckSchema(t *testing.T, preds, types []string) {
+	pdirs := []string{
+		"./data/restore/p1",
+		"./data/restore/p2",
+		"./data/restore/p3",
+	}
+
+	restoredPreds := make([]string, 0)
+	for _, pdir := range pdirs {
+		groupPreds, err := GetPredicateNames(pdir)
+		require.NoError(t, err)
+		restoredPreds = append(restoredPreds, groupPreds...)
+
+		restoredTypes, err := GetTypeNames(pdir)
+		require.NoError(t, err)
+		require.ElementsMatch(t, types, restoredTypes)
+	}
+	require.ElementsMatch(t, preds, restoredPreds)
 }

--- a/worker/backup_processor.go
+++ b/worker/backup_processor.go
@@ -233,9 +233,12 @@ func (pr *BackupProcessor) toBackupList(key []byte, itr *badger.Iterator) (*bpb.
 	list := &bpb.KVList{}
 
 	item := itr.Item()
-	if item.Version() < pr.Request.SinceTs || item.IsDeletedOrExpired() {
+	if item.UserMeta() != posting.BitSchemaPosting && (item.Version() < pr.Request.SinceTs ||
+		item.IsDeletedOrExpired()) {
 		// Ignore versions less than given timestamp, or skip older versions of
 		// the given key by returning an empty list.
+		// Do not do this for schema and type keys. Those keys always have a
+		// version of one so they would be incorrectly rejected by above check.
 		return list, nil
 	}
 

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -84,6 +84,14 @@ func loadFromBackup(db *badger.DB, r io.Reader, preds predicateSet) (uint64, err
 	br := bufio.NewReaderSize(r, 16<<10)
 	unmarshalBuf := make([]byte, 1<<10)
 
+	// Delete schemas and types. Each backup file should have a complete copy of the schema.
+	if err := db.DropPrefix([]byte{x.ByteSchema}); err != nil {
+		return 0, err
+	}
+	if err := db.DropPrefix([]byte{x.ByteType}); err != nil {
+		return 0, err
+	}
+
 	loader := db.NewKVLoader(16)
 	var maxUid uint64
 	for {

--- a/x/keys.go
+++ b/x/keys.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// TODO(pawan) - Make this 2 bytes long. Right now ParsedKey has byteType and
+	// TODO(pawan) - Make this 2 bytes long. Right now ParsedKey has ByteType and
 	// bytePrefix. Change it so that it just has one field which has all the information.
 
 	// ByteData indicates the key stores data.
@@ -43,8 +43,8 @@ const (
 	// DefaultPrefix is the prefix used for data, index and reverse keys so that relative
 	// order of data doesn't change keys of same attributes are located together.
 	DefaultPrefix = byte(0x00)
-	byteSchema    = byte(0x01)
-	byteType      = byte(0x02)
+	ByteSchema    = byte(0x01)
+	ByteType      = byte(0x02)
 	// ByteSplit signals that the key stores an individual part of a multi-part list.
 	ByteSplit = byte(0x04)
 	// ByteUnused is a constant to specify keys which need to be discarded.
@@ -79,22 +79,22 @@ func generateKey(typeByte byte, attr string, totalLen int) []byte {
 // separately with unique prefix, since we need to iterate over all schema keys.
 // The structure of a schema key is as follows:
 //
-// byte 0: key type prefix (set to byteSchema)
+// byte 0: key type prefix (set to ByteSchema)
 // byte 1-2: length of attr
 // next len(attr) bytes: value of attr
 func SchemaKey(attr string) []byte {
-	return generateKey(byteSchema, attr, 1+2+len(attr))
+	return generateKey(ByteSchema, attr, 1+2+len(attr))
 }
 
 // TypeKey returns type key for given type name. Type keys are stored separately
 // with a unique prefix, since we need to iterate over all type keys.
 // The structure of a type key is as follows:
 //
-// byte 0: key type prefix (set to byteType)
+// byte 0: key type prefix (set to ByteType)
 // byte 1-2: length of typeName
 // next len(attr) bytes: value of attr (the type name)
 func TypeKey(attr string) []byte {
-	return generateKey(byteType, attr, 1+2+len(attr))
+	return generateKey(ByteType, attr, 1+2+len(attr))
 }
 
 // DataKey generates a data key with the given attribute and UID.
@@ -193,7 +193,7 @@ func CountKey(attr string, count uint32, reverse bool) []byte {
 
 // ParsedKey represents a key that has been parsed into its multiple attributes.
 type ParsedKey struct {
-	byteType    byte
+	ByteType    byte
 	Attr        string
 	Uid         uint64
 	HasStartUid bool
@@ -205,12 +205,12 @@ type ParsedKey struct {
 
 // IsData returns whether the key is a data key.
 func (p ParsedKey) IsData() bool {
-	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.byteType == ByteData
+	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.ByteType == ByteData
 }
 
 // IsReverse returns whether the key is a reverse key.
 func (p ParsedKey) IsReverse() bool {
-	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.byteType == ByteReverse
+	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.ByteType == ByteReverse
 }
 
 // IsCountOrCountRev returns whether the key is a count or a count rev key.
@@ -220,27 +220,27 @@ func (p ParsedKey) IsCountOrCountRev() bool {
 
 // IsCount returns whether the key is a count key.
 func (p ParsedKey) IsCount() bool {
-	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.byteType == ByteCount
+	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.ByteType == ByteCount
 }
 
 // IsCountRev returns whether the key is a count rev key.
 func (p ParsedKey) IsCountRev() bool {
-	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.byteType == ByteCountRev
+	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.ByteType == ByteCountRev
 }
 
 // IsIndex returns whether the key is an index key.
 func (p ParsedKey) IsIndex() bool {
-	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.byteType == ByteIndex
+	return (p.bytePrefix == DefaultPrefix || p.bytePrefix == ByteSplit) && p.ByteType == ByteIndex
 }
 
 // IsSchema returns whether the key is a schema key.
 func (p ParsedKey) IsSchema() bool {
-	return p.bytePrefix == byteSchema
+	return p.bytePrefix == ByteSchema
 }
 
 // IsType returns whether the key is a type key.
 func (p ParsedKey) IsType() bool {
-	return p.bytePrefix == byteType
+	return p.bytePrefix == ByteType
 }
 
 // IsOfType checks whether the key is of the given type.
@@ -274,14 +274,14 @@ func (p ParsedKey) SkipPredicate() []byte {
 // SkipSchema returns the first key after all the schema keys.
 func (p ParsedKey) SkipSchema() []byte {
 	var buf [1]byte
-	buf[0] = byteSchema + 1
+	buf[0] = ByteSchema + 1
 	return buf[:]
 }
 
 // SkipType returns the first key after all the type keys.
 func (p ParsedKey) SkipType() []byte {
 	var buf [1]byte
-	buf[0] = byteType + 1
+	buf[0] = ByteType + 1
 	return buf[:]
 }
 
@@ -396,14 +396,14 @@ func FromBackupKey(backupKey *pb.BackupKey) []byte {
 // SchemaPrefix returns the prefix for Schema keys.
 func SchemaPrefix() []byte {
 	var buf [1]byte
-	buf[0] = byteSchema
+	buf[0] = ByteSchema
 	return buf[:]
 }
 
 // TypePrefix returns the prefix for Schema keys.
 func TypePrefix() []byte {
 	var buf [1]byte
-	buf[0] = byteType
+	buf[0] = ByteType
 	return buf[:]
 }
 
@@ -462,15 +462,15 @@ func Parse(key []byte) (ParsedKey, error) {
 	k = k[sz:]
 
 	switch p.bytePrefix {
-	case byteSchema, byteType:
+	case ByteSchema, ByteType:
 		return p, nil
 	default:
 	}
 
-	p.byteType = k[0]
+	p.ByteType = k[0]
 	k = k[1:]
 
-	switch p.byteType {
+	switch p.ByteType {
 	case ByteData, ByteReverse:
 		if len(k) < 8 {
 			return p, errors.Errorf("uid length < 8 for key: %q, parsed key: %+v", key, p)


### PR DESCRIPTION
The full schema should be backed up during incremental backups.
During restore, the schema should be cleared before processing each backup
to end up with only the final schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5159)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-691a8b1b7a-53915.surge.sh)
<!-- Dgraph:end -->