### PR TITLE
Export GraphQL schema to separate file. (#5501)

### DIFF
--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -107,10 +107,7 @@ func TestLoaderXidmap(t *testing.T) {
 	out, err := exec.Command("sh", "-c", cmd).Output()
 	require.NoError(t, err)
 
-	expected = `<0x1> <dgraph.graphql.schema> ""^^<xs:string> .
-<0x1> <dgraph.graphql.xid> "dgraph.graphql.schema"^^<xs:string> .
-<0x1> <dgraph.type> "dgraph.graphql"^^<xs:string> .
-<0x2712> <name> "Bob" .
+	expected = `<0x2712> <name> "Bob" .
 <0x2> <age> "13" .
 <0x2> <friend> <0x2712> .
 <0x2> <location> "Wonderland" .

--- a/worker/export.go
+++ b/worker/export.go
@@ -435,6 +435,17 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		return err
 	}
 
+	// Open graphql schema.
+	gqlSchemaPath, err := fpath(".gql_schema.gz")
+	if err != nil {
+		return errors.Wrapf(err, "cannot get path for the GraphQL schema file")
+	}
+	glog.Infof("Exporting GraphQL schema at %s", gqlSchemaPath)
+	gqlSchemaWriter := &fileWriter{}
+	if err := gqlSchemaWriter.open(gqlSchemaPath); err != nil {
+		return errors.Wrapf(err, "cannot open export GraphQL schema file at %s", gqlSchemaPath)
+	}
+
 	stream := pstore.NewStreamAt(in.ReadTs)
 	stream.LogPrefix = "Export"
 	stream.ChooseKey = func(item *badger.Item) bool {
@@ -511,11 +522,56 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 			}
 			return toType(pk.Attr, update)
 
+		case pk.Attr == "dgraph.graphql.xid":
+			// Ignore this predicate.
+
+		case pk.IsData() && pk.Attr == "dgraph.graphql.schema":
+			// Export the graphql schema.
+			pl, err := posting.ReadPostingList(key, itr)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot read posting list for GraphQL schema")
+			}
+			vals, err := pl.AllValues(in.ReadTs)
+			if err != nil {
+				return nil, errors.Wrapf(err, "cannot read value of GraphQL schema")
+			}
+			if len(vals) != 1 {
+				return nil, errors.Errorf("found multiple values for the GraphQL schema")
+			}
+			val, ok := vals[0].Value.([]byte)
+			if !ok {
+				return nil, errors.Errorf("cannot convert value of GraphQL schema to byte array")
+			}
+			kv := &bpb.KV{
+				Value:   val,
+				Version: 3, // GraphQL schema value
+			}
+			return listWrap(kv), nil
+
 		case pk.IsData():
 			e.pl, err = posting.ReadPostingList(key, itr)
 			if err != nil {
 				return nil, err
 			}
+
+			// The GraphQL layer will create a node of type "dgraph.graphql". That entry
+			// should not be exported.
+			if pk.Attr == "dgraph.type" {
+				vals, err := e.pl.AllValues(in.ReadTs)
+				if err != nil {
+					return nil, errors.Wrapf(err, "cannot read value of dgraph.type entry")
+				}
+				if len(vals) == 1 {
+					val, ok := vals[0].Value.([]byte)
+					if !ok {
+						return nil, errors.Errorf("cannot read value of dgraph.type entry")
+					}
+					if string(val) == "dgraph.graphql" {
+						return nil, nil
+					}
+				}
+			}
+
 			switch in.Format {
 			case "json":
 				return e.toJSON()
@@ -557,6 +613,8 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 				writer = dataWriter
 			case 2: // schema and types
 				writer = schemaWriter
+			case 3:
+				writer = gqlSchemaWriter
 			default:
 				glog.Fatalf("Invalid data type found: %x", kv.Key)
 			}
@@ -594,6 +652,9 @@ func export(ctx context.Context, in *pb.ExportRequest) error {
 		return err
 	}
 	if err := schemaWriter.Close(); err != nil {
+		return err
+	}
+	if err := gqlSchemaWriter.Close(); err != nil {
 		return err
 	}
 	glog.Infof("Export DONE for group %d at timestamp %d.", in.GroupId, in.ReadTs)
@@ -679,6 +740,7 @@ func ExportOverNetwork(ctx context.Context, format string) error {
 			return rerr
 		}
 	}
+
 	glog.Infof("Export at readTs %d DONE", readTs)
 	return nil
 }

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -374,6 +374,9 @@ func TestMain(m *testing.M) {
 	gr.tablets["http://www.w3.org/2000/01/rdf-schema#range"] = &pb.Tablet{GroupId: 1}
 	gr.tablets["friend_not_served"] = &pb.Tablet{GroupId: 2}
 	gr.tablets[""] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.type"] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.graphql.xid"] = &pb.Tablet{GroupId: 1}
+	gr.tablets["dgraph.graphql.schema"] = &pb.Tablet{GroupId: 1}
 
 	dir, err := ioutil.TempDir("", "storetest_")
 	x.Check(err)


### PR DESCRIPTION
The GraphQL schema is all that's needed to restore the graphql layer. Export it to a separate
file and don't export the existing triples.

First part of the fix for DGRAPH-1283

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5528)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5260db303f-66937.surge.sh)
<!-- Dgraph:end -->