### PR TITLE
release/v20.03 Alpha Close: Wait for indexing to complete (#5137)

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -179,9 +179,6 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	defer stopIndexing(closer)
 
 	buildIndexesHelper := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) error {
-		// in case background indexing is running, we should call it here again.
-		defer stopIndexing(closer)
-
 		wrtCtx := schema.GetWriteContext(context.Background())
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {
 			return err
@@ -200,6 +197,9 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	wg.Add(1)
 	defer wg.Done()
 	buildIndexes := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) {
+		// In case background indexing is running, we should call it here again.
+		defer stopIndexing(closer)
+
 		// We should only start building indexes once this function has returned.
 		// This is in order to ensure that we do not call DropPrefix for one predicate
 		// and write indexes for another predicate simultaneously. because that could


### PR DESCRIPTION
The background reindexing starts indexing in the background but we
do not wait for the indexing to complete in case of error while shutting
down alpha. This PR fixes that issue by waiting for the background
indexing to complete before we shutdown alpha. 

The issue can be easily seen by adding a long sleep in the
background indexing and trying to shutdown alpha. It can be seen
that Alpha doesn't wait for the indexing to complete while shutting
down.

Fixes https://github.com/dgraph-io/dgraph/issues/3873

(cherry picked from commit dc75424d576bcda9e170adc24573204b7b822684)

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5597)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b765f8ad0e-69191.surge.sh)
<!-- Dgraph:end -->