### PR TITLE
docs: Add example commands to apply enterprise license.

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -11,7 +11,7 @@ forum](https://discuss.dgraph.io).
 
 **Dgraph enterprise features are enabled by default for 30 days in a new cluster**.
 After the trial period of thirty (30) days, the cluster must obtain a license from Dgraph to
-continue enjoying the enterprise features released in the proprietary code.
+continue using the enterprise features released in the proprietary code.
 
 {{% notice "note" %}}
 At the conclusion of your 30-day trial period if a license has not been applied to the cluster,

--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -13,18 +13,26 @@ forum](https://discuss.dgraph.io).
 After the trial period of thirty (30) days, the cluster must obtain a license from Dgraph to
 continue enjoying the enterprise features released in the proprietary code.
 
-The license can be applied to the cluster by including it as the body of a POST
-request and calling `/enterpriseLicense` HTTP endpoint on any Zero server. It
-can also be applied by passing the path to the enterprise license file (using
-the flag `--enterprise_license`) to the `dgraph zero` command used to start the
-server. The second option is useful when the process needs to be automated.
-
 {{% notice "note" %}}
 At the conclusion of your 30-day trial period if a license has not been applied to the cluster,
 access to the enterprise features will be suspended. The cluster will continue to operate without
 enterprise features.
 {{% /notice %}}
 
+When you have an enterprise license key, the license can be applied to the cluster by including it
+as the body of a POST request and calling `/enterpriseLicense` HTTP endpoint on any Zero server.
+
+```sh
+curl -X POST localhost:6080/enterpriseLicense --upload-file ./licensekey.txt
+```
+
+It can also be applied by passing the path to the enterprise license file (using the flag
+`--enterprise_license`) to the `dgraph zero` command used to start the server. The second option is
+useful when the process needs to be automated.
+
+```sh
+dgraph zero --enterprise_license ./licensekey.txt
+```
 
 [dcl]: https://github.com/dgraph-io/dgraph/blob/master/licenses/DCL.txt
 


### PR DESCRIPTION
This adds two example commands to the docs to apply an enterprise license.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5373)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-1225d7082a-61070.surge.sh)
<!-- Dgraph:end -->