### PR TITLE
Force users to explicitly tell restore command to run without zero.

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -34,6 +34,7 @@ var LsBackup x.SubCommand
 
 var opt struct {
 	backupId, location, pdir, zero, keyfile string
+	forceNoZero                             bool
 }
 
 func init() {
@@ -107,6 +108,10 @@ $ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
 		"restore. If empty, it will restore the latest series.")
 	flag.StringVarP(&opt.keyfile, "keyfile", "k", "", "Key file to decrypt the backup. "+
 		"The same key is also used to re-encrypt the restored data.")
+	flag.BoolVarP(&opt.forceNoZero, "force_no_zero", "", false, "If true, no connection to "+
+		"a zero in the cluster will be required. Keep in mind this requires you to manually "+
+		"update the timestamp and max uid when you start the cluster. The correct values are "+
+		"printed near the end of this command's output.")
 	_ = Restore.Cmd.MarkFlagRequired("postings")
 	_ = Restore.Cmd.MarkFlagRequired("location")
 }
@@ -169,8 +174,11 @@ func runRestoreCmd() error {
 	fmt.Println("Restoring backups from:", opt.location)
 	fmt.Println("Writing postings to:", opt.pdir)
 
-	// TODO: Remove this dependency on Zero. It complicates restore for the end
-	// user.
+	if opt.zero == "" && !opt.forceNoZero {
+		return errors.Errorf("No zero address passed. Use the --force-no-zero option if you " +
+			"meant to do this")
+	}
+
 	if opt.zero != "" {
 		fmt.Println("Updating Zero timestamp at:", opt.zero)
 

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -34,7 +34,7 @@ var LsBackup x.SubCommand
 
 var opt struct {
 	backupId, location, pdir, zero, keyfile string
-	forceNoZero                             bool
+	forceZero                               bool
 }
 
 func init() {
@@ -108,7 +108,7 @@ $ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
 		"restore. If empty, it will restore the latest series.")
 	flag.StringVarP(&opt.keyfile, "keyfile", "k", "", "Key file to decrypt the backup. "+
 		"The same key is also used to re-encrypt the restored data.")
-	flag.BoolVarP(&opt.forceNoZero, "force_no_zero", "", false, "If true, no connection to "+
+	flag.BoolVarP(&opt.forceZero, "force_zero", "", true, "If false, no connection to "+
 		"a zero in the cluster will be required. Keep in mind this requires you to manually "+
 		"update the timestamp and max uid when you start the cluster. The correct values are "+
 		"printed near the end of this command's output.")
@@ -174,8 +174,8 @@ func runRestoreCmd() error {
 	fmt.Println("Restoring backups from:", opt.location)
 	fmt.Println("Writing postings to:", opt.pdir)
 
-	if opt.zero == "" && !opt.forceNoZero {
-		return errors.Errorf("No zero address passed. Use the --force-no-zero option if you " +
+	if opt.zero == "" && opt.forceZero {
+		return errors.Errorf("No Dgraph Zero address passed. Use the --force_zero option if you " +
 			"meant to do this")
 	}
 

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -273,7 +273,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	testutil.KeyFile = "../../../ee/enc/enc-key"
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"-k", testutil.KeyFile}
+		"-k", testutil.KeyFile, "--force_zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -295,7 +295,8 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	require.NoError(t, os.RemoveAll(restoreDir))
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
-	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore"}
+	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
+		"--force_zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -181,12 +181,12 @@ The `--postings` (`-p`) flag sets the directory to which the restored posting
 directories will be saved. This directory will contain a posting directory for
 each group in the restored backup.
 
-The `--zero` (`-z`) optional flag specifies a Dgraph Zero address to update the
-start timestamp and UID lease using the restored version. If no zero address is
-passed, the command will complain unless you explicitly pass the
-`--force_no_zero` flag. If do not pass a zero value to this command, the
-timestamp and UID lease must be manually updated through Zero's HTTP 'assign'
-endpoint using the values printed near the end of the command's output.
+The `--zero` (`-z`) flag specifies a Dgraph Zero address to update the start
+timestamp and UID lease using the restored version. If no zero address is
+passed, the command will complain unless you set the value of the
+`--force_zero` flag to false. If do not pass a zero value to this command,
+the timestamp and UID lease must be manually updated through Zero's HTTP
+'assign' endpoint using the values printed near the end of the command's output.
 
 The `--backup_id` optional flag specifies the ID of the backup series to
 restore. A backup series consists of a full backup and all the incremental

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -179,8 +179,11 @@ directories will be saved. This directory will contain a posting directory for
 each group in the restored backup.
 
 The `--zero` (`-z`) optional flag specifies a Dgraph Zero address to update the
-start timestamp using the restored version. Otherwise, the timestamp must be
-manually updated through Zero's HTTP 'assign' endpoint.
+start timestamp and UID lease using the restored version. If no zero address is
+passed, the command will complain unless you explicitly pass the
+`--force_no_zero` flag. If do not pass a zero value to this command, the
+timestamp and UID lease must be manually updated through Zero's HTTP 'assign'
+endpoint using the values printed near the end of the command's output.
 
 The `--backup_id` optional flag specifies the ID of the backup series to
 restore. A backup series consists of a full backup and all the incremental


### PR DESCRIPTION
The zero value passed to the command is optional, which can lead to
users forgetting about it and being surprised that the cluster does
not work (because the uid lease and the timestamp need to be updated
first).

This change makes the zero flag required unless the `--force_zero`
flag is explicitly passed. Not passing a zero value can still be useful
when only the p directories need to be generated.

Fixes DGRAPH-1251

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes #JiraIssue".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5206)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-bf980ba833-54944.surge.sh)
<!-- Dgraph:end -->