### PR TITLE
graphql: Support mutations on remote GraphQL endpoints

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -38,6 +38,12 @@ type expectedRequest struct {
 	headers map[string][]string
 }
 
+type expectedGraphqlRequest struct {
+	urlSuffix string
+	// Send body as empty string to make sure that only introspection queries are expected
+	body string
+}
+
 func check2(v interface{}, err error) {
 	if err != nil {
 		log.Fatal(err)
@@ -93,6 +99,35 @@ func verifyRequest(r *http.Request, expectedRequest expectedRequest) error {
 	}
 
 	return nil
+}
+
+// bool parameter in return signifies whether it is an introspection query or not:
+//
+// true -> introspection query
+//
+// false -> not an introspection query
+func verifyGraphqlRequest(r *http.Request, expectedRequest expectedGraphqlRequest) (bool, error) {
+	if r.Method != http.MethodPost {
+		return false, getError("Invalid HTTP method", r.Method)
+	}
+
+	if !strings.HasSuffix(r.URL.String(), expectedRequest.urlSuffix) {
+		return false, getError("Invalid URL", r.URL.String())
+	}
+
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return false, getError("Unable to read request body", err.Error())
+	}
+	actualBody := string(b)
+	if strings.Contains(actualBody, "__schema") {
+		return true, nil
+	}
+	if actualBody != expectedRequest.body {
+		return false, getError("Unexpected value for request body", actualBody)
+	}
+
+	return false, nil
 }
 
 func getDefaultResponse(resKey string) []byte {
@@ -258,7 +293,14 @@ func favMoviesDeleteHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func emptyQuerySchema(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, `
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/noquery",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -276,11 +318,18 @@ func emptyQuerySchema(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
+	`))
 }
 
 func invalidArgument(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, `
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/invalidargument",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -312,9 +361,13 @@ func invalidArgument(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "NON_NULL",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -324,11 +377,19 @@ func invalidArgument(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
+	`))
 }
 
 func invalidType(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, `
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/invalidtype",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+
+	check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -360,9 +421,13 @@ func invalidType(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "NON_NULL",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -372,14 +437,21 @@ func invalidType(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
+	`))
 }
 
 func validCountryResponse(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/validcountry",
+		body:      `{"query":"query { country(code: $id) {\ncode\nname\n}}","variables":{"id":"BI"}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
 
-	if strings.Contains(string(body), "__schema") {
-		fmt.Fprintf(w, `
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -411,9 +483,13 @@ func validCountryResponse(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "NON_NULL",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -423,11 +499,9 @@ func validCountryResponse(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
-		return
-	}
-
-	fmt.Fprintf(w, `
+	`))
+	} else {
+		check2(fmt.Fprintf(w, `
 	{
 		"data": {
 		  "country": {
@@ -435,14 +509,22 @@ func validCountryResponse(w http.ResponseWriter, r *http.Request) {
 			"code": "BI"
 		  }
 		}
-	  }`)
+	  }`))
+	}
 }
 
 func graphqlErrResponse(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/graphqlerr",
+		body:      `{"query":"query { country(code: $id) {\ncode\nname\n}}","variables":{"id":"BI"}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
 
-	if strings.Contains(string(body), "__schema") {
-		fmt.Fprintf(w, `
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -474,9 +556,13 @@ func graphqlErrResponse(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "LIST",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -486,23 +572,29 @@ func graphqlErrResponse(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
-		return
-	}
-
-	fmt.Fprintf(w, `
+	`))
+	} else {
+		check2(fmt.Fprintf(w, `
 	{
 	   "errors":[{
 			"message": "dummy error"
 		}]
-	  }`)
+	  }`))
+	}
 }
 
 func validCountryWithErrorResponse(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/validcountrywitherror",
+		body:      `{"query":"query { country(code: $id) {\ncode\nname\n}}","variables":{"id":"BI"}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
 
-	if strings.Contains(string(body), "__schema") {
-		fmt.Fprintf(w, `
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -534,9 +626,13 @@ func validCountryWithErrorResponse(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "NON_NULL",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -546,11 +642,9 @@ func validCountryWithErrorResponse(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
-		return
-	}
-
-	fmt.Fprintf(w, `
+	`))
+	} else {
+		check2(fmt.Fprintf(w, `
 	{
 		"data": {
 		  "country": {
@@ -561,14 +655,22 @@ func validCountryWithErrorResponse(w http.ResponseWriter, r *http.Request) {
 		"errors":[{
 			"message": "dummy error"
 		}]
-	  }`)
+	  }`))
+	}
 }
 
 func validCountries(w http.ResponseWriter, r *http.Request) {
-	body, _ := ioutil.ReadAll(r.Body)
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/validcountries",
+		body:      `{"query":"query { country(code: $id) {\ncode\nname\n}}","variables":{"id":"BI"}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
 
-	if strings.Contains(string(body), "__schema") {
-		fmt.Fprintf(w, `
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
 	{
 	"data": {
 		"__schema": {
@@ -600,9 +702,13 @@ func validCountries(w http.ResponseWriter, r *http.Request) {
 					  }
 					],
 					"type": {
-					  "kind": "OBJECT",
-					  "name": "Country",
-					  "ofType": null
+					  "kind": "LIST",
+					  "name": null,
+					  "ofType": {
+						"kind": "OBJECT",
+						"name": "Country",
+						"ofType": null
+					  }
 					},
 					"isDeprecated": false,
 					"deprecationReason": null
@@ -612,11 +718,9 @@ func validCountries(w http.ResponseWriter, r *http.Request) {
 		  }
 	   }
 	}
-	`)
-		return
-	}
-
-	fmt.Fprintf(w, `
+	`))
+	} else {
+		check2(fmt.Fprintf(w, `
 	{
 		"data": {
 		  "country": [
@@ -626,7 +730,90 @@ func validCountries(w http.ResponseWriter, r *http.Request) {
 			}
 		  ]
 	  }
-	  }`)
+	  }`))
+	}
+}
+
+func setCountry(w http.ResponseWriter, r *http.Request) {
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/setCountry",
+		body:      `{"query":"mutation { setCountry(country: $input) {\ncode\nname\nstates{\ncode\nname\n}\n}}","variables":{"input":{"code":"IN","name":"India","states":[{"code":"RJ","name":"Rajasthan"},{"code":"KA","name":"Karnataka"}]}}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
+		{
+		"data": {
+			"__schema": {
+			  "queryType": null,
+			  "mutationType":  {
+				"name": "MyMutations"
+			  },
+			  "subscriptionType": null,
+			  "types": [
+				{
+				  "kind": "OBJECT",
+				  "name": "MyMutations",
+				  "fields": [
+					{
+						"name": "setCountry",
+						"args": [
+						  {
+							"name": "country",
+							"type": {
+							  "kind": "NON_NULL",
+							  "name": null,
+							  "ofType": {
+								"kind": "OBJECT",
+								"name": "CountryInput",
+								"ofType": null
+							  }
+							},
+							"defaultValue": null
+						  }
+						],
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+							"kind": "OBJECT",
+							"name": "Country",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					  }
+				  ]
+				}]
+			  }
+		   }
+		}`))
+	} else {
+		check2(fmt.Fprintf(w, `
+		{
+			"data": {
+				"setCountry": {
+					"code": "IN",
+					"name": "India",
+					"states": [
+						{
+							"code": "RJ",
+							"name": "Rajasthan"
+						},
+						{
+							"code": "KA",
+							"name": "Karnataka"
+						}
+					]
+				}
+			}
+		}`))
+	}
 }
 
 type input struct {
@@ -862,6 +1049,8 @@ func main() {
 	http.HandleFunc("/validcountrywitherror", validCountryWithErrorResponse)
 	http.HandleFunc("/graphqlerr", graphqlErrResponse)
 	http.HandleFunc("/validcountries", validCountries)
+	http.HandleFunc("/setCountry", setCountry)
+
 	// for mutations
 	http.HandleFunc("/favMoviesCreate", favMoviesCreateHandler)
 	http.HandleFunc("/favMoviesUpdate/", favMoviesUpdateHandler)

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -816,6 +816,97 @@ func setCountry(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func updateCountries(w http.ResponseWriter, r *http.Request) {
+	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/updateCountries",
+		body:      `{"query":"mutation { updateCountries(name: $name, std: $std) {\nname\nstd\n}}","variables":{"name":"Australia","std":91}}`,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+
+	if isIntrospection {
+		check2(fmt.Fprintf(w, `
+		{
+		"data": {
+			"__schema": {
+			  "queryType": null,
+			  "mutationType":  {
+				"name": "Mutation"
+			  },
+			  "subscriptionType": null,
+			  "types": [
+				{
+				  "kind": "OBJECT",
+				  "name": "Mutation",
+				  "fields": [
+					{
+						"name": "updateCountries",
+						"args": [
+						  {
+							"name": "name",
+							"type": {
+							  "kind": "SCALAR",
+							  "name": "String",
+							  "ofType": null
+							},
+							"defaultValue": null
+						  },
+						  {
+							"name": "std",
+							"type": {
+							  "kind": "SCALAR",
+							  "name": "Int",
+							  "ofType": null
+							},
+							"defaultValue": null
+						  }
+						],
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+							  "kind": "NON_NULL",
+							  "name": null,
+							  "ofType": {
+								"kind": "OBJECT",
+								"name": "Country",
+								"ofType": null
+							  }
+							}
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					  }
+				  ]
+				}]
+			  }
+		   }
+		}`))
+	} else {
+		check2(fmt.Fprintf(w, `
+		{
+			"data": {
+				"updateCountries": [
+					{
+						"name": "India",
+						"std": 91
+					},
+					{
+						"name": "Australia",
+						"std": 61
+					}
+				]
+			}
+		}`))
+	}
+}
+
 type input struct {
 	ID string `json:"uid"`
 }
@@ -1050,6 +1141,7 @@ func main() {
 	http.HandleFunc("/graphqlerr", graphqlErrResponse)
 	http.HandleFunc("/validcountries", validCountries)
 	http.HandleFunc("/setCountry", setCountry)
+	http.HandleFunc("/updateCountries", updateCountries)
 
 	// for mutations
 	http.HandleFunc("/favMoviesCreate", favMoviesCreateHandler)

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -67,12 +67,22 @@ const (
 		native: String
 		rtl: Int
 	  }
-	  
-	  
+
 	  type State @remote {
 		code: String
 		name: String
 		country: Country
+	  }
+
+	  input CountryInput {
+		code: String!
+		name: String!
+		states: [StateInput]
+	  }
+
+	  input StateInput {
+		code: String!
+		name: String!
 	  }
  `
 )
@@ -91,6 +101,11 @@ func updateSchema(t *testing.T, sch string) *common.GraphQLResponse {
 	return add.ExecuteAsPost(t, alphaAdminURL)
 }
 
+func updateSchemaRequireNoGQLErrors(t *testing.T, sch string) {
+	resp := updateSchema(t, sch)
+	common.RequireNoGQLErrors(t, resp)
+}
+
 func TestCustomGetQuery(t *testing.T) {
 	schema := customTypes + `
 	 type Query {
@@ -99,7 +114,7 @@ func TestCustomGetQuery(t *testing.T) {
 				 method: "GET"
 		 })
 	 }`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	query := `
 	 query {
@@ -131,7 +146,7 @@ func TestCustomPostQuery(t *testing.T) {
 				 method: "POST"
 		 })
 	 }`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	query := `
 	 query {
@@ -164,7 +179,7 @@ func TestCustomQueryShouldForwardHeaders(t *testing.T) {
 				 forwardHeaders: ["X-App-Token", "X-User-Id"]
 		 })
 	 }`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	query := `
 	 query {
@@ -216,7 +231,7 @@ func TestServerShouldAllowForwardHeaders(t *testing.T) {
 		})
 	}`
 
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	req, err := http.NewRequest(http.MethodOptions, alphaURL, nil)
 	require.NoError(t, err)
@@ -246,7 +261,7 @@ func addTeachers(t *testing.T) []*teacher {
 	}
 
 	result := addTeacherParams.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	var res struct {
 		AddTeacher struct {
@@ -291,7 +306,7 @@ func addSchools(t *testing.T, teachers []*teacher) []*school {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nilf(t, result.Errors, "%+v", result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	var res struct {
 		AddSchool struct {
@@ -334,7 +349,7 @@ func addUsers(t *testing.T, schools []*school) []*user {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nilf(t, result.Errors, "%+v", result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	var res struct {
 		AddUser struct {
@@ -379,7 +394,7 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected := `{
 		 "queryUser": [
@@ -555,7 +570,7 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 	}
 
 	result = params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected = `{
 		 "getUser": {
@@ -670,7 +685,7 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 					 })
 	 }`
 
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	teachers := addTeachers(t)
 	schools := addSchools(t, teachers)
@@ -743,46 +758,73 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 func TestForInvalidCustomQuery(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountry(id: ID!): Country! @custom(http: {url: "http://mock:8888/noquery", method: "POST",forwardHeaders: ["Content-Type"]}, graphql: {query: "country(code: $id)"})
-	}	
-	`
+		getCountry(id: ID!): Country! @custom(http: {
+										url: "http://mock:8888/noquery",
+										method: "POST",
+										forwardHeaders: ["Content-Type"],
+										graphql: "query { country(code: $id) }"
+									})
+	}`
 	res := updateSchema(t, schema)
-	require.Equal(t, res.Errors[0].Error(), "couldn't rewrite mutation updateGQLSchema because input:46: Type Query; Field getCountry; country is not present in remote schema\n")
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Query"+
+		"; Field getCountry: @custom directive: graphql; given query: country is not present in"+
+		" remote schema.\n", res.Errors[0].Error())
 }
 
-func TestForInvalidArguement(t *testing.T) {
+func TestForInvalidArgument(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountry(id: ID!): Country! @custom(http: {url: "http://mock:8888/invalidargument", method: "POST",forwardHeaders: ["Content-Type"]}, graphql: {query: "country(code: $id)"})
-	}	
-	`
+		getCountry(id: ID!): Country! @custom(http: {
+										url: "http://mock:8888/invalidargument",
+										method: "POST",
+										forwardHeaders: ["Content-Type"],
+										graphql: "query { country(code: $id) }"
+									})
+	}`
 	res := updateSchema(t, schema)
-	require.Equal(t, res.Errors[0].Error(), "couldn't rewrite mutation updateGQLSchema because input:46: Type Query; Field getCountry; code arg not present in the remote query country\n")
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Query"+
+		"; Field getCountry: @custom directive: graphql; given query: country: arg code not"+
+		" present in remote query.\n", res.Errors[0].Error())
 }
 
 func TestForInvalidType(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountry(id: ID!): Country! @custom(http: {url: "http://mock:8888/invalidtype", method: "POST",forwardHeaders: ["Content-Type"]}, graphql: {query: "country(code: $id)"})
-	}	
-	`
+		getCountry(id: ID!): Country! @custom(http: {
+										url: "http://mock:8888/invalidtype",
+										method: "POST",
+										forwardHeaders: ["Content-Type"],
+										graphql: "query { country(code: $id) }"
+									})
+	}`
 	res := updateSchema(t, schema)
-	require.Equal(t, res.Errors[0].Error(), "couldn't rewrite mutation updateGQLSchema because input:46: Type Query; Field getCountry; expected type for variable  $id is Int. But got ID!\n")
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Query"+
+		"; Field getCountry: @custom directive: graphql; given query: country: type mismatch for"+
+		" variable $id; expected: Int!, got: ID!.\n", res.Errors[0].Error())
 }
 
 func TestCustomLogicGraphql(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountry(id: ID!): Country! @custom(http: {url: "http://mock:8888/validcountry", method: "POST"}, graphql: {query: "country(code: $id)"})
-	}	
-	`
-	res := updateSchema(t, schema)
-	require.Nil(t, res.Errors)
+		getCountry(id: ID!): Country! @custom(http: {
+										url: "http://mock:8888/validcountry",
+										method: "POST",
+										forwardHeaders: ["Content-Type"],
+										graphql: "query { country(code: $id) }"
+									})
+	}`
+	updateSchemaRequireNoGQLErrors(t, schema)
 	query := `
 	query {
 		getCountry(id: "BI"){
 			code
-			name 
+			name
 		}
 	}`
 	params := &common.GraphQLParams{
@@ -791,23 +833,24 @@ func TestCustomLogicGraphql(t *testing.T) {
 
 	result := params.ExecuteAsPost(t, alphaURL)
 	common.RequireNoGQLErrors(t, result)
-	require.JSONEq(t, string(result.Data), `
-	{"getCountry":{"code":"BI","name":"Burundi"}}
-	`)
+	require.JSONEq(t, string(result.Data), `{"getCountry":{"code":"BI","name":"Burundi"}}`)
 }
 
 func TestCustomLogicGraphqlWithError(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountry(id: ID!): Country! @custom(http: {url: "http://mock:8888/validcountrywitherror", method: "POST"}, graphql: {query: "country(code: $id)"})
-	}	
-	`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		getCountry(id: ID!): Country! @custom(http: {
+										url: "http://mock:8888/validcountrywitherror",
+										method: "POST",
+										graphql: "query { country(code: $id) }"
+									})
+	}`
+	updateSchemaRequireNoGQLErrors(t, schema)
 	query := `
 	query {
 		getCountry(id: "BI"){
 			code
-			name 
+			name
 		}
 	}`
 	params := &common.GraphQLParams{
@@ -815,19 +858,20 @@ func TestCustomLogicGraphqlWithError(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.JSONEq(t, string(result.Data), `
-	{"getCountry":{"code":"BI","name":"Burundi"}}
-	`)
+	require.JSONEq(t, string(result.Data), `{"getCountry":{"code":"BI","name":"Burundi"}}`)
 	require.Equal(t, "dummy error", result.Errors.Error())
 }
 
 func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountries(id: ID!): [Country] @custom(http: {url: "http://mock:8888/validcountries", method: "POST"}, graphql: {query: "country(code: $id)"})
-	}
-	`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		getCountries(id: ID!): [Country] @custom(http: {
+										url: "http://mock:8888/validcountries",
+										method: "POST",
+										graphql: "query { country(code: $id) }"
+									})
+	}`
+	updateSchemaRequireNoGQLErrors(t, schema)
 	query := `
 	query {
 		getCountries(id: "BI"){
@@ -840,23 +884,20 @@ func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.JSONEq(t, string(result.Data), `
-	{"getCountries":[
-		{
-		  "name": "Burundi",
-		  "code": "BI"
-		}
-	  ]}
-	`)
+	common.RequireNoGQLErrors(t, result)
+	require.JSONEq(t, string(result.Data), `{"getCountries":[{"name":"Burundi","code":"BI"}]}`)
 }
 
 func TestCustomLogicWithErrorResponse(t *testing.T) {
 	schema := customTypes + `
 	type Query {
-		getCountries(id: ID!): [Country] @custom(http: {url: "http://mock:8888/graphqlerr", method: "POST"}, graphql: {query: "country(code: $id)"})
-	}
-	`
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		getCountries(id: ID!): [Country] @custom(http: {
+										url: "http://mock:8888/graphqlerr",
+										method: "POST",
+										graphql: "query { country(code: $id) }"
+									})
+	}`
+	updateSchemaRequireNoGQLErrors(t, schema)
 	query := `
 	query {
 		getCountries(id: "BI"){
@@ -869,6 +910,7 @@ func TestCustomLogicWithErrorResponse(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
+	require.Equal(t, `{"getCountries":[]}`, string(result.Data))
 	require.Equal(t, "dummy error", result.Errors.Error())
 }
 
@@ -891,7 +933,7 @@ func addEpisode(t *testing.T, name string) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	var res struct {
 		AddEpisode struct {
@@ -927,7 +969,7 @@ func addCharacter(t *testing.T, name string, episodes interface{}) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	var res struct {
 		AddCharacter struct {
@@ -962,7 +1004,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 					})
 		episodes: [Episode]
 	}`
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	ep1 := "episode-1"
 	ep2 := "episode-2"
@@ -992,7 +1034,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected := `{
 		"queryCharacter": [
@@ -1068,10 +1110,10 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 					})
 		episodes: [Episode]
 	}`
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	result = params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 	testutil.CompareJSON(t, expected, string(result.Data))
 
 }
@@ -1095,7 +1137,7 @@ func TestCustomPostMutation(t *testing.T) {
 			body: "{ movies: $input}"
         })
 	}`
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	params := &common.GraphQLParams{
 		Query: `
@@ -1120,7 +1162,7 @@ func TestCustomPostMutation(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected := `
 	{
@@ -1164,7 +1206,7 @@ func TestCustomPatchMutation(t *testing.T) {
 			body: "$input"
         })
 	}`
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	params := &common.GraphQLParams{
 		Query: `
@@ -1187,7 +1229,7 @@ func TestCustomPatchMutation(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected := `
 	{
@@ -1214,7 +1256,7 @@ func TestCustomMutationShouldForwardHeaders(t *testing.T) {
 			forwardHeaders: ["X-App-Token", "X-User-Id"]
         })
 	}`
-	updateSchema(t, schema)
+	updateSchemaRequireNoGQLErrors(t, schema)
 
 	params := &common.GraphQLParams{
 		Query: `
@@ -1232,7 +1274,7 @@ func TestCustomMutationShouldForwardHeaders(t *testing.T) {
 	}
 
 	result := params.ExecuteAsPost(t, alphaURL)
-	require.Nil(t, result.Errors)
+	common.RequireNoGQLErrors(t, result)
 
 	expected := `
 	{
@@ -1240,6 +1282,121 @@ func TestCustomMutationShouldForwardHeaders(t *testing.T) {
         "id": "0x1",
         "name": "Mov1"
       }
+    }`
+	require.JSONEq(t, expected, string(result.Data))
+}
+
+func TestCustomGraphqlMissingMutation(t *testing.T) {
+	schema := customTypes + `
+	type Mutation {
+		addCountry(input: CountryInput!): Country! @custom(http: {
+										url: "http://mock:8888/setCountry",
+										method: "POST",
+										graphql: "mutation { putCountry(country: $input) }"
+									})
+	}`
+	res := updateSchema(t, schema)
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:59: Type Mutation"+
+		"; Field addCountry: @custom directive: graphql; given mutation: putCountry is not"+
+		" present in remote schema.\n", res.Errors[0].Error())
+}
+
+func TestCustomGraphqlReturnTypeMismatch(t *testing.T) {
+	schema := customTypes + `
+	type Mutation {
+		addCountry(input: CountryInput!): Movie! @custom(http: {
+										url: "http://mock:8888/setCountry",
+										method: "POST",
+										graphql: "mutation { setCountry(country: $input) }"
+									})
+	}`
+	res := updateSchema(t, schema)
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:59: Type Mutation"+
+		"; Field addCountry: @custom directive: graphql; given mutation: setCountry: return type"+
+		" mismatch; expected: Country!, got: Movie!.\n", res.Errors[0].Error())
+}
+
+func TestCustomGraphqlMissingRequiredArgument(t *testing.T) {
+	schema := customTypes + `
+	type Mutation {
+		addCountry(input: CountryInput!): Country! @custom(http: {
+										url: "http://mock:8888/setCountry",
+										method: "POST",
+										graphql: "mutation { setCountry() }"
+									})
+	}`
+	res := updateSchema(t, schema)
+	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
+	require.Len(t, res.Errors, 1)
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:59: Type Mutation"+
+		"; Field addCountry: @custom directive: graphql; given mutation: setCountry: required arg"+
+		" country is missing.\n", res.Errors[0].Error())
+}
+
+func TestCustomGraphqlMutation(t *testing.T) {
+	schema := customTypes + `
+	type Mutation {
+		addCountry(input: CountryInput!): Country! @custom(http: {
+										url: "http://mock:8888/setCountry",
+										method: "POST",
+										graphql: "mutation { setCountry(country: $input) }"
+									})
+	}`
+	updateSchemaRequireNoGQLErrors(t, schema)
+
+	params := &common.GraphQLParams{
+		Query: `
+		mutation addCountry($input: CountryInput!) {
+			addCountry(input: $input) {
+				code
+				name
+				states {
+					code
+					name
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{
+			"input": map[string]interface{}{
+				"code": "IN",
+				"name": "India",
+				"states": []interface{}{
+					map[string]interface{}{
+						"code": "RJ",
+						"name": "Rajasthan",
+					},
+					map[string]interface{}{
+						"code": "KA",
+						"name": "Karnataka",
+					},
+				},
+			},
+		},
+	}
+
+	result := params.ExecuteAsPost(t, alphaURL)
+	common.RequireNoGQLErrors(t, result)
+
+	expected := `
+	{
+		"addCountry": {
+			"code": "IN",
+			"name": "India",
+			"states": [
+				{
+					"code": "RJ",
+					"name": "Rajasthan"
+				},
+				{
+					"code": "KA",
+					"name": "Karnataka"
+				}
+			]
+		}
     }`
 	require.JSONEq(t, expected, string(result.Data))
 }

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -255,7 +255,7 @@ func TestCustomHTTPMutation(t *testing.T) {
 			gqlMutation := test.GetMutation(t, op)
 
 			client := newClient(t, tcase)
-			resolver := NewHTTPMutationResolver(client, StdQueryCompletion(), false)
+			resolver := NewHTTPMutationResolver(client, StdQueryCompletion())
 			resolved, isResolved := resolver.Resolve(context.Background(), gqlMutation)
 			require.True(t, isResolved)
 

--- a/graphql/resolve/query_test.go
+++ b/graphql/resolve/query_test.go
@@ -156,7 +156,7 @@ func TestCustomHTTPQuery(t *testing.T) {
 			gqlQuery := test.GetQuery(t, op)
 
 			client := newClient(t, tcase)
-			resolver := NewHTTPQueryResolver(client, StdQueryCompletion(), false)
+			resolver := NewHTTPQueryResolver(client, StdQueryCompletion())
 			resolved := resolver.Resolve(context.Background(), gqlQuery)
 			b, err := json.Marshal(resolved.Data)
 			require.NoError(t, err)

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -255,15 +255,6 @@ var scalarToDgraph = map[string]string{
 	"Password": "password",
 }
 
-// graphqlScalarType holds all the scalar types supported by the graphql spec.
-var graphqlScalarType = map[string]bool{
-	"Int":     true,
-	"Float":   true,
-	"String":  true,
-	"Boolean": true,
-	"ID":      true,
-}
-
 var directiveValidators = map[string]directiveValidator{
 	inverseDirective: hasInverseValidation,
 	searchDirective:  searchValidation,
@@ -302,6 +293,8 @@ func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	return dst
 }
 
+// expandSchema adds schemaExtras to the doc and adds any fields inherited from interfaces into
+// implementing types
 func expandSchema(doc *ast.SchemaDocument) {
 	docExtras, gqlErr := parser.ParseSchema(&ast.Source{Input: schemaExtras})
 	if gqlErr != nil {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -754,8 +754,34 @@ invalid_schemas:
     {"message": "Type Y; Field f10: has the @dgraph predicate, but that conflicts with type W @secret directive on the same predicate. @secret predicates are stored encrypted and so the same predicate can't be used as a String.",
      "locations":[{"line":22, "column":3}]}]
 
-  -
-    name: "@custom directive with wrong argument name"
+  - name: "input type can't have same name as the type generated for other types"
+    input: |
+      type Author {
+        id: ID!
+      }
+      input UpdateAuthorInput {
+        id: ID!
+      }
+    errlist: [
+    {"message": "UpdateAuthorInput is a reserved word, so you can't declare an input type with this name. Pick a different name for the input type.",
+     "locations":[{"line":4, "column":7}]},
+    ]
+
+  - name: "@custom directive with extra arguments"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {url: "blah.com", method: "GET"}, extra: "random")
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: has 2 arguments for @custom directive, it should contain exactly 1 argument.",
+     "locations":[{"line":6, "column":31}]},
+    ]
+
+  - name: "@custom directive without http argument"
     input: |
       type Author {
         id: ID!
@@ -767,20 +793,6 @@ invalid_schemas:
     errlist: [
       {"message": "Type Query; Field getAuthor: http argument for @custom directive should not be empty.",
       "locations":[{"line":6, "column":31}]},
-    ]
-
-  - name: "@custom directive with wrong argument name"
-    input: |
-      type Author {
-        id: ID!
-      }
-
-      type Query {
-        getAuthor(id: ID): Author! @custom(https: {url: "blah.com", method: "GET"})
-      }
-    errlist: [
-    {"message": "Type Query; Field getAuthor: http argument for @custom directive should not be empty.",
-     "locations":[{"line":6, "column":31}]},
     ]
 
   -
@@ -795,7 +807,7 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Type Query; Field getAuthor; url field inside @custom directive is invalid.",
-      "locations":[{"line":6, "column":31}]},
+      "locations":[{"line":6, "column":51}]},
     ]
 
   -
@@ -809,8 +821,8 @@ invalid_schemas:
         getAuthor(id: ID): Author! @custom(http: {url: "http://google.com/$id", method: "GET"})
       }
     errlist: [
-      {"message": "Type Query; Field getAuthor; url path inside @custom directive uses a field id that can be null.",
-      "locations":[{"line":6, "column":31}]},
+      {"message": "Type Query; Field getAuthor; url path inside @custom directive uses an argument id that can be null.",
+      "locations":[{"line":6, "column":51}]},
     ]
 
   -
@@ -825,20 +837,22 @@ invalid_schemas:
       }
     errlist: [
     {"message": "Type Query; Field getAuthor; method field inside @custom directive can only be GET/POST/PUT/PATCH/DELETE.",
-     "locations":[{"line":6, "column":31}]},
+     "locations":[{"line":6, "column":81}]},
     ]
 
-  - name: "input type can't have same name as the type generated for other types"
+  -
+    name: "@custom directive with operation on Query/Mutation"
     input: |
       type Author {
         id: ID!
       }
-      input UpdateAuthorInput {
-        id: ID!
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {url: "http://google.com/", method: "GET", operation: "single"})
       }
     errlist: [
-    {"message": "UpdateAuthorInput is a reserved word, so you can't declare an input type with this name. Pick a different name for the input type.",
-     "locations":[{"line":4, "column":7}]},
+    {"message": "Type Query; Field getAuthor; operation field inside @custom directive can't be present on Query/Mutation.",
+     "locations":[{"line":6, "column":99}]},
     ]
 
   -
@@ -848,12 +862,317 @@ invalid_schemas:
         id: ID!
       }
 
-      type Query {
-        getAuthor(id: ID): Author! @custom(http: {url: "http://google.com/", method: "GET", operation: "random"})
+      type Post {
+        id: ID!
+        author: Author! @custom(http: {url: "http://google.com/", method: "GET", operation: "random"})
       }
     errlist: [
-      {"message": "Type Query; Field getAuthor; operation field inside @custom directive can only be single/batch.",
-      "locations":[{"line":6, "column":31}]},
+    {"message": "Type Post; Field author; operation field inside @custom directive can only be single/batch.",
+     "locations":[{"line":7, "column":88}]},
+    ]
+
+  -
+    name: "@custom directive with url params and graphql together"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/?q=$id",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor; has parameters in url along with graphql field inside @custom directive, url can't contain parameters if graphql field is present.",
+     "locations":[{"line":6, "column":31}]},
+    ]
+
+
+  -
+    name: "@custom directive with non-POST method and graphql together"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "GET",
+          graphql: "query { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor; has method GET while graphql field is also present inside @custom directive, method can only be POST if graphql field is present.",
+     "locations":[{"line":6, "column":31}]},
+    ]
+
+  -
+    name: "@custom directive with both body and graphql together"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          body: "{id: $id}",
+          graphql: "query { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor; has both body and graphql field inside @custom directive, they can't be present together.",
+     "locations":[{"line":6, "column":31}]},
+    ]
+
+  -
+    name: "@custom directive with empty graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "   "
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 0 operations, it can have exactly one operation.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with invalid graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) } garbage"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; unable to parse input: 30: Unexpected Name \"garbage\"",
+     "locations":[{"line":8, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with multiple operations in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) } query { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 2 operations, it can have exactly one operation.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with non query/mutation operation"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "subscription { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found subscription operation, it can only have query/mutation.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with operation name in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query opName { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with name opName, it can't have a name.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with variable definitions in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query ($id: ID){ getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with variables, it can't have any variable definitions.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with directives in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query @test { getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with directives, it can't have any directives.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with multiple fields in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) getUser(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 2 fields inside operation query, it can have exactly one field.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with alias for field in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "mutation { authors: getAuthor(id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found mutation getAuthor with alias authors, it can't have any alias.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with return type for field in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id): Author! }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; unable to parse input: 27: Expected Name, found :",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with directive on field in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) @test }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found query getAuthor with directives, it can't have any directives.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with selection set on field in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id) { id } }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found query getAuthor with a selection set, it can't have any selection set.",
+     "locations":[{"line":9, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with repeating arguments for field in operation in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+      type Query {
+        getAuthor(id: ID): Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          graphql: "query { getAuthor(id: $id, id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Query; Field getAuthor: @custom directive: graphql; given query: getAuthor: arguments [id ] appear more than once, each argument can appear only once.",
+     "locations":[{"line":8, "column":15}]},
     ]
 
   -
@@ -870,7 +1189,7 @@ invalid_schemas:
     errlist: [
       {"message": "Type Author; Field name; @custom directive, body template must use fields
        defined within the type, found: abc.",
-      "locations":[{"line":3, "column":18}]},
+      "locations":[{"line":6, "column":12}]},
     ]
 
   -
@@ -886,7 +1205,7 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Type Author; Field name; @custom directive, body template can't require itself.",
-      "locations":[{"line":3, "column":18}]},
+       "locations":[{"line":6, "column":12}]},
     ]
 
   -
@@ -922,7 +1241,7 @@ invalid_schemas:
     errlist: [
       {"message": "Type Author; Field yo: @custom directive, body template must use a field with type
       ID! or a field with @id directive.",
-      "locations":[{"line":5, "column":16}]},
+      "locations":[{"line":8, "column":12}]},
     ]
 
   -
@@ -1004,7 +1323,7 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Type Author; Field name; url path inside @custom directive uses a field fooz that is not defined.",
-          "locations":[{"line":4, "column":18}]},
+          "locations":[{"line":5, "column":11}]},
         ]
 
   -
@@ -1022,7 +1341,7 @@ invalid_schemas:
       }
     errlist: [
       {"message": "Type Author; Field name; url path inside @custom directive uses a field foo that can be null.",
-          "locations":[{"line":5, "column":18}]},
+          "locations":[{"line":6, "column":11}]},
         ]
 
 valid_schemas:

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -24,9 +24,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
-	"github.com/vektah/gqlparser/v2/gqlerror"
-	"github.com/vektah/gqlparser/v2/parser"
 )
 
 // introspectRemoteSchema introspectes remote schema
@@ -41,7 +40,7 @@ func introspectRemoteSchema(url string) (*IntrospectedSchema, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
 	}
@@ -148,189 +147,144 @@ const introspectionQuery = `
   `
 
 type remoteGraphqlEndpoint struct {
-	graphqlArg *ast.Argument
-	rootQuery  *ast.Definition
-	schema     *ast.Schema
-	field      *ast.FieldDefinition
-	directive  *ast.Directive
-	url        string
+	parentType   *ast.Definition
+	parentField  *ast.FieldDefinition
+	graphqlOpDef *ast.OperationDefinition
+	url          string
 }
 
-func validateRemoteGraphqlCall(endpoint *remoteGraphqlEndpoint) *gqlerror.Error {
-	query := endpoint.graphqlArg.Value.Children.ForName("query")
-	if query == nil {
-		return gqlerror.ErrorPosf(
-			endpoint.directive.Position,
-			"Type %s; Field %s; query field inside @custom directive is mandatory.",
-			endpoint.rootQuery.Name,
-			endpoint.field.Name)
-	}
-	parsedQuery, gqlErr := parser.ParseQuery(&ast.Source{Input: fmt.Sprintf(`query {%s}`,
-		query.Raw)})
-	if gqlErr != nil {
-		return gqlErr
-	}
-
-	if len(parsedQuery.Operations[0].SelectionSet) > 1 {
-		return gqlerror.ErrorPosf(
-			endpoint.directive.Position,
-			"Type %s; Field %s; only one query is possible inside query argument. For eg:"+
-				" valid input: @custom(..., graphql:{ query: \"getUser(id: $id)\"})"+"invalid input:"+
-				"@custom(..., graphql:{query: \"getUser(id: $id) getAuthor(id: $id)\"})",
-			endpoint.rootQuery.Name,
-			endpoint.field.Name)
-	}
-
-	// Validate given remote query is present in the remote schema or not.
-	remoteQuery := parsedQuery.Operations[0].SelectionSet[0].(*ast.Field)
-
-	// remoteQuery should not contain any selection set.
-	// for eg: bla(..){
-	// 	..
-	// }
-	if len(remoteQuery.SelectionSet) != 0 {
-		return gqlerror.ErrorPosf(
-			endpoint.directive.Position, "Type %s; Field %s;Remote query %s should not contain"+
-				" any selection statement. eg: Remote query should be like this %s(...) and not"+
-				" like %s(..){...}", endpoint.rootQuery.Name,
-			endpoint.field.Name,
-			remoteQuery.Name,
-			remoteQuery.Name,
-			remoteQuery.Name)
-	}
-
-	// Check whether the given argument and query is present in the remote schema by introspecting.
+// Check whether the given argument and query is present in the remote schema by introspecting.
+func validateRemoteGraphqlCall(endpoint *remoteGraphqlEndpoint) error {
 	remoteIntrospection, err := introspectRemoteSchema(endpoint.url)
 	if err != nil {
-		return gqlerror.ErrorPosf(
-			endpoint.directive.Position, "Type %s; Field %s; unable to introspect remote schema"+
-				" for the url %s", endpoint.rootQuery.Name,
-			endpoint.field.Name,
-			endpoint.url)
+		return err
+	}
+
+	var remoteQueryTypename string
+	operationType := endpoint.graphqlOpDef.Operation
+	switch operationType {
+	case "query":
+		remoteQueryTypename = remoteIntrospection.Data.Schema.QueryType.Name
+	case "mutation":
+		remoteQueryTypename = remoteIntrospection.Data.Schema.MutationType.Name
+	default:
+		// this case is not possible as we are validating the operation to be query/mutation in
+		// @custom directive validation
 	}
 
 	var introspectedRemoteQuery GqlField
-	queryExist := false
-	for _, types := range remoteIntrospection.Data.Schema.Types {
-		if types.Name != "Query" {
+	remoteQueryExists := false
+	givenQuery := endpoint.graphqlOpDef.SelectionSet[0].(*ast.Field)
+	for _, typ := range remoteIntrospection.Data.Schema.Types {
+		if typ.Name != remoteQueryTypename {
 			continue
 		}
-		for _, queryType := range types.Fields {
-			if queryType.Name == remoteQuery.Name {
-				queryExist = true
-				introspectedRemoteQuery = queryType
+		for _, remoteQuery := range typ.Fields {
+			if remoteQuery.Name == givenQuery.Name {
+				remoteQueryExists = true
+				introspectedRemoteQuery = remoteQuery
+				break
 			}
 		}
+		if remoteQueryExists {
+			break
+		}
 	}
 
-	if !queryExist {
-		return gqlerror.ErrorPosf(
-			endpoint.directive.Position, "Type %s; Field %s; %s is not present in remote schema",
-			endpoint.rootQuery.Name,
-			endpoint.field.Name,
-			remoteQuery.Name)
+	// check whether given query/mutation is present in remote schema
+	if !remoteQueryExists {
+		return errors.Errorf("given %s: %s is not present in remote schema.",
+			operationType, givenQuery.Name)
 	}
 
-	// check whether given arguments are present in the remote query.
-	remoteArguments := collectArgumentsFromQuery(remoteQuery)
-	argValToType := make(map[string]string)
+	// check whether the return type of remote query is same as the required return type
+	// TODO: need to check whether same will work for @custom on fields which have batch operation
+	expectedReturnType := introspectedRemoteQuery.Type.String()
+	gotReturnType := endpoint.parentField.Type.String()
+	if expectedReturnType != gotReturnType {
+		return errors.Errorf("given %s: %s: return type mismatch; expected: %s, got: %s.",
+			operationType, givenQuery.Name, expectedReturnType, gotReturnType)
+	}
 
-	introspectedArgs, notNullArgs := collectArgsFromIntrospection(introspectedRemoteQuery)
+	givenQryArgDefs, givenQryArgVals := getGivenQueryArgsAsMap(givenQuery, endpoint.parentField,
+		endpoint.parentType)
+	remoteQryArgDefs, remoteQryRequiredArgs := getRemoteQueryArgsAsMap(introspectedRemoteQuery)
 
-	for remoteArg, remoteArgVal := range remoteArguments {
-
-		argType, ok := introspectedArgs[remoteArg]
+	// check whether args of given query/mutation match the args of remote query/mutation
+	for givenArgName, givenArgDef := range givenQryArgDefs {
+		remoteArgDef, ok := remoteQryArgDefs[givenArgName]
 		if !ok {
-			return gqlerror.ErrorPosf(
-				endpoint.directive.Position, "Type %s; Field %s; %s arg not present in the remote"+
-					" query %s",
-				endpoint.rootQuery.Name,
-				endpoint.field.Name,
-				remoteArg,
-				remoteQuery.Name)
+			return errors.Errorf("given %s: %s: arg %s not present in remote %s.", operationType,
+				givenQuery.Name, givenArgName, operationType)
 		}
-
-		if _, ok = graphqlScalarType[argType]; !ok {
-			fmt.Println(argType)
-			return gqlerror.ErrorPosf(
-				endpoint.directive.Position, "Type %s; Field %s; %s is not scalar. only scalar"+
-					" argument is supported in the remote graphql call.",
-				endpoint.rootQuery.Name,
-				endpoint.field.Name,
-				remoteArg)
+		if givenArgDef == nil {
+			return errors.Errorf("given %s: %s: variable %s is missing in given context.",
+				operationType, givenQuery.Name, givenQryArgVals[givenArgName])
 		}
-		argValToType[remoteArgVal] = argType
-	}
-
-	// We are only checking whether the required variable is exist in the
-	// local remote call.
-	for requiredArg := range notNullArgs {
-		if _, ok := remoteArguments[requiredArg]; !ok {
-			return gqlerror.ErrorPosf(
-				endpoint.directive.Position, "Type %s; Field %s;%s is a required argument in the "+
-					"remote query %s. But, the %s is not present in the custom logic call for %s. "+
-					"Please provide the required arg in the remote query %s",
-				endpoint.rootQuery.Name,
-				endpoint.field.Name,
-				requiredArg,
-				remoteQuery.Name,
-				requiredArg,
-				remoteQuery.Name,
-				remoteQuery.Name)
+		expectedArgType := remoteArgDef.Type.String()
+		gotArgType := givenArgDef.Type.String()
+		if expectedArgType != gotArgType {
+			return errors.Errorf("given %s: %s: type mismatch for variable %s; expected: %s, "+
+				"got: %s.", operationType, givenQuery.Name, givenQryArgVals[givenArgName],
+				expectedArgType, gotArgType)
 		}
 	}
 
-	// Validate given argument type is matching with the remote query argument.
-	for variable, typeName := range argValToType {
-		localRemoteCallArg := endpoint.field.Arguments.ForName(variable[1:])
-		if localRemoteCallArg == nil {
-			return gqlerror.ErrorPosf(
-				endpoint.directive.Position, `Type %s; Field %s; unable to find the variable %s in 
-				  %s`,
-				endpoint.rootQuery.Name,
-				endpoint.field.Name,
-				variable,
-				endpoint.field.Name)
-		}
-
-		if localRemoteCallArg.Type.Name() != typeName {
-			return gqlerror.ErrorPosf(
-				endpoint.directive.Position, "Type %s; Field %s; expected type for variable  "+
-					"%s is %s. But got %s",
-				endpoint.rootQuery.Name,
-				endpoint.field.Name,
-				variable,
-				typeName,
-				localRemoteCallArg.Type)
+	// check all non-null args required by remote query/mutation are present in given query/mutation
+	for _, remoteArgName := range remoteQryRequiredArgs {
+		_, ok := givenQryArgVals[remoteArgName]
+		if !ok {
+			return errors.Errorf("given %s: %s: required arg %s is missing.", operationType,
+				givenQuery.Name, remoteArgName)
 		}
 	}
+
 	return nil
 }
 
-// collectArgumentsFromQuery will collect all the arguments and values from the query.
-func collectArgumentsFromQuery(query *ast.Field) map[string]string {
-	arguments := make(map[string]string)
-	for _, arg := range query.Arguments {
-		val := arg.Value.String()
-		arguments[arg.Name] = val
+// getGivenQueryArgsAsMap returns following maps:
+// 1. arg name -> *ast.ArgumentDefinition
+// 2. arg name -> argument value (i.e., variable like $id)
+func getGivenQueryArgsAsMap(givenQuery *ast.Field, parentField *ast.FieldDefinition,
+	parentType *ast.Definition) (map[string]*ast.ArgumentDefinition, map[string]string) {
+	argDefMap := make(map[string]*ast.ArgumentDefinition)
+	argValMap := make(map[string]string)
+
+	if parentType.Name == "Query" || parentType.Name == "Mutation" {
+		parentFieldArgMap := getFieldArgDefsAsMap(parentField)
+		for _, arg := range givenQuery.Arguments {
+			varName := arg.Value.String()
+			argDefMap[arg.Name] = parentFieldArgMap[varName[1:]]
+			argValMap[arg.Name] = varName
+		}
+	} else {
+		// TODO: handle @custom graphql validation for fields here
 	}
-	return arguments
+	return argDefMap, argValMap
 }
 
-// collectArgsFromIntrospection will collect all the arguments with it's type and required argument
-func collectArgsFromIntrospection(query GqlField) (map[string]string, map[string]int) {
-	notNullArgs := make(map[string]int)
-	arguments := make(map[string]string)
-	for _, introspectedArg := range query.Args {
-
-		// Collect all the required variable to validate against provided variable.
-		if introspectedArg.Type.Kind == "NOT_NULL" {
-			notNullArgs[introspectedArg.Name] = 0
-		}
-
-		arguments[introspectedArg.Name] = introspectedArg.Type.OfType.Name
+func getFieldArgDefsAsMap(fieldDef *ast.FieldDefinition) map[string]*ast.ArgumentDefinition {
+	argMap := make(map[string]*ast.ArgumentDefinition)
+	for _, v := range fieldDef.Arguments {
+		argMap[v.Name] = v
 	}
-	return arguments, notNullArgs
+	return argMap
+}
+
+// getRemoteQueryArgsAsMap returns following things:
+// 1. map of arg name -> Argument Definition in Gql introspection response format
+// 2. list of arg name for NON_NULL args
+func getRemoteQueryArgsAsMap(remoteQuery GqlField) (map[string]Args, []string) {
+	argDefMap := make(map[string]Args)
+	requiredArgs := make([]string, 0)
+
+	for _, arg := range remoteQuery.Args {
+		argDefMap[arg.Name] = arg
+		if arg.Type.Kind == "NON_NULL" {
+			requiredArgs = append(requiredArgs, arg.Name)
+		}
+	}
+	return argDefMap, requiredArgs
 }
 
 type IntrospectedSchema struct {
@@ -339,20 +293,15 @@ type IntrospectedSchema struct {
 type IntrospectionQueryType struct {
 	Name string `json:"name"`
 }
-type OfType struct {
-	Kind   string      `json:"kind"`
-	Name   string      `json:"name"`
-	OfType interface{} `json:"ofType"`
-}
 type GqlType struct {
-	Kind   string `json:"kind"`
-	Name   string `json:"name"`
-	OfType OfType `json:"ofType"`
+	Kind   string   `json:"kind"`
+	Name   string   `json:"name"`
+	OfType *GqlType `json:"ofType"`
 }
 type GqlField struct {
 	Name              string      `json:"name"`
 	Args              []Args      `json:"args"`
-	Type              GqlType     `json:"type"`
+	Type              *GqlType    `json:"type"`
 	IsDeprecated      bool        `json:"isDeprecated"`
 	DeprecationReason interface{} `json:"deprecationReason"`
 }
@@ -367,7 +316,7 @@ type Types struct {
 }
 type Args struct {
 	Name         string      `json:"name"`
-	Type         GqlType     `json:"type"`
+	Type         *GqlType    `json:"type"`
 	DefaultValue interface{} `json:"defaultValue"`
 }
 type Directives struct {
@@ -377,11 +326,28 @@ type Directives struct {
 }
 type IntrospectionSchema struct {
 	QueryType        IntrospectionQueryType `json:"queryType"`
-	MutationType     interface{}            `json:"mutationType"`
-	SubscriptionType interface{}            `json:"subscriptionType"`
+	MutationType     IntrospectionQueryType `json:"mutationType"`
+	SubscriptionType IntrospectionQueryType `json:"subscriptionType"`
 	Types            []Types                `json:"types"`
 	Directives       []Directives           `json:"directives"`
 }
 type Data struct {
 	Schema IntrospectionSchema `json:"__schema"`
+}
+
+func (t *GqlType) String() string {
+	if t == nil {
+		return ""
+	}
+	// refer http://spec.graphql.org/June2018/#sec-Type-Kinds
+	// it confirms, if type kind is LIST or NON_NULL all other fields except ofType will be
+	// null, so there won't be any name at that level.
+	switch t.Kind {
+	case "LIST":
+		return fmt.Sprintf("[%s]", t.OfType.String())
+	case "NON_NULL":
+		return fmt.Sprintf("%s!", t.OfType.String())
+	default:
+		return t.Name
+	}
 }

--- a/graphql/schema/remote_test.go
+++ b/graphql/schema/remote_test.go
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGqlType_String(t *testing.T) {
+	tcases := []struct {
+		name            string
+		gqlType         *GqlType
+		expectedTypeStr string
+	}{
+		{
+			name:            "Nil type gives empty string",
+			gqlType:         nil,
+			expectedTypeStr: "",
+		},
+		{
+			name: "Scalar type",
+			gqlType: &GqlType{
+				Kind:   "SCALAR",
+				Name:   "Int",
+				OfType: nil,
+			},
+			expectedTypeStr: "Int",
+		},
+		{
+			name: "Non-null Scalar type",
+			gqlType: &GqlType{
+				Kind: "NON_NULL",
+				Name: "",
+				OfType: &GqlType{
+					Kind:   "SCALAR",
+					Name:   "String",
+					OfType: nil,
+				},
+			},
+			expectedTypeStr: "String!",
+		},
+		{
+			name: "Object type",
+			gqlType: &GqlType{
+				Kind:   "OBJECT",
+				Name:   "Author",
+				OfType: nil,
+			},
+			expectedTypeStr: "Author",
+		},
+		{
+			name: "Non-null Object type",
+			gqlType: &GqlType{
+				Kind: "NON_NULL",
+				Name: "",
+				OfType: &GqlType{
+					Kind:   "OBJECT",
+					Name:   "Author",
+					OfType: nil,
+				},
+			},
+			expectedTypeStr: "Author!",
+		},
+		{
+			name: "List of Scalar type",
+			gqlType: &GqlType{
+				Kind: "LIST",
+				Name: "",
+				OfType: &GqlType{
+					Kind:   "SCALAR",
+					Name:   "ID",
+					OfType: nil,
+				},
+			},
+			expectedTypeStr: "[ID]",
+		},
+		{
+			name: "List of Non-null Scalar type",
+			gqlType: &GqlType{
+				Kind: "LIST",
+				Name: "",
+				OfType: &GqlType{
+					Kind: "NON_NULL",
+					Name: "",
+					OfType: &GqlType{
+						Kind:   "SCALAR",
+						Name:   "Float",
+						OfType: nil,
+					},
+				},
+			},
+			expectedTypeStr: "[Float!]",
+		},
+		{
+			name: "Non-null List of Non-null Scalar type",
+			gqlType: &GqlType{
+				Kind: "NON_NULL",
+				Name: "",
+				OfType: &GqlType{
+					Kind: "LIST",
+					Name: "",
+					OfType: &GqlType{
+						Kind: "NON_NULL",
+						Name: "",
+						OfType: &GqlType{
+							Kind:   "SCALAR",
+							Name:   "Boolean",
+							OfType: nil,
+						},
+					},
+				},
+			},
+			expectedTypeStr: "[Boolean!]!",
+		},
+		{
+			name: "List of Object type",
+			gqlType: &GqlType{
+				Kind: "LIST",
+				Name: "",
+				OfType: &GqlType{
+					Kind:   "OBJECT",
+					Name:   "Author",
+					OfType: nil,
+				},
+			},
+			expectedTypeStr: "[Author]",
+		},
+		{
+			name: "List of Non-null Object type",
+			gqlType: &GqlType{
+				Kind: "LIST",
+				Name: "",
+				OfType: &GqlType{
+					Kind: "NON_NULL",
+					Name: "",
+					OfType: &GqlType{
+						Kind:   "OBJECT",
+						Name:   "Author",
+						OfType: nil,
+					},
+				},
+			},
+			expectedTypeStr: "[Author!]",
+		},
+		{
+			name: "Non-null List of Non-null Object type",
+			gqlType: &GqlType{
+				Kind: "NON_NULL",
+				Name: "",
+				OfType: &GqlType{
+					Kind: "LIST",
+					Name: "",
+					OfType: &GqlType{
+						Kind: "NON_NULL",
+						Name: "",
+						OfType: &GqlType{
+							Kind:   "OBJECT",
+							Name:   "Author",
+							OfType: nil,
+						},
+					},
+				},
+			},
+			expectedTypeStr: "[Author!]!",
+		},
+		{
+			name: "Non-null List of List of List of Non-Null Object type",
+			gqlType: &GqlType{
+				Kind: "NON_NULL",
+				Name: "",
+				OfType: &GqlType{
+					Kind: "LIST",
+					Name: "",
+					OfType: &GqlType{
+						Kind: "LIST",
+						Name: "",
+						OfType: &GqlType{
+							Kind: "LIST",
+							Name: "",
+							OfType: &GqlType{
+								Kind: "NON_NULL",
+								Name: "",
+								OfType: &GqlType{
+									Kind:   "OBJECT",
+									Name:   "Author",
+									OfType: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedTypeStr: "[[[Author!]]]!",
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			require.Equal(t, tcase.expectedTypeStr, tcase.gqlType.String())
+		})
+	}
+}

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+	"github.com/vektah/gqlparser/v2/parser"
 	"github.com/vektah/gqlparser/v2/validator"
 )
 
@@ -892,6 +893,7 @@ func customDirectiveValidation(sch *ast.Schema,
 	field *ast.FieldDefinition,
 	dir *ast.Directive) *gqlerror.Error {
 
+	// 1. Validating custom directive itself
 	search := field.Directives.ForName(searchDirective)
 	if search != nil {
 		return gqlerror.ErrorPosf(
@@ -910,75 +912,7 @@ func customDirectiveValidation(sch *ast.Schema,
 		)
 	}
 
-	httpArg := dir.Arguments.ForName("http")
-	if httpArg == nil || httpArg.Value.String() == "" {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s: http argument for @custom directive should not be empty.",
-			typ.Name, field.Name,
-		)
-	}
-	if httpArg.Value.Kind != ast.ObjectValue {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s: http argument for @custom directive should of type Object.",
-			typ.Name, field.Name,
-		)
-	}
-
 	defn := sch.Types[typ.Name]
-	u := httpArg.Value.Children.ForName("url")
-	if u == nil {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s; url field inside @custom directive is mandatory.", typ.Name,
-			field.Name)
-	}
-	parsedURL, err := url.ParseRequestURI(u.Raw)
-	if err != nil {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s; url field inside @custom directive is invalid.", typ.Name,
-			field.Name)
-	}
-
-	elems := strings.Split(parsedURL.Path, "/")
-	for _, elem := range elems {
-		if strings.HasPrefix(elem, "$") {
-			if typ.Name != "Query" && typ.Name != "Mutation" {
-				// For fields url variables come from the fields defined within the type. So we
-				// check that they should be a valid field in the type definition.
-				fd := defn.Fields.ForName(elem[1:])
-				if fd == nil {
-					return gqlerror.ErrorPosf(
-						dir.Position,
-						"Type %s; Field %s; url path inside @custom directive uses a field %s that is "+
-							"not defined.", typ.Name, field.Name, elem[1:])
-				}
-				if !fd.Type.NonNull {
-					return gqlerror.ErrorPosf(
-						dir.Position,
-						"Type %s; Field %s; url path inside @custom directive uses a field %s that "+
-							"can be null.", typ.Name, field.Name, elem[1:])
-				}
-			} else {
-				arg := field.Arguments.ForName(elem[1:])
-				if arg == nil {
-					return gqlerror.ErrorPosf(
-						dir.Position,
-						"Type %s; Field %s; url path inside @custom directive uses a field %s that is "+
-							"not defined.", typ.Name, field.Name, elem[1:])
-				}
-				if !arg.Type.NonNull {
-					return gqlerror.ErrorPosf(
-						dir.Position,
-						"Type %s; Field %s; url path inside @custom directive uses a field %s that "+
-							"can be null.", typ.Name, field.Name, elem[1:])
-				}
-			}
-		}
-	}
-
 	id := getIDField(defn)
 	xid := getXIDField(defn)
 	if typ.Name != "Query" && typ.Name != "Mutation" {
@@ -992,12 +926,170 @@ func customDirectiveValidation(sch *ast.Schema,
 		}
 	}
 
+	// 2. Validating arguments to custom directive
+	l := len(dir.Arguments)
+	if l == 0 || l > 1 {
+		return gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s: has %d arguments for @custom directive, "+
+				"it should contain exactly 1 argument.",
+			typ.Name, field.Name, l,
+		)
+	}
+
+	// 3. Validating http argument
+	httpArg := dir.Arguments.ForName("http")
+	if httpArg == nil || httpArg.Value.String() == "" {
+		return gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s: http argument for @custom directive should not be empty.",
+			typ.Name, field.Name,
+		)
+	}
+	if httpArg.Value.Kind != ast.ObjectValue {
+		return gqlerror.ErrorPosf(
+			httpArg.Position,
+			"Type %s; Field %s: http argument for @custom directive should be of type Object.",
+			typ.Name, field.Name,
+		)
+	}
+
+	// Start validating children of http argument
+
+	// 4. Validating url
+	u := httpArg.Value.Children.ForName("url")
+	if u == nil {
+		return gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s; url field inside @custom directive is mandatory.", typ.Name,
+			field.Name)
+	}
+	parsedURL, err := url.ParseRequestURI(u.Raw)
+	if err != nil {
+		return gqlerror.ErrorPosf(
+			u.Position,
+			"Type %s; Field %s; url field inside @custom directive is invalid.", typ.Name,
+			field.Name)
+	}
+
+	// will be used later while validating graphql field for @custom
+	urlHasParams := false
+	for _, valList := range parsedURL.Query() {
+		for _, val := range valList {
+			if strings.HasPrefix(val, "$") {
+				urlHasParams = true
+				break
+			}
+		}
+		if urlHasParams {
+			break
+		}
+	}
+
+	elems := strings.Split(parsedURL.Path, "/")
+	for _, elem := range elems {
+		if strings.HasPrefix(elem, "$") {
+			urlHasParams = true
+			if typ.Name != "Query" && typ.Name != "Mutation" {
+				// For fields url variables come from the fields defined within the type. So we
+				// check that they should be a valid field in the type definition.
+				fd := defn.Fields.ForName(elem[1:])
+				if fd == nil {
+					return gqlerror.ErrorPosf(
+						u.Position,
+						"Type %s; Field %s; url path inside @custom directive uses a field %s that is "+
+							"not defined.", typ.Name, field.Name, elem[1:])
+				}
+				if !fd.Type.NonNull {
+					return gqlerror.ErrorPosf(
+						u.Position,
+						"Type %s; Field %s; url path inside @custom directive uses a field %s that "+
+							"can be null.", typ.Name, field.Name, elem[1:])
+				}
+			} else {
+				arg := field.Arguments.ForName(elem[1:])
+				if arg == nil {
+					return gqlerror.ErrorPosf(
+						u.Position,
+						"Type %s; Field %s; url path inside @custom directive uses an argument %s"+
+							" that is not defined.", typ.Name, field.Name, elem[1:])
+				}
+				if !arg.Type.NonNull {
+					return gqlerror.ErrorPosf(
+						u.Position,
+						"Type %s; Field %s; url path inside @custom directive uses an argument %s"+
+							" that can be null.", typ.Name, field.Name, elem[1:])
+				}
+			}
+		}
+	}
+
+	// 5. Validating method
+	method := httpArg.Value.Children.ForName("method")
+	if method == nil {
+		return gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s; method field inside @custom directive is mandatory.", typ.Name,
+			field.Name)
+	}
+	if !(method.Raw == "GET" || method.Raw == "POST" || method.Raw == "PUT" || method.
+		Raw == "PATCH" || method.Raw == "DELETE") {
+		return gqlerror.ErrorPosf(
+			method.Position,
+			"Type %s; Field %s; method field inside @custom directive can only be GET/POST/PUT"+
+				"/PATCH/DELETE.",
+			typ.Name, field.Name)
+	}
+
+	// 6. Validating operation
+	operation := httpArg.Value.Children.ForName("operation")
+	if operation != nil {
+		if typ.Name == "Query" || typ.Name == "Mutation" {
+			return gqlerror.ErrorPosf(
+				operation.Position,
+				"Type %s; Field %s; operation field inside @custom directive can't be "+
+					"present on Query/Mutation.", typ.Name, field.Name)
+		}
+
+		op := operation.Raw
+		if op != "single" && op != "batch" {
+			return gqlerror.ErrorPosf(
+				operation.Position,
+				"Type %s; Field %s; operation field inside @custom directive can only be "+
+					"single/batch.", typ.Name, field.Name)
+		}
+	}
+
+	// 7. Validating graphql combination with url params, method and body
 	body := httpArg.Value.Children.ForName("body")
+	graphql := httpArg.Value.Children.ForName("graphql")
+	if graphql != nil {
+		if urlHasParams {
+			return gqlerror.ErrorPosf(dir.Position,
+				"Type %s; Field %s; has parameters in url along with graphql field inside"+
+					" @custom directive, url can't contain parameters if graphql field is present.",
+				typ.Name, field.Name)
+		}
+		if method.Raw != "POST" {
+			return gqlerror.ErrorPosf(dir.Position,
+				"Type %s; Field %s; has method %s while graphql field is also present inside"+
+					" @custom directive, method can only be POST if graphql field is present.",
+				typ.Name, field.Name, method.Raw)
+		}
+		if body != nil {
+			return gqlerror.ErrorPosf(dir.Position,
+				"Type %s; Field %s; has both body and graphql field inside @custom directive, "+
+					"they can't be present together.",
+				typ.Name, field.Name)
+		}
+	}
+
+	// 8. Validating body
 	if body != nil {
 		br := body.Raw
 		_, rf, err := parseBodyTemplate(br)
 		if err != nil {
-			return gqlerror.ErrorPosf(dir.Position,
+			return gqlerror.ErrorPosf(body.Position,
 				"Type %s; Field %s; body template inside @custom directive could not be parsed.",
 				typ.Name, field.Name)
 		}
@@ -1030,7 +1122,7 @@ func customDirectiveValidation(sch *ast.Schema,
 			for fname := range rf {
 				if fname == field.Name {
 					return gqlerror.ErrorPosf(
-						dir.Position,
+						body.Position,
 						"Type %s; Field %s; @custom directive, body template can't require itself.",
 						typ.Name, field.Name,
 					)
@@ -1038,7 +1130,7 @@ func customDirectiveValidation(sch *ast.Schema,
 
 				if fd := typ.Fields.ForName(fname); fd == nil {
 					return gqlerror.ErrorPosf(
-						dir.Position,
+						body.Position,
 						"Type %s; Field %s; @custom directive, body template must use fields defined "+
 							"within the type, found: %s.",
 						typ.Name, field.Name, fname,
@@ -1050,7 +1142,7 @@ func customDirectiveValidation(sch *ast.Schema,
 			}
 			if !requiresID {
 				return gqlerror.ErrorPosf(
-					dir.Position,
+					body.Position,
 					"Type %s; Field %s: @custom directive, body template must use a field with type "+
 						"ID! or a field with @id directive.",
 					typ.Name, field.Name,
@@ -1059,44 +1151,118 @@ func customDirectiveValidation(sch *ast.Schema,
 		}
 	}
 
-	method := httpArg.Value.Children.ForName("method")
-	if method == nil {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s; method field inside @custom directive is mandatory.", typ.Name,
-			field.Name)
-	}
-	if !(method.Raw == "GET" || method.Raw == "POST" || method.Raw == "PUT" || method.
-		Raw == "PATCH" || method.Raw == "DELETE") {
-		return gqlerror.ErrorPosf(
-			dir.Position,
-			"Type %s; Field %s; method field inside @custom directive can only be GET/POST/PUT"+
-				"/PATCH/DELETE.",
-			typ.Name, field.Name)
-	}
-
-	operation := httpArg.Value.Children.ForName("operation")
-	if operation != nil {
-		op := operation.Raw
-		if op != "single" && op != "batch" {
-			return gqlerror.ErrorPosf(
-				dir.Position,
-				"Type %s; Field %s; operation field inside @custom directive can only be "+
-					"single/batch.", typ.Name, field.Name)
+	// 9. Validating graphql
+	if graphql != nil {
+		queryDoc, gqlErr := parser.ParseQuery(&ast.Source{Input: graphql.Raw})
+		if gqlErr != nil {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; unable to parse input: %d: %s",
+				typ.Name, field.Name, gqlErr.Locations[0].Column, gqlErr.Message)
 		}
-	}
-
-	graphqlArg := dir.Arguments.ForName("graphql")
-	if graphqlArg != nil {
-		// This is remote graphql so validate remote graphql end point.
-		return validateRemoteGraphqlCall(&remoteGraphqlEndpoint{
-			graphqlArg: graphqlArg,
-			schema:     sch,
-			field:      field,
-			directive:  dir,
-			rootQuery:  typ,
-			url:        u.Raw,
-		})
+		opCount := len(queryDoc.Operations)
+		if opCount == 0 || opCount > 1 {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %d operations, "+
+					"it can have exactly one operation.",
+				typ.Name, field.Name, opCount,
+			)
+		}
+		opZero := queryDoc.Operations[0]
+		if opZero.Operation != "mutation" && opZero.Operation != "query" {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %s operation, "+
+					"it can only have query/mutation.",
+				typ.Name, field.Name, opZero.Operation,
+			)
+		}
+		if opZero.Name != "" {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found operation with name %s,"+
+					" it can't have a name.",
+				typ.Name, field.Name, opZero.Name,
+			)
+		}
+		if opZero.VariableDefinitions != nil {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found operation with variables,"+
+					" it can't have any variable definitions.",
+				typ.Name, field.Name,
+			)
+		}
+		if opZero.Directives != nil {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found operation with directives, "+
+					"it can't have any directives.",
+				typ.Name, field.Name,
+			)
+		}
+		opSelSetCount := len(opZero.SelectionSet)
+		if opSelSetCount == 0 || opSelSetCount > 1 {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %d fields inside operation"+
+					" %s, it can have exactly one field.",
+				typ.Name, field.Name, opSelSetCount, opZero.Operation,
+			)
+		}
+		query := opZero.SelectionSet[0].(*ast.Field)
+		if query.Alias != query.Name {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %s %s with alias %s, "+
+					"it can't have any alias.",
+				typ.Name, field.Name, opZero.Operation, query.Name, query.Alias,
+			)
+		}
+		// There can't be any ObjectDefinition as it is a query document; if there were, parser
+		// would have given error. So not checking that query.ObjectDefinition is nil
+		if query.Directives != nil {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %s %s with directives, "+
+					"it can't have any directives.",
+				typ.Name, field.Name, opZero.Operation, query.Name,
+			)
+		}
+		if len(query.SelectionSet) != 0 {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; found %s %s with a selection set,"+
+					" it can't have any selection set.",
+				typ.Name, field.Name, opZero.Operation, query.Name,
+			)
+		}
+		if len(query.Arguments) > 0 {
+			argCountMap := make(map[string]int)
+			for _, arg := range query.Arguments {
+				argCountMap[arg.Name] = argCountMap[arg.Name] + 1
+			}
+			repeatingArgs := strings.Builder{}
+			repeatingArgs.WriteRune('[')
+			for argName, count := range argCountMap {
+				if count > 1 {
+					repeatingArgs.WriteString(argName)
+					repeatingArgs.WriteString(" ")
+				}
+			}
+			repeatingArgs.WriteRune(']')
+			repeatingArgsStr := repeatingArgs.String()
+			if repeatingArgsStr != "[]" {
+				return gqlerror.ErrorPosf(graphql.Position,
+					"Type %s; Field %s: @custom directive: graphql; given %s: %s: arguments %s"+
+						" appear more than once, each argument can appear only once.",
+					typ.Name, field.Name, opZero.Operation, query.Name, repeatingArgsStr,
+				)
+			}
+		}
+		// finally validate the given operation on remote server
+		if err := validateRemoteGraphqlCall(&remoteGraphqlEndpoint{
+			parentType:   typ,
+			parentField:  field,
+			graphqlOpDef: opZero,
+			url:          u.Raw,
+		}); err != nil {
+			return gqlerror.ErrorPosf(graphql.Position,
+				"Type %s; Field %s: @custom directive: graphql; %s",
+				typ.Name, field.Name, err.Error(),
+			)
+		}
 	}
 
 	return nil

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1252,7 +1252,7 @@ func customDirectiveValidation(sch *ast.Schema,
 			}
 		}
 		// finally validate the given operation on remote server
-		if err := validateRemoteGraphqlCall(&remoteGraphqlEndpoint{
+		if err := validateRemoteGraphql(&remoteGraphqlMetadata{
 			parentType:   typ,
 			parentField:  field,
 			graphqlOpDef: opZero,

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -28,6 +28,8 @@ import (
 	"strings"
 	"text/scanner"
 
+	"github.com/vektah/gqlparser/v2/parser"
+
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -48,13 +50,12 @@ type QueryType string
 type MutationType string
 
 type FieldHTTPConfig struct {
-	URL             string
-	Method          string
-	Template        *interface{}
-	Operation       string
-	ForwardHeaders  http.Header
-	Body            string
-	RemoteQueryName string
+	URL                string
+	Method             string
+	Template           *interface{}
+	Operation          string
+	ForwardHeaders     http.Header
+	RemoteGqlQueryName string
 }
 
 // Query/Mutation types and arg names
@@ -64,7 +65,6 @@ const (
 	SchemaQuery          QueryType    = "schema"
 	PasswordQuery        QueryType    = "checkPassword"
 	HTTPQuery            QueryType    = "http"
-	GraphqlQuery         QueryType    = "graphql"
 	NotSupportedQuery    QueryType    = "notsupported"
 	AddMutation          MutationType = "add"
 	UpdateMutation       MutationType = "update"
@@ -118,7 +118,7 @@ type Field interface {
 	IncludeInterfaceField(types []interface{}) bool
 	TypeName(dgraphTypes []interface{}) string
 	GetObjectName() string
-	CustomHTTPConfig(graphql bool) (FieldHTTPConfig, error)
+	CustomHTTPConfig() (FieldHTTPConfig, error)
 }
 
 // A Mutation is a field (from the schema's Mutation type) from an Operation
@@ -708,7 +708,7 @@ func (f *field) GetObjectName() string {
 	return f.field.ObjectDefinition.Name
 }
 
-func getCustomHTTPConfig(f *field, isQueryOrMutation bool, graphql bool) (FieldHTTPConfig, error) {
+func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, error) {
 	typeDef := f.op.inSchema.schema.Types[f.GetObjectName()]
 	tf := typeDef.Fields.ForName(f.Name())
 	custom := tf.Directives.ForName(customDirective)
@@ -718,18 +718,23 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool, graphql bool) (FieldH
 		Method: httpArg.Value.Children.ForName("method").Raw,
 	}
 
+	// both body and graphql can't be present together
 	bodyArg := httpArg.Value.Children.ForName("body")
+	graphqlArg := httpArg.Value.Children.ForName("graphql")
+	var bodyTemplate string
 	if bodyArg != nil {
-		bodyTemplate := bodyArg.Raw
-		if !graphql {
-			bt, _, err := parseBodyTemplate(bodyTemplate)
-			if err != nil {
-				return fconf, err
-			}
-			fconf.Template = bt
-		}
-		fconf.Body = bodyTemplate
+		bodyTemplate = bodyArg.Raw
+	} else if graphqlArg != nil {
+		bodyTemplate = `{ query: $query, variables: $variables }`
 	}
+	if bodyTemplate != "" {
+		bt, _, err := parseBodyTemplate(bodyTemplate)
+		if err != nil {
+			return fconf, err
+		}
+		fconf.Template = bt
+	}
+
 	forwardHeaders := httpArg.Value.Children.ForName("forwardHeaders")
 	if forwardHeaders != nil {
 		headers := http.Header{}
@@ -740,52 +745,38 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool, graphql bool) (FieldH
 	}
 
 	// if it is a query or mutation, substitute the vars in URL and Body here itself
-	if isQueryOrMutation && !graphql {
+	if isQueryOrMutation {
 		var err error
 		argMap := f.field.ArgumentMap(f.op.vars)
-		fconf.URL, err = SubstituteVarsInURL(fconf.URL, argMap)
-		if err != nil {
-			return fconf, errors.Wrapf(err, "while substituting vars in URL")
+		var bodyVars map[string]interface{}
+		// url params can exist only with body, and not with graphql
+		if graphqlArg == nil {
+			fconf.URL, err = SubstituteVarsInURL(fconf.URL, argMap)
+			if err != nil {
+				return fconf, errors.Wrapf(err, "while substituting vars in URL")
+			}
+			bodyVars = argMap
+		} else {
+			queryDoc, gqlErr := parser.ParseQuery(&ast.Source{Input: graphqlArg.Raw})
+			if gqlErr != nil {
+				return fconf, err
+			}
+			// queryDoc will always have only one operation with only one field
+			fconf.RemoteGqlQueryName = queryDoc.Operations[0].SelectionSet[0].(*ast.Field).Name
+			buf := &bytes.Buffer{}
+			buildGraphqlRequestFields(buf, f.field)
+			remoteQuery := graphqlArg.Raw
+			remoteQuery = remoteQuery[:strings.LastIndex(remoteQuery, "}")]
+			remoteQuery = fmt.Sprintf("%s%s}", remoteQuery, buf.String())
+			bodyVars = make(map[string]interface{})
+			bodyVars["query"] = remoteQuery
+			bodyVars["variables"] = argMap
 		}
 		if fconf.Template != nil {
-			if err = SubstituteVarsInBody(fconf.Template, argMap); err != nil {
+			if err = SubstituteVarsInBody(fconf.Template, bodyVars); err != nil {
 				return fconf, errors.Wrapf(err, "while substituting vars in Body")
 			}
 		}
-	} else if graphql {
-		graphqlArg := custom.Arguments.ForName("graphql")
-		remoteQuery := graphqlArg.Value.Children.ForName("query").Raw
-		queryEndIndex := strings.Index(remoteQuery, "(")
-		fconf.RemoteQueryName = strings.TrimSpace(remoteQuery[:queryEndIndex])
-		argMap := f.field.ArgumentMap(f.op.vars)
-
-		for _, arg := range f.field.Definition.Arguments {
-			val, ok := argMap[arg.Name]
-			if !ok {
-				continue
-			}
-			value := ""
-			if arg.Type.Name() == "String" || arg.Type.Name() == "ID" || val == nil {
-				if val == nil {
-					val = "null"
-				}
-				value = `"` + fmt.Sprintf("%+v", val) + `"`
-			}
-			remoteQuery = strings.ReplaceAll(remoteQuery, "$"+arg.Name, value)
-		}
-		buf := &bytes.Buffer{}
-		buildGraphqlRequestFields(buf, f.field)
-		remoteQuery += buf.String()
-		// contact method and request object
-		remoteQuery = `query{` + remoteQuery + `}`
-		param := Request{
-			Query: remoteQuery,
-		}
-		remoteQueryBuf, err := json.Marshal(param)
-		if err != nil {
-			return fconf, err
-		}
-		fconf.Body = string(remoteQueryBuf)
 	} else {
 		fconf.Operation = "batch"
 		op := httpArg.Value.Children.ForName("operation")
@@ -796,8 +787,8 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool, graphql bool) (FieldH
 	return fconf, nil
 }
 
-func (f *field) CustomHTTPConfig(graphql bool) (FieldHTTPConfig, error) {
-	return getCustomHTTPConfig(f, false, graphql)
+func (f *field) CustomHTTPConfig() (FieldHTTPConfig, error) {
+	return getCustomHTTPConfig(f, false)
 }
 
 func (f *field) SelectionSet() (flds []Field) {
@@ -935,8 +926,8 @@ func (q *query) GetObjectName() string {
 	return q.field.ObjectDefinition.Name
 }
 
-func (q *query) CustomHTTPConfig(graphql bool) (FieldHTTPConfig, error) {
-	return getCustomHTTPConfig((*field)(q), true, graphql)
+func (q *query) CustomHTTPConfig() (FieldHTTPConfig, error) {
+	return getCustomHTTPConfig((*field)(q), true)
 }
 
 func (q *query) QueryType() QueryType {
@@ -946,9 +937,6 @@ func (q *query) QueryType() QueryType {
 func queryType(name string, custom *ast.Directive) QueryType {
 	switch {
 	case custom != nil:
-		if custom.Arguments.ForName("graphql") != nil {
-			return GraphqlQuery
-		}
 		return HTTPQuery
 	case strings.HasPrefix(name, "get"):
 		return GetQuery
@@ -1072,8 +1060,8 @@ func (m *mutation) MutatedType() Type {
 	return m.op.inSchema.mutatedType[m.Name()]
 }
 
-func (m *mutation) CustomHTTPConfig(graphql bool) (FieldHTTPConfig, error) {
-	return getCustomHTTPConfig((*field)(m), true, graphql)
+func (m *mutation) CustomHTTPConfig() (FieldHTTPConfig, error) {
+	return getCustomHTTPConfig((*field)(m), true)
 }
 
 func (m *mutation) GetObjectName() string {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -50,11 +50,13 @@ type QueryType string
 type MutationType string
 
 type FieldHTTPConfig struct {
-	URL                string
-	Method             string
-	Template           *interface{}
-	Operation          string
-	ForwardHeaders     http.Header
+	URL    string
+	Method string
+	// would be nil if there is no http body
+	Template       *interface{}
+	Operation      string
+	ForwardHeaders http.Header
+	// would be empty for non-GraphQL requests
 	RemoteGqlQueryName string
 }
 
@@ -727,6 +729,7 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 	} else if graphqlArg != nil {
 		bodyTemplate = `{ query: $query, variables: $variables }`
 	}
+	// bodyTemplate will be empty if there was no body or graphql, like the case of a simple GET req
 	if bodyTemplate != "" {
 		bt, _, err := parseBodyTemplate(bodyTemplate)
 		if err != nil {

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -354,6 +354,13 @@ func TestSubstituteVarsInBody(t *testing.T) {
 			nil,
 		},
 		{
+			"substitutes nil variables correctly",
+			map[string]interface{}{"id": nil},
+			map[string]interface{}{"author": "$id"},
+			map[string]interface{}{"author": nil},
+			nil,
+		},
+		{
 			"substitutes variables with an array in template correctly",
 			map[string]interface{}{"id": "0x3", "admin": false, "postID": "0x9",
 				"text": "Random comment", "age": 28},


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.

This PR adds support for mutations on remote GraphQL endpoints through graphql.
```graphql
type Mutation {
     // Note - The input/return payload here should be something that the user should
     // have defined or we should have.
     updateMyFavoriteUsers(input: [User!]): AddUserPayload @custom(input: {
              url: "http://api-gateway.com/graphql",
              method: "POST"
              graphql: "mutation { updateUsers(input: $input) }"
     })
}
```

Something like the above is now possible. It is possible to pass the input parameters in the graphql request.

### GitHub Issue or Jira number.

Fixes #GRAPHQL-325

### Other components or 3rd party tools affected (or regression areas).

None

### Affected releases.

<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

 \>= 20.07.0

### Changelog tags.

added support for mutations on remote GraphQL endpoints through graphql.

### Please indicate if this is a breaking change.

No

### Please indicate if this is an enterprise feature.

No

### Please indicate if documentation needs to be updated.

Yes

### Please indicate if end to end testing is needed.

No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5264)
<!-- Reviewable:end -->
