### PR TITLE
Replace shutdownCh and wait groups to a y.Closer for shutting down Alpha

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -531,7 +531,7 @@ func setupServer(closer *y.Closer) {
 
 	go func() {
 		defer wg.Done()
-		<-worker.ShutdownCh
+		<-admin.ShutdownCh
 		atomic.StoreUint64(&globalEpoch, math.MaxUint64)
 
 		// Stops grpc/http servers; Already accepted connections are not closed.
@@ -674,7 +674,6 @@ func run() {
 
 	// setup shutdown os signal handler
 	sdCh := make(chan os.Signal, 3)
-	worker.ShutdownCh = make(chan struct{})
 
 	defer func() {
 		signal.Stop(sdCh)
@@ -686,9 +685,9 @@ func run() {
 		var numShutDownSig int
 		for range sdCh {
 			select {
-			case <-worker.ShutdownCh:
+			case <-admin.ShutdownCh:
 			default:
-				close(worker.ShutdownCh)
+				close(admin.ShutdownCh)
 			}
 			numShutDownSig++
 			glog.Infoln("Caught Ctrl-C. Terminating now (this may take a few seconds)...")

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -374,8 +373,8 @@ func setupListener(addr string, port int) (net.Listener, error) {
 	return net.Listen("tcp", fmt.Sprintf("%s:%d", addr, port))
 }
 
-func serveGRPC(l net.Listener, tlsCfg *tls.Config, wg *sync.WaitGroup) {
-	defer wg.Done()
+func serveGRPC(l net.Listener, tlsCfg *tls.Config, closer *y.Closer) {
+	defer closer.Done()
 
 	x.RegisterExporters(Alpha.Conf, "dgraph.alpha")
 
@@ -397,8 +396,8 @@ func serveGRPC(l net.Listener, tlsCfg *tls.Config, wg *sync.WaitGroup) {
 	s.Stop()
 }
 
-func serveHTTP(l net.Listener, tlsCfg *tls.Config, wg *sync.WaitGroup) {
-	defer wg.Done()
+func serveHTTP(l net.Listener, tlsCfg *tls.Config, closer *y.Closer) {
+	defer closer.Done()
 	srv := &http.Server{
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 600 * time.Second,
@@ -519,19 +518,19 @@ func setupServer(closer *y.Closer) {
 	http.HandleFunc("/", homeHandler)
 	http.HandleFunc("/ui/keywords", keywordHandler)
 
-	// Initilize the servers.
-	var wg sync.WaitGroup
-	wg.Add(3)
-	go serveGRPC(grpcListener, tlsCfg, &wg)
-	go serveHTTP(httpListener, tlsCfg, &wg)
+	// Initialize the servers.
+	admin.ServerCloser = y.NewCloser(3)
+	go serveGRPC(grpcListener, tlsCfg, admin.ServerCloser)
+	go serveHTTP(httpListener, tlsCfg, admin.ServerCloser)
 
 	if Alpha.Conf.GetBool("telemetry") {
 		go edgraph.PeriodicallyPostTelemetry()
 	}
 
 	go func() {
-		defer wg.Done()
-		<-admin.ShutdownCh
+		defer admin.ServerCloser.Done()
+
+		<-admin.ServerCloser.HasBeenClosed()
 		atomic.StoreUint64(&globalEpoch, math.MaxUint64)
 
 		// Stops grpc/http servers; Already accepted connections are not closed.
@@ -545,7 +544,8 @@ func setupServer(closer *y.Closer) {
 
 	glog.Infoln("gRPC server started.  Listening on port", grpcPort())
 	glog.Infoln("HTTP server started.  Listening on port", httpPort())
-	wg.Wait()
+
+	admin.ServerCloser.Wait()
 }
 
 func run() {
@@ -685,9 +685,9 @@ func run() {
 		var numShutDownSig int
 		for range sdCh {
 			select {
-			case <-admin.ShutdownCh:
+			case <-admin.ServerCloser.HasBeenClosed():
 			default:
-				close(admin.ShutdownCh)
+				admin.ServerCloser.Signal()
 			}
 			numShutDownSig++
 			glog.Infoln("Caught Ctrl-C. Terminating now (this may take a few seconds)...")

--- a/graphql/admin/shutdown.go
+++ b/graphql/admin/shutdown.go
@@ -21,14 +21,21 @@ import (
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/dgraph/worker"
 	"github.com/golang/glog"
+)
+
+var (
+	// ShutdownCh is used to pass the shutdown signal for the Alpha server between goroutines.
+	// When a shutdown command is issued by the user, the admin package closes this channel
+	// and as a response the setupServer() function in cmd/alpha/run.go gracefully stops the
+	// gRPC and HTTP server before stopping Alpha.
+	ShutdownCh = make(chan struct{})
 )
 
 func resolveShutdown(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {
 	glog.Info("Got shutdown request through GraphQL admin API")
 
-	close(worker.ShutdownCh)
+	close(ShutdownCh)
 
 	return &resolve.Resolved{
 		Data:  map[string]interface{}{m.Name(): response("Success", "Server is shutting down")},

--- a/graphql/admin/shutdown.go
+++ b/graphql/admin/shutdown.go
@@ -19,23 +19,22 @@ package admin
 import (
 	"context"
 
+	"github.com/dgraph-io/badger/v2/y"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/golang/glog"
 )
 
 var (
-	// ShutdownCh is used to pass the shutdown signal for the Alpha server between goroutines.
-	// When a shutdown command is issued by the user, the admin package closes this channel
-	// and as a response the setupServer() function in cmd/alpha/run.go gracefully stops the
-	// gRPC and HTTP server before stopping Alpha.
-	ShutdownCh = make(chan struct{})
+	// ServerCloser is used to signal and wait for other goroutines to return gracefully after user
+	// requests shutdown.
+	ServerCloser *y.Closer
 )
 
 func resolveShutdown(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {
 	glog.Info("Got shutdown request through GraphQL admin API")
 
-	close(ShutdownCh)
+	ServerCloser.Signal()
 
 	return &resolve.Resolved{
 		Data:  map[string]interface{}{m.Name(): response("Success", "Server is shutting down")},

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -32,8 +32,7 @@ import (
 
 // ServerState holds the state of the Dgraph server.
 type ServerState struct {
-	FinishCh   chan struct{} // channel to wait for all pending reqs to finish.
-	ShutdownCh chan struct{} // channel to signal shutdown.
+	FinishCh chan struct{} // channel to wait for all pending reqs to finish.
 
 	Pstore   *badger.DB
 	WALstore *badger.DB
@@ -50,7 +49,6 @@ func InitServerState() {
 	Config.validate()
 
 	State.FinishCh = make(chan struct{})
-	State.ShutdownCh = make(chan struct{})
 	State.needTs = make(chan tsReq, 100)
 
 	State.initStorage()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -43,8 +43,6 @@ var (
 	pstore       *badger.DB
 	workerServer *grpc.Server
 	raftServer   conn.RaftServer
-	// ShutdownCh is used while trying to shutdown the server.
-	ShutdownCh chan struct{}
 
 	// In case of flaky network connectivity we would try to keep upto maxPendingEntries in wal
 	// so that the nodes which have lagged behind leader can just replay entries instead of


### PR DESCRIPTION
Earlier we had `worker.ShutdownCh` which was used to pass information between `alpha/run.go` and `graphql/admin.go` which was causing confusion and was being used to stop the worker itself. We now have a `y.Closer` in `graphql/admin` which manages the WaitGroup and passing of signals between goroutines using channels. 

Fixes DGRAPH-1169

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5560)
<!-- Reviewable:end -->
