### PR TITLE
docs: Update Hugo config for latest Hugo version.

### DIFF
--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -1,5 +1,9 @@
 languageCode = "en-us"
 theme = "hugo-docs"
+canonifyURLs = true
+
+[markup.goldmark.renderer]
+unsafe = true
 
 # set by build script: title, baseurl
 title = "Dgraph Documentation"

--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -5,6 +5,9 @@ canonifyURLs = true
 [markup.goldmark.renderer]
 unsafe = true
 
+[markup.highlight]
+noClasses = false
+
 # set by build script: title, baseurl
 title = "Dgraph Documentation"
 

--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -11,7 +11,7 @@ set -e
 
 GREEN='\033[32;1m'
 RESET='\033[0m'
-HOST="${HOST:-https://docs.dgraph.io}"
+HOST="${HOST:-https://dgraph.io/docs}"
 # Name of output public directory
 PUBLIC="${PUBLIC:-public}"
 # LOOP true makes this script run in a loop to check for updates


### PR DESCRIPTION
These changes make docs work with Hugo v0.69.2 (the current latest version).

Starting with [Hugo v0.60.0](https://gohugo.io/news/0.60.0-relnotes/) and later, setting `markup.goldmark.renderer.unsafe = true` is required to use inline HTML. Otherwise, inline HTML in Markdown documents is replaced with `<!-- raw HTML omitted -->`. We use raw HTML in some places of the docs (e.g., on the front page).

Changes
* Set canonifyURLs to true and set the base URL to dgraph.io/docs
* Set the Markdown renderer to unsafe mode to render inline HTML
* Set `[markdown.highlight] noClasses = false` to keep the same syntax highlighting.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5337)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6e2dd8339c-60860.surge.sh)
<!-- Dgraph:end -->