### PR TITLE
release/v20.03 - Alpha: Gracefully shutdown ludicrous mode (#5561) 

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -903,10 +903,10 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 				time.Sleep(time.Second) // Let transfer happen.
 			}
 			n.Raft().Stop()
-			close(done)
 			if x.WorkerConfig.LudicrousMode {
 				n.ex.closer.SignalAndWait()
 			}
+			close(done)
 			return
 		}
 	}


### PR DESCRIPTION
Fixes - DGRAPH-1353

When live loader in running on an Alpha in ludicrous mode, alpha will
crash with a segmentation fault error because badger was closed before
ludicrous mode goroutines were stopped. This PR fixed that issue.

The crash can be reproduced by
```
1. dgraph zero --ludicrous_mode
2. dgraph alpha --ludicrous_mode --enable_sentry=false
3. dgraph live -f $GOPATH/src/github.com/dgraph-io/benchmarks/data/21million.rdf.gz \
-s $GOPATH/src/github.com/dgraph-io/benchmarks/data/21million.schema \
-z localhost:5080 -a localhost:9080 --ludicrous_mode

Hit <CTRL+C> while alpha is receiving data from live loader.
```

(cherry picked from commit e326b9e802f2f04eedf8044361ca28573dbff5a8)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5584)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-42060abdd7-68810.surge.sh)
<!-- Dgraph:end -->