### PR TITLE
Alpha: Gracefully shutdown ludicrous mode

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -943,10 +943,10 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 				time.Sleep(time.Second) // Let transfer happen.
 			}
 			n.Raft().Stop()
-			close(done)
 			if x.WorkerConfig.LudicrousMode {
 				n.ex.closer.SignalAndWait()
 			}
+			close(done)
 			return
 		}
 	}

--- a/worker/executor.go
+++ b/worker/executor.go
@@ -56,6 +56,12 @@ func (e *executor) processMutationCh(ch chan *subMutation) {
 	for payload := range ch {
 		ptxn := posting.NewTxn(payload.startTs)
 		for _, edge := range payload.edges {
+			// Return fast if executor has been closed.
+			select {
+			case <-e.closer.HasBeenClosed():
+				return
+			default:
+			}
 			for {
 				err := runMutation(payload.ctx, edge, ptxn)
 				if err == nil {


### PR DESCRIPTION
Fixes - DGRAPH-1353

When live loader in running on an Alpha in ludicrous mode, alpha will
crash with a segmentation fault error because badger was closed before
ludicrous mode goroutines were stopped. This PR fixed that issue.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->
