### PR TITLE
Change the expected response structure for queries/mutations that are resolved through HTTP endpoints.

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -130,9 +130,8 @@ func verifyGraphqlRequest(r *http.Request, expectedRequest expectedGraphqlReques
 	return false, nil
 }
 
-func getDefaultResponse(resKey string) []byte {
-	resTemplate := `{
-		"%s": [
+func getDefaultResponse() []byte {
+	resTemplate := `[
 			{
 				"id": "0x3",
 				"name": "Star Wars",
@@ -153,10 +152,9 @@ func getDefaultResponse(resKey string) []byte {
 					}
 				]
 			}
-		]
-	}`
+		]`
 
-	return []byte(fmt.Sprintf(resTemplate, resKey))
+	return []byte(resTemplate)
 }
 
 func getFavMoviesHandler(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +168,7 @@ func getFavMoviesHandler(w http.ResponseWriter, r *http.Request) {
 		check2(w.Write([]byte(err.Error())))
 		return
 	}
-	check2(w.Write(getDefaultResponse("myFavoriteMovies")))
+	check2(w.Write(getDefaultResponse()))
 }
 
 func postFavMoviesHandler(w http.ResponseWriter, r *http.Request) {
@@ -184,7 +182,7 @@ func postFavMoviesHandler(w http.ResponseWriter, r *http.Request) {
 		check2(w.Write([]byte(err.Error())))
 		return
 	}
-	check2(w.Write(getDefaultResponse("myFavoriteMoviesPost")))
+	check2(w.Write(getDefaultResponse()))
 }
 
 func verifyHeadersHandler(w http.ResponseWriter, r *http.Request) {
@@ -203,7 +201,7 @@ func verifyHeadersHandler(w http.ResponseWriter, r *http.Request) {
 		check2(w.Write([]byte(err.Error())))
 		return
 	}
-	check2(w.Write([]byte(`{"verifyHeaders":[{"id":"0x3","name":"Star Wars"}]}`)))
+	check2(w.Write([]byte(`[{"id":"0x3","name":"Star Wars"}]`)))
 }
 
 func favMoviesCreateHandler(w http.ResponseWriter, r *http.Request) {
@@ -218,9 +216,7 @@ func favMoviesCreateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	check2(w.Write([]byte(`
-	{
-      "createMyFavouriteMovies": [
+	check2(w.Write([]byte(`[
         {
           "id": "0x1",
           "name": "Mov1",
@@ -235,8 +231,7 @@ func favMoviesCreateHandler(w http.ResponseWriter, r *http.Request) {
           "id": "0x3",
           "name": "Mov2"
         }
-      ]
-    }`)))
+    ]`)))
 }
 
 func favMoviesUpdateHandler(w http.ResponseWriter, r *http.Request) {
@@ -253,7 +248,6 @@ func favMoviesUpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 	check2(w.Write([]byte(`
 	{
-      "updateMyFavouriteMovie": {
         "id": "0x1",
         "name": "Mov1",
         "director": [
@@ -262,7 +256,6 @@ func favMoviesUpdateHandler(w http.ResponseWriter, r *http.Request) {
             "name": "Dir1"
           }
         ]
-      }
     }`)))
 }
 
@@ -285,10 +278,8 @@ func favMoviesDeleteHandler(w http.ResponseWriter, r *http.Request) {
 
 	check2(w.Write([]byte(`
 	{
-      "deleteMyFavouriteMovie": {
         "id": "0x1",
         "name": "Mov1"
-      }
     }`)))
 }
 

--- a/graphql/resolve/custom_mutation_test.yaml
+++ b/graphql/resolve/custom_mutation_test.yaml
@@ -18,24 +18,22 @@
       ]
     }
   httpresponse: |
-    {
-      "createMyFavouriteMovies": [
-        {
-          "id": "0x1",
-          "name": "Mov1",
-          "director": [
-            {
-              "id": "0x2",
-              "name": "Dir1"
-            }
-          ]
-        },
-        {
-          "id": "0x3",
-          "name": "Mov2"
-        }
-      ]
-    }
+    [
+      {
+        "id": "0x1",
+        "name": "Mov1",
+        "director": [
+          {
+            "id": "0x2",
+            "name": "Dir1"
+          }
+        ]
+      },
+      {
+        "id": "0x3",
+        "name": "Mov2"
+      }
+    ]
   url: http://myapi.com/favMovies
   method: POST
   body: |
@@ -88,16 +86,14 @@
     }
   httpresponse: |
     {
-      "updateMyFavouriteMovie": {
-        "id": "0x1",
-        "name": "Mov1",
-        "director": [
-          {
-            "id": "0x2",
-            "name": "Dir1"
-          }
-        ]
-      }
+      "id": "0x1",
+      "name": "Mov1",
+      "director": [
+        {
+          "id": "0x2",
+          "name": "Dir1"
+        }
+      ]
     }
   url: http://myapi.com/favMovies/0x01
   method: PATCH
@@ -140,16 +136,14 @@
     }
   httpresponse: |
     {
-      "deleteMyFavouriteMovie": {
-        "id": "0x1",
-        "name": "Mov1",
-        "director": [
-          {
-            "id": "0x2",
-            "name": "Dir1"
-          }
-        ]
-      }
+      "id": "0x1",
+      "name": "Mov1",
+      "director": [
+        {
+          "id": "0x2",
+          "name": "Dir1"
+        }
+      ]
     }
   url: http://myapi.com/favMovies/0x01
   method: DELETE

--- a/graphql/resolve/custom_query_test.yaml
+++ b/graphql/resolve/custom_query_test.yaml
@@ -12,24 +12,22 @@
       }
     }
   httpresponse: |
-    {
-      "myFavoriteMovies": [
-        {
-          "id": "0x1",
-          "name": "Star Wars",
-          "director": [
-            {
-              "id": "0x2",
-              "name": "George Lucas"
-            }
-          ]
-        },
-        {
-          "id": "0x3",
-          "name": "Star Trek"
-        }
-      ]
-    }
+    [
+      {
+        "id": "0x1",
+        "name": "Star Wars",
+        "director": [
+          {
+            "id": "0x2",
+            "name": "George Lucas"
+          }
+        ]
+      },
+      {
+        "id": "0x3",
+        "name": "Star Trek"
+      }
+    ]
   url: http://myapi.com/favMovies/0x1?name=Michael&num=
   method: GET
   resolvedresponse: |
@@ -68,23 +66,21 @@
   variables: |
     { "id": "0x9" }
   httpresponse: |
-    {
-      "myFavoriteMoviesPart2": [
-        {
-          "id": "0x1",
-          "director": [
-            {
-              "id": "0x2",
-              "name": "George Lucas"
-            }
-          ]
-        },
-        {
-          "id": "0x3",
-          "name": "Star Trek"
-        }
-      ]
-    }
+    [
+      {
+        "id": "0x1",
+        "director": [
+          {
+            "id": "0x2",
+            "name": "George Lucas"
+          }
+        ]
+      },
+      {
+        "id": "0x3",
+        "name": "Star Trek"
+      }
+    ]
   url: http://myapi.com/favMovies/0x9?name=Michael&num=10
   method: POST
   body: '{ "id": "0x9", "name": "Michael", "director": { "number": 10 }}'

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1439,12 +1439,12 @@ func (hr *httpResolver) rewriteAndExecute(ctx context.Context, field schema.Fiel
 
 	// this means it had body and not graphql, so just unmarshal it and return
 	if hrc.RemoteGqlQueryName == "" {
-		var result map[string]interface{}
+		var result interface{}
 		if err := json.Unmarshal(b, &result); err != nil {
 			return emptyResult(jsonUnmarshalError(err, field))
 		}
 		return &Resolved{
-			Data:  result,
+			Data:  map[string]interface{}{field.Name(): result},
 			Field: field,
 		}
 	}


### PR DESCRIPTION
Earlier, we expected the response to be an object with a key that was the same as the key defined in our GraphQL schema as the query/mutation name. We have removed that limitation for now and just take the response as it is. Fixes GRAPHQL-340.

There were also discussions around the `http` arguments inside `@custom` accepting another key called `responseKey` which allows keeping the same functionality we have right now but being more configurable. We are not doing that right now but if we decide to, we should do it for both query/mutation and also fields resolved through custom HTTP endpoints.
For e.g.
```
type Query {
		 myFavoriteMovies(id: ID!, name: String!, num: Int): [Movie] @custom(http: {
				 url: "http://mock:8888/favMovies/$id?name=$name&num=$num",
				 method: "GET",
                                 responseKey: "favMovies",
		 })
	 }
```
In this case we would expect the output from the custom HTTP endpoint to have `favMovies` as the top level key and would use its value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5319)
<!-- Reviewable:end -->
