### PR TITLE
graphql: make updateGQLSchema always return the new schema (#5540)

### DIFF
--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -38,6 +38,10 @@ type updateSchemaResolver struct {
 
 	mutation schema.Mutation
 
+	// new GraphQL schema that is given as mutation input
+	newSchema string
+	// GraphQL schema that is generated from that input
+	generatedSchema string
 	// dgraph schema that is generated from the mutation input
 	newDgraphSchema string
 
@@ -73,11 +77,12 @@ func (asr *updateSchemaResolver) Rewrite(
 		return nil, err
 	}
 
-	_, err = schema.FromString(schHandler.GQLSchema())
+	asr.generatedSchema = schHandler.GQLSchema()
+	_, err = schema.FromString(asr.generatedSchema)
 	if err != nil {
 		return nil, err
 	}
-
+	asr.newSchema = input.Set.Schema
 	asr.newDgraphSchema = schHandler.DGSchema()
 
 	// There will always be a graphql schema node present in Dgraph cluster. So, we just need to
@@ -108,7 +113,11 @@ func (asr *updateSchemaResolver) Execute(
 	if req == nil || (req.Query == "" && len(req.Mutations) == 0) {
 		// For schema updates, Execute will get called twice.  Once for the
 		// mutation and once for the following query.  This is the query case.
-		b, err := doQuery(asr.admin.schema, asr.mutation.QueryField())
+		b, err := doQuery(&gqlSchema{
+			ID:              asr.admin.schema.ID,
+			Schema:          asr.newSchema,
+			GeneratedSchema: asr.generatedSchema,
+		}, asr.mutation.QueryField())
 		return &dgoapi.Response{Json: b}, err
 	}
 
@@ -118,7 +127,8 @@ func (asr *updateSchemaResolver) Execute(
 		return nil, err
 	}
 
-	_, err = (&edgraph.Server{}).Alter(ctx, &dgoapi.Operation{Schema: asr.newDgraphSchema})
+	_, err = (&edgraph.Server{}).Alter(ctx, &dgoapi.Operation{Schema: asr.newDgraphSchema,
+		RunInBackground: false})
 	if err != nil {
 		return nil, schema.GQLWrapf(err,
 			"succeeded in saving GraphQL schema but failed to alter Dgraph schema ")

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -705,11 +705,16 @@ func addSchema(url string, schema string) error {
 				}
 			}
 		}
+		Errors []interface{}
 	}
 
 	err = json.Unmarshal(resp, &addResult)
 	if err != nil {
 		return errors.Wrap(err, "error trying to unmarshal GraphQL mutation result")
+	}
+
+	if len(addResult.Errors) > 0 {
+		return errors.Errorf("%v", addResult.Errors)
 	}
 
 	if addResult.Data.UpdateGQLSchema.GQLSchema.Schema == "" {


### PR DESCRIPTION
This PR makes the updateGQLSchema mutation return the updated schema always, instead of relying on async badger update.

Fixes #GRAPHQL-497.

(cherry-picked from commit 265086f98d04e9a2bfddb5e8e40f677d2f426167)

\# Conflicts:
\#	graphql/admin/schema.go

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5582)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-35dc57ae86-68789.surge.sh)
<!-- Dgraph:end -->