### PR TITLE
Edit test cases to remove flaky behavior

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -699,7 +699,7 @@ func populateCluster() {
 		<52> <connects> <54>  (weight=10) .
 
 		<54> <connects> <51>  (weight=10) .
-		<54> <connects> <52>  (weight=1) .
+		<54> <connects> <52>  (weight=2) .
 		<54> <connects> <53>  (weight=10) .
 		<54> <connects> <55>  (weight=1) .
 

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -693,7 +693,7 @@ func TestKShortestPathTwoPaths(t *testing.T) {
 	query := `
 	{
 		A as shortest(from: 51, to:55, numpaths: 2, depth:2) {
-			connects
+			connects @facets(weight)
 		}
 		me(func: uid(A)) {
 			name
@@ -702,44 +702,44 @@ func TestKShortestPathTwoPaths(t *testing.T) {
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{
 		"data": {
-			"me": [
-			  {
-				"name": "A"
-			  },
-			  {
-				"name": "D"
-			  },
-			  {
-				"name": "E"
-			  }
-			],
-			"_path_": [
-			  {
-				"connects": {
-				  "connects": {
-					"uid": "0x37"
-				  },
-				  "uid": "0x36"
-				},
-				"uid": "0x33",
-				"_weight_": 2
-			  },
-			  {
-				"connects": {
-				  "connects": {
-					"connects": {
-					  "uid": "0x37"
-					},
-					"uid": "0x36"
-				  },
-				  "uid": "0x34"
-				},
-				"uid": "0x33",
-				"_weight_": 3
-			  }
-			]
+		 "me": [
+		  {"name": "A"},
+		  {"name": "C"},
+		  {"name": "D"},
+		  {"name": "E"}
+		 ],
+		 "_path_": [
+		  {
+		   "connects": {
+			"connects": {
+			 "connects": {
+			  "uid": "0x37"
+			 },
+			 "connects|weight": 1,
+			 "uid": "0x36"
+			},
+			"connects|weight": 1,
+			"uid": "0x35"
+		   },
+		   "connects|weight": 1,
+		   "uid": "0x33",
+		   "_weight_": 3
+		  },
+		  {
+		   "connects": {
+			"connects": {
+			 "uid": "0x37"
+			},
+			"connects|weight": 1,
+			"uid": "0x36"
+		   },
+		   "connects|weight": 10,
+		   "uid": "0x33",
+		   "_weight_": 11
+		  }
+		 ]
 		}
-	}`, js)
+	   }`, js)
 }
 
 // There are 5 paths between 51 to 55 under "connects" predicate.
@@ -1111,7 +1111,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 							"connects": {
 								"uid": "0x34"
 							},
-							"connects|weight": 1,
+							"connects|weight": 2,
 							"uid": "0x36"
 						},
 						"connects|weight": 1,
@@ -1119,7 +1119,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 					},
 					"connects|weight": 1,
 					"uid": "0x33",
-					"_weight_": 3
+					"_weight_": 4
 				}
 			]
 		}
@@ -1142,7 +1142,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 			 "connects": {
 			  "uid": "0x34"
 			 },
-			 "connects|weight": 1,
+			 "connects|weight": 2,
 			 "uid": "0x36"
 			},
 			"connects|weight": 1,
@@ -1150,7 +1150,7 @@ func TestShortestPathWithDepth(t *testing.T) {
 		   },
 		   "connects|weight": 1,
 		   "uid": "0x33",
-		   "_weight_": 3
+		   "_weight_": 4
 		  },
 		  {
 		   "connects": {
@@ -1177,12 +1177,12 @@ func TestShortestPathWithDepth(t *testing.T) {
 			"connects": {
 			 "uid": "0x34"
 			},
-			"connects|weight": 1,
+			"connects|weight": 2,
 			"uid": "0x36"
 		   },
 		   "connects|weight": 10,
 		   "uid": "0x33",
-		   "_weight_": 11
+		   "_weight_": 12
 		  },
 		  {
 		   "connects": {
@@ -1302,9 +1302,9 @@ func TestShortestPathWithDepth_direct_path_is_shortest(t *testing.T) {
 					"connects": {
 						"uid": "0x34"
 					},
-					"connects|weight": 1,
+					"connects|weight": 2,
 					"uid": "0x36",
-					"_weight_": 1
+					"_weight_": 2
 				}
 			]
 		}


### PR DESCRIPTION
This PR edits test cases to remove non-deterministic behavior in shortest path queries when there are more than one paths with identical cost. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5464)
<!-- Reviewable:end -->
