### PR TITLE
Minor changes in fastJsonNode

### DIFF
--- a/query/fastjson_test.go
+++ b/query/fastjson_test.go
@@ -66,11 +66,11 @@ func TestEncode(t *testing.T) {
 	enc := newEncoder()
 
 	t.Run("with uid list predicate", func(t *testing.T) {
-		root := enc.newNode()
-		friendNode1 := enc.newNodeWithAttr(enc.idForAttr("friend"))
+		root := enc.newNode(0)
+		friendNode1 := enc.newNode(enc.idForAttr("friend"))
 		enc.AddValue(friendNode1, enc.idForAttr("name"),
 			types.Val{Tid: types.StringID, Value: "alice"})
-		friendNode2 := enc.newNodeWithAttr(enc.idForAttr("friend"))
+		friendNode2 := enc.newNode(enc.idForAttr("friend"))
 		enc.AddValue(friendNode2, enc.idForAttr("name"),
 			types.Val{Tid: types.StringID, Value: "bob"})
 
@@ -94,7 +94,7 @@ func TestEncode(t *testing.T) {
 	})
 
 	t.Run("with value list predicate", func(t *testing.T) {
-		root := enc.newNode()
+		root := enc.newNode(0)
 		enc.AddValue(root, enc.idForAttr("name"),
 			types.Val{Tid: types.StringID, Value: "alice"})
 		enc.AddValue(root, enc.idForAttr("name"),
@@ -113,9 +113,9 @@ func TestEncode(t *testing.T) {
 	})
 
 	t.Run("with uid predicate", func(t *testing.T) {
-		root := enc.newNode()
+		root := enc.newNode(0)
 
-		person := enc.newNodeWithAttr(enc.idForAttr("person"))
+		person := enc.newNode(enc.idForAttr("person"))
 		enc.AddValue(person, enc.idForAttr("name"), types.Val{Tid: types.StringID, Value: "alice"})
 		enc.AddValue(person, enc.idForAttr("age"), types.Val{Tid: types.IntID, Value: 25})
 

--- a/query/fastjson_test.go
+++ b/query/fastjson_test.go
@@ -74,8 +74,8 @@ func TestEncode(t *testing.T) {
 		enc.AddValue(friendNode2, enc.idForAttr("name"),
 			types.Val{Tid: types.StringID, Value: "bob"})
 
-		enc.AddListChild(root, enc.idForAttr("friend"), friendNode1)
-		enc.AddListChild(root, enc.idForAttr("friend"), friendNode2)
+		enc.AddListChild(root, friendNode1)
+		enc.AddListChild(root, friendNode2)
 
 		buf := new(bytes.Buffer)
 		require.NoError(t, enc.encode(root, buf))
@@ -115,11 +115,11 @@ func TestEncode(t *testing.T) {
 	t.Run("with uid predicate", func(t *testing.T) {
 		root := enc.newNode()
 
-		person := enc.newNode()
+		person := enc.newNodeWithAttr(enc.idForAttr("person"))
 		enc.AddValue(person, enc.idForAttr("name"), types.Val{Tid: types.StringID, Value: "alice"})
 		enc.AddValue(person, enc.idForAttr("age"), types.Val{Tid: types.IntID, Value: 25})
 
-		enc.AddListChild(root, enc.idForAttr("person"), person)
+		enc.AddListChild(root, person)
 
 		buf := new(bytes.Buffer)
 		require.NoError(t, enc.encode(root, buf))

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -261,7 +261,7 @@ func (enc *encoder) AddListValue(fj fastJsonNode, attr uint16, v types.Val, list
 	return nil
 }
 
-func (enc *encoder) AddMapChild(fj fastJsonNode, val fastJsonNode) {
+func (enc *encoder) AddMapChild(fj, val fastJsonNode) {
 	var childNode fastJsonNode
 	for _, c := range enc.getAttrs(fj) {
 		if enc.getAttr(c) == enc.getAttr(val) {
@@ -277,7 +277,7 @@ func (enc *encoder) AddMapChild(fj fastJsonNode, val fastJsonNode) {
 	}
 }
 
-func (enc *encoder) AddListChild(fj fastJsonNode, child fastJsonNode) {
+func (enc *encoder) AddListChild(fj, child fastJsonNode) {
 	enc.setList(child, true)
 	enc.appendAttrs(fj, child)
 }
@@ -602,7 +602,7 @@ func (enc *encoder) encode(fj fastJsonNode, out *bytes.Buffer) error {
 	return nil
 }
 
-func merge(parent [][]fastJsonNode, child [][]fastJsonNode) ([][]fastJsonNode, error) {
+func merge(parent, child [][]fastJsonNode) ([][]fastJsonNode, error) {
 	if len(parent) == 0 {
 		return child, nil
 	}
@@ -811,10 +811,7 @@ func processNodeUids(fj fastJsonNode, enc *encoder, sg *SubGraph) error {
 		if len(sg.GroupbyRes) == 0 {
 			return errors.Errorf("Expected GroupbyRes to have length > 0.")
 		}
-		if err := sg.addGroupby(enc, fj, sg.GroupbyRes[0], sg.Params.Alias); err != nil {
-			return err
-		}
-		return nil
+		return sg.addGroupby(enc, fj, sg.GroupbyRes[0], sg.Params.Alias)
 	}
 
 	lenList := len(sg.uidMatrix[0].Uids)
@@ -930,11 +927,7 @@ func (sg *SubGraph) addCount(enc *encoder, count uint64, dst fastJsonNode) error
 	if fieldName == "" {
 		fieldName = fmt.Sprintf("count(%s)", sg.Attr)
 	}
-	if err := enc.AddValue(dst, enc.idForAttr(fieldName), c); err != nil {
-		return err
-	}
-
-	return nil
+	return enc.AddValue(dst, enc.idForAttr(fieldName), c)
 }
 
 func (sg *SubGraph) aggWithVarFieldName() string {
@@ -957,10 +950,7 @@ func (sg *SubGraph) addInternalNode(enc *encoder, uid uint64, dst fastJsonNode) 
 		return nil
 	}
 	fieldName := sg.aggWithVarFieldName()
-	if err := enc.AddValue(dst, enc.idForAttr(fieldName), sv); err != nil {
-		return err
-	}
-	return nil
+	return enc.AddValue(dst, enc.idForAttr(fieldName), sv)
 }
 
 func (sg *SubGraph) addCheckPwd(enc *encoder, vals []*pb.TaskValue, dst fastJsonNode) error {
@@ -975,10 +965,7 @@ func (sg *SubGraph) addCheckPwd(enc *encoder, vals []*pb.TaskValue, dst fastJson
 	if fieldName == "" {
 		fieldName = fmt.Sprintf("checkpwd(%s)", sg.Attr)
 	}
-	if err := enc.AddValue(dst, enc.idForAttr(fieldName), c); err != nil {
-		return err
-	}
-	return nil
+	return enc.AddValue(dst, enc.idForAttr(fieldName), c)
 }
 
 func alreadySeen(parentIds []uint64, uid uint64) bool {
@@ -1228,7 +1215,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 					if lang != "" && lang != "*" {
 						fieldNameWithTag += "@" + lang
 					}
-					encodeAsList := pc.List && len(lang) == 0
+					encodeAsList := pc.List && lang == ""
 					if err := enc.AddListValue(dst, enc.idForAttr(fieldNameWithTag),
 						sv, encodeAsList); err != nil {
 						return err

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -277,7 +277,8 @@ func (enc *encoder) AddListChild(fj fastJsonNode, child fastJsonNode) {
 
 func (enc *encoder) SetUID(fj fastJsonNode, uid uint64, attr uint16) error {
 	// if we're in debug mode, uid may be added second time, skip this
-	if attr == enc.idForAttr("uid") {
+	uidAttrID := enc.idForAttr("uid")
+	if attr == uidAttrID {
 		fjAttrs := enc.getAttrs(fj)
 		for _, a := range fjAttrs {
 			if enc.getAttr(a) == attr {
@@ -493,6 +494,7 @@ func (enc *encoder) writeKey(fj fastJsonNode, out *bytes.Buffer) error {
 func (enc *encoder) attachFacets(fj fastJsonNode, fieldName string, isList bool,
 	fList []*api.Facet, facetIdx int) error {
 
+	idxFieldID := enc.idForAttr(strconv.Itoa(facetIdx))
 	for _, f := range fList {
 		fName := facetName(fieldName, f)
 		fVal, err := facets.ValFor(f)
@@ -506,7 +508,7 @@ func (enc *encoder) attachFacets(fj fastJsonNode, fieldName string, isList bool,
 			}
 		} else {
 			facetNode := enc.newNodeWithAttr(enc.idForAttr(fName))
-			err := enc.AddValue(facetNode, enc.idForAttr(strconv.Itoa(facetIdx)), fVal)
+			err := enc.AddValue(facetNode, idxFieldID, fVal)
 			if err != nil {
 				return err
 			}
@@ -672,13 +674,15 @@ func (enc *encoder) normalize(fj fastJsonNode) ([][]fastJsonNode, error) {
 			return nil, err
 		}
 	}
+
+	uidAttrID := enc.idForAttr("uid")
 	for i, slice := range parentSlice {
 		sort.Sort(nodeSlice{nodes: slice, enc: enc})
 
 		first := -1
 		last := 0
 		for i := range slice {
-			if enc.getAttr(slice[i]) == enc.idForAttr("uid") {
+			if enc.getAttr(slice[i]) == uidAttrID {
 				if first == -1 {
 					first = i
 				}
@@ -753,6 +757,7 @@ func (sg *SubGraph) addAggregations(enc *encoder, fj fastJsonNode) error {
 func (sg *SubGraph) handleCountUIDNodes(enc *encoder, n fastJsonNode, count int) (bool, error) {
 	addedNewChild := false
 	fieldName := sg.fieldName()
+	sgFieldID := enc.idForAttr(fieldName)
 	for _, child := range sg.Children {
 		uidCount := child.Attr == "uid" && child.Params.DoCount && child.IsInternal()
 		normWithoutAlias := child.Params.Alias == "" && child.Params.Normalize
@@ -767,7 +772,7 @@ func (sg *SubGraph) handleCountUIDNodes(enc *encoder, n fastJsonNode, count int)
 				field = "count"
 			}
 
-			fjChild := enc.newNodeWithAttr(enc.idForAttr(fieldName))
+			fjChild := enc.newNodeWithAttr(sgFieldID)
 			if err := enc.AddValue(fjChild, enc.idForAttr(field), c); err != nil {
 				return false, err
 			}
@@ -1053,6 +1058,9 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 				pc.Params.ParentIds = sg.Params.ParentIds
 			}
 
+			// calculate it once to avoid mutliple call to idToAttr()
+			fieldID := enc.idForAttr(fieldName)
+
 			// We create as many predicate entity children as the length of uids for
 			// this predicate.
 			ul := pc.uidMatrix[idx]
@@ -1063,7 +1071,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 				if fieldName == "" || (invalidUids != nil && invalidUids[childUID]) {
 					continue
 				}
-				uc := enc.newNodeWithAttr(enc.idForAttr(fieldName))
+				uc := enc.newNodeWithAttr(fieldID)
 				if rerr := pc.preTraverse(enc, childUID, uc); rerr != nil {
 					if rerr.Error() == "_INV_" {
 						if invalidUids == nil {
@@ -1124,7 +1132,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 							// }
 							// boss should be of list type because there can be mutliple friends of
 							// boss.
-							node := enc.newNodeWithAttr(enc.idForAttr(fieldName))
+							node := enc.newNodeWithAttr(fieldID)
 							enc.appendAttrs(node, c...)
 							enc.AddListChild(dst, node)
 						}
@@ -1161,8 +1169,11 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 				fieldName += strings.Join(pc.Params.Langs, ":")
 			}
 
+			// calculate it once to avoid mutliple call to idToAttr()
+			fieldID := enc.idForAttr(fieldName)
+
 			if pc.Attr == "uid" {
-				if err := enc.SetUID(dst, uid, enc.idForAttr(pc.fieldName())); err != nil {
+				if err := enc.SetUID(dst, uid, fieldID); err != nil {
 					return err
 				}
 				continue
@@ -1208,7 +1219,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 
 				encodeAsList := pc.List && len(pc.Params.Langs) == 0
 				if !pc.Params.Normalize {
-					err := enc.AddListValue(dst, enc.idForAttr(fieldName), sv, encodeAsList)
+					err := enc.AddListValue(dst, fieldID, sv, encodeAsList)
 					if err != nil {
 						return err
 					}
@@ -1217,7 +1228,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 				// If the query had the normalize directive, then we only add nodes
 				// with an Alias.
 				if pc.Params.Alias != "" {
-					err := enc.AddListValue(dst, enc.idForAttr(fieldName), sv, encodeAsList)
+					err := enc.AddListValue(dst, fieldID, sv, encodeAsList)
 					if err != nil {
 						return err
 					}

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -855,7 +855,7 @@ type Extensions struct {
 	Metrics *api.Metrics    `json:"metrics,omitempty"`
 }
 
-const maxEncodedSize = (4 << 30) // 4GB
+const maxEncodedSize = int64(4 << 30) // 4GB
 
 func (sg *SubGraph) toFastJSON(l *Latency) ([]byte, error) {
 	encodingStart := time.Now()
@@ -889,7 +889,7 @@ func (sg *SubGraph) toFastJSON(l *Latency) ([]byte, error) {
 	}
 
 	// Return error if encoded buffer size exceeds than a threshold size.
-	if bufw.Len() > maxEncodedSize {
+	if int64(bufw.Len()) > maxEncodedSize {
 		return nil, fmt.Errorf("encoded response size: %d is bigger than threshold: %d",
 			bufw.Len(), maxEncodedSize)
 	}

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -855,6 +855,8 @@ type Extensions struct {
 	Metrics *api.Metrics    `json:"metrics,omitempty"`
 }
 
+const maxEncodedSize = (4 << 30) // 4GB
+
 func (sg *SubGraph) toFastJSON(l *Latency) ([]byte, error) {
 	encodingStart := time.Now()
 	defer func() {
@@ -884,6 +886,12 @@ func (sg *SubGraph) toFastJSON(l *Latency) ([]byte, error) {
 		if err := enc.encode(n, &bufw); err != nil {
 			return nil, err
 		}
+	}
+
+	// Return error if encoded buffer size exceeds than a threshold size.
+	if bufw.Len() > maxEncodedSize {
+		return nil, fmt.Errorf("encoded response size: %d is bigger than threshold: %d",
+			bufw.Len(), maxEncodedSize)
 	}
 
 	// Put encoder's arena back to arena pool.

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -199,7 +199,7 @@ func (enc *encoder) setScalarVal(fj fastJsonNode, sv []byte) error {
 	}
 	enc.metaSlice[fj] |= uint64(offset)
 
-	// Also increase estSize.
+	// Also increase curSize.
 	enc.curSize += uint64(len(sv))
 
 	// check if it exceeds threshold size.
@@ -1065,7 +1065,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 
 			// calculate it once to avoid mutliple call to idToAttr()
 			fieldID := enc.idForAttr(fieldName)
-			// Add len of fieldName to enc.estSize.
+			// Add len of fieldName to enc.curSize.
 			enc.curSize += uint64(len(fieldName))
 
 			// We create as many predicate entity children as the length of uids for
@@ -1178,7 +1178,7 @@ func (sg *SubGraph) preTraverse(enc *encoder, uid uint64, dst fastJsonNode) erro
 
 			// calculate it once to avoid mutliple call to idToAttr()
 			fieldID := enc.idForAttr(fieldName)
-			// Add len of fieldName to enc.estSize.
+			// Add len of fieldName to enc.curSize.
 			enc.curSize += uint64(len(fieldName))
 
 			if pc.Attr == "uid" {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -75,8 +75,7 @@ type encoder struct {
 	// estSize tracking has been kept simple. estSize is crossing threshold value or not is only
 	// checked at leaf(scalar) nodes as of now. estSize is updated in following cases:
 	// 1. By adding predicate len, while expanding it for an uid in preTraverse().
-	// 2. By adding facets name len, while adding facets node for a predicate in attachFacets()
-	// 3. By adding scalarVal len in setScalarVal function for a leaf(scalar) node.
+	// 2. By adding scalarVal len in setScalarVal function for a leaf(scalar) node.
 	estSize uint64
 
 	// metaSlice has meta data for all fastJsonNodes.
@@ -505,7 +504,6 @@ func (enc *encoder) attachFacets(fj fastJsonNode, fieldName string, isList bool,
 	idxFieldID := enc.idForAttr(strconv.Itoa(facetIdx))
 	for _, f := range fList {
 		fName := facetName(fieldName, f)
-		enc.estSize += uint64(len(fName))
 		fVal, err := facets.ValFor(f)
 		if err != nil {
 			return err

--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -38,13 +38,13 @@ func TestEncodeMemory(t *testing.T) {
 
 	for i := 0; i < runtime.NumCPU(); i++ {
 		enc := newEncoder()
-		n := enc.newNode()
+		n := enc.newNode(0)
 		require.NotNil(t, n)
 		for i := 0; i < 15000; i++ {
 			enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 				types.ValueForType(types.StringID))
 			enc.AddListChild(n,
-				enc.newNodeWithAttr(enc.idForAttr(fmt.Sprintf("another long child %06d", i))))
+				enc.newNode(enc.idForAttr(fmt.Sprintf("another long child %06d", i))))
 		}
 		wg.Add(1)
 		go func() {
@@ -68,24 +68,24 @@ func TestNormalizeJSONLimit(t *testing.T) {
 	}
 
 	enc := newEncoder()
-	n := enc.newNodeWithAttr(enc.idForAttr("root"))
+	n := enc.newNode(enc.idForAttr("root"))
 	require.NotNil(t, n)
 	for i := 0; i < 1000; i++ {
 		enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 			types.ValueForType(types.StringID))
-		child1 := enc.newNodeWithAttr(enc.idForAttr("child1"))
+		child1 := enc.newNode(enc.idForAttr("child1"))
 		enc.AddListChild(n, child1)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child1, enc.idForAttr(fmt.Sprintf("long child1 attr %06d", j)),
 				types.ValueForType(types.StringID))
 		}
-		child2 := enc.newNodeWithAttr(enc.idForAttr("child2"))
+		child2 := enc.newNode(enc.idForAttr("child2"))
 		enc.AddListChild(n, child2)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child2, enc.idForAttr(fmt.Sprintf("long child2 attr %06d", j)),
 				types.ValueForType(types.StringID))
 		}
-		child3 := enc.newNodeWithAttr(enc.idForAttr("child3"))
+		child3 := enc.newNode(enc.idForAttr("child3"))
 		enc.AddListChild(n, child3)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child3, enc.idForAttr(fmt.Sprintf("long child3 attr %06d", j)),
@@ -150,7 +150,7 @@ func TestFastJsonNode(t *testing.T) {
 	list := true
 
 	enc := newEncoder()
-	fj := enc.newNodeWithAttr(attrId)
+	fj := enc.newNode(attrId)
 	require.NoError(t, enc.setScalarVal(fj, scalarVal))
 	enc.setList(fj, list)
 
@@ -160,7 +160,7 @@ func TestFastJsonNode(t *testing.T) {
 	require.Equal(t, scalarVal, sv)
 	require.Equal(t, list, enc.getList(fj))
 
-	fj2 := enc.newNodeWithAttr(attrId)
+	fj2 := enc.newNode(attrId)
 	require.NoError(t, enc.setScalarVal(fj2, scalarVal))
 	enc.setList(fj2, list)
 
@@ -178,7 +178,7 @@ func BenchmarkFastJsonNodeEmpty(b *testing.B) {
 		enc := newEncoder()
 		var fj fastJsonNode
 		for i := 0; i < 2e6; i++ {
-			fj = enc.newNode()
+			fj = enc.newNode(0)
 		}
 		_ = fj
 	}
@@ -206,7 +206,7 @@ func buildTestTree(b *testing.B, enc *encoder, level, maxlevel int, fj fastJsonN
 			ch, err = enc.makeScalarNode(enc.idForAttr(testAttr), val, false)
 			require.NoError(b, err)
 		} else {
-			ch := enc.newNodeWithAttr(enc.idForAttr(testAttr))
+			ch := enc.newNode(enc.idForAttr(testAttr))
 			buildTestTree(b, enc, level+1, maxlevel, ch)
 		}
 		enc.appendAttrs(fj, ch)
@@ -216,7 +216,7 @@ func buildTestTree(b *testing.B, enc *encoder, level, maxlevel int, fj fastJsonN
 func BenchmarkFastJsonNode2Chilren(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		enc := newEncoder()
-		root := enc.newNodeWithAttr(enc.idForAttr(testAttr))
+		root := enc.newNode(enc.idForAttr(testAttr))
 		buildTestTree(b, enc, 1, 20, root)
 	}
 }

--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -43,8 +43,8 @@ func TestEncodeMemory(t *testing.T) {
 		for i := 0; i < 15000; i++ {
 			enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 				types.ValueForType(types.StringID))
-			enc.AddListChild(n, enc.idForAttr(fmt.Sprintf("another long child %06d", i)),
-				enc.newNode())
+			enc.AddListChild(n,
+				enc.newNodeWithAttr(enc.idForAttr(fmt.Sprintf("another long child %06d", i))))
 		}
 		wg.Add(1)
 		go func() {
@@ -74,19 +74,19 @@ func TestNormalizeJSONLimit(t *testing.T) {
 		enc.AddValue(n, enc.idForAttr(fmt.Sprintf("very long attr name %06d", i)),
 			types.ValueForType(types.StringID))
 		child1 := enc.newNodeWithAttr(enc.idForAttr("child1"))
-		enc.AddListChild(n, enc.idForAttr("child1"), child1)
+		enc.AddListChild(n, child1)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child1, enc.idForAttr(fmt.Sprintf("long child1 attr %06d", j)),
 				types.ValueForType(types.StringID))
 		}
 		child2 := enc.newNodeWithAttr(enc.idForAttr("child2"))
-		enc.AddListChild(n, enc.idForAttr("child2"), child2)
+		enc.AddListChild(n, child2)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child2, enc.idForAttr(fmt.Sprintf("long child2 attr %06d", j)),
 				types.ValueForType(types.StringID))
 		}
 		child3 := enc.newNodeWithAttr(enc.idForAttr("child3"))
-		enc.AddListChild(n, enc.idForAttr("child3"), child3)
+		enc.AddListChild(n, child3)
 		for j := 0; j < 100; j++ {
 			enc.AddValue(child3, enc.idForAttr(fmt.Sprintf("long child3 attr %06d", j)),
 				types.ValueForType(types.StringID))
@@ -150,8 +150,7 @@ func TestFastJsonNode(t *testing.T) {
 	list := true
 
 	enc := newEncoder()
-	fj := enc.newNode()
-	enc.setAttr(fj, attrId)
+	fj := enc.newNodeWithAttr(attrId)
 	require.NoError(t, enc.setScalarVal(fj, scalarVal))
 	enc.setList(fj, list)
 
@@ -161,8 +160,7 @@ func TestFastJsonNode(t *testing.T) {
 	require.Equal(t, scalarVal, sv)
 	require.Equal(t, list, enc.getList(fj))
 
-	fj2 := enc.newNode()
-	enc.setAttr(fj2, attrId)
+	fj2 := enc.newNodeWithAttr(attrId)
 	require.NoError(t, enc.setScalarVal(fj2, scalarVal))
 	enc.setList(fj2, list)
 


### PR DESCRIPTION
This PR further tries to simplify `fastJsonNode` processing. It has following changes:
* Return error response if encoded response is > 4GB in size.
* Replace `idMap` with `idSlice` in `encoder`.
* Refactor `AddListChild` and `AddMapChild` to remove `attr` from their arguments. Both functions
  accept parent, child and attr as arguments. This attr is equal to attr field of child, hence sending
  it explicitly can be avoided.
* Minimise calls to `idForAttr()`.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5359)
<!-- Reviewable:end -->
