### PR TITLE
Support bulk loader use-case to import unencrypted export and encrypt the result

### DIFF
--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -348,9 +348,10 @@ func slurpQuoted(r *bufio.Reader, out *bytes.Buffer) error {
 	}
 }
 
-// FileReader returns an open reader and file on the given file. Gzip-compressed input is detected
-// and decompressed automatically even without the gz extension. The caller is responsible for
-// calling the returned cleanup function when done with the reader.
+// FileReader returns an open reader on the given file. Gzip-compressed input is detected
+// and decompressed automatically even without the gz extension. The keyfile, if non-nil,
+// is used to decrypt the file. The caller is responsible for calling the returned cleanup
+// function when done with the reader.
 func FileReader(file string, keyfile string) (rd *bufio.Reader, cleanup func()) {
 	var f *os.File
 	var err error

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -58,6 +58,8 @@ func init() {
 		"Location of schema file.")
 	flag.String("format", "",
 		"Specify file format (rdf or json) instead of getting it from filename.")
+	flag.Bool("encrypted", false,
+		"Flag to indicate whether schema and data files are encrypted.")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -100,9 +102,10 @@ func init() {
 
 	// Options around how to set up Badger.
 	flag.String("encryption_key_file", "",
-		"The file that stores the encryption key. The key size must be 16, 24, or 32 bytes long. "+
-			"The key size determines the corresponding block size for AES encryption "+
-			"(AES-128, AES-192, and AES-256 respectively). Enterprise feature.")
+		"The file that stores the encryption key. The key size must be 16/24/32 bytes long."+
+			" The key size indicates the chosen AES encryption (AES-128/192/256 respectively). "+
+			" This key is used to encrypt the output data directories and to decrypt the input "+
+			" schema and data files (if encrytped). Enterprise feature.")
 	flag.Int("badger.compression_level", 1,
 		"The compression level for Badger. A higher value uses more resources.")
 }
@@ -112,6 +115,7 @@ func run() {
 		DataFiles:        Bulk.Conf.GetString("files"),
 		DataFormat:       Bulk.Conf.GetString("format"),
 		SchemaFile:       Bulk.Conf.GetString("schema"),
+		Encrypted:        Bulk.Conf.GetBool("encrypted"),
 		OutDir:           Bulk.Conf.GetString("out"),
 		ReplaceOutDir:    Bulk.Conf.GetBool("replace_out"),
 		TmpDir:           Bulk.Conf.GetString("tmp"),
@@ -141,6 +145,10 @@ func run() {
 	// OSS, non-nil key file --> crash
 	if !enc.EeBuild && opt.BadgerKeyFile != "" {
 		fmt.Printf("Cannot enable encryption: %s", x.ErrNotSupported)
+		os.Exit(1)
+	}
+	if opt.Encrypted && opt.BadgerKeyFile == "" {
+		fmt.Printf("Must use --encryption_key_file option with --encrypted option.\n")
 		os.Exit(1)
 	}
 	if opt.SchemaFile == "" {


### PR DESCRIPTION
Support bulk loader use-case to import unencrypted export and encrypt the result
Fixes DGRAPH-1254
(cherry-picked from commit d982be3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5212)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f9a00233d7-55226.surge.sh)
<!-- Dgraph:end -->