### PR TITLE
Sentry should be initialized first on Alpha.Run()

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -534,6 +534,12 @@ func setupServer(closer *y.Closer) {
 }
 
 func run() {
+	if Alpha.Conf.GetBool("enable_sentry") {
+		x.InitSentry(enc.EeBuild)
+		defer x.FlushSentry()
+		x.ConfigureSentryScope("alpha")
+		x.WrapPanics()
+	}
 	bindall = Alpha.Conf.GetBool("bindall")
 
 	opts := worker.Options{
@@ -617,13 +623,6 @@ func run() {
 	x.Config.QueryEdgeLimit = cast.ToUint64(Alpha.Conf.GetString("query_edge_limit"))
 	x.Config.NormalizeNodeLimit = cast.ToInt(Alpha.Conf.GetString("normalize_node_limit"))
 	x.Config.PollInterval = Alpha.Conf.GetDuration("graphql_poll_interval")
-
-	if Alpha.Conf.GetBool("enable_sentry") {
-		x.InitSentry(enc.EeBuild)
-		defer x.FlushSentry()
-		x.ConfigureSentryScope("alpha")
-		x.WrapPanics()
-	}
 
 	x.PrintVersion()
 	glog.Infof("x.Config: %+v", x.Config)


### PR DESCRIPTION
Fixes DGRAPH-1359

Sentry init on alpha is not done asap when Run() is called. This results in the monitoring process to have additional state, including the HMAC Secret and the Enc Key, that it should not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5409)
<!-- Reviewable:end -->
