### PR TITLE
Return nil instead of emptyTablet in groupi.Tablet()

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -461,8 +461,6 @@ func (g *groupi) ServesTablet(key string) (bool, error) {
 
 // Do not modify the returned Tablet
 func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
-	emptyTablet := pb.Tablet{}
-
 	// TODO: Remove all this later, create a membership state and apply it
 	g.RLock()
 	tablet, ok := g.tablets[key]
@@ -480,7 +478,7 @@ func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
 	out, err := zc.ShouldServe(context.Background(), tablet)
 	if err != nil {
 		glog.Errorf("Error while ShouldServe grpc call %v", err)
-		return &emptyTablet, err
+		return nil, err
 	}
 
 	// Do not store tablets with group ID 0, as they are just dummy tablets for


### PR DESCRIPTION
`groupi.Tablet()` returns error and empty Tablet when error is returned while querying zero for Tablet
serving info. This results in allocation of space by empty Tablet and it shows up in alloc_space
profile.

```go
         .          .    463:func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
      16.22GB    16.22GB    464:	emptyTablet := pb.Tablet{}
         .          .    465:
         .          .    466:	// TODO: Remove all this later, create a membership state and apply it
         .          .    467:	g.RLock()
         .          .    468:	tablet, ok := g.tablets[key]
         .          .    469:	g.RUnlock()
         .          .    470:	if ok {
         .          .    471:		return tablet, nil
         .          .    472:	}
         .          .    473:
         .          .    474:	// We don't know about this tablet.
         .          .    475:	// Check with dgraphzero if we can serve it.
         .          .    476:	pl := g.connToZeroLeader()
         .          .    477:	zc := pb.NewZeroClient(pl.Get())
         .          .    478:
         .          .    479:	tablet = &pb.Tablet{GroupId: g.groupId(), Predicate: key}
         .     1.07MB    480:	out, err := zc.ShouldServe(context.Background(), tablet)
         .          .    481:	if err != nil {
         .          .    482:		glog.Errorf("Error while ShouldServe grpc call %v", err)
         .          .    483:		return &emptyTablet, err
         .          .    484:	}
```

This can be avoided. We can return nil instead of emptyTablet and save
allocations here. Caller function always checks for error first before
accessing tablet information.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5469)
<!-- Reviewable:end -->
