### PR TITLE
Add support for multiple uids in uid_in function

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1556,11 +1556,11 @@ loop:
 	return nil
 }
 
-// parseIneqArgs will try to parse the arguments inside an array ([]). If the values
+// parseFuncArgs will try to parse the arguments inside an array ([]). If the values
 // are prefixed with $ they are treated as Gql variables, otherwise they are used as scalar values.
 // Returns nil on success while appending arguments to the function Args slice. Otherwise
 // returns an error, which can be a parsing or value error.
-func parseIneqArgs(it *lex.ItemIterator, g *Function) error {
+func parseFuncArgs(it *lex.ItemIterator, g *Function) error {
 	var expectArg, isDollar bool
 
 	expectArg = true
@@ -1764,10 +1764,10 @@ L:
 					err = parseGeoArgs(it, function)
 
 				case IsInequalityFn(function.Name):
-					err = parseIneqArgs(it, function)
+					err = parseFuncArgs(it, function)
 
 				case function.Name == "uid_in":
-					err = parseIneqArgs(it, function)
+					err = parseFuncArgs(it, function)
 
 				default:
 					err = itemInFunc.Errorf("Unexpected character [ while parsing request.")

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1660,7 +1660,9 @@ L:
 		if _, ok := tryParseItemType(it, itemLeftRound); !ok {
 			return nil, it.Errorf("Expected ( after func name [%s]", function.Name)
 		}
-
+		// fmt.Println("Function name: ", function.Name)
+		// fmt.Println("Item type: ", item.Typ)
+		// fmt.Println("Item : ", item)
 		attrItemsAgo := -1
 		expectArg = true
 		for it.Next() {
@@ -1669,6 +1671,9 @@ L:
 				attrItemsAgo++
 			}
 			var val string
+			// fmt.Println("IteminFunc type: ", itemInFunc.Typ)
+			// fmt.Println("IteminFunc : ", itemInFunc)
+
 			switch itemInFunc.Typ {
 			case itemRightRound:
 				break L
@@ -1764,6 +1769,9 @@ L:
 					err = parseGeoArgs(it, function)
 
 				case IsInequalityFn(function.Name):
+					err = parseIneqArgs(it, function)
+
+				case function.Name == "uid_in":
 					err = parseIneqArgs(it, function)
 
 				default:
@@ -3232,6 +3240,8 @@ func IsInequalityFn(name string) bool {
 	}
 	return false
 }
+
+// func IsUIDINFn(name string)
 
 // Name can have dashes or alphanumeric characters. Lexer lexes them as separate items.
 // We put it back together here.

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1669,7 +1669,6 @@ L:
 				attrItemsAgo++
 			}
 			var val string
-
 			switch itemInFunc.Typ {
 			case itemRightRound:
 				break L

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -1660,9 +1660,7 @@ L:
 		if _, ok := tryParseItemType(it, itemLeftRound); !ok {
 			return nil, it.Errorf("Expected ( after func name [%s]", function.Name)
 		}
-		// fmt.Println("Function name: ", function.Name)
-		// fmt.Println("Item type: ", item.Typ)
-		// fmt.Println("Item : ", item)
+
 		attrItemsAgo := -1
 		expectArg = true
 		for it.Next() {
@@ -1671,8 +1669,6 @@ L:
 				attrItemsAgo++
 			}
 			var val string
-			// fmt.Println("IteminFunc type: ", itemInFunc.Typ)
-			// fmt.Println("IteminFunc : ", itemInFunc)
 
 			switch itemInFunc.Typ {
 			case itemRightRound:
@@ -3240,8 +3236,6 @@ func IsInequalityFn(name string) bool {
 	}
 	return false
 }
-
-// func IsUIDINFn(name string)
 
 // Name can have dashes or alphanumeric characters. Lexer lexes them as separate items.
 // We put it back together here.

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4849,6 +4849,15 @@ func TestParseGraphQLVarArray(t *testing.T) {
 			vars: map[string]string{"$a": "srfrog"}, args: 2},
 		{q: `query test($a: string){q(func: eq(name, ["mrtrout", $a])) {name}}`,
 			vars: map[string]string{"$a": "srfrog"}, args: 2},
+		// uid_in test cases (uids and predicate inside uid_in are dummy)
+		{q: `query test($a: string){q(func: uid_in(director.film, [$a])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a"}, args: 1},
+		{q: `query test($a: string, $b: string){q(func: uid_in(director.film, [$a, $b])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a", "$b": "0x4e9545"}, args: 2},
+		{q: `query test($a: string){q(func: uid_in(name, [$a, "0x4e9545"])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a"}, args: 2},
+		{q: `query test($a: string){q(func: eq(name, ["0x4e9545", $a])) {name}}`,
+			vars: map[string]string{"$a": "srfrog"}, args: 2},
 	}
 	for _, tc := range tests {
 		gq, err := Parse(Request{Str: tc.q, Variables: tc.vars})

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4849,15 +4849,6 @@ func TestParseGraphQLVarArray(t *testing.T) {
 			vars: map[string]string{"$a": "srfrog"}, args: 2},
 		{q: `query test($a: string){q(func: eq(name, ["mrtrout", $a])) {name}}`,
 			vars: map[string]string{"$a": "srfrog"}, args: 2},
-		// uid_in test cases (uids and predicate inside uid_in are dummy)
-		{q: `query test($a: string){q(func: uid_in(director.film, [$a])) {name}}`,
-			vars: map[string]string{"$a": "0x4e472a"}, args: 1},
-		{q: `query test($a: string, $b: string){q(func: uid_in(director.film, [$a, $b])) {name}}`,
-			vars: map[string]string{"$a": "0x4e472a", "$b": "0x4e9545"}, args: 2},
-		{q: `query test($a: string){q(func: uid_in(name, [$a, "0x4e9545"])) {name}}`,
-			vars: map[string]string{"$a": "0x4e472a"}, args: 2},
-		{q: `query test($a: string){q(func: eq(name, ["0x4e9545", $a])) {name}}`,
-			vars: map[string]string{"$a": "srfrog"}, args: 2},
 	}
 	for _, tc := range tests {
 		gq, err := Parse(Request{Str: tc.q, Variables: tc.vars})

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4865,8 +4865,8 @@ func TestParseGraphQLVarArray(t *testing.T) {
 					break
 				}
 			}
+			require.True(t, found, "vars not matched: %v", tc.vars)
 		}
-		require.True(t, found, "vars not matched: %v", tc.vars)
 	}
 }
 
@@ -4901,8 +4901,8 @@ func TestParseGraphQLVarArrayUID_IN(t *testing.T) {
 					break
 				}
 			}
+			require.True(t, found, "vars not matched: %v", tc.vars)
 		}
-		require.True(t, found, "vars not matched: %v", tc.vars)
 	}
 }
 

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4856,8 +4856,9 @@ func TestParseGraphQLVarArray(t *testing.T) {
 		require.Equal(t, 1, len(gq.Query))
 		require.Equal(t, "eq", gq.Query[0].Func.Name)
 		require.Equal(t, tc.args, len(gq.Query[0].Func.Args))
-		found := false
+		var found bool
 		for _, val := range tc.vars {
+			found = false
 			for _, arg := range gq.Query[0].Func.Args {
 				if val == arg.Value {
 					found = true
@@ -4891,8 +4892,9 @@ func TestParseGraphQLVarArrayUID_IN(t *testing.T) {
 		require.Equal(t, 1, len(gq.Query))
 		require.Equal(t, "uid_in", gq.Query[0].Func.Name)
 		require.Equal(t, tc.args, len(gq.Query[0].Func.Args))
-		found := false
+		var found bool
 		for _, val := range tc.vars {
+			found = false
 			for _, arg := range gq.Query[0].Func.Args {
 				if val == arg.Value {
 					found = true

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -4878,6 +4878,41 @@ func TestParseGraphQLVarArray(t *testing.T) {
 	}
 }
 
+func TestParseGraphQLVarArrayUID_IN(t *testing.T) {
+	tests := []struct {
+		q    string
+		vars map[string]string
+		args int
+	}{
+		// uid_in test cases (uids and predicate inside uid_in are dummy)
+		{q: `query test($a: string){q(func: uid_in(director.film, [$a])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a"}, args: 1},
+		{q: `query test($a: string, $b: string){q(func: uid_in(director.film, [$a, $b])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a", "$b": "0x4e9545"}, args: 2},
+		{q: `query test($a: string){q(func: uid_in(name, [$a, "0x4e9545"])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a"}, args: 2},
+		{q: `query test($a: string){q(func: uid_in(name, ["0x4e9545", $a])) {name}}`,
+			vars: map[string]string{"$a": "0x4e472a"}, args: 2},
+	}
+	for _, tc := range tests {
+		gq, err := Parse(Request{Str: tc.q, Variables: tc.vars})
+		require.NoError(t, err)
+		require.Equal(t, 1, len(gq.Query))
+		require.Equal(t, "uid_in", gq.Query[0].Func.Name)
+		require.Equal(t, tc.args, len(gq.Query[0].Func.Args))
+		found := false
+		for _, val := range tc.vars {
+			for _, arg := range gq.Query[0].Func.Args {
+				if val == arg.Value {
+					found = true
+					break
+				}
+			}
+		}
+		require.True(t, found, "vars not matched: %v", tc.vars)
+	}
+}
+
 func TestParseGraphQLValueArray(t *testing.T) {
 	q := `
 	{

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1038,10 +1038,10 @@ func TestUidInFunction2(t *testing.T) {
 }
 
 func TestUidInFunction3a(t *testing.T) {
-
+	// query at top level with unsorted input UIDs
 	query := `
 	{
-		me(func: UID(1, 23, 24)) @filter(uid_in(school, 5000, 5001)) {
+		me(func: UID(1, 23, 24)) @filter(uid_in(school, [5001, 5000])) {
 			name
 		}
 	}`
@@ -1050,7 +1050,7 @@ func TestUidInFunction3a(t *testing.T) {
 }
 
 func TestUidInFunction3b(t *testing.T) {
-
+	// query at top level with sorted input UIDs
 	query := `
 	{
 		me(func: UID(1, 23, 24)) @filter(uid_in(school, [5000, 5001])) {
@@ -1060,23 +1060,20 @@ func TestUidInFunction3b(t *testing.T) {
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
 }
-func TestUidInFunction4a(t *testing.T) {
 
+func TestUidInFunction3c(t *testing.T) {
+	// query at top level with no UIDs present in predicate
 	query := `
 	{
-		me(func: uid(1, 23, 24 )) {
-			friend @filter(uid_in(school, 5000, 5001)) {
-				name
-			}
+		me(func: UID(1, 23, 24)) @filter(uid_in(school, [500, 501])) {
+			name
 		}
 	}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]},{"friend":[{"name":"Michonne"}]}]}}`,
-		js)
+	require.JSONEq(t, `{"data":{"me":[]}}`, js)
 }
-
-func TestUidInFunction4b(t *testing.T) {
-
+func TestUidInFunction4a(t *testing.T) {
+	// query inside with sorted input UIDs
 	query := `
 	{
 		me(func: uid(1, 23, 24 )) {
@@ -1087,6 +1084,21 @@ func TestUidInFunction4b(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]},{"friend":[{"name":"Michonne"}]}]}}`,
+		js)
+}
+
+func TestUidInFunction4b(t *testing.T) {
+	// query inside with unsorted input UIDs + not all uids present in predicate
+	query := `
+	{
+		me(func: uid(1, 23, 24 )) {
+			friend @filter(uid_in(school, [5001, 500])) {
+				name
+			}
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"friend":[{"name":"Rick Grimes"},{"name":"Andrea"}]}]}}`,
 		js)
 }
 func TestUidInFunctionAtRoot(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1037,6 +1037,58 @@ func TestUidInFunction2(t *testing.T) {
 		js)
 }
 
+func TestUidInFunction3a(t *testing.T) {
+
+	query := `
+	{
+		me(func: UID(1, 23, 24)) @filter(uid_in(school, 5000, 5001)) {
+			name
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
+}
+
+func TestUidInFunction3b(t *testing.T) {
+
+	query := `
+	{
+		me(func: UID(1, 23, 24)) @filter(uid_in(school, [5000, 5001])) {
+			name
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Michonne"},{"name":"Rick Grimes"},{"name":"Glenn Rhee"}]}}`, js)
+}
+func TestUidInFunction4a(t *testing.T) {
+
+	query := `
+	{
+		me(func: uid(1, 23, 24 )) {
+			friend @filter(uid_in(school, 5000, 5001)) {
+				name
+			}
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]},{"friend":[{"name":"Michonne"}]}]}}`,
+		js)
+}
+
+func TestUidInFunction4b(t *testing.T) {
+
+	query := `
+	{
+		me(func: uid(1, 23, 24 )) {
+			friend @filter(uid_in(school, [5000, 5001])) {
+				name
+			}
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"friend":[{"name":"Rick Grimes"}, {"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]},{"friend":[{"name":"Michonne"}]}]}}`,
+		js)
+}
 func TestUidInFunctionAtRoot(t *testing.T) {
 
 	query := `

--- a/worker/task.go
+++ b/worker/task.go
@@ -1830,6 +1830,7 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			}
 			fc.uidsPresent = append(fc.uidsPresent, uidParsed)
 		}
+		sort.Slice(fc.uidsPresent, func(i, j int) bool { return fc.uidsPresent[i] < fc.uidsPresent[j] })
 		checkRoot(q, fc)
 		if fc.isFuncAtRoot {
 			return nil, errors.Errorf("uid_in function not allowed at root")

--- a/worker/task.go
+++ b/worker/task.go
@@ -19,7 +19,6 @@ package worker
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -1817,7 +1816,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		checkRoot(q, fc)
 	case uidInFn:
-		fmt.Println("q.SrcFunc.Args: ", q.SrcFunc.Args)
 		if len(q.SrcFunc.Args) == 0 {
 			err := errors.Errorf("Function '%s' requires atleast 1 argument, but got %d (%v)",
 				q.SrcFunc.Name, len(q.SrcFunc.Args), q.SrcFunc.Args)

--- a/worker/task.go
+++ b/worker/task.go
@@ -701,7 +701,6 @@ func (qs *queryState) handleUidPostings(
 			}
 			var key []byte
 			switch srcFn.fnType {
-			//Check with pawan/ashish if this needs any changes
 			case notAFunction, compareScalarFn, hasFn, uidInFn:
 				if q.Reverse {
 					key = x.ReverseKey(q.Attr, q.UidList.Uids[i])
@@ -758,10 +757,9 @@ func (qs *queryState) handleUidPostings(
 					tlist := &pb.List{Uids: []uint64{q.UidList.Uids[i]}}
 					out.UidMatrix = append(out.UidMatrix, tlist)
 				}
-			//Check with Pawan/Ashish what this function do? I suppose itreturns the relevant posting/uid list to append to uid matrix
 			case srcFn.fnType == uidInFn:
 				if i == 0 {
-					span.Annotate(nil, "UidInFn") //Check with Pawan/Ashish what does this do?
+					span.Annotate(nil, "UidInFn")
 				}
 				reqList := &pb.List{Uids: srcFn.uidsPresent}
 				topts := posting.ListOptions{

--- a/worker/task.go
+++ b/worker/task.go
@@ -903,6 +903,7 @@ func (qs *queryState) helpProcessTask(ctx context.Context, q *pb.Query, gid uint
 	span := otrace.FromContext(ctx)
 	out := new(pb.Result)
 	attr := q.Attr
+
 	srcFn, err := parseSrcFn(ctx, q)
 	if err != nil {
 		return nil, err
@@ -1635,6 +1636,7 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 	if err == nil && fnType != notAFunction && t.Name() == types.StringID.Name() {
 		fc.isStringFn = true
 	}
+
 	switch fnType {
 	case notAFunction:
 		fc.n = len(q.UidList.Uids)
@@ -1828,7 +1830,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			}
 			fc.uidsPresent = append(fc.uidsPresent, uidParsed)
 		}
-
 		checkRoot(q, fc)
 		if fc.isFuncAtRoot {
 			return nil, errors.Errorf("uid_in function not allowed at root")

--- a/worker/task.go
+++ b/worker/task.go
@@ -1639,7 +1639,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 	case notAFunction:
 		fc.n = len(q.UidList.Uids)
 	case aggregatorFn:
-
 		// confirm aggregator could apply on the attributes
 		typ, err := schema.State().TypeOf(attr)
 		if err != nil {
@@ -1651,7 +1650,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		fc.n = len(q.UidList.Uids)
 	case compareAttrFn:
-
 		args := q.SrcFunc.Args
 		// Only eq can have multiple args. It should have atleast one.
 		if fc.fname == eq {
@@ -1712,7 +1710,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			fc.n = len(fc.tokens)
 		}
 	case compareScalarFn:
-
 		if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
 			return nil, err
 		}
@@ -1735,7 +1732,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		fc.n = len(q.UidList.Uids)
 	case standardFn, fullTextSearchFn:
-
 		// srcfunc 0th val is func name and and [2:] are args.
 		// we tokenize the arguments of the query.
 		if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
@@ -1751,7 +1747,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		fc.intersectDest = needsIntersect(f)
 		fc.n = len(fc.tokens)
 	case matchFn:
-
 		if err = ensureArgsCount(q.SrcFunc, 2); err != nil {
 			return nil, err
 		}
@@ -1774,7 +1769,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		fc.tokens = q.SrcFunc.Args
 		fc.n = len(fc.tokens)
 	case customIndexFn:
-
 		if err = ensureArgsCount(q.SrcFunc, 2); err != nil {
 			return nil, err
 		}
@@ -1823,9 +1817,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		checkRoot(q, fc)
 	case uidInFn:
 		//TODO (Anurag) Implement an argsCount for min 1 argument
-		// if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
-		// 	return nil, err
-		// }
 		for _, arg := range q.SrcFunc.Args {
 			uidParsed, err := strconv.ParseUint(arg, 0, 64)
 			if err != nil {

--- a/worker/task.go
+++ b/worker/task.go
@@ -1832,7 +1832,9 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			}
 			fc.uidsPresent = append(fc.uidsPresent, uidParsed)
 		}
-		sort.Slice(fc.uidsPresent, func(i, j int) bool { return fc.uidsPresent[i] < fc.uidsPresent[j] })
+		sort.Slice(fc.uidsPresent, func(i, j int) bool {
+			return fc.uidsPresent[i] < fc.uidsPresent[j]
+		})
 		checkRoot(q, fc)
 		if fc.isFuncAtRoot {
 			return nil, errors.Errorf("uid_in function not allowed at root")

--- a/worker/task.go
+++ b/worker/task.go
@@ -19,7 +19,6 @@ package worker
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -904,7 +903,6 @@ func (qs *queryState) helpProcessTask(ctx context.Context, q *pb.Query, gid uint
 	span := otrace.FromContext(ctx)
 	out := new(pb.Result)
 	attr := q.Attr
-	fmt.Println("Attr: ", attr)
 	srcFn, err := parseSrcFn(ctx, q)
 	if err != nil {
 		return nil, err
@@ -1637,17 +1635,10 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 	if err == nil && fnType != notAFunction && t.Name() == types.StringID.Name() {
 		fc.isStringFn = true
 	}
-	fmt.Println("fnType: ", fnType)
-	fmt.Println("fnName: ", f)
 	switch fnType {
 	case notAFunction:
-		fmt.Println("Not a function")
 		fc.n = len(q.UidList.Uids)
-		fmt.Println("fc: ", fc)
-		fmt.Println("fc.n: ", fc.n)
-		fmt.Println("q.UidList.Uid: ", q.UidList.Uids)
 	case aggregatorFn:
-		fmt.Println("Aggregator function")
 
 		// confirm aggregator could apply on the attributes
 		typ, err := schema.State().TypeOf(attr)
@@ -1660,7 +1651,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		fc.n = len(q.UidList.Uids)
 	case compareAttrFn:
-		fmt.Println("compareAttr function")
 
 		args := q.SrcFunc.Args
 		// Only eq can have multiple args. It should have atleast one.
@@ -1722,7 +1712,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			fc.n = len(fc.tokens)
 		}
 	case compareScalarFn:
-		fmt.Println("compare Scalar function")
 
 		if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
 			return nil, err
@@ -1746,7 +1735,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		fc.n = len(q.UidList.Uids)
 	case standardFn, fullTextSearchFn:
-		fmt.Println("Standard or fullTextSearch function")
 
 		// srcfunc 0th val is func name and and [2:] are args.
 		// we tokenize the arguments of the query.
@@ -1763,7 +1751,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		fc.intersectDest = needsIntersect(f)
 		fc.n = len(fc.tokens)
 	case matchFn:
-		fmt.Println("match function")
 
 		if err = ensureArgsCount(q.SrcFunc, 2); err != nil {
 			return nil, err
@@ -1787,7 +1774,6 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		fc.tokens = q.SrcFunc.Args
 		fc.n = len(fc.tokens)
 	case customIndexFn:
-		fmt.Println("customIndex function")
 
 		if err = ensureArgsCount(q.SrcFunc, 2); err != nil {
 			return nil, err
@@ -1836,12 +1822,10 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		checkRoot(q, fc)
 	case uidInFn:
-		fmt.Println("uidIn function")
-		fmt.Println("Q.SrcFunc: ", q.SrcFunc)
-		fmt.Println("Q.SrcFunc.Args: ", q.SrcFunc.Args)
-		//if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
-		//	return nil, err
-		//}
+		//TODO (Anurag) Implement an argsCount for min 1 argument
+		// if err = ensureArgsCount(q.SrcFunc, 1); err != nil {
+		// 	return nil, err
+		// }
 		for _, arg := range q.SrcFunc.Args {
 			uidParsed, err := strconv.ParseUint(arg, 0, 64)
 			if err != nil {
@@ -1853,14 +1837,7 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 			}
 			fc.uidsPresent = append(fc.uidsPresent, uidParsed)
 		}
-		//fc.uidsPresent, err = strconv.ParseUint(q.SrcFunc.Args[0], 0, 64)
-		// if err != nil {
-		// 	if e, ok := err.(*strconv.NumError); ok && e.Err == strconv.ErrSyntax {
-		// 		return nil, errors.Errorf("Value %q in %s is not a number",
-		// 			q.SrcFunc.Args[0], q.SrcFunc.Name)
-		// 	}
-		// 	return nil, err
-		// }
+
 		checkRoot(q, fc)
 		if fc.isFuncAtRoot {
 			return nil, errors.Errorf("uid_in function not allowed at root")

--- a/worker/task.go
+++ b/worker/task.go
@@ -19,6 +19,7 @@ package worker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -1816,7 +1817,12 @@ func parseSrcFn(ctx context.Context, q *pb.Query) (*functionContext, error) {
 		}
 		checkRoot(q, fc)
 	case uidInFn:
-		//TODO (Anurag) Implement an argsCount for min 1 argument
+		fmt.Println("q.SrcFunc.Args: ", q.SrcFunc.Args)
+		if len(q.SrcFunc.Args) == 0 {
+			err := errors.Errorf("Function '%s' requires atleast 1 argument, but got %d (%v)",
+				q.SrcFunc.Name, len(q.SrcFunc.Args), q.SrcFunc.Args)
+			return nil, err
+		}
 		for _, arg := range q.SrcFunc.Args {
 			uidParsed, err := strconv.ParseUint(arg, 0, 64)
 			if err != nil {


### PR DESCRIPTION
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes #JiraIssue".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->
Currently `uid_in` functions checks membership of only one **uid** across a given predicate edge. This PR will extend the support of membership checks to multiple **uids** in a single query fragment. Particularly we can run queries like this which checks for the presense of two uids (0x4e472a and 0x4e472b):
```
q(func: eq(name, "Jane Doe") ){
                name
                friend @filter( uid_in(memberOf, [0x4e472a, 0x4e472b]) ) {
                    name
                }
 }
```
Fixes #JiraIssue [DGRAPH-1292](https://dgraph.atlassian.net/browse/DGRAPH-1292)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5292)
<!-- Reviewable:end -->
