### PR TITLE
graphql: Fix response for partial admin queries.

### DIFF
--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -427,6 +428,34 @@ func health(t *testing.T) {
 	if diff := cmp.Diff(health, result.Health, opts...); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func partialHealth(t *testing.T) {
+	queryParams := &GraphQLParams{
+		Query: `query {
+            health {
+              instance
+              status
+              group
+            }
+        }`,
+	}
+	gqlResponse := queryParams.ExecuteAsPost(t, graphqlAdminTestAdminURL)
+	RequireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t, `{
+        "health": [
+          {
+            "instance": "zero",
+            "status": "healthy",
+            "group": "0"
+          },
+          {
+            "instance": "alpha",
+            "status": "healthy",
+            "group": "1"
+          }
+        ]
+      }`, string(gqlResponse.Data))
 }
 
 // The GraphQL /admin state result should be the same as /state

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -213,6 +213,7 @@ func RunAll(t *testing.T) {
 	// admin tests
 	t.Run("admin", admin)
 	t.Run("health", health)
+	t.Run("partial health", partialHealth)
 	t.Run("state", adminState)
 	t.Run("propagate client remote ip", clientInfoLogin)
 

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1178,6 +1178,14 @@ func completeValue(
 		return completeObject(path, field.SelectionSet(), val)
 	case []interface{}:
 		return completeList(path, field, val)
+	case []map[string]interface{}:
+		// This case is different from the []interface{} case above and is true for admin queries
+		// where we built the val ourselves.
+		listVal := make([]interface{}, 0, len(val))
+		for _, v := range val {
+			listVal = append(listVal, v)
+		}
+		return completeList(path, field, listVal)
 	default:
 		if val == nil {
 			if field.Type().ListType() != nil {


### PR DESCRIPTION
@martinmr pointed as part of https://github.com/dgraph-io/dgraph/pull/5307 that partial backup queries were not working. On inspection, I found out that partial admin queries are broken after the refactoring that happened as part of simplifying how resolver are written. The reason being that `[]interface{}` is different from `[]map[string]interface{}`. We also didn't have any test which did partial queries. I have added a test for the same and have a fix in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5317)
<!-- Reviewable:end -->
