### PR TITLE
graphql: Resolve fields through custom GraphQL endpoints

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1177,14 +1177,16 @@ type request struct {
 	Query string
 }
 
-var userReqRegex *regexp.Regexp
+var (
+	userRegex    = regexp.MustCompile(`query{userName\(id\: \"([a-z0-9]+)\"\)}`)
+	carRegex     = regexp.MustCompile(`query{car\(id\: \"([a-z0-9]+)\"\){\nname\n}}`)
+	schoolRegex  = regexp.MustCompile(`query{schoolName\(id\: \"([a-z0-9]+)\"\)}`)
+	teacherRegex = regexp.MustCompile(`query{teacherName\(id\: \"([a-z0-9]+)\"\)}`)
+	classRegex   = regexp.MustCompile(`query{class\(id\: \"([a-z0-9]+)\"\){\nname\n}}`)
+)
 
-func init() {
-	userReqRegex = regexp.MustCompile(`query{userName\(id\: \"([a-z0-9]+)\"\)}`)
-}
-
-func verifyUserQuery(q string) string {
-	matches := userReqRegex.FindStringSubmatch(q)
+func verifyQuery(reg *regexp.Regexp, q string) string {
+	matches := reg.FindStringSubmatch(q)
 	if len(matches) == 2 {
 		return matches[1]
 	}
@@ -1206,8 +1208,13 @@ func gqlUserNameHandler(w http.ResponseWriter, r *http.Request) {
 	if err := json.Unmarshal(b, &req); err != nil {
 		return
 	}
-	userId := verifyUserQuery(req.Query)
-	fmt.Println("userId: ", userId)
+	userID := verifyQuery(userRegex, req.Query)
+	fmt.Fprintf(w, `
+	{
+		"data": {
+		  "userName": "uname-%s"
+		}
+	}`, userID)
 }
 
 func gqlCarHandler(w http.ResponseWriter, r *http.Request) {
@@ -1216,11 +1223,26 @@ func gqlCarHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// FIXME - Return type isn't validated yet.
 	if strings.Contains(string(b), "__schema") {
 		fmt.Fprintf(w, introspectedSchemaForGetQuery("car"))
 		return
 	}
-	fmt.Println("body: ", string(b))
+
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return
+	}
+
+	userID := verifyQuery(carRegex, req.Query)
+	fmt.Fprintf(w, `
+	{
+		"data": {
+		  	"car": {
+				"name": "car-%s"
+			}
+		}
+	}`, userID)
 }
 
 func gqlClassHandler(w http.ResponseWriter, r *http.Request) {
@@ -1233,7 +1255,20 @@ func gqlClassHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, introspectedSchemaForGetQuery("class"))
 		return
 	}
-	fmt.Println("body: ", string(b))
+
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return
+	}
+	schoolID := verifyQuery(classRegex, req.Query)
+	fmt.Fprintf(w, `
+	{
+		"data": {
+		  "class": [{
+			  "name": "class-%s"
+		  }]
+		}
+	}`, schoolID)
 }
 
 func gqlTeacherNameHandler(w http.ResponseWriter, r *http.Request) {
@@ -1246,7 +1281,18 @@ func gqlTeacherNameHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, introspectedSchemaForGetQuery("teacherName"))
 		return
 	}
-	fmt.Println("body: ", string(b))
+
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return
+	}
+	teacherID := verifyQuery(teacherRegex, req.Query)
+	fmt.Fprintf(w, `
+	{
+		"data": {
+		  "teacherName": "tname-%s"
+		}
+	}`, teacherID)
 }
 
 func gqlSchoolNameHandler(w http.ResponseWriter, r *http.Request) {
@@ -1259,7 +1305,18 @@ func gqlSchoolNameHandler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, introspectedSchemaForGetQuery("schoolName"))
 		return
 	}
-	fmt.Println("body: ", string(b))
+
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return
+	}
+	schoolID := verifyQuery(schoolRegex, req.Query)
+	fmt.Fprintf(w, `
+	{
+		"data": {
+		  "schoolName": "sname-%s"
+		}
+	}`, schoolID)
 }
 
 func main() {

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1184,7 +1184,7 @@ func gqlUserNameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectedSchemaForQuery("userName", "id"))
+		fmt.Fprint(w, introspectedSchemaForQuery("userName", "id"))
 		return
 	}
 
@@ -1354,7 +1354,7 @@ func gqlTeacherNameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectedSchemaForQuery("teacherName", "id"))
+		fmt.Fprint(w, introspectedSchemaForQuery("teacherName", "id"))
 		return
 	}
 
@@ -1378,7 +1378,7 @@ func gqlSchoolNameHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectedSchemaForQuery("schoolName", "id"))
+		fmt.Fprint(w, introspectedSchemaForQuery("schoolName", "id"))
 		return
 	}
 
@@ -1479,7 +1479,7 @@ func gqlUserNamesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectionResult("userNames"))
+		fmt.Fprint(w, introspectionResult("userNames"))
 		return
 	}
 
@@ -1487,7 +1487,7 @@ func gqlUserNamesHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	fmt.Fprintf(w, res)
+	fmt.Fprint(w, res)
 }
 
 func gqlTeacherNamesHandler(w http.ResponseWriter, r *http.Request) {
@@ -1497,7 +1497,7 @@ func gqlTeacherNamesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectionResult("teacherNames"))
+		fmt.Fprint(w, introspectionResult("teacherNames"))
 		return
 	}
 
@@ -1505,7 +1505,7 @@ func gqlTeacherNamesHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	fmt.Fprintf(w, res)
+	fmt.Fprint(w, res)
 }
 
 func gqlSchoolNamesHandler(w http.ResponseWriter, r *http.Request) {
@@ -1515,7 +1515,7 @@ func gqlSchoolNamesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectionResult("schoolNames"))
+		fmt.Fprint(w, introspectionResult("schoolNames"))
 		return
 	}
 
@@ -1523,7 +1523,7 @@ func gqlSchoolNamesHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	fmt.Fprintf(w, res)
+	fmt.Fprint(w, res)
 }
 
 func gqlCarsHandler(w http.ResponseWriter, r *http.Request) {

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1125,6 +1125,118 @@ func schoolNameHandler(w http.ResponseWriter, r *http.Request) {
 	nameHandler(w, r, &inputBody)
 }
 
+func introspectedSchemaForGetQuery(fieldName string) string {
+	return fmt.Sprintf(`{
+		"data":{
+			"__schema":{
+			"queryType":{
+				"name":"Query"
+			},
+			"mutationType":null,
+			"subscriptionType":null,
+			"types":[
+				{
+				"kind":"OBJECT",
+				"name":"Query",
+				"fields":[
+					{
+					"name":"%s",
+					"args":[
+						{
+						"name":"id",
+						"type":{
+							"kind":"NON_NULL",
+							"name":null,
+							"ofType":{
+								"kind":"SCALAR",
+								"name":"ID",
+								"ofType":null
+							}
+						},
+						"defaultValue":null
+						}
+					],
+					"type":{
+						"kind":"SCALAR",
+						"name":"String",
+						"ofType":null
+					},
+					"isDeprecated":false,
+					"deprecationReason":null
+					}
+				]
+				}
+			]
+			}
+		}
+	}`, fieldName)
+}
+
+func gqlUserNameHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectedSchemaForGetQuery("userName"))
+		return
+	}
+	fmt.Println("body: ", string(b))
+}
+
+func gqlCarHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectedSchemaForGetQuery("car"))
+		return
+	}
+	fmt.Println("body: ", string(b))
+}
+
+func gqlClassHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectedSchemaForGetQuery("class"))
+		return
+	}
+	fmt.Println("body: ", string(b))
+}
+
+func gqlTeacherNameHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectedSchemaForGetQuery("teacherName"))
+		return
+	}
+	fmt.Println("body: ", string(b))
+}
+
+func gqlSchoolNameHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectedSchemaForGetQuery("schoolName"))
+		return
+	}
+	fmt.Println("body: ", string(b))
+}
+
 func main() {
 
 	// for queries
@@ -1148,6 +1260,7 @@ func main() {
 	http.HandleFunc("/favMoviesUpdate/", favMoviesUpdateHandler)
 	http.HandleFunc("/favMoviesDelete/", favMoviesDeleteHandler)
 
+	// The endpoints below are for testing custom resolution of fields within type definitions.
 	// for testing batch mode
 	http.HandleFunc("/userNames", userNamesHandler)
 	http.HandleFunc("/cars", carsHandler)
@@ -1161,6 +1274,15 @@ func main() {
 	http.HandleFunc("/class", classHandler)
 	http.HandleFunc("/teacherName", teacherNameHandler)
 	http.HandleFunc("/schoolName", schoolNameHandler)
+
+	// endpoints for testing custom resolution of fields within type definitions using GraphQL
+	// resolvers.
+	// for testing single mode
+	http.HandleFunc("/gqlUserName", gqlUserNameHandler)
+	http.HandleFunc("/gqlCar", gqlCarHandler)
+	http.HandleFunc("/gqlClass", gqlClassHandler)
+	http.HandleFunc("/gqlTeacherName", gqlTeacherNameHandler)
+	http.HandleFunc("/gqlSchoolName", gqlSchoolNameHandler)
 
 	fmt.Println("Listening on port 8888")
 	log.Fatal(http.ListenAndServe(":8888", nil))

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1395,6 +1395,83 @@ func gqlSchoolNameHandler(w http.ResponseWriter, r *http.Request) {
 	}`, schoolID)
 }
 
+func introspectionResult(name string) string {
+	return fmt.Sprintf(`{
+		"data":{
+			"__schema":{
+			"queryType":{
+				"name":"Query"
+			},
+			"mutationType":null,
+			"subscriptionType":null,
+			"types":[
+				{
+				"kind":"OBJECT",
+				"name":"Query",
+				"fields":[
+					{
+					"name":"%s",
+					"args":[
+						{
+						"name":"input",
+						"type":{
+							"kind":"LIST",
+							"name":null,
+							"ofType": {
+								"kind": "OBJECT",
+								"name": "UserInput",
+								"ofType": null
+							}
+						},
+						"defaultValue":null
+						}
+					],
+					"type":{
+						"kind": "LIST",
+						"name": null,
+						"ofType": {
+							"kind":"SCALAR",
+							"name":"String",
+							"ofType":null
+						}
+					},
+					"isDeprecated":false,
+					"deprecationReason":null
+					}
+				]
+				}
+			]
+			}
+		}
+	}`, name)
+}
+
+func makeResponse(b []byte, id, key, prefix string) (string, error) {
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return "", err
+	}
+	input := req.Variables["input"]
+	output := []string{}
+	for _, i := range input.([]interface{}) {
+		im := i.(map[string]interface{})
+		id := im[id].(string)
+		output = append(output, prefix+id)
+	}
+
+	response := map[string]interface{}{
+		"data": map[string]interface{}{
+			key: output,
+		},
+	}
+
+	b, err := json.Marshal(response)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 func gqlUserNamesHandler(w http.ResponseWriter, r *http.Request) {
 	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -1402,22 +1479,227 @@ func gqlUserNamesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if strings.Contains(string(b), "__schema") {
-		fmt.Fprintf(w, introspectedSchemaForQuery("userNames", "ids"))
+		fmt.Fprintf(w, introspectionResult("userNames"))
 		return
 	}
 
-	fmt.Println(string(b))
+	res, err := makeResponse(b, "id", "userNames", "uname-")
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, res)
+}
+
+func gqlTeacherNamesHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectionResult("teacherNames"))
+		return
+	}
+
+	res, err := makeResponse(b, "tid", "teacherNames", "tname-")
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, res)
+}
+
+func gqlSchoolNamesHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, introspectionResult("schoolNames"))
+		return
+	}
+
+	res, err := makeResponse(b, "id", "schoolNames", "sname-")
+	if err != nil {
+		return
+	}
+	fmt.Fprintf(w, res)
+}
+
+func gqlCarsHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, `{
+			"data":{
+				"__schema":{
+				"queryType":{
+					"name":"Query"
+				},
+				"mutationType":null,
+				"subscriptionType":null,
+				"types":[
+					{
+					"kind":"OBJECT",
+					"name":"Query",
+					"fields":[
+						{
+						"name":"cars",
+						"args":[
+							{
+							"name":"input",
+							"type":{
+								"kind":"LIST",
+								"name":null,
+								"ofType": {
+									"kind": "OBJECT",
+									"name": "UserInput",
+									"ofType": null
+								}
+							},
+							"defaultValue":null
+							}
+						],
+						"type":{
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind":"OBJECT",
+								"name":"Car",
+								"ofType":null
+							}
+						},
+						"isDeprecated":false,
+						"deprecationReason":null
+						}
+					]
+					}
+				]
+				}
+			}
+		}`)
+		return
+	}
+
 	var req request
 	if err := json.Unmarshal(b, &req); err != nil {
 		return
 	}
-	userID := req.Variables["id"]
-	fmt.Fprintf(w, `
-	{
-		"data": {
-		  "userName": "uname-%s"
-		}
-	}`, userID)
+	input := req.Variables["input"]
+	output := []interface{}{}
+	for _, i := range input.([]interface{}) {
+		im := i.(map[string]interface{})
+		id := im["id"].(string)
+		output = append(output, map[string]interface{}{
+			"name": "car-" + id,
+		})
+	}
+
+	response := map[string]interface{}{
+		"data": map[string]interface{}{
+			"cars": output,
+		},
+	}
+
+	b, err = json.Marshal(response)
+	if err != nil {
+		return
+	}
+	check2(fmt.Fprint(w, string(b)))
+}
+
+func gqlClassesHandler(w http.ResponseWriter, r *http.Request) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+
+	if strings.Contains(string(b), "__schema") {
+		fmt.Fprintf(w, `{
+			"data":{
+				"__schema":{
+				"queryType":{
+					"name":"Query"
+				},
+				"mutationType":null,
+				"subscriptionType":null,
+				"types":[
+					{
+					"kind":"OBJECT",
+					"name":"Query",
+					"fields":[
+						{
+						"name":"classes",
+						"args":[
+							{
+							"name":"input",
+							"type":{
+								"kind":"LIST",
+								"name":null,
+								"ofType": {
+									"kind": "OBJECT",
+									"name": "UserInput",
+									"ofType": null
+								}
+							},
+							"defaultValue":null
+							}
+						],
+						"type":{
+							"kind": "LIST",
+							"name": null,
+							"ofType": {
+								"kind": "LIST",
+								"name": null,
+								"ofType": {
+									"kind":"OBJECT",
+									"name":"Class",
+									"ofType":null
+								}
+							}
+						},
+						"isDeprecated":false,
+						"deprecationReason":null
+						}
+					]
+					}
+				]
+				}
+			}
+		}`)
+		return
+	}
+
+	var req request
+	if err := json.Unmarshal(b, &req); err != nil {
+		return
+	}
+	input := req.Variables["input"]
+	output := []interface{}{}
+	for _, i := range input.([]interface{}) {
+		im := i.(map[string]interface{})
+		id := im["id"].(string)
+		output = append(output, []map[string]interface{}{
+			{
+				"name": "class-" + id,
+			},
+		})
+	}
+
+	response := map[string]interface{}{
+		"data": map[string]interface{}{
+			"classes": output,
+		},
+	}
+
+	b, err = json.Marshal(response)
+	if err != nil {
+		return
+	}
+	check2(fmt.Fprint(w, string(b)))
 }
 
 func main() {
@@ -1469,6 +1751,10 @@ func main() {
 
 	// for testing in batch mode
 	http.HandleFunc("/gqlUserNames", gqlUserNamesHandler)
+	http.HandleFunc("/gqlCars", gqlCarsHandler)
+	http.HandleFunc("/gqlClasses", gqlClassesHandler)
+	http.HandleFunc("/gqlTeacherNames", gqlTeacherNamesHandler)
+	http.HandleFunc("/gqlSchoolNames", gqlSchoolNamesHandler)
 
 	fmt.Println("Listening on port 8888")
 	log.Fatal(http.ListenAndServe(":8888", nil))

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1418,7 +1418,7 @@ func introspectionResult(name string) string {
 							"kind":"LIST",
 							"name":null,
 							"ofType": {
-								"kind": "OBJECT",
+								"kind": "INPUT_OBJECT",
 								"name": "UserInput",
 								"ofType": null
 							}
@@ -1555,7 +1555,7 @@ func gqlCarsHandler(w http.ResponseWriter, r *http.Request) {
 								"kind":"LIST",
 								"name":null,
 								"ofType": {
-									"kind": "OBJECT",
+									"kind": "INPUT_OBJECT",
 									"name": "UserInput",
 									"ofType": null
 								}
@@ -1640,7 +1640,7 @@ func gqlClassesHandler(w http.ResponseWriter, r *http.Request) {
 								"kind":"LIST",
 								"name":null,
 								"ofType": {
-									"kind": "OBJECT",
+									"kind": "INPUT_OBJECT",
 									"name": "UserInput",
 									"ofType": null
 								}

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -1601,3 +1601,76 @@ func TestCustomGraphqlMutation2(t *testing.T) {
     }`
 	require.JSONEq(t, expected, string(result.Data))
 }
+
+func TestCustomFieldsShouldBeResolvedUsingGraphQLEndpoints(t *testing.T) {
+	// lets check single mode first
+	schema := `type Car @remote {
+		id: ID!
+		name: String!
+	}
+
+	type User {
+		id: ID!
+		name: String @custom(http: {
+						url: "http://mock:8888/gqlUserName",
+						method: "POST",
+						operation: "single",
+						graphql: "query { userName(id: $id)}"
+					}
+				)
+		age: Int! @search
+		cars: Car @custom(http: {
+						url: "http://mock:8888/gqlCar",
+						method: "POST",
+						operation: "single",
+						graphql: "query { car(id: $id)}"
+					}
+				)
+		schools: [School]
+	}
+
+	type School {
+		id: ID!
+		established: Int! @search
+		name: String @custom(http: {
+							url: "http://mock:8888/gqlSchoolName",
+							method: "POST",
+							operation: "single",
+							graphql: "query { schoolName(id: $id) }"
+						}
+					)
+		classes: [Class] @custom(http: {
+							url: "http://mock:8888/gqlClass",
+							method: "POST",
+							operation: "single",
+							graphql: "query { class(id: $id) }"
+						}
+					)
+		teachers: [Teacher]
+	}
+
+	type Class @remote {
+		id: ID!
+		name: String!
+	}
+
+	type Teacher {
+		tid: ID!
+		age: Int!
+		name: String @custom(http: {
+						url: "http://mock:8888/gqlTeacherName",
+						method: "POST",
+						operation: "single",
+						graphql: "query { teacherName(id: $tid) }"
+					}
+				)
+	}`
+
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+
+	teachers := addTeachers(t)
+	schools := addSchools(t, teachers)
+	users := addUsers(t, schools)
+
+	verifyData(t, users, teachers, schools)
+}

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -529,9 +529,6 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 		 queryUser(order: {asc: age}) {
 			name
 			age
-			cars {
-				name
-			}
 			schools(order: {asc: established}) {
 				name
 				established
@@ -805,16 +802,18 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	// verifyData(t, users, teachers, schools)
 
 	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	schema := readFile(t, "schemas/single-mode-graphql.graphql")
+	// schema := readFile(t, "schemas/single-mode-graphql.graphql")
+	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
+
+	// verifyData(t, users, teachers, schools)
+
+	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	schema := readFile(t, "schemas/batch-mode-graphql.graphql")
 	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 	teachers := addTeachers(t)
 	schools := addSchools(t, teachers)
 	users := addUsers(t, schools)
 	verifyData(t, users, teachers, schools)
-
-	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	// schema = readFile(t, "schemas/batch-mode-graphql.graphql")
-	// verifyData(t, users, teachers, schools)
 }
 
 func TestForInvalidCustomQuery(t *testing.T) {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -794,35 +794,40 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	// 3. Batch operation mode along with GraphQL.
 	// 4. Single operation mode along with GraphQL.
 
+	var teachers []*teacher
+	var schools []*school
+	var users []*user
 	// lets check batch mode first using REST endpoints.
-	schema := readFile(t, "schemas/batch-mode-rest.graphql")
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	t.Run("rest batch operation mode", func(t *testing.T) {
+		schema := readFile(t, "schemas/batch-mode-rest.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
 
-	// add some data
-	teachers := addTeachers(t)
-	schools := addSchools(t, teachers)
-	users := addUsers(t, schools)
+		// add some data
+		teachers = addTeachers(t)
+		schools = addSchools(t, teachers)
+		users = addUsers(t, schools)
 
-	verifyData(t, users, teachers, schools)
+		verifyData(t, users, teachers, schools)
+	})
 
 	t.Run("rest single operation mode", func(t *testing.T) {
 		// lets update the schema and check single mode now
-		schema = readFile(t, "schemas/single-mode-rest.graphql")
-		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		schema := readFile(t, "schemas/single-mode-rest.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
 		verifyData(t, users, teachers, schools)
 	})
 
 	t.Run("graphql single operation mode", func(t *testing.T) {
 		// update schema to single mode where fields are resolved using GraphQL endpoints.
-		schema = readFile(t, "schemas/single-mode-graphql.graphql")
-		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		schema := readFile(t, "schemas/single-mode-graphql.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
 		verifyData(t, users, teachers, schools)
 	})
 
 	t.Run("graphql batch operation mode", func(t *testing.T) {
 		// update schema to single mode where fields are resolved using GraphQL endpoints.
-		schema = readFile(t, "schemas/batch-mode-graphql.graphql")
-		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		schema := readFile(t, "schemas/batch-mode-graphql.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
 		verifyData(t, users, teachers, schools)
 	})
 }

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -18,11 +18,8 @@ package custom_logic
 
 import (
 	"encoding/json"
-<<<<<<< HEAD
 	"fmt"
-=======
 	"io/ioutil"
->>>>>>> 0f4d42401... Fix up the tests and also the code so that it works for single mode across graphql/REST
 	"net/http"
 	"sort"
 	"strings"
@@ -802,17 +799,19 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 
 	verifyData(t, users, teachers, schools)
 
-	// // lets update the schema and check single mode now
-	// schema = readFile(t, "schemas/single-mode-rest.graphql")
-	// verifyData(t, users, teachers, schools)
-
-	// // update schema to single mode where fields are resolved using GraphQL endpoints.
-	// schema = readFile(t, "schemas/single-mode-graphql.graphql")
-	// verifyData(t, users, teachers, schools)
+	// lets update the schema and check single mode now
+	schema = readFile(t, "schemas/single-mode-rest.graphql")
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	verifyData(t, users, teachers, schools)
 
 	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	schema = readFile(t, "schemas/batch-mode-graphql.graphql")
+	schema = readFile(t, "schemas/single-mode-graphql.graphql")
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 	verifyData(t, users, teachers, schools)
+
+	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	// schema = readFile(t, "schemas/batch-mode-graphql.graphql")
+	// verifyData(t, users, teachers, schools)
 }
 
 func TestForInvalidCustomQuery(t *testing.T) {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -391,8 +391,7 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 			"returned an error: unexpected status code: 404 for field: cars within type: Person.",
 			Locations: []x.Location{{6, 4}}},
 		&x.GqlError{Message: "Evaluation of custom field failed because external request returned" +
-			" an error: unexpected status code: 404 for field: bikes within type: Person," +
-			" index: 0.",
+			" an error: unexpected status code: 404 for field: bikes within type: Person.",
 			Locations: []x.Location{{9, 4}}},
 	}
 	require.Contains(t, result.Errors, expectedErrors[0])

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -794,19 +794,16 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	// 3. Batch operation mode along with GraphQL.
 	// 4. Single operation mode along with GraphQL.
 
-	var teachers []*teacher
-	var schools []*school
-	var users []*user
+	schema := readFile(t, "schemas/batch-mode-rest.graphql")
+	updateSchemaRequireNoGQLErrors(t, schema)
+
+	// add some data
+	teachers := addTeachers(t)
+	schools := addSchools(t, teachers)
+	users := addUsers(t, schools)
+
 	// lets check batch mode first using REST endpoints.
 	t.Run("rest batch operation mode", func(t *testing.T) {
-		schema := readFile(t, "schemas/batch-mode-rest.graphql")
-		updateSchemaRequireNoGQLErrors(t, schema)
-
-		// add some data
-		teachers = addTeachers(t)
-		schools = addSchools(t, teachers)
-		users = addUsers(t, schools)
-
 		verifyData(t, users, teachers, schools)
 	})
 
@@ -827,6 +824,14 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	t.Run("graphql batch operation mode", func(t *testing.T) {
 		// update schema to single mode where fields are resolved using GraphQL endpoints.
 		schema := readFile(t, "schemas/batch-mode-graphql.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
+		verifyData(t, users, teachers, schools)
+	})
+
+	// Fields are fetched through a combination of REST/GraphQL and single/batch mode.
+	t.Run("mixed mode", func(t *testing.T) {
+		// update schema to single mode where fields are resolved using GraphQL endpoints.
+		schema := readFile(t, "schemas/mixed-modes.graphql")
 		updateSchemaRequireNoGQLErrors(t, schema)
 		verifyData(t, users, teachers, schools)
 	})

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -18,7 +18,11 @@ package custom_logic
 
 import (
 	"encoding/json"
+<<<<<<< HEAD
 	"fmt"
+=======
+	"io/ioutil"
+>>>>>>> 0f4d42401... Fix up the tests and also the code so that it works for single mode across graphql/REST
 	"net/http"
 	"sort"
 	"strings"
@@ -778,70 +782,20 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 	 }`
 
 	testutil.CompareJSON(t, expected, string(result.Data))
+}
 
+func readFile(t *testing.T, name string) string {
+	b, err := ioutil.ReadFile(name)
+	require.NoError(t, err)
+	return string(b)
 }
 
 func TestCustomFieldsShouldBeResolved(t *testing.T) {
-	// lets check batch mode first
-	schema := `type Car @remote {
-		 id: ID!
-		 name: String!
-	 }
+	// lets check batch mode first using REST endpoints.
+	schema := readFile(t, "schemas/batch-mode-rest.graphql")
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 
-	 type User {
-		 id: ID!
-		 name: String @custom(http: {
-						 url: "http://mock:8888/userNames",
-						 method: "GET",
-						 body: "{uid: $id}",
-						 operation: "batch"
-					 })
-		 age: Int! @search
-		 cars: Car @custom(http: {
-						 url: "http://mock:8888/cars",
-						 method: "GET",
-						 body: "{uid: $id}",
-						 operation: "batch"
-					 })
-		 schools: [School]
-	 }
-
-	 type School {
-		 id: ID!
-		 established: Int! @search
-		 name: String @custom(http: {
-						 url: "http://mock:8888/schoolNames",
-						 method: "POST",
-						 body: "{sid: $id}",
-						 operation: "batch"
-					   })
-		 classes: [Class] @custom(http: {
-							 url: "http://mock:8888/classes",
-							 method: "POST",
-							 body: "{sid: $id}",
-							 operation: "batch"
-						 })
-		 teachers: [Teacher]
-	 }
-
-	 type Class @remote {
-		 id: ID!
-		 name: String!
-	 }
-
-	 type Teacher {
-		 tid: ID!
-		 age: Int!
-		 name: String @custom(http: {
-						 url: "http://mock:8888/teacherNames",
-						 method: "POST",
-						 body: "{tid: $tid}",
-						 operation: "batch"
-					 })
-	 }`
-
-	updateSchemaRequireNoGQLErrors(t, schema)
-
+	// add some data
 	teachers := addTeachers(t)
 	schools := addSchools(t, teachers)
 	users := addUsers(t, schools)
@@ -849,64 +803,11 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	verifyData(t, users, teachers, schools)
 
 	// lets update the schema and check single mode now
-	schema = `
-	 type Car @remote {
-		 id: ID!
-		 name: String!
-	 }
+	schema = readFile(t, "schemas/single-mode-rest.graphql")
+	verifyData(t, users, teachers, schools)
 
-	 type User {
-		 id: ID!
-		 name: String @custom(http: {
-						 url: "http://mock:8888/userName",
-						 method: "GET",
-						 body: "{uid: $id}",
-						 operation: "single"
-					 })
-		 age: Int! @search
-		 cars: Car @custom(http: {
-						 url: "http://mock:8888/car",
-						 method: "GET",
-						 body: "{uid: $id}",
-						 operation: "single"
-					 })
-		 schools: [School]
-	 }
-
-	 type School {
-		 id: ID!
-		 established: Int! @search
-		 name: String @custom(http: {
-						 url: "http://mock:8888/schoolName",
-						 method: "POST",
-						 body: "{sid: $id}",
-						 operation: "single"
-					   })
-		 classes: [Class] @custom(http: {
-							 url: "http://mock:8888/class",
-							 method: "POST",
-							 body: "{sid: $id}",
-							 operation: "single"
-						 })
-		 teachers: [Teacher]
-	 }
-
-	 type Class @remote {
-		 id: ID!
-		 name: String!
-	 }
-
-	 type Teacher {
-		 tid: ID!
-		 age: Int!
-		 name: String @custom(http: {
-						 url: "http://mock:8888/teacherName",
-						 method: "POST",
-						 body: "{tid: $tid}",
-						 operation: "single"
-					   })
-	 }`
-
+	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	schema = readFile(t, "schemas/single-mode-graphql.graphql")
 	verifyData(t, users, teachers, schools)
 }
 
@@ -1600,77 +1501,4 @@ func TestCustomGraphqlMutation2(t *testing.T) {
 		]
     }`
 	require.JSONEq(t, expected, string(result.Data))
-}
-
-func TestCustomFieldsShouldBeResolvedUsingGraphQLEndpoints(t *testing.T) {
-	// lets check single mode first
-	schema := `type Car @remote {
-		id: ID!
-		name: String!
-	}
-
-	type User {
-		id: ID!
-		name: String @custom(http: {
-						url: "http://mock:8888/gqlUserName",
-						method: "POST",
-						operation: "single",
-						graphql: "query { userName(id: $id)}"
-					}
-				)
-		age: Int! @search
-		cars: Car @custom(http: {
-						url: "http://mock:8888/gqlCar",
-						method: "POST",
-						operation: "single",
-						graphql: "query { car(id: $id)}"
-					}
-				)
-		schools: [School]
-	}
-
-	type School {
-		id: ID!
-		established: Int! @search
-		name: String @custom(http: {
-							url: "http://mock:8888/gqlSchoolName",
-							method: "POST",
-							operation: "single",
-							graphql: "query { schoolName(id: $id) }"
-						}
-					)
-		classes: [Class] @custom(http: {
-							url: "http://mock:8888/gqlClass",
-							method: "POST",
-							operation: "single",
-							graphql: "query { class(id: $id) }"
-						}
-					)
-		teachers: [Teacher]
-	}
-
-	type Class @remote {
-		id: ID!
-		name: String!
-	}
-
-	type Teacher {
-		tid: ID!
-		age: Int!
-		name: String @custom(http: {
-						url: "http://mock:8888/gqlTeacherName",
-						method: "POST",
-						operation: "single",
-						graphql: "query { teacherName(id: $tid) }"
-					}
-				)
-	}`
-
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
-
-	teachers := addTeachers(t)
-	schools := addSchools(t, teachers)
-	users := addUsers(t, schools)
-
-	verifyData(t, users, teachers, schools)
 }

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -526,22 +526,22 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 	queryUser := `
 	 query {
 		 queryUser(order: {asc: age}) {
-			 name
-			 age
-			 cars {
-				 name
-			 }
-			 schools(order: {asc: established}) {
-				 name
-				 established
-				 teachers(order: {desc: age}) {
-					 name
-					 age
-				 }
-				 classes {
-					 name
-				 }
-			 }
+			name
+			age
+			cars {
+				name
+			}
+			schools(order: {asc: established}) {
+				name
+				established
+				teachers(order: {desc: age}) {
+					name
+					age
+				}
+				classes {
+					name
+				}
+			}
 		 }
 	 }`
 	params := &common.GraphQLParams{

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -802,12 +802,16 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 
 	verifyData(t, users, teachers, schools)
 
-	// lets update the schema and check single mode now
-	schema = readFile(t, "schemas/single-mode-rest.graphql")
-	verifyData(t, users, teachers, schools)
+	// // lets update the schema and check single mode now
+	// schema = readFile(t, "schemas/single-mode-rest.graphql")
+	// verifyData(t, users, teachers, schools)
+
+	// // update schema to single mode where fields are resolved using GraphQL endpoints.
+	// schema = readFile(t, "schemas/single-mode-graphql.graphql")
+	// verifyData(t, users, teachers, schools)
 
 	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	schema = readFile(t, "schemas/single-mode-graphql.graphql")
+	schema = readFile(t, "schemas/batch-mode-graphql.graphql")
 	verifyData(t, users, teachers, schools)
 }
 

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -787,6 +787,13 @@ func readFile(t *testing.T, name string) string {
 }
 
 func TestCustomFieldsShouldBeResolved(t *testing.T) {
+	// This test adds data, modifies the schema multiple times and fetches the data.
+	// It has the following modes.
+	// 1. Batch operation mode along with REST.
+	// 2. Single operation mode along with REST.
+	// 3. Batch operation mode along with GraphQL.
+	// 4. Single operation mode along with GraphQL.
+
 	// lets check batch mode first using REST endpoints.
 	schema := readFile(t, "schemas/batch-mode-rest.graphql")
 	common.RequireNoGQLErrors(t, updateSchema(t, schema))

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -529,6 +529,9 @@ func verifyData(t *testing.T, users []*user, teachers []*teacher, schools []*sch
 		 queryUser(order: {asc: age}) {
 			name
 			age
+			cars {
+				name
+			}
 			schools(order: {asc: established}) {
 				name
 				established
@@ -786,34 +789,36 @@ func readFile(t *testing.T, name string) string {
 
 func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	// lets check batch mode first using REST endpoints.
-	// schema := readFile(t, "schemas/batch-mode-rest.graphql")
-	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	schema := readFile(t, "schemas/batch-mode-rest.graphql")
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 
 	// add some data
-	// teachers := addTeachers(t)
-	// schools := addSchools(t, teachers)
-	// users := addUsers(t, schools)
-
-	// verifyData(t, users, teachers, schools)
-
-	// lets update the schema and check single mode now
-	// schema = readFile(t, "schemas/single-mode-rest.graphql")
-	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
-	// verifyData(t, users, teachers, schools)
-
-	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	// schema := readFile(t, "schemas/single-mode-graphql.graphql")
-	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
-
-	// verifyData(t, users, teachers, schools)
-
-	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	schema := readFile(t, "schemas/batch-mode-graphql.graphql")
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 	teachers := addTeachers(t)
 	schools := addSchools(t, teachers)
 	users := addUsers(t, schools)
+
 	verifyData(t, users, teachers, schools)
+
+	t.Run("rest single operation mode", func(t *testing.T) {
+		// lets update the schema and check single mode now
+		schema = readFile(t, "schemas/single-mode-rest.graphql")
+		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		verifyData(t, users, teachers, schools)
+	})
+
+	t.Run("graphql single operation mode", func(t *testing.T) {
+		// update schema to single mode where fields are resolved using GraphQL endpoints.
+		schema = readFile(t, "schemas/single-mode-graphql.graphql")
+		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		verifyData(t, users, teachers, schools)
+	})
+
+	t.Run("graphql batch operation mode", func(t *testing.T) {
+		// update schema to single mode where fields are resolved using GraphQL endpoints.
+		schema = readFile(t, "schemas/batch-mode-graphql.graphql")
+		common.RequireNoGQLErrors(t, updateSchema(t, schema))
+		verifyData(t, users, teachers, schools)
+	})
 }
 
 func TestForInvalidCustomQuery(t *testing.T) {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -789,24 +789,27 @@ func readFile(t *testing.T, name string) string {
 
 func TestCustomFieldsShouldBeResolved(t *testing.T) {
 	// lets check batch mode first using REST endpoints.
-	schema := readFile(t, "schemas/batch-mode-rest.graphql")
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	// schema := readFile(t, "schemas/batch-mode-rest.graphql")
+	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
 
 	// add some data
+	// teachers := addTeachers(t)
+	// schools := addSchools(t, teachers)
+	// users := addUsers(t, schools)
+
+	// verifyData(t, users, teachers, schools)
+
+	// lets update the schema and check single mode now
+	// schema = readFile(t, "schemas/single-mode-rest.graphql")
+	// common.RequireNoGQLErrors(t, updateSchema(t, schema))
+	// verifyData(t, users, teachers, schools)
+
+	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	schema := readFile(t, "schemas/single-mode-graphql.graphql")
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 	teachers := addTeachers(t)
 	schools := addSchools(t, teachers)
 	users := addUsers(t, schools)
-
-	verifyData(t, users, teachers, schools)
-
-	// lets update the schema and check single mode now
-	schema = readFile(t, "schemas/single-mode-rest.graphql")
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
-	verifyData(t, users, teachers, schools)
-
-	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	schema = readFile(t, "schemas/single-mode-graphql.graphql")
-	common.RequireNoGQLErrors(t, updateSchema(t, schema))
 	verifyData(t, users, teachers, schools)
 
 	// update schema to single mode where fields are resolved using GraphQL endpoints.

--- a/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
@@ -11,8 +11,8 @@ type User {
         url: "http://mock:8888/gqlUserNames"
         method: "POST"
         operation: "batch"
+        graphql: "query { userNames(input: [{ id: $id, age: $age}]) }"
       }
-      graphql: { query: "userNames(ids: $id)" }
     )
   age: Int! @search
   cars: Car
@@ -21,8 +21,8 @@ type User {
         url: "http://mock:8888/gqlCars"
         method: "POST"
         operation: "batch"
+        graphql: "query { cars(input: [{ id: $id}]) }"
       }
-      graphql: { query: "cars(ids: $id)" }
     )
   schools: [School]
 }
@@ -36,8 +36,8 @@ type School {
         url: "http://mock:8888/gqlSchoolNames"
         method: "POST"
         operation: "batch"
+        graphql: "query { schoolNames(input: [{ id: $id}]) }"
       }
-      graphql: { query: "schoolNames(ids: $id)" }
     )
   classes: [Class]
     @custom(
@@ -45,8 +45,8 @@ type School {
         url: "http://mock:8888/gqlClasses"
         method: "POST"
         operation: "batch"
+        graphql: "query { classes(input: [{ id: $id}]) }"
       }
-      graphql: { query: "classes(ids: $id)" }
     )
   teachers: [Teacher]
 }
@@ -65,7 +65,7 @@ type Teacher {
         url: "http://mock:8888/gqlTeacherNames"
         method: "POST"
         operation: "batch"
+        graphql: "query { teacherNames(input: [{ xid: $tid}]) }"
       }
-      graphql: { query: "teacherNames(ids: $tid)" }
     )
 }

--- a/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
@@ -1,0 +1,71 @@
+type Car @remote {
+  id: ID!
+  name: String!
+}
+
+type User {
+  id: ID!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlUserNames"
+        method: "POST"
+        operation: "batch"
+      }
+      graphql: { query: "userNames(ids: $id)" }
+    )
+  age: Int! @search
+  cars: Car
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlCars"
+        method: "POST"
+        operation: "batch"
+      }
+      graphql: { query: "cars(ids: $id)" }
+    )
+  schools: [School]
+}
+
+type School {
+  id: ID!
+  established: Int! @search
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlSchoolNames"
+        method: "POST"
+        operation: "batch"
+      }
+      graphql: { query: "schoolNames(ids: $id)" }
+    )
+  classes: [Class]
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlClasses"
+        method: "POST"
+        operation: "batch"
+      }
+      graphql: { query: "classes(ids: $id)" }
+    )
+  teachers: [Teacher]
+}
+
+type Class @remote {
+  id: ID!
+  name: String!
+}
+
+type Teacher {
+  tid: ID!
+  age: Int!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlTeacherNames"
+        method: "POST"
+        operation: "batch"
+      }
+      graphql: { query: "teacherNames(ids: $tid)" }
+    )
+}

--- a/graphql/e2e/custom_logic/schemas/batch-mode-rest.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-rest.graphql
@@ -1,0 +1,71 @@
+type Car @remote {
+  id: ID!
+  name: String!
+}
+
+type User {
+  id: ID!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/userNames"
+        method: "GET"
+        body: "{uid: $id}"
+        operation: "batch"
+      }
+    )
+  age: Int! @search
+  cars: Car
+    @custom(
+      http: {
+        url: "http://mock:8888/cars"
+        method: "GET"
+        body: "{uid: $id}"
+        operation: "batch"
+      }
+    )
+  schools: [School]
+}
+
+type School {
+  id: ID!
+  established: Int! @search
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/schoolNames"
+        method: "POST"
+        body: "{sid: $id}"
+        operation: "batch"
+      }
+    )
+  classes: [Class]
+    @custom(
+      http: {
+        url: "http://mock:8888/classes"
+        method: "POST"
+        body: "{sid: $id}"
+        operation: "batch"
+      }
+    )
+  teachers: [Teacher]
+}
+
+type Class @remote {
+  id: ID!
+  name: String!
+}
+
+type Teacher {
+  tid: ID!
+  age: Int!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/teacherNames"
+        method: "POST"
+        body: "{tid: $tid}"
+        operation: "batch"
+      }
+    )
+}

--- a/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
+++ b/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
@@ -31,12 +31,12 @@ type School {
   id: ID!
   established: Int! @search
   name: String
-    @custom(
+     @custom(
       http: {
-        url: "http://mock:8888/gqlSchoolNames"
+        url: "http://mock:8888/gqlSchoolName"
         method: "POST"
         operation: "single"
-        graphql: "query { schoolNames(input: [{ id: $id}]) }"
+        graphql: "query { schoolName(id: $id) }"
       }
     )
   classes: [Class]

--- a/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
+++ b/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
@@ -1,0 +1,71 @@
+type Car @remote {
+  id: ID!
+  name: String!
+}
+
+type User {
+  id: ID!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlUserNames"
+        method: "POST"
+        operation: "batch"
+        graphql: "query { userNames(input: [{ id: $id, age: $age}]) }"
+      }
+    )
+  age: Int! @search
+  cars: Car
+    @custom(
+      http: {
+        url: "http://mock:8888/cars"
+        method: "GET"
+        body: "{uid: $id}"
+        operation: "batch"
+      }
+    )
+  schools: [School]
+}
+
+type School {
+  id: ID!
+  established: Int! @search
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlSchoolNames"
+        method: "POST"
+        operation: "single"
+        graphql: "query { schoolNames(input: [{ id: $id}]) }"
+      }
+    )
+  classes: [Class]
+    @custom(
+      http: {
+        url: "http://mock:8888/class"
+        method: "POST"
+        body: "{sid: $id}"
+        operation: "single"
+      }
+    )
+  teachers: [Teacher]
+}
+
+type Class @remote {
+  id: ID!
+  name: String!
+}
+
+type Teacher {
+  tid: ID!
+  age: Int!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlTeacherNames"
+        method: "POST"
+        operation: "batch"
+        graphql: "query { teacherNames(input: [{ xid: $tid}]) }"
+      }
+    )
+}

--- a/graphql/e2e/custom_logic/schemas/single-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/single-mode-graphql.graphql
@@ -1,0 +1,71 @@
+type Car @remote {
+  id: ID!
+  name: String!
+}
+
+type User {
+  id: ID!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlUserName"
+        method: "POST"
+        operation: "single"
+        graphql: "query { userName(id: $id)}"
+      }
+    )
+  age: Int! @search
+  cars: Car
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlCar"
+        method: "POST"
+        operation: "single"
+        graphql: "query { car(id: $id)}"
+      }
+    )
+  schools: [School]
+}
+
+type School {
+  id: ID!
+  established: Int! @search
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlSchoolName"
+        method: "POST"
+        operation: "single"
+        graphql: "query { schoolName(id: $id) }"
+      }
+    )
+  classes: [Class]
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlClass"
+        method: "POST"
+        operation: "single"
+        graphql: "query { class(id: $id) }"
+      }
+    )
+  teachers: [Teacher]
+}
+
+type Class @remote {
+  id: ID!
+  name: String!
+}
+
+type Teacher {
+  tid: ID!
+  age: Int!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/gqlTeacherName"
+        method: "POST"
+        operation: "single"
+        graphql: "query { teacherName(id: $tid) }"
+      }
+    )
+}

--- a/graphql/e2e/custom_logic/schemas/single-mode-rest.graphql
+++ b/graphql/e2e/custom_logic/schemas/single-mode-rest.graphql
@@ -1,0 +1,71 @@
+type Car @remote {
+  id: ID!
+  name: String!
+}
+
+type User {
+  id: ID!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/userName"
+        method: "GET"
+        body: "{uid: $id}"
+        operation: "single"
+      }
+    )
+  age: Int! @search
+  cars: Car
+    @custom(
+      http: {
+        url: "http://mock:8888/car"
+        method: "GET"
+        body: "{uid: $id}"
+        operation: "single"
+      }
+    )
+  schools: [School]
+}
+
+type School {
+  id: ID!
+  established: Int! @search
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/schoolName"
+        method: "POST"
+        body: "{sid: $id}"
+        operation: "single"
+      }
+    )
+  classes: [Class]
+    @custom(
+      http: {
+        url: "http://mock:8888/class"
+        method: "POST"
+        body: "{sid: $id}"
+        operation: "single"
+      }
+    )
+  teachers: [Teacher]
+}
+
+type Class @remote {
+  id: ID!
+  name: String!
+}
+
+type Teacher {
+  tid: ID!
+  age: Int!
+  name: String
+    @custom(
+      http: {
+        url: "http://mock:8888/teacherName"
+        method: "POST"
+        body: "{tid: $tid}"
+        operation: "single"
+      }
+    )
+}

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -795,13 +795,13 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 				errChan <- jsonMarshalError(err, f, requestInput)
 				return
 			}
-			input = string(b)
 
 			if !graphql {
 				// For REST requests, we'll have to substitute the variables used in the URL.
 				// TODO - Have validation to ensure that GraphQL endpoints don't use variables.
 				mu.RLock()
-				fconf.URL, err = schema.SubstituteVarsInURL(fconf.URL, vals[idx].(map[string]interface{}))
+				fconf.URL, err = schema.SubstituteVarsInURL(fconf.URL,
+					vals[idx].(map[string]interface{}))
 				if err != nil {
 					mu.RUnlock()
 					// TODO - Fix this.
@@ -811,7 +811,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 				mu.RUnlock()
 			}
 
-			b, err = makeRequest(nil, fconf.Method, fconf.URL, input.(string), fconf.ForwardHeaders)
+			b, err = makeRequest(nil, fconf.Method, fconf.URL, string(b), fconf.ForwardHeaders)
 			if err != nil {
 				errChan <- externalRequestError(err, f)
 				return
@@ -857,6 +857,10 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 		}
 	}
 
+	if len(errs) == 0 {
+		errCh <- nil
+		return
+	}
 	errCh <- errs
 }
 

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -684,7 +684,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 				args = append(args, k)
 			}
 			// TODO - See if args is required.
-			b, err := schema.SubstituteFieldsInGraphqlRequest("", f, m, args)
+			b, err := schema.SubstituteArgsInGraphqlRequest("", f, m, args)
 			if err != nil {
 				mu.RUnlock()
 				errCh <- err

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -658,7 +658,11 @@ func externalRequestError(err error, f schema.Field) *x.GqlError {
 }
 
 func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, errCh chan error) {
-	fconf, _ := f.CustomHTTPConfig()
+	fconf, err := f.CustomHTTPConfig()
+	if err != nil {
+		errCh <- err
+		return
+	}
 
 	// Here we build the array of objects which is sent as the body for the request.
 	body := make([]interface{}, len(vals))

--- a/graphql/schema/errors.go
+++ b/graphql/schema/errors.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"fmt"
+
 	"github.com/vektah/gqlparser/v2/ast"
 
 	"github.com/dgraph-io/dgraph/x"

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -265,7 +265,12 @@ func getGivenQueryArgsAsMap(givenQuery *ast.Field, parentField *ast.FieldDefinit
 			argValMap[arg.Name] = varName
 		}
 	} else {
-		// TODO: handle @custom graphql validation for fields here
+		for _, arg := range givenQuery.Arguments {
+			varName := arg.Value.String()
+			argValMap[arg.Name] = varName
+		}
+		// TODO: Handle other checks as above here.
+		// TODO: handle batch/single mode properly here.
 	}
 	return argDefMap, argValMap
 }

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -157,7 +157,8 @@ type remoteGraphqlMetadata struct {
 	// The operation can only be a query or mutation
 	graphqlOpDef *ast.OperationDefinition
 	// url is the url of remote graphql endpoint
-	url string
+	url       string
+	operation string
 }
 
 // validates the graphql given in @custom->http->graphql by introspecting remote schema.
@@ -208,6 +209,9 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 	// TODO: need to check whether same will work for @custom on fields which have batch operation
 	expectedReturnType := introspectedRemoteQuery.Type.String()
 	gotReturnType := metadata.parentField.Type.String()
+	if metadata.operation == "batch" {
+		gotReturnType = "[" + gotReturnType + "]"
+	}
 	if expectedReturnType != gotReturnType {
 		return errors.Errorf("given %s: %s: return type mismatch; expected: %s, got: %s.",
 			operationType, givenQuery.Name, expectedReturnType, gotReturnType)

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -273,8 +273,6 @@ func getGivenQueryArgsAsMap(givenQuery *ast.Field, parentField *ast.FieldDefinit
 			varName := arg.Value.String()
 			argValMap[arg.Name] = varName
 		}
-		// TODO: Handle other checks as above here.
-		// TODO: handle batch/single mode properly here.
 	}
 	return argDefMap, argValMap
 }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1251,12 +1251,18 @@ func customDirectiveValidation(sch *ast.Schema,
 				)
 			}
 		}
+
+		op := ""
+		if operation != nil {
+			op = operation.Raw
+		}
 		// finally validate the given operation on remote server
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{
 			parentType:   typ,
 			parentField:  field,
 			graphqlOpDef: opZero,
 			url:          u.Raw,
+			operation:    op,
 		}); err != nil {
 			return gqlerror.ErrorPosf(graphql.Position,
 				"Type %s; Field %s: @custom directive: graphql; %s",

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -60,8 +60,7 @@ type FieldHTTPConfig struct {
 	ForwardHeaders http.Header
 	// would be empty for non-GraphQL requests
 	RemoteGqlQueryName string
-	// TODO - See if we need both this and the field above.
-	RemoteGqlQuery string
+	RemoteGqlQuery     string
 }
 
 // Query/Mutation types and arg names
@@ -1809,8 +1808,7 @@ func ParseRequiredArgsFromGQLRequest(req string, operation string) (map[string]b
 			return nil, errors.Errorf("Expected list value for input argument, got: %v",
 				input.Value.Kind)
 		}
-		// TODO - Make sure we are validating the format during schema update so that accessing
-		// the children is safe here.
+		// We are validating the format during schema update so accessing the children is safe here.
 		_, rf, err := parseBodyTemplate(input.Value.Children[0].Value.String())
 		return rf, err
 	}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -628,6 +628,14 @@ func (f *field) HasCustomDirective() (bool, map[string]bool) {
 			rf[val[1:]] = true
 		}
 	}
+
+	graphql := custom.Arguments.ForName("graphql")
+	if graphql == nil {
+		return true, rf
+	}
+
+	query := graphql.Value.Children.ForName("query")
+	rf = parseRequiredFieldsFromGQLRequest(query.Raw)
 	return true, rf
 }
 
@@ -801,6 +809,7 @@ func (f *field) CustomHTTPConfig() (FieldHTTPConfig, error) {
 
 func SubstituteFieldsInGraphqlRequest(req string, f Field, argMap map[string]interface{},
 	args []string) (string, error) {
+	fmt.Println("args: ", args, "argMap: ", args)
 	for _, arg := range args {
 		val, ok := argMap[arg]
 		if !ok {
@@ -1790,6 +1799,9 @@ func (t *astType) FieldOriginatedFrom(fieldName string) string {
 // }
 func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 	// Add begining curly braces
+	if len(field.SelectionSet) == 0 {
+		return
+	}
 	writer.WriteString("{\n")
 	for i := 0; i < len(field.SelectionSet); i++ {
 		castedField := field.SelectionSet[i].(*ast.Field)
@@ -1803,4 +1815,20 @@ func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 	}
 	// Add ending curly braces
 	writer.WriteString("}")
+}
+
+func parseRequiredFieldsFromGQLRequest(req string) map[string]bool {
+	// These errors should have already been checked during schema validation.
+	parsedQuery, _ := parser.ParseQuery(&ast.Source{Input: fmt.Sprintf(`query {%s}`,
+		req)})
+
+	result := make(map[string]bool)
+	query := parsedQuery.Operations[0].SelectionSet[0].(*ast.Field)
+	for _, arg := range query.Arguments {
+		val := arg.Value.String()
+		if strings.HasPrefix(val, "$") {
+			result[val[1:]] = true
+		}
+	}
+	return result
 }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -799,24 +799,24 @@ func (f *field) CustomHTTPConfig() (FieldHTTPConfig, error) {
 	return getCustomHTTPConfig(f, false)
 }
 
-func SubstituteFieldsInGraphqlRequest(req string, f *ast.Field, argMap map[string]interface{},
-	args ast.ArgumentDefinitionList) (string, error) {
+func SubstituteFieldsInGraphqlRequest(req string, f Field, argMap map[string]interface{},
+	args []string) (string, error) {
 	for _, arg := range args {
-		val, ok := argMap[arg.Name]
+		val, ok := argMap[arg]
 		if !ok {
 			continue
 		}
 		value := ""
-		if arg.Type.Name() == "String" || arg.Type.Name() == "ID" || val == nil {
-			if val == nil {
-				val = "null"
-			}
-			value = `"` + fmt.Sprintf("%+v", val) + `"`
+		// if arg.Type.Name() == "String" || arg.Type.Name() == "ID" || val == nil {
+		if val == nil {
+			val = "null"
 		}
-		req = strings.ReplaceAll(req, "$"+arg.Name, value)
+		value = `"` + fmt.Sprintf("%+v", val) + `"`
+		// }
+		req = strings.ReplaceAll(req, "$"+arg, value)
 	}
 	buf := &bytes.Buffer{}
-	buildGraphqlRequestFields(buf, f)
+	buildGraphqlRequestFields(buf, f.(*field).field)
 	req += buf.String()
 	// contact method and request object
 	req = `query{` + req + `}`

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -637,7 +637,7 @@ func (f *field) HasCustomDirective() (bool, map[string]bool) {
 	}
 
 	query := graphql.Value.Children.ForName("query")
-	rf = parseRequiredFieldsFromGQLRequest(query.Raw)
+	rf = parseArgsFromGQLRequest(query.Raw)
 	return true, rf
 }
 
@@ -809,7 +809,10 @@ func (f *field) CustomHTTPConfig() (FieldHTTPConfig, error) {
 	return getCustomHTTPConfig(f, false)
 }
 
-func SubstituteFieldsInGraphqlRequest(req string, f Field, argMap map[string]interface{},
+// SubstituteArgsInGraphqlRequest substitutes the arguments in a graphql request by filling it up
+// from the argMap. It returns the final request body which is sent to the remote server to be
+// resolved.
+func SubstituteArgsInGraphqlRequest(req string, f Field, argMap map[string]interface{},
 	args []string) (string, error) {
 	for _, arg := range args {
 		val, ok := argMap[arg]
@@ -817,6 +820,8 @@ func SubstituteFieldsInGraphqlRequest(req string, f Field, argMap map[string]int
 			continue
 		}
 		value := ""
+		// TODO - Bring back the check below or it might not be needed after we support other
+		// types.
 		// if arg.Type.Name() == "String" || arg.Type.Name() == "ID" || val == nil {
 		if val == nil {
 			val = "null"
@@ -1818,7 +1823,8 @@ func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 	writer.WriteString("}")
 }
 
-func parseRequiredFieldsFromGQLRequest(req string) map[string]bool {
+// parseArgsFromGQLRequest parses a GraphQL request and gets the arguments required by it.
+func parseArgsFromGQLRequest(req string) map[string]bool {
 	// These errors should have already been checked during schema validation.
 	parsedQuery, _ := parser.ParseQuery(&ast.Source{Input: fmt.Sprintf(`query {%s}`,
 		req)})

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -49,6 +49,8 @@ type QueryType string
 // MutationType is currently supported mutations
 type MutationType string
 
+// FieldHTTPConfig contains the config needed to resolve a field using a remote HTTP endpoint
+// which could a GraphQL or a REST endpoint.
 type FieldHTTPConfig struct {
 	URL    string
 	Method string
@@ -809,7 +811,6 @@ func (f *field) CustomHTTPConfig() (FieldHTTPConfig, error) {
 
 func SubstituteFieldsInGraphqlRequest(req string, f Field, argMap map[string]interface{},
 	args []string) (string, error) {
-	fmt.Println("args: ", args, "argMap: ", args)
 	for _, arg := range args {
 		val, ok := argMap[arg]
 		if !ok {

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -656,3 +656,34 @@ func TestSubstituteVarsInURL(t *testing.T) {
 		})
 	}
 }
+
+func TestParseRequiredArgsFromGQLRequest(t *testing.T) {
+	tcases := []struct {
+		name         string
+		req          string
+		operation    string
+		requiredArgs map[string]bool
+	}{
+		// TODO - Add tests for single mode.
+		{
+			"parse required args for batch request",
+			"query { userNames(input: [{ id: $id, age: $age}]) }",
+			"batch",
+			map[string]bool{"id": true, "age": true},
+		},
+		{
+			"parse required nested args for batch request",
+			"query { userNames(input: [{ id: $id, car: { age: $age}}]) }",
+			"batch",
+			map[string]bool{"id": true, "age": true},
+		},
+	}
+
+	for _, test := range tcases {
+		t.Run(test.name, func(t *testing.T) {
+			args, err := ParseRequiredArgsFromGQLRequest(test.req, test.operation)
+			require.NoError(t, err)
+			require.Equal(t, test.requiredArgs, args)
+		})
+	}
+}

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -664,7 +664,18 @@ func TestParseRequiredArgsFromGQLRequest(t *testing.T) {
 		operation    string
 		requiredArgs map[string]bool
 	}{
-		// TODO - Add tests for single mode.
+		{
+			"parse required args for single request",
+			"query { userNames(id: $id, age: $age) }",
+			"single",
+			map[string]bool{"id": true, "age": true},
+		},
+		{
+			"parse required nested args for single request",
+			"query { userNames(id: $id, car: {age: $age}) }",
+			"single",
+			map[string]bool{"id": true, "age": true},
+		},
 		{
 			"parse required args for batch request",
 			"query { userNames(input: [{ id: $id, age: $age}]) }",
@@ -674,6 +685,12 @@ func TestParseRequiredArgsFromGQLRequest(t *testing.T) {
 		{
 			"parse required nested args for batch request",
 			"query { userNames(input: [{ id: $id, car: { age: $age}}]) }",
+			"batch",
+			map[string]bool{"id": true, "age": true},
+		},
+		{
+			"parse required nested array args for batch request",
+			"query { userNames(input: [{ id: $id, car: [{ age: $age}]}]) }",
 			"batch",
 			map[string]bool{"id": true, "age": true},
 		},


### PR DESCRIPTION
Fields could earlier be resolved through custom REST endpoints. This change adds support for resolving fields through GraphQL endpoints which could be a query/mutation.

TODO
---
- [x] Add an integration test where remote endpoint also returns an `error` key along with data and make sure that is also propagated back to the client.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5271)
<!-- Reviewable:end -->
