### PR TITLE
test: Show cluster logs on failure for 21million systest.

### DIFF
--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -147,7 +147,6 @@ go test -v -tags standalone $SAVEDIR $QUIET || FOUND_DIFFS=1
 if [[ $FOUND_DIFFS -eq 1 ]]; then
     Info "no diffs found in query results"
 else
-    Info "found some diffs in query results"
     Info "Cluster logs for alpha1"
     docker logs alpha1
     Info "Cluster logs for alpha2"
@@ -156,6 +155,7 @@ else
     docker logs alpha3
     Info "Cluster logs for zero1"
     docker logs zero1
+    Info "found some diffs in query results"
 fi
 
 if [[ $CLEANUP == all ]]; then

--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -144,6 +144,20 @@ if [[ ! -z "$TEAMCITY_VERSION" ]]; then
 fi
 go test -v -tags standalone $SAVEDIR $QUIET || FOUND_DIFFS=1
 
+if [[ $FOUND_DIFFS -eq 1 ]]; then
+    Info "no diffs found in query results"
+else
+    Info "found some diffs in query results"
+    Info "Cluster logs for alpha1"
+    docker logs alpha1
+    Info "Cluster logs for alpha2"
+    docker logs alpha2
+    Info "Cluster logs for alpha3"
+    docker logs alpha3
+    Info "Cluster logs for zero1"
+    docker logs zero1
+fi
+
 if [[ $CLEANUP == all ]]; then
     Info "bringing down zero and alpha and data volumes"
     DockerCompose down -v
@@ -152,12 +166,6 @@ elif [[ $CLEANUP == none ]]; then
 else
     Info "bringing down zero and alpha only"
     DockerCompose down
-fi
-
-if [[ $FOUND_DIFFS -eq 0 ]]; then
-    Info "no diffs found in query results"
-else
-    Info "found some diffs in query results"
 fi
 
 exit $FOUND_DIFFS

--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -144,7 +144,7 @@ if [[ ! -z "$TEAMCITY_VERSION" ]]; then
 fi
 go test -v -tags standalone $SAVEDIR $QUIET || FOUND_DIFFS=1
 
-if [[ $FOUND_DIFFS -eq 1 ]]; then
+if [[ $FOUND_DIFFS -eq 0 ]]; then
     Info "no diffs found in query results"
 else
     Info "Cluster logs for alpha1"


### PR DESCRIPTION
test-21million.sh can show failures like the following in CI builds:

```
------- Stdout: -------
=== RUN   TestQueries/query-044
    --- FAIL: TestQueries/query-044 (4.74s)
        run_test.go:86: 
            	Error Trace:	run_test.go:86
            	Error:      	Received unexpected error:
            	            	rpc error: code = Unknown desc = : rpc error: code = Unavailable desc = transport is closing
            	Test:       	TestQueries/query-044
```
```
------- Stdout: -------
=== RUN   TestQueries/query-045
    --- FAIL: TestQueries/query-045 (0.01s)
        run_test.go:86: 
            	Error Trace:	run_test.go:86
            	Error:      	Received unexpected error:
            	            	rpc error: code = Unknown desc = : rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = "transport: Error while dialing dial tcp 172.24.0.4:7182: connect: connection refused"
            	Test:       	TestQueries/query-045
```

It looks like something happened to the Dgraph cluster, but we're lost without any cluster logs.

This change prints out the cluster logs for alpha1, alpha2, alpha3, and zero1 if there are test failures in test-21million.sh.

Changes
* Print out cluster logs on test failure
* Move cluster tear down to the very end of the test so logs can be captured beforehand.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5507)
<!-- Reviewable:end -->
