### PR TITLE
Restore: Handle incorrect encryption key

### DIFF
--- a/worker/restore.go
+++ b/worker/restore.go
@@ -55,7 +55,7 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 			gzReader, err := gzip.NewReader(r)
 			if err != nil {
 				return 0, errors.Wrap(err,
-					"Unable to read backup. Ensure encryption key is correctly set")
+					"Unable to read the backup. Ensure encryption key is correct.")
 			}
 			// The badger DB should be opened only after creating the backup
 			// file reader. The following sequence of events can occur if

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -58,22 +58,7 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 					"Unable to read the backup. Ensure encryption key is correct.")
 			}
 			// The badger DB should be opened only after creating the backup
-			// file reader. The following sequence of events can occur if
-			// badger is opened before creating a reader -
-			// 1. Backup is created without encryption (alpha running without encryption)
-			// 2. Restore is called on an unencrypted backup with encryption set.
-			//		dgraph restore --encryption_key=xxx
-			//		If badger was opened before enc.GetReader() then the new
-			//		badger DB would have encryption set. Eventually
-			//		enc.GetReader() would crash because of invalid key but
-			//		encryption would be set in badger.
-			// 3. Re-attempt restore with encryption key not set.
-			//		dgraph restore
-			//		This command would fail with "encryption key
-			//		mismatch" because the badger DB initialized by the previous
-			//		restore command has encryption set and the current call
-			//		doesn't have the encryption key set.
-			//
+			// file reader and verifying the encryption in the backup file.
 			db, err := badger.OpenManaged(badger.DefaultOptions(dir).
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -47,6 +47,33 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 		func(r io.Reader, groupId int, preds predicateSet) (uint64, error) {
 
 			dir := filepath.Join(pdir, fmt.Sprintf("p%d", groupId))
+			r, err := enc.GetReader(keyfile, r)
+			if err != nil {
+				return 0, err
+			}
+
+			gzReader, err := gzip.NewReader(r)
+			if err != nil {
+				return 0, errors.Wrap(err,
+					"Unable to read backup. Ensure encryption key is correctly set")
+			}
+			// The badger DB should be opened only after creating the backup
+			// file reader. The following sequence of events can occur if
+			// badger is opened before creating a reader -
+			// 1. Backup is created without encryption (alpha running without encryption)
+			// 2. Restore is called on an unencrypted backup with encryption set.
+			//		dgraph restore --encryption_key=xxx
+			//		If badger was opened before enc.GetReader() then the new
+			//		badger DB would have encryption set. Eventually
+			//		enc.GetReader() would crash because of invalid key but
+			//		encryption would be set in badger.
+			// 3. Re-attempt restore with encryption key not set.
+			//		dgraph restore
+			//		This command would fail with "encryption key
+			//		mismatch" because the badger DB initialized by the previous
+			//		restore command has encryption set and the current call
+			//		doesn't have the encryption key set.
+			//
 			db, err := badger.OpenManaged(badger.DefaultOptions(dir).
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).
@@ -59,14 +86,6 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 			defer db.Close()
 			if !pathExist(dir) {
 				fmt.Println("Creating new db:", dir)
-			}
-			r, err = enc.GetReader(keyfile, r)
-			if err != nil {
-				return 0, err
-			}
-			gzReader, err := gzip.NewReader(r)
-			if err != nil {
-				return 0, err
 			}
 			maxUid, err := loadFromBackup(db, gzReader, 0, preds)
 			if err != nil {

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -54,8 +54,12 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 
 			gzReader, err := gzip.NewReader(r)
 			if err != nil {
-				return 0, errors.Wrap(err,
-					"Unable to read the backup. Ensure encryption key is correct.")
+				if len(keyfile) != 0 {
+					err = errors.Wrap(err,
+						"Unable to read the backup. Ensure the encryption key is correct.")
+				}
+				return 0, err
+
 			}
 			// The badger DB should be opened only after creating the backup
 			// file reader and verifying the encryption in the backup file.


### PR DESCRIPTION
Jira - DGRAPH-1281 and DGRAPH-1282

When the restore is started, we open a badger instance with the provided encryption key and then check if the backup file can be opened using the encryption key. If the backup cannot be opened using the encryption key, we return an error to the user but the badger DB stores the encryption key.
When the user tries to restore the same backup to the same badger instance without a key (because backup is unencrypted), badger complaints about the missing key. 

This PR fixes by opening badger after opening the backup file. This ensures we don't open an encrypted badger db for an unencrypted backup file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5284)
<!-- Reviewable:end -->
