### PR TITLE
Cherry-Pick v20.03: Use SensitiveByteSlice type for hmac secret (#5445)

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -161,7 +161,7 @@ func validateToken(jwtStr string) ([]string, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
-		return worker.Config.HmacSecret, nil
+		return []byte(worker.Config.HmacSecret), nil
 	})
 
 	if err != nil {
@@ -233,7 +233,7 @@ func getAccessJwt(userId string, groups []acl.Group) (string, error) {
 		"exp": time.Now().Add(worker.Config.AccessJwtTtl).Unix(),
 	})
 
-	jwtString, err := token.SignedString(worker.Config.HmacSecret)
+	jwtString, err := token.SignedString([]byte(worker.Config.HmacSecret))
 	if err != nil {
 		return "", errors.Errorf("unable to encode jwt to string: %v", err)
 	}
@@ -248,7 +248,7 @@ func getRefreshJwt(userId string) (string, error) {
 		"exp":    time.Now().Add(worker.Config.RefreshJwtTtl).Unix(),
 	})
 
-	jwtString, err := token.SignedString(worker.Config.HmacSecret)
+	jwtString, err := token.SignedString([]byte(worker.Config.HmacSecret))
 	if err != nil {
 		return "", errors.Errorf("unable to encode jwt to string: %v", err)
 	}

--- a/graphql/admin/current_user.go
+++ b/graphql/admin/current_user.go
@@ -45,7 +45,7 @@ func extractName(ctx context.Context) (string, error) {
 			return nil, errors.Errorf("unexpected signing method: %v",
 				token.Header["alg"])
 		}
-		return worker.Config.HmacSecret, nil
+		return []byte(worker.Config.HmacSecret), nil
 	})
 
 	if err != nil {

--- a/worker/config.go
+++ b/worker/config.go
@@ -17,7 +17,6 @@
 package worker
 
 import (
-	"fmt"
 	"path/filepath"
 	"time"
 
@@ -60,7 +59,7 @@ type Options struct {
 	AllottedMemory float64
 
 	// HmacSecret stores the secret used to sign JSON Web Tokens (JWT).
-	HmacSecret []byte
+	HmacSecret x.SensitiveByteSlice
 	// AccessJwtTtl is the TTL for the access JWT.
 	AccessJwtTtl time.Duration
 	// RefreshJwtTtl is the TTL of the refresh JWT.
@@ -71,20 +70,6 @@ type Options struct {
 
 // Config holds an instance of the server options..
 var Config Options
-
-// String will generate the string output an Options struct without including
-// the HmacSecret field, which prevents revealing the secret during logging
-func (opt *Options) String() string {
-	if opt == nil {
-		return ""
-	}
-
-	return fmt.Sprintf("{PostingDir:%s BadgerTables:%s BadgerVlog:%s WALDir:%s MutationsMode:%d "+
-		"AuthToken:%s AllottedMemory:%.1fMB AccessJwtTtl:%v RefreshJwtTtl:%v "+
-		"AclRefreshInterval:%v}", opt.PostingDir, opt.BadgerTables, opt.BadgerVlog, opt.WALDir,
-		opt.MutationsMode, opt.AuthToken, opt.AllottedMemory, opt.AccessJwtTtl, opt.RefreshJwtTtl,
-		opt.AclRefreshInterval)
-}
 
 // SetConfiguration sets the server configuration to the given config.
 func SetConfiguration(newConfig *Options) {

--- a/x/types.go
+++ b/x/types.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015-2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package x
+
+// SensitiveByteSlice implements the Stringer interface to redact its contents.
+// Use this type for sensitive info such as keys, passwords, or secrets so it doesn't leak
+// as output such as logs.
+type SensitiveByteSlice []byte
+
+func (SensitiveByteSlice) String() string {
+	return "****"
+}

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -17,10 +17,18 @@
 package x
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestSensitiveByteSlice(t *testing.T) {
+	var v SensitiveByteSlice = SensitiveByteSlice("mysecretkey")
+
+	s := fmt.Sprintf("%s,%v,%s,%+v", v, v, &v, &v)
+	require.EqualValues(t, "****,****,****,****", s)
+}
 
 func TestRemoveDuplicates(t *testing.T) {
 	set := RemoveDuplicates([]string{"a", "a", "a", "b", "b", "c", "c"})


### PR DESCRIPTION
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5450)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-fd81269a7b-64118.surge.sh)
<!-- Dgraph:end -->