### PR TITLE
graphql: move alias to end of graphql pipeline (#5369)

### DIFF
--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -144,7 +144,7 @@ func doQuery(gql *gqlSchema, field schema.Field) ([]byte, error) {
 
 	var buf bytes.Buffer
 	x.Check2(buf.WriteString(`{ "`))
-	x.Check2(buf.WriteString(field.ResponseName()))
+	x.Check2(buf.WriteString(field.Name()))
 	x.Check2(buf.WriteString(`": [{`))
 
 	for i, sel := range field.SelectionSet() {
@@ -164,7 +164,7 @@ func doQuery(gql *gqlSchema, field schema.Field) ([]byte, error) {
 			x.Check2(buf.WriteString(","))
 		}
 		x.Check2(buf.WriteString(`"`))
-		x.Check2(buf.WriteString(sel.ResponseName()))
+		x.Check2(buf.WriteString(sel.Name()))
 		x.Check2(buf.WriteString(`":`))
 		x.Check2(buf.Write(val))
 	}

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgo/v2"
 	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
@@ -428,6 +429,35 @@ func health(t *testing.T) {
 	if diff := cmp.Diff(health, result.Health, opts...); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
+}
+
+// The /admin endpoints should respond to alias
+func adminAlias(t *testing.T) {
+	queryParams := &GraphQLParams{
+		Query: `query {
+            dgraphHealth: health {
+              type: instance
+              status
+              inGroup: group
+            }
+        }`,
+	}
+	gqlResponse := queryParams.ExecuteAsPost(t, graphqlAdminTestAdminURL)
+	requireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t, `{
+        "dgraphHealth": [
+          {
+            "type": "zero",
+            "status": "healthy",
+            "inGroup": "0"
+          },
+          {
+            "type": "alpha",
+            "status": "healthy",
+            "inGroup": "1"
+          }
+        ]
+      }`, string(gqlResponse.Data))
 }
 
 // The GraphQL /admin state result should be the same as /state

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -212,6 +212,7 @@ func RunAll(t *testing.T) {
 	// admin tests
 	t.Run("admin", admin)
 	t.Run("health", health)
+	t.Run("alias should work in admin", adminAlias)
 	t.Run("state", adminState)
 	t.Run("propagate client remote ip", clientInfoLogin)
 
@@ -264,6 +265,7 @@ func RunAll(t *testing.T) {
 	t.Run("query state by xid regex", queryStateByXidRegex)
 	t.Run("multiple operations", multipleOperations)
 	t.Run("query post with author", queryPostWithAuthor)
+	t.Run("alias works for queries", queryWithAlias)
 
 	// mutation tests
 	t.Run("add mutation", addMutation)
@@ -295,6 +297,7 @@ func RunAll(t *testing.T) {
 	t.Run("empty delete", mutationEmptyDelete)
 	t.Run("password in mutation", passwordTest)
 	t.Run("duplicate xid in single mutation", deepMutationDuplicateXIDsSameObjectTest)
+	t.Run("alias works for mutations", mutationsWithAlias)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -1401,3 +1401,27 @@ func queryPostWithAuthor(t *testing.T) {
 		`{"queryPost":[{"title":"Introducing GraphQL in Dgraph","author":{"name":"Ann Author"}}]}`,
 		string(gqlResponse.Data))
 }
+
+func queryWithAlias(t *testing.T) {
+	queryPostParams := &GraphQLParams{
+		Query: `query {
+			post : queryPost (filter: {title : { anyofterms : "Introducing" }} ) {
+				type : __typename
+				postTitle : title
+				postAuthor : author {
+					theName : name
+				}
+			}
+		}`,
+	}
+
+	gqlResponse := queryPostParams.ExecuteAsPost(t, graphqlURL)
+	requireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t,
+		`{
+			"post": [ {
+				"type": "Post",
+				"postTitle": "Introducing GraphQL in Dgraph",
+				"postAuthor": { "theName": "Ann Author" }}]}`,
+		string(gqlResponse.Data))
+}

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -177,7 +177,7 @@ func getNumUids(m schema.Mutation, a map[string]string, r map[string]interface{}
 	case schema.AddMutation:
 		return len(a)
 	default:
-		mutated := extractMutated(r, m.ResponseName())
+		mutated := extractMutated(r, m.Name())
 		return len(mutated)
 	}
 }
@@ -188,7 +188,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 
 	emptyResult := func(err error) *Resolved {
 		return &Resolved{
-			Data:  map[string]interface{}{mutation.ResponseName(): nil},
+			Data:  map[string]interface{}{mutation.Name(): nil},
 			Field: mutation,
 			Err:   err,
 		}
@@ -242,10 +242,9 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	if resolved.Data == nil && resolved.Err != nil {
 		return &Resolved{
 			Data: map[string]interface{}{
-				mutation.ResponseName(): map[string]interface{}{
-					schema.NumUid:                        numUids,
-					schema.Typename:                      mutation.TypeName,
-					mutation.QueryField().ResponseName(): nil,
+				mutation.Name(): map[string]interface{}{
+					schema.NumUid:                numUids,
+					mutation.QueryField().Name(): nil,
 				}},
 			Field: mutation,
 			Err:   err,
@@ -259,8 +258,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	dgRes := resolved.Data.(map[string]interface{})
 	dgRes[schema.NumUid] = numUids
 	dgRes[schema.Typename] = mutation.Type().Name()
-	resolved.Data = map[string]interface{}{mutation.ResponseName(): dgRes}
-
+	resolved.Data = map[string]interface{}{mutation.Name(): dgRes}
 	resolved.Field = mutation
 	return resolved, resolverSucceeded
 }
@@ -269,7 +267,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 func deleteCompletion() CompletionFunc {
 	return CompletionFunc(func(ctx context.Context, resolved *Resolved) {
 		if fld, ok := resolved.Data.(map[string]interface{}); ok {
-			if rsp, ok := fld[resolved.Field.ResponseName()].(map[string]interface{}); ok {
+			if rsp, ok := fld[resolved.Field.Name()].(map[string]interface{}); ok {
 				rsp["msg"] = "Deleted"
 			}
 		}

--- a/graphql/resolve/mutation_query_test.yaml
+++ b/graphql/resolve/mutation_query_test.yaml
@@ -20,41 +20,28 @@ ADD_UPDATE_MUTATION:
       }
 
   -
-    name: "with alias"
+    name: "alias is ignored in query rewriting"
     gqlquery: |
       mutation {
         ADD_UPDATE_MUTATION {
           result : post {
             postID
-            title
-          }
-        }
-      }
-    dgquery: |-
-      query {
-        result(func: uid(0x4)) {
-          postID : uid
-          title : Post.title
-          dgraph.uid : uid
-        }
-      }
-
-  -
-    name: "with field alias"
-    gqlquery: |
-      mutation {
-        ADD_UPDATE_MUTATION {
-          post {
-            id : postID
-            postTitle : title
+            titleAlias : title
+            theAuthor : author {
+              nameAlias : name
+            }
           }
         }
       }
     dgquery: |-
       query {
         post(func: uid(0x4)) {
-          id : uid
-          postTitle : Post.title
+          postID : uid
+          title : Post.title
+          author : Post.author {
+            name : Author.name
+            dgraph.uid : uid
+          }
           dgraph.uid : uid
         }
       }
@@ -100,35 +87,6 @@ ADD_UPDATE_MUTATION:
           title : Post.title
           author : Post.author {
             name : Author.name
-            dgraph.uid : uid
-          }
-          dgraph.uid : uid
-        }
-      }
-
-  -
-    name: "deep with alias"
-    gqlquery: |
-      mutation {
-        ADD_UPDATE_MUTATION {
-          post {
-            postID
-            title
-            postAuthor: author {
-              authorID: id
-              authorName: name
-            }
-          }
-        }
-      }
-    dgquery: |-
-      query {
-        post(func: uid(0x4)) {
-          postID : uid
-          title : Post.title
-          postAuthor : Post.author {
-            authorID : uid
-            authorName : Author.name
             dgraph.uid : uid
           }
           dgraph.uid : uid

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -463,7 +463,7 @@ func (urw *UpdateRewriter) FromMutationResult(
 		return nil, err
 	}
 
-	mutated := extractMutated(result, mutation.ResponseName())
+	mutated := extractMutated(result, mutation.Name())
 
 	var uids []uint64
 	if len(mutated) > 0 {
@@ -546,7 +546,7 @@ func RewriteUpsertQueryFromMutation(m schema.Mutation) *gql.GraphQuery {
 	// The query needs to assign the results to a variable, so that the mutation can use them.
 	dgQuery := &gql.GraphQuery{
 		Var:  MutationQueryVar,
-		Attr: m.ResponseName(),
+		Attr: m.Name(),
 	}
 	// Add uid child to the upsert query, so that we can get the list of nodes upserted.
 	dgQuery.Children = append(dgQuery.Children, &gql.GraphQuery{

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -71,7 +71,7 @@ func (qr *queryResolver) Resolve(ctx context.Context, query schema.Query) *Resol
 
 	resolved := qr.rewriteAndExecute(ctx, query)
 	if resolved.Data == nil {
-		resolved.Data = map[string]interface{}{query.ResponseName(): nil}
+		resolved.Data = map[string]interface{}{query.Name(): nil}
 	}
 
 	qr.resultCompleter.Complete(ctx, resolved)
@@ -82,7 +82,7 @@ func (qr *queryResolver) rewriteAndExecute(ctx context.Context, query schema.Que
 
 	emptyResult := func(err error) *Resolved {
 		return &Resolved{
-			Data:  map[string]interface{}{query.ResponseName(): nil},
+			Data:  map[string]interface{}{query.Name(): nil},
 			Field: query,
 			Err:   err,
 		}

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -164,7 +164,7 @@ func addUID(dgQuery *gql.GraphQuery) {
 
 func rewriteAsQueryByIds(field schema.Field, uids []uint64) *gql.GraphQuery {
 	dgQuery := &gql.GraphQuery{
-		Attr: field.ResponseName(),
+		Attr: field.Name(),
 		Func: &gql.Function{
 			Name: "uid",
 			UID:  uids,
@@ -210,7 +210,7 @@ func rewriteAsGet(field schema.Field, uid uint64, xid *string) *gql.GraphQuery {
 
 	if uid > 0 {
 		dgQuery = &gql.GraphQuery{
-			Attr: field.ResponseName(),
+			Attr: field.Name(),
 			Func: &gql.Function{
 				Name: "uid",
 				UID:  []uint64{uid},
@@ -222,7 +222,7 @@ func rewriteAsGet(field schema.Field, uid uint64, xid *string) *gql.GraphQuery {
 
 	} else {
 		dgQuery = &gql.GraphQuery{
-			Attr: field.ResponseName(),
+			Attr: field.Name(),
 			Func: eqXidFunc,
 		}
 	}
@@ -234,7 +234,7 @@ func rewriteAsGet(field schema.Field, uid uint64, xid *string) *gql.GraphQuery {
 
 func rewriteAsQuery(field schema.Field) *gql.GraphQuery {
 	dgQuery := &gql.GraphQuery{
-		Attr: field.ResponseName(),
+		Attr: field.Name(),
 	}
 
 	if ids := idFilter(field, field.Type().IDField()); ids != nil {
@@ -299,11 +299,7 @@ func addSelectionSetFrom(q *gql.GraphQuery, field schema.Field) {
 
 		child := &gql.GraphQuery{}
 
-		if f.Alias() != "" {
-			child.Alias = f.Alias()
-		} else {
-			child.Alias = f.Name()
-		}
+		child.Alias = f.Name()
 
 		if f.Type().Name() == schema.IDType {
 			child.Attr = "uid"

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -15,68 +15,47 @@
     }
 
 -
-  name: "UID alias"
-  gqlquery: |
-    query {
-      getAuthor(id: "0x1") {
-        id
-        uid: name
-      }
-    }
-  dgquery: |-
-    query {
-      getAuthor(func: uid(0x1)) @filter(type(Author)) {
-        id : uid
-        uid : Author.name
-        dgraph.uid : uid
-      }
-    }
-
--
-  name: "UID alias without id"
-  gqlquery: |
-    query {
-      getAuthor(id: "0x1") {
-        uid: name
-      }
-    }
-  dgquery: |-
-    query {
-      getAuthor(func: uid(0x1)) @filter(type(Author)) {
-        uid : Author.name
-        dgraph.uid : uid
-      }
-    }
-
-
--
-  name: "ID query with query alias"
+  name: "Alias is ignored in query rewriting - get"
   gqlquery: |
     query {
       author : getAuthor(id: "0x1") {
-        name
-      }
-    }
-  dgquery: |-
-    query {
-      author(func: uid(0x1)) @filter(type(Author)) {
-        name : Author.name
-        dgraph.uid : uid
-      }
-    }
-
--
-  name: "ID query with field alias"
-  gqlquery: |
-    query {
-      getAuthor(id: "0x1") {
-        authName : name
+        anAlias : name
+        postAlias : posts {
+          titleAlias : title
+        }
       }
     }
   dgquery: |-
     query {
       getAuthor(func: uid(0x1)) @filter(type(Author)) {
-        authName : Author.name
+        name : Author.name
+        posts : Author.posts {
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Alias is ignored in query rewriting - query"
+  gqlquery: |
+    query {
+      author : queryAuthor {
+        anAlias : name
+        postAlias : posts {
+          titleAlias : title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts {
+          title : Post.title
+          dgraph.uid : uid
+        }
         dgraph.uid : uid
       }
     }
@@ -125,41 +104,16 @@
     }
 
 -
-  name: "ID query with depth and alias"
-  gqlquery: |
-    query {
-      getAuthor(id: "0x1") {
-        name
-        allPosts : posts {
-          postTitle : title
-          postText : text
-        }
-      }
-    }
-  dgquery: |-
-    query {
-      getAuthor(func: uid(0x1)) @filter(type(Author)) {
-        name : Author.name
-        allPosts : Author.posts {
-          postTitle : Post.title
-          postText : Post.text
-          dgraph.uid : uid
-        }
-        dgraph.uid : uid
-      }
-    }
-
--
   name: "ID query deep"
   gqlquery: |
     query {
       getAuthor(id: "0x1") {
         name
-        allPosts : posts {
+        posts {
           title
           text
           author {
-            authorID : id
+            id
             name
           }
         }
@@ -169,11 +123,11 @@
     query {
       getAuthor(func: uid(0x1)) @filter(type(Author)) {
         name : Author.name
-        allPosts : Author.posts {
+        posts : Author.posts {
           title : Post.title
           text : Post.text
           author : Post.author {
-            authorID : uid
+            id : uid
             name : Author.name
             dgraph.uid : uid
           }

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -122,7 +122,7 @@ func (ex *executor) Execute(ctx context.Context, req *dgoapi.Request) (*dgoapi.R
 //
 // The []bytes built by Resolve() have some other properties, such as ordering of
 // fields, which are tested by TestResponseOrder().
-func TestResolver(t *testing.T) {
+func TestGraphQLErrorPropagation(t *testing.T) {
 	b, err := ioutil.ReadFile("resolver_error_test.yaml")
 	require.NoError(t, err, "Unable to read test file")
 
@@ -141,65 +141,6 @@ func TestResolver(t *testing.T) {
 			}
 
 			require.JSONEq(t, tcase.Expected, resp.Data.String(), tcase.Explanation)
-		})
-	}
-}
-
-// Ordering of results and inserted null values matters in GraphQL:
-// https://graphql.github.io/graphql-spec/June2018/#sec-Serialized-Map-Ordering
-func TestResponseOrder(t *testing.T) {
-	query := `query {
-		 getAuthor(id: "0x1") {
-			 name
-			 dob
-			 postsNullable {
-				 title
-				 text
-			 }
-		 }
-	 }`
-
-	tests := []QueryCase{
-		{Name: "Response is in same order as GQL query",
-			GQLQuery: query,
-			Response: `{ "getAuthor": [ { "name": "A.N. Author", "dob": "2000-01-01", ` +
-				`"postsNullable": [ ` +
-				`{ "title": "A Title", "text": "Some Text" }, ` +
-				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
-			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": "2000-01-01", ` +
-				`"postsNullable": [` +
-				`{"title": "A Title", "text": "Some Text"}, ` +
-				`{"title": "Another Title", "text": "More Text"}]}}`},
-		{Name: "Response is in same order as GQL query no matter Dgraph order",
-			GQLQuery: query,
-			Response: `{ "getAuthor": [ { "dob": "2000-01-01", "name": "A.N. Author", ` +
-				`"postsNullable": [ ` +
-				`{ "text": "Some Text", "title": "A Title" }, ` +
-				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
-			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": "2000-01-01", ` +
-				`"postsNullable": [` +
-				`{"title": "A Title", "text": "Some Text"}, ` +
-				`{"title": "Another Title", "text": "More Text"}]}}`},
-		{Name: "Inserted null is in GQL query order",
-			GQLQuery: query,
-			Response: `{ "getAuthor": [ { "name": "A.N. Author", ` +
-				`"postsNullable": [ ` +
-				`{ "title": "A Title" }, ` +
-				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
-			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": null, ` +
-				`"postsNullable": [` +
-				`{"title": "A Title", "text": null}, ` +
-				`{"title": "Another Title", "text": "More Text"}]}}`},
-	}
-
-	gqlSchema := test.LoadSchemaFromString(t, testGQLSchema)
-
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			resp := resolve(gqlSchema, test.GQLQuery, test.Response)
-
-			require.Nil(t, resp.Errors)
-			require.Equal(t, test.Expected, resp.Data.String())
 		})
 	}
 }

--- a/graphql/resolve/resolver_error_test.yaml
+++ b/graphql/resolve/resolver_error_test.yaml
@@ -74,8 +74,8 @@
       getAuthor(id: "0x1") {
         name
       }
-      auth : getAuthor(id: "0x1") {
-        name
+      post : getPost(id: "0x2") {
+        text
       }
     }
   explanation: "Even if some queries result in null, we should return all the
@@ -83,7 +83,7 @@
   response: |
     { "getAuthor": [ { "uid": "0x1", "name": "A.N. Author" } ] }
   expected: |
-    { "getAuthor": { "name": "A.N. Author" }, "auth": null }
+    { "getAuthor": { "name": "A.N. Author" }, "post": null }
 
 -
   name: "Missing nullable field becomes null"

--- a/graphql/resolve/resolver_test.go
+++ b/graphql/resolve/resolver_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2019 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolve
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryAlias(t *testing.T) {
+	tests := []QueryCase{
+		{Name: "top level alias",
+			GQLQuery: `query { auth : getAuthor(id: "0x1") { name } }`,
+			Response: `{ "getAuthor": [ { "name": "A.N. Author" } ] }`,
+			Expected: `{"auth": {"name": "A.N. Author"}}`},
+		{Name: "field level alias",
+			GQLQuery: `query { getAuthor(id: "0x1") { authName: name } }`,
+			Response: `{ "getAuthor": [ { "name": "A.N. Author" } ] }`,
+			Expected: `{"getAuthor": {"authName": "A.N. Author"}}`},
+		{Name: "deep alias",
+			GQLQuery: `query { getAuthor(id: "0x1") { name posts { theTitle : title } } }`,
+			Response: `{"getAuthor": [{"name": "A.N. Author", "posts": [{"title": "A Post"}]}]}`,
+			Expected: `{"getAuthor": {"name": "A.N. Author", "posts": [{"theTitle": "A Post"}]}}`},
+		{Name: "many aliases",
+			GQLQuery: `query { 
+				auth : getAuthor(id: "0x1") { name myPosts : posts { theTitle : title } }
+				post : getPost(postID: "0x2") { postTitle: title } }`,
+			Response: `{ 
+				"getAuthor": [{"name": "A.N. Author", "posts": [{"title": "A Post"}]}],
+				"getPost": [ { "title": "A Post" } ] }`,
+			Expected: `{"auth": {"name": "A.N. Author", "myPosts": [{"theTitle": "A Post"}]},` +
+				`"post": {"postTitle": "A Post"}}`},
+	}
+
+	gqlSchema := test.LoadSchemaFromFile(t, "schema.graphql")
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			resp := resolve(gqlSchema, test.GQLQuery, test.Response)
+
+			require.Nil(t, resp.Errors)
+			require.JSONEq(t, test.Expected, resp.Data.String())
+		})
+	}
+}
+
+func TestMutationAlias(t *testing.T) {
+
+	tests := map[string]struct {
+		gqlQuery      string
+		mutResponse   map[string]string
+		mutQryResp    map[string]interface{}
+		queryResponse string
+		expected      string
+	}{
+		"mutation top level alias ": {
+			gqlQuery: `mutation {
+				add: addPost(input: [{title: "A Post", text: "Some text", author: {id: "0x1"}}]) {
+					post { title }
+				}
+			}`,
+			mutResponse: map[string]string{"Post1": "0x2"},
+			mutQryResp: map[string]interface{}{
+				"Author2": []interface{}{map[string]string{"uid": "0x1"}}},
+			queryResponse: `{ "post" : [ { "title": "A Post" } ] }`,
+			expected:      `{ "add": { "post" : [{ "title": "A Post"}] } }`,
+		},
+		"mutation deep alias ": {
+			gqlQuery: `mutation {
+				addPost(input: [{title: "A Post", text: "Some text", author: {id: "0x1"}}]) {
+					thePosts : post { postTitle : title }
+				}
+			}`,
+			mutResponse: map[string]string{"Post1": "0x2"},
+			mutQryResp: map[string]interface{}{
+				"Author2": []interface{}{map[string]string{"uid": "0x1"}}},
+			queryResponse: `{ "post" : [ { "title": "A Post" } ] }`,
+			expected:      `{ "addPost": { "thePosts" : [{ "postTitle": "A Post"}] } }`,
+		},
+		"mutation many aliases ": {
+			gqlQuery: `mutation {
+				add1: addPost(input: [{title: "A Post", text: "Some text", author: {id: "0x1"}}]) {
+					thePosts : post { postTitle : title }
+				}
+				add2: addPost(input: [{title: "A Post", text: "Some text", author: {id: "0x1"}}]) {
+					otherPosts : post { t : title }
+				}
+			}`,
+			mutResponse: map[string]string{"Post1": "0x2"},
+			mutQryResp: map[string]interface{}{
+				"Author2": []interface{}{map[string]string{"uid": "0x1"}}},
+			queryResponse: `{ "post" : [ { "title": "A Post" } ] }`,
+			expected: `{ 
+				"add1": { "thePosts" : [{ "postTitle": "A Post"}] },
+				"add2": { "otherPosts" : [{ "t": "A Post"}] } }`,
+		},
+	}
+
+	gqlSchema := test.LoadSchemaFromString(t, testGQLSchema)
+
+	for name, tcase := range tests {
+		t.Run(name, func(t *testing.T) {
+			resp := resolveWithClient(gqlSchema, tcase.gqlQuery, nil,
+				&executor{
+					resp:     tcase.queryResponse,
+					assigned: tcase.mutResponse,
+					result:   tcase.mutQryResp,
+				})
+
+			require.Nil(t, resp.Errors)
+			require.JSONEq(t, tcase.expected, resp.Data.String())
+		})
+	}
+}
+
+// Ordering of results and inserted null values matters in GraphQL:
+// https://graphql.github.io/graphql-spec/June2018/#sec-Serialized-Map-Ordering
+func TestResponseOrder(t *testing.T) {
+	query := `query {
+		 getAuthor(id: "0x1") {
+			 name
+			 dob
+			 postsNullable {
+				 title
+				 text
+			 }
+		 }
+	 }`
+
+	tests := []QueryCase{
+		{Name: "Response is in same order as GQL query",
+			GQLQuery: query,
+			Response: `{ "getAuthor": [ { "name": "A.N. Author", "dob": "2000-01-01", ` +
+				`"postsNullable": [ ` +
+				`{ "title": "A Title", "text": "Some Text" }, ` +
+				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
+			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": "2000-01-01", ` +
+				`"postsNullable": [` +
+				`{"title": "A Title", "text": "Some Text"}, ` +
+				`{"title": "Another Title", "text": "More Text"}]}}`},
+		{Name: "Response is in same order as GQL query no matter Dgraph order",
+			GQLQuery: query,
+			Response: `{ "getAuthor": [ { "dob": "2000-01-01", "name": "A.N. Author", ` +
+				`"postsNullable": [ ` +
+				`{ "text": "Some Text", "title": "A Title" }, ` +
+				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
+			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": "2000-01-01", ` +
+				`"postsNullable": [` +
+				`{"title": "A Title", "text": "Some Text"}, ` +
+				`{"title": "Another Title", "text": "More Text"}]}}`},
+		{Name: "Inserted null is in GQL query order",
+			GQLQuery: query,
+			Response: `{ "getAuthor": [ { "name": "A.N. Author", ` +
+				`"postsNullable": [ ` +
+				`{ "title": "A Title" }, ` +
+				`{ "title": "Another Title", "text": "More Text" } ] } ] }`,
+			Expected: `{"getAuthor": {"name": "A.N. Author", "dob": null, ` +
+				`"postsNullable": [` +
+				`{"title": "A Title", "text": null}, ` +
+				`{"title": "Another Title", "text": "More Text"}]}}`},
+		{Name: "Whole operation GQL query order",
+			GQLQuery: `query { ` +
+				`getAuthor(id: "0x1") { name }` +
+				`getPost(id: "0x2") { title } }`,
+			Response: `{ "getAuthor": [ { "name": "A.N. Author" } ],` +
+				`"getPost": [ { "title": "A Post" } ] }`,
+			Expected: `{"getAuthor": {"name": "A.N. Author"},` +
+				`"getPost": {"title": "A Post"}}`},
+	}
+
+	gqlSchema := test.LoadSchemaFromString(t, testGQLSchema)
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			resp := resolve(gqlSchema, test.GQLQuery, test.Response)
+
+			require.Nil(t, resp.Errors)
+			require.Equal(t, test.Expected, resp.Data.String())
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit cb01b0d76d6a0ad36c5e88d0a28dbf19493ff757)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5484)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-00d727bba2-65441.surge.sh)
<!-- Dgraph:end -->