### PR TITLE
Fix protobuf headers check.

### DIFF
--- a/protos/Makefile
+++ b/protos/Makefile
@@ -51,6 +51,7 @@ copy-protos:
 regenerate: copy-protos check clean
 	@protoc \
 		--proto_path=/usr/local/include \
+		--proto_path=/usr/include \
 		--proto_path=${PROTO_PATH} \
 		--gofast_out=plugins=grpc,Mapi.proto=${DGO_PATH}/protos/api:pb \
 		pb.proto

--- a/protos/depcheck.sh
+++ b/protos/depcheck.sh
@@ -28,11 +28,13 @@ function CompareSemVer() {
 }
 
 function CheckProtobufIncludes() {
-	echo -n "Checking for directory /usr/local/include/google/protobuf... "
-	if [ ! -d /usr/local/include/google/protobuf ]; then
+	echo -n "Checking for directory /usr/include/google/protobuf or /usr/local/include/google/protobuf... "
+	if !([ -d /usr/include/google/protobuf ] || [ -d /usr/local/include/google/protobuf ]) ; then
 		echo "FAIL" >&2
-		echo "Missing protobuf types in /usr/local/include/google/protobuf: directory not found" >&2
-		echo "Download and install protoc and the protobuf types from protobuf releases page:" >&2
+		echo "Missing protobuf headers in /usr/include/google/protobuf or /usr/local/include/google/protobuf:" \
+         "directory not found." >&2
+		echo "Download and install protoc and the protobuf headers by installing protoc via a package manager" \
+         "or downloading it from the protobuf releases page:" >&2
 		echo "https://github.com/protocolbuffers/protobuf/releases/" >&2
 		exit 1
 	fi


### PR DESCRIPTION
If installed from a package manager, the header files will be at
/usr/include not /usr/local/include.

This change fixes the check by looking at both places and including
them in the call to protoc.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5381)
<!-- Reviewable:end -->
