### PR TITLE
Update group checksums when combining multiple deltas.

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -947,6 +947,7 @@ func (g *groupi) processOracleDeltaStream() {
 					batch++
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
+					delta.GroupChecksums = more.GroupChecksums
 				default:
 					break SLURP
 				}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -947,7 +947,9 @@ func (g *groupi) processOracleDeltaStream() {
 					batch++
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
-					delta.GroupChecksums = more.GroupChecksums
+					for gid, checksum := range more.GroupChecksums {
+						delta.GroupChecksums[gid] = checksum
+					}
 				default:
 					break SLURP
 				}


### PR DESCRIPTION
The function processing the oracle delta stream combines multiple deltas
into one to reduce the number of proposal. However, the group checksums
were not being updated, causing some group checksums update to be lost.

gRPC guarantees that the ordering of the deltas coming from the stream
so overwriting the group checksums is safe.

Tested by following the steps in #5368.

Fixes #5368, DGRAPH-1333

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5394)
<!-- Reviewable:end -->
