### PR TITLE
Alpha: Enable bloom filter caching

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -767,10 +767,8 @@ func run() {
 	}
 	bopts := badger.DefaultOptions(dir).
 		WithTableLoadingMode(options.MemoryMap).
-		WithReadOnly(opt.readOnly).WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.keyFile))
-
-	// TODO(Ibrahim): Remove this once badger is updated.
-	bopts.ZSTDCompressionLevel = 1
+		WithReadOnly(opt.readOnly).
+		WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.keyFile))
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -36,8 +36,7 @@ var KeyFile string
 
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
-		// TOOD(Ibrahim): Remove compression level once badger is updated.
-		WithReadOnly(true).WithZSTDCompressionLevel(1).
+		WithReadOnly(true).
 		WithEncryptionKey(enc.ReadEncryptionKeyFile(KeyFile))
 	return badger.OpenManaged(opt)
 }

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -153,7 +153,8 @@ func (s *ServerState) initStorage() {
 			WithNumVersionsToKeep(math.MaxInt32).
 			WithMaxCacheSize(1 << 30).
 			WithKeepBlockIndicesInCache(true).
-			WithKeepBlocksInCache(true)
+			WithKeepBlocksInCache(true).
+			WithMaxBfCacheSize(500 << 20) // 500 MB of bloom filter cache.
 		opt = setBadgerOptions(opt)
 
 		// Print the options w/o exposing key.


### PR DESCRIPTION
Badger supports caching of SST bloom filters, this PR enables caching
bloom filters in ristretto.
The bloom filter cache is enabled only for the `p` directory. The bloom filters for the `w` directory will be kept in memory. We can add those later if necessary. 

This PR also removes old state todos.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5552)
<!-- Reviewable:end -->
