### PR TITLE
graphql: ensure upserts don't have accidental edge removal

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -1284,3 +1284,215 @@
   error:
     message: |-
       failed to rewrite mutation payload because duplicate XID found: S1
+
+# Additional Deletes
+#
+# If we have
+# 
+# type Post { ... author: Author @hasInverse(field: posts) ... }
+# type Author { ... posts: [Post] ... }
+#
+# and existing edge
+# 
+# Post1 --- author --> Author1
+# 
+# there must also exist edge
+# 
+# Author1 --- posts --> Post1
+#
+# So if we did an add Author2 and connect the author to Post1, that changes the 
+# author of Post1 to Author2, we need to
+#  * add edge Post1 --- author --> Author2 (done by asIDReference/asXIDReference)
+#  * add edge Author2 --- posts --> Post1 (done by addInverseLink)
+#  * delete edge Author1 --- posts --> Post1 (done by addAdditionalDeletes)
+#
+# This delete only needs to be done when there is a singular edge in the mutation:
+# i.e. if both directions of the edge are [], then it's just an add.
+#
+# There's three cases to consider: add by ID, add by XID, deep add
+
+- name: "Additional Deletes - Add connects to existing node by ID"
+  gqlmutation: |
+    mutation addAuthor($auth: AddAuthorInput!) {
+      addAuthor(input: [$auth]) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "auth": {
+        "name": "A.N. Author",
+        "posts": [ { "postID": "0x456" } ]
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { 
+          "uid":"_:Author1",
+          "dgraph.type":["Author"],
+          "Author.name":"A.N. Author",
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "_:Author1" }
+            }
+          ]
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Author3)",
+            "Author.posts": [ { "uid": "uid(Post2)" } ]
+          }
+        ]
+      cond: "@if(eq(len(Post2), 1))"
+  dgquery: |-
+    query {
+      Post2 as Post2(func: uid(0x456)) @filter(type(Post)) {
+        uid
+      }
+      var(func: uid(Post2)) {
+        Author3 as Post.author
+      }
+    }
+
+- name: "Additional Deletes - Add connects to existing node by XID"
+  gqlmutation: |
+    mutation addCountry($inp: AddCountryInput!) {
+      addCountry(input: [$inp]) {
+        country {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "inp": { 
+        "name": "A Country",
+        "states": [ { "code": "abc", "name": "Alphabet" } ]
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { 
+          "uid" : "_:Country1",
+          "dgraph.type": ["Country"],
+          "Country.name": "A Country",
+          "Country.states": [
+            {
+              "uid": "_:State3",
+              "dgraph.type": ["State"],
+              "State.code": "abc",
+              "State.name": "Alphabet",
+              "State.country": { "uid": "_:Country1" }
+            }
+          ]
+        }
+      cond: "@if(eq(len(State3), 0))"
+    - setjson: |
+        { 
+          "uid" : "_:Country1",
+          "dgraph.type": ["Country"],
+          "Country.name": "A Country",
+          "Country.states": [
+            {
+              "uid": "uid(State3)",
+              "State.country": { "uid": "_:Country1" }
+            }
+          ]
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Country4)",
+            "Country.states": [ { "uid": "uid(State3)" } ]
+          }
+        ]
+      cond: "@if(eq(len(State3), 1))"
+  dgquery: |-
+    query {
+      State3 as State3(func: eq(State.code, "abc")) @filter(type(State)) {
+        uid
+      }
+      var(func: uid(State3)) {
+        Country4 as State.country
+      }
+    }
+
+- name: "Additional Deletes - deep mutation"
+  gqlmutation: |
+    mutation addAuthor($auth: AddAuthorInput!) {
+      addAuthor(input: [$auth]) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "auth": {
+        "name": "A.N. Author",
+        "country": { 
+          "name": "A Country",
+          "states": [ { "code": "abc", "name": "Alphabet" } ]
+        }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { 
+          "uid":"_:Author1",
+          "dgraph.type":["Author"],
+          "Author.name":"A.N. Author",
+          "Author.country": {
+            "uid": "_:Country2",
+            "dgraph.type": ["Country"],
+            "Country.name": "A Country",
+            "Country.states": [
+              {
+                "uid": "_:State4",
+                "dgraph.type": ["State"],
+                "State.code": "abc",
+                "State.name": "Alphabet",
+                "State.country": { "uid": "_:Country2" }
+              }
+            ]
+          }
+        }
+      cond: "@if(eq(len(State4), 0))"
+    - setjson: |
+        { 
+          "uid":"_:Author1",
+          "dgraph.type":["Author"],
+          "Author.name":"A.N. Author",
+          "Author.country": {
+            "uid" : "_:Country2",
+            "dgraph.type": ["Country"],
+            "Country.name": "A Country",
+            "Country.states": [
+              {
+                "uid": "uid(State4)",
+                "State.country": { "uid": "_:Country2" }
+              }
+            ]
+          }
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Country5)",
+            "Country.states": [ { "uid": "uid(State4)" } ]
+          }
+        ]
+      cond: "@if(eq(len(State4), 1))"
+  dgquery: |-
+    query {
+      State4 as State4(func: eq(State.code, "abc")) @filter(type(State)) {
+        uid
+      }
+      var(func: uid(State4)) {
+        Country5 as State.country
+      }
+    }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1111,7 +1111,7 @@ func addAdditionalDeletes(
 //
 // we are about to attach
 //
-// Post1 --- author --> Author1
+// Post2 --- author --> Author1
 //
 // So Post2 should get removed from Author3's posts edge
 //

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1138,16 +1138,17 @@ func addDelete(frag *mutationFragment,
 	// We shouldn't do the delete if it ends up that the mutation is linking to the existing
 	// value for this edge in Dgraph - otherwise (because there's a non-deterministic order
 	// in executing set and delete) we might end up deleting the value in a set mutation.
-	//
-	// That can only happen at the top level of an update, where the variable is
-	// already uid(...)
+	exclude := excludeVar
 	if strings.HasPrefix(excludeVar, "uid(") {
+		exclude = excludeVar[4 : len(excludeVar)-1]
+	}
+	if !strings.HasPrefix(excludeVar, "_:") {
 		qry.Children[0].Filter = &gql.FilterTree{
 			Op: "not",
 			Child: []*gql.FilterTree{{
 				Func: &gql.Function{
 					Name: "uid",
-					Args: []gql.Arg{{Value: excludeVar[4 : len(excludeVar)-1]}}}}},
+					Args: []gql.Arg{{Value: exclude}}}}},
 		}
 	}
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1102,6 +1102,46 @@ func addAdditionalDeletes(
 	addDelete(frag, varGen, srcUID, variable, srcField, invField)
 }
 
+// addDelete adds a delete to the mutation if adding/updating an edge will cause another
+// edge to disappear (see notes at addAdditionalDeletes)
+//
+// e.g. we have edges
+// Post2 --- author --> Author3
+// Author3 --- posts --> Post2
+//
+// we are about to attach
+//
+// Post1 --- author --> Author1
+//
+// So Post2 should get removed from Author3's posts edge
+//
+// qryVar - is the variable storing Post2's uid
+// excludeVar - is the uid we might have to exclude from the query
+//
+// e.g. if qryVar = Post2, we'll generate
+//
+// query {
+//   ...
+// 	 var(func: uid(Post2)) {
+// 	  Author3 as Post.author
+// 	 }
+//  }
+//
+// and delete Json
+//
+// { "uid": "uid(Author3)", "Author.posts": [ { "uid": "uid(Post2)" } ] }
+//
+// removing the post from Author3
+//
+// but if there's a chance (e.g. during an update) that Author1 and Author3 are the same
+// e.g. the update isn't really changing an existing edge, we have to definitely not
+// do the delete. So we add a condition using the excludeVar
+//
+// 	 var(func: uid(Post2)) {
+// 	  Author3 as Post.author @filter(NOT(uid(Author1)))
+// 	 }
+//
+// and the delete won't run.
 func addDelete(frag *mutationFragment,
 	varGen *VariableGenerator,
 	qryVar, excludeVar string,
@@ -1135,13 +1175,21 @@ func addDelete(frag *mutationFragment,
 		}},
 	}
 
-	// We shouldn't do the delete if it ends up that the mutation is linking to the existing
-	// value for this edge in Dgraph - otherwise (because there's a non-deterministic order
-	// in executing set and delete) we might end up deleting the value in a set mutation.
 	exclude := excludeVar
 	if strings.HasPrefix(excludeVar, "uid(") {
 		exclude = excludeVar[4 : len(excludeVar)-1]
 	}
+
+	// We shouldn't do the delete if it ends up that the mutation is linking to the existing
+	// value for this edge in Dgraph - otherwise (because there's a non-deterministic order
+	// in executing set and delete) we might end up deleting the value in a set mutation.
+	//
+	// The only time that we always remove the edge and not check is a new node: e.g.
+	// excludeVar is a blank node like _:Author1.   E.g. if
+	// Post2 --- author --> Author3
+	// Author3 --- posts --> Post2
+	// is in the graph and we are creating a new node _:Author1 ... there's no way
+	// Author3 and _:Author1 can be the same uid, so the check isn't required.
 	if !strings.HasPrefix(excludeVar, "_:") {
 		qry.Children[0].Filter = &gql.FilterTree{
 			Op: "not",

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -839,7 +839,7 @@
         Owner3 as House.owner @filter(NOT (uid(x)))
       }
       var(func: uid(x)) {
-        House4 as Owner.house
+        House4 as Owner.house @filter(NOT (uid(House2)))
       }
     }
 
@@ -1138,3 +1138,267 @@
   error:
     message: |-
       failed to rewrite mutation payload because duplicate XID found: T1
+
+
+# Additional Deletes
+#
+# If we have
+# 
+# type Post { ... author: Author @hasInverse(field: posts) ... }
+# type Author { ... posts: [Post] ... }
+#
+# and existing edge
+# 
+# Post1 --- author --> Author1
+# 
+# there must also exist edge
+# 
+# Author1 --- posts --> Post1
+#
+# So if we did an update that changes the author of Post1 to Author2, we need to
+#  * add edge Post1 --- author --> Author2 (done by asIDReference/asXIDReference)
+#  * add edge Author2 --- posts --> Post1 (done by addInverseLink)
+#  * delete edge Author1 --- posts --> Post1 (done by addAdditionalDeletes)
+#
+# This delete only needs to be done when there is a singular edge in the mutation:
+# i.e. if both directions of the edge are [], then it's just an add.  We also need
+# to guard all these cases.  For example: an updateAuthor mutation might contain
+#   "set": { ... "posts": [ { "postID": "0x456" } ] ... }
+# but we don't know if the author we are updating already has "0x456" in its list
+# of posts, so we only do the delete if that post's author is different to the
+# author we are updating.
+#
+# Updates can only happen at the top level of a mutation, so there's no deep cases.
+# There's four cases to consider: 
+#  * updating a node by adding a reference by ID (e.g. attaching a post to an author
+#    causes a delete on the author the post was attached to - if it's not the post
+#    being updated)
+#  * updating a node by adding a reference by XID (e.g. updating a country to set
+#    a state by xid)
+#  * as per case one, but updating the post rather than the author (i.e. the singular
+#    edge is in the updated node, not the reference node)
+#  * as per case two, but with the singular edge in the updated node.
+
+- name: "Additional Deletes - Update references existing node by ID (updt list edge)"
+  gqlmutation: |
+    mutation updateAuthor($patch: UpdateAuthorInput!) {
+      updateAuthor(input: $patch) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "patch": { 
+        "filter": {
+          "id": ["0x123"]
+        },
+        "set": {
+          "posts": [ { "postID": "0x456" } ]
+        }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { 
+          "uid" : "uid(x)",
+          "Author.posts": [
+            {
+              "uid": "0x456",
+              "Post.author": { "uid": "uid(x)" }
+            }
+          ]
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Author3)",
+            "Author.posts": [{"uid": "uid(Post2)"}]
+          }
+        ]
+      cond: "@if(eq(len(Post2), 1) AND gt(len(x), 0))"
+  dgquery: |-
+    query {
+      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+        uid
+      }
+      Post2 as Post2(func: uid(0x456)) @filter(type(Post)) {
+        uid
+      }
+      var(func: uid(Post2)) {
+        Author3 as Post.author @filter(NOT (uid(x)))
+      }
+    }
+
+- name: "Additional Deletes - Update references existing node by ID (updt single edge)"
+  gqlmutation: |
+    mutation updatePost($patch: UpdatePostInput!) {
+      updatePost(input: $patch) {
+        post {
+          postID
+        }
+      }
+    }
+  gqlvariables: |
+    { "patch":
+      { "filter": {
+          "postID": ["0x123"]
+        },
+        "set": {
+          "text": "updated text",
+          "author": { "id": "0x456" }
+        }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid" : "uid(x)",
+          "Post.text": "updated text",
+          "Post.author": { 
+            "uid": "0x456",
+            "Author.posts": [ { "uid": "uid(x)" } ]
+          }
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Author3)",
+            "Author.posts": [ { "uid": "uid(x)" } ]
+          }
+        ]
+      cond: "@if(eq(len(Author2), 1) AND gt(len(x), 0))"
+  dgquery: |-
+    query {
+      x as updatePost(func: type(Post)) @filter(uid(0x123)) {
+        uid
+      }
+      Author2 as Author2(func: uid(0x456)) @filter(type(Author)) {
+        uid
+      }
+      var(func: uid(x)) {
+        Author3 as Post.author @filter(NOT (uid(Author2)))
+      }
+    }
+
+- name: "Additional Deletes - Update references existing node by XID (updt list edge)"
+  gqlmutation: |
+    mutation updateCountry($patch: UpdateCountryInput!) {
+      updateCountry(input: $patch) {
+        country {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "patch": { 
+        "filter": {
+          "id": ["0x123"]
+        },
+        "set": {
+          "states": [ { "code": "abc", "name": "Alphabet" } ]
+        }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { 
+          "uid" : "uid(x)",
+          "Country.states": [
+            {
+              "uid": "_:State3",
+              "dgraph.type": ["State"],
+              "State.code": "abc",
+              "State.name": "Alphabet",
+              "State.country": { "uid": "uid(x)" }
+            }
+          ]
+        }
+      cond: "@if(eq(len(State3), 0) AND gt(len(x), 0))"
+    - setjson: |
+        { 
+          "uid" : "uid(x)",
+          "Country.states": [
+            {
+              "uid": "uid(State3)",
+              "State.country": { "uid": "uid(x)" }
+            }
+          ]
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Country4)",
+            "Country.states": [ { "uid": "uid(State3)" } ]
+          }
+        ]
+      cond: "@if(eq(len(State3), 1) AND gt(len(x), 0))"
+  dgquery: |-
+    query {
+      x as updateCountry(func: type(Country)) @filter(uid(0x123)) {
+        uid
+      }
+      State3 as State3(func: eq(State.code, "abc")) @filter(type(State)) {
+        uid
+      }
+      var(func: uid(State3)) {
+        Country4 as State.country @filter(NOT (uid(x)))
+      }
+    }
+
+- name: "Additional Deletes - Update references existing node by XID (updt single edge)"
+  gqlmutation: |
+    mutation updateComputerOwner($patch: UpdateComputerOwnerInput!) {
+      updateComputerOwner(input: $patch) {
+        computerowner {
+          name
+        }
+      }
+    }
+  gqlvariables: |
+    { 
+      "patch":
+      { 
+        "filter": { "name": { "eq": "A.N. Owner" } },
+        "set": { "computers": { "name": "Comp" } }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid" : "uid(x)",
+          "ComputerOwner.computers": { 
+            "uid": "_:Computer3",
+            "dgraph.type": ["Computer"],
+            "Computer.name": "Comp",
+            "Computer.owners": [ { "uid": "uid(x)" } ]
+          }
+        }
+      cond: "@if(eq(len(Computer3), 0) AND gt(len(x), 0))"
+    - setjson: |
+        { "uid" : "uid(x)",
+          "ComputerOwner.computers": { 
+            "uid": "uid(Computer3)",
+            "Computer.owners": [ { "uid": "uid(x)" } ]
+          }
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Computer4)",
+            "Computer.owners": [ { "uid": "uid(x)" } ]
+          }
+        ]
+      cond: "@if(eq(len(Computer3), 1) AND gt(len(x), 0))"
+  dgquery: |-
+    query {
+      x as updateComputerOwner(func: type(ComputerOwner)) @filter(eq(ComputerOwner.name, "A.N. Owner")) {
+        uid
+      }
+      Computer3 as Computer3(func: eq(Computer.name, "Comp")) @filter(type(Computer)) {
+        uid
+      }
+      var(func: uid(x)) {
+        Computer4 as ComputerOwner.computers @filter(NOT (uid(Computer3)))
+      }
+    }


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph/issues/5355

Adds testing around the issue.  The tests now represent all the possible cases.  One case ("updt single edge" cases) was the issue and failing.

The fix doesn't change any existing tests, except one that was also incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5356)
<!-- Reviewable:end -->
