### PR TITLE
graphql: Support reading secret headers from schema file and forwarding them for client requests.

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -136,6 +136,37 @@ func getError(key, val string) error {
 	return fmt.Errorf(`{ "errors": [{"message": "%s: %s"}] }`, key, val)
 }
 
+func compareHeaders(headers map[string][]string, actual http.Header) error {
+	if headers == nil {
+		return nil
+	}
+	actualHeaderLen := len(actual)
+	expectedHeaderLen := len(headers)
+	if actualHeaderLen != expectedHeaderLen {
+		return getError(fmt.Sprintf("Wanted %d headers in request, got", expectedHeaderLen),
+			strconv.Itoa(actualHeaderLen))
+	}
+
+	for k, v := range headers {
+		rv, ok := actual[k]
+		if !ok {
+			return getError("Required header not found", k)
+		}
+
+		if v == nil {
+			continue
+		}
+
+		sort.Strings(rv)
+		sort.Strings(v)
+
+		if !reflect.DeepEqual(rv, v) {
+			return getError(fmt.Sprintf("Unexpected value for %s header", k), fmt.Sprint(rv))
+		}
+	}
+	return nil
+}
+
 func verifyRequest(r *http.Request, expectedRequest expectedRequest) error {
 	if r.Method != expectedRequest.method {
 		return getError("Invalid HTTP method", r.Method)
@@ -153,34 +184,7 @@ func verifyRequest(r *http.Request, expectedRequest expectedRequest) error {
 		return getError("Unexpected value for request body", string(b))
 	}
 
-	if expectedRequest.headers != nil {
-		actualHeaderLen := len(r.Header)
-		expectedHeaderLen := len(expectedRequest.headers)
-		if actualHeaderLen != expectedHeaderLen {
-			return getError(fmt.Sprintf("Wanted %d headers in request, got", expectedHeaderLen),
-				strconv.Itoa(actualHeaderLen))
-		}
-
-		for k, v := range expectedRequest.headers {
-			rv, ok := r.Header[k]
-			if !ok {
-				return getError("Required header not found", k)
-			}
-
-			if v == nil {
-				continue
-			}
-
-			sort.Strings(rv)
-			sort.Strings(v)
-
-			if !reflect.DeepEqual(rv, v) {
-				return getError(fmt.Sprintf("Unexpected value for %s header", k), fmt.Sprint(rv))
-			}
-		}
-	}
-
-	return nil
+	return compareHeaders(expectedRequest.headers, r.Header)
 }
 
 // bool parameter in return signifies whether it is an introspection query or not:
@@ -273,10 +277,11 @@ func verifyHeadersHandler(w http.ResponseWriter, r *http.Request) {
 		urlSuffix: "/verifyHeaders",
 		body:      "",
 		headers: map[string][]string{
-			"X-App-Token":     {"app-token"},
-			"X-User-Id":       {"123"},
-			"Accept-Encoding": nil,
-			"User-Agent":      nil,
+			"X-App-Token":      {"app-token"},
+			"X-User-Id":        {"123"},
+			"Github-Api-Token": {"random-fake-token"},
+			"Accept-Encoding":  nil,
+			"User-Agent":       nil,
 		},
 	})
 	if err != nil {
@@ -641,6 +646,34 @@ func schoolNamesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	check2(fmt.Fprint(w, string(b)))
+}
+
+func deleteCommonHeaders(headers http.Header) {
+	delete(headers, "Accept-Encoding")
+	delete(headers, "Content-Length")
+	delete(headers, "User-Agent")
+}
+
+func carsHandlerWithHeaders(w http.ResponseWriter, r *http.Request) {
+	deleteCommonHeaders(r.Header)
+	if err := compareHeaders(map[string][]string{
+		"Stripe-Api-Key": []string{"some-api-key"},
+	}, r.Header); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprint(w, `[{"name": "foo"},{"name": "foo"},{"name": "foo"}]`))
+}
+
+func userNameHandlerWithHeaders(w http.ResponseWriter, r *http.Request) {
+	deleteCommonHeaders(r.Header)
+	if err := compareHeaders(map[string][]string{
+		"Github-Api-Token": []string{"some-api-token"},
+	}, r.Header); err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(fmt.Fprint(w, `"foo"`))
 }
 
 func carsHandler(w http.ResponseWriter, r *http.Request) {
@@ -1062,12 +1095,14 @@ func main() {
 	// for testing batch mode
 	http.HandleFunc("/userNames", userNamesHandler)
 	http.HandleFunc("/cars", carsHandler)
+	http.HandleFunc("/checkHeadersForCars", carsHandlerWithHeaders)
 	http.HandleFunc("/classes", classesHandler)
 	http.HandleFunc("/teacherNames", teacherNamesHandler)
 	http.HandleFunc("/schoolNames", schoolNamesHandler)
 
 	// for testing single mode
 	http.HandleFunc("/userName", userNameHandler)
+	http.HandleFunc("/checkHeadersForUserName", userNameHandlerWithHeaders)
 	http.HandleFunc("/car", carHandler)
 	http.HandleFunc("/class", classHandler)
 	http.HandleFunc("/teacherName", teacherNameHandler)

--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -1134,6 +1134,15 @@ func main() {
 	})
 	http.HandleFunc("/invalidfield", commonGraphqlHandler("invalidfield"))
 	http.HandleFunc("/nestedinvalid", commonGraphqlHandler("nestedinvalid"))
+	http.HandleFunc("/validatesecrettoken", func(w http.ResponseWriter, r *http.Request) {
+		if h := r.Header.Get("Github-Api-Token"); h != "random-api-token" {
+			return
+		}
+		rh := &relay.Handler{
+			Schema: graphql.MustParseSchema(graphqlResponses["validinputfield"].Schema, &query{}),
+		}
+		rh.ServeHTTP(w, r)
+	})
 
 	// for mutations
 	http.HandleFunc("/setCountry", commonGraphqlHandler("setcountry"))

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -196,6 +196,25 @@ func TestCustomQueryShouldForwardHeaders(t *testing.T) {
 	require.Equal(t, expected, string(result.Data))
 }
 
+func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
+	schema := customTypes + `
+		type Query {
+			myCustom(yo: CountryInput!): [Country!]!
+			  @custom(
+				http: {
+				  url: "http://mock:8888/validatesecrettoken"
+				  method: "POST"
+				  forwardHeaders: ["Content-Type", "GITHUB-API-TOKEN"]
+				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
+				}
+			  )
+		  }
+
+		# Dgraph.Secret GITHUB-API-TOKEN "random-api-token"
+		  `
+	common.RequireNoGQLErrors(t, updateSchema(t, schema))
+}
+
 func TestServerShouldAllowForwardHeaders(t *testing.T) {
 	schema := `
 	type User {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -164,7 +164,8 @@ func TestCustomQueryShouldForwardHeaders(t *testing.T) {
 		 verifyHeaders(id: ID!): [Movie] @custom(http: {
 				 url: "http://mock:8888/verifyHeaders",
 				 method: "GET",
-				 forwardHeaders: ["X-App-Token", "X-User-Id", "Github-Api-Token"]
+				 forwardHeaders: ["X-App-Token", "X-User-Id"],
+				 secretHeaders: ["Github-Api-Token", "X-App-Token"]
 		 })
 	 }
 
@@ -204,7 +205,8 @@ func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
 				http: {
 				  url: "http://mock:8888/validatesecrettoken"
 				  method: "POST"
-				  forwardHeaders: ["Content-Type", "GITHUB-API-TOKEN"]
+				  forwardHeaders: ["Content-Type"]
+				  secretHeaders: ["GITHUB-API-TOKEN"]
 				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 				}
 			  )
@@ -917,7 +919,7 @@ func TestCustomFieldsShouldForwardHeaders(t *testing.T) {
 					method: "GET"
 					body: "{uid: $id}"
 					mode: SINGLE,
-					forwardHeaders: ["GITHUB-API-TOKEN"]
+					secretHeaders: ["GITHUB-API-TOKEN"]
 				}
 			)
 		age: Int! @search
@@ -928,7 +930,7 @@ func TestCustomFieldsShouldForwardHeaders(t *testing.T) {
 			method: "GET"
 			body: "{uid: $id}"
 			mode: BATCH,
-			forwardHeaders: ["STRIPE-API-KEY"]
+			secretHeaders: ["STRIPE-API-KEY"]
 			}
 		)
   	}

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -164,9 +164,13 @@ func TestCustomQueryShouldForwardHeaders(t *testing.T) {
 		 verifyHeaders(id: ID!): [Movie] @custom(http: {
 				 url: "http://mock:8888/verifyHeaders",
 				 method: "GET",
-				 forwardHeaders: ["X-App-Token", "X-User-Id"]
+				 forwardHeaders: ["X-App-Token", "X-User-Id", "Github-Api-Token"]
 		 })
-	 }`
+	 }
+
+		 # Dgraph.Secret Github-Api-Token random-fake-token
+		 # Dgraph.Secret X-App-Token should-be-overriden
+	 `
 	updateSchemaRequireNoGQLErrors(t, schema)
 	time.Sleep(2 * time.Second)
 
@@ -876,6 +880,67 @@ func readFile(t *testing.T, name string) string {
 	b, err := ioutil.ReadFile(name)
 	require.NoError(t, err)
 	return string(b)
+}
+
+func TestCustomFieldsShouldForwardHeaders(t *testing.T) {
+	schema := `
+	type Car @remote {
+		id: ID!
+		name: String!
+	}
+
+	type User {
+		id: ID!
+		name: String
+			@custom(
+				http: {
+					url: "http://mock:8888/checkHeadersForUserName"
+					method: "GET"
+					body: "{uid: $id}"
+					mode: SINGLE,
+					forwardHeaders: ["GITHUB-API-TOKEN"]
+				}
+			)
+		age: Int! @search
+		cars: Car
+		@custom(
+			http: {
+			url: "http://mock:8888/checkHeadersForCars"
+			method: "GET"
+			body: "{uid: $id}"
+			mode: BATCH,
+			forwardHeaders: ["STRIPE-API-KEY"]
+			}
+		)
+  	}
+
+# Dgraph.Secret GITHUB-API-TOKEN some-api-token
+# Dgraph.Secret STRIPE-API-KEY some-api-key
+  `
+
+	updateSchemaRequireNoGQLErrors(t, schema)
+	time.Sleep(2 * time.Second)
+
+	users := addUsers(t)
+
+	queryUser := `
+	query ($id: [ID!]){
+		queryUser(filter: {id: $id}, order: {asc: age}) {
+			name
+			age
+			cars {
+				name
+			}
+		}
+	}`
+	params := &common.GraphQLParams{
+		Query: queryUser,
+		Variables: map[string]interface{}{"id": []interface{}{
+			users[0].ID, users[1].ID, users[2].ID}},
+	}
+
+	result := params.ExecuteAsPost(t, alphaURL)
+	require.Nilf(t, result.Errors, "%+v", result.Errors)
 }
 
 func TestCustomFieldsShouldBeResolved(t *testing.T) {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -854,7 +854,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 		}
 
 		if len(result) != len(vals) {
-			gqlErr := x.GqlErrorf("Evaluation of custom field failed because expected result of"+
+			gqlErr := x.GqlErrorf("Evaluation of custom field failed because expected result of "+
 				"external request to be of size %v, got: %v for field: %s within type: %s.",
 				len(vals), len(result), f.Name(), f.GetObjectName()).WithLocations(f.Location())
 			errCh <- schema.AppendGQLErrs(errs, gqlErr)
@@ -1508,7 +1508,6 @@ func makeRequest(client *http.Client, method, url, body string,
 	defer resp.Body.Close()
 
 	b, err := ioutil.ReadAll(resp.Body)
-
 	return b, err
 }
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -111,9 +111,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
@@ -186,7 +186,8 @@ type directiveValidator func(
 	sch *ast.Schema,
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
-	dir *ast.Directive) *gqlerror.Error
+	dir *ast.Directive,
+	secrets map[string]string) *gqlerror.Error
 
 type searchTypeIndex struct {
 	gqlType string
@@ -297,7 +298,8 @@ var directiveValidators = map[string]directiveValidator{
 		sch *ast.Schema,
 		typ *ast.Definition,
 		field *ast.FieldDefinition,
-		dir *ast.Directive) *gqlerror.Error {
+		dir *ast.Directive,
+		secrets map[string]string) *gqlerror.Error {
 		return nil
 	},
 	// Just go get it printed into generated schema
@@ -305,7 +307,8 @@ var directiveValidators = map[string]directiveValidator{
 		sch *ast.Schema,
 		typ *ast.Definition,
 		field *ast.FieldDefinition,
-		dir *ast.Directive) *gqlerror.Error {
+		dir *ast.Directive,
+		secrets map[string]string) *gqlerror.Error {
 		return nil
 	},
 }
@@ -402,7 +405,8 @@ func preGQLValidation(schema *ast.SchemaDocument) gqlerror.List {
 // are easier to run once we know that the schema is GraphQL valid and that validation
 // has fleshed out the schema structure; we just need to check if it also satisfies
 // the extra rules.
-func postGQLValidation(schema *ast.Schema, definitions []string) gqlerror.List {
+func postGQLValidation(schema *ast.Schema, definitions []string,
+	secrets map[string]string) gqlerror.List {
 	var errs []*gqlerror.Error
 
 	for _, defn := range definitions {
@@ -418,7 +422,7 @@ func postGQLValidation(schema *ast.Schema, definitions []string) gqlerror.List {
 					continue
 				}
 				errs = appendIfNotNull(errs,
-					directiveValidators[dir.Name](schema, typ, field, dir))
+					directiveValidators[dir.Name](schema, typ, field, dir, secrets))
 			}
 		}
 	}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -102,6 +102,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -187,7 +187,7 @@ type directiveValidator func(
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error
 
 type searchTypeIndex struct {
 	gqlType string
@@ -299,7 +299,7 @@ var directiveValidators = map[string]directiveValidator{
 		typ *ast.Definition,
 		field *ast.FieldDefinition,
 		dir *ast.Directive,
-		secrets map[string]string) *gqlerror.Error {
+		secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 		return nil
 	},
 	// Just go get it printed into generated schema
@@ -308,7 +308,7 @@ var directiveValidators = map[string]directiveValidator{
 		typ *ast.Definition,
 		field *ast.FieldDefinition,
 		dir *ast.Directive,
-		secrets map[string]string) *gqlerror.Error {
+		secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 		return nil
 	},
 }
@@ -406,7 +406,7 @@ func preGQLValidation(schema *ast.SchemaDocument) gqlerror.List {
 // has fleshed out the schema structure; we just need to check if it also satisfies
 // the extra rules.
 func postGQLValidation(schema *ast.Schema, definitions []string,
-	secrets map[string]string) gqlerror.List {
+	secrets map[string]x.SensitiveByteSlice) gqlerror.List {
 	var errs []*gqlerror.Error
 
 	for _, defn := range definitions {

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1479,10 +1479,10 @@ func customDirectiveValidation(sch *ast.Schema,
 		}
 	}
 	if graphql != nil && !skip && graphqlOpDef != nil {
-		forwardHeaders := httpArg.Value.Children.ForName("forwardHeaders")
+		secretHeaders := httpArg.Value.Children.ForName("secretHeaders")
 		headers := http.Header{}
-		if forwardHeaders != nil {
-			for _, h := range forwardHeaders.Children {
+		if secretHeaders != nil {
+			for _, h := range secretHeaders.Children {
 				// We try and fetch the value from the stored secrets.
 				val := secrets[h.Value.Raw]
 				headers.Add(h.Value.Raw, string(val))

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/vektah/gqlparser/v2/ast"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	"github.com/vektah/gqlparser/v2/parser"
@@ -630,7 +631,8 @@ func listValidityCheck(typ *ast.Definition, field *ast.FieldDefinition) *gqlerro
 }
 
 func hasInverseValidation(sch *ast.Schema, typ *ast.Definition,
-	field *ast.FieldDefinition, dir *ast.Directive, secrets map[string]string) *gqlerror.Error {
+	field *ast.FieldDefinition, dir *ast.Directive,
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	invTypeName := field.Type.Name()
 	if sch.Types[invTypeName].Kind != ast.Object && sch.Types[invTypeName].Kind != ast.Interface {
@@ -802,7 +804,7 @@ func searchValidation(
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error {
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	arg := dir.Arguments.ForName(searchArgs)
 	if arg == nil {
@@ -874,7 +876,7 @@ func searchValidation(
 }
 
 func dgraphDirectiveValidation(sch *ast.Schema, typ *ast.Definition, field *ast.FieldDefinition,
-	dir *ast.Directive, secrets map[string]string) *gqlerror.Error {
+	dir *ast.Directive, secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	if isID(field) {
 		return gqlerror.ErrorPosf(
@@ -980,7 +982,7 @@ func passwordValidation(sch *ast.Schema,
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error {
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	return passwordDirectiveValidation(typ)
 }
@@ -989,7 +991,7 @@ func remoteDirectiveValidation(sch *ast.Schema,
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error {
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 	return nil
 }
 
@@ -997,7 +999,7 @@ func customDirectiveValidation(sch *ast.Schema,
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error {
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	// 1. Validating custom directive itself
 	search := field.Directives.ForName(searchDirective)
@@ -1483,7 +1485,7 @@ func customDirectiveValidation(sch *ast.Schema,
 			for _, h := range forwardHeaders.Children {
 				// We try and fetch the value from the stored secrets.
 				val := secrets[h.Value.Raw]
-				headers.Add(h.Value.Raw, val)
+				headers.Add(h.Value.Raw, string(val))
 			}
 		}
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{
@@ -1508,7 +1510,7 @@ func idValidation(sch *ast.Schema,
 	typ *ast.Definition,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
-	secrets map[string]string) *gqlerror.Error {
+	secrets map[string]x.SensitiveByteSlice) *gqlerror.Error {
 
 	if field.Type.String() != "String!" {
 		return gqlerror.ErrorPosf(

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -102,7 +102,8 @@ func parseSecrets(sch string) (map[string]string, error) {
 		}
 
 		val := strings.Trim(parts[3], `"`)
-		m[parts[2]] = val
+		key := strings.Trim(parts[2], `"`)
+		m[key] = val
 	}
 
 	if err := scanner.Err(); err != nil {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -178,7 +178,7 @@ func NewHandler(input string) (Handler, error) {
 		return nil, gqlerror.List{gqlErr}
 	}
 
-	gqlErrList = postGQLValidation(sch, defns)
+	gqlErrList = postGQLValidation(sch, defns, schemaSecrets)
 	if gqlErrList != nil {
 		return nil, gqlErrList
 	}
@@ -209,6 +209,8 @@ type headersConfig struct {
 	// in the @custom directive. They are returned to the client as part of
 	// Access-Control-Allow-Headers.
 	allowed string
+	// secrets are key value pairs stored in the GraphQL schema which can be added as headers
+	// to requests which resolve custom queries/mutations.
 	secrets map[string]string
 	sync.RWMutex
 }

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -80,8 +80,18 @@ func (s *handler) DisableSubscription() {
 func parseSecrets(sch string) (map[string]string, error) {
 	m := make(map[string]string)
 	scanner := bufio.NewScanner(strings.NewReader(sch))
+	seenAuthSecret := false
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
+
+		if strings.HasPrefix(text, "# Dgraph.Authorization") {
+			if seenAuthSecret {
+				return nil, errors.Errorf("Dgraph.Authorization should be only be specified once in "+
+					"a schema, found second mention: %v", text)
+			}
+			seenAuthSecret = true
+			continue
+		}
 		if !strings.HasPrefix(text, "# Dgraph.Secret") {
 			continue
 		}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -124,9 +124,14 @@ func NewHandler(input string) (Handler, error) {
 		return nil, gqlerror.Errorf("No schema specified")
 	}
 
-	schemaSecrets, err := parseSecrets(input)
+	secrets, err := parseSecrets(input)
 	if err != nil {
 		return nil, err
+	}
+	// lets obfuscate the value of the secrets from here on.
+	schemaSecrets := make(map[string]x.SensitiveByteSlice, len(secrets))
+	for k, v := range secrets {
+		schemaSecrets[k] = x.SensitiveByteSlice([]byte(v))
 	}
 
 	// The input schema contains just what's required to describe the types,
@@ -223,7 +228,7 @@ type headersConfig struct {
 	allowed string
 	// secrets are key value pairs stored in the GraphQL schema which can be added as headers
 	// to requests which resolve custom queries/mutations.
-	secrets map[string]string
+	secrets map[string]x.SensitiveByteSlice
 	sync.RWMutex
 }
 

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -204,7 +204,7 @@ func NewHandler(input string) (Handler, error) {
 	hc.Lock()
 	hc.allowed = headers
 	hc.secrets = schemaSecrets
-	defer hc.Unlock()
+	hc.Unlock()
 
 	return &handler{
 		input:          input,

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -109,12 +109,11 @@ func parseSecrets(sch string) (map[string]string, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, errors.Wrapf(err, "while trying to parse secrets from schema file")
 	}
-	if authSecret != "" {
-		if err := authorization.ParseAuthMeta(authSecret); err != nil {
-			return nil, err
-		}
+	if authSecret == "" {
+		return m, nil
 	}
-	return m, nil
+	err := authorization.ParseAuthMeta(authSecret)
+	return m, err
 }
 
 // NewHandler processes the input schema. If there are no errors, it returns

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -17,6 +17,7 @@
 package schema
 
 import (
+	"bufio"
 	"fmt"
 	"sort"
 	"strings"
@@ -76,6 +77,30 @@ func (s *handler) DisableSubscription() {
 	s.completeSchema.Subscription = nil
 }
 
+func parseSecrets(sch string) (map[string]string, error) {
+	m := make(map[string]string)
+	scanner := bufio.NewScanner(strings.NewReader(sch))
+	for scanner.Scan() {
+		text := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(text, "# Dgraph.Secret") {
+			continue
+		}
+		parts := strings.Fields(text)
+		if len(parts) != 4 {
+			return nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
+				"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+		}
+
+		val := strings.Trim(parts[3], `"`)
+		m[parts[2]] = val
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, errors.Wrapf(err, "while trying to parse secrets from schema file")
+	}
+	return m, nil
+}
+
 // NewHandler processes the input schema. If there are no errors, it returns
 // a valid Handler, otherwise it returns nil and an error.
 func NewHandler(input string) (Handler, error) {
@@ -84,6 +109,11 @@ func NewHandler(input string) (Handler, error) {
 	}
 
 	if err := authorization.ParseAuthMeta(input); err != nil {
+		return nil, err
+	}
+
+	schemaSecrets, err := parseSecrets(input)
+	if err != nil {
 		return nil, err
 	}
 
@@ -161,9 +191,10 @@ func NewHandler(input string) (Handler, error) {
 		return nil, gqlerror.Errorf("No query or mutation found in the generated schema")
 	}
 
-	ah.Lock()
-	ah.headers = headers
-	defer ah.Unlock()
+	hc.Lock()
+	hc.allowed = headers
+	hc.secrets = schemaSecrets
+	defer hc.Unlock()
 
 	return &handler{
 		input:          input,
@@ -173,13 +204,17 @@ func NewHandler(input string) (Handler, error) {
 	}, nil
 }
 
-type allowedHeaders struct {
-	headers string // comma separated list of allowed headers
+type headersConfig struct {
+	// comma separated list of allowed headers. These are parsed from the forwardHeaders specified
+	// in the @custom directive. They are returned to the client as part of
+	// Access-Control-Allow-Headers.
+	allowed string
+	secrets map[string]string
 	sync.RWMutex
 }
 
-var ah = allowedHeaders{
-	headers: x.AccessControlAllowedHeaders,
+var hc = headersConfig{
+	allowed: x.AccessControlAllowedHeaders,
 }
 
 func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
@@ -233,9 +268,9 @@ func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
 }
 
 func AllowedHeaders() string {
-	ah.RLock()
-	defer ah.RUnlock()
-	return ah.headers
+	hc.RLock()
+	defer hc.RUnlock()
+	return hc.allowed
 }
 
 func getAllSearchIndexes(val *ast.Value) []string {

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -76,9 +76,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -67,6 +67,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -81,9 +81,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -72,6 +72,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -69,9 +69,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -60,6 +60,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -86,9 +86,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -77,6 +77,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -70,9 +70,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -61,6 +61,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -69,9 +69,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -60,6 +60,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -65,9 +65,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -56,6 +56,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -65,9 +65,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -56,6 +56,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -79,9 +79,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -70,6 +70,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -79,9 +79,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -70,6 +70,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -78,9 +78,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -69,6 +69,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -72,9 +72,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -63,6 +63,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -89,9 +89,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -80,6 +80,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -90,9 +90,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -81,6 +81,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -89,9 +89,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -80,6 +80,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -70,9 +70,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -61,6 +61,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -72,9 +72,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -63,6 +63,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -74,9 +74,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -65,6 +65,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -74,9 +74,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -65,6 +65,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -96,9 +96,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -87,6 +87,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -96,9 +96,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -87,6 +87,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -64,9 +64,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -55,6 +55,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -76,9 +76,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -67,6 +67,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -65,9 +65,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -56,6 +56,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -74,9 +74,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -65,6 +65,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -91,9 +91,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -82,6 +82,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -73,9 +73,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -67,9 +67,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -58,6 +58,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -80,9 +80,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -71,6 +71,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -72,9 +72,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -63,6 +63,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -72,9 +72,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -63,6 +63,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -72,9 +72,9 @@ directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFI
 directive @id on FIELD_DEFINITION
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
-	query: AuthRule, 
-	add: AuthRule, 
-	update: AuthRule, 
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -63,6 +63,7 @@ input CustomHTTP {
 	graphql: String
 	mode: Mode
 	forwardHeaders: [String!]
+	secretHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -841,7 +841,7 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 		for _, h := range forwardHeaders.Children {
 			// We try and fetch the value from the stored secrets. If there was a value specified
 			// in the request header, that takes precedence.
-			val := hc.secrets[h.Value.Raw]
+			val := string(hc.secrets[h.Value.Raw])
 			reqHeaderVal := f.op.header.Get(h.Value.Raw)
 			if reqHeaderVal != "" {
 				val = reqHeaderVal

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -931,6 +932,7 @@ func TestParseSecrets(t *testing.T) {
 				require.EqualError(t, err, test.err.Error())
 				return
 			}
+			fmt.Println(s)
 			require.Equal(t, test.expectedSecrets, s)
 			if test.expectedAuthHeader != "" {
 				require.Equal(t, test.expectedAuthHeader, authorization.GetHeader())

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -897,7 +897,7 @@ func TestParseSecrets(t *testing.T) {
 				name: String!
 			}
 
-			# Dgraph.Secret  GITHUB_API_TOKEN   some-super-secret-token
+			# Dgraph.Secret  "GITHUB_API_TOKEN"   some-super-secret-token
 			# Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims HS256 "key"
 			# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
 			`,
@@ -932,7 +932,9 @@ func TestParseSecrets(t *testing.T) {
 				return
 			}
 			require.Equal(t, test.expectedSecrets, s)
-			require.Equal(t, test.expectedAuthHeader, authorization.GetHeader())
+			if test.expectedAuthHeader != "" {
+				require.Equal(t, test.expectedAuthHeader, authorization.GetHeader())
+			}
 		})
 	}
 }

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -18,7 +18,6 @@ package schema
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -932,7 +931,7 @@ func TestParseSecrets(t *testing.T) {
 				require.EqualError(t, err, test.err.Error())
 				return
 			}
-			fmt.Println(s)
+
 			require.Equal(t, test.expectedSecrets, s)
 			if test.expectedAuthHeader != "" {
 				require.Equal(t, test.expectedAuthHeader, authorization.GetHeader())


### PR DESCRIPTION
This PR adds support for reading and parsing secrets from the GraphQL schema file and filling them in if they are specified in `forwardHeaders` before resolving a custom query/mutation/field.
Fixes GRAPHQL-339

TODO
---
- [x] Also send these for introspection requests.
- [x] Add a test case which checks headers are sent for introspection queries as well.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5440)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-db9fdf8586-65101.surge.sh)
<!-- Dgraph:end -->