### PR TITLE
Enable draining mode when doing an online restore.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -570,6 +570,10 @@ func (n *node) applyCommitted(proposal *pb.Proposal) error {
 		return nil
 
 	case proposal.Restore != nil:
+		// Enable draining mode for the duration of the restore processing.
+		x.UpdateDrainingMode(true)
+		defer x.UpdateDrainingMode(false)
+
 		if err := handleRestoreProposal(ctx, proposal.Restore); err != nil {
 			return err
 		}

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -116,7 +116,6 @@ func (w *grpcWorker) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.S
 
 // TODO(DGRAPH-1220): Online restores support passing the backup id.
 // TODO(DGRAPH-1230): Track restore operations.
-// TODO(DGRAPH-1231): Use draining mode during restores.
 // TODO(DGRAPH-1232): Ensure all groups receive the restore proposal.
 func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 	if req == nil {


### PR DESCRIPTION
While doing an online restore, queries and mutations should be
disallowed.

Fixes DGRAPH-1231

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5265)
<!-- Reviewable:end -->
