### PR TITLE
add an option to add flags automatically.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,6 +5,7 @@ about: File a bug report.
 ---
 
 <!-- If you suspect this could be a bug, follow the template. -->
+<!-- flag: /&bug -->
 
 ### What version of Dgraph are you using?
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -8,3 +8,4 @@ about: Suggest improvements, additions, or revisions to Dgraph documentation.
 
 <!-- If you think Dgraph's documentation at https://docs.dgraph.io is lacking, please -->
 <!-- explain it here. -->
+<!-- flag: /&docs -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,3 +15,5 @@ Note: Feature requests are judged based on user experience and modeled on [Go Ex
 ### Why that wasn't great, with examples
 
 ### Any external references to support your case
+
+<!-- flag: /&feature -->

--- a/.github/ISSUE_TEMPLATE/issue_question.md
+++ b/.github/ISSUE_TEMPLATE/issue_question.md
@@ -10,3 +10,5 @@ The issue tracker is not for questions.
 If you have a question, please ask it on https://discuss.dgraph.io
 Our Docs: https://docs.dgraph.io/
 Slack Channel: https://slack.dgraph.io/
+
+<!-- flag: /&question -->

--- a/.github/issueLabeler.yml
+++ b/.github/issueLabeler.yml
@@ -1,0 +1,8 @@
+kind/bug:
+    - '(/&bug)'
+kind/question:
+    - '(/&question)'
+area/documentation:
+    - '(/&docs)'
+kind/feature:
+    - '(/&feature)'

--- a/.github/workflows/issueLabeler.yml
+++ b/.github/workflows/issueLabeler.yml
@@ -1,0 +1,15 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/issueLabeler.yml
+        not-before: 2020-05-04T02:54:32Z
+        enable-versioned-regex: 0


### PR DESCRIPTION
Add basic flags based on commands

Don't merge - it needs @lgalatin review.

It adds basic flags based on commands hardcoded in issue templates we already have.

No issues to fix.
No Jira ref.
No Braking Change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5406)
<!-- Reviewable:end -->
