### PR TITLE
graphql: Propogate errors encountered from external endpoints back to the client 

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -286,9 +286,9 @@ func TestCustomQueryWithNonExistentURLShouldReturnError(t *testing.T) {
 	require.JSONEq(t, `{ "myFavoriteMovies": [] }`, string(result.Data))
 	require.Equal(t, x.GqlErrorList{
 		{
-			Message: "Evaluation of custom field failed because json unmarshaling result: 404" +
-				" page not found\n of external request failed with error: invalid character" +
-				" 'p' after top-level value for field: myFavoriteMovies within type: Query.",
+			Message: "Evaluation of custom field failed because external request returned an " +
+				"error: unexpected status code: 404 for field: myFavoriteMovies within" +
+				" type: Query.",
 			Locations: []x.Location{{3, 3}},
 		},
 	}, result.Errors)
@@ -370,13 +370,12 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 	require.Equal(t, 2, len(result.Errors))
 
 	expectedErrors := x.GqlErrorList{
-		&x.GqlError{Message: "Evaluation of custom field failed because json unmarshaling " +
-			"result: 404 page not found\n of external request failed with error: invalid" +
-			" character 'p' after top-level value for field: cars within type: Person.",
+		&x.GqlError{Message: "Evaluation of custom field failed because external request " +
+			"returned an error: unexpected status code: 404 for field: cars within type: Person.",
 			Locations: []x.Location{{6, 4}}},
-		&x.GqlError{Message: "Evaluation of custom field failed because json unmarshaling " +
-			"result: 404 page not found\n of external request failed with error: invalid" +
-			" character 'p' after top-level value for field: bikes within type: Person, index: 0.",
+		&x.GqlError{Message: "Evaluation of custom field failed because external request returned" +
+			" an error: unexpected status code: 404 for field: bikes within type: Person," +
+			" index: 0.",
 			Locations: []x.Location{{9, 4}}},
 	}
 	require.Contains(t, result.Errors, expectedErrors[0])

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -286,7 +286,9 @@ func TestCustomQueryWithNonExistentURLShouldReturnError(t *testing.T) {
 	require.JSONEq(t, `{ "myFavoriteMovies": [] }`, string(result.Data))
 	require.Equal(t, x.GqlErrorList{
 		{
-			Message:   "couldn't unmarshal result because invalid character 'p' after top-level value",
+			Message: "Evaluation of custom field failed because json unmarshaling result: 404" +
+				" page not found\n of external request failed with error: invalid character" +
+				" 'p' after top-level value for field: myFavoriteMovies within type: Query.",
 			Locations: []x.Location{{3, 3}},
 		},
 	}, result.Errors)

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -368,10 +368,11 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 	require.Equal(t, 2, len(result.Errors))
 
 	expectedErrors := x.GqlErrorList{
-		x.GqlErrorf("while json unmarshaling result from remote endpoint: 404 page not found\n " +
-			"for field: cars within type: Person (Locations: [{Line: 6, Column: 4}])"),
-		x.GqlErrorf("while json unmarshaling result from remote endpoint: 404 page not found\n " +
-			"for field: bikes within type: Person, index: 0 (Locations: [{Line: 9, Column: 4}])"),
+		&x.GqlError{Message: "while json unmarshaling result from remote endpoint: 404 page not" +
+			" found\n for field: bikes within type: Person, index: 0",
+			Locations: []x.Location{{9, 4}}},
+		&x.GqlError{Message: "while json unmarshaling result from remote endpoint: 404 page not" +
+			" found\n for field: cars within type: Person", Locations: []x.Location{{6, 4}}},
 	}
 	require.Contains(t, result.Errors, expectedErrors[0])
 	require.Contains(t, result.Errors, expectedErrors[1])

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -368,8 +368,10 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 	require.Equal(t, 2, len(result.Errors))
 
 	expectedErrors := x.GqlErrorList{
-		x.GqlErrorf("while json unmarshaling result: 404 page not found\n for field: cars"),
-		x.GqlErrorf("while json unmarshaling result: 404 page not found\n for field: bikes"),
+		x.GqlErrorf("while json unmarshaling result from remote endpoint: 404 page not found\n " +
+			"for field: cars within type: Person (Locations: [{Line: 6, Column: 4}])"),
+		x.GqlErrorf("while json unmarshaling result from remote endpoint: 404 page not found\n " +
+			"for field: bikes within type: Person, index: 0 (Locations: [{Line: 9, Column: 4}])"),
 	}
 	require.Contains(t, result.Errors, expectedErrors[0])
 	require.Contains(t, result.Errors, expectedErrors[1])

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -283,7 +283,7 @@ func TestCustomQueryWithNonExistentURLShouldReturnError(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.JSONEq(t, `{ "myFavoriteMovies": null }`, string(result.Data))
+	require.JSONEq(t, `{ "myFavoriteMovies": [] }`, string(result.Data))
 	require.Equal(t, x.GqlErrorList{
 		{
 			Message:   "couldn't unmarshal result because invalid character 'p' after top-level value",
@@ -368,11 +368,14 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 	require.Equal(t, 2, len(result.Errors))
 
 	expectedErrors := x.GqlErrorList{
-		&x.GqlError{Message: "while json unmarshaling result from remote endpoint: 404 page not" +
-			" found\n for field: bikes within type: Person, index: 0",
+		&x.GqlError{Message: "Evaluation of custom field failed because json unmarshaling " +
+			"result: 404 page not found\n of external request failed with error: invalid" +
+			" character 'p' after top-level value for field: cars within type: Person.",
+			Locations: []x.Location{{6, 4}}},
+		&x.GqlError{Message: "Evaluation of custom field failed because json unmarshaling " +
+			"result: 404 page not found\n of external request failed with error: invalid" +
+			" character 'p' after top-level value for field: bikes within type: Person, index: 0.",
 			Locations: []x.Location{{9, 4}}},
-		&x.GqlError{Message: "while json unmarshaling result from remote endpoint: 404 page not" +
-			" found\n for field: cars within type: Person", Locations: []x.Location{{6, 4}}},
 	}
 	require.Contains(t, result.Errors, expectedErrors[0])
 	require.Contains(t, result.Errors, expectedErrors[1])

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -624,9 +624,9 @@ func completeDgraphResult(
 		// case
 	}
 
-	gqlErr := resolveCustomFields(field.SelectionSet(), valToComplete[field.ResponseName()])
-	if gqlErr != nil {
-		errs = append(errs, schema.AsGQLErrors(gqlErr)...)
+	err = resolveCustomFields(field.SelectionSet(), valToComplete[field.ResponseName()])
+	if err != nil {
+		errs = append(errs, schema.AsGQLErrors(err)...)
 	}
 
 	return &Resolved{

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -622,12 +622,9 @@ func completeDgraphResult(
 		// case
 	}
 
-	err = resolveCustomFields(field.SelectionSet(), valToComplete[field.ResponseName()])
-	if err != nil {
-		errs = append(errs, x.GqlErrorf(err.Error()))
-		// TODO
-		// 1. All errors received from downstream remote servers should be propogated to the
-		// client.
+	gqlErr := resolveCustomFields(field.SelectionSet(), valToComplete[field.ResponseName()])
+	if len(gqlErr) != 0 {
+		errs = append(errs, gqlErr...)
 	}
 
 	return &Resolved{
@@ -650,7 +647,7 @@ func copyTemplate(input interface{}) (interface{}, error) {
 	return result, nil
 }
 
-func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan error) {
+func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan x.GqlErrorList) {
 	fconf, _ := f.CustomHTTPConfig(false)
 
 	// Here we build the array of objects which is sent as the body for the request.
@@ -658,12 +655,12 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 	for i := 0; i < len(body); i++ {
 		temp, err := copyTemplate(*fconf.Template)
 		if err != nil {
-			errCh <- err
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			return
 		}
 		mu.RLock()
 		if err := schema.SubstituteVarsInBody(&temp, vals[i].(map[string]interface{})); err != nil {
-			errCh <- err
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			mu.RUnlock()
 			return
 		}
@@ -674,24 +671,29 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 	if fconf.Operation == "batch" {
 		b, err := json.Marshal(body)
 		if err != nil {
-			errCh <- errors.Wrapf(err, "while json marshaling body: %s", b)
+			err = errors.Wrapf(err, "while json marshaling body: %s", b)
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			return
 		}
 
 		b, err = makeRequest(nil, fconf.Method, fconf.URL, string(b), fconf.ForwardHeaders)
 		if err != nil {
-			errCh <- errors.Wrapf(err, "while making request to fetch data for field: %s", f.Name())
+			err = errors.Wrapf(err, "while making request to fetch data for field: %s", f.Name())
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			return
 		}
 
 		var result []interface{}
 		if err := json.Unmarshal(b, &result); err != nil {
-			errCh <- errors.Wrapf(err, "while json unmarshaling result: %s", b)
+			err = errors.Errorf("while json unmarshaling result: %s for field: %s", b, f.Name())
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			return
 		}
 
 		if len(result) != len(vals) {
-			errCh <- nil
+			err = errors.Errorf("expected result to be of size %v, got: %v for field: %s",
+				len(vals), len(result), f.Name())
+			errCh <- x.GqlErrorList{x.GqlErrorf(err.Error())}
 			return
 		}
 
@@ -709,13 +711,15 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 
 	// This is single mode, make calls concurrently for each input and fill in the results.
 	var wg sync.WaitGroup
+	errs := make(x.GqlErrorList, len(body))
 	for i := 0; i < len(body); i++ {
 		wg.Add(1)
 		go func(idx int, input interface{}) {
 			defer wg.Done()
 			b, err := json.Marshal(input)
 			if err != nil {
-				// TODO - Propogate this error
+				errs[idx] = x.GqlErrorf("while json marshaling input: %+v to resolve "+
+					"field: %s", input, f.Name())
 				return
 			}
 
@@ -723,19 +727,23 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 			fconf.URL, err = schema.SubstituteVarsInURL(fconf.URL, vals[idx].(map[string]interface{}))
 			if err != nil {
 				mu.RUnlock()
+				errs[idx] = x.GqlErrorf("while substituting variables in URL to resolve"+
+					" field: %s, err: %s", f.Name(), err)
 				return
 			}
 			mu.RUnlock()
 
 			b, err = makeRequest(nil, fconf.Method, fconf.URL, string(b), fconf.ForwardHeaders)
 			if err != nil {
-				// TODO - Propogate this error.
+				errs[idx] = x.GqlErrorf("while making request to resolve field: %s, err: %s",
+					f.Name(), err)
 				return
 			}
 
 			var result interface{}
 			if err := json.Unmarshal(b, &result); err != nil {
-				// TODO - Propogate this error.
+				errs[idx] = x.GqlErrorf("while json unmarshaling result: %s for field: %s",
+					b, f.Name())
 				return
 			}
 
@@ -748,7 +756,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 		}(i, body[i])
 	}
 	wg.Wait()
-	errCh <- nil
+	errCh <- errs
 }
 
 // resolveNestedFields resolves fields which themselves don't have the @custom directive but their
@@ -762,7 +770,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 // }
 // In the example above, resolveNestedFields would be called on classes field and vals would be the
 // list of all users.
-func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan error) {
+func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan x.GqlErrorList) {
 	// If this field doesn't have custom directive and also doesn't have any children,
 	// then there is nothing to do and we can just continue.
 	if len(f.SelectionSet()) == 0 {
@@ -827,7 +835,7 @@ func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, e
 	mu.RUnlock()
 
 	if err := resolveCustomFields(f.SelectionSet(), input); err != nil {
-		errCh <- nil
+		errCh <- err
 		return
 	}
 
@@ -889,7 +897,7 @@ func resolveNestedFields(f schema.Field, vals []interface{}, mu *sync.RWMutex, e
 // work.
 // TODO - We can be smarter about this and know before processing the query if we should be making
 // this recursive call upfront.
-func resolveCustomFields(fields []schema.Field, data interface{}) error {
+func resolveCustomFields(fields []schema.Field, data interface{}) x.GqlErrorList {
 	if data == nil {
 		return nil
 	}
@@ -909,7 +917,7 @@ func resolveCustomFields(fields []schema.Field, data interface{}) error {
 	// This mutex protects access to vals as it is concurrently read and written to by multiple
 	// goroutines.
 	mu := &sync.RWMutex{}
-	errCh := make(chan error, len(fields))
+	errCh := make(chan x.GqlErrorList, len(fields))
 	numRoutines := 0
 
 	for _, f := range fields {
@@ -926,14 +934,15 @@ func resolveCustomFields(fields []schema.Field, data interface{}) error {
 		}
 	}
 
-	var finalErr error
+	var errs x.GqlErrorList
+
 	for i := 0; i < numRoutines; i++ {
 		if err := <-errCh; err != nil {
-			finalErr = err
+			errs = append(errs, &x.GqlError{Message: err.Error()})
 		}
 	}
 
-	return finalErr
+	return errs
 }
 
 // completeObject builds a json GraphQL result object for the current query level.

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -564,14 +564,16 @@ func completeDgraphResult(
 	// GQL type checking should ensure query results are only object types
 	// https://graphql.github.io/graphql-spec/June2018/#sec-Query
 	// So we are only building object results.
+	// Update - This function is also called by HTTP resolver for resolving custom logic queries
+	// hence the comment above doesn't hold right now.
 	var valToComplete map[string]interface{}
 	err := json.Unmarshal(dgResult, &valToComplete)
 	if err != nil {
-		glog.Errorf("%+v \n Dgraph result :\n%s\n",
-			errors.Wrap(err, "failed to unmarshal Dgraph query result"),
+		glog.Errorf("%+v \n result :\n%s\n",
+			errors.Wrap(err, "failed to unmarshal query result"),
 			string(dgResult))
-		return nullResponse(
-			schema.GQLWrapLocationf(err, field.Location(), "couldn't unmarshal Dgraph result"))
+		return nullResponse(schema.GQLWrapLocationf(err, field.Location(),
+			"couldn't unmarshal Dgraph result"))
 	}
 
 	switch val := valToComplete[field.ResponseName()].(type) {


### PR DESCRIPTION
Append errors encountered while making HTTP requests to resolve fields to the list of errors returned to the client. Addresses the comments on #5176. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5261)
<!-- Reviewable:end -->
