### PR TITLE
Expose zero HTTP API to enable or disable tablet rebalance

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -369,6 +369,10 @@ func (n *node) applyProposal(e raftpb.Entry) (string, error) {
 		state.License.Enabled = time.Now().UTC().Before(expiry)
 	}
 
+	if p.Rebalance != "" {
+		state.Rebalance = p.Rebalance
+	}
+
 	switch {
 	case p.MaxLeaseId > state.MaxLeaseId:
 		state.MaxLeaseId = p.MaxLeaseId

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -254,6 +254,7 @@ func run() {
 	http.HandleFunc("/moveTablet", st.moveTablet)
 	http.HandleFunc("/assign", st.assign)
 	http.HandleFunc("/enterpriseLicense", st.applyEnterpriseLicense)
+	http.HandleFunc("/rebalance", st.setRebalance)
 	zpages.Handle(http.DefaultServeMux, "/z")
 
 	// This must be here. It does not work if placed before Grpc init.

--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -62,12 +62,16 @@ This would trigger G1 to get latest state. Wait for it.
 func (s *Server) rebalanceTablets() {
 	ticker := time.NewTicker(opts.rebalanceInterval)
 	for range ticker.C {
-		predicate, srcGroup, dstGroup := s.chooseTablet()
-		if len(predicate) == 0 {
-			continue
-		}
-		if err := s.movePredicate(predicate, srcGroup, dstGroup); err != nil {
-			glog.Errorln(err)
+		if s.state.Rebalance == "enabled" {
+			predicate, srcGroup, dstGroup := s.chooseTablet()
+			if len(predicate) == 0 {
+				continue
+			}
+			if err := s.movePredicate(predicate, srcGroup, dstGroup); err != nil {
+				glog.Errorln(err)
+			}
+		} else {
+			glog.Infof("Rebalance is %+v", s.state.Rebalance)
 		}
 	}
 }

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -80,8 +80,9 @@ func (s *Server) Init() {
 	s.orc = &Oracle{}
 	s.orc.Init()
 	s.state = &pb.MembershipState{
-		Groups: make(map[uint32]*pb.Group),
-		Zeros:  make(map[uint64]*pb.Member),
+		Rebalance: "enabled",
+		Groups:    make(map[uint32]*pb.Group),
+		Zeros:     make(map[uint64]*pb.Member),
 	}
 	s.nextLeaseId = 1
 	s.nextTxnTs = 1
@@ -782,4 +783,10 @@ func (s *Server) applyLicense(ctx context.Context, signedData io.Reader) error {
 	}
 	glog.Infof("Enterprise license proposed to the cluster %+v", proposal)
 	return nil
+}
+func (s *Server) setRebalance(ctx context.Context, rebalance string) error {
+	proposal := &pb.ZeroProposal{
+		Rebalance: rebalance,
+	}
+	return s.Node.proposeAndWait(ctx, proposal)
 }

--- a/protos/pb.proto
+++ b/protos/pb.proto
@@ -159,6 +159,7 @@ message ZeroProposal {
 	string key = 8;  // Used as unique identifier for proposal id.
 	string cid = 9; // Used as unique identifier for the cluster.
 	License license = 10;
+	string rebalance = 11;
 }
 
 // MembershipState is used to pack together the current membership state of all the nodes
@@ -174,6 +175,7 @@ message MembershipState {
 	repeated Member removed = 7;
 	string cid = 8; // Used to uniquely identify the Dgraph cluster.
 	License license = 9;
+	string rebalance = 10;
 }
 
 message ConnectionState {

--- a/protos/pb/pb.pb.go
+++ b/protos/pb/pb.pb.go
@@ -1291,6 +1291,7 @@ type ZeroProposal struct {
 	Key                  string            `protobuf:"bytes,8,opt,name=key,proto3" json:"key,omitempty"`
 	Cid                  string            `protobuf:"bytes,9,opt,name=cid,proto3" json:"cid,omitempty"`
 	License              *License          `protobuf:"bytes,10,opt,name=license,proto3" json:"license,omitempty"`
+	Rebalance            string            `protobuf:"bytes,11,opt,name=rebalance,proto3" json:"rebalance,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
 	XXX_sizecache        int32             `json:"-"`
@@ -1399,6 +1400,13 @@ func (m *ZeroProposal) GetLicense() *License {
 	return nil
 }
 
+func (m *ZeroProposal) GetRebalance() string {
+	if m != nil {
+		return m.Rebalance
+	}
+	return ""
+}
+
 // MembershipState is used to pack together the current membership state of all the nodes
 // in the caller server; and the membership updates recorded by the callee server since
 // the provided lastUpdate.
@@ -1412,6 +1420,7 @@ type MembershipState struct {
 	Removed              []*Member          `protobuf:"bytes,7,rep,name=removed,proto3" json:"removed,omitempty"`
 	Cid                  string             `protobuf:"bytes,8,opt,name=cid,proto3" json:"cid,omitempty"`
 	License              *License           `protobuf:"bytes,9,opt,name=license,proto3" json:"license,omitempty"`
+	Rebalance            string             `protobuf:"bytes,10,opt,name=rebalance,proto3" json:"rebalance,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
 	XXX_unrecognized     []byte             `json:"-"`
 	XXX_sizecache        int32              `json:"-"`
@@ -1511,6 +1520,13 @@ func (m *MembershipState) GetLicense() *License {
 		return m.License
 	}
 	return nil
+}
+
+func (m *MembershipState) GetRebalance() string {
+	if m != nil {
+		return m.Rebalance
+	}
+	return ""
 }
 
 type ConnectionState struct {
@@ -7204,6 +7220,13 @@ func (m *ZeroProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
 	}
+	if len(m.Rebalance) > 0 {
+		i -= len(m.Rebalance)
+		copy(dAtA[i:], m.Rebalance)
+		i = encodeVarintPb(dAtA, i, uint64(len(m.Rebalance)))
+		i--
+		dAtA[i] = 0x5a
+	}
 	if m.License != nil {
 		{
 			size, err := m.License.MarshalToSizedBuffer(dAtA[:i])
@@ -7322,6 +7345,13 @@ func (m *MembershipState) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	if m.XXX_unrecognized != nil {
 		i -= len(m.XXX_unrecognized)
 		copy(dAtA[i:], m.XXX_unrecognized)
+	}
+	if len(m.Rebalance) > 0 {
+		i -= len(m.Rebalance)
+		copy(dAtA[i:], m.Rebalance)
+		i = encodeVarintPb(dAtA, i, uint64(len(m.Rebalance)))
+		i--
+		dAtA[i] = 0x52
 	}
 	if m.License != nil {
 		{
@@ -10596,6 +10626,10 @@ func (m *ZeroProposal) Size() (n int) {
 		l = m.License.Size()
 		n += 1 + l + sovPb(uint64(l))
 	}
+	l = len(m.Rebalance)
+	if l > 0 {
+		n += 1 + l + sovPb(uint64(l))
+	}
 	if m.XXX_unrecognized != nil {
 		n += len(m.XXX_unrecognized)
 	}
@@ -10658,6 +10692,10 @@ func (m *MembershipState) Size() (n int) {
 	}
 	if m.License != nil {
 		l = m.License.Size()
+		n += 1 + l + sovPb(uint64(l))
+	}
+	l = len(m.Rebalance)
+	if l > 0 {
 		n += 1 + l + sovPb(uint64(l))
 	}
 	if m.XXX_unrecognized != nil {
@@ -14772,6 +14810,38 @@ func (m *ZeroProposal) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 11:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rebalance", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPb
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPb
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPb
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Rebalance = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skipPb(dAtA[iNdEx:])
@@ -15233,6 +15303,38 @@ func (m *MembershipState) Unmarshal(dAtA []byte) error {
 			if err := m.License.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
+			iNdEx = postIndex
+		case 10:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rebalance", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowPb
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthPb
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthPb
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Rebalance = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex


### PR DESCRIPTION
Moving tablet will cause write failures, but we want to reduce the failure time, especially when writing intensively. One way is setting rebalance_ Interval to a very large value, but that means I have to think about which tablets to move myself, and use moveTablet API one time to move one tablet. I think adding a switch might make things easier. By disabling rebalance when business traffic is high (in the daytime), and enabling rebalance at night.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5519)
<!-- Reviewable:end -->
 
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6d9d67f034-68720.surge.sh)
<!-- Dgraph:end -->