### PR TITLE
segregate dev and prod into its own projects; handle panic bt and type info for better grouping

### DIFF
--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -66,18 +66,19 @@ func initSentry() {
 		Release:          Version(),
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Modify the event here before sending it to sentry server.
-			if len(event.Exception) > 0 {
-				ex := &event.Exception[0]
-				// Filter out the stacktrace since it is of no use.
-				ex.RawStacktrace = nil
-				ex.Stacktrace = nil
+			if len(event.Exception) == 0 {
+				return event
+			}
+			ex := &event.Exception[0]
+			// Filter out the stacktrace since it is of no use.
+			ex.RawStacktrace = nil
+			ex.Stacktrace = nil
 
-				// Set exception type to the panic message.
-				if strings.HasPrefix(event.Exception[0].Value, "panic") {
-					indexofNewline := strings.IndexByte(event.Exception[0].Value, '\n')
-					if indexofNewline != -1 {
-						ex.Type = ex.Value[:indexofNewline]
-					}
+			// Set exception type to the panic message.
+			if strings.HasPrefix(event.Exception[0].Value, "panic") {
+				indexofNewline := strings.IndexByte(event.Exception[0].Value, '\n')
+				if indexofNewline != -1 {
+					ex.Type = ex.Value[:indexofNewline]
 				}
 			}
 			return event

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -27,15 +27,18 @@ import (
 	"github.com/mitchellh/panicwrap"
 )
 
-var env string
+var (
+	env string
+	dsn string // API KEY to use
+)
 
-// API KEY for dgraph-gh project (production/release builds)
-const dsnProd = "https://58a035f0d85a4c1c80aee0a3e72f3899@o318308.ingest.sentry.io/1805390"
-
-// API KEY for dgraph-devtest-playground project (dev builds)
-const dsnDevtest = "https://84c2ad450005436fa27d97ef72b52425@o318308.ingest.sentry.io/5208688"
-
-var dsn string
+// Sentry API KEYs to use.
+const (
+	// dgraph-gh project (production/release builds).
+	dsnProd = "https://58a035f0d85a4c1c80aee0a3e72f3899@o318308.ingest.sentry.io/1805390"
+	// dgraph-devtest-playground project (dev builds).
+	dsnDevtest = "https://84c2ad450005436fa27d97ef72b52425@o318308.ingest.sentry.io/5208688"
+)
 
 // InitSentry initializes the sentry machinery.
 func InitSentry(ee bool) {
@@ -69,7 +72,7 @@ func initSentry() {
 				ex.RawStacktrace = nil
 				ex.Stacktrace = nil
 
-				// sSet exception type to the panic message.
+				// Set exception type to the panic message.
 				if strings.HasPrefix(event.Exception[0].Value, "panic") {
 					indexofNewline := strings.IndexByte(event.Exception[0].Value, '\n')
 					if indexofNewline != -1 {

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -64,15 +64,16 @@ func initSentry() {
 		BeforeSend: func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			// Modify the event here before sending it to sentry server.
 			if len(event.Exception) > 0 {
+				ex := &event.Exception[0]
 				// Filter out the stacktrace since it is of no use.
-				event.Exception[0].RawStacktrace = nil
-				event.Exception[0].Stacktrace = nil
+				ex.RawStacktrace = nil
+				ex.Stacktrace = nil
 
 				// sSet exception type to the panic message.
 				if strings.HasPrefix(event.Exception[0].Value, "panic") {
 					indexofNewline := strings.IndexByte(event.Exception[0].Value, '\n')
 					if indexofNewline != -1 {
-						event.Exception[0].Type = event.Exception[0].Value[:indexofNewline]
+						ex.Type = ex.Value[:indexofNewline]
 					}
 				}
 			}


### PR DESCRIPTION
Fixes #DGRAPh-1270

1. Separate dev and release events into its own projects. The DSN (API KEY) determines the project the event goes to.
2. Implement beforeSend() method. This method
     - Removes the stacktrace in the event. They are of no use. 
     - Sets the event type to the panic's message. 

On the sentry side, I created a new project "dgraph-devtest-playground" where the dev build events will go. The "dgraph-gh" project will now only be used for prod/release events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5288)
<!-- Reviewable:end -->
