### PR TITLE
graphql: Support fetching custom fields for types which use a field with id directive

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -600,13 +600,7 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	updateSchema(t, schema)
 
 	teachers := addTeachers(t)
-	sort.Slice(teachers, func(i, j int) bool {
-		return teachers[i].ID < teachers[j].ID
-	})
 	schools := addSchools(t, teachers)
-	sort.Slice(schools, func(i, j int) bool {
-		return schools[i].ID < schools[j].ID
-	})
 	users := addUsers(t, schools)
 
 	verifyData(t, users, teachers, schools)

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -601,11 +601,11 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 
 	teachers := addTeachers(t)
 	sort.Slice(teachers, func(i, j int) bool {
-		return teachers[i].ID < teachers[i].ID
+		return teachers[i].ID < teachers[j].ID
 	})
 	schools := addSchools(t, teachers)
 	sort.Slice(schools, func(i, j int) bool {
-		return schools[i].ID < schools[i].ID
+		return schools[i].ID < schools[j].ID
 	})
 	users := addUsers(t, schools)
 

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -672,3 +672,175 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 
 	verifyData(t, users, teachers, schools)
 }
+
+type episode struct {
+	Name string
+}
+
+func addEpisode(t *testing.T, name string) {
+	params := &common.GraphQLParams{
+		Query: `mutation addEpisode($name: String!) {
+			addEpisode(input: [{ name: $name }]) {
+				episode {
+					name
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"name": name,
+		},
+	}
+
+	result := params.ExecuteAsPost(t, alphaURL)
+	require.Nil(t, result.Errors)
+
+	var res struct {
+		AddEpisode struct {
+			Episode []*episode
+		}
+	}
+	err := json.Unmarshal([]byte(result.Data), &res)
+	require.NoError(t, err)
+
+	require.Equal(t, len(res.AddEpisode.Episode), 1)
+}
+
+type character struct {
+	Name string
+}
+
+func addCharacter(t *testing.T, name string, episodes interface{}) {
+	params := &common.GraphQLParams{
+		Query: `mutation addCharacter($name: String!, $episodes: [EpisodeRef]) {
+			addCharacter(input: [{ name: $name, episodes: $episodes }]) {
+				character {
+					name
+					episodes {
+						name
+					}
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"name":     name,
+			"episodes": episodes,
+		},
+	}
+
+	result := params.ExecuteAsPost(t, alphaURL)
+	require.Nil(t, result.Errors)
+
+	var res struct {
+		AddCharacter struct {
+			Character []*character
+		}
+	}
+	err := json.Unmarshal([]byte(result.Data), &res)
+	require.NoError(t, err)
+
+	require.Equal(t, len(res.AddCharacter.Character), 1)
+}
+
+func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
+	schema := `
+	type Episode {
+		name: String! @id
+		anotherName: String! @custom(http: {
+					url: "http://mock:8888/userNames",
+					method: "GET",
+					body: "{uid: $name}",
+					operation: "batch"
+				})
+	}
+
+	type Character {
+		name: String! @id
+		lastName: String @custom(http: {
+						url: "http://mock:8888/userNames",
+						method: "GET",
+						body: "{uid: $name}",
+						operation: "batch"
+					})
+		episodes: [Episode]
+	}`
+	updateSchema(t, schema)
+
+	ep1 := "episode-1"
+	ep2 := "episode-2"
+	ep3 := "episode-3"
+
+	addEpisode(t, ep1)
+	addEpisode(t, ep2)
+	addEpisode(t, ep3)
+
+	addCharacter(t, "character-1", []map[string]interface{}{{"name": ep1}, {"name": ep2}})
+	addCharacter(t, "character-2", []map[string]interface{}{{"name": ep2}, {"name": ep3}})
+	addCharacter(t, "character-3", []map[string]interface{}{{"name": ep3}, {"name": ep1}})
+
+	queryCharacter := `
+	query {
+		queryCharacter {
+			name
+			lastName
+			episodes {
+				name
+				anotherName
+			}
+		}
+	}`
+	params := &common.GraphQLParams{
+		Query: queryCharacter,
+	}
+
+	result := params.ExecuteAsPost(t, alphaURL)
+	require.Nil(t, result.Errors)
+
+	expected := `{
+		"queryCharacter": [
+		  {
+			"name": "character-1",
+			"lastName": "uname-character-1",
+			"episodes": [
+			  {
+				"name": "episode-1",
+				"anotherName": "uname-episode-1"
+			  },
+			  {
+				"name": "episode-2",
+				"anotherName": "uname-episode-2"
+			  }
+			]
+		  },
+		  {
+			"name": "character-2",
+			"lastName": "uname-character-2",
+			"episodes": [
+			  {
+				"name": "episode-2",
+				"anotherName": "uname-episode-2"
+			  },
+			  {
+				"name": "episode-3",
+				"anotherName": "uname-episode-3"
+			  }
+			]
+		  },
+		  {
+			"name": "character-3",
+			"lastName": "uname-character-3",
+			"episodes": [
+			  {
+				"name": "episode-1",
+				"anotherName": "uname-episode-1"
+			  },
+			  {
+				"name": "episode-3",
+				"anotherName": "uname-episode-3"
+			  }
+			]
+		  }
+		]
+	  }`
+
+	testutil.CompareJSON(t, expected, string(result.Data))
+}

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -894,6 +894,17 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 	errCh <- nil
 }
 
+// resolveNestedFields resolves fields which themselves don't have the @custom directive but their
+// children might
+//
+// queryUser {
+//	 id
+//	 classes {
+//	   name @custom...
+//   }
+// }
+// In the example above, resolveNestedFields would be called on classes field and vals would be the
+// list of all users.
 func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan error) {
 	// If this field doesn't have custom directive and also doesn't have any children,
 	// then there is nothing to do and we can just continue.
@@ -902,18 +913,25 @@ func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, e
 		return
 	}
 
-	// Here below we do the de-duplication by walking through the result set.
+	// Here below we do the de-duplication by walking through the result set. That is we would
+	// go over vals and find the data for f to collect all unique values.
 	var input []interface{}
 	// node stores the pointer for a node. It is a map from id to the map for it.
 	nodes := make(map[string]interface{})
 
 	idField := f.Type().IDField()
 	if idField == nil {
-		errCh <- nil
-		return
+		idField = f.Type().XIDField()
+		if idField == nil {
+			// This should not happen as we only allow custom fields on types which either have
+			// ID or a field with @id directive.
+			errCh <- nil
+			return
+		}
 	}
+
 	// Here we walk through the array and collect all unique values for this field. In the
-	// example at the start of the function, we could be collecting all unique schools
+	// example at the start of the function, we could be collecting all unique classes
 	// across all users. This is where the batching happens so that we make one call per
 	// field and not a separate call per user.
 	mu.RLock()
@@ -963,7 +981,6 @@ func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, e
 			if !ok {
 				continue
 			}
-			// TODO - Support xids here.
 			id, ok := fv[idField.Name()].(string)
 			if !ok {
 				continue


### PR DESCRIPTION
This PR adds a couple of test cases and supports using xid fields (fields with @id directive) similar to how fields of type ID! can be used to fetch information from remote endpoints and do the de-duplication.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5183)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c0852757e0-54382.surge.sh)
<!-- Dgraph:end -->