### PR TITLE
Use request context while handling queries

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -194,7 +194,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx := context.WithValue(context.Background(), query.DebugKey, isDebugMode)
+	ctx := context.WithValue(r.Context(), query.DebugKey, isDebugMode)
 	ctx = x.AttachAccessJwt(ctx, r)
 
 	if queryTimeout != 0 {


### PR DESCRIPTION
while running queries, we should propagate the request context down the tree. This ensures that if the caller has cancelled the request i.e. not waiting for the response, we stop executing the query too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5418)
<!-- Reviewable:end -->
