### PR TITLE
Return immediately if compareandswap updates the maxUidSeen.

### DIFF
--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -191,7 +191,9 @@ func (m *XidMap) updateMaxSeen(max uint64) {
 		if prev >= max {
 			return
 		}
-		atomic.CompareAndSwapUint64(&m.maxUidSeen, prev, max)
+		if atomic.CompareAndSwapUint64(&m.maxUidSeen, prev, max) {
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Small optimization to avoid reading the atomic once again after the
value is successfully updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5224)
<!-- Reviewable:end -->
