### PR TITLE
Fix warning about issues with the cancel function.

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -787,6 +787,7 @@ START:
 	ctx, cancel := context.WithCancel(context.Background())
 	stream, err := c.StreamMembership(ctx, &api.Payload{})
 	if err != nil {
+		cancel()
 		glog.Errorf("Error while calling update %v\n", err)
 		time.Sleep(time.Second)
 		goto START


### PR DESCRIPTION
The context created with context.WithCancel should be cancelled before
jumping to the START label.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5397)
<!-- Reviewable:end -->
