### PR TITLE
Cherry-Pick v20.03 : Initialize sentry  at the begin of alpha.Run() (#5409)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -515,6 +515,12 @@ func setupServer(closer *y.Closer) {
 }
 
 func run() {
+	if Alpha.Conf.GetBool("enable_sentry") {
+		x.InitSentry(enc.EeBuild)
+		defer x.FlushSentry()
+		x.ConfigureSentryScope("alpha")
+		x.WrapPanics()
+	}
 	bindall = Alpha.Conf.GetBool("bindall")
 
 	opts := worker.Options{
@@ -597,13 +603,6 @@ func run() {
 	x.Config.PortOffset = Alpha.Conf.GetInt("port_offset")
 	x.Config.QueryEdgeLimit = cast.ToUint64(Alpha.Conf.GetString("query_edge_limit"))
 	x.Config.NormalizeNodeLimit = cast.ToInt(Alpha.Conf.GetString("normalize_node_limit"))
-
-	if Alpha.Conf.GetBool("enable_sentry") {
-		x.InitSentry(enc.EeBuild)
-		defer x.FlushSentry()
-		x.ConfigureSentryScope("alpha")
-		x.WrapPanics()
-	}
 
 	x.PrintVersion()
 	glog.Infof("x.Config: %+v", x.Config)


### PR DESCRIPTION
cherry pick from commit c9bc5cab2a521d5c9b6c572023d3a0db572eb48f

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5429)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-2f8ec0a86f-63059.surge.sh)
<!-- Dgraph:end -->