### PR TITLE
release/v1.2: Restore: Handle incorrect encryption key (#5284)

### DIFF
--- a/ee/backup/restore.go
+++ b/ee/backup/restore.go
@@ -47,6 +47,22 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 		func(r io.Reader, groupId int, preds predicateSet) (uint64, error) {
 
 			dir := filepath.Join(pdir, fmt.Sprintf("p%d", groupId))
+			r, err := enc.GetReader(keyfile, r)
+			if err != nil {
+				return 0, err
+			}
+
+			gzReader, err := gzip.NewReader(r)
+			if err != nil {
+				if len(keyfile) != 0 {
+					err = errors.Wrap(err,
+						"Unable to read the backup. Ensure the encryption key is correct.")
+				}
+				return 0, err
+
+			}
+			// The badger DB should be opened only after creating the backup
+			// file reader and verifying the encryption in the backup file.
 			db, err := badger.OpenManaged(badger.DefaultOptions(dir).
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).
@@ -61,14 +77,7 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 			if !pathExist(dir) {
 				fmt.Println("Creating new db:", dir)
 			}
-			r, err = enc.GetReader(keyfile, r)
-			if err != nil {
-				return 0, err
-			}
-			gzReader, err := gzip.NewReader(r)
-			if err != nil {
-				return 0, err
-			}
+
 			maxUid, err := loadFromBackup(db, gzReader, preds)
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
Jira - DGRAPH-1281 and DGRAPH-1282

When the restore is started, we open a badger instance with the
provided encryption key and then check if the backup file can be
opened using the encryption key. If the backup cannot be opened
using the encryption key, we return an error to the user but the
badger DB stores the encryption key.
When the user tries to restore the same backup to the same badger
instance without a key (because backup is unencrypted), badger
complaints about the missing key.

This PR fixes by opening badger after opening the backup file.
This ensures we don't open an encrypted badger db for an
unencrypted backup file.

(cherry picked from commit 25c37c823593fe4480ca10e3354336503be3785b)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes #JiraIssue".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5286)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-53495db493-57892.surge.sh)
<!-- Dgraph:end -->