### PR TITLE
graphql: add validations and tests for @custom graphql on fields

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -440,6 +440,176 @@ func invalidType(w http.ResponseWriter, r *http.Request) {
 	`))
 }
 
+func nullQueryAndMutationType(w http.ResponseWriter, r *http.Request) {
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/nullQueryAndMutationType",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
+	{
+		"data": {
+			"__schema": {
+				"queryType": null,
+				"mutationType": null,
+				"subscriptionType": null
+			}
+		}
+	}
+	`))
+}
+
+func missingQueryAndMutationType(w http.ResponseWriter, r *http.Request) {
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/missingQueryAndMutationType",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
+	{
+		"data": {
+			"__schema": {
+				"queryType": {
+					"name": "Query"
+				},
+				"mutationType": {
+					"name": "Mutation"
+				},
+				"subscriptionType": null
+			}
+		}
+	}
+	`))
+}
+
+func invalidInputForBatchedField(w http.ResponseWriter, r *http.Request) {
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/invalidInputForBatchedField",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
+		{
+		"data": {
+			"__schema": {
+			  "queryType": {
+				"name": "Query"
+			  },
+			  "mutationType": null,
+			  "subscriptionType": null,
+			  "types": [
+				{
+				  "kind": "OBJECT",
+				  "name": "Query",
+				  "fields": [
+					{
+						"name": "getPosts",
+						"args": [
+						  {
+							"name": "input",
+							"type": {
+							  "kind": "LIST",
+							  "name": null,
+							  "ofType": {
+								"kind": "SCALAR",
+								"name": "Int",
+								"ofType": null
+							  }
+							},
+							"defaultValue": null
+						  }
+						],
+						"type": {
+						  "kind": "LIST",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "NON_NULL",
+						 	"name": null,
+							"ofType": {
+							  "kind": "OBJECT",
+							  "name": "Post",
+							  "ofType": null
+							}
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					  }
+				  ]
+				}]
+			  }
+		   }
+		}`))
+}
+
+func missingTypeForBatchedFieldInput(w http.ResponseWriter, r *http.Request) {
+	if _, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/missingTypeForBatchedFieldInput",
+		body:      ``,
+	}); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprintf(w, `
+		{
+		"data": {
+			"__schema": {
+			  "queryType": {
+				"name": "Query"
+			  },
+			  "mutationType": null,
+			  "subscriptionType": null,
+			  "types": [
+				{
+				  "kind": "OBJECT",
+				  "name": "Query",
+				  "fields": [
+					{
+						"name": "getPosts",
+						"args": [
+						  {
+							"name": "input",
+							"type": {
+							  "kind": "LIST",
+							  "name": null,
+							  "ofType": {
+								"kind": "OBJECT",
+								"name": "PostFilterInput",
+								"ofType": null
+							  }
+							},
+							"defaultValue": null
+						  }
+						],
+						"type": {
+						  "kind": "LIST",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "NON_NULL",
+						 	"name": null,
+							"ofType": {
+							  "kind": "OBJECT",
+							  "name": "Post",
+							  "ofType": null
+							}
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					  }
+				  ]
+				}]
+			  }
+		   }
+		}`))
+}
+
 func validCountryResponse(w http.ResponseWriter, r *http.Request) {
 	isIntrospection, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
 		urlSuffix: "/validcountry",
@@ -907,6 +1077,104 @@ func updateCountries(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func getPosts(w http.ResponseWriter, r *http.Request) {
+	_, err := verifyGraphqlRequest(r, expectedGraphqlRequest{
+		urlSuffix: "/getPosts",
+		body:      ``,
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+
+	check2(fmt.Fprintf(w, `
+		{
+		"data": {
+			"__schema": {
+			  "queryType": {
+				"name": "Query"
+			  },
+			  "mutationType": null,
+			  "subscriptionType": null,
+			  "types": [
+				{
+				  "kind": "OBJECT",
+				  "name": "Query",
+				  "fields": [
+					{
+						"name": "getPosts",
+						"args": [
+						  {
+							"name": "input",
+							"type": {
+							  "kind": "LIST",
+							  "name": null,
+							  "ofType": {
+								"kind": "OBJECT",
+								"name": "PostFilterInput",
+								"ofType": null
+							  }
+							},
+							"defaultValue": null
+						  }
+						],
+						"type": {
+						  "kind": "LIST",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "NON_NULL",
+						 	"name": null,
+							"ofType": {
+							  "kind": "OBJECT",
+							  "name": "Post",
+							  "ofType": null
+							}
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					  }
+				  ]
+				},
+				{
+				  "kind": "OBJECT",
+				  "name": "PostFilterInput",
+				  "fields": [
+					{
+						"name": "id",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "ID",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "text",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "String",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				  ]
+				}]
+			  }
+		   }
+		}`))
+}
+
 type input struct {
 	ID string `json:"uid"`
 }
@@ -1127,21 +1395,14 @@ func schoolNameHandler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 
+	/*************************************
+	* For testing http without graphql
+	*************************************/
+
 	// for queries
 	http.HandleFunc("/favMovies/", getFavMoviesHandler)
 	http.HandleFunc("/favMoviesPost/", postFavMoviesHandler)
 	http.HandleFunc("/verifyHeaders", verifyHeadersHandler)
-
-	// for graphql testing
-	http.HandleFunc("/noquery", emptyQuerySchema)
-	http.HandleFunc("/invalidargument", invalidArgument)
-	http.HandleFunc("/invalidtype", invalidType)
-	http.HandleFunc("/validcountry", validCountryResponse)
-	http.HandleFunc("/validcountrywitherror", validCountryWithErrorResponse)
-	http.HandleFunc("/graphqlerr", graphqlErrResponse)
-	http.HandleFunc("/validcountries", validCountries)
-	http.HandleFunc("/setCountry", setCountry)
-	http.HandleFunc("/updateCountries", updateCountries)
 
 	// for mutations
 	http.HandleFunc("/favMoviesCreate", favMoviesCreateHandler)
@@ -1161,6 +1422,32 @@ func main() {
 	http.HandleFunc("/class", classHandler)
 	http.HandleFunc("/teacherName", teacherNameHandler)
 	http.HandleFunc("/schoolName", schoolNameHandler)
+
+	/*************************************
+	* For testing http with graphql
+	*************************************/
+
+	// for remote schema validation
+	http.HandleFunc("/noquery", emptyQuerySchema)
+	http.HandleFunc("/invalidargument", invalidArgument)
+	http.HandleFunc("/invalidtype", invalidType)
+	http.HandleFunc("/nullQueryAndMutationType", nullQueryAndMutationType)
+	http.HandleFunc("/missingQueryAndMutationType", missingQueryAndMutationType)
+	http.HandleFunc("/invalidInputForBatchedField", invalidInputForBatchedField)
+	http.HandleFunc("/missingTypeForBatchedFieldInput", missingTypeForBatchedFieldInput)
+
+	// for queries
+	http.HandleFunc("/validcountry", validCountryResponse)
+	http.HandleFunc("/validcountrywitherror", validCountryWithErrorResponse)
+	http.HandleFunc("/graphqlerr", graphqlErrResponse)
+	http.HandleFunc("/validcountries", validCountries)
+
+	// for mutations
+	http.HandleFunc("/setCountry", setCountry)
+	http.HandleFunc("/updateCountries", updateCountries)
+
+	// for batch mode
+	http.HandleFunc("/getPosts", getPosts)
 
 	fmt.Println("Listening on port 8888")
 	log.Fatal(http.ListenAndServe(":8888", nil))

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -579,7 +579,7 @@ func missingTypeForBatchedFieldInput(w http.ResponseWriter, r *http.Request) {
 							  "kind": "LIST",
 							  "name": null,
 							  "ofType": {
-								"kind": "OBJECT",
+								"kind": "INPUT_OBJECT",
 								"name": "PostFilterInput",
 								"ofType": null
 							  }
@@ -1110,7 +1110,7 @@ func getPosts(w http.ResponseWriter, r *http.Request) {
 							  "kind": "LIST",
 							  "name": null,
 							  "ofType": {
-								"kind": "OBJECT",
+								"kind": "INPUT_OBJECT",
 								"name": "PostFilterInput",
 								"ofType": null
 							  }
@@ -1137,7 +1137,7 @@ func getPosts(w http.ResponseWriter, r *http.Request) {
 				  ]
 				},
 				{
-				  "kind": "OBJECT",
+				  "kind": "INPUT_OBJECT",
 				  "name": "PostFilterInput",
 				  "fields": [
 					{

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1878,7 +1878,41 @@ func gqlCarsHandler(w http.ResponseWriter, r *http.Request) {
 						"deprecationReason":null
 						}
 					]
+					},
+				{
+				  "kind": "INPUT_OBJECT",
+				  "name": "UserInput",
+				  "fields": [
+					{
+						"name": "id",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "ID",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "age",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "Int",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
 					}
+				  ]
+				}
 				]
 				}
 			}
@@ -1967,7 +2001,41 @@ func gqlClassesHandler(w http.ResponseWriter, r *http.Request) {
 						"deprecationReason":null
 						}
 					]
+					},
+				{
+				  "kind": "INPUT_OBJECT",
+				  "name": "UserInput",
+				  "fields": [
+					{
+						"name": "id",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "ID",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "age",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "Int",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
 					}
+				  ]
+				}
 				]
 				}
 			}

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1707,6 +1707,40 @@ func introspectionResult(name string) string {
 					"deprecationReason":null
 					}
 				]
+				},
+				{
+				  "kind": "INPUT_OBJECT",
+				  "name": "UserInput",
+				  "fields": [
+					{
+						"name": "id",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "ID",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					},
+					{
+						"name": "age",
+						"type": {
+						  "kind": "NON_NULL",
+						  "name": null,
+						  "ofType": {
+						 	"kind": "SCALAR",
+						 	"name": "Int",
+							"ofType": null
+						  }
+						},
+						"isDeprecated": false,
+						"deprecationReason": null
+					}
+				  ]
 				}
 			]
 			}

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -888,7 +888,7 @@ func TestForInvalidType(t *testing.T) {
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:61: Type Query"+
 		"; Field getCountry: inside graphql in @custom directive, found type mismatch for "+
-		"variable `$id` in query `country`, expected `String!`, got `Int!`.\n", res.Errors[0].Error())
+		"variable `$id` in query `country`, expected `ID!`, got `Int!`.\n", res.Errors[0].Error())
 }
 
 func TestCustomLogicGraphql(t *testing.T) {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -924,8 +924,8 @@ func TestForInvalidCustomQuery(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:61: Type Query"+
-		"; Field getCountry: @custom directive: graphql; given query: country is not present in"+
-		" remote schema.\n", res.Errors[0].Error())
+		"; Field getCountry: inside graphql in @custom directive, query `country` is not present"+
+		" in remote schema.\n", res.Errors[0].Error())
 }
 
 func TestForInvalidArgument(t *testing.T) {
@@ -942,8 +942,8 @@ func TestForInvalidArgument(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:61: Type Query"+
-		"; Field getCountry: @custom directive: graphql; given query: country: arg code not"+
-		" present in remote query.\n", res.Errors[0].Error())
+		"; Field getCountry: inside graphql in @custom directive, argument `code` is not present"+
+		" in remote query `country`.\n", res.Errors[0].Error())
 }
 
 func TestForInvalidType(t *testing.T) {
@@ -960,8 +960,8 @@ func TestForInvalidType(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:61: Type Query"+
-		"; Field getCountry: @custom directive: graphql; given query: country: type mismatch for"+
-		" variable $id; expected: ID!, got: Int!.\n", res.Errors[0].Error())
+		"; Field getCountry: inside graphql in @custom directive, found type mismatch for "+
+		"variable `$id` in query `country`, expected `String!`, got `Int!`.\n", res.Errors[0].Error())
 }
 
 func TestCustomLogicGraphql(t *testing.T) {
@@ -1454,8 +1454,8 @@ func TestCustomGraphqlNullQueryType(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Query"+
-		"; Field getCountry: @custom directive: graphql; remote schema doesn't have any queries.\n",
-		res.Errors[0].Error())
+		"; Field getCountry: inside graphql in @custom directive, remote schema doesn't have any"+
+		" queries.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlNullMutationType(t *testing.T) {
@@ -1471,8 +1471,8 @@ func TestCustomGraphqlNullMutationType(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Mutation"+
-		"; Field addCountry: @custom directive: graphql; remote schema doesn't have any mutations."+
-		"\n", res.Errors[0].Error())
+		"; Field addCountry: inside graphql in @custom directive, remote schema doesn't have any"+
+		" mutations.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingQueryType(t *testing.T) {
@@ -1488,8 +1488,8 @@ func TestCustomGraphqlMissingQueryType(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Query"+
-		"; Field getCountry: @custom directive: graphql; remote schema doesn't have any type"+
-		" named Query.\n", res.Errors[0].Error())
+		"; Field getCountry: inside graphql in @custom directive, remote schema doesn't have any "+
+		"type named Query.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingMutationType(t *testing.T) {
@@ -1505,8 +1505,8 @@ func TestCustomGraphqlMissingMutationType(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Mutation"+
-		"; Field addCountry: @custom directive: graphql; remote schema doesn't have any type"+
-		" named Mutation.\n", res.Errors[0].Error())
+		"; Field addCountry: inside graphql in @custom directive, remote schema doesn't have any"+
+		" type named Mutation.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingMutation(t *testing.T) {
@@ -1522,7 +1522,7 @@ func TestCustomGraphqlMissingMutation(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Mutation"+
-		"; Field addCountry: @custom directive: graphql; given mutation: putCountry is not"+
+		"; Field addCountry: inside graphql in @custom directive, mutation `putCountry` is not"+
 		" present in remote schema.\n", res.Errors[0].Error())
 }
 
@@ -1539,8 +1539,8 @@ func TestCustomGraphqlReturnTypeMismatch(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Mutation"+
-		"; Field addCountry: @custom directive: graphql; given mutation: setCountry: return type"+
-		" mismatch; expected: Movie!, got: Country!.\n", res.Errors[0].Error())
+		"; Field addCountry: inside graphql in @custom directive, found return type mismatch for"+
+		" mutation `setCountry`, expected `Movie!`, got `Country!`.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlReturnTypeMismatchForBatchedField(t *testing.T) {
@@ -1564,8 +1564,8 @@ func TestCustomGraphqlReturnTypeMismatchForBatchedField(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:13: Type Post"+
-		"; Field author: @custom directive: graphql; given query: getPosts: return type"+
-		" mismatch; expected: [Author!], got: [Post!].\n", res.Errors[0].Error())
+		"; Field author: inside graphql in @custom directive, found return type mismatch for "+
+		"query `getPosts`, expected `[Author!]`, got `[Post!]`.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlInvalidInputFormatForBatchedField(t *testing.T) {
@@ -1585,9 +1585,9 @@ func TestCustomGraphqlInvalidInputFormatForBatchedField(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: @custom directive: graphql; given query: getPosts: arg `input` is not"+
-		" of the form `[{param1: $var1, param2: $var2, ...}]` in remote query.\n",
-		res.Errors[0].Error())
+		"; Field comments: inside graphql in @custom directive, argument `input` for given query"+
+		" `getPosts` must be of the form `[{param1: $var1, param2: $var2, ...}]` for batch "+
+		"operations in remote query.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingTypeForBatchedFieldInput(t *testing.T) {
@@ -1607,8 +1607,8 @@ func TestCustomGraphqlMissingTypeForBatchedFieldInput(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: @custom directive: graphql; remote schema doesn't have any type named"+
-		" PostFilterInput.\n", res.Errors[0].Error())
+		"; Field comments: inside graphql in @custom directive, remote schema doesn't have any "+
+		"type named PostFilterInput.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlInvalidArgForBatchedField(t *testing.T) {
@@ -1628,29 +1628,30 @@ func TestCustomGraphqlInvalidArgForBatchedField(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: @custom directive: graphql; given query: getPosts: arg name not"+
-		" present in remote query.\n", res.Errors[0].Error())
+		"; Field comments: inside graphql in @custom directive, argument `name` is not present "+
+		"in remote query `getPosts`.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlArgTypeMismatchForBatchedField(t *testing.T) {
 	schema := `
 	type Post {
 		id: ID!
+		likes: Int
 		text: String
 		comments: Post! @custom(http: {
 							url: "http://mock:8888/getPosts",
 							method: "POST",
 							operation: "batch"
-							graphql: "query { getPosts(input: [{id: $id, text: $id}]) }"
+							graphql: "query { getPosts(input: [{id: $id, text: $likes}]) }"
 						})
 	}
 	`
 	res := updateSchema(t, schema)
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
-	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: @custom directive: graphql; given query: getPosts: type mismatch for"+
-		" variable $id; expected: ID!, got: String!.\n", res.Errors[0].Error())
+	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:10: Type Post"+
+		"; Field comments: inside graphql in @custom directive, found type mismatch for variable"+
+		" `$likes` in query `getPosts`, expected `Int`, got `String!`.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingRequiredArgument(t *testing.T) {
@@ -1666,8 +1667,8 @@ func TestCustomGraphqlMissingRequiredArgument(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:60: Type Mutation"+
-		"; Field addCountry: @custom directive: graphql; given mutation: setCountry: required arg"+
-		" country is missing.\n", res.Errors[0].Error())
+		"; Field addCountry: inside graphql in @custom directive, argument `country` in mutation"+
+		" `setCountry` is missing, it is required by remote mutation.\n", res.Errors[0].Error())
 }
 
 func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
@@ -1687,8 +1688,8 @@ func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: @custom directive: graphql; given query: getPosts: required arg text"+
-		" is missing.\n", res.Errors[0].Error())
+		"; Field comments: inside graphql in @custom directive, argument `text` in query "+
+		"`getPosts` is missing, it is required by remote query.\n", res.Errors[0].Error())
 }
 
 // this one accepts an object and returns an object

--- a/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
@@ -21,7 +21,7 @@ type User {
         url: "http://mock:8888/gqlCars"
         method: "POST"
         operation: "batch"
-        graphql: "query { cars(input: [{ id: $id}]) }"
+        graphql: "query { cars(input: [{ id: $id, age: $age}]) }"
       }
     )
   schools: [School]
@@ -36,7 +36,7 @@ type School {
         url: "http://mock:8888/gqlSchoolNames"
         method: "POST"
         operation: "batch"
-        graphql: "query { schoolNames(input: [{ id: $id}]) }"
+        graphql: "query { schoolNames(input: [{ id: $id, age: $established}]) }"
       }
     )
   classes: [Class]
@@ -45,7 +45,7 @@ type School {
         url: "http://mock:8888/gqlClasses"
         method: "POST"
         operation: "batch"
-        graphql: "query { classes(input: [{ id: $id}]) }"
+        graphql: "query { classes(input: [{ id: $id, age: $established}]) }"
       }
     )
   teachers: [Teacher]
@@ -65,7 +65,7 @@ type Teacher {
         url: "http://mock:8888/gqlTeacherNames"
         method: "POST"
         operation: "batch"
-        graphql: "query { teacherNames(input: [{ xid: $tid}]) }"
+        graphql: "query { teacherNames(input: [{ id: $tid, age: $age}]) }"
       }
     )
 }

--- a/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
+++ b/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
@@ -65,7 +65,7 @@ type Teacher {
         url: "http://mock:8888/gqlTeacherNames"
         method: "POST"
         operation: "batch"
-        graphql: "query { teacherNames(input: [{ xid: $tid}]) }"
+        graphql: "query { teacherNames(input: [{ id: $tid, age: $age}]) }"
       }
     )
 }

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -471,7 +471,7 @@ func completeSchema(sch *ast.Schema, definitions []string) {
 	}
 
 	for _, key := range definitions {
-		if key == "Query" || key == "Mutation" {
+		if isQueryOrMutation(key) {
 			continue
 		}
 		defn := sch.Types[key]
@@ -1459,7 +1459,7 @@ func Stringify(schema *ast.Schema, originalTypes []string) string {
 	// original defs can only be types and enums, print those in the same order
 	// as the original schema.
 	for _, typName := range originalTypes {
-		if typName == "Query" || typName == "Mutation" {
+		if isQueryOrMutation(typName) {
 			// These would be printed later in schema.Query and schema.Mutation
 			continue
 		}
@@ -1494,7 +1494,7 @@ func Stringify(schema *ast.Schema, originalTypes []string) string {
 	// left to be printed.
 	typeNames := make([]string, 0, len(schema.Types)-len(printed))
 	for typName, typDef := range schema.Types {
-		if typName == "Query" || typName == "Mutation" {
+		if isQueryOrMutation(typName) {
 			// These would be printed later in schema.Query and schema.Mutation
 			continue
 		}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -1158,7 +1158,48 @@ invalid_schemas:
     ]
 
   -
-    name: "@custom directive with repeating arguments for field in operation in graphql"
+    name: "@custom directive with batch mode on field and invalid input format for query in graphql"
+    input: |
+      type Author {
+        id: ID!
+        name: String!
+      }
+      type Post {
+        id: ID!
+        author: Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          operation: "batch"
+          graphql: "query { getAuthor(postId: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Post; Field author: @custom directive: graphql; for batch operations query `getAuthor` can have only one argument named `input` with value formatted as `[{param1: $var1, param2: $var2, ...}]`.",
+     "locations":[{"line":11, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with batch mode on field and repeating arguments for query in graphql"
+    input: |
+      type Author {
+        id: ID!
+      }
+      type Post {
+        id: ID!
+        author: Author! @custom(http: {
+          url: "http://google.com/",
+          method: "POST",
+          operation: "batch"
+          graphql: "query { getAuthor(input: [{id: $id, id: $id}]) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Post; Field author: @custom directive: graphql; given query: getAuthor: arguments [id ] appear more than once, each argument can appear only once.",
+     "locations":[{"line":10, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive with repeating arguments for query in graphql"
     input: |
       type Author {
         id: ID!
@@ -1176,20 +1217,35 @@ invalid_schemas:
     ]
 
   -
-    name: "@custom directive on field where body uses undefined field"
+    name: "@custom directive not allowed on field of type ID!"
     input: |
       type Author {
-        id: ID!
-        name: String! @custom(http: {
+        id: ID! @custom(http: {
           url: "http://google.com",
           method: "GET",
-          body: "{ abc: $abc }"
+          body: "{ abc: $foo }"
         })
       }
     errlist: [
-      {"message": "Type Author; Field name; @custom directive, body template must use fields
-       defined within the type, found: abc.",
-      "locations":[{"line":6, "column":12}]},
+    {"message": "Type Author; Field id; custom directive not allowed on field of type ID! or
+      field with @id directive.",
+     "locations":[{"line":2, "column":12}]},
+    ]
+
+  -
+    name: "@custom directive not allowed on field with @id directive"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @id @custom(http: {
+          url: "http://google.com",
+          method: "GET",
+          body: "{ id: $id }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field name; custom directive not allowed on field of type ID! or field with @id directive.",
+     "locations":[{"line":3, "column":22}]},
     ]
 
   -
@@ -1204,8 +1260,134 @@ invalid_schemas:
         })
       }
     errlist: [
-      {"message": "Type Author; Field name; @custom directive, body template can't require itself.",
-       "locations":[{"line":6, "column":12}]},
+    {"message": "Type Author; Field name; @custom directive, body template can't require itself.",
+     "locations":[{"line":6, "column":12}]},
+    ]
+
+  -
+    name: "@custom directive on field where body uses undefined field"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @custom(http: {
+          url: "http://google.com",
+          method: "GET",
+          body: "{ abc: $abc }"
+        })
+      }
+    errlist: [
+      {"message": "Type Author; Field name; @custom directive, body template must use fields defined within the type, found: abc.",
+      "locations":[{"line":6, "column":12}]},
+    ]
+
+  -
+    name: "@custom directive on field where body doesn't use scalar field"
+    input: |
+      type Note {
+        test: String!
+      }
+      type Author {
+        id: ID!
+        name: String! @id
+        foo: Note
+        yo: String! @custom(http: {
+          url: "http://google.com",
+          method: "POST",
+          body: "{ id: $id, abc: $foo }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field yo; @custom directive, body template must use scalar fields, found field of type: Note.",
+     "locations":[{"line":11, "column":12}]},
+    ]
+
+  -
+    name: "@custom directive on field doesn't use field with ID! type or @id directive in body"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @id
+        foo: String
+        yo: String! @custom(http: {
+          url: "http://google.com",
+          method: "GET",
+          body: "{ abc: $foo }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field yo: @custom directive, body template must use a field with type ID! or a field with @id directive.",
+     "locations":[{"line":8, "column":12}]},
+    ]
+
+  -
+    name: "@custom directive on field where graphql required itself"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @custom(http: {
+          url: "http://google.com",
+          method: "POST",
+          graphql: "query { getName(abc: $name, id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field name; @custom directive, graphql can't require itself.",
+     "locations":[{"line":6, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive on field where graphql uses undefined field"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @custom(http: {
+          url: "http://google.com",
+          method: "POST",
+          graphql: "query { getName(abc: $abc, id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field name; @custom directive, graphql must use fields defined within the type, found: abc.",
+     "locations":[{"line":6, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive on field where graphql doesn't use scalar field"
+    input: |
+      type Note {
+        test: String!
+      }
+      type Author {
+        id: ID!
+        name: String! @id
+        foo: Note
+        yo: String! @custom(http: {
+          url: "http://google.com",
+          method: "POST",
+          graphql: "query { getName(abc: $foo, id: $id) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field yo; @custom directive, graphql must use scalar fields, found field of type: Note.",
+     "locations":[{"line":11, "column":15}]},
+    ]
+
+  -
+    name: "@custom directive on field doesn't use field with ID! type or @id directive in graphql"
+    input: |
+      type Author {
+        id: ID!
+        name: String! @id
+        foo: String
+        yo: String! @custom(http: {
+          url: "http://google.com",
+          method: "POST",
+          graphql: "query { getName(abc: $foo) }"
+        })
+      }
+    errlist: [
+    {"message": "Type Author; Field yo: @custom directive, graphql must use a field with type ID! or a field with @id directive.",
+     "locations":[{"line":8, "column":15}]},
     ]
 
   -
@@ -1223,58 +1405,6 @@ invalid_schemas:
       {"message": "Type Author; Field name; @custom directive is only allowed on fields where the type
        definition has a field with type ID! or a field with @id directive.",
       "locations":[{"line":3, "column":18}]},
-    ]
-
-  -
-    name: "@custom directive on field doesn't use field with ID! type or @id directive"
-    input: |
-      type Author {
-        id: ID!
-        name: String! @id
-        foo: String
-        yo: String! @custom(http: {
-          url: "http://google.com",
-          method: "GET",
-          body: "{ abc: $foo }"
-        })
-      }
-    errlist: [
-      {"message": "Type Author; Field yo: @custom directive, body template must use a field with type
-      ID! or a field with @id directive.",
-      "locations":[{"line":8, "column":12}]},
-    ]
-
-  -
-    name: "@custom directive not allowed on field of type ID!"
-    input: |
-      type Author {
-        id: ID! @custom(http: {
-          url: "http://google.com",
-          method: "GET",
-          body: "{ abc: $foo }"
-        })
-      }
-    errlist: [
-      {"message": "Type Author; Field id; custom directive not allowed on field of type ID! or
-      field with @id directive.",
-      "locations":[{"line":2, "column":12}]},
-    ]
-
-  -
-    name: "@custom directive not allowed on field with @id directive"
-    input: |
-      type Author {
-        id: ID!
-        name: String! @id @custom(http: {
-          url: "http://google.com",
-          method: "GET",
-          body: "{ id: $id }"
-        })
-      }
-    errlist: [
-      {"message": "Type Author; Field name; custom directive not allowed on field of type ID! or
-      field with @id directive.",
-      "locations":[{"line":3, "column":22}]},
     ]
 
   -

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -945,7 +945,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 0 operations, it can have exactly one operation.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found 0 operations, it can have exactly one operation.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -963,7 +963,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; unable to parse input: 30: Unexpected Name \"garbage\"",
+    {"message": "Type Query; Field getAuthor: unable to parse graphql in @custom directive because: Unexpected Name \"garbage\"",
      "locations":[{"line":8, "column":15}]},
     ]
 
@@ -982,7 +982,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 2 operations, it can have exactly one operation.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found 2 operations, it can have exactly one operation.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1001,7 +1001,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found subscription operation, it can only have query/mutation.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found `subscription` operation, it can only have query/mutation.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1020,7 +1020,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with name opName, it can't have a name.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found operation with name `opName`, it can't have a name.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1039,7 +1039,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with variables, it can't have any variable definitions.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found operation with variables, it can't have any variable definitions.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1058,7 +1058,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found operation with directives, it can't have any directives.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found operation with directives, it can't have any directives.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1077,7 +1077,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found 2 fields inside operation query, it can have exactly one field.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found 2 fields inside operation `query`, it can have exactly one field.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1096,7 +1096,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found mutation getAuthor with alias authors, it can't have any alias.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found mutation `getAuthor` with alias `authors`, it can't have any alias.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1115,7 +1115,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; unable to parse input: 27: Expected Name, found :",
+    {"message": "Type Query; Field getAuthor: unable to parse graphql in @custom directive because: Expected Name, found :",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1134,7 +1134,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found query getAuthor with directives, it can't have any directives.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found query `getAuthor` with directives, it can't have any directives.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1153,7 +1153,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; found query getAuthor with a selection set, it can't have any selection set.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, found query `getAuthor` with a selection set, it can't have any selection set.",
      "locations":[{"line":9, "column":15}]},
     ]
 
@@ -1174,7 +1174,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Post; Field author: @custom directive: graphql; for batch operations query `getAuthor` can have only one argument named `input` with value formatted as `[{param1: $var1, param2: $var2, ...}]`.",
+    {"message": "Type Post; Field author: inside graphql in @custom directive, for batch operations, query `getAuthor` can have only one argument with value formatted as `[{param1: $var1, param2: $var2, ...}]`.",
      "locations":[{"line":11, "column":15}]},
     ]
 
@@ -1194,7 +1194,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Post; Field author: @custom directive: graphql; given query: getAuthor: arguments [id ] appear more than once, each argument can appear only once.",
+    {"message": "Type Post; Field author: inside graphql in @custom directive, query `getAuthor` has arguments [id ] which appear more than once, each argument can appear only once.",
      "locations":[{"line":10, "column":15}]},
     ]
 
@@ -1212,7 +1212,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor: @custom directive: graphql; given query: getAuthor: arguments [id ] appear more than once, each argument can appear only once.",
+    {"message": "Type Query; Field getAuthor: inside graphql in @custom directive, query `getAuthor` has arguments [id ] which appear more than once, each argument can appear only once.",
      "locations":[{"line":8, "column":15}]},
     ]
 
@@ -1276,7 +1276,7 @@ invalid_schemas:
         })
       }
     errlist: [
-      {"message": "Type Author; Field name; @custom directive, body template must use fields defined within the type, found: abc.",
+      {"message": "Type Author; Field name; @custom directive, body template must use fields defined within the type, found `abc`.",
       "locations":[{"line":6, "column":12}]},
     ]
 
@@ -1297,7 +1297,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Author; Field yo; @custom directive, body template must use scalar fields, found field of type: Note.",
+    {"message": "Type Author; Field yo; @custom directive, body template must use scalar fields, found field of type `Note`.",
      "locations":[{"line":11, "column":12}]},
     ]
 
@@ -1347,7 +1347,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Author; Field name; @custom directive, graphql must use fields defined within the type, found: abc.",
+    {"message": "Type Author; Field name; @custom directive, graphql must use fields defined within the type, found `abc`.",
      "locations":[{"line":6, "column":15}]},
     ]
 
@@ -1368,7 +1368,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Author; Field yo; @custom directive, graphql must use scalar fields, found field of type: Note.",
+    {"message": "Type Author; Field yo; @custom directive, graphql must use scalar fields, found field of type `Note`.",
      "locations":[{"line":11, "column":15}]},
     ]
 

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -29,7 +29,7 @@ import (
 )
 
 // introspectRemoteSchema introspectes remote schema
-func introspectRemoteSchema(url string) (*IntrospectedSchema, error) {
+func introspectRemoteSchema(url string) (*introspectedSchema, error) {
 	param := &Request{
 		Query: introspectionQuery,
 	}
@@ -55,7 +55,7 @@ func introspectRemoteSchema(url string) (*IntrospectedSchema, error) {
 	if err != nil {
 		return nil, err
 	}
-	result := &IntrospectedSchema{}
+	result := &introspectedSchema{}
 
 	return result, json.Unmarshal(body, result)
 }
@@ -162,6 +162,20 @@ type remoteGraphqlMetadata struct {
 	url string
 }
 
+type argMatchingMetadata struct {
+	givenArgVals  map[string]*ast.Value
+	givenVarTypes map[string]*ast.Type
+	remoteArgMd   *remoteArgMetadata
+	remoteTypes   map[string]*types
+	givenQryName  *string
+	operationType *string
+}
+
+type remoteArgMetadata struct {
+	typMap       map[string]*gqlType
+	requiredArgs []string
+}
+
 // validates the graphql given in @custom->http->graphql by introspecting remote schema.
 // It assumes that the graphql syntax is correct, only remote validation is needed.
 func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
@@ -171,7 +185,7 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 	}
 
 	var remoteQueryTypename string
-	operationType := metadata.graphqlOpDef.Operation
+	operationType := string(metadata.graphqlOpDef.Operation)
 	switch operationType {
 	case "query":
 		if remoteIntrospection.Data.Schema.QueryType == nil {
@@ -186,21 +200,21 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 	default:
 		// this case is not possible as we are validating the operation to be query/mutation in
 		// @custom directive validation
-		return errors.Errorf("found %s operation, it can only have query/mutation.", operationType)
+		return errors.Errorf("found `%s` operation, it can only have query/mutation.", operationType)
 	}
 
-	remoteTypes := make(map[string]*Types)
+	remoteTypes := make(map[string]*types)
 	for _, typ := range remoteIntrospection.Data.Schema.Types {
 		remoteTypes[typ.Name] = typ
 	}
 
 	remoteQryType, ok := remoteTypes[remoteQueryTypename]
 	if !ok {
-		return errors.Errorf("remote schema doesn't have any type named %s.", remoteQueryTypename)
+		return missingRemoteTypeError(remoteQueryTypename)
 	}
 
 	// check whether given query/mutation is present in remote schema
-	var introspectedRemoteQuery *GqlField
+	var introspectedRemoteQuery *gqlField
 	givenQuery := metadata.graphqlOpDef.SelectionSet[0].(*ast.Field)
 	for _, remoteQuery := range remoteQryType.Fields {
 		if remoteQuery.Name == givenQuery.Name {
@@ -209,10 +223,11 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 		}
 	}
 	if introspectedRemoteQuery == nil {
-		return errors.Errorf("given %s: %s is not present in remote schema.",
+		return errors.Errorf("%s `%s` is not present in remote schema.",
 			operationType, givenQuery.Name)
 	}
 
+	// TODO: still need to do deep type checking for return types
 	// check whether the return type of remote query is same as the required return type
 	expectedReturnType := metadata.parentField.Type.String()
 	gotReturnType := introspectedRemoteQuery.Type.String()
@@ -220,203 +235,312 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 		expectedReturnType = fmt.Sprintf("[%s]", expectedReturnType)
 	}
 	if expectedReturnType != gotReturnType {
-		return errors.Errorf("given %s: %s: return type mismatch; expected: %s, got: %s.",
+		return errors.Errorf("found return type mismatch for %s `%s`, expected `%s`, got `%s`.",
 			operationType, givenQuery.Name, expectedReturnType, gotReturnType)
 	}
 
-	givenQryArgDefs, givenQryArgVals := getGivenQueryArgsAsMap(givenQuery, metadata.isBatch,
-		metadata.parentField, metadata.parentType)
-	remoteQryArgDefs, remoteQryRequiredArgs := getRemoteQueryArgsAsMap(introspectedRemoteQuery)
+	givenQryArgVals := getGivenQueryArgValsAsMap(givenQuery)
+	givenQryVarTypes := getVarTypesAsMap(metadata.parentField, metadata.parentType)
+	remoteQryArgMetadata := getRemoteQueryArgMetadata(introspectedRemoteQuery)
 
-	// correctly set remoteQryArgDefs and remoteQryRequiredArgs for batch operations
+	// verify remote query arg format for batch operations
 	if metadata.isBatch {
 		// TODO: make sure if it is [{}] or [{}!] or [{}]! or [{}!]!
-		input, ok := remoteQryArgDefs["input"]
-		if !ok || input.Type.Kind != "LIST" || input.Type.OfType == nil || input.Type.OfType.
-			Kind != "INPUT_OBJECT" {
-			return errors.Errorf("given %s: %s: arg `input` is not of the form `[{param1: $var1, "+
-				"param2: $var2, ...}]` in remote %s.",
-				operationType, givenQuery.Name, operationType)
+		if len(remoteQryArgMetadata.typMap) != 1 {
+			return errors.Errorf("remote %s `%s` accepts %d arguments, It must have only one "+
+				"argument of the form `[{param1: $var1, param2: $var2, ...}]` for batch operation.",
+				operationType, givenQuery.Name, len(remoteQryArgMetadata.typMap))
 		}
-		inputTypName := input.Type.OfType.Name
-		typ, ok := remoteTypes[inputTypName]
-		if !ok {
-			return errors.Errorf("remote schema doesn't have any type named %s.", inputTypName)
-		}
-		if typ.Kind != "INPUT_OBJECT" {
-			return errors.Errorf("type %s in remote schema is not an INPUT_OBJECT.", inputTypName)
-		}
-		remoteQryArgDefs = make(map[string]*Args)
-		remoteQryRequiredArgs = make([]string, 0)
-		for _, field := range typ.Fields {
-			remoteQryArgDefs[field.Name] = &Args{Type: field.Type}
-			if field.Type.Kind == "NON_NULL" {
-				remoteQryRequiredArgs = append(remoteQryRequiredArgs, field.Name)
+		for argName, inputTyp := range remoteQryArgMetadata.typMap {
+			if inputTyp.Kind != "LIST" || inputTyp.OfType == nil || inputTyp.OfType.
+				Kind != "INPUT_OBJECT" {
+				return errors.Errorf("argument `%s` for given %s `%s` must be of the form `[{param1"+
+					": $var1, param2: $var2, ...}]` for batch operations in remote %s.", argName,
+					operationType, givenQuery.Name, operationType)
+			}
+			inputTypName := inputTyp.OfType.Name
+			typ, ok := remoteTypes[inputTypName]
+			if !ok {
+				return missingRemoteTypeError(inputTypName)
+			}
+			if typ.Kind != "INPUT_OBJECT" {
+				return errors.Errorf("type %s in remote schema is not an INPUT_OBJECT.", inputTypName)
 			}
 		}
 	}
 
 	// check whether args of given query/mutation match the args of remote query/mutation
-	for givenArgName, givenArgDef := range givenQryArgDefs {
-		remoteArgDef, ok := remoteQryArgDefs[givenArgName]
+	if err = matchArgSignature(&argMatchingMetadata{
+		givenArgVals:  givenQryArgVals,
+		givenVarTypes: givenQryVarTypes,
+		remoteArgMd:   remoteQryArgMetadata,
+		remoteTypes:   remoteTypes,
+		givenQryName:  &givenQuery.Name,
+		operationType: &operationType,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func missingRemoteTypeError(typName string) error {
+	return errors.Errorf("remote schema doesn't have any type named %s.", typName)
+}
+
+// matchArgSignature matches the type signature for arguments supplied in metadata with
+// corresponding remote arguments
+func matchArgSignature(md *argMatchingMetadata) error {
+	// TODO: maybe add path information in error messages,
+	// so they are more informative. Like if query was `query { userNames(car: {age: $var}) }`,
+	// then for errors on `age`, we shouldn't just be putting `age` in error messages,
+	// instead we should put `car.age`
+	for givenArgName, givenArgVal := range md.givenArgVals {
+		remoteArgTyp, ok := md.remoteArgMd.typMap[givenArgName]
 		if !ok {
-			return errors.Errorf("given %s: %s: arg %s not present in remote %s.", operationType,
-				givenQuery.Name, givenArgName, operationType)
+			return errors.Errorf("argument `%s` is not present in remote %s `%s`.",
+				givenArgName, *md.operationType, *md.givenQryName)
 		}
-		if givenArgDef == nil {
-			return errors.Errorf("given %s: %s: variable %s is missing in given context.",
-				operationType, givenQuery.Name, givenQryArgVals[givenArgName])
-		}
-		expectedArgType := givenArgDef.Type.String()
-		gotArgType := remoteArgDef.Type.String()
-		if expectedArgType != gotArgType {
-			return errors.Errorf("given %s: %s: type mismatch for variable %s; expected: %s, "+
-				"got: %s.", operationType, givenQuery.Name, givenQryArgVals[givenArgName],
-				expectedArgType, gotArgType)
+
+		switch givenArgVal.Kind {
+		case ast.Variable:
+			givenArgTyp, ok := md.givenVarTypes[givenArgVal.Raw]
+			if !ok {
+				return errors.Errorf("variable $%s is missing in given context.", givenArgVal.Raw)
+			}
+			// we will consider ID as String for the purpose of type matching
+			rootType := givenArgTyp
+			for rootType.NamedType == "" {
+				rootType = rootType.Elem
+			}
+			if rootType.NamedType == "ID" {
+				rootType.NamedType = "String"
+			}
+			expectedArgType := givenArgTyp.String()
+			gotArgType := remoteArgTyp.String()
+			if expectedArgType != gotArgType {
+				return errors.Errorf("found type mismatch for variable `$%s` in %s `%s`, expected"+
+					" `%s`, got `%s`.", givenArgVal.Raw, *md.operationType, *md.givenQryName,
+					expectedArgType, gotArgType)
+			}
+		case ast.ObjectValue:
+			if !(remoteArgTyp.Kind == "INPUT_OBJECT" || (remoteArgTyp.
+				Kind == "NON_NULL" && remoteArgTyp.OfType != nil && remoteArgTyp.OfType.
+				Kind == "INPUT_OBJECT")) {
+				return errors.Errorf("object value supplied for argument `%s` in %s `%s`, "+
+					"but remote argument doesn't accept INPUT_OBJECT.", givenArgName,
+					*md.operationType, *md.givenQryName)
+			}
+			remoteObjTypname := remoteArgTyp.Name
+			if remoteArgTyp.Kind != "INPUT_OBJECT" {
+				remoteObjTypname = remoteArgTyp.OfType.Name
+			}
+			remoteObjTyp, ok := md.remoteTypes[remoteObjTypname]
+			if !ok {
+				return missingRemoteTypeError(remoteObjTypname)
+			}
+			if err := matchArgSignature(&argMatchingMetadata{
+				givenArgVals:  getObjChildrenValsAsMap(givenArgVal),
+				givenVarTypes: md.givenVarTypes,
+				remoteArgMd:   getRemoteTypeFieldsMetadata(remoteObjTyp),
+				remoteTypes:   md.remoteTypes,
+				givenQryName:  md.givenQryName,
+				operationType: md.operationType,
+			}); err != nil {
+				return err
+			}
+		case ast.ListValue:
+			if !((remoteArgTyp.Kind == "LIST" && remoteArgTyp.OfType != nil) || (remoteArgTyp.
+				Kind == "NON_NULL" && remoteArgTyp.OfType != nil && remoteArgTyp.OfType.
+				Kind == "LIST" && remoteArgTyp.OfType.OfType != nil)) {
+				return errors.Errorf("LIST value supplied for argument `%s` in %s `%s`, "+
+					"but remote argument doesn't accept LIST.", givenArgName, *md.operationType,
+					*md.givenQryName)
+			}
+			remoteListElemTypname := remoteArgTyp.OfType.Name
+			if remoteArgTyp.Kind != "LIST" {
+				remoteListElemTypname = remoteArgTyp.OfType.OfType.Name
+			}
+			remoteObjTyp, ok := md.remoteTypes[remoteListElemTypname]
+			if !ok {
+				return missingRemoteTypeError(remoteListElemTypname)
+			}
+			if remoteObjTyp.Kind != "INPUT_OBJECT" {
+				return errors.Errorf("argument `%s` in %s `%s` of List kind has non-object"+
+					" elements in remote %s, Lists can have only INPUT_OBJECT as element.",
+					givenArgName, *md.operationType, *md.givenQryName, *md.operationType)
+			}
+			remoteObjChildMap := getRemoteTypeFieldsMetadata(remoteObjTyp)
+			for _, givenElem := range givenArgVal.Children {
+				if givenElem.Value.Kind != ast.ObjectValue {
+					return errors.Errorf("argument `%s` in %s `%s` of List kind has non-object"+
+						" elements, Lists can have only objects as element.", givenArgName,
+						*md.operationType, *md.givenQryName)
+				}
+				if err := matchArgSignature(&argMatchingMetadata{
+					givenArgVals:  getObjChildrenValsAsMap(givenElem.Value),
+					givenVarTypes: md.givenVarTypes,
+					remoteArgMd:   remoteObjChildMap,
+					remoteTypes:   md.remoteTypes,
+					givenQryName:  md.givenQryName,
+					operationType: md.operationType,
+				}); err != nil {
+					return err
+				}
+			}
+		default:
+			return errors.Errorf("scalar value supplied for argument `%s` in %s `%s`, "+
+				"only Variable, Object, or List values are allowed.", givenArgName,
+				*md.operationType, *md.givenQryName)
+
 		}
 	}
 
 	// check all non-null args required by remote query/mutation are present in given query/mutation
-	for _, remoteArgName := range remoteQryRequiredArgs {
-		_, ok := givenQryArgVals[remoteArgName]
+	for _, remoteArgName := range md.remoteArgMd.requiredArgs {
+		_, ok := md.givenArgVals[remoteArgName]
 		if !ok {
-			return errors.Errorf("given %s: %s: required arg %s is missing.", operationType,
-				givenQuery.Name, remoteArgName)
+			return errors.Errorf("argument `%s` in %s `%s` is missing, it is required by remote"+
+				" %s.", remoteArgName, *md.operationType, *md.givenQryName, *md.operationType)
 		}
 	}
 
 	return nil
 }
 
-// getGivenQueryArgsAsMap returns following maps:
-// 1. arg name -> *ast.ArgumentDefinition (Currently, we only need to use the Type field from this)
-// 2. arg name -> argument value (i.e., variable like $id)
-// It takes care of the special format for batch mode operations
-func getGivenQueryArgsAsMap(givenQuery *ast.Field, isBatch bool, parentField *ast.FieldDefinition,
-	parentType *ast.Definition) (map[string]*ast.ArgumentDefinition, map[string]string) {
-	argDefMap := make(map[string]*ast.ArgumentDefinition)
-	argValMap := make(map[string]string)
-	givenQueryArgs := givenQuery.Arguments
+func getObjChildrenValsAsMap(object *ast.Value) map[string]*ast.Value {
+	childValMap := make(map[string]*ast.Value)
 
-	var inputArgDefsMap map[string]*ast.ArgumentDefinition
+	for _, val := range object.Children {
+		childValMap[val.Name] = val.Value
+	}
+	return childValMap
+}
+
+func getRemoteTypeFieldsMetadata(remoteTyp *types) *remoteArgMetadata {
+	md := &remoteArgMetadata{
+		typMap:       make(map[string]*gqlType),
+		requiredArgs: make([]string, 0),
+	}
+
+	for _, field := range remoteTyp.Fields {
+		md.typMap[field.Name] = field.Type
+		if field.Type.Kind == "NON_NULL" {
+			md.requiredArgs = append(md.requiredArgs, field.Name)
+		}
+	}
+	return md
+}
+
+func getVarTypesAsMap(parentField *ast.FieldDefinition,
+	parentType *ast.Definition) map[string]*ast.Type {
+	typMap := make(map[string]*ast.Type)
 	if isQueryOrMutationType(parentType) {
 		// this is the case of @custom on some Query or Mutation
-		inputArgDefsMap = getFieldArgDefsAsMap(parentField)
+		for _, v := range parentField.Arguments {
+			typMap[v.Name] = v.Type
+		}
 	} else {
 		// this is the case of @custom on fields inside some user defined type
-		inputArgDefsMap = getTypeFieldsAsArgDefsMap(parentType)
-		if isBatch {
-			givenQueryArgs = make([]*ast.Argument, 0)
-			for _, arg := range givenQuery.Arguments[0].Value.Children[0].Value.Children {
-				givenQueryArgs = append(givenQueryArgs, &ast.Argument{
-					Name:     arg.Name,
-					Value:    arg.Value,
-					Position: arg.Position,
-				})
-			}
+		for _, v := range parentType.Fields {
+			typMap[v.Name] = v.Type
 		}
 	}
 
-	for _, arg := range givenQueryArgs {
-		varName := arg.Value.String()
-		argDefMap[arg.Name] = inputArgDefsMap[varName[1:]]
-		argValMap[arg.Name] = varName
-	}
-	return argDefMap, argValMap
+	return typMap
 }
 
-func getFieldArgDefsAsMap(fieldDef *ast.FieldDefinition) map[string]*ast.ArgumentDefinition {
-	argMap := make(map[string]*ast.ArgumentDefinition)
-	for _, v := range fieldDef.Arguments {
-		argMap[v.Name] = v
+func getGivenQueryArgValsAsMap(givenQuery *ast.Field) map[string]*ast.Value {
+	argValMap := make(map[string]*ast.Value)
+
+	for _, arg := range givenQuery.Arguments {
+		argValMap[arg.Name] = arg.Value
 	}
-	return argMap
+	return argValMap
 }
 
-func getTypeFieldsAsArgDefsMap(typ *ast.Definition) map[string]*ast.ArgumentDefinition {
-	argMap := make(map[string]*ast.ArgumentDefinition)
-	for _, v := range typ.Fields {
-		argMap[v.Name] = &ast.ArgumentDefinition{Type: v.Type}
+// getRemoteQueryArgMetadata returns the argument metadata for given remote query
+func getRemoteQueryArgMetadata(remoteQuery *gqlField) *remoteArgMetadata {
+	md := &remoteArgMetadata{
+		typMap:       make(map[string]*gqlType),
+		requiredArgs: make([]string, 0),
 	}
-	return argMap
-}
-
-// getRemoteQueryArgsAsMap returns following things:
-// 1. map of arg name -> Argument Definition in Gql introspection response format
-// 2. list of arg name for NON_NULL args
-func getRemoteQueryArgsAsMap(remoteQuery *GqlField) (map[string]*Args, []string) {
-	argDefMap := make(map[string]*Args)
-	requiredArgs := make([]string, 0)
 
 	for _, arg := range remoteQuery.Args {
-		argDefMap[arg.Name] = arg
+		md.typMap[arg.Name] = arg.Type
 		if arg.Type.Kind == "NON_NULL" {
-			requiredArgs = append(requiredArgs, arg.Name)
+			md.requiredArgs = append(md.requiredArgs, arg.Name)
 		}
 	}
-	return argDefMap, requiredArgs
+	return md
 }
 
-type IntrospectedSchema struct {
-	Data Data `json:"data"`
+type introspectedSchema struct {
+	Data data `json:"data"`
 }
-type IntrospectionQueryType struct {
+type data struct {
+	Schema introspectionSchema `json:"__schema"`
+}
+type introspectionSchema struct {
+	QueryType        *introspectionQueryType `json:"queryType"`
+	MutationType     *introspectionQueryType `json:"mutationType"`
+	SubscriptionType *introspectionQueryType `json:"subscriptionType"`
+	Types            []*types                `json:"types"`
+	Directives       []*directive            `json:"directives"`
+}
+type introspectionQueryType struct {
 	Name string `json:"name"`
 }
-type GqlType struct {
-	Kind   string   `json:"kind"`
-	Name   string   `json:"name"`
-	OfType *GqlType `json:"ofType"`
-}
-type GqlField struct {
-	Name              string      `json:"name"`
-	Args              []*Args     `json:"args"`
-	Type              *GqlType    `json:"type"`
-	IsDeprecated      bool        `json:"isDeprecated"`
-	DeprecationReason interface{} `json:"deprecationReason"`
-}
-type Types struct {
+type types struct {
 	Kind          string        `json:"kind"`
 	Name          string        `json:"name"`
-	Fields        []*GqlField   `json:"fields"`
-	InputFields   []*GqlField   `json:"inputFields"`
+	Fields        []*gqlField   `json:"fields"`
+	InputFields   []*gqlField   `json:"inputFields"`
 	Interfaces    []interface{} `json:"interfaces"`
 	EnumValues    interface{}   `json:"enumValues"`
 	PossibleTypes interface{}   `json:"possibleTypes"`
 }
-type Args struct {
-	Name         string      `json:"name"`
-	Type         *GqlType    `json:"type"`
-	DefaultValue interface{} `json:"defaultValue"`
-}
-type Directives struct {
+type directive struct {
 	Name      string   `json:"name"`
 	Locations []string `json:"locations"`
-	Args      []*Args  `json:"args"`
+	Args      []*arg   `json:"args"`
 }
-type IntrospectionSchema struct {
-	QueryType        *IntrospectionQueryType `json:"queryType"`
-	MutationType     *IntrospectionQueryType `json:"mutationType"`
-	SubscriptionType *IntrospectionQueryType `json:"subscriptionType"`
-	Types            []*Types                `json:"types"`
-	Directives       []*Directives           `json:"directives"`
+type gqlField struct {
+	Name              string      `json:"name"`
+	Args              []*arg      `json:"args"`
+	Type              *gqlType    `json:"type"`
+	IsDeprecated      bool        `json:"isDeprecated"`
+	DeprecationReason interface{} `json:"deprecationReason"`
 }
-type Data struct {
-	Schema IntrospectionSchema `json:"__schema"`
+type arg struct {
+	Name         string      `json:"name"`
+	Type         *gqlType    `json:"type"`
+	DefaultValue interface{} `json:"defaultValue"`
+}
+type gqlType struct {
+	Kind   string   `json:"kind"`
+	Name   string   `json:"name"`
+	OfType *gqlType `json:"ofType"`
 }
 
-func (t *GqlType) String() string {
+func (t *gqlType) String() string {
 	if t == nil {
 		return ""
 	}
 	// refer http://spec.graphql.org/June2018/#sec-Type-Kinds
 	// it confirms, if type kind is LIST or NON_NULL all other fields except ofType will be
-	// null, so there won't be any name at that level.
+	// null, so there won't be any name at that level. For other kinds, there will always be a name.
 	switch t.Kind {
 	case "LIST":
 		return fmt.Sprintf("[%s]", t.OfType.String())
 	case "NON_NULL":
 		return fmt.Sprintf("%s!", t.OfType.String())
+	case "SCALAR":
+		// we will consider ID as String for the purpose of type matching
+		if t.Name == "ID" {
+			return "String"
+		}
+		return t.Name
 	default:
 		return t.Name
 	}

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -308,14 +308,14 @@ func matchArgSignature(md *argMatchingMetadata) error {
 			if !ok {
 				return errors.Errorf("variable $%s is missing in given context.", givenArgVal.Raw)
 			}
-			// we will consider ID as String for the purpose of type matching
-			rootType := givenArgTyp
-			for rootType.NamedType == "" {
-				rootType = rootType.Elem
-			}
-			if rootType.NamedType == "ID" {
-				rootType.NamedType = "String"
-			}
+			// TODO: we will consider ID as String for the purpose of type matching
+			//rootType := givenArgTyp
+			//for rootType.NamedType == "" {
+			//	rootType = rootType.Elem
+			//}
+			//if rootType.NamedType == "ID" {
+			//	rootType.NamedType = "String"
+			//}
 			expectedArgType := givenArgTyp.String()
 			gotArgType := remoteArgTyp.String()
 			if expectedArgType != gotArgType {
@@ -535,12 +535,12 @@ func (t *gqlType) String() string {
 		return fmt.Sprintf("[%s]", t.OfType.String())
 	case "NON_NULL":
 		return fmt.Sprintf("%s!", t.OfType.String())
-	case "SCALAR":
-		// we will consider ID as String for the purpose of type matching
-		if t.Name == "ID" {
-			return "String"
-		}
-		return t.Name
+	// TODO: we will consider ID as String for the purpose of type matching
+	//case "SCALAR":
+	//	if t.Name == "ID" {
+	//		return "String"
+	//	}
+	//	return t.Name
 	default:
 		return t.Name
 	}

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -230,9 +230,10 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 
 	// correctly set remoteQryArgDefs and remoteQryRequiredArgs for batch operations
 	if metadata.isBatch {
+		// TODO: make sure if it is [{}] or [{}!] or [{}]! or [{}!]!
 		input, ok := remoteQryArgDefs["input"]
 		if !ok || input.Type.Kind != "LIST" || input.Type.OfType == nil || input.Type.OfType.
-			Kind != "OBJECT" {
+			Kind != "INPUT_OBJECT" {
 			return errors.Errorf("given %s: %s: arg `input` is not of the form `[{param1: $var1, "+
 				"param2: $var2, ...}]` in remote %s.",
 				operationType, givenQuery.Name, operationType)
@@ -241,6 +242,9 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 		typ, ok := remoteTypes[inputTypName]
 		if !ok {
 			return errors.Errorf("remote schema doesn't have any type named %s.", inputTypName)
+		}
+		if typ.Kind != "INPUT_OBJECT" {
+			return errors.Errorf("type %s in remote schema is not an INPUT_OBJECT.", inputTypName)
 		}
 		remoteQryArgDefs = make(map[string]*Args)
 		remoteQryRequiredArgs = make([]string, 0)

--- a/graphql/schema/remote_test.go
+++ b/graphql/schema/remote_test.go
@@ -25,7 +25,7 @@ import (
 func TestGqlType_String(t *testing.T) {
 	tcases := []struct {
 		name            string
-		gqlType         *GqlType
+		gqlType         *gqlType
 		expectedTypeStr string
 	}{
 		{
@@ -35,7 +35,7 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Scalar type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind:   "SCALAR",
 				Name:   "Int",
 				OfType: nil,
@@ -44,10 +44,10 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Non-null Scalar type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "NON_NULL",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind:   "SCALAR",
 					Name:   "String",
 					OfType: nil,
@@ -57,7 +57,7 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind:   "OBJECT",
 				Name:   "Author",
 				OfType: nil,
@@ -66,10 +66,10 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Non-null Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "NON_NULL",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind:   "OBJECT",
 					Name:   "Author",
 					OfType: nil,
@@ -79,26 +79,26 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "List of Scalar type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "LIST",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind:   "SCALAR",
 					Name:   "ID",
 					OfType: nil,
 				},
 			},
-			expectedTypeStr: "[ID]",
+			expectedTypeStr: "[String]", // we interpret ID as String
 		},
 		{
 			name: "List of Non-null Scalar type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "LIST",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind: "NON_NULL",
 					Name: "",
-					OfType: &GqlType{
+					OfType: &gqlType{
 						Kind:   "SCALAR",
 						Name:   "Float",
 						OfType: nil,
@@ -109,16 +109,16 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Non-null List of Non-null Scalar type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "NON_NULL",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind: "LIST",
 					Name: "",
-					OfType: &GqlType{
+					OfType: &gqlType{
 						Kind: "NON_NULL",
 						Name: "",
-						OfType: &GqlType{
+						OfType: &gqlType{
 							Kind:   "SCALAR",
 							Name:   "Boolean",
 							OfType: nil,
@@ -130,10 +130,10 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "List of Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "LIST",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind:   "OBJECT",
 					Name:   "Author",
 					OfType: nil,
@@ -143,13 +143,13 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "List of Non-null Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "LIST",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind: "NON_NULL",
 					Name: "",
-					OfType: &GqlType{
+					OfType: &gqlType{
 						Kind:   "OBJECT",
 						Name:   "Author",
 						OfType: nil,
@@ -160,16 +160,16 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Non-null List of Non-null Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "NON_NULL",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind: "LIST",
 					Name: "",
-					OfType: &GqlType{
+					OfType: &gqlType{
 						Kind: "NON_NULL",
 						Name: "",
-						OfType: &GqlType{
+						OfType: &gqlType{
 							Kind:   "OBJECT",
 							Name:   "Author",
 							OfType: nil,
@@ -181,22 +181,22 @@ func TestGqlType_String(t *testing.T) {
 		},
 		{
 			name: "Non-null List of List of List of Non-Null Object type",
-			gqlType: &GqlType{
+			gqlType: &gqlType{
 				Kind: "NON_NULL",
 				Name: "",
-				OfType: &GqlType{
+				OfType: &gqlType{
 					Kind: "LIST",
 					Name: "",
-					OfType: &GqlType{
+					OfType: &gqlType{
 						Kind: "LIST",
 						Name: "",
-						OfType: &GqlType{
+						OfType: &gqlType{
 							Kind: "LIST",
 							Name: "",
-							OfType: &GqlType{
+							OfType: &gqlType{
 								Kind: "NON_NULL",
 								Name: "",
-								OfType: &GqlType{
+								OfType: &gqlType{
 									Kind:   "OBJECT",
 									Name:   "Author",
 									OfType: nil,

--- a/graphql/schema/remote_test.go
+++ b/graphql/schema/remote_test.go
@@ -88,7 +88,7 @@ func TestGqlType_String(t *testing.T) {
 					OfType: nil,
 				},
 			},
-			expectedTypeStr: "[String]", // we interpret ID as String
+			expectedTypeStr: "[ID]", // TODO: interpret ID as String
 		},
 		{
 			name: "List of Non-null Scalar type",

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -385,8 +385,7 @@ func dgraphMapping(sch *ast.Schema) map[string]map[string]string {
 	for _, inputTyp := range sch.Types {
 		// We only want to consider input types (object and interface) defined by the user as part
 		// of the schema hence we ignore BuiltIn, query and mutation types.
-		if inputTyp.BuiltIn || inputTyp.Name == "Query" || inputTyp.Name == "Mutation" ||
-			inputTyp.Name == "Subscription" ||
+		if inputTyp.BuiltIn || isQueryOrMutationType(inputTyp) || inputTyp.Name == "Subscription" ||
 			(inputTyp.Kind != ast.Object && inputTyp.Kind != ast.Interface) {
 			continue
 		}


### PR DESCRIPTION
<!-- Please, fill up the PR details. -->

### Description.

This PR adds validations and tests for `@custom` graphql on fields

### GitHub Issue or Jira number.

Fixes #GRAPHQL-392

### Other components or 3rd party tools affected (or regression areas).

None

### Affected releases.

<!-- for exmaple 2.0 and 1.2 or just 2.0. -->

 \>= 20.07.0

### Changelog tags.

added validations and tests for `@custom` graphql on fields

### Please indicate if this is a breaking change.

No

### Please indicate if this is an enterprise feature.

No

### Please indicate if documentation needs to be updated.

Yes

### Please indicate if end to end testing is needed.

No

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5283)
<!-- Reviewable:end -->
