### PR TITLE
Get lists of predicates and types before sending the snapshot.

### DIFF
--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -220,16 +220,20 @@ func doStreamSnapshot(snap *pb.Snapshot, out pb.Worker_StreamSnapshotServer) err
 		return pk.IsSchema() || pk.IsType()
 	}
 
+	// Get the list of all the predicate and types at the time of the snapshot so that the receiver
+	// can delete predicates
+	predicates := schema.State().Predicates()
+	types := schema.State().Types()
+
 	if err := stream.Orchestrate(out.Context()); err != nil {
 		return err
 	}
 
-	// Indicate that sending is done. Send a list of all the predicate and types at the
-	// time of the snapshot so that the receiver can delete predicates
+	// Indicate that sending is done.
 	done := &pb.KVS{
 		Done:       true,
-		Predicates: schema.State().Predicates(),
-		Types:      schema.State().Types(),
+		Predicates: predicates,
+		Types:      types,
 	}
 	if err := out.Send(done); err != nil {
 		return err


### PR DESCRIPTION
There could be changes to the schema while the snapshot is being sent.
Therefore, the list of types and predicates that is sent at the end
should be computed before the snapshot is sent.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5488)
<!-- Reviewable:end -->
