### PR TITLE
graphql: parse auth rules

### DIFF
--- a/graphql/schema/auth.go
+++ b/graphql/schema/auth.go
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+	"github.com/vektah/gqlparser/v2/parser"
+	"github.com/vektah/gqlparser/v2/validator"
+)
+
+type RuleNode struct {
+	Or   []*RuleNode
+	And  []*RuleNode
+	Not  *RuleNode
+	Rule Query
+}
+
+type AuthContainer struct {
+	Query  *RuleNode
+	Add    *RuleNode
+	Update *RuleNode
+	Delete *RuleNode
+}
+
+type TypeAuth struct {
+	rules  *AuthContainer
+	fields map[string]*AuthContainer
+}
+
+func authRules(s *ast.Schema) (map[string]*TypeAuth, error) {
+	var errResult, err error
+	authRules := make(map[string]*TypeAuth)
+
+	for _, typ := range s.Types {
+		name := typeName(typ)
+		authRules[name] = &TypeAuth{fields: make(map[string]*AuthContainer)}
+		auth := typ.Directives.ForName(authDirective)
+		if auth != nil {
+			authRules[name].rules, err = parseAuthDirective(s, typ, auth)
+			errResult = AppendGQLErrs(errResult, err)
+		}
+
+		for _, field := range typ.Fields {
+			auth := field.Directives.ForName(authDirective)
+			if auth != nil {
+				authRules[name].fields[field.Name], err = parseAuthDirective(s, typ, auth)
+				errResult = AppendGQLErrs(errResult, err)
+			}
+		}
+	}
+
+	return authRules, errResult
+}
+
+func parseAuthDirective(
+	s *ast.Schema,
+	typ *ast.Definition,
+	dir *ast.Directive) (*AuthContainer, error) {
+
+	if dir == nil || len(dir.Arguments) == 0 {
+		return nil, nil
+	}
+
+	var errResult, err error
+	result := &AuthContainer{}
+
+	if qry := dir.Arguments.ForName("query"); qry != nil && qry.Value != nil {
+		result.Query, err = parseAuthNode(s, typ, qry.Value)
+		errResult = AppendGQLErrs(errResult, err)
+	}
+
+	if add := dir.Arguments.ForName("add"); add != nil && add.Value != nil {
+		result.Add, err = parseAuthNode(s, typ, add.Value)
+		errResult = AppendGQLErrs(errResult, err)
+	}
+
+	if upd := dir.Arguments.ForName("update"); upd != nil && upd.Value != nil {
+		result.Update, err = parseAuthNode(s, typ, upd.Value)
+		errResult = AppendGQLErrs(errResult, err)
+	}
+
+	if del := dir.Arguments.ForName("delete"); del != nil && del.Value != nil {
+		result.Delete, err = parseAuthNode(s, typ, del.Value)
+		errResult = AppendGQLErrs(errResult, err)
+	}
+
+	return result, errResult
+}
+
+func parseAuthNode(s *ast.Schema, typ *ast.Definition, val *ast.Value) (*RuleNode, error) {
+
+	if len(val.Children) == 0 {
+		return nil,
+			gqlerror.ErrorPosf(val.Position,
+				`no arguments - there should be only one of "and", "or", "not" and "rule"`)
+	}
+
+	numChildren := 0
+	var errResult error
+	result := &RuleNode{}
+
+	if ors := val.Children.ForName("or"); ors != nil && len(ors.Children) > 0 {
+		for _, or := range ors.Children {
+			rn, err := parseAuthNode(s, typ, or.Value)
+			result.Or = append(result.Or, rn)
+			errResult = AppendGQLErrs(errResult, err)
+		}
+		if len(result.Or) < 2 {
+			errResult = AppendGQLErrs(errResult,
+				gqlerror.ErrorPosf(ors.Position,
+					`it doesn't make sense to 'OR' less than two rules`))
+		}
+		numChildren++
+	}
+
+	if ands := val.Children.ForName("and"); ands != nil && len(ands.Children) > 0 {
+		for _, and := range ands.Children {
+			rn, err := parseAuthNode(s, typ, and.Value)
+			result.Or = append(result.Or, rn)
+			errResult = AppendGQLErrs(errResult, err)
+		}
+		if len(result.And) < 2 {
+			errResult = AppendGQLErrs(errResult,
+				gqlerror.ErrorPosf(ands.Position,
+					`it doesn't make sense to 'And' less than two rules`))
+		}
+		numChildren++
+	}
+
+	if not := val.Children.ForName("not"); not != nil &&
+		len(not.Children) == 1 && not.Children[0] != nil {
+
+		var err error
+		result.Not, err = parseAuthNode(s, typ, not.Children[0].Value)
+		errResult = AppendGQLErrs(errResult, err)
+		numChildren++
+	}
+
+	if rule := val.Children.ForName("rule"); rule != nil {
+		q, err := gqlValidateRule(s, typ, rule.Raw, rule.Position)
+		result.Rule = q
+		errResult = AppendGQLErrs(errResult, err)
+		numChildren++
+	}
+
+	if numChildren != 1 {
+		errResult = AppendGQLErrs(errResult,
+			gqlerror.ErrorPosf(val.Position,
+				`there should be only one of "and", "or", "not" and "rule"`))
+	}
+
+	return result, errResult
+}
+
+func gqlValidateRule(
+	s *ast.Schema,
+	typ *ast.Definition,
+	rule string,
+	position *ast.Position) (Query, error) {
+
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: rule})
+	if gqlErr != nil {
+		return nil, x.GqlErrorf(
+			"failed to parse GraphQL rule [reason : %s]", toGqlError(gqlErr).Error()).
+			WithLocations(x.Location{Line: position.Line, Column: position.Column})
+	}
+
+	if len(doc.Operations) != 1 {
+		return nil, gqlerror.ErrorPosf(position,
+			"a rule should be exactly one query, found %v GraphQL operations", len(doc.Operations))
+	}
+	op := doc.Operations[0]
+
+	if op == nil {
+		return nil, gqlerror.ErrorPosf(position,
+			"a rule should be exactly one query, found an empty GraphQL operation")
+	}
+
+	if op.Operation != "query" {
+		return nil, gqlerror.ErrorPosf(position,
+			"a rule should be exactly one query, found an %s", op.Name)
+	}
+
+	listErr := validator.Validate(s, doc)
+	if len(listErr) != 0 {
+		var errs error
+		for _, err := range listErr {
+			errs = AppendGQLErrs(
+				errs,
+				x.GqlErrorf("failed to validate GraphQL rule [reason : %s]", toGqlError(err)).
+					WithLocations(x.Location{Line: position.Line, Column: position.Column}))
+		}
+		return nil, errs
+	}
+
+	if len(op.SelectionSet) != 1 {
+		return nil, gqlerror.ErrorPosf(position,
+			"a rule should be exactly one query, found %v queries", len(op.SelectionSet))
+	}
+
+	f, ok := op.SelectionSet[0].(*ast.Field)
+	if !ok {
+		return nil, gqlerror.ErrorPosf(position,
+			"error couldn't generate query from rule")
+	}
+
+	if f.Name != "query"+typ.Name {
+		return nil, gqlerror.ErrorPosf(position,
+			"on type %s expected only query%s rules,but found %s", typ.Name, typ.Name, f.Name)
+	}
+
+	return &query{
+		field: f,
+		op: &operation{op: op,
+			query: rule,
+			doc:   doc,
+			// need to fill in vars and schema at query time
+		},
+		sel: op.SelectionSet[0]}, nil
+}

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -1,0 +1,88 @@
+invalid_schemas:
+
+  - name: "GraphQL parsing errors should be reported"
+    input: |
+      type X @auth(
+        query: { rule: "query { " }
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      {"message": "failed to parse GraphQL rule 
+        [reason : Expected Name, found <EOF> (Locations: [{Line: 1, Column: 9}])]",
+      "locations":[{"line":5, "column":28}]}
+    ]
+
+  - name: "GraphQL validation errors should be reported"
+    input: |
+      type X @auth(
+        query: {rule: "query { queryX(filter: { userRle: { eq: \"ADMIN\" } }) { __typename } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      {"message": "failed to validate GraphQL rule 
+        [reason : Field \"userRle\" is not defined by type XFilter. 
+        Did you mean userRole or username? (Locations: [{Line: 1, Column: 26}])]",
+      "locations":[{"line":5, "column":28}]}
+    ]
+      
+
+valid_schemas:
+
+  - name: "GraphQL Should Parse"
+    input: |
+      type X @auth(
+        query: {rule: """
+          query { 
+            queryX(filter: { userRole: { eq: "ADMIN" } }) { 
+              __typename 
+            } 
+          }"""
+        }
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+
+  - name: "GraphQL With Variable Should Parse"
+    input: |
+      type X @auth(
+        query: { rule: """
+          query($usr: String!) { 
+            queryX(filter: { username: { eq: $usr } }) { 
+              __typename 
+            } 
+          }"""
+        }
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+
+  - name: "Complex GraphQL Should Parse"
+    input: |
+      type Proj @auth(
+        update: { rule: """
+          query($usr: String!) { 
+            queryProj {
+              roles(filter: { perm: { ge: 4 }}) {
+                users(filter: { username: { eq: $usr } }) { 
+                  __typename 
+                } 
+              }
+            }
+          }""" }
+      ) {
+        projID: ID!
+        roles: [Role]
+      }
+      type Role {
+        perm: Int! @search
+        users: [User]
+      }
+      type User {
+        username: String! @id
+      }

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -257,6 +257,14 @@ var directiveValidators = map[string]directiveValidator{
 		dir *ast.Directive) *gqlerror.Error {
 		return nil
 	},
+	// Just go get it printed into generated schema
+	authDirective: func(
+		sch *ast.Schema,
+		typ *ast.Definition,
+		field *ast.FieldDefinition,
+		dir *ast.Directive) *gqlerror.Error {
+		return nil
+	},
 }
 
 var schemaValidations []func(schema *ast.Schema, definitions []string) gqlerror.List

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -57,7 +57,7 @@ func FromString(schema string) (Schema, error) {
 		return nil, errors.Wrap(gqlErr, "while validating GraphQL schema")
 	}
 
-	return AsSchema(gqlSchema), nil
+	return AsSchema(gqlSchema)
 }
 
 func (s *handler) GQLSchema() string {

--- a/graphql/schema/schemagen_test.go
+++ b/graphql/schema/schemagen_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	dschema "github.com/dgraph-io/dgraph/schema"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"github.com/vektah/gqlparser/v2/gqlerror"
@@ -121,6 +122,48 @@ func TestSchemas(t *testing.T) {
 			t.Run(sch.Name, func(t *testing.T) {
 				_, errlist := NewHandler(sch.Input)
 				if diff := cmp.Diff(sch.Errlist, errlist); diff != "" {
+					t.Errorf("error mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
+	})
+}
+
+func TestAuthSchemas(t *testing.T) {
+	fileName := "auth_schemas_test.yaml"
+	byts, err := ioutil.ReadFile(fileName)
+	require.NoError(t, err, "Unable to read file %s", fileName)
+
+	var tests map[string][]struct {
+		Name    string
+		Input   string
+		Errlist x.GqlErrorList
+		Output  string
+	}
+	err = yaml.Unmarshal(byts, &tests)
+	require.NoError(t, err, "Error Unmarshalling to yaml!")
+
+	t.Run("Valid Schemas", func(t *testing.T) {
+		for _, sch := range tests["valid_schemas"] {
+			t.Run(sch.Name, func(t *testing.T) {
+				schHandler, errlist := NewHandler(sch.Input)
+				require.NoError(t, errlist, sch.Name)
+
+				_, authError := FromString(schHandler.GQLSchema())
+				require.NoError(t, authError, sch.Name)
+			})
+		}
+	})
+
+	t.Run("Invalid Schemas", func(t *testing.T) {
+		for _, sch := range tests["invalid_schemas"] {
+			t.Run(sch.Name, func(t *testing.T) {
+				schHandler, errlist := NewHandler(sch.Input)
+				require.NoError(t, errlist, sch.Name)
+
+				_, authError := FromString(schHandler.GQLSchema())
+
+				if diff := cmp.Diff(authError, sch.Errlist); diff != "" {
 					t.Errorf("error mismatch (-want +got):\n%s", diff)
 				}
 			})

--- a/graphql/schema/testdata/schemagen/input/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/input/authorization.graphql
@@ -1,0 +1,74 @@
+type Todo @auth(
+    query: {
+        or: [
+            { rule: """
+            query($X_MyApp_User: String!) { 
+                queryTodo { 
+                    owner (filter: { username: { eq: $X_MyApp_User }}) {
+                        username
+                    }
+                }
+            }""" },
+            { rule: """
+            query($X_MyApp_User: String!) { 
+                queryTodo {
+                    sharedWith (filter: { username: { eq: $X_MyApp_User }}) {
+                        username
+                    }
+                }
+            }""" },
+            { rule: """
+            query { 
+                queryTodo(filter: { isPublic: true }) {
+                    id
+                }
+            }""" },
+        ]
+    },
+    add: { rule: """
+            query($X_MyApp_User: String!) { 
+                queryTodo {
+                    owner (filter: { username: { eq: $X_MyApp_User }}) {
+                        username
+                    }
+                }
+            }""" },
+    update: { rule: """
+            query($X_MyApp_User: String!) { 
+                queryTodo {
+                    owner (filter: { username: { eq: $X_MyApp_User }}) {
+                        username
+                    }
+                }
+            }""" },
+) {
+    id: ID!
+    title: String
+    text: String
+    isPublic: Boolean @search
+    dateCompleted: String @search 
+    sharedWith: [User]
+    owner: User @hasInverse(field: "todos")
+    somethingPrivate: String @auth(
+        query: { rule: """
+            query($X_MyApp_User: String!) { 
+                queryTodo {
+                    owner (filter: { username: { eq: $X_MyApp_User }}) {
+                        username
+                    }
+                }
+            }""" }
+    )
+}
+
+type User @auth(
+    update: { rule: """
+            query($X_MyApp_User: String!) { 
+                queryUser(filter: { username: { eq: $X_MyApp_User }}) {
+                    username
+                }
+            }""" }
+){
+    username: String! @id
+    todos: [Todo]
+}

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -1,0 +1,271 @@
+#######################
+# Input Schema
+#######################
+
+type Todo @auth(query: {or:[{rule:"query($X_MyApp_User: String!) { \n    queryTodo { \n        owner (filter: { username: { eq: $X_MyApp_User }}) {\n            username\n        }\n    }\n}"},{rule:"query($X_MyApp_User: String!) { \n    queryTodo {\n        sharedWith (filter: { username: { eq: $X_MyApp_User }}) {\n            username\n        }\n    }\n}"},{rule:"query { \n    queryTodo(filter: { isPublic: true }) {\n        id\n    }\n}"}]}, add: {rule:"query($X_MyApp_User: String!) { \n    queryTodo {\n        owner (filter: { username: { eq: $X_MyApp_User }}) {\n            username\n        }\n    }\n}"}, update: {rule:"query($X_MyApp_User: String!) { \n    queryTodo {\n        owner (filter: { username: { eq: $X_MyApp_User }}) {\n            username\n        }\n    }\n}"}) {
+	id: ID!
+	title: String
+	text: String
+	isPublic: Boolean @search
+	dateCompleted: String @search
+	sharedWith(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	owner(filter: UserFilter): User @hasInverse(field: "todos")
+	somethingPrivate: String @auth(query: {rule:"query($X_MyApp_User: String!) { \n    queryTodo {\n        owner (filter: { username: { eq: $X_MyApp_User }}) {\n            username\n        }\n    }\n}"})
+}
+
+type User @auth(update: {rule:"query($X_MyApp_User: String!) { \n    queryUser(filter: { username: { eq: $X_MyApp_User }}) {\n        username\n    }\n}"}) {
+	username: String! @id
+	todos(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo] @hasInverse(field: owner)
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	query: AuthRule, 
+	add: AuthRule, 
+	update: AuthRule, 
+	delete:AuthRule) on OBJECT | FIELD_DEFINITION
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddTodoPayload {
+	todo(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo]
+	numUids: Int
+}
+
+type AddUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
+}
+
+type DeleteTodoPayload {
+	msg: String
+	numUids: Int
+}
+
+type DeleteUserPayload {
+	msg: String
+	numUids: Int
+}
+
+type UpdateTodoPayload {
+	todo(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo]
+	numUids: Int
+}
+
+type UpdateUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum TodoOrderable {
+	title
+	text
+	dateCompleted
+	somethingPrivate
+}
+
+enum UserOrderable {
+	username
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddTodoInput {
+	title: String
+	text: String
+	isPublic: Boolean
+	dateCompleted: String
+	sharedWith: [UserRef]
+	owner: UserRef
+	somethingPrivate: String
+}
+
+input AddUserInput {
+	username: String!
+	todos: [TodoRef]
+}
+
+input TodoFilter {
+	id: [ID!]
+	isPublic: Boolean
+	dateCompleted: StringTermFilter
+	and: TodoFilter
+	or: TodoFilter
+	not: TodoFilter
+}
+
+input TodoOrder {
+	asc: TodoOrderable
+	desc: TodoOrderable
+	then: TodoOrder
+}
+
+input TodoPatch {
+	title: String
+	text: String
+	isPublic: Boolean
+	dateCompleted: String
+	sharedWith: [UserRef]
+	owner: UserRef
+	somethingPrivate: String
+}
+
+input TodoRef {
+	id: ID
+	title: String
+	text: String
+	isPublic: Boolean
+	dateCompleted: String
+	sharedWith: [UserRef]
+	owner: UserRef
+	somethingPrivate: String
+}
+
+input UpdateTodoInput {
+	filter: TodoFilter!
+	set: TodoPatch
+	remove: TodoPatch
+}
+
+input UpdateUserInput {
+	filter: UserFilter!
+	set: UserPatch
+	remove: UserPatch
+}
+
+input UserFilter {
+	username: StringHashFilter
+	and: UserFilter
+	or: UserFilter
+	not: UserFilter
+}
+
+input UserOrder {
+	asc: UserOrderable
+	desc: UserOrderable
+	then: UserOrder
+}
+
+input UserPatch {
+	todos: [TodoRef]
+}
+
+input UserRef {
+	username: String
+	todos: [TodoRef]
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getTodo(id: ID!): Todo
+	queryTodo(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo]
+	getUser(username: String!): User
+	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addTodo(input: [AddTodoInput!]!): AddTodoPayload
+	updateTodo(input: UpdateTodoInput!): UpdateTodoPayload
+	deleteTodo(filter: TodoFilter!): DeleteTodoPayload
+	addUser(input: [AddUserInput!]!): AddUserPayload
+	updateUser(input: UpdateUserInput!): UpdateUserPayload
+	deleteUser(filter: UserFilter!): DeleteUserPayload
+}

--- a/graphql/test/test.go
+++ b/graphql/test/test.go
@@ -43,7 +43,9 @@ func LoadSchema(t *testing.T, gqlSchema string) schema.Schema {
 	gql, gqlErr := validator.ValidateSchemaDocument(doc)
 	require.Nil(t, gqlErr)
 
-	return schema.AsSchema(gql)
+	schema, err := schema.AsSchema(gql)
+	require.Nil(t, err)
+	return schema
 }
 
 // LoadSchemaFromFile reads a graphql schema file as would be the initial schema


### PR DESCRIPTION
Adds just parsing of auth.

Tests to come in another PR.

What should work

* rules can have as many edge traversals as you like and can contain multiple and/or complex filters

What's not included:

* RBAC rules


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5180)
<!-- Reviewable:end -->
