### PR TITLE
Cherry-Pick to v20.03 - EE license fixes. (#5383)

### DIFF
--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/dgraph-io/badger/v2/y"
+	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
 // dummy function as enterprise features are not available in oss binary.
@@ -38,6 +39,10 @@ func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNotFound)
 }
 
-func (st *state) applyLicenseFile(path string) error {
+func (s *Server) applyLicenseFile(path string) {
+	return
+}
+
+func (s *Server) license() *pb.License {
 	return nil
 }

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -42,7 +42,7 @@ func (n *node) proposeTrialLicense() error {
 		return err
 
 	}
-	glog.Infof("Enterprise state proposed to the cluster: %v", proposal)
+	glog.Infof("Enterprise trial license proposed to the cluster: %v", proposal)
 	return nil
 }
 
@@ -135,14 +135,15 @@ func (st *state) applyEnterpriseLicense(w http.ResponseWriter, r *http.Request) 
 	}
 }
 
-// applyLicenseFile applies the license file stored at the given path.
-func (st *state) applyLicenseFile(path string) error {
+func (s *Server) applyLicenseFile(path string) {
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return err
+		glog.Infof("Unable to apply license at %v due to error %v", path, err)
+		return
 	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
-	return st.zero.applyLicense(ctx, bytes.NewReader(content))
+	if err = s.applyLicense(ctx, bytes.NewReader(content)); err != nil {
+		glog.Infof("Unable to apply license at %v due to error %v", path, err)
+	}
 }

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -188,6 +188,10 @@ func run() {
 		LudicrousMode: Zero.Conf.GetBool("ludicrous_mode"),
 	}
 
+	if !enc.EeBuild && Zero.Conf.GetString("enterprise_license") != "" {
+		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
+	}
+
 	if opts.numReplicas < 0 || opts.numReplicas%2 == 0 {
 		log.Fatalf("ERROR: Number of replicas must be odd for consensus. Found: %d",
 			opts.numReplicas)
@@ -240,14 +244,6 @@ func run() {
 	var st state
 	st.serveGRPC(grpcListener, store)
 	st.serveHTTP(httpListener)
-
-	// Apply enterprise license if one was given.
-	if license := Zero.Conf.GetString("enterprise_license"); len(license) > 0 {
-		if err := st.applyLicenseFile(license); err != nil {
-			glog.Warningf("Applying enterprise license file %s failed with error: %s", license,
-				err.Error())
-		}
-	}
 
 	http.HandleFunc("/health", st.pingResponse)
 	http.HandleFunc("/state", st.getState)

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -780,6 +780,6 @@ func (s *Server) applyLicense(ctx context.Context, signedData io.Reader) error {
 	if err != nil {
 		return errors.Wrapf(err, "while proposing enterprise license state to cluster")
 	}
-	glog.Infof("Enterprise license state proposed to the cluster")
+	glog.Infof("Enterprise license proposed to the cluster %+v", proposal)
 	return nil
 }


### PR DESCRIPTION
( git cherry-pick 4e35cba37f8176f8d3681451d6faa4df021d4130)
Fixes DGRAPH-1341

This patch make several fixes and improvements
 -  Apply the option enterprise_license only after the node's Raft is initialized and it is the leader.
  - Don't apply the trial license if a license already exists.
  - Disallow the enterprise_license option for OSS build and bail out.
  - Apply the option even if there is a license from a previous life of the Zero (i.e. Zero is restarted with same the zw/

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5384)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-de08e30ad2-61417.surge.sh)
<!-- Dgraph:end -->