### PR TITLE
graphql: Introduce `@cascade` in GraphQL

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -270,6 +270,7 @@ func RunAll(t *testing.T) {
 	t.Run("query post with author", queryPostWithAuthor)
 	t.Run("queries have extensions", queriesHaveExtensions)
 	t.Run("alias works for queries", queryWithAlias)
+	t.Run("cascade directive", queryWithCascade)
 
 	// mutation tests
 	t.Run("add mutation", addMutation)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -1514,13 +1514,12 @@ func deleteCountry(
 	deleteGqlType(t, "Country", filter, expectedNumUids, expectedErrors)
 }
 
-func deleteAuthor(
+func deleteAuthors(
 	t *testing.T,
-	authorID string,
-	expectedNumUids int,
+	authorIDs []string,
 	expectedErrors x.GqlErrorList) {
-	filter := map[string]interface{}{"id": []string{authorID}}
-	deleteGqlType(t, "Author", filter, expectedNumUids, expectedErrors)
+	filter := map[string]interface{}{"id": authorIDs}
+	deleteGqlType(t, "Author", filter, len(authorIDs), expectedErrors)
 }
 
 func deletePost(
@@ -1911,7 +1910,7 @@ func cleanUp(t *testing.T, countries []*country, authors []*author, posts []*pos
 		}
 
 		for _, author := range authors {
-			deleteAuthor(t, author.ID, 1, nil)
+			deleteAuthors(t, []string{author.ID}, nil)
 		}
 
 		for _, country := range countries {

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -1579,6 +1579,7 @@ func queryWithCascade(t *testing.T) {
 					  queryAuthor(filter: {id: $ids}) {
 						reputation
 						posts @cascade {
+						  title
 						  text
 						}
 					  }
@@ -1588,6 +1589,7 @@ func queryWithCascade(t *testing.T) {
 							"queryAuthor": [{
 								"reputation": 4.5,
 								"posts": [{
+									"title": "A show about nothing",
 									"text": "Got ya!"
 								}]
 							},{
@@ -1596,6 +1598,7 @@ func queryWithCascade(t *testing.T) {
 							},{
 								"reputation": null,
 								"posts": [{
+									"title": "Ha! Cosmo Kramer",
 									"text": "Giddy up!"
 								}]
 							}]

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -1464,3 +1464,160 @@ func queryWithAlias(t *testing.T) {
 				"postAuthor": { "theName": "Ann Author" }}]}`,
 		string(gqlResponse.Data))
 }
+
+func queryWithCascade(t *testing.T) {
+	// for testing @cascade with get by ID and filter queries, also for testing @cascade on field
+	authors := addMultipleAuthorFromRef(t, []*author{
+		{
+			Name:       "George",
+			Reputation: 4.5,
+			Posts:      []*post{{Title: "A show about nothing", Text: "Got ya!", Tags: []string{}}},
+		}, {
+			Name:       "Jerry",
+			Reputation: 4.6,
+			Posts:      []*post{{Title: "Outside", Tags: []string{}}},
+		}, {
+			Name:  "Kramer",
+			Posts: []*post{{Title: "Ha! Cosmo Kramer", Text: "Giddy up!", Tags: []string{}}},
+		},
+	}, postExecutor)
+	authorIds := []string{authors[0].ID, authors[1].ID, authors[2].ID}
+	postIds := []string{authors[0].Posts[0].PostID, authors[1].Posts[0].PostID,
+		authors[2].Posts[0].PostID}
+	getAuthorByIdQuery := `query ($id: ID!) {
+							  getAuthor(id: $id) @cascade {
+								reputation
+								posts {
+								  text
+								}
+							  }
+							}`
+
+	// for testing @cascade with get by XID queries
+	states := []*state{
+		{Name: "California", Code: "CA", Capital: "Sacramento"},
+		{Name: "Texas", Code: "TX"},
+	}
+	addStateParams := GraphQLParams{
+		Query: `mutation ($input: [AddStateInput!]!) {
+					addState(input: $input) {
+						numUids
+					}
+				}`,
+		Variables: map[string]interface{}{"input": states},
+	}
+	resp := addStateParams.ExecuteAsPost(t, graphqlURL)
+	RequireNoGQLErrors(t, resp)
+	testutil.CompareJSON(t, `{"addState":{"numUids":2}}`, string(resp.Data))
+	getStateByXidQuery := `query ($xid: String!) {
+							  getState(xcode: $xid) @cascade {
+								xcode
+								capital
+							  }
+							}`
+
+	tcases := []struct {
+		name      string
+		query     string
+		variables map[string]interface{}
+		respData  string
+	}{
+		{
+			name:      "@cascade on get by ID query returns null",
+			query:     getAuthorByIdQuery,
+			variables: map[string]interface{}{"id": authors[1].ID},
+			respData:  `{"getAuthor": null}`,
+		}, {
+			name:      "@cascade on get by ID query returns author",
+			query:     getAuthorByIdQuery,
+			variables: map[string]interface{}{"id": authors[0].ID},
+			respData: `{
+							"getAuthor": {
+								"reputation": 4.5,
+								"posts": [{
+									"text": "Got ya!"
+								}]
+							}
+						}`,
+		}, {
+			name:      "@cascade on get by XID query returns null",
+			query:     getStateByXidQuery,
+			variables: map[string]interface{}{"xid": states[1].Code},
+			respData:  `{"getState": null}`,
+		}, {
+			name:      "@cascade on get by XID query returns state",
+			query:     getStateByXidQuery,
+			variables: map[string]interface{}{"xid": states[0].Code},
+			respData: `{
+							"getState": {
+								"xcode": "CA",
+								"capital": "Sacramento"
+							}
+						}`,
+		}, {
+			name: "@cascade on filter query",
+			query: `query ($ids: [ID!]) {
+					  queryAuthor(filter: {id: $ids}) @cascade {
+						reputation
+						posts {
+						  text
+						}
+					  }
+					}`,
+			variables: map[string]interface{}{"ids": authorIds},
+			respData: `{
+							"queryAuthor": [{
+								"reputation": 4.5,
+								"posts": [{
+									"text": "Got ya!"
+								}]
+							}]
+						}`,
+		}, {
+			name: "@cascade on query field",
+			query: `query ($ids: [ID!]) {
+					  queryAuthor(filter: {id: $ids}) {
+						reputation
+						posts @cascade {
+						  text
+						}
+					  }
+					}`,
+			variables: map[string]interface{}{"ids": authorIds},
+			respData: `{
+							"queryAuthor": [{
+								"reputation": 4.5,
+								"posts": [{
+									"text": "Got ya!"
+								}]
+							},{
+								"reputation": 4.6,
+								"posts": []
+							},{
+								"reputation": null,
+								"posts": [{
+									"text": "Giddy up!"
+								}]
+							}]
+						}`,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			params := &GraphQLParams{
+				Query:     tcase.query,
+				Variables: tcase.variables,
+			}
+			resp := params.ExecuteAsPost(t, graphqlURL)
+			RequireNoGQLErrors(t, resp)
+			testutil.CompareJSON(t, tcase.respData, string(resp.Data))
+		})
+	}
+
+	// cleanup
+	deleteAuthors(t, authorIds, nil)
+	deleteGqlType(t, "Post", map[string]interface{}{"postID": postIds}, len(postIds), nil)
+	deleteState(t, getXidFilter("xcode", []string{states[0].Code, states[1].Code}), len(states),
+		nil)
+}

--- a/graphql/resolve/mutation_query_test.yaml
+++ b/graphql/resolve/mutation_query_test.yaml
@@ -150,6 +150,93 @@ ADD_UPDATE_MUTATION:
         }
       }
 
+  -
+    name: "cascade directive on mutation payload"
+    gqlquery: |
+      mutation {
+        ADD_UPDATE_MUTATION @cascade {
+          post {
+            title
+            text
+            author {
+              name
+              dob
+            }
+          }
+        }
+      }
+    dgquery: |-
+      query {
+        post(func: uid(0x4)) @cascade {
+          title : Post.title
+          text : Post.text
+          author : Post.author {
+            name : Author.name
+            dob : Author.dob
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+      }
+
+  -
+    name: "cascade directive on mutation query field"
+    gqlquery: |
+      mutation {
+        ADD_UPDATE_MUTATION {
+          post @cascade {
+            title
+            text
+            author {
+              name
+              dob
+            }
+          }
+        }
+      }
+    dgquery: |-
+      query {
+        post(func: uid(0x4)) @cascade {
+          title : Post.title
+          text : Post.text
+          author : Post.author {
+            name : Author.name
+            dob : Author.dob
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+      }
+
+  -
+    name: "cascade directive inside mutation query"
+    gqlquery: |
+      mutation {
+        ADD_UPDATE_MUTATION {
+          post {
+            title
+            text
+            author @cascade {
+              name
+              dob
+            }
+          }
+        }
+      }
+    dgquery: |-
+      query {
+        post(func: uid(0x4)) {
+          title : Post.title
+          text : Post.text
+          author : Post.author @cascade {
+            name : Author.name
+            dob : Author.dob
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+      }
+
 UPDATE_MUTATION:
   -
     name: "filter update result"

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -214,6 +214,7 @@ func rewriteAsQueryByIds(field schema.Field, uids []uint64, authRw *authRewriter
 	addArgumentsToField(dgQuery, field)
 	selectionAuth := addSelectionSetFrom(dgQuery, field, authRw)
 	addUID(dgQuery)
+	addCascadeDirective(dgQuery, field)
 
 	if rbac == schema.Uncertain {
 		dgQuery = authRw.addAuthQueries(field.Type(), dgQuery)
@@ -293,6 +294,7 @@ func rewriteAsGet(
 	selectionAuth := addSelectionSetFrom(dgQuery, field, auth)
 	addUID(dgQuery)
 	addTypeFilter(dgQuery, field.Type())
+	addCascadeDirective(dgQuery, field)
 
 	if rbac == schema.Uncertain {
 		dgQuery = auth.addAuthQueries(field.Type(), dgQuery)
@@ -339,6 +341,7 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) *gql.GraphQuery {
 	addArgumentsToField(dgQuery, field)
 	selectionAuth := addSelectionSetFrom(dgQuery, field, authRw)
 	addUID(dgQuery)
+	addCascadeDirective(dgQuery, field)
 
 	if rbac == schema.Uncertain {
 		dgQuery = authRw.addAuthQueries(field.Type(), dgQuery)
@@ -613,6 +616,7 @@ func addSelectionSetFrom(
 		addFilter(child, f.Type(), filter)
 		addOrder(child, f)
 		addPagination(child, f)
+		addCascadeDirective(child, f)
 		rbac := auth.evaluateStaticRules(f.Type())
 
 		selectionAuth := addSelectionSetFrom(child, f, auth)
@@ -701,6 +705,10 @@ func addPagination(q *gql.GraphQuery, field schema.Field) {
 	if offset != nil {
 		q.Args["offset"] = fmt.Sprintf("%v", offset)
 	}
+}
+
+func addCascadeDirective(q *gql.GraphQuery, field schema.Field) {
+	q.Cascade = field.Cascade()
 }
 
 func convertIDs(idsSlice []interface{}) []uint64 {

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -721,6 +721,29 @@
     }
 
 -
+  name: "Cascade directive on root query and query field"
+  gqlquery: |
+    query {
+      queryAuthor @cascade {
+        dob
+        posts @cascade {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade {
+        dob : Author.dob
+        posts : Author.posts @cascade {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "getHuman which implements an interface"
   gqlquery: |
     query {

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -652,6 +652,75 @@
     }
 
 -
+  name: "Cascade directive on get query"
+  gqlquery: |
+    query {
+      getAuthor(id: "0x1") @cascade {
+        dob
+        posts {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      getAuthor(func: uid(0x1)) @filter(type(Author)) @cascade {
+        dob : Author.dob
+        posts : Author.posts {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Cascade directive on filter query"
+  gqlquery: |
+    query {
+      queryAuthor @cascade {
+        dob
+        posts {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade {
+        dob : Author.dob
+        posts : Author.posts {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Cascade directive on query field"
+  gqlquery: |
+    query {
+      queryAuthor {
+        dob
+        posts @cascade {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        dob : Author.dob
+        posts : Author.posts @cascade {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "getHuman which implements an interface"
   gqlquery: |
     query {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -34,14 +34,15 @@ const (
 	searchDirective = "search"
 	searchArgs      = "by"
 
-	dgraphDirective = "dgraph"
-	dgraphTypeArg   = "type"
-	dgraphPredArg   = "pred"
-	idDirective     = "id"
-	secretDirective = "secret"
-	authDirective   = "auth"
-	customDirective = "custom"
-	remoteDirective = "remote" // types with this directive are not stored in Dgraph.
+	dgraphDirective  = "dgraph"
+	dgraphTypeArg    = "type"
+	dgraphPredArg    = "pred"
+	idDirective      = "id"
+	secretDirective  = "secret"
+	authDirective    = "auth"
+	customDirective  = "custom"
+	remoteDirective  = "remote" // types with this directive are not stored in Dgraph.
+	cascadeDirective = "cascade"
 
 	// custom directive args and fields
 	mode   = "mode"
@@ -117,6 +118,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -82,6 +82,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -87,6 +87,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -75,6 +75,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -92,6 +92,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -76,6 +76,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -75,6 +75,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -71,6 +71,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -71,6 +71,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -85,6 +85,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -85,6 +85,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -84,6 +84,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -78,6 +78,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -95,6 +95,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -96,6 +96,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -95,6 +95,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -76,6 +76,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -78,6 +78,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -80,6 +80,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -80,6 +80,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -102,6 +102,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -102,6 +102,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -70,6 +70,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -82,6 +82,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -71,6 +71,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -80,6 +80,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -97,6 +97,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -79,6 +79,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -73,6 +73,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -86,6 +86,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -78,6 +78,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -78,6 +78,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -78,6 +78,7 @@ directive @auth(
 	delete:AuthRule) on OBJECT
 directive @custom(http: CustomHTTP) on FIELD_DEFINITION
 directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -658,10 +658,7 @@ func (f *field) Include() bool {
 }
 
 func (f *field) Cascade() bool {
-	if f.field.Directives.ForName(cascadeDirective) == nil {
-		return false
-	}
-	return true
+	return f.field.Directives.ForName(cascadeDirective) != nil
 }
 
 func (f *field) HasCustomDirective() (bool, map[string]bool) {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -122,6 +122,7 @@ type Field interface {
 	SetArgTo(arg string, val interface{})
 	Skip() bool
 	Include() bool
+	Cascade() bool
 	HasCustomDirective() (bool, map[string]bool)
 	Type() Type
 	SelectionSet() []Field
@@ -656,6 +657,13 @@ func (f *field) Include() bool {
 	return dir.ArgumentMap(f.op.vars)["if"].(bool)
 }
 
+func (f *field) Cascade() bool {
+	if f.field.Directives.ForName(cascadeDirective) == nil {
+		return false
+	}
+	return true
+}
+
 func (f *field) HasCustomDirective() (bool, map[string]bool) {
 	custom := f.op.inSchema.customDirectives[f.GetObjectName()][f.Name()]
 	if custom == nil {
@@ -1012,6 +1020,10 @@ func (q *query) Include() bool {
 	return true
 }
 
+func (q *query) Cascade() bool {
+	return (*field)(q).Cascade()
+}
+
 func (q *query) HasCustomDirective() (bool, map[string]bool) {
 	return (*field)(q).HasCustomDirective()
 }
@@ -1117,6 +1129,10 @@ func (m *mutation) Include() bool {
 	return true
 }
 
+func (m *mutation) Cascade() bool {
+	return (*field)(m).Cascade()
+}
+
 func (m *mutation) HasCustomDirective() (bool, map[string]bool) {
 	return (*field)(m).HasCustomDirective()
 }
@@ -1145,6 +1161,10 @@ func (m *mutation) QueryField() Field {
 	for _, f := range m.SelectionSet() {
 		if f.Name() == NumUid || f.Name() == Typename {
 			continue
+		}
+		if m.Cascade() && !f.Cascade() {
+			field := f.(*field).field
+			field.Directives = append(field.Directives, &ast.Directive{Name: cascadeDirective})
 		}
 		return f
 	}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1159,6 +1159,8 @@ func (m *mutation) QueryField() Field {
 		if f.Name() == NumUid || f.Name() == Typename {
 			continue
 		}
+		// if @cascade was given on mutation itself, then it should get applied for the query which
+		// gets executed to fetch the results of that mutation, so propagating it to the QueryField.
 		if m.Cascade() && !f.Cascade() {
 			field := f.(*field).field
 			field.Directives = append(field.Directives, &ast.Directive{Name: cascadeDirective})


### PR DESCRIPTION
Fixes #4789.
Fixes #GRAPHQL-277.
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5511)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-798a6c8936-66836.surge.sh)
<!-- Dgraph:end -->