### PR TITLE
Reduce number of allocations in SingleListRollup.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -810,26 +810,29 @@ func (l *List) Rollup() ([]*bpb.KV, error) {
 
 // SingleListRollup works like rollup but generates a single list with no splits.
 // It's used during backup so that each backed up posting list is stored in a single key.
-func (l *List) SingleListRollup() (*bpb.KV, error) {
+func (l *List) SingleListRollup(kv *bpb.KV) error {
+	if kv == nil {
+		return errors.Errorf("passed kv pointer cannot be nil")
+	}
+
 	l.RLock()
 	defer l.RUnlock()
 
 	out, err := l.rollup(math.MaxUint64, false)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed when calling List.rollup")
+		return errors.Wrapf(err, "failed when calling List.rollup")
 	}
 	// out is only nil when the list's minTs is greater than readTs but readTs
 	// is math.MaxUint64 so that's not possible. Assert that's true.
 	x.AssertTrue(out != nil)
 
-	kv := &bpb.KV{}
 	kv.Version = out.newMinTs
 	kv.Key = l.key
 	val, meta := marshalPostingList(out.plist)
 	kv.UserMeta = []byte{meta}
 	kv.Value = val
 
-	return kv, nil
+	return nil
 }
 
 func (out *rollupOutput) marshalPostingListPart(

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1246,7 +1246,8 @@ func TestSingleListRollup(t *testing.T) {
 	ol, commits := createMultiPartList(t, size, true)
 
 	// Roll list into a single list.
-	kv, err := ol.SingleListRollup()
+	kv := &bpb.KV{}
+	err := ol.SingleListRollup(kv)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(kv.UserMeta))
 	require.Equal(t, BitCompletePosting, kv.UserMeta[0])


### PR DESCRIPTION
The memory profiles obtained during backup showed that the allocation
of KV protos in SingleListRollup is the top source of memory usage. This
PR does for this allocations what was done previously for the protobufs
used for conversion.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5542)
<!-- Reviewable:end -->
