### PR TITLE
release/v1.2: Alpha: Enable bloom filter caching (#5552)

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -767,10 +767,8 @@ func run() {
 	}
 	bopts := badger.DefaultOptions(dir).
 		WithTableLoadingMode(options.MemoryMap).
-		WithReadOnly(opt.readOnly).WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.badgerKeyFile))
-
-	// TODO(Ibrahim): Remove this once badger is updated.
-	bopts.ZSTDCompressionLevel = 1
+		WithReadOnly(opt.readOnly).
+		WithEncryptionKey(enc.ReadEncryptionKeyFile(opt.badgerKeyFile))
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -36,8 +36,7 @@ var KeyFile string
 
 func openDgraph(pdir string) (*badger.DB, error) {
 	opt := badger.DefaultOptions(pdir).WithTableLoadingMode(options.MemoryMap).
-		// TOOD(Ibrahim): Remove compression level once badger is updated.
-		WithReadOnly(true).WithZSTDCompressionLevel(1).
+		WithReadOnly(true).
 		WithEncryptionKey(enc.ReadEncryptionKeyFile(KeyFile))
 	return badger.OpenManaged(opt)
 }

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -154,7 +154,8 @@ func (s *ServerState) initStorage() {
 			WithNumVersionsToKeep(math.MaxInt32).
 			WithMaxCacheSize(1 << 30).
 			WithKeepBlockIndicesInCache(true).
-			WithKeepBlocksInCache(true)
+			WithKeepBlocksInCache(true).
+			WithMaxBfCacheSize(500 << 20) // 500 MB of bloom filter cache.
 		opt = setBadgerOptions(opt)
 
 		// Print the options w/o exposing key.


### PR DESCRIPTION
Badger supports the caching of SST bloom filters. This PR enables
caching bloom filters in ristretto. The bloom filter cache is enabled
only for the p directory. The bloom filters for the w directory will be
kept in memory. We can add caching for it later if necessary.

This PR also removes old stale todos.

(cherry picked from commit 92328a777993769a45a2b084577af62512c0021b)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5554)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a06415f649-67886.surge.sh)
<!-- Dgraph:end -->