### PR TITLE
release/v1.2: test: Show cluster logs on failure for 21million systest.

### DIFF
--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -144,6 +144,20 @@ if [[ ! -z "$TEAMCITY_VERSION" ]]; then
 fi
 go test -v -tags standalone $SAVEDIR $QUIET || FOUND_DIFFS=1
 
+if [[ $FOUND_DIFFS -eq 0 ]]; then
+    Info "no diffs found in query results"
+else
+    Info "Cluster logs for alpha1"
+    docker logs alpha1
+    Info "Cluster logs for alpha2"
+    docker logs alpha2
+    Info "Cluster logs for alpha3"
+    docker logs alpha3
+    Info "Cluster logs for zero1"
+    docker logs zero1
+    Info "found some diffs in query results"
+fi
+
 if [[ $CLEANUP == all ]]; then
     Info "bringing down zero and alpha and data volumes"
     DockerCompose down -v
@@ -152,12 +166,6 @@ elif [[ $CLEANUP == none ]]; then
 else
     Info "bringing down zero and alpha only"
     DockerCompose down
-fi
-
-if [[ $FOUND_DIFFS -eq 0 ]]; then
-    Info "no diffs found in query results"
-else
-    Info "found some diffs in query results"
 fi
 
 exit $FOUND_DIFFS


### PR DESCRIPTION
Cherry-pick of #5507 onto release/v1.2.
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5520)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-7807091e01-66722.surge.sh)
<!-- Dgraph:end -->