### PR TITLE
release/v1.2: Alpha: Expose compression_level option (#5278)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -107,6 +107,8 @@ they form a Raft group and provide synchronous replication.
 	flag.String("badger.vlog", "mmap",
 		"[mmap, disk] Specifies how Badger Value log is stored."+
 			" mmap consumes more RAM, but provides better performance.")
+	flag.Int("badger.compression_level", 3,
+		"The compression level for Badger. A higher value uses more resources.")
 	flag.String("encryption_key_file", "",
 		"The file that stores the encryption key. The key size must be 16, 24, or 32 bytes long. "+
 			"The key size determines the corresponding block size for AES encryption "+
@@ -510,9 +512,10 @@ func run() {
 	bindall = Alpha.Conf.GetBool("bindall")
 
 	opts := worker.Options{
-		BadgerTables:  Alpha.Conf.GetString("badger.tables"),
-		BadgerVlog:    Alpha.Conf.GetString("badger.vlog"),
-		BadgerKeyFile: Alpha.Conf.GetString("encryption_key_file"),
+		BadgerTables:           Alpha.Conf.GetString("badger.tables"),
+		BadgerVlog:             Alpha.Conf.GetString("badger.vlog"),
+		BadgerKeyFile:          Alpha.Conf.GetString("encryption_key_file"),
+		BadgerCompressionLevel: Alpha.Conf.GetInt("badger.compression_level"),
 
 		PostingDir: Alpha.Conf.GetString("postings"),
 		WALDir:     Alpha.Conf.GetString("wal"),

--- a/worker/config.go
+++ b/worker/config.go
@@ -46,6 +46,10 @@ type Options struct {
 	BadgerVlog string
 	// BadgerKeyFile is the file containing the key used for encryption. Enterprise only feature.
 	BadgerKeyFile string
+	// BadgerCompressionLevel is the ZSTD compression level used by badger. A
+	// higher value means more CPU intensive compression and better compression
+	// ratio.
+	BadgerCompressionLevel int
 	// WALDir is the path to the directory storing the write-ahead log.
 	WALDir string
 	// MutationsMode is the mode used to handle mutation requests.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -97,8 +97,18 @@ func (s *ServerState) runVlogGC(store *badger.DB) {
 func setBadgerOptions(opt badger.Options) badger.Options {
 	opt = opt.WithSyncWrites(false).WithTruncate(true).WithLogger(&x.ToGlog{}).
 		WithEncryptionKey(enc.ReadEncryptionKeyFile(Config.BadgerKeyFile))
-	// TODO(ibrahim): Remove this once badger is updated in dgraph.
-	opt.ZSTDCompressionLevel = 1
+
+	// Do not load bloom filters on DB open.
+	opt.LoadBloomsOnOpen = false
+
+	glog.Infof("Setting Badger Compression Level: %d", Config.BadgerCompressionLevel)
+	// Default value of badgerCompressionLevel is 3 so compression will always
+	// be enabled, unless it is explicitly disabled by setting the value to 0.
+	if Config.BadgerCompressionLevel != 0 {
+		// By default, compression is disabled in badger.
+		opt.Compression = options.ZSTD
+		opt.ZSTDCompressionLevel = Config.BadgerCompressionLevel
+	}
 
 	glog.Infof("Setting Badger table load option: %s", Config.BadgerTables)
 	switch Config.BadgerTables {
@@ -160,10 +170,6 @@ func (s *ServerState) initStorage() {
 		glog.Infof("Opening write-ahead log BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
 
-		opt.ZSTDCompressionLevel = 3
-		opt.Compression = options.ZSTD
-		opt.LoadBloomsOnOpen = false
-
 		s.WALstore, err = badger.Open(opt)
 		x.Checkf(err, "Error while creating badger KV WAL store")
 	}
@@ -182,10 +188,6 @@ func (s *ServerState) initStorage() {
 		opt.EncryptionKey = nil
 		glog.Infof("Opening postings BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
-
-		opt.ZSTDCompressionLevel = 3
-		opt.Compression = options.ZSTD
-		opt.LoadBloomsOnOpen = false
 
 		s.Pstore, err = badger.OpenManaged(opt)
 		x.Checkf(err, "Error while creating badger KV posting store")


### PR DESCRIPTION
This PR exposes the `compression_level` flag in `alpha`. The flag can be set as
```
dgraph alpha --badger.compression_level=xxx
```
A higher value of the compression level is more CPU intensive but
offers a better compression ratio. The default value is `3`.

`compression_level=0` disables compression.

(cherry picked from commit 7442993fb862d16d1181a2accd860acd9ebbf67d)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes #JiraIssue".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5279)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-20099d09b1-57550.surge.sh)
<!-- Dgraph:end -->