### PR TITLE
During shutdown, generate snapshot before closing raft node.

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -292,13 +292,14 @@ func run() {
 
 		// Stop all HTTP requests.
 		_ = httpListener.Close()
+		// Try to generate a snapshot before the shutdown.
+		st.node.trySnapshot(0)
 		// Stop Raft.
 		st.node.closer.SignalAndWait()
 		// Stop Raft store.
 		store.Closer.SignalAndWait()
 		// Stop all internal requests.
 		_ = grpcListener.Close()
-		st.node.trySnapshot(0)
 	}()
 
 	glog.Infoln("Running Dgraph Zero...")

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -292,10 +292,10 @@ func run() {
 
 		// Stop all HTTP requests.
 		_ = httpListener.Close()
-		// Try to generate a snapshot before the shutdown.
-		st.node.trySnapshot(0)
 		// Stop Raft.
 		st.node.closer.SignalAndWait()
+		// Try to generate a snapshot before the shutdown.
+		st.node.trySnapshot(0)
 		// Stop Raft store.
 		store.Closer.SignalAndWait()
 		// Stop all internal requests.


### PR DESCRIPTION
This will prevent trySnapshot from trying to send a range to the index
range channel before it's closed.

Fixes DGRAPH-1574

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5476)
<!-- Reviewable:end -->
