### PR TITLE
Export GraphQL schema to separate file.

### DIFF
--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -107,9 +107,7 @@ func TestLoaderXidmap(t *testing.T) {
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	require.NoError(t, err)
 
-	expected = `<0x1> <dgraph.graphql.schema> ""^^<xs:string> .
-<0x1> <dgraph.graphql.xid> "dgraph.graphql.schema"^^<xs:string> .
-<0x1> <dgraph.type> "dgraph.graphql"^^<xs:string> .
+	expected = `
 <0x2712> <name> "Bob" .
 <0x2> <age> "13" .
 <0x2> <friend> <0x2712> .

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -107,8 +107,7 @@ func TestLoaderXidmap(t *testing.T) {
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	require.NoError(t, err)
 
-	expected = `
-<0x2712> <name> "Bob" .
+	expected = `<0x2712> <name> "Bob" .
 <0x2> <age> "13" .
 <0x2> <friend> <0x2712> .
 <0x2> <location> "Wonderland" .

--- a/worker/export.go
+++ b/worker/export.go
@@ -435,6 +435,17 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		return err
 	}
 
+	// Open graphql schema.
+	gqlSchemaPath, err := fpath(".gql_schema.gz")
+	if err != nil {
+		return errors.Wrapf(err, "cannot get path for the GraphQL schema file")
+	}
+	glog.Infof("Exporting GraphQL schema at %s", gqlSchemaPath)
+	gqlSchemaWriter := &fileWriter{}
+	if err := gqlSchemaWriter.open(gqlSchemaPath); err != nil {
+		return errors.Wrapf(err, "cannot open export GraphQL schema file at %s", gqlSchemaPath)
+	}
+
 	stream := pstore.NewStreamAt(in.ReadTs)
 	stream.LogPrefix = "Export"
 	stream.ChooseKey = func(item *badger.Item) bool {
@@ -513,11 +524,57 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 			}
 			return toType(pk.Attr, update)
 
+		case pk.Attr == "dgraph.graphql.xid":
+			// Ignore this predicate.
+			glog.V(2).Infof("Ignoring key %v for predicate dgraph.graphql.xid",
+				hex.Dump(item.Key()))
+
+		case pk.IsData() && pk.Attr == "dgraph.graphql.schema":
+			pl, err := posting.ReadPostingList(key, itr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot read posting list for GraphQL schema")
+			}
+			vals, err := pl.AllValues(in.ReadTs)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot read value of GraphQL schema")
+			}
+			if len(vals) != 1 {
+				return nil, errors.Errorf("found multiple values for the GraphQL schema")
+			}
+			val, ok := vals[0].Value.([]byte)
+			if !ok {
+				return nil, errors.Errorf("cannot convert value of GraphQL schema to byte array")
+			}
+			kv := &bpb.KV{
+				Value:   val,
+				Version: 3, // GrqphQL schema value
+			}
+			return listWrap(kv), nil
+
 		case pk.IsData():
 			e.pl, err = posting.ReadPostingList(key, itr)
 			if err != nil {
 				return nil, err
 			}
+
+			// The GraphQL layer will create a node of type "dgraph.graphql". That entry
+			// should not be exported.
+			if pk.Attr == "dgraph.type" {
+				vals, err := e.pl.AllValues(in.ReadTs)
+				if err != nil {
+					return nil, errors.Wrapf(err, "cannot read value of dgraph.type entry")
+				}
+				if len(vals) == 1 {
+					val, ok := vals[0].Value.(string)
+					if !ok {
+						return nil, errors.Errorf("cannot read value of dgraph.type entry")
+					}
+					if val == "dgraph.graphql" {
+						return nil, nil
+					}
+				}
+			}
+
 			switch in.Format {
 			case "json":
 				return e.toJSON()
@@ -559,6 +616,8 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 				writer = dataWriter
 			case 2: // schema and types
 				writer = schemaWriter
+			case 3:
+				writer = gqlSchemaWriter
 			default:
 				glog.Fatalf("Invalid data type found: %x", kv.Key)
 			}
@@ -681,6 +740,7 @@ func ExportOverNetwork(ctx context.Context, format string) error {
 			return rerr
 		}
 	}
+
 	glog.Infof("Export at readTs %d DONE", readTs)
 	return nil
 }

--- a/worker/export.go
+++ b/worker/export.go
@@ -474,11 +474,9 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		}
 
 		if !pk.IsType() {
-			fmt.Printf("attr: %s\n", pk.Attr)
 			if servesTablet, err := groups().ServesTablet(pk.Attr); err != nil || !servesTablet {
 				return false
 			}
-			fmt.Printf("served attr: %s\n", pk.Attr)
 		}
 
 		// We need to ensure that schema keys are separately identifiable, so they can be
@@ -528,10 +526,9 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 
 		case pk.Attr == "dgraph.graphql.xid":
 			// Ignore this predicate.
-			glog.V(2).Infof("Ignoring key %v for predicate dgraph.graphql.xid",
-				hex.Dump(item.Key()))
 
 		case pk.IsData() && pk.Attr == "dgraph.graphql.schema":
+			// Export the graphql schema.
 			pl, err := posting.ReadPostingList(key, itr)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot read posting list for GraphQL schema")

--- a/worker/export.go
+++ b/worker/export.go
@@ -546,7 +546,7 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 			}
 			kv := &bpb.KV{
 				Value:   val,
-				Version: 3, // GrqphQL schema value
+				Version: 3, // GraphQL schema value
 			}
 			return listWrap(kv), nil
 

--- a/worker/export.go
+++ b/worker/export.go
@@ -474,9 +474,11 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		}
 
 		if !pk.IsType() {
+			fmt.Printf("attr: %s\n", pk.Attr)
 			if servesTablet, err := groups().ServesTablet(pk.Attr); err != nil || !servesTablet {
 				return false
 			}
+			fmt.Printf("served attr: %s\n", pk.Attr)
 		}
 
 		// We need to ensure that schema keys are separately identifiable, so they can be
@@ -565,11 +567,11 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 					return nil, errors.Wrapf(err, "cannot read value of dgraph.type entry")
 				}
 				if len(vals) == 1 {
-					val, ok := vals[0].Value.(string)
+					val, ok := vals[0].Value.([]byte)
 					if !ok {
 						return nil, errors.Errorf("cannot read value of dgraph.type entry")
 					}
-					if val == "dgraph.graphql" {
+					if string(val) == "dgraph.graphql" {
 						return nil, nil
 					}
 				}
@@ -655,6 +657,9 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		return err
 	}
 	if err := schemaWriter.Close(); err != nil {
+		return err
+	}
+	if err := gqlSchemaWriter.Close(); err != nil {
 		return err
 	}
 	glog.Infof("Export DONE for group %d at timestamp %d.", in.GroupId, in.ReadTs)

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -80,6 +80,9 @@ func populateGraphExport(t *testing.T) {
 		`<5> <name> "" .`,
 		`<6> <name> "Ding!\u0007Ding!\u0007Ding!\u0007" .`,
 		`<7> <name> "node_to_delete" .`,
+		`<8> <dgraph.graphql.schema> "type Example { name: String }" .`,
+		`<8> <dgraph.graphql.xid> "dgraph.graphql.schema" .`,
+		`<8> <dgraph.type> "dgraph.graphql" .`,
 	}
 	// This triplet will be deleted to ensure deleted nodes do not affect the output of the export.
 	edgeToDelete := `<7> <name> "node_to_delete" .`
@@ -116,8 +119,11 @@ func populateGraphExport(t *testing.T) {
 }
 
 func initTestExport(t *testing.T, schemaStr string) {
-	schema.ParseBytes([]byte(schemaStr), 1)
-
+	schema.ParseBytes([]byte(schemaStr + "\n" + `
+		dgraph.type: string @index(exact) .
+		dgraph.graphql.xid: string @index(exact) @upsert .
+		dgraph.graphql.schema: string . 
+	`), 1)
 	val, err := (&pb.SchemaUpdate{ValueType: pb.Posting_UID}).Marshal()
 	require.NoError(t, err)
 

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -22,6 +22,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -46,6 +47,10 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
+)
+
+const (
+	gqlSchema = "type Example { name: String }"
 )
 
 var personType = &pb.TypeUpdate{
@@ -80,7 +85,7 @@ func populateGraphExport(t *testing.T) {
 		`<5> <name> "" .`,
 		`<6> <name> "Ding!\u0007Ding!\u0007Ding!\u0007" .`,
 		`<7> <name> "node_to_delete" .`,
-		`<8> <dgraph.graphql.schema> "type Example { name: String }" .`,
+		fmt.Sprintf("<8> <dgraph.graphql.schema> \"%s\" .", gqlSchema),
 		`<8> <dgraph.graphql.xid> "dgraph.graphql.schema" .`,
 		`<8> <dgraph.type> "dgraph.graphql" .`,
 	}
@@ -119,11 +124,8 @@ func populateGraphExport(t *testing.T) {
 }
 
 func initTestExport(t *testing.T, schemaStr string) {
-	schema.ParseBytes([]byte(schemaStr + "\n" + `
-		dgraph.type: string @index(exact) .
-		dgraph.graphql.xid: string @index(exact) @upsert .
-		dgraph.graphql.schema: string . 
-	`), 1)
+	require.NoError(t, schema.ParseBytes([]byte(schemaStr), 1))
+
 	val, err := (&pb.SchemaUpdate{ValueType: pb.Posting_UID}).Marshal()
 	require.NoError(t, err)
 
@@ -159,16 +161,19 @@ func initTestExport(t *testing.T, schemaStr string) {
 	require.NoError(t, txn.CommitAt(1, nil))
 }
 
-func getExportFileList(t *testing.T, bdir string) (dataFiles, schemaFiles []string) {
+func getExportFileList(t *testing.T, bdir string) (dataFiles, schemaFiles, gqlSchema []string) {
 	searchDir := bdir
 	err := filepath.Walk(searchDir, func(path string, f os.FileInfo, err error) error {
 		if f.IsDir() {
 			return nil
 		}
 		if path != bdir {
-			if strings.Contains(path, "schema") {
+			switch {
+			case strings.Contains(path, "gql_schema"):
+				gqlSchema = append(gqlSchema, path)
+			case strings.Contains(path, "schema"):
 				schemaFiles = append(schemaFiles, path)
-			} else {
+			default:
 				dataFiles = append(dataFiles, path)
 			}
 		}
@@ -204,11 +209,24 @@ func checkExportSchema(t *testing.T, schemaFileList []string) {
 	require.True(t, proto.Equal(result.Types[0], personType))
 }
 
+func checkExportGqlSchema(t *testing.T, gqlSchemaFiles []string) {
+	require.Equal(t, 1, len(gqlSchemaFiles))
+	file := gqlSchemaFiles[0]
+	f, err := os.Open(file)
+	require.NoError(t, err)
+
+	r, err := gzip.NewReader(f)
+	require.NoError(t, err)
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	require.Equal(t, gqlSchema, buf.String())
+}
+
 func TestExportRdf(t *testing.T) {
 	// Index the name predicate. We ensure it doesn't show up on export.
 	initTestExport(t, `
-		name:string @index .
-		age:int.
+		name: string @index(exact) .
+		age: int .
 		`)
 
 	bdir, err := ioutil.TempDir("", "export")
@@ -225,7 +243,7 @@ func TestExportRdf(t *testing.T) {
 	err = export(context.Background(), &pb.ExportRequest{ReadTs: readTs, GroupId: 1, Format: "rdf"})
 	require.NoError(t, err)
 
-	fileList, schemaFileList := getExportFileList(t, bdir)
+	fileList, schemaFileList, gqlSchema := getExportFileList(t, bdir)
 
 	file := fileList[0]
 	f, err := os.Open(file)
@@ -300,11 +318,12 @@ func TestExportRdf(t *testing.T) {
 	require.Equal(t, 9, count)
 
 	checkExportSchema(t, schemaFileList)
+	checkExportGqlSchema(t, gqlSchema)
 }
 
 func TestExportJson(t *testing.T) {
 	// Index the name predicate. We ensure it doesn't show up on export.
-	initTestExport(t, "name:string @index .")
+	initTestExport(t, "name: string @index(exact) .")
 
 	bdir, err := ioutil.TempDir("", "export")
 	require.NoError(t, err)
@@ -321,7 +340,7 @@ func TestExportJson(t *testing.T) {
 	err = export(context.Background(), &req)
 	require.NoError(t, err)
 
-	fileList, schemaFileList := getExportFileList(t, bdir)
+	fileList, schemaFileList, gqlSchema := getExportFileList(t, bdir)
 
 	file := fileList[0]
 	f, err := os.Open(file)
@@ -348,6 +367,7 @@ func TestExportJson(t *testing.T) {
 	require.JSONEq(t, wantJson, string(gotJson))
 
 	checkExportSchema(t, schemaFileList)
+	checkExportGqlSchema(t, gqlSchema)
 }
 
 const exportRequest = `mutation export($format: String!) {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -466,7 +466,6 @@ func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
 	tablet, ok := g.tablets[key]
 	g.RUnlock()
 	if ok {
-		fmt.Printf("tablets %v\n", g.tablets)
 		return tablet, nil
 	}
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -466,6 +466,7 @@ func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
 	tablet, ok := g.tablets[key]
 	g.RUnlock()
 	if ok {
+		fmt.Printf("tablets %v\n", g.tablets)
 		return tablet, nil
 	}
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -374,6 +374,9 @@ func TestMain(m *testing.M) {
 	gr.tablets["http://www.w3.org/2000/01/rdf-schema#range"] = &pb.Tablet{GroupId: 1}
 	gr.tablets["friend_not_served"] = &pb.Tablet{GroupId: 2}
 	gr.tablets[""] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.type"] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.graphql.xid"] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.graphql.schema"] = &pb.Tablet{GroupId: 1}
 
 	dir, err := ioutil.TempDir("", "storetest_")
 	x.Check(err)


### PR DESCRIPTION
The GraphQL schema is all that's needed to restore the graphql layer. Export it to a separate
file and don't export the existing triples.

First part of the fix for DGRAPH-1283

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5501)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-376a56b2ca-66753.surge.sh)
<!-- Dgraph:end -->