### PR TITLE
update zero health check for dgraph-ha.yaml

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -172,7 +172,7 @@ spec:
           successThreshold: 1
         readinessProbe:
           httpGet:
-            path: /state
+            path: /health
             port: 6080
           initialDelaySeconds: 15
           periodSeconds: 10


### PR DESCRIPTION
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->


Discovered issue with `dgraph-ha.yaml` where dgraph cluster may not come back to a healthy state when zero has a  `readinessProbe.httpGet.path` set to `/state`.  Changing this value to `/health`.

Fixes #5583.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5580)
<!-- Reviewable:end -->
