### PR TITLE
DGRAPH-1287 Updated example dgraph-ha.yaml for sec best practices

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/README.md
+++ b/contrib/config/kubernetes/dgraph-ha/README.md
@@ -1,6 +1,6 @@
 # Dgraph High Availability
 
-Enclosed is an example manifest `dgraph-ha.yaml` to deploy Dgraph cluster on Kubernetes:
+`dgraph-ha.yaml` is an example manifest to deploy Dgraph cluster on Kubernetes:
 
 * 3 zero nodes
 * 3 alpha nodes
@@ -25,7 +25,7 @@ kubectl port-forward svc/dgraph-alpha-public 8080:8080
 
 ## Public Services
 
-There are four services specified in the manifest that can be used to expose services outside the cluster.  Highly recommend that when doing this, they are only accessible on a private subnet, and not exposed to the public Internet.
+There are three services specified in the manifest that can be used to expose services outside the cluster.  Highly recommend that when doing this, they are only accessible on a private subnet, and not exposed to the public Internet.
 
 * `dgraph-zero-public` - To load data using Live & Bulk Loaders
 * `dgraph-alpha-public` - To connect clients and for HTTP APIs

--- a/contrib/config/kubernetes/dgraph-ha/README.md
+++ b/contrib/config/kubernetes/dgraph-ha/README.md
@@ -1,0 +1,64 @@
+# Dgraph High Availability
+
+Enclosed is an example manifest `dgraph-ha.yaml` to deploy Dgraph cluster on Kubernetes:
+
+* 3 zero nodes
+* 3 alpha nodes
+* 1 ratel UI node
+
+You can deploy the manifest with `kubectl`:
+
+```bash
+kubectl apply --filename dgraph-ha.yaml
+```
+
+## Accessing the Services
+
+You can access services deploy from `dgraph-ha.yaml` running each of these commands in a separate terminal window or tab:
+
+```bash
+# port-forward to ratel ui
+kubectl port-forward svc/dgraph-ratel-public 8000:8000
+# port-forward to alpha
+kubectl port-forward svc/dgraph-alpha-public 8080:8080
+```
+
+## Public Services
+
+There are four services specified in the manifest that can be used to expose services outside the cluster.  Highly recommend that when doing this, they are only accessible on a private subnet, and not exposed to the public Internet.
+
+* `dgraph-zero-public` - To load data using Live & Bulk Loaders
+* `dgraph-alpha-public` - To connect clients and for HTTP APIs
+* `dgraph-ratel-public` - For Dgraph UI
+
+For security best practices, these are set as `ClusterIP` service type, so they are only accessible from within the Kubernetes cluster.  If you need to expose these to outside of the cluster, there are a few options:
+
+* Change the [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to `LoadBalancer` for the private intranet access.
+* Install an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) that can provide access to the service from outside the Kubernetes cluster for private intranet access.
+
+Configuring a service with `LoadBalancer` service type or an Ingress Controller to use a private subnet is very implementation specific. Here are some examples:
+
+|Provider    | Documentation Reference   | Annotation |
+|------------|---------------------------|------------|
+|AWS         |[Amazon EKS: Load Balancing](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html)|`service.beta.kubernetes.io/aws-load-balancer-internal: "true"`|
+|Azure       |[AKS: Internal Load Balancer](https://docs.microsoft.com/en-us/azure/aks/internal-lb)|`service.beta.kubernetes.io/azure-load-balancer-internal: "true"`|
+|Google Cloud|[GKE: Internal Load Balancing](https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing)|`cloud.google.com/load-balancer-type: "Internal"`|
+
+
+
+
+## Amazon EKS
+
+### Create K8S using eksctl (optional)
+
+An example cluster manifest for use with `eksctl` is provided quickly provision an Amazon EKS cluster.  
+
+The `eksctl` tool can be installed following these instructions:
+
+* https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html
+
+Once installed, you can provision Amazon EKS with the following command (takes ~20 minutes):
+
+```bash
+eksctl create cluster --config-file cluster.yaml
+```

--- a/contrib/config/kubernetes/dgraph-ha/cluster.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/cluster.yaml
@@ -6,7 +6,7 @@ metadata:
 managedNodeGroups:
   - name: dgraph-ha-cluster-workers
     minSize: 3
-    maxSize: 5
+    maxSize: 6
     desiredCapacity: 3
     labels: {role: worker}
     tags:

--- a/contrib/config/kubernetes/dgraph-ha/cluster.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/cluster.yaml
@@ -1,0 +1,19 @@
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: dgraph-ha-cluster
+  region: us-east-2
+managedNodeGroups:
+  - name: dgraph-ha-cluster-workers
+    minSize: 3
+    maxSize: 5
+    desiredCapacity: 3
+    labels: {role: worker}
+    tags:
+      nodegroup-role: worker
+    iam:
+      withAddonPolicies:
+        # allow k8s update Route53 if external-dns installed
+        externalDNS: true
+        # access ACM (AWS Cert Mngr) for LoadBalancer or Ingress
+        certManager: true

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -3,11 +3,11 @@
 # will still be available to service requests even when one Zero
 # and/or one Alpha are down.
 #
-# There are 4 public services exposed, users can use:
+# There are 3 services can can be used to expose outside the cluster as needed:
 #       dgraph-zero-public - To load data using Live & Bulk Loaders
 #       dgraph-alpha-public - To connect clients and for HTTP APIs
 #       dgraph-ratel-public - For Dgraph UI
-#       dgraph-alpha-x-http-public - Use for debugging & profiling
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -16,7 +16,7 @@ metadata:
     app: dgraph-zero
     monitor: zero-dgraph-io
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 5080
     targetPort: 5080
@@ -35,7 +35,7 @@ metadata:
     app: dgraph-alpha
     monitor: alpha-dgraph-io
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 8080
     targetPort: 8080
@@ -46,24 +46,6 @@ spec:
   selector:
     app: dgraph-alpha
 ---
-# This service is created in-order to debug & profile a specific alpha.
-# You can create one for each alpha that you need to profile.
-# For a more general HTTP APIs use the above service instead.
-apiVersion: v1
-kind: Service
-metadata:
-  name: dgraph-alpha-0-http-public
-  labels:
-    app: dgraph-alpha
-spec:
-  type: LoadBalancer
-  ports:
-  - port: 8080
-    targetPort: 8080
-    name: alpha-http
-  selector:
-    statefulset.kubernetes.io/pod-name: dgraph-alpha-0
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -71,7 +53,7 @@ metadata:
   labels:
     app: dgraph-ratel
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 8000
     targetPort: 8000


### PR DESCRIPTION
This PR changes the example `dgraph-ha.yaml` to use `ClusterIP` service type for security best practices.  Previously, the default was to expose the Dgraph cluster to the wilds of public Internet.  

Changes:

* Services `LoadBalancer` to `ClusterIP`
* Removed single node service, as not needed.
* Added example eksctl script for easy provisioning of Amazon EKS
* Added README to add more depth, as well as show options on how to access and secure endpoints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5346)
<!-- Reviewable:end -->
