### PR TITLE
Fix memory leak in live loader

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -216,7 +216,9 @@ func (l *loader) uid(val string) string {
 		}
 	}
 
-	uid, _ := l.alloc.AssignUid(val)
+	sb := strings.Builder{}
+	x.Check2(sb.WriteString(val))
+	uid, _ := l.alloc.AssignUid(sb.String())
 	return fmt.Sprintf("%#x", uint64(uid))
 }
 


### PR DESCRIPTION
This PR aims to fix a memory leak in live loader. Currently while getting uid for a NQuad
subject/uid object, we call `xidMap.AssignUid()`. This subject/uid object is of string type.
We suspect that these uids(strings) are still holding references to original string, which
we get after reading single lines in `checker.Parse()`. Hence GC is unable to clean these strings.
In this PR, while getting uid for any NQuad subject/uid object, we pass a copy of it to
`xidMap.AssignUid()`.

Original profile:
```
File: dgraph
Build ID: b80d1c50901c66e79b21afb1ed72a92bed950dc9
Type: inuse_space
Time: May 19, 2020 at 3:52pm (IST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 62468.74MB, 100% of 62486.76MB total
Dropped 28 nodes (cum <= 312.43MB)
      flat  flat%   sum%        cum   cum%
42551.37MB 68.10% 68.10% 42551.37MB 68.10%  github.com/dgraph-io/dgraph/xidmap.(*XidMap).AssignUid
19902.91MB 31.85% 99.95% 19902.91MB 31.85%  bytes.(*Buffer).ReadString
   13.50MB 0.022%   100% 19923.42MB 31.88%  github.com/dgraph-io/dgraph/chunker.(*rdfChunker).Parse
    0.95MB 0.0015%   100% 42554.34MB 68.10%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).processLoadFile.func1
         0     0%   100% 19931.42MB 31.90%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).processFile
         0     0%   100% 19931.42MB 31.90%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).processLoadFile
         0     0%   100% 42553.38MB 68.10%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).uid
         0     0%   100% 19931.42MB 31.90%  github.com/dgraph-io/dgraph/dgraph/cmd/live.run.func2
```

This PR:
```
File: dgraph
Build ID: d49e85006a57b932fa73218470d0e0b97fbb81d8
Type: inuse_space
Time: May 19, 2020 at 7:33pm (IST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 28967.65MB, 99.43% of 29134.97MB total
Dropped 71 nodes (cum <= 145.67MB)
      flat  flat%   sum%        cum   cum%
16028.87MB 55.02% 55.02% 16034.87MB 55.04%  github.com/dgraph-io/dgraph/xidmap.(*XidMap).AssignUid
12928.89MB 44.38% 99.39% 12928.89MB 44.38%  strings.(*Builder).WriteString
    8.88MB  0.03% 99.42% 28990.15MB 99.50%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).processLoadFile.func1
       1MB 0.0034% 99.43% 28975.27MB 99.45%  github.com/dgraph-io/dgraph/dgraph/cmd/live.(*loader).uid

```

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5473)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d6241d9a06-65507.surge.sh)
<!-- Dgraph:end -->