### PR TITLE
Update names of graphql variables to match correct capitalization.

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -174,7 +174,7 @@ mutation {
 
 #### Overriding Credentials
 
-The `access_key`, `secret_key`, and `session_token` parameters can be used to
+The `accessKey`, `secretKey`, and `sessionToken` parameters can be used to
 override the default credentials. Please note that unless HTTPS is used, the
 credentials will be transmitted in plain text so use these parameters with
 discretion. The environment variables should be used by default but these


### PR DESCRIPTION
The backup GraphQL interface uses camel case instead of underscores.
This updates the documentation to match the new names.

Fixes DGRAPH-1589

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5489)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-11d3b3d91a-65613.surge.sh)
<!-- Dgraph:end -->