### PR TITLE
graphql: Queries or mutations shouldn't be part of generated Dgraph schema

### DIFF
--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -543,3 +543,26 @@ schemas:
         B.p
       }
       B.p: string .
+
+  -
+    name: "custom query and mutation shouldn't be part of Dgraph schema"
+    input: |
+      type User @remote {
+        id: ID!
+        name: String!
+      }
+
+      type Query {
+        favUsers(id: ID!, name: String!): [User] @custom(http: {
+          url: "http://mock:8888/users",
+          method: "GET"
+        })
+      }
+
+      type Mutation {
+        setFavUsers(id: ID!, name: String!): [User] @custom(http: {
+          url: "http://mock:8888/users",
+          method: "POST"
+        })
+      }
+    output:

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -323,6 +323,9 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 	}
 
 	for _, key := range definitions {
+		if isQueryOrMutation(key) {
+			continue
+		}
 		def := gqlSch.Types[key]
 		switch def.Kind {
 		case ast.Object, ast.Interface:


### PR DESCRIPTION
I observed from the logs that this was happening, which is unexpected behavior. Fixes GRAPHQL-482.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5524)
<!-- Reviewable:end -->
