### PR TITLE
Always set BlockSize in encoder.

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -102,6 +102,7 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 		// do nothing as expected.
 		return
 	}
+
 	// Pick the shorter list and do binary search
 	if ld < lq {
 		uids := dec.Uids()

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -96,9 +96,6 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	ld := dec.ApproxLen()
 	lq := len(q)
 
-	if ld == 0 || lq == 0 {
-		return
-	}
 	// Pick the shorter list and do binary search
 	if ld < lq {
 		uids := dec.Uids()

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -96,6 +96,12 @@ func IntersectCompressedWithBin(dec *codec.Decoder, q []uint64, o *[]uint64) {
 	ld := dec.ApproxLen()
 	lq := len(q)
 
+	if lq == 0 {
+		// Not checking whether ld == 0 because that is an approximate size.
+		// If the actual length of the list is zero, the for loop below will
+		// do nothing as expected.
+		return
+	}
 	// Pick the shorter list and do binary search
 	if ld < lq {
 		uids := dec.Uids()

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -459,9 +459,58 @@ func TestIntersectCompressedWithLinJump(t *testing.T) {
 
 			pack := enc.Done()
 			dec := codec.Decoder{Pack: pack}
+			dec.Seek(0, codec.SeekStart)
 
 			actual := make([]uint64, 0)
 			IntersectCompressedWithLinJump(&dec, otherNums, &actual)
+			require.Equal(t, commonNums, actual)
+		}
+	}
+}
+
+func TestIntersectCompressedWithBin(t *testing.T) {
+	lengths := []int{0, 1, 3, 11, 100}
+
+	for _, N1 := range lengths {
+		for _, N2 := range lengths {
+			// Intersection of blockNums and otherNums is commonNums.
+			commonNums, blockNums, otherNums := fillNums(N1, N2)
+
+			enc := codec.Encoder{BlockSize: 10}
+			for _, num := range blockNums {
+				enc.Add(num)
+			}
+
+			pack := enc.Done()
+			dec := codec.Decoder{Pack: pack}
+			dec.Seek(0, codec.SeekStart)
+
+			actual := make([]uint64, 0)
+			IntersectCompressedWithBin(&dec, otherNums, &actual)
+			require.Equal(t, commonNums, actual)
+		}
+	}
+}
+
+func TestIntersectCompressedWithBinMissingSize(t *testing.T) {
+	lengths := []int{0, 1, 3, 11, 100}
+
+	for _, N1 := range lengths {
+		for _, N2 := range lengths {
+			// Intersection of blockNums and otherNums is commonNums.
+			commonNums, blockNums, otherNums := fillNums(N1, N2)
+
+			enc := codec.Encoder{BlockSize: 0}
+			for _, num := range blockNums {
+				enc.Add(num)
+			}
+
+			pack := enc.Done()
+			dec := codec.Decoder{Pack: pack}
+			dec.Seek(0, codec.SeekStart)
+
+			actual := make([]uint64, 0)
+			IntersectCompressedWithBin(&dec, otherNums, &actual)
 			require.Equal(t, commonNums, actual)
 		}
 	}

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -500,6 +500,7 @@ func TestIntersectCompressedWithBinMissingSize(t *testing.T) {
 			// Intersection of blockNums and otherNums is commonNums.
 			commonNums, blockNums, otherNums := fillNums(N1, N2)
 
+			// Set the block size to 0 to verify that the method still works in this case.
 			enc := codec.Encoder{BlockSize: 0}
 			for _, num := range blockNums {
 				enc.Add(num)

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -169,6 +169,12 @@ func (d *Decoder) UnpackBlock() []uint64 {
 
 // ApproxLen returns the approximate number of UIDs in the pb.UidPack object.
 func (d *Decoder) ApproxLen() int {
+	if d == nil {
+		return 0
+	}
+	if d.Pack == nil {
+		return 0
+	}
 	return int(d.Pack.BlockSize) * (len(d.Pack.Blocks) - d.blockIdx)
 }
 

--- a/posting/list.go
+++ b/posting/list.go
@@ -932,10 +932,15 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		return nil
 	})
 	// Finish  writing the last part of the list (or the whole list if not a multi-part list).
-	x.Check(err)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot iterate through the list")
+	}
 	plist.Pack = enc.Done()
 	if plist.Pack != nil {
-		x.AssertTrue(plist.Pack.BlockSize == uint32(blockSize))
+		if plist.Pack.BlockSize != uint32(blockSize) {
+			return nil, errors.Errorf("actual block size %d is different from expected value %d",
+				plist.Pack.BlockSize, blockSize)
+		}
 	}
 
 	if len(l.plist.Splits) > 0 {

--- a/posting/list.go
+++ b/posting/list.go
@@ -934,7 +934,9 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	// Finish  writing the last part of the list (or the whole list if not a multi-part list).
 	x.Check(err)
 	plist.Pack = enc.Done()
-	x.AssertTrue(plist.Pack.BlockSize == uint32(blockSize))
+	if plist.Pack != nil {
+		x.AssertTrue(plist.Pack.BlockSize == uint32(blockSize))
+	}
 
 	if len(l.plist.Splits) > 0 {
 		out.parts[startUid] = plist

--- a/posting/list.go
+++ b/posting/list.go
@@ -888,9 +888,9 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	}
 
 	var plist *pb.PostingList
-	var enc codec.Encoder
 	var startUid, endUid uint64
 	var splitIdx int
+	enc := codec.Encoder{BlockSize: blockSize}
 
 	// Method to properly initialize the variables above
 	// when a multi-part list boundary is crossed.
@@ -934,6 +934,8 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	// Finish  writing the last part of the list (or the whole list if not a multi-part list).
 	x.Check(err)
 	plist.Pack = enc.Done()
+	x.AssertTrue(plist.Pack.BlockSize == uint32(blockSize))
+
 	if len(l.plist.Splits) > 0 {
 		out.parts[startUid] = plist
 	}


### PR DESCRIPTION
Rollup was setting the BlockSize of the encoder for multi-part list but not for
normal lists.

This caused ApproxLen to return 0. Then the intersect algorithm exited early in this case.
Existing data will be encoded with the right block size the next time the list is rolled up.

This PR does the following.

1. Set the blocksize.
1. Add an assert in rollup to verify that the blocksize is always the right value.
1. Eliminate the check in the intersect algorithm to not return immediately even if ApproxLen
    returns 0. There's no difference if the actual length is zero since the smallest list is picked
    to perform the iteration. If the list has data but a block size of zero, removing this check allows
    the query to return the right result. Added a test to verify this scenario.
1. Added missing tests for the binary search intersect algorithm.

Fixes #5102

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5255)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-68cc4a4df8-57570.surge.sh)
<!-- Dgraph:end -->