### PR TITLE
graphql: Allow user to define and pass arguments to fields.

### DIFF
--- a/graphql/schema/custom_http_config_test.yaml
+++ b/graphql/schema/custom_http_config_test.yaml
@@ -124,7 +124,7 @@
     }
 
     type Country @remote {
-      code(first: Int!, filter: MyFilter): String
+      code(get: Int!, choose: MyFilter): String
       name: String
       states: [State]
       std: Int
@@ -158,7 +158,7 @@
   gqlquery: |
     mutation addCountry1($input: CountryInput!) {
       addCountry1(input: $input) {
-        code(first: 10, filter: {ids: "0x123", name: { eq: "github" }})
+        code(get: 10, choose: {ids: "0x123", name: { eq: "github" }})
         name
         states {
           code
@@ -194,7 +194,7 @@
     }
 
     type Country {
-      code(first: Int!, filter: MyFilter): String
+      code(get: Int!, choose: MyFilter): String
       name: String
       states: [State]
       std: Int
@@ -227,7 +227,7 @@
     }
   remotequery: |-
     mutation($input: CountryInput!) { setCountry(country: $input) {
-    code(first: 10, filter: {ids:"0x123",name:{eq:"github"}})
+    code(get: 10, choose: {ids:"0x123",name:{eq:"github"}})
     name
     states{
     code

--- a/graphql/schema/custom_http_config_test.yaml
+++ b/graphql/schema/custom_http_config_test.yaml
@@ -46,6 +46,71 @@
     { "id": "0x1" }
 
 -
+  name: "custom query with arguments on fields"
+  type: "query"
+  gqlschema: |
+    input ExactFilter {
+      eq: String
+    }
+
+    input MyFilter {
+      ids: ID
+      name: ExactFilter
+    }
+
+    type Country @remote {
+        code(first: Int!, filter: MyFilter): String
+        name: String
+    }
+
+    type Query {
+      getCountry1(id: ID!): Country! @custom(http: {
+          url: "http://google.com/validcountry",
+          method: "POST",
+          forwardHeaders: ["Content-Type"],
+          graphql: "query($id: ID!) { country(code: $id) }",
+          skipIntrospection: true
+      })
+    }
+  gqlquery: |
+    query {
+      getCountry1(id: "0x1") {
+        name
+        code(first: 10, filter: {ids: "0x123", name: { eq: "github" }})
+      }
+    }
+  remoteschema: |
+    input ExactFilter {
+      eq: String
+    }
+
+    input MyFilter {
+      ids: ID
+      name: ExactFilter
+    }
+
+    type Country @remote {
+      code(first: Int!, filter: MyFilter): String
+      name: String
+    }
+
+    type Query {
+      country(code: ID!): Country! @custom(http: {
+        url: "http://google.com/validcountry",
+        method: "POST",
+        graphql: "query($code: ID!) { country(code: $code) }",
+        skipIntrospection: true
+      })
+    }
+  remotequery: |-
+    query($id: ID!) { country(code: $id) {
+    name
+    code(first: 10, filter: {ids:"0x123",name:{eq:"github"}})
+    }}
+  remotevariables: |-
+    { "id": "0x1" }
+
+-
   name: "custom mutation"
   type: "mutation"
   gqlschema: |

--- a/graphql/schema/custom_http_config_test.yaml
+++ b/graphql/schema/custom_http_config_test.yaml
@@ -111,11 +111,20 @@
     { "id": "0x1" }
 
 -
-  name: "custom mutation"
+  name: "custom mutation with arguments on field"
   type: "mutation"
   gqlschema: |
+    input ExactFilter {
+      eq: String
+    }
+
+    input MyFilter {
+      ids: ID
+      name: ExactFilter
+    }
+
     type Country @remote {
-      code: String
+      code(first: Int!, filter: MyFilter): String
       name: String
       states: [State]
       std: Int
@@ -149,7 +158,7 @@
   gqlquery: |
     mutation addCountry1($input: CountryInput!) {
       addCountry1(input: $input) {
-        code
+        code(first: 10, filter: {ids: "0x123", name: { eq: "github" }})
         name
         states {
           code
@@ -175,8 +184,17 @@
       }
     }
   remoteschema: |
+    input ExactFilter {
+      eq: String
+    }
+
+    input MyFilter {
+      ids: ID
+      name: ExactFilter
+    }
+
     type Country {
-      code: String
+      code(first: Int!, filter: MyFilter): String
       name: String
       states: [State]
       std: Int
@@ -209,7 +227,7 @@
     }
   remotequery: |-
     mutation($input: CountryInput!) { setCountry(country: $input) {
-    code
+    code(first: 10, filter: {ids:"0x123",name:{eq:"github"}})
     name
     states{
     code

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -325,13 +325,13 @@ func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	var dirs ast.DirectiveList
 	dirs = append(dirs, src.Directives...)
 
-	// Lets leave out copying the arguments as types in input schemas are not supposed to contain
-	// them. We add arguments for filters and order statements later.
+	// We add arguments for filters and order statements later.
 	dst := &ast.FieldDefinition{
 		Name:         src.Name,
 		DefaultValue: src.DefaultValue,
 		Type:         src.Type,
 		Directives:   dirs,
+		Arguments:    src.Arguments,
 		Position:     src.Position,
 	}
 	return dst
@@ -1241,6 +1241,7 @@ func createField(schema *ast.Schema, fld *ast.FieldDefinition) *ast.FieldDefinit
 	newFldType := *fld.Type
 	newFld.Type = &newFldType
 	newFld.Directives = nil
+	newFld.Arguments = nil
 	return &newFld
 }
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -63,16 +63,6 @@ invalid_schemas:
     ]
 
   -
-    name: "There shoudnt be arguments on any field"
-    input: |
-      type T {
-        f(a: Int): String
-      }
-    errlist: [
-      {"message": "Type T; Field f: You can't give arguments to fields.", "locations": [{"line": 2, "column": 3}]}
-    ]
-
-  -
     name: "Enum indexes clash trigram and regexp"
     input: |
       type T {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -1893,6 +1893,17 @@ invalid_schemas:
      "locations":[{"line":1, "column":11}]},
     ]
 
+
+  - name: "There shoudnt be any reserved arguments on any field"
+    input: |
+      type T {
+        f(first: Int): String
+      }
+    errlist: [
+    {"message": "Type T; Field f: can't have first as an argument because it is a reserved argument.", "locations": [{"line": 2, "column": 3}]}
+    ]
+
+
 valid_schemas:
   - name: "@auth on interface implementation"
     input: |

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -39,8 +39,8 @@ func init() {
 	schemaValidations = append(schemaValidations, dgraphDirectivePredicateValidation)
 	typeValidations = append(typeValidations, idCountCheck, dgraphDirectiveTypeValidation,
 		passwordDirectiveValidation, conflictingDirectiveValidation, nonIdFieldsCheck)
-	fieldValidations = append(fieldValidations, listValidityCheck, fieldNameCheck,
-		isValidFieldForList, hasAuthDirective)
+	fieldValidations = append(fieldValidations, listValidityCheck, fieldArgumentCheck,
+		fieldNameCheck, isValidFieldForList, hasAuthDirective)
 
 	validator.AddRule("Check variable type is correct", variableTypeCheck)
 	validator.AddRule("Check for list type value", listTypeCheck)
@@ -628,6 +628,30 @@ func isValidFieldForList(typ *ast.Definition, field *ast.FieldDefinition) *gqler
 		return gqlerror.ErrorPosf(
 			field.Position, "Type %s; Field %s: %s lists are invalid.",
 			typ.Name, field.Name, field.Type.Elem.Name())
+	}
+	return nil
+}
+
+func fieldArgumentCheck(typ *ast.Definition, field *ast.FieldDefinition) *gqlerror.Error {
+	if isQueryOrMutationType(typ) {
+		return nil
+	}
+	// We don't need to verify the argument names for fields which are part of a remote type as
+	// we don't add any of our own arguments to them.
+	remote := typ.Directives.ForName(remoteDirective)
+	if remote != nil {
+		return nil
+	}
+	for _, arg := range field.Arguments {
+		if isReservedArgument(arg.Name) {
+			return gqlerror.ErrorPosf(
+				field.Position,
+				"Type %s; Field %s: can't have %s as an argument because it is a reserved "+
+					"argument.",
+				typ.Name, field.Name, arg.Name,
+			)
+
+		}
 	}
 	return nil
 }
@@ -1575,6 +1599,14 @@ func searchMessage(sch *ast.Schema, field *ast.FieldDefinition) string {
 func isScalar(s string) bool {
 	_, ok := scalarToDgraph[s]
 	return ok
+}
+
+func isReservedArgument(name string) bool {
+	switch name {
+	case "first", "offset", "filter", "order":
+		return true
+	}
+	return false
 }
 
 func isReservedKeyWord(name string) bool {

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -39,8 +39,8 @@ func init() {
 	schemaValidations = append(schemaValidations, dgraphDirectivePredicateValidation)
 	typeValidations = append(typeValidations, idCountCheck, dgraphDirectiveTypeValidation,
 		passwordDirectiveValidation, conflictingDirectiveValidation, nonIdFieldsCheck)
-	fieldValidations = append(fieldValidations, listValidityCheck, fieldArgumentCheck,
-		fieldNameCheck, isValidFieldForList, hasAuthDirective)
+	fieldValidations = append(fieldValidations, listValidityCheck, fieldNameCheck,
+		isValidFieldForList, hasAuthDirective)
 
 	validator.AddRule("Check variable type is correct", variableTypeCheck)
 	validator.AddRule("Check for list type value", listTypeCheck)
@@ -628,20 +628,6 @@ func isValidFieldForList(typ *ast.Definition, field *ast.FieldDefinition) *gqler
 		return gqlerror.ErrorPosf(
 			field.Position, "Type %s; Field %s: %s lists are invalid.",
 			typ.Name, field.Name, field.Type.Elem.Name())
-	}
-	return nil
-}
-
-func fieldArgumentCheck(typ *ast.Definition, field *ast.FieldDefinition) *gqlerror.Error {
-	if isQueryOrMutationType(typ) {
-		return nil
-	}
-	if field.Arguments != nil {
-		return gqlerror.ErrorPosf(
-			field.Position,
-			"Type %s; Field %s: You can't give arguments to fields.",
-			typ.Name, field.Name,
-		)
 	}
 	return nil
 }

--- a/graphql/schema/testdata/schemagen/input/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/input/type-with-arguments-on-field.graphql
@@ -1,0 +1,10 @@
+interface Abstract {
+    id: ID!
+    name(random: Int!, size: String): String!
+}
+
+type Message implements Abstract {
+    content(pick: Int!, name: String): String!
+    author: String
+    datePosted: DateTime
+}

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -1,0 +1,279 @@
+#######################
+# Input Schema
+#######################
+
+interface Abstract {
+	id: ID!
+	name(random: Int!, size: String): String!
+}
+
+type Message implements Abstract {
+	id: ID!
+	name(random: Int!, size: String): String!
+	content(pick: Int!, name: String): String!
+	author: String
+	datePosted: DateTime
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete:AuthRule) on OBJECT
+directive @custom(http: CustomHTTP) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	numUids: Int
+}
+
+type DeleteAbstractPayload {
+	msg: String
+	numUids: Int
+}
+
+type DeleteMessagePayload {
+	msg: String
+	numUids: Int
+}
+
+type UpdateAbstractPayload {
+	abstract(filter: AbstractFilter, order: AbstractOrder, first: Int, offset: Int): [Abstract]
+	numUids: Int
+}
+
+type UpdateMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AbstractOrderable {
+	name
+}
+
+enum MessageOrderable {
+	name
+	content
+	author
+	datePosted
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AbstractFilter {
+	id: [ID!]
+	not: AbstractFilter
+}
+
+input AbstractOrder {
+	asc: AbstractOrderable
+	desc: AbstractOrderable
+	then: AbstractOrder
+}
+
+input AbstractPatch {
+	name: String
+}
+
+input AbstractRef {
+	id: ID!
+}
+
+input AddMessageInput {
+	name: String!
+	content: String!
+	author: String
+	datePosted: DateTime
+}
+
+input MessageFilter {
+	id: [ID!]
+	not: MessageFilter
+}
+
+input MessageOrder {
+	asc: MessageOrderable
+	desc: MessageOrderable
+	then: MessageOrder
+}
+
+input MessagePatch {
+	name: String
+	content: String
+	author: String
+	datePosted: DateTime
+}
+
+input MessageRef {
+	id: ID
+	name: String
+	content: String
+	author: String
+	datePosted: DateTime
+}
+
+input UpdateAbstractInput {
+	filter: AbstractFilter!
+	set: AbstractPatch
+	remove: AbstractPatch
+}
+
+input UpdateMessageInput {
+	filter: MessageFilter!
+	set: MessagePatch
+	remove: MessagePatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAbstract(id: ID!): Abstract
+	queryAbstract(filter: AbstractFilter, order: AbstractOrder, first: Int, offset: Int): [Abstract]
+	getMessage(id: ID!): Message
+	queryMessage(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	updateAbstract(input: UpdateAbstractInput!): UpdateAbstractPayload
+	deleteAbstract(filter: AbstractFilter!): DeleteAbstractPayload
+	addMessage(input: [AddMessageInput!]!): AddMessagePayload
+	updateMessage(input: UpdateMessageInput!): UpdateMessagePayload
+	deleteMessage(filter: MessageFilter!): DeleteMessagePayload
+}
+
+#######################
+# Generated Subscriptions
+#######################
+
+type Subscription {
+	getAbstract(id: ID!): Abstract
+	queryAbstract(filter: AbstractFilter, order: AbstractOrder, first: Int, offset: Int): [Abstract]
+	getMessage(id: ID!): Message
+	queryMessage(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1956,8 +1956,22 @@ func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 	}
 	writer.WriteString("{\n")
 	for i := 0; i < len(field.SelectionSet); i++ {
+		// TODO - Check if this type conversion is safe.
 		castedField := field.SelectionSet[i].(*ast.Field)
 		writer.WriteString(castedField.Name)
+
+		if len(castedField.Arguments) > 0 {
+			writer.WriteString("(")
+			for idx, arg := range castedField.Arguments {
+				if idx != 0 {
+					writer.WriteString(", ")
+				}
+				writer.WriteString(arg.Name)
+				writer.WriteString(": ")
+				writer.WriteString(arg.Value.String())
+			}
+			writer.WriteString(")")
+		}
 
 		if len(castedField.SelectionSet) > 0 {
 			// recursively add fields.


### PR DESCRIPTION
This would allow users to pass in arguments to fields of remote endpoints.

Fixes GRAPHQL-366
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->
