### PR TITLE
Worker: Return nil on error

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -2024,6 +2024,8 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 			switch {
 			case err != nil && strings.Contains(err.Error(), worker.ErrNonExistentTabletMessage):
 				sg.UnknownAttr = true
+				// Create an empty result because the code below depends on it.
+				result = &pb.Result{}
 			case err != nil:
 				rch <- err
 				return

--- a/query/query.go
+++ b/query/query.go
@@ -2021,10 +2021,10 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 				return
 			}
 			result, err := worker.ProcessTaskOverNetwork(ctx, taskQuery)
-			switch {
-			case err != nil && strings.Contains(err.Error(), worker.ErrNonExistentTabletMessage):
-				sg.UnknownAttr = true
-			case err != nil:
+			if err != nil {
+				if strings.Contains(err.Error(), worker.ErrNonExistentTabletMessage) {
+					sg.UnknownAttr = true
+				}
 				rch <- err
 				return
 			}

--- a/query/query.go
+++ b/query/query.go
@@ -2021,10 +2021,10 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 				return
 			}
 			result, err := worker.ProcessTaskOverNetwork(ctx, taskQuery)
-			if err != nil {
-				if strings.Contains(err.Error(), worker.ErrNonExistentTabletMessage) {
-					sg.UnknownAttr = true
-				}
+			switch {
+			case err != nil && strings.Contains(err.Error(), worker.ErrNonExistentTabletMessage):
+				sg.UnknownAttr = true
+			case err != nil:
 				rch <- err
 				return
 			}


### PR DESCRIPTION
The following output from pprof shows that the `pb.Result{}` takes up a lot of memory. This PR tries to reduce the unnecessary allocation
From https://discuss.dgraph.io/t/optimize-dgraph-memory-usage/6665
```
(pprof) list processTask

         .     1.91GB    887:	out, err := qs.helpProcessTask(ctx, q, gid)
         .          .    888:	if err != nil {
    4.50MB     4.45GB    889:		return &pb.Result{}, err // Create this object once, use it repeatedly.
         .          .    890:	}
         .     4.97GB    891:	return out, nil
         .          .    892:}
```
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5414)
<!-- Reviewable:end -->
