### PR TITLE
graphql: refactor custom directive http operation -> mode

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -244,7 +244,7 @@ func TestCustomFieldsInSubscription(t *testing.T) {
 			  url: "http://mock:8888/teacherName"
 			  method: "POST"
 			  body: "{tid: $tid}"
-			  operation: "single"
+			  mode: SINGLE
 			}
 		  )
 	  }
@@ -270,7 +270,7 @@ func TestSubscriptionInNestedCustomField(t *testing.T) {
 					url: "http://mock:8888/userNames",
 					method: "GET",
 					body: "{uid: $name}",
-					operation: "batch"
+					mode: BATCH
 				})
 	}
 
@@ -280,7 +280,7 @@ func TestSubscriptionInNestedCustomField(t *testing.T) {
 						url: "http://mock:8888/userNames",
 						method: "GET",
 						body: "{uid: $name}",
-						operation: "batch"
+						mode: BATCH
 					})
 		episodes: [Episode]
 	}`)
@@ -388,20 +388,20 @@ func TestCustomQueryShouldPropagateErrorFromFields(t *testing.T) {
 						url: "http://mock:8888/userNames",
 						method: "GET",
 						body: "{uid: $id}",
-						operation: "batch"
+						mode: BATCH
 					})
 		age: Int! @search
 		cars: Car @custom(http: {
 						url: "http://mock:8888/carsWrongURL",
 						method: "GET",
 						body: "{uid: $id}",
-						operation: "batch"
+						mode: BATCH
 					})
 		bikes: MotorBike @custom(http: {
 						url: "http://mock:8888/bikesWrongURL",
 						method: "GET",
 						body: "{uid: $id}",
-						operation: "single"
+						mode: SINGLE
 					})
 	}`
 
@@ -940,7 +940,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			http: {
 			  url: "http://mock:8888/gqlUserNameWithError"
 			  method: "POST"
-			  operation: "single"
+			  mode: SINGLE
 			  graphql: "query($id: ID!) { userName(id: $id) }"
 			}
 		  )
@@ -950,7 +950,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			http: {
 			  url: "http://mock:8888/gqlCarsWithErrors"
 			  method: "POST"
-			  operation: "batch"
+			  mode: BATCH
 			  graphql: "query($input: [UserInput]) { cars(input: $input) }"
 			  body: "{ id: $id, age: $age}"
 			}
@@ -1279,7 +1279,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 					url: "http://mock:8888/userNames",
 					method: "GET",
 					body: "{uid: $name}",
-					operation: "batch"
+					mode: BATCH
 				})
 	}
 
@@ -1289,7 +1289,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 						url: "http://mock:8888/userNames",
 						method: "GET",
 						body: "{uid: $name}",
-						operation: "batch"
+						mode: BATCH
 					})
 		episodes: [Episode]
 	}`
@@ -1385,7 +1385,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 					url: "http://mock:8888/userNames",
 					method: "GET",
 					body: "{uid: $name}",
-					operation: "batch"
+					mode: BATCH
 				})
 	}
 
@@ -1396,7 +1396,7 @@ func TestCustomFieldsWithXidShouldBeResolved(t *testing.T) {
 						url: "http://mock:8888/userNames",
 						method: "GET",
 						body: "{uid: $name}",
-						operation: "batch"
+						mode: BATCH
 					})
 		episodes: [Episode]
 	}`
@@ -1686,7 +1686,7 @@ func TestCustomGraphqlReturnTypeMismatchForBatchedField(t *testing.T) {
 		author: Author! @custom(http: {
 			url: "http://mock:8888/getPosts",
 			method: "POST",
-			operation: "batch"
+			mode: BATCH
 			graphql: "query ($abc: [PostInput]) { getPosts(input: $abc) }"
 			body: "{id: $id}"
 		})
@@ -1708,7 +1708,7 @@ func TestCustomGraphqlInvalidInputFormatForBatchedField(t *testing.T) {
 		comments: Post! @custom(http: {
 			url: "http://mock:8888/invalidInputForBatchedField",
 			method: "POST",
-			operation: "batch"
+			mode: BATCH
 			graphql: "query { getPosts(input: [{id: $id}]) }"
 			body: "{id: $id}"
 		})
@@ -1718,7 +1718,7 @@ func TestCustomGraphqlInvalidInputFormatForBatchedField(t *testing.T) {
 	require.Equal(t, `{"updateGQLSchema":null}`, string(res.Data))
 	require.Len(t, res.Errors, 1)
 	require.Equal(t, "couldn't rewrite mutation updateGQLSchema because input:9: Type Post"+
-		"; Field comments: inside graphql in @custom directive, for batch operations, query"+
+		"; Field comments: inside graphql in @custom directive, for BATCH mode, query"+
 		" `getPosts` can have only one argument whose value should be a variable.\n",
 		res.Errors[0].Error())
 }
@@ -1731,7 +1731,7 @@ func TestCustomGraphqlMissingTypeForBatchedFieldInput(t *testing.T) {
 		comments: String! @custom(http: {
 							url: "http://mock:8888/missingTypeForBatchedFieldInput",
 							method: "POST",
-							operation: "batch"
+							mode: BATCH
 							graphql: "query ($abc: [PostInput]) { getPosts(input: $abc) }"
 							body: "{id: $id}"
 						})
@@ -1754,7 +1754,7 @@ func TestCustomGraphqlInvalidArgForBatchedField(t *testing.T) {
 		comments: Post! @custom(http: {
 							url: "http://mock:8888/getPosts",
 							method: "POST",
-							operation: "batch"
+							mode: BATCH
 							graphql: "query { getPosts(input: [{name: $id}]) }"
 						})
 	}
@@ -1777,7 +1777,7 @@ func TestCustomGraphqlArgTypeMismatchForBatchedField(t *testing.T) {
 		comments: Post! @custom(http: {
 							url: "http://mock:8888/getPostswithLike",
 							method: "POST",
-							operation: "batch"
+							mode: BATCH
 							graphql: "query { getPosts(input: [{id: $id, text: $likes}]) }"
 						})
 	}
@@ -1815,7 +1815,7 @@ func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
 		comments: Post! @custom(http: {
 							url: "http://mock:8888/getPosts",
 							method: "POST",
-							operation: "batch"
+							mode: BATCH
 							graphql: "query { getPosts(input: [{id: $id}]) }"
 						})
 	}

--- a/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-graphql.graphql
@@ -10,7 +10,7 @@ type User {
       http: {
         url: "http://mock:8888/gqlUserNames"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($uinput: [UserInput]) { userNames(users: $uinput) }"
         body: "{ id: $id, age: $age }"
       }
@@ -21,7 +21,7 @@ type User {
       http: {
         url: "http://mock:8888/gqlCars"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($cinput: [UserInput]) { cars(users: $cinput) }"
         body: "{ id: $id, age: $age }",
       }
@@ -37,7 +37,7 @@ type School {
       http: {
         url: "http://mock:8888/gqlSchoolNames"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($sinput: [SchoolInput]) { schoolNames(schools: $sinput) }",
         body: "{ id: $id, established: $established }"
       }
@@ -47,7 +47,7 @@ type School {
       http: {
         url: "http://mock:8888/gqlClasses"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($cinput: [SchoolInput]) { classes(schools: $cinput) }",
         body: "{ id: $id, established: $established }"
       }
@@ -68,7 +68,7 @@ type Teacher {
       http: {
         url: "http://mock:8888/gqlTeacherNames"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($tinput: [TeacherInput]) { teacherNames(teachers: $tinput) }"
         body: "{ id: $tid, age: $age }"
       }

--- a/graphql/e2e/custom_logic/schemas/batch-mode-rest.graphql
+++ b/graphql/e2e/custom_logic/schemas/batch-mode-rest.graphql
@@ -11,7 +11,7 @@ type User {
         url: "http://mock:8888/userNames"
         method: "GET"
         body: "{uid: $id}"
-        operation: "batch"
+        mode: BATCH
       }
     )
   age: Int! @search
@@ -21,7 +21,7 @@ type User {
         url: "http://mock:8888/cars"
         method: "GET"
         body: "{uid: $id}"
-        operation: "batch"
+        mode: BATCH
       }
     )
   schools: [School]
@@ -36,7 +36,7 @@ type School {
         url: "http://mock:8888/schoolNames"
         method: "POST"
         body: "{sid: $id}"
-        operation: "batch"
+        mode: BATCH
       }
     )
   classes: [Class]
@@ -45,7 +45,7 @@ type School {
         url: "http://mock:8888/classes"
         method: "POST"
         body: "{sid: $id}"
-        operation: "batch"
+        mode: BATCH
       }
     )
   teachers: [Teacher]
@@ -65,7 +65,7 @@ type Teacher {
         url: "http://mock:8888/teacherNames"
         method: "POST"
         body: "{tid: $tid}"
-        operation: "batch"
+        mode: BATCH
       }
     )
 }

--- a/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
+++ b/graphql/e2e/custom_logic/schemas/mixed-modes.graphql
@@ -10,7 +10,7 @@ type User {
       http: {
         url: "http://mock:8888/gqlUserNames"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($input: [UserInput]) { userNames(users: $input) }"
         body: "{ id: $id, age: $age }"
       }
@@ -22,7 +22,7 @@ type User {
         url: "http://mock:8888/cars"
         method: "GET"
         body: "{uid: $id}"
-        operation: "batch"
+        mode: BATCH
       }
     )
   schools: [School]
@@ -36,7 +36,7 @@ type School {
       http: {
         url: "http://mock:8888/gqlSchoolName"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($id: ID!) { schoolName(id: $id) }"
       }
     )
@@ -46,7 +46,7 @@ type School {
         url: "http://mock:8888/class"
         method: "POST"
         body: "{sid: $id}"
-        operation: "single"
+        mode: SINGLE
       }
     )
   teachers: [Teacher]
@@ -65,7 +65,7 @@ type Teacher {
       http: {
         url: "http://mock:8888/gqlTeacherNames"
         method: "POST"
-        operation: "batch"
+        mode: BATCH
         graphql: "query($input: [TeacherInput]) { teacherNames(teachers: $input) }",
         body: "{ id: $tid, age: $age}"
       }

--- a/graphql/e2e/custom_logic/schemas/single-mode-graphql.graphql
+++ b/graphql/e2e/custom_logic/schemas/single-mode-graphql.graphql
@@ -10,7 +10,7 @@ type User {
       http: {
         url: "http://mock:8888/gqlUserName"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($id: ID!) { userName(id: $id)}"
       }
     )
@@ -20,7 +20,7 @@ type User {
       http: {
         url: "http://mock:8888/gqlCar"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($id: ID!) { car(id: $id)}"
       }
     )
@@ -35,7 +35,7 @@ type School {
       http: {
         url: "http://mock:8888/gqlSchoolName"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($id: ID!) { schoolName(id: $id) }"
       }
     )
@@ -44,7 +44,7 @@ type School {
       http: {
         url: "http://mock:8888/gqlClass"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($id: ID!) { class(id: $id) }"
       }
     )
@@ -64,7 +64,7 @@ type Teacher {
       http: {
         url: "http://mock:8888/gqlTeacherName"
         method: "POST"
-        operation: "single"
+        mode: SINGLE
         graphql: "query($tid: ID!) { teacherName(id: $tid) }"
       }
     )

--- a/graphql/e2e/custom_logic/schemas/single-mode-rest.graphql
+++ b/graphql/e2e/custom_logic/schemas/single-mode-rest.graphql
@@ -11,7 +11,7 @@ type User {
         url: "http://mock:8888/userName"
         method: "GET"
         body: "{uid: $id}"
-        operation: "single"
+        mode: SINGLE
       }
     )
   age: Int! @search
@@ -21,7 +21,7 @@ type User {
         url: "http://mock:8888/car"
         method: "GET"
         body: "{uid: $id}"
-        operation: "single"
+        mode: SINGLE
       }
     )
   schools: [School]
@@ -36,7 +36,7 @@ type School {
         url: "http://mock:8888/schoolName"
         method: "POST"
         body: "{sid: $id}"
-        operation: "single"
+        mode: SINGLE
       }
     )
   classes: [Class]
@@ -45,7 +45,7 @@ type School {
         url: "http://mock:8888/class"
         method: "POST"
         body: "{sid: $id}"
-        operation: "single"
+        mode: SINGLE
       }
     )
   teachers: [Teacher]
@@ -65,7 +65,7 @@ type Teacher {
         url: "http://mock:8888/teacherName"
         method: "POST"
         body: "{tid: $tid}"
-        operation: "single"
+        mode: SINGLE
       }
     )
 }

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -769,7 +769,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 		}
 	}
 
-	if fconf.Operation == "batch" {
+	if fconf.Mode == schema.BATCH {
 		var requestInput interface{}
 		requestInput = inputs
 

--- a/graphql/schema/custom_http_config_test.yaml
+++ b/graphql/schema/custom_http_config_test.yaml
@@ -180,7 +180,7 @@
         http: {
           url: "http://mock:8888/gqlUserName"
           method: "POST"
-          operation: "single"
+          mode: SINGLE
           graphql: "query($id: ID!, $age: Float!) { userName(id: $id, age: $age)}"
           skipIntrospection: true
         }
@@ -217,7 +217,7 @@
         http: {
           url: "http://mock:8888/gqlUserName"
           method: "POST"
-          operation: "batch"
+          mode: BATCH
           graphql: "query($random: [UserInput]) { userName(random: $random)}",
           body: "{id: $id, age: $age}"
           skipIntrospection: true

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -85,11 +85,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -43,6 +43,11 @@ const (
 	customDirective = "custom"
 	remoteDirective = "remote" // types with this directive are not stored in Dgraph.
 
+	// custom directive args and fields
+	mode   = "mode"
+	BATCH  = "BATCH"
+	SINGLE = "SINGLE"
+
 	deprecatedDirective = "deprecated"
 	NumUid              = "numUids"
 
@@ -85,9 +90,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -95,7 +100,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -899,22 +899,22 @@ invalid_schemas:
     ]
 
   -
-    name: "@custom directive with operation on Query/Mutation"
+    name: "@custom directive with mode on Query/Mutation"
     input: |
       type Author {
         id: ID!
       }
 
       type Query {
-        getAuthor1(id: ID): Author! @custom(http: {url: "http://google.com/", method: "GET", operation: "single"})
+        getAuthor1(id: ID): Author! @custom(http: {url: "http://google.com/", method: "GET", mode: SINGLE})
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor1; operation field inside @custom directive can't be present on Query/Mutation.",
-     "locations":[{"line":6, "column":100}]},
+    {"message": "Type Query; Field getAuthor1; mode field inside @custom directive can't be present on Query/Mutation.",
+     "locations":[{"line":6, "column":94}]},
     ]
 
   -
-    name: "@custom directive with wrong value for operation"
+    name: "@custom directive with wrong value for mode"
     input: |
       type Author {
         id: ID!
@@ -922,11 +922,11 @@ invalid_schemas:
 
       type Post {
         id: ID!
-        author: Author! @custom(http: {url: "http://google.com/", method: "GET", operation: "random"})
+        author: Author! @custom(http: {url: "http://google.com/", method: "GET", mode: RANDOM})
       }
     errlist: [
-    {"message": "Type Post; Field author; operation field inside @custom directive can only be single/batch.",
-     "locations":[{"line":7, "column":88}]},
+    {"message": "Type Post; Field author; mode field inside @custom directive can only be SINGLE/BATCH.",
+     "locations":[{"line":7, "column":82}]},
     ]
 
   -
@@ -941,10 +941,10 @@ invalid_schemas:
         author: Author! @custom(http: {
           url: "http://google.com?a=$id",
           method: "GET",
-          operation: "batch"})
+          mode: BATCH})
       }
     errlist: [
-    {"message": "Type Post; Field author; has parameters in url inside @custom directive while operation is batch, url can't contain parameters if operation is batch.",
+    {"message": "Type Post; Field author; has parameters in url inside @custom directive while mode is BATCH, url can't contain parameters if mode is BATCH.",
      "locations":[{"line":8, "column":11}]},
     ]
 
@@ -1265,13 +1265,13 @@ invalid_schemas:
         author: Author! @custom(http: {
           url: "http://google.com/",
           method: "POST",
-          operation: "batch"
+          mode: BATCH,
           graphql: "query { getAuthor(postId: {id: $id}) }",
           body: "{id: $id}"
         })
       }
     errlist: [
-    {"message": "Type Post; Field author: inside graphql in @custom directive, for batch operations, query `getAuthor` can have only one argument whose value should be a variable.",
+    {"message": "Type Post; Field author: inside graphql in @custom directive, for BATCH mode, query `getAuthor` can have only one argument whose value should be a variable.",
      "locations":[{"line":11, "column":15}]},
     ]
 
@@ -1440,7 +1440,7 @@ invalid_schemas:
         name: String! @custom(http: {
           url: "http://google.com",
           method: "POST",
-          operation: "batch",
+          mode: BATCH,
           graphql: "query ($abc: [AuthorInput]) { getName(obj: $abc) }"
           body: "{abc: $abc, id: $id}"
         })
@@ -1777,7 +1777,7 @@ invalid_schemas:
           url: "http://google.com"
           method: "POST"
           graphql: "query($id: ID!) { getName(obj: $input) }"
-          operation: "batch"
+          mode: BATCH
           body: "{ id: $id, age: $age }"
         })
       }
@@ -1796,7 +1796,7 @@ invalid_schemas:
           url: "http://google.com"
           method: "POST"
           graphql: "query($id: ID!) { getName(id: $id) }"
-          operation: "single"
+          mode: SINGLE
           skipIntrospection: "random"
         })
       }

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -161,7 +161,7 @@ type remoteGraphqlMetadata struct {
 	// graphqlOpDef is the Operation Definition for the operation given in @custom->http->graphql
 	// The operation can only be a query or mutation
 	graphqlOpDef *ast.OperationDefinition
-	// isBatch tells whether it is single/batch operation for resolving custom fields
+	// isBatch tells whether it is SINGLE/BATCH mode for resolving custom fields
 	isBatch bool
 	// url is the url of remote graphql endpoint
 	url string
@@ -273,11 +273,11 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 	givenQryVarTypes := getVarTypesAsMap(metadata.parentField, metadata.parentType)
 	remoteQryArgMetadata := getRemoteQueryArgMetadata(introspectedRemoteQuery)
 
-	// verify remote query arg format for batch operations
+	// verify remote query arg format for BATCH mode
 	if metadata.isBatch {
 		if len(remoteQryArgMetadata.typMap) != 1 {
 			return errors.Errorf("remote %s `%s` accepts %d arguments, It must have only one "+
-				"argument of the form `[{param1: $var1, param2: $var2, ...}]` for batch operation.",
+				"argument of the form `[{param1: $var1, param2: $var2, ...}]` for BATCH mode.",
 				operationType, givenQuery.Name, len(remoteQryArgMetadata.typMap))
 		}
 		for argName, inputTyp := range remoteQryArgMetadata.typMap {
@@ -294,7 +294,7 @@ func validateRemoteGraphql(metadata *remoteGraphqlMetadata) error {
 					Kind == nonNull && inputTyp.OfType.OfType.OfType != nil && inputTyp.
 					OfType.OfType.OfType.Kind == inputObject)) {
 				return errors.Errorf("argument `%s` for given %s `%s` must be of the form `[{param1"+
-					": $var1, param2: $var2, ...}]` for batch operations in remote %s.", argName,
+					": $var1, param2: $var2, ...}]` for BATCH mode in remote %s.", argName,
 					operationType, givenQuery.Name, operationType)
 			}
 			inputTypName := inputTyp.NamedType()

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -55,11 +55,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -55,9 +55,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -65,7 +65,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -60,9 +60,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -70,7 +70,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -60,11 +60,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -48,9 +48,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -58,7 +58,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -48,11 +48,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -65,9 +65,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -75,7 +75,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -65,11 +65,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -49,9 +49,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -59,7 +59,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -49,11 +49,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -48,9 +48,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -58,7 +58,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -48,11 +48,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -44,11 +44,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -44,9 +44,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -54,7 +54,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -44,11 +44,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -44,9 +44,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -54,7 +54,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -58,11 +58,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -58,9 +58,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -68,7 +68,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -58,11 +58,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -58,9 +58,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -68,7 +68,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -57,9 +57,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -67,7 +67,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -57,11 +57,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -51,9 +51,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -61,7 +61,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -51,11 +51,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -68,9 +68,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -78,7 +78,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -68,11 +68,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -69,11 +69,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -69,9 +69,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -79,7 +79,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -68,9 +68,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -78,7 +78,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -68,11 +68,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -49,9 +49,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -59,7 +59,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -49,11 +49,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -51,9 +51,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -61,7 +61,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -51,11 +51,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -53,9 +53,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -63,7 +63,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -53,11 +53,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -53,9 +53,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -63,7 +63,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -53,11 +53,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -75,11 +75,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -75,9 +75,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -85,7 +85,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -75,11 +75,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -75,9 +75,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -85,7 +85,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -43,11 +43,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -43,9 +43,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -53,7 +53,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -55,11 +55,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -55,9 +55,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -65,7 +65,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -44,11 +44,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -44,9 +44,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -54,7 +54,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -53,9 +53,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -63,7 +63,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -53,11 +53,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -70,11 +70,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -70,9 +70,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -80,7 +80,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -52,11 +52,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -52,9 +52,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -62,7 +62,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -46,11 +46,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -46,9 +46,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -56,7 +56,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -59,9 +59,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -69,7 +69,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -59,11 +59,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -51,9 +51,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -61,7 +61,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -51,11 +51,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -51,9 +51,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -61,7 +61,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -51,11 +51,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -51,9 +51,9 @@ enum HTTPMethod {
 	DELETE
 }
 
-enum Operation {
-	single
-	batch
+enum Mode {
+	BATCH
+	SINGLE
 }
 
 input CustomHTTP {
@@ -61,7 +61,7 @@ input CustomHTTP {
 	method: HTTPMethod!
 	body: String
 	graphql: String
-	operation: Operation
+	mode: Mode
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -51,11 +51,17 @@ enum HTTPMethod {
 	DELETE
 }
 
+enum Operation {
+	single
+	batch
+}
+
 input CustomHTTP {
 	url: String!
 	method: HTTPMethod!
 	body: String
 	graphql: String
+	operation: Operation
 	forwardHeaders: [String!]
 	skipIntrospection: Boolean
 }


### PR DESCRIPTION
This PR refactors `operation` to `mode` inside `@custom->http`.
Also, the generated GraphQL schema was missing `mode` inside `@custom`. This PR fixes this issue.

Fixes GRAPHQL-450

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5415)
<!-- Reviewable:end -->
