### PR TITLE
release/v1.2: Avoid crashing live loader in case the network is interrupted.

### DIFF
--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -114,7 +114,12 @@ func handleError(err error, isRetry bool) {
 	s := status.Convert(err)
 	switch {
 	case s.Code() == codes.Internal, s.Code() == codes.Unavailable:
-		x.Fatalf(s.Message())
+		// Let us not crash live loader due to this. Instead, we should infinitely retry to
+		// reconnect and retry the request.
+		dur := time.Duration(1+rand.Intn(60)) * time.Second
+		fmt.Printf("Connection has been possibly interrupted. Got error: %v."+
+			" Will retry after %s.\n", err, dur.Round(time.Second))
+		time.Sleep(dur)
 	case strings.Contains(s.Message(), "x509"):
 		x.Fatalf(s.Message())
 	case s.Code() == codes.Aborted:

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1195,7 +1195,7 @@ func (n *node) abortOldTransactions() {
 	glog.Infof("Found %d old transactions. Acting to abort them.\n", len(starts))
 	req := &pb.TxnTimestamps{Ts: starts}
 	err := n.blockingAbort(req)
-	glog.Infof("Done abortOldTransactions for %d txns. Error: %+v\n", len(req.Ts), err)
+	glog.Infof("Done abortOldTransactions for %d txns. Error: %v\n", len(req.Ts), err)
 }
 
 // calculateSnapshot would calculate a snapshot index, considering these factors:


### PR DESCRIPTION
Cherry-pick of #5268 onto release/v1.2:

> Live loader currently runs x.Fatalf the moment it has a connection interrupt. Instead, it should just retry indefinitely.
>
> Also, remove a `%+v` error print for aborting transactions, which causes the entire error stack trace to be printed, which makes it look like a crash.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes #JiraIssue".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5276)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cd5a8983bb-57454.surge.sh)
<!-- Dgraph:end -->