### PR TITLE
Allow backup ID to be passed to restore endpoint.

### DIFF
--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -64,6 +64,11 @@ const adminTypes = `
 		location: String!
 
 		"""
+		Backup ID of the backup series to restore. This ID is included in the manifest.json file.
+		"""
+		backupId: String!
+
+		"""
 		Access key credential for the destination.
 		"""
 		accessKey: String

--- a/graphql/admin/restore.go
+++ b/graphql/admin/restore.go
@@ -35,6 +35,7 @@ type restoreResolver struct {
 
 type restoreInput struct {
 	Location     string
+	BackupId     string
 	AccessKey    string
 	SecretKey    string
 	SessionToken string
@@ -52,6 +53,7 @@ func (rr *restoreResolver) Rewrite(
 
 	req := pb.RestoreRequest{
 		Location:     input.Location,
+		BackupId:     input.BackupId,
 		AccessKey:    input.AccessKey,
 		SecretKey:    input.SecretKey,
 		SessionToken: input.SessionToken,

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -37,7 +37,7 @@ import (
 
 func sendRestoreRequest(t *testing.T) {
 	restoreRequest := `mutation restore() {
-		 restore(input: {location: "/data/alpha1/backup"}) {
+		 restore(input: {location: "/data/alpha1/backup", backupId: "compassionate_antonelli7"}) {
 			response {
 				code
 				message

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -135,3 +135,27 @@ func TestBasicRestore(t *testing.T) {
 	runQueries(t, dg)
 	runMutations(t, dg)
 }
+
+func TestInvalidBackupId(t *testing.T) {
+	restoreRequest := `mutation restore() {
+		 restore(input: {location: "/data/alpha1/backup", backupId: "bad-backup-id"}) {
+			response {
+				code
+				message
+			}
+		}
+	}`
+
+	adminUrl := "http://localhost:8180/admin"
+	params := testutil.GraphQLParams{
+		Query: restoreRequest,
+	}
+	b, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
+	require.NoError(t, err)
+	buf, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Contains(t, string(buf), "failed to verify backup")
+}


### PR DESCRIPTION
The backup ID can now be passed to select a specific series of backups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5208)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-713d7c5795-55297.surge.sh)
<!-- Dgraph:end -->