### PR TITLE
If JWT custom claim field is string, parse as JSON

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -152,8 +152,14 @@ func (c *CustomClaims) UnmarshalJSON(data []byte) error {
 	}
 
 	// Unmarshal the auth variables for a particular namespace.
-	if authVariables, ok := result[metainfo.Namespace]; ok {
-		c.AuthVariables, _ = authVariables.(map[string]interface{})
+	if authValue, ok := result[metainfo.Namespace]; ok {
+		if authJson, ok := authValue.(string); ok {
+			if err := json.Unmarshal([]byte(authJson), &c.AuthVariables); err != nil {
+				return err
+			}
+		} else {
+			c.AuthVariables, _ = authValue.(map[string]interface{})
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Amazon Cognito does not support objects as JWT custom claim values. If custom claim is string, parse as JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5513)
<!-- Reviewable:end -->
