### PR TITLE
graphql: add Graphql-TouchedUids header in HTTP response

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -221,6 +221,9 @@ func RunAll(t *testing.T) {
 	// schema tests
 	t.Run("graphql descriptions", graphQLDescriptions)
 
+	// header tests
+	t.Run("touched uids header", touchedUidsHeader)
+
 	// encoding
 	t.Run("gzip compression", gzipCompression)
 	t.Run("gzip compression header", gzipCompressionHeader)

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -19,8 +19,11 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
+	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -59,6 +62,33 @@ func queryCountryByRegExp(t *testing.T, regexp string, expectedCountries []*coun
 	if diff := cmp.Diff(expected, result); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func touchedUidsHeader(t *testing.T) {
+	query := &GraphQLParams{
+		Query: `query {
+			queryCountry {
+				name
+			}
+		}`,
+	}
+	req, err := query.createGQLPost(graphqlURL)
+	require.NoError(t, err)
+
+	client := http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	// confirm that the header value is a non-negative integer
+	touchedUidsInHeader, err := strconv.ParseUint(resp.Header.Get("X-Dgraph-TouchedUids"), 10, 64)
+	require.NoError(t, err)
+
+	// confirm that the value in header is same as the value in body
+	var gqlResp GraphQLResponse
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(b, &gqlResp))
+	require.Equal(t, touchedUidsInHeader, uint64(gqlResp.Extensions["touched_uids"].(float64)))
 }
 
 // This test checks that all the different combinations of

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -80,7 +80,7 @@ func touchedUidsHeader(t *testing.T) {
 	require.NoError(t, err)
 
 	// confirm that the header value is a non-negative integer
-	touchedUidsInHeader, err := strconv.ParseUint(resp.Header.Get("X-Dgraph-TouchedUids"), 10, 64)
+	touchedUidsInHeader, err := strconv.ParseUint(resp.Header.Get("Graphql-TouchedUids"), 10, 64)
 	require.NoError(t, err)
 
 	// confirm that the value in header is same as the value in body

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -32,6 +32,14 @@ type Extensions struct {
 	TouchedUids uint64 `json:"touched_uids,omitempty"`
 }
 
+// GetTouchedUids returns TouchedUids
+func (e *Extensions) GetTouchedUids() uint64 {
+	if e == nil {
+		return 0
+	}
+	return e.TouchedUids
+}
+
 // Merge merges ext with e
 func (e *Extensions) Merge(ext *Extensions) {
 	if e == nil || ext == nil {
@@ -67,6 +75,14 @@ func ErrorResponse(err error) *Response {
 	return &Response{
 		Errors: AsGQLErrors(err),
 	}
+}
+
+// GetExtensions returns a *Extensions
+func (r *Response) GetExtensions() *Extensions {
+	if r == nil {
+		return nil
+	}
+	return r.Extensions
 }
 
 // WithError generates GraphQL errors from err and records those in r.

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"io"
 	"io/ioutil"
@@ -38,6 +39,8 @@ import (
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
+
+const touchedUidsHeader = "X-Dgraph-TouchedUids"
 
 // An IServeGraphQL can serve a GraphQL endpoint (currently only ons http)
 type IServeGraphQL interface {
@@ -85,6 +88,9 @@ func (gh *graphqlHandler) Resolve(ctx context.Context, gqlReq *schema.Request) *
 // and sends the schema response using that.
 func write(w http.ResponseWriter, rr *schema.Response, acceptGzip bool) {
 	var out io.Writer = w
+
+	// set TouchedUids header
+	w.Header().Set(touchedUidsHeader, strconv.FormatUint(rr.GetExtensions().GetTouchedUids(), 10))
 
 	// If the receiver accepts gzip, then we would update the writer
 	// and send gzipped content instead.

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -40,7 +40,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-const touchedUidsHeader = "X-Dgraph-TouchedUids"
+const touchedUidsHeader = "Graphql-TouchedUids"
 
 // An IServeGraphQL can serve a GraphQL endpoint (currently only ons http)
 type IServeGraphQL interface {


### PR DESCRIPTION
This PR adds the `Graphql-TouchedUids` header in the HTTP response sent by GraphQL.

Fixes #GRAPHQL-489.
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5572)
<!-- Reviewable:end -->
