### PR TITLE
graphql: refactor types returned by completion and execution

### DIFF
--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -112,7 +112,7 @@ func (asr *updateSchemaResolver) Mutate(
 }
 
 func (asr *updateSchemaResolver) Query(ctx context.Context, query *gql.GraphQuery) ([]byte, error) {
-	return doQuery(asr.admin.schema, asr.mutation.SelectionSet()[0])
+	return doQuery(asr.admin.schema, asr.mutation.QueryField())
 }
 
 func (gsr *getSchemaResolver) Rewrite(ctx context.Context,

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -686,7 +686,7 @@ func addSchema(url string, schema string) error {
 	}
 	req, err := add.createGQLPost(url)
 	if err != nil {
-		return errors.Wrap(err, "error running GraphQL query")
+		return errors.Wrap(err, "error creating GraphQL query")
 	}
 
 	resp, err := runGQLRequest(req)

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -258,7 +258,7 @@ func panicCatcher(t *testing.T) {
 					"Please let us know : https://github.com/dgraph-io/dgraph/issues.")}},
 				gqlResponse.Errors)
 
-			require.Nil(t, gqlResponse.Data)
+			require.Nil(t, gqlResponse.Data, string(gqlResponse.Data))
 		})
 	}
 }
@@ -299,7 +299,7 @@ func clientInfoLogin(t *testing.T) {
 	mErr := resolve.MutationResolverFunc(
 		func(ctx context.Context, mutation schema.Mutation) (*resolve.Resolved, bool) {
 			loginCtx = ctx
-			return &resolve.Resolved{Err: errFunc(mutation.ResponseName())}, false
+			return &resolve.Resolved{Err: errFunc(mutation.ResponseName()), Field: mutation}, false
 		})
 
 	resolverFactory := resolve.NewResolverFactory(nil, mErr).

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -239,11 +239,10 @@ func (mr *mutationResolver) rewriteAndExecute(
 		resolved.Data = map[string]interface{}{}
 	}
 
-	if dgRes, ok := resolved.Data.(map[string]interface{}); ok {
-		dgRes[schema.NumUid] = numUids
-		dgRes[schema.Typename] = mutation.Type().Name()
-		resolved.Data = map[string]interface{}{mutation.ResponseName(): dgRes}
-	}
+	dgRes := resolved.Data.(map[string]interface{})
+	dgRes[schema.NumUid] = numUids
+	dgRes[schema.Typename] = mutation.Type().Name()
+	resolved.Data = map[string]interface{}{mutation.ResponseName(): dgRes}
 
 	resolved.Field = mutation
 	return resolved, resolverSucceeded

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -18,8 +18,6 @@ package resolve
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/gql"
@@ -159,8 +157,6 @@ type mutationResolver struct {
 	queryExecutor    QueryExecutor
 	mutationExecutor MutationExecutor
 	resultCompleter  ResultCompleter
-
-	numUids int
 }
 
 func (mr *mutationResolver) Resolve(
@@ -174,94 +170,91 @@ func (mr *mutationResolver) Resolve(
 			mutation.MutationType())
 	}
 
-	res, success, err := mr.rewriteAndExecute(ctx, mutation)
-
-	completed, err := mr.resultCompleter.Complete(ctx, mutation.QueryField(), res, err)
-
-	selSets := mutation.SelectionSet()
-	for _, selSet := range selSets {
-		if selSet.Name() != schema.NumUid {
-			continue
-		}
-
-		s := string(completed)
-		switch {
-		case strings.Contains(s, schema.NumUid):
-			completed = []byte(strings.ReplaceAll(s, fmt.Sprintf(`"%s": null`,
-				schema.NumUid), fmt.Sprintf(`"%s": %d`, schema.NumUid,
-				mr.numUids)))
-
-		case s[len(s)-1] == '}':
-			completed = []byte(fmt.Sprintf(`%s, "%s": %d}`, s[:len(s)-1],
-				schema.NumUid, mr.numUids))
-
-		default:
-			completed = []byte(fmt.Sprintf(`%s, "%s": %d`, s,
-				schema.NumUid, mr.numUids))
-		}
-		break
-	}
-
-	return &Resolved{
-		Data: completed,
-		Err:  err,
-	}, success
+	resolved, success := mr.rewriteAndExecute(ctx, mutation)
+	mr.resultCompleter.Complete(ctx, resolved)
+	return resolved, success
 }
 
-func (mr *mutationResolver) getNumUids(mutation schema.Mutation, assigned map[string]string,
-	result map[string]interface{}) {
-	switch mr.mutationRewriter.(type) {
-	case *AddRewriter:
-		mr.numUids = len(assigned)
-
+func getNumUids(m schema.Mutation, a map[string]string, r map[string]interface{}) int {
+	switch m.MutationType() {
+	case schema.AddMutation:
+		return len(a)
 	default:
-		mutated := extractMutated(result, mutation.ResponseName())
-		mr.numUids = len(mutated)
+		mutated := extractMutated(r, m.ResponseName())
+		return len(mutated)
 	}
 }
 
 func (mr *mutationResolver) rewriteAndExecute(
-	ctx context.Context, mutation schema.Mutation) ([]byte, bool, error) {
+	ctx context.Context,
+	mutation schema.Mutation) (*Resolved, bool) {
+
 	query, mutations, err := mr.mutationRewriter.Rewrite(mutation)
+
+	emptyResult := func(err error, uids int) *Resolved {
+		return &Resolved{
+			Data: map[string]interface{}{
+				mutation.ResponseName(): map[string]interface{}{
+					schema.NumUid:                        uids,
+					schema.Typename:                      mutation.TypeName,
+					mutation.QueryField().ResponseName(): nil,
+				}},
+			Field: mutation,
+			Err:   err,
+		}
+	}
+
 	if err != nil {
-		return nil, resolverFailed,
-			schema.GQLWrapf(err, "couldn't rewrite mutation %s", mutation.Name())
+		return emptyResult(
+				schema.GQLWrapf(err, "couldn't rewrite mutation %s", mutation.Name()), 0),
+			resolverFailed
 	}
 
 	assigned, result, err := mr.mutationExecutor.Mutate(ctx, query, mutations)
 	if err != nil {
-		return nil, resolverFailed,
-			schema.GQLWrapLocationf(err, mutation.Location(), "mutation %s failed", mutation.Name())
+		gqlErr := schema.GQLWrapLocationf(
+			err, mutation.Location(), "mutation %s failed", mutation.Name())
+		return emptyResult(gqlErr, 0), resolverFailed
+
 	}
 
-	mr.getNumUids(mutation, assigned, result)
-	var errs error
+	numUids := getNumUids(mutation, assigned, result)
 	dgQuery, err := mr.mutationRewriter.FromMutationResult(mutation, assigned, result)
-	errs = schema.AppendGQLErrs(errs, schema.GQLWrapf(err,
-		"couldn't rewrite query for mutation %s", mutation.Name()))
+	errs := schema.GQLWrapf(err, "couldn't rewrite query for mutation %s", mutation.Name())
 
 	if dgQuery == nil && err != nil {
-		return nil, resolverFailed, errs
+		return emptyResult(errs, numUids), resolverFailed
 	}
 
 	resp, err := mr.queryExecutor.Query(ctx, dgQuery)
 	errs = schema.AppendGQLErrs(errs, schema.GQLWrapf(err,
 		"couldn't rewrite query for mutation %s", mutation.Name()))
 
-	return resp, resolverSucceeded, errs
+	resolved := completeDgraphResult(ctx, mutation.QueryField(), resp, errs)
+	if resolved.Data == nil && resolved.Err != nil {
+		return emptyResult(resolved.Err, numUids), resolverSucceeded
+	}
+
+	if resolved.Data == nil {
+		resolved.Data = map[string]interface{}{}
+	}
+
+	if dgRes, ok := resolved.Data.(map[string]interface{}); ok {
+		dgRes[schema.NumUid] = numUids
+		dgRes[schema.Typename] = mutation.Type().Name()
+		resolved.Data = map[string]interface{}{mutation.ResponseName(): dgRes}
+	}
+
+	resolved.Field = mutation
+	return resolved, resolverSucceeded
 }
 
-// deleteCompletion returns `{ "msg": "Deleted" }`
-// FIXME: after upsert mutations changes are done, it will return info about
-// the result of a deletion.
 func deleteCompletion() CompletionFunc {
-	return CompletionFunc(func(
-		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-
-		if field.Name() == "msg" {
-			return []byte(`{ "msg": "Deleted" }`), err
+	return CompletionFunc(func(ctx context.Context, resolved *Resolved) {
+		if fld, ok := resolved.Data.(map[string]interface{}); ok {
+			if rsp, ok := fld[resolved.Field.ResponseName()].(map[string]interface{}); ok {
+				rsp["msg"] = "Deleted"
+			}
 		}
-
-		return []byte(fmt.Sprintf(`{ "%s": null }`, schema.NumUid)), err
 	})
 }

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -18,6 +18,7 @@ package resolve
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/golang/glog"
 	otrace "go.opencensus.io/trace"
@@ -104,27 +105,48 @@ func (qr *queryResolver) Resolve(ctx context.Context, query schema.Query) *Resol
 	stop := x.SpanTimer(span, "resolveQuery")
 	defer stop()
 
-	res, err := qr.rewriteAndExecute(ctx, query)
-
-	completed, err := qr.resultCompleter.Complete(ctx, query, res, err)
-	return &Resolved{Data: completed, Err: err}
+	resolved := qr.rewriteAndExecute(ctx, query)
+	qr.resultCompleter.Complete(ctx, resolved)
+	return resolved
 }
 
-func (qr *queryResolver) rewriteAndExecute(
-	ctx context.Context, query schema.Query) ([]byte, error) {
+func (qr *queryResolver) rewriteAndExecute(ctx context.Context, query schema.Query) *Resolved {
+
+	emptyResult := func(err error) *Resolved {
+		return &Resolved{
+			Data:  map[string]interface{}{query.ResponseName(): nil},
+			Field: query,
+			Err:   err,
+		}
+	}
 
 	dgQuery, err := qr.queryRewriter.Rewrite(ctx, query)
 	if err != nil {
-		return nil, schema.GQLWrapf(err, "couldn't rewrite query %s", query.ResponseName())
+		return emptyResult(schema.GQLWrapf(err, "couldn't rewrite query %s", query.ResponseName()))
 	}
 
 	resp, err := qr.queryExecutor.Query(ctx, dgQuery)
 	if err != nil {
 		glog.Infof("Dgraph query execution failed : %s", err)
-		return nil, schema.GQLWrapf(err, "Dgraph query failed")
+		return emptyResult(schema.GQLWrapf(err, "Dgraph query failed"))
 	}
 
-	return resp, nil
+	// FIXME: just to get it running for now - this should have it's own .Resolve()
+	if query.QueryType() == schema.SchemaQuery {
+		var result map[string]interface{}
+		var err2 error
+		if len(resp) > 0 {
+			err2 = json.Unmarshal(resp, &result)
+		}
+
+		return &Resolved{
+			Data:  result,
+			Field: query,
+			Err:   schema.AppendGQLErrs(err, err2),
+		}
+	}
+
+	return completeDgraphResult(ctx, query, resp, err)
 }
 
 func introspectionExecution(q schema.Query) QueryExecutionFunc {

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -106,6 +106,10 @@ func (qr *queryResolver) Resolve(ctx context.Context, query schema.Query) *Resol
 	defer stop()
 
 	resolved := qr.rewriteAndExecute(ctx, query)
+	if resolved.Data == nil {
+		resolved.Data = map[string]interface{}{query.ResponseName(): nil}
+	}
+
 	qr.resultCompleter.Complete(ctx, resolved)
 	return resolved
 }

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -75,10 +75,13 @@ type ResolverFactory interface {
 // in resolving field and applies a completion step - for example, apply GraphQL
 // error propagation or massaging error paths.
 type ResultCompleter interface {
-	Complete(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error)
+	Complete(ctx context.Context, resolved *Resolved)
 }
 
 // RequestResolver can process GraphQL requests and write GraphQL JSON responses.
+// A schema.Request may contain any number of queries or mutations (never both).
+// RequestResolver.Resolve() resolves all of them by finding the resolved answers
+// of the component queries/mutations and joining into a single schema.Response.
 type RequestResolver struct {
 	schema    schema.Schema
 	resolvers ResolverFactory
@@ -120,28 +123,20 @@ type dgraphExecutor struct {
 type adminExecutor struct {
 }
 
-// A Resolved is the result of resolving a single query or mutation.
-// A schema.Request may contain any number of queries or mutations (never both).
-// RequestResolver.Resolve() resolves all of them by finding the resolved answers
-// of the component queries/mutations and joining into a single schema.Response.
+// A Resolved is the result of resolving a single field - generally a query or mutation.
 type Resolved struct {
-	Data []byte
-	Err  error
+	Data  interface{}
+	Field schema.Field
+	Err   error
 }
 
 // CompletionFunc is an adapter that allows us to compose completions and build a
 // ResultCompleter from a function.  Based on the http.HandlerFunc pattern.
-type CompletionFunc func(
-	ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error)
+type CompletionFunc func(ctx context.Context, resolved *Resolved)
 
-// Complete calls cf(ctx, field, result, err)
-func (cf CompletionFunc) Complete(
-	ctx context.Context,
-	field schema.Field,
-	result []byte,
-	err error) ([]byte, error) {
-
-	return cf(ctx, field, result, err)
+// Complete calls cf(ctx, resolved)
+func (cf CompletionFunc) Complete(ctx context.Context, resolved *Resolved) {
+	cf(ctx, resolved)
 }
 
 // DgraphAsQueryExecutor builds a QueryExecutor for proxying requests through dgraph.
@@ -207,7 +202,7 @@ func (rf *resolverFactory) WithSchemaIntrospection() ResolverFactory {
 		return &queryResolver{
 			queryRewriter:   NoOpQueryRewrite(),
 			queryExecutor:   introspectionExecution(q),
-			resultCompleter: removeObjectCompletion(noopCompletion),
+			resultCompleter: StdQueryCompletion(),
 		}
 	}
 
@@ -246,7 +241,7 @@ func (rf *resolverFactory) WithConventionResolvers(
 	for _, m := range s.Mutations(schema.DeleteMutation) {
 		rf.WithMutationResolver(m, func(m schema.Mutation) MutationResolver {
 			return NewMutationResolver(
-				fns.Drw, NoOpQueryExecution(), fns.Me, StdDeleteCompletion(m.ResponseName()))
+				fns.Drw, NoOpQueryExecution(), fns.Me, deleteCompletion())
 		})
 	}
 
@@ -271,23 +266,17 @@ func NewResolverFactory(
 
 // StdQueryCompletion is the completion steps that get run for queries
 func StdQueryCompletion() CompletionFunc {
-	return removeObjectCompletion(completeDgraphResult)
-}
-
-// AliasQueryCompletion is the completion steps that get run for admin queries
-// those don't have the alias built in like Dgraph queries.
-func AliasQueryCompletion() CompletionFunc {
-	return removeObjectCompletion(injectAliasCompletion(completeResult))
+	return noopCompletion
 }
 
 // StdMutationCompletion is the completion steps that get run for add and update mutations
 func StdMutationCompletion(name string) CompletionFunc {
-	return addPathCompletion(name, addRootFieldCompletion(name, completeDgraphResult))
+	return noopCompletion
 }
 
 // StdDeleteCompletion is the completion steps that get run for add and update mutations
 func StdDeleteCompletion(name string) CompletionFunc {
-	return addPathCompletion(name, addRootFieldCompletion(name, deleteCompletion()))
+	return deleteCompletion()
 }
 
 func (rf *resolverFactory) queryResolverFor(query schema.Query) QueryResolver {
@@ -374,7 +363,10 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 				defer wg.Done()
 				defer api.PanicHandler(
 					func(err error) {
-						allResolved[storeAt] = &Resolved{Err: err}
+						allResolved[storeAt] = &Resolved{
+							Data:  nil,
+							Field: q,
+							Err:   err}
 					})
 
 				allResolved[storeAt] = r.resolvers.queryResolverFor(q).Resolve(ctx, q)
@@ -387,8 +379,7 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 		for _, res := range allResolved {
 			// Errors and data in the same response is valid.  Both WithError and
 			// AddData handle nil cases.
-			resp.WithError(res.Err)
-			resp.AddData(res.Data)
+			addResult(resp, res)
 		}
 	case op.IsMutation():
 		// A mutation operation can contain any number of mutation fields.  Those should be executed
@@ -417,8 +408,7 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 
 			var res *Resolved
 			res, allSuccessful = r.resolvers.mutationResolverFor(m).Resolve(ctx, m)
-			resp.WithError(res.Err)
-			resp.AddData(res.Data)
+			addResult(resp, res)
 		}
 	case op.IsSubscription():
 		resp.WithError(errors.Errorf("Subscriptions not yet supported."))
@@ -427,144 +417,31 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 	return resp
 }
 
+func addResult(resp *schema.Response, res *Resolved) {
+	// Errors should report the "path" into the result where the error was found.
+	//
+	// The definition of a path in a GraphQL error is here:
+	// https://graphql.github.io/graphql-spec/June2018/#sec-Errors
+	// For a query like (assuming field f is of a list type and g is a scalar type):
+	// - q { f { g } }
+	// a path to the 2nd item in the f list would look like:
+	// - [ "q", "f", 2, "g" ]
+	path := make([]interface{}, 0, maxPathLength(res.Field))
+	var b []byte
+	var gqlErr x.GqlErrorList
+
+	if res.Data != nil {
+		b, gqlErr = completeObject(path, res.Field.Type(), []schema.Field{res.Field},
+			res.Data.(map[string]interface{}))
+	}
+
+	resp.WithError(res.Err)
+	resp.WithError(gqlErr)
+	resp.AddData(b)
+}
+
 // noopCompletion just passes back it's result and err arguments
-func noopCompletion(
-	ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-	return result, err
-}
-
-// removeObjectCompletion chops leading '{' and trailing '}' from a JSON object
-//
-// The final GraphQL result gets built like
-// { data:
-//    {
-//      q1: {...},
-//      q2: [ {...}, {...} ],
-//      ...
-//    }
-// }
-//
-// When we are building a single one of the q's, the result is built initially as
-// { q1: {...} }
-// so the completed result should be
-// q1: {...}
-func removeObjectCompletion(cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(
-		func(ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-			res, err := cf(ctx, field, result, err)
-			if len(res) >= 2 {
-				res = res[1 : len(res)-1]
-			}
-			return res, err
-		})
-}
-
-// addRootFieldCompletion adds an extra object name to the start of a result.
-//
-// A mutation always looks like
-//   `addFoo(...) { foo { ... } }`
-// What's resolved initially is
-//   `foo { ... }`
-// So `addFoo: ...` is added.
-func addRootFieldCompletion(name string, cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(
-		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-
-		res, err := cf(ctx, field, result, err)
-
-		var b bytes.Buffer
-		x.Check2(b.WriteString("\""))
-		x.Check2(b.WriteString(name))
-		x.Check2(b.WriteString(`": `))
-		if len(res) > 0 {
-			x.Check2(b.Write(res))
-		} else {
-			x.Check2(b.WriteString("null"))
-		}
-
-		return b.Bytes(), err
-	})
-}
-
-// addPathCompletion adds an extra object name to the start of every error path
-// arrising from applying cf.
-//
-// A mutation always looks like
-//   `addFoo(...) { foo { ... } }`
-// But cf's error paths begin at `foo`, so `addFoo` needs to be added to all.
-func addPathCompletion(name string, cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(
-		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-
-		res, err := cf(ctx, field, result, err)
-
-		resErrs := schema.AsGQLErrors(err)
-		for _, err := range resErrs {
-			if len(err.Path) > 0 {
-				err.Path = append([]interface{}{name}, err.Path...)
-			}
-		}
-
-		return res, resErrs
-	})
-}
-
-// injectAliasCompletion takes a result with names as per the type names and swaps those for
-// any aliases specified in the query before apply cf.
-func injectAliasCompletion(cf CompletionFunc) CompletionFunc {
-	return CompletionFunc(func(
-		ctx context.Context, field schema.Field, result []byte, err error) ([]byte, error) {
-
-		if len(result) == 0 {
-			return nil, schema.AsGQLErrors(err)
-		}
-
-		var val interface{}
-		if marshErr := json.Unmarshal(result, &val); marshErr != nil {
-			return nil,
-				schema.AppendGQLErrs(marshErr,
-					schema.GQLWrapLocationf(err, field.Location(), "unable to complete result"))
-		}
-
-		var aliased interface{}
-		var resErr error
-		switch val := val.(type) {
-		case []interface{}:
-			aliased, resErr = aliasList(field, val)
-		case map[string]interface{}:
-			aliased, resErr = aliasObject([]schema.Field{field}, val)
-		case interface{}:
-			aliased, resErr = aliasValue(field, val)
-		}
-
-		res, marshErr := json.Marshal(aliased)
-		err = schema.AppendGQLErrs(err, marshErr)
-
-		return cf(ctx, field, res, schema.AppendGQLErrs(err, resErr))
-	})
-}
-
-// completeResult takes a result like {"res":{"a":...,"b":...}} and does the standard
-// object completion.  This is different to doing completion from Dgraph, because that requires
-// handling {"res":[{...}]} even if we expect a single value
-func completeResult(ctx context.Context, field schema.Field, result []byte, e error) (
-	[]byte, error) {
-
-	var val interface{}
-	if err := json.Unmarshal(result, &val); err != nil {
-		return nil, schema.GQLWrapLocationf(err, field.Location(), "unable to complete result")
-	}
-
-	path := make([]interface{}, 0, maxPathLength(field))
-
-	switch val := val.(type) {
-	case []interface{}:
-		return completeList(path, field, val)
-	case map[string]interface{}:
-		return completeObject(path, field.Type(), []schema.Field{field}, val)
-	}
-	return completeValue(path, field, val)
-}
+func noopCompletion(ctx context.Context, resolved *Resolved) {}
 
 // Once a result has been returned from Dgraph, that result needs to be worked
 // through for two main reasons:
@@ -631,8 +508,12 @@ func completeResult(ctx context.Context, field schema.Field, result []byte, e er
 //
 // Returned errors are generally lists of errors resulting from the value completion
 // algorithm that may emit multiple errors
-func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []byte, e error) (
-	[]byte, error) {
+func completeDgraphResult(
+	ctx context.Context,
+	field schema.Field,
+	dgResult []byte,
+	e error) *Resolved {
+
 	span := trace.FromContext(ctx)
 	stop := x.SpanTimer(span, "completeDgraphResult")
 	defer stop()
@@ -648,27 +529,28 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 	//
 	//    { }  --->  { "q": null }
 
-	errs := schema.AsGQLErrors(e)
-	if len(dgResult) == 0 {
-		return nil, errs
+	nullResponse := func(err error) *Resolved {
+		return &Resolved{
+			Data:  nil,
+			Field: field,
+			Err:   err,
+		}
 	}
 
-	nullResponse := func() []byte {
-		var buf bytes.Buffer
-		x.Check2(buf.WriteString(`{ "`))
-		x.Check2(buf.WriteString(field.ResponseName()))
-		x.Check2(buf.WriteString(`": null }`))
-		return buf.Bytes()
-	}
-
-	dgraphError := func() ([]byte, error) {
+	dgraphError := func() *Resolved {
 		glog.Errorf("Could not process Dgraph result : \n%s", string(dgResult))
-		return nullResponse(),
+		return nullResponse(
 			x.GqlErrorf("Couldn't process the result from Dgraph.  " +
 				"This probably indicates a bug in the Dgraph GraphQL layer.  " +
 				"Please let us know : https://github.com/dgraph-io/dgraph/issues.").
-				WithLocations(field.Location())
+				WithLocations(field.Location()))
 	}
+
+	if len(dgResult) == 0 {
+		return nullResponse(e)
+	}
+
+	errs := schema.AsGQLErrors(e)
 
 	// Dgraph should only return {} or a JSON object.  Also,
 	// GQL type checking should ensure query results are only object types
@@ -680,8 +562,8 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 		glog.Errorf("%+v \n Dgraph result :\n%s\n",
 			errors.Wrap(err, "failed to unmarshal Dgraph query result"),
 			string(dgResult))
-		return nullResponse(),
-			schema.GQLWrapLocationf(err, field.Location(), "couldn't unmarshal Dgraph result")
+		return nullResponse(
+			schema.GQLWrapLocationf(err, field.Location(), "couldn't unmarshal Dgraph result"))
 	}
 
 	switch val := valToComplete[field.ResponseName()].(type) {
@@ -730,34 +612,12 @@ func completeDgraphResult(ctx context.Context, field schema.Field, dgResult []by
 		// case
 	}
 
-	// Errors should report the "path" into the result where the error was found.
-	//
-	// The definition of a path in a GraphQL error is here:
-	// https://graphql.github.io/graphql-spec/June2018/#sec-Errors
-	// For a query like (assuming field f is of a list type and g is a scalar type):
-	// - q { f { g } }
-	// a path to the 2nd item in the f list would look like:
-	// - [ "q", "f", 2, "g" ]
-	path := make([]interface{}, 0, maxPathLength(field))
-
-	completed, gqlErrs := completeObject(
-		path, field.Type(), []schema.Field{field}, valToComplete)
-
-	if len(completed) < 2 {
-		// This could only occur completeObject crushed the whole query, but
-		// that should never happen because the result type shouldn't be '!'.
-		// We should wrap enough testing around the schema generation that this
-		// just can't happen.
-		//
-		// This isn't really an observable GraphQL error, so no need to add anything
-		// to the payload of errors for the result.
-		glog.Errorf("Top level completeObject didn't return a result.  " +
-			"That's only possible if the query result is non-nullable.  " +
-			"There's something wrong in the GraphQL schema.")
-		return nullResponse(), append(errs, gqlErrs...)
+	return &Resolved{
+		Data:  valToComplete,
+		Field: field,
+		Err:   errs,
 	}
 
-	return completed, append(errs, gqlErrs...)
 }
 
 // completeObject builds a json GraphQL result object for the current query level.

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -63,6 +63,10 @@ func (r *Response) AddData(p []byte) {
 		return
 	}
 
+	if len(p) > 0 {
+		p = p[1 : len(p)-1]
+	}
+
 	if r.Data.Len() > 0 {
 		// The end of the buffer is always the closing `}`
 		r.Data.Truncate(r.Data.Len() - 1)

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -844,11 +844,11 @@ func (m *mutation) SelectionSet() []Field {
 }
 
 func (m *mutation) QueryField() Field {
-	for _, i := range m.SelectionSet() {
-		if i.Name() == NumUid {
+	for _, f := range m.SelectionSet() {
+		if f.Name() == NumUid {
 			continue
 		}
-		return i
+		return f
 	}
 	return m.SelectionSet()[0]
 }


### PR DESCRIPTION
Originally, we just took the Dgraph result, did some GraphQL error propagation on it and sent out a GraphQL byte slice.  But things are moving on.  Lots more is happening in the pipeline and we need to make the processing more generic to handle the new cases. 

This :

* Moves where the final completeObject is done until right at the end of processing.  That means internally we can move around `interface{}` not `[]byte`
* Moves completion to complete `Resolved` objects

In turn that simplifies/removes lots of completion processing and fixes the horrible `numUids` code and makes `__typename` work properly.  It will also mean that we can handle the metrics properly for https://github.com/dgraph-io/dgraph/pull/5157

Following PRs will:

* Move the `Resolved` processing a bit deeper so that non-dgraph things don't have to call `completeDgraphResult
* Fix up the admin endpoints and simplify how they set up the resolvers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5196)
<!-- Reviewable:end -->
