### PR TITLE
graphql: strip custom logic from exposed schema

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -525,6 +525,14 @@ func generateGQLSchema(sch *gqlSchema) (*schema.Schema, error) {
 		return nil, err
 	}
 
+	// Now strip the exposed schema
+	strippedSchema, err := schema.Strip(sch.Schema)
+	if err != nil {
+		return nil, err
+	}
+	sch.Schema = strippedSchema
+	sch.GeneratedSchema = schHandler.StrippedGQLSchema()
+
 	return &generatedSchema, nil
 }
 


### PR DESCRIPTION
This PR removes custom directive from exposed schema. Particularly if the custom logic has any keys, private urls, etc embedded in it, it shouldn’t be public.

Fixes #GRAPHQL-347
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5338)
<!-- Reviewable:end -->
