### PR TITLE
dont set n.ops map entries to nil. Instead just delete them

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -137,15 +137,15 @@ func (n *node) startTask(id op) (*y.Closer, error) {
 			if otherId == opRestore {
 				return nil, errors.Errorf("another restore operation is already running")
 			}
-			// We set to nil so that stopAllTasks doesn't call SignalAndWait again.
-			n.ops[otherId] = nil
+			// remove from map and signal the closer to cancel the operation.
+			delete(n.ops, otherId)
 			otherCloser.SignalAndWait()
 		}
 	case opSnapshot, opIndexing:
 		for otherId, otherCloser := range n.ops {
 			if otherId == opRollup {
-				// We set to nil so that stopAllTasks doesn't call SignalAndWait again.
-				n.ops[opRollup] = nil
+				// remove from map and signal the closer to cancel the operation.
+				delete(n.ops, otherId)
 				otherCloser.SignalAndWait()
 			} else {
 				return nil, errors.Errorf("operation %s is already running", otherId)
@@ -182,9 +182,6 @@ func (n *node) stopAllTasks() {
 	n.opsLock.Lock()
 	defer n.opsLock.Unlock()
 	for _, closer := range n.ops {
-		if closer == nil {
-			continue
-		}
 		closer.SignalAndWait()
 	}
 	glog.Infof("Stopped all ongoing registered tasks.")

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -137,14 +137,14 @@ func (n *node) startTask(id op) (*y.Closer, error) {
 			if otherId == opRestore {
 				return nil, errors.Errorf("another restore operation is already running")
 			}
-			// remove from map and signal the closer to cancel the operation.
+			// Remove from map and signal the closer to cancel the operation.
 			delete(n.ops, otherId)
 			otherCloser.SignalAndWait()
 		}
 	case opSnapshot, opIndexing:
 		for otherId, otherCloser := range n.ops {
 			if otherId == opRollup {
-				// remove from map and signal the closer to cancel the operation.
+				// Remove from map and signal the closer to cancel the operation.
 				delete(n.ops, otherId)
 				otherCloser.SignalAndWait()
 			} else {


### PR DESCRIPTION
A panic was caused because n.ops map entry was set to nil in some cases. 
 Fix is to not set n.ops map entries to nil. Instead, just delete them.
Fixed DGRAPH-1573

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5551)
<!-- Reviewable:end -->
