### PR TITLE
docs: Add section about ludricrous mode.

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2019,6 +2019,8 @@ Dgraph alpha instances more evenly.
 
 ## Ludicrous Mode
 
+Ludicrous mode is available in Dgraph v20.03.1 or later.
+
 Ludicrous mode allows Dgraph to ingest data at an incredibly fast speed. It differs from the normal mode in terms of fewer guarantees that it provides. In normal scenarios dgraph provides strict consistency, which is not the case in ludicrous mode. In ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph starts later. In normal scenarios, Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
 
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2017,6 +2017,37 @@ Dgraph alpha instances more evenly.
 - The `--shufflers` controls the level of parallelism in the shuffle/reduce
   stage. Increasing this increases memory consumption.
 
+## Ludicrous Mode
+
+Ludicrous mode allows Dgraph to ingest data at an incredibly fast speed. It differs from the normal mode in terms of fewer guarantees that it provides. In normal scenarios dgraph provides strict consistency, which is not the case in ludicrous mode. In ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph starts later. In normal scenarios, Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
+
+
+**How do I enable it?**
+
+Ludicrous mode can be enabled by setting the `--ludicrous_mode` config option to all Zero and Alpha instances in the cluster.
+
+
+**What does it do?**
+
+It doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. One doesn’t need to send a commit request for mutation. It's equivalent to all mutations having CommitNow set automatically. All the mutations are then sent to background workers which keep applying all the mutation. Also we are not using sync mode while writing to disk. 
+
+
+**What is the trade off?**
+
+As mentioned in the section above, it provides amazing speed at the cost of some guarantees.
+
+It can be used when we have write-heavy operations and there is a time gap between queries and mutations, or you are fine with potentially reading stale data.
+
+There are no transactions in ludicrous mode. That is, you cannot open a transaction, apply a mutation, and then decide to cancel the transaction. Every mutation request is committed to Dgraph.
+
+**Can the cluster run with HA?**
+
+Yes, ludicrous mode works with the cluster set up in a highly-available (HA) configuration.
+
+**Can the cluster run with multiple data shards?**
+
+Yes, ludicrous mode works with the cluster set up with multiple data shards.
+
 ## Monitoring
 Dgraph exposes metrics via the `/debug/vars` endpoint in json format and the `/debug/prometheus_metrics` endpoint in Prometheus's text-based format. Dgraph doesn't store the metrics and only exposes the value of the metrics at that instant. You can either poll this endpoint to get the data in your monitoring systems or install **[Prometheus](https://prometheus.io/docs/introduction/install/)**. Replace targets in the below config file with the ip of your Dgraph instances and run prometheus using the command `prometheus -config.file my_config.yaml`.
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2021,7 +2021,7 @@ Dgraph alpha instances more evenly.
 
 Ludicrous mode is available in Dgraph v20.03.1 or later.
 
-Ludicrous mode allows Dgraph to ingest data at an incredibly fast speed. It differs from the normal mode in terms of fewer guarantees that it provides. In normal scenarios dgraph provides strict consistency, which is not the case in ludicrous mode. In ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph starts later. In normal scenarios, Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
+Ludicrous mode allows Dgraph to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
 
 
 **How do I enable it?**
@@ -2031,7 +2031,9 @@ Ludicrous mode can be enabled by setting the `--ludicrous_mode` config option to
 
 **What does it do?**
 
-It doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. One doesn’t need to send a commit request for mutation. It's equivalent to all mutations having CommitNow set automatically. All the mutations are then sent to background workers which keep applying all the mutation. Also we are not using sync mode while writing to disk. 
+It doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutation. It's equivalent to having CommitNow set automatically for all mutations. All the mutations are then sent to background workers which keep applying them.
+
+Also, Dgraph does not sync writes to disk. This increases throughput but may result in loss of unsynced writes in the event of hardware failure.
 
 
 **What is the trade off?**


### PR DESCRIPTION
Add a section to the Deploy docs about ludicrous mode.

All the ludicrous mode changes made it in v20.03.1.

* What is it
* How to enable it
* What are the trade offs
* Can it work with HA clusters (yes)
* Can it work with sharded clusters (yes)

Fixes DGRAPH-1187.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5310)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-37c35605f8-58878.surge.sh)
<!-- Dgraph:end -->