### PR TITLE
Avoid deleting empty ranges from the write-ahead log.

### DIFF
--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -92,6 +92,9 @@ func (w *DiskStorage) processIndexRange() {
 	defer w.Closer.Done()
 
 	processSingleRange := func(r indexRange) {
+		if r.from == r.until {
+			return
+		}
 		batch := w.db.NewWriteBatch()
 		if err := w.deleteRange(batch, r.from, r.until); err != nil {
 			glog.Errorf("deleteRange failed with error: %v, from: %d, until: %d\n",


### PR DESCRIPTION
Somebody reported that an error message is printed in this line (due to
compaction happening at the same time). However, the range in question
goes from zero to zero. We should skip deleting empty ranges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5343)
<!-- Reviewable:end -->
