### PR TITLE
docs: Set v20.03.1 as the latest docs.

### DIFF
--- a/wiki/content/releases/index.md
+++ b/wiki/content/releases/index.md
@@ -11,14 +11,14 @@ You can watch the [Announce][] Discuss category to know about the latest release
 
  Dgraph Release Series | Current Release | Supported? | First Release Date | End of life
 -----------------------|-----------------|------------|--------------------|------------
- v20.03.x              | [v20.03.0][]    | Yes        | March 2020         | March 2021
- v1.2.x                | [v1.2.2][]      | Yes        | January 2020       | January 2021
+ v20.03.x              | [v20.03.1][]    | Yes        | March 2020         | March 2021
+ v1.2.x                | [v1.2.3][]      | Yes        | January 2020       | January 2021
  v1.1.x                | [v1.1.1][]      | Yes        | January 2020       | January 2021
  v1.0.x                | [v1.0.18][]     | No         | December 2017      | March 2020
 
 
-[v20.03.0]: https://discuss.dgraph.io/t/dgraph-v20-03-0-release/6216
-[v1.2.2]: https://discuss.dgraph.io/t/dgraph-v1-2-2-release/6158
+[v20.03.1]: https://discuss.dgraph.io/t/dgraph-v20-03-1-release/6444
+[v1.2.3]: https://discuss.dgraph.io/t/dgraph-v1-2-3-release/6443
 [v1.1.1]: https://discuss.dgraph.io/t/dgraph-v1-1-1-release/5664
 [v1.0.18]: https://discuss.dgraph.io/t/dgraph-v1-0-18-release/5663
 

--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -27,8 +27,9 @@ HUGO="${HUGO:-hugo}"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 VERSIONS_ARRAY=(
-	'v20.03.0'
+	'v20.03.1'
 	'master'
+	'v20.03.0'
 	'v1.2.2'
 	'v1.2.1'
 	'v1.2.0'


### PR DESCRIPTION
This PR sets v20.03.1 as the latest docs.

Changes
* Update build script to set v20.03.1 as the latest docs.
* Update Releases page with newest release versions.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5309)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-33fd341f0c-58763.surge.sh)
<!-- Dgraph:end -->