### PR TITLE
Document support for encryption with debug tool

### DIFF
--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -60,6 +60,8 @@ The HTTP page `/debug/pprof/` is available at the HTTP port of a Dgraph Zero or 
 To debug a running Dgraph cluster, first copy the postings ("p") directory to
 another location. If the Dgraph cluster is not running, then you can use the
 same postings directory with the debug tool.
+
+If the “p” directory has been encrypted, then the debug tool will need to use the --keyfile <path-to-keyfile> option. This file must contain the same key that was used to encrypt the “p” directory.
 {{% /notice %}}
 
 The `dgraph debug` tool can be used to inspect Dgraph's posting list structure.
@@ -104,6 +106,20 @@ Debug the p directory, inspecting the history of a particular key:
 $ dgraph debug --postings ./p --lookup 00000b6465736372697074696f6e020866617374 --history
 ```
 
+Debug an encrypted p directory with the key in a local file at the path  ./key_file:
+
+```sh
+$ dgraph debug --postings ./p --keyfile ./key_file
+```
+
+
+{{% notice "note" %}}
+The key file contains the key used to decrypt/encrypt the db. This key should be kept secret. As a best practice, 
+
+- Do not store permanently the key in the local disk.  Delete it after using it for debug tool.
+
+- If the above is not possible, make sure correct privileges are set on key file. Only the user who owns the dgraph process should be able to read / write the key file: `chmod 600` 
+{{% /notice %}}
 
 ### Debug Tool Output
 

--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -116,9 +116,9 @@ $ dgraph debug --postings ./p --keyfile ./key_file
 {{% notice "note" %}}
 The key file contains the key used to decrypt/encrypt the db. This key should be kept secret. As a best practice, 
 
-- Do not store permanently the key in the local disk.  Delete it after using it for debug tool.
+- Do not store the key file on the disk permanently. Back it up in a safe place and delete it after using it with the debug tool.
 
-- If the above is not possible, make sure correct privileges are set on key file. Only the user who owns the dgraph process should be able to read / write the key file: `chmod 600` 
+- If the above is not possible, make sure correct privileges are set on the keyfile. Only the user who owns the dgraph process should be able to read / write the key file: `chmod 600` 
 {{% /notice %}}
 
 ### Debug Tool Output


### PR DESCRIPTION
This PR is meant to document support for encryption with the debug tool per this ticket: https://dgraph.atlassian.net/browse/DGRAPH-1202?atlOrigin=eyJpIjoiMjk3NGE5YjY2NTc1NDM2MGFmNTMyODViMGVjZDM5OWUiLCJwIjoiaiJ9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5202)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c1411b6795-55996.surge.sh)
<!-- Dgraph:end -->