### PR TITLE
added shellcheck fix for preview scripts

### DIFF
--- a/wiki/scripts/local.sh
+++ b/wiki/scripts/local.sh
@@ -23,9 +23,10 @@ run() {
   export DGRAPH_ENDPOINT=${DGRAPH_ENDPOINT:-"https://play.dgraph.io/query?latency=true"}
 
 
-  HUGO_TITLE="Dgraph Doc - Preview" \
-  VERSIONS=${VERSION_STRING} \
-  CURRENT_BRANCH="master" \
+  export HUGO_TITLE="Dgraph Doc - Preview" \
+  export VERSIONS=${VERSION_STRING} \
+  export CURRENT_BRANCH="master" \
+  export CURRENT_VERSION=${CURRENT_VERSION}
 
   pushd "$(dirname "$0")/.." > /dev/null
   pushd themes > /dev/null
@@ -43,13 +44,13 @@ run() {
 
   if [[ $1 == "-p" || $1 == "--preview" ]]; then
     echo -e "$(date) $GREEN  Generating documentation static pages in the public folder. $RESET"
-    hugo --destination=public --baseURL="$2" 1> /dev/null
+      hugo --destination=public --baseURL="$2" 1> /dev/null
     echo -e "$(date) $GREEN  Done building. $RESET"
   else
-    CURRENT_VERSION=${CURRENT_VERSION} hugo server -w --baseURL=http://localhost:1313
+    hugo server -w --baseURL=http://localhost:1313
   fi
   popd > /dev/null
 }
 
-run $1 $2
+run "$1" "$2"
 


### PR DESCRIPTION
Fixes DGRAPH-1295

For now, we will only include fixes for the scripts in *wiki* folder.

(WIP) There are 42 other shell scripts in the repository that will need to be included.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5505)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-071acb1792-66032.surge.sh)
<!-- Dgraph:end -->