### PR TITLE
EE license fixes.

### DIFF
--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/dgraph-io/badger/v2/y"
+	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
 // dummy function as enterprise features are not available in oss binary.
@@ -38,6 +39,10 @@ func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNotFound)
 }
 
-func (st *state) applyLicenseFile(path string) error {
+func (s *Server) applyLicenseFile(path string) {
+	return
+}
+
+func (s *Server) license() *pb.License {
 	return nil
 }

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -42,7 +42,7 @@ func (n *node) proposeTrialLicense() error {
 		return err
 
 	}
-	glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
+	glog.Infof("Enterprise trial license proposed to the cluster: %v", proposal)
 	return nil
 }
 
@@ -135,14 +135,15 @@ func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// applyLicenseFile applies the license file stored at the given path.
-func (st *state) applyLicenseFile(path string) error {
+func (s *Server) applyLicenseFile(path string) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return err
+		glog.Infof("Unable to apply license at %v due to error %v", path, err)
+		return
 	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	return st.zero.applyLicense(ctx, bytes.NewReader(content))
+	if err = s.applyLicense(ctx, bytes.NewReader(content)); err != nil {
+		glog.Infof("Unable to apply license at %v due to error %v", path, err)
+	}
 }

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -517,7 +517,7 @@ func (n *node) initAndStartNode() error {
 				time.Sleep(3 * time.Second)
 			}
 
-			// Don't apply trial license if it has an enabled licensed already.
+			// Apply trial license only if not already licensed.
 			if n.server.license() == nil {
 				if err := n.proposeTrialLicense(); err != nil {
 					glog.Errorf("while proposing trial license to cluster: %v", err)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -743,7 +743,9 @@ func (n *node) Run() {
 			// Apply license when I am the leader.
 			if !licenseApplied && n.AmLeader() {
 				licenseApplied = true
-				// Apply enterprise license if one was given.
+				// Apply the EE License given on CLI which may over-ride previous
+				// license, if present. That is an intended behavior to allow customers
+				// to apply new/renewed licenses.
 				if license := Zero.Conf.GetString("enterprise_license"); len(license) > 0 {
 					go n.server.applyLicenseFile(license)
 				}

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -517,8 +517,11 @@ func (n *node) initAndStartNode() error {
 				time.Sleep(3 * time.Second)
 			}
 
-			if err := n.proposeTrialLicense(); err != nil {
-				glog.Errorf("while proposing trial license to cluster: %v", err)
+			// Don't apply trial license if it has an enabled licensed already.
+			if n.server.license() == nil {
+				if err := n.proposeTrialLicense(); err != nil {
+					glog.Errorf("while proposing trial license to cluster: %v", err)
+				}
 			}
 		}()
 	}
@@ -618,6 +621,7 @@ func (n *node) trySnapshot(skip uint64) {
 
 func (n *node) Run() {
 	var leader bool
+	licenseApplied := false
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -734,6 +738,15 @@ func (n *node) Run() {
 					"Raft.Ready took too long to process: %s."+
 						" Num entries: %d. MustSync: %v",
 					timer.String(), len(rd.Entries), rd.MustSync)
+			}
+
+			// Apply license when I am the leader.
+			if !licenseApplied && n.AmLeader() {
+				licenseApplied = true
+				// Apply enterprise license if one was given.
+				if license := Zero.Conf.GetString("enterprise_license"); len(license) > 0 {
+					go n.server.applyLicenseFile(license)
+				}
 			}
 		}
 	}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -188,6 +188,10 @@ func run() {
 		LudicrousMode: Zero.Conf.GetBool("ludicrous_mode"),
 	}
 
+	if !enc.EeBuild && Zero.Conf.GetString("enterprise_license") != "" {
+		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
+	}
+
 	if opts.numReplicas < 0 || opts.numReplicas%2 == 0 {
 		log.Fatalf("ERROR: Number of replicas must be odd for consensus. Found: %d",
 			opts.numReplicas)
@@ -240,14 +244,6 @@ func run() {
 	var st state
 	st.serveGRPC(grpcListener, store)
 	st.serveHTTP(httpListener)
-
-	// Apply enterprise license if one was given.
-	if license := Zero.Conf.GetString("enterprise_license"); len(license) > 0 {
-		if err := st.applyLicenseFile(license); err != nil {
-			glog.Warningf("Applying enterprise license file %s failed with error: %s", license,
-				err.Error())
-		}
-	}
 
 	http.HandleFunc("/health", st.pingResponse)
 	http.HandleFunc("/state", st.getState)

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -780,6 +780,6 @@ func (s *Server) applyLicense(ctx context.Context, signedData io.Reader) error {
 	if err != nil {
 		return errors.Wrapf(err, "while proposing enterprise license state to cluster")
 	}
-	glog.Infof("Enterprise license state proposed to the cluster")
+	glog.Infof("Enterprise license proposed to the cluster %+v", proposal)
 	return nil
 }


### PR DESCRIPTION
Fixes DGRAPH-1341

The enterprise_license option on zero is not applied properly. There were couple issues: 1) It would be over-written by trial license. 2) It generally failed because when the license was applied, Raft was not initialized and the zero was not the leader.

This patch make several fixes and improvements
1. Apply the option `enterprise_license` only after the node's Raft is initialized and it is the leader. 
2. Don't apply the trial license if a license already exists.
3. Disallow the enterprise_license option for OSS build and bail out. 
4. Apply the option even if there is a license from a previous life of the Zero (i.e. Zero is restarted with same the `zw/`

Tests:
1. New Cluster, `dgraph zero` 
Trial license is applied.
2. New Cluster, `dgraph zero --enterprise_license=<path to EE license file>`
EE License is applied. 
3. Existing Cluster, Previously Trial License applied., Now  `dgraph zero --enterprise_license=<path to EE license file>`
EE License is applied.
4. Existing Cluster, Previously EE License. Now `dgraph zero`
Old EE License is used. Trial license is not applied. 
5. OSS with `enterprise_license` option
ERROR
6. OSS without `enterprise_license` option on New, Existing Cluster
No Licenses applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5383)
<!-- Reviewable:end -->
