### PR TITLE
Changing the default code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 /wiki/ @danielmai @MichaelJCompton
 /contrib/config/ @danielmai
 /query/ @pawanrawal
+/graphql/ @pawanrawal @MichaelJCompton

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @manishrjain @dgraph-io/team
+* @manishrjain @vvbalaji-dgraph
 /posting/ @manishrjain @martinmr
 /ee/acl/ @manishrjain @gitlw
 /wiki/ @danielmai @MichaelJCompton


### PR DESCRIPTION
This stops everyone from getting tagged on every PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5438)
<!-- Reviewable:end -->
