### PR TITLE
graphql: more testing around additional deletes and auth

### DIFF
--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -210,14 +210,21 @@ type Ticket @auth(
                     }
                 }
             }
-        }"""}
-    # update: { rule: """onColumn {
-    #                     inProject {
-    #                         role(filter: { permission: { eq: WRITE } } ) {
-    #                             users(filter: { username: { eq: $USER } })
-    #                         }
-    #                     }
-    #                 }"""},
+        }"""},
+    update: { rule: """
+        query($USER: String!) {
+            queryTicket {
+                onColumn{
+                    inProject {
+                        roles(filter: { permission: { eq: EDIT } } ) {
+                            assignedTo(filter: { username: { eq: $USER } }) {
+                                __typename
+                            }
+                        }
+                    }
+                }
+            }
+        }"""},
     delete: { rule: """
         query($USER: String!) {
             queryTicket {

--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -405,6 +405,11 @@
   error:
     { "message": "mutation failed because authorization failed" }
 
+# See comments about additional deletes in add_mutation_test.yaml.
+# Because of those additional deletes, for example, when we add a column and 
+# link it to an existing ticket, we remove that ticket from the column it was
+# attached to ... so we need authorization to update that column as well
+# as to add the new column.
 - name: "Add with auth on additional delete"
   gqlquery: |
     mutation addColumn($col: AddColumnInput!) {
@@ -453,8 +458,8 @@
     { 
       "Project2": [ { "uid": "0x123" } ],
       "Ticket3": [ { "uid": "0x789" } ],
-      "Column4":  [ { "uid": "0x456" } ],
-      "Column4.auth": [ { "uid": "0x456" } ]
+      "Column4":  [ { "uid": "0x799" } ],
+      "Column4.auth": [ { "uid": "0x799" } ]
     }
   uids: |
     { "Column1": "0x456" }
@@ -478,7 +483,7 @@
   authjson: |
     { 
       "Column": [ { "uid": "0x456" } ] 
-    }  
+    }
   
 - name: "Add with auth on additional delete that fails"
   gqlquery: |
@@ -528,7 +533,7 @@
     { 
       "Project2": [ { "uid": "0x123" } ],
       "Ticket3": [ { "uid": "0x789" } ],
-      "Column4":  [ { "uid": "0x456" } ]
+      "Column4":  [ { "uid": "0x799" } ]
     }
   uids: |
     { "Column1": "0x456" }
@@ -555,3 +560,158 @@
     }  
   error:
     { "message": "couldn't rewrite query for mutation addColumn because authorization failed" }
+
+- name: "Add with deep auth on additional delete"
+  gqlquery: |
+    mutation addProject($proj: AddProjectInput!) {
+      addProject(input: [$proj]) {
+        project {
+          projID
+        }
+      }
+    }
+  variables: |
+    { 
+      "proj": {
+        "name": "Project1",
+        "columns": [ { 
+          "name": "a column",
+          "tickets": [ { "id": "0x789" } ]
+        } ]
+      }
+    }
+  dgquery: |-
+    query {
+      Ticket3 as Ticket3(func: uid(0x789)) @filter(type(Ticket)) {
+        uid
+      }
+      var(func: uid(Ticket3)) {
+        Column4 as Ticket.onColumn
+      }
+      Column4(func: uid(Column4)) {
+        uid
+      }
+      Column4.auth(func: uid(Column4)) @filter(uid(Column5)) {
+        uid
+      }
+      Column5 as var(func: uid(Column4)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  json: |
+    { 
+      "Ticket3": [ { "uid": "0x789" } ],
+      "Column4":  [ { "uid": "0x799" } ],
+      "Column4.auth": [ { "uid": "0x799" } ]
+    }
+  uids: |
+    { 
+      "Project1": "0x123",
+      "Column2": "0x456" 
+    }
+  authquery: |-
+    query {
+      Column(func: uid(Column1)) @filter(uid(Column2)) {
+        uid
+      }
+      Column1 as var(func: uid(0x456))
+      Column2 as var(func: uid(Column1)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  authjson: |
+    { 
+      "Column": [ { "uid": "0x456" } ] 
+    }
+
+- name: "Add with deep auth on additional delete that fails"
+  gqlquery: |
+    mutation addProject($proj: AddProjectInput!) {
+      addProject(input: [$proj]) {
+        project {
+          projID
+        }
+      }
+    }
+  variables: |
+    { 
+      "proj": {
+        "name": "Project1",
+        "columns": [ { 
+          "name": "a column",
+          "tickets": [ { "id": "0x789" } ]
+        } ]
+      }
+    }
+  dgquery: |-
+    query {
+      Ticket3 as Ticket3(func: uid(0x789)) @filter(type(Ticket)) {
+        uid
+      }
+      var(func: uid(Ticket3)) {
+        Column4 as Ticket.onColumn
+      }
+      Column4(func: uid(Column4)) {
+        uid
+      }
+      Column4.auth(func: uid(Column4)) @filter(uid(Column5)) {
+        uid
+      }
+      Column5 as var(func: uid(Column4)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  json: |
+    { 
+      "Ticket3": [ { "uid": "0x789" } ],
+      "Column4":  [ { "uid": "0x799" } ]
+    }
+  uids: |
+    { 
+      "Project1": "0x123",
+      "Column2": "0x456" 
+    }
+  authquery: |-
+    query {
+      Column(func: uid(Column1)) @filter(uid(Column2)) {
+        uid
+      }
+      Column1 as var(func: uid(0x456))
+      Column2 as var(func: uid(Column1)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  authjson: |
+    { 
+      "Column": [ { "uid": "0x456" } ] 
+    }  
+  error:
+    { "message": "couldn't rewrite query for mutation addProject because authorization failed" }

--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -155,8 +155,11 @@
   error:
     { "message": "mutation failed because authorization failed" }
 
-
-- name: "update with auth on additional delete"
+# See comments about additional deletes in update_mutation_test.yaml.
+# Because of those additional deletes, for example, when we update a column and 
+# link it to an existing ticket, we might remove that ticket from the column it was
+# attached to ... so we need authorization to update that column as well.
+- name: "update with auth on additional delete (updt list edge)"
   gqlquery: |
     mutation updateColumn($upd: UpdateColumnInput!) {
       updateColumn(input: $upd) {
@@ -222,7 +225,7 @@
       "Column5.auth": [ { "uid": "0x456" } ]
     }
   
-- name: "update with auth on additional delete that fails"
+- name: "update with auth on additional delete that fails (updt list edge)"
   gqlquery: |
     mutation updateColumn($upd: UpdateColumnInput!) {
       updateColumn(input: $upd) {
@@ -288,3 +291,140 @@
     }
   error:
     { "message": "couldn't rewrite query for mutation updateColumn because authorization failed" }
+
+- name: "update with auth on additional delete (updt single edge)"
+  gqlquery: |
+    mutation updateTicket($upd: UpdateTicketInput!) {
+      updateTicket(input: $upd) {
+        ticket {
+          id
+        }
+      }
+    }
+  variables: |
+    { "upd":
+      { 
+        "filter": { "id": [ "0x123" ] },
+        "set": { 
+          "title": "new title", 
+          "onColumn": { "colID": "0x456" }
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      x as updateTicket(func: uid(Ticket1)) @filter(uid(Ticket2)) {
+        uid
+      }
+      Ticket1 as var(func: type(Ticket)) @filter(uid(0x123))
+      Ticket2 as var(func: uid(Ticket1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      Column4 as Column4(func: uid(0x456)) @filter(type(Column)) {
+        uid
+      }
+      var(func: uid(x)) {
+        Column5 as Ticket.onColumn @filter(NOT (uid(Column4)))
+      }
+      Column5(func: uid(Column5)) {
+        uid
+      }
+      Column5.auth(func: uid(Column5)) @filter(uid(Column6)) {
+        uid
+      }
+      Column6 as var(func: uid(Column5)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  json: |
+    { 
+      "Column4": [ { "uid": "0x456" } ],
+      "Column5":  [ { "uid": "0x499" } ],
+      "Column5.auth": [ { "uid": "0x499" } ]
+    }
+  
+- name: "update with auth on additional delete that fails (updt single edge)"
+  gqlquery: |
+    mutation updateTicket($upd: UpdateTicketInput!) {
+      updateTicket(input: $upd) {
+        ticket {
+          id
+        }
+      }
+    }
+  variables: |
+    { "upd":
+      { 
+        "filter": { "id": [ "0x123" ] },
+        "set": { 
+          "title": "new title", 
+          "onColumn": { "colID": "0x456" }
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      x as updateTicket(func: uid(Ticket1)) @filter(uid(Ticket2)) {
+        uid
+      }
+      Ticket1 as var(func: type(Ticket)) @filter(uid(0x123))
+      Ticket2 as var(func: uid(Ticket1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      Column4 as Column4(func: uid(0x456)) @filter(type(Column)) {
+        uid
+      }
+      var(func: uid(x)) {
+        Column5 as Ticket.onColumn @filter(NOT (uid(Column4)))
+      }
+      Column5(func: uid(Column5)) {
+        uid
+      }
+      Column5.auth(func: uid(Column5)) @filter(uid(Column6)) {
+        uid
+      }
+      Column6 as var(func: uid(Column5)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+  json: |
+    { 
+      "Column4": [ { "uid": "0x456" } ],
+      "Column5":  [ { "uid": "0x499" } ]
+    }
+  error:
+    { "message": "couldn't rewrite query for mutation updateTicket because authorization failed" }


### PR DESCRIPTION
Adds more testing around authorization given https://github.com/dgraph-io/dgraph/issues/5355.

This will fail testing until the changes from https://github.com/dgraph-io/dgraph/pull/5356 get merged through.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5357)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-dfba003062-60673.surge.sh)
<!-- Dgraph:end -->