### PR TITLE
graphql: support existing gqlschema nodes without xid

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -468,6 +468,15 @@ func upsertEmptyGQLSchema() (*gqlSchema, error) {
 	xidInSchemaVar := "XidInSchema"
 	gqlType := "dgraph.graphql"
 
+	/*
+		query {
+		  ExistingGQLSchema as ExistingGQLSchema(func: type(dgraph.graphql)) {
+		    uid
+		    dgraph.graphql.schema
+		    XidInSchema as dgraph.graphql.xid
+		  }
+		}
+	*/
 	qry := &gql.GraphQuery{
 		Attr: existingSchemaVar,
 		Var:  existingSchemaVar,
@@ -482,6 +491,22 @@ func upsertEmptyGQLSchema() (*gqlSchema, error) {
 		},
 	}
 
+	/*
+		mutation @if(eq(len(ExistingGQLSchema),1) AND eq(len(XidInSchema),0)) {
+			set {
+				"uid": "uid(ExistingGQLSchema)",
+				"dgraph.graphql.xid": "dgraph.graphql.schema"
+			}
+		}
+		mutation @if(eq(len(ExistingGQLSchema),0) AND eq(len(XidInSchema),0))
+			set {
+				"uid": "_:XidInSchema",
+				"dgraph.type": ["dgraph.graphql"],
+				"dgraph.graphql.xid": "dgraph.graphql.schema",
+				"dgraph.graphql.schema": ""
+			}
+		}
+	*/
 	mutations := []*dgoapi.Mutation{
 		{
 			SetJson: []byte(fmt.Sprintf(`

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -321,6 +321,7 @@ func admin(t *testing.T) {
 	addGQLSchema(t, client)
 	updateSchema(t, client)
 	updateSchemaThroughAdminSchemaEndpt(t, client)
+	gqlSchemaNodeHasXid(t, client)
 }
 
 func schemaIsInInitialState(t *testing.T, client *dgo.Dgraph) {
@@ -364,6 +365,21 @@ func updateSchemaThroughAdminSchemaEndpt(t *testing.T, client *dgo.Dgraph) {
 	require.JSONEq(t, adminSchemaEndptSchema, string(resp.GetJson()))
 
 	introspect(t, adminSchemaEndptGQLSchema)
+}
+
+func gqlSchemaNodeHasXid(t *testing.T, client *dgo.Dgraph) {
+	resp, err := client.NewReadOnlyTxn().Query(context.Background(), `query {
+		gqlSchema(func: type(dgraph.graphql)) {
+			dgraph.graphql.xid
+		}
+	}`)
+	require.NoError(t, err)
+	// confirm that there is only one node of type dgraph.graphql and it has xid.
+	require.JSONEq(t, `{
+		"gqlSchema": [{
+			"dgraph.graphql.xid": "dgraph.graphql.schema"
+		}]
+	}`, string(resp.GetJson()))
 }
 
 func introspect(t *testing.T, expected string) {


### PR DESCRIPTION
This PR adds support for adding xid to existing gqlschema nodes as it was not taken into consideration in #5054.

Fixes #GRAPHQL-417.
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5457)
<!-- Reviewable:end -->
