### PR TITLE
graphql: ensure upserts don't have accidental edge removal (#5356)

### DIFF
--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -1294,8 +1294,8 @@ func updateMutationOnlyUpdatesRefsIfDifferent(t *testing.T, executeRequest reque
 					set: $set
 				}
 			) {
-			  	post { 
-					postID 
+			  	post {
+					postID
 					text
 					author { id }
 				}
@@ -1315,9 +1315,9 @@ func updateMutationOnlyUpdatesRefsIfDifferent(t *testing.T, executeRequest reque
 	// The text is updated as expected
 	// The author is unchanged
 	expected := fmt.Sprintf(`
-		{ "updatePost": {  "post": [ 
-			{ 
-				"postID": "%s", 
+		{ "updatePost": {  "post": [
+			{
+				"postID": "%s",
 				"text": "The Updated Text",
 				"author": { "id": "%s" }
 			}


### PR DESCRIPTION
Fixes #5355

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5463)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-4f2f08a7e7-64630.surge.sh)
<!-- Dgraph:end -->