### PR TITLE
Export: Ignore deleted predicates from schema

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -484,6 +484,10 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		// considered data keys.
 		switch {
 		case pk.IsSchema():
+			// Do not add dropped predicates to schema.
+			if item.IsDeletedOrExpired() {
+				return nil, nil
+			}
 			var update pb.SchemaUpdate
 			err := item.Value(func(val []byte) error {
 				return update.Unmarshal(val)
@@ -567,6 +571,7 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 				// prepended
 				hasDataBefore = true
 			}
+
 			if _, err := writer.gw.Write(kv.Value); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph/issues/5053
Fixes DGRAPH-1260

The current implementation of export would add dropped predicates to the exported schema.
This PR fixes it by ignoring the deleted predicates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5302)
<!-- Reviewable:end -->
