### PR TITLE
release/v1.2: Export: Ignore deleted predicates from schema (#5302)

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -438,6 +438,10 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 	stream := pstore.NewStreamAt(in.ReadTs)
 	stream.LogPrefix = "Export"
 	stream.ChooseKey = func(item *badger.Item) bool {
+		// Skip exporting delete data including Schema and Types.
+		if item.IsDeletedOrExpired() {
+			return false
+		}
 		pk, err := x.Parse(item.Key())
 		if err != nil {
 			glog.Errorf("error %v while parsing key %v during export. Skip.", err, hex.EncodeToString(item.Key()))
@@ -561,6 +565,7 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 				// prepended
 				hasDataBefore = true
 			}
+
 			if _, err := writer.gw.Write(kv.Value); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph/issues/5053
Fixes DGRAPH-1260

The current implementation of export would add dropped
predicates and deleted types to the exported schema.
This PR fixes it by ignoring the deleted predicates and types.

(cherry picked from commit 23140a9f61116ead3defda05bbade9eeca161aef)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5327)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d5221e4649-59452.surge.sh)
<!-- Dgraph:end -->