### PR TITLE
Rollup: Reduce memory consumption of the map

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -110,7 +110,7 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 	m := make(map[uint64]int64) // map hash(key) to ts. hash(key) to limit the size of the map.
 	limiter := time.NewTicker(100 * time.Millisecond)
 	defer limiter.Stop()
-	cleanupTick := time.NewTicker(2 * time.Minute)
+	cleanupTick := time.NewTicker(5 * time.Minute)
 	defer cleanupTick.Stop()
 
 	for {
@@ -118,20 +118,12 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 		case <-closer.HasBeenClosed():
 			return
 		case <-cleanupTick.C:
-			timeout := time.NewTimer(3 * time.Second)
 			currTs := time.Now().UnixNano()
-		LOOP:
 			for hash, ts := range m {
-				select {
-				// Set 3 second timeout on cleanup operation.
-				case <-timeout.C:
-					break LOOP
-				default:
-					// Remove entries from map which have been there for more
-					// than a minute.
-					if currTs-ts >= 60*60 {
-						delete(m, hash)
-					}
+				// Remove entries from map which have been there for more
+				// than a two minutes.
+				if currTs-ts >= 2*60*60 {
+					delete(m, hash)
 				}
 			}
 		case batch := <-ir.keysCh:

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -121,8 +121,8 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 			currTs := time.Now().UnixNano()
 			for hash, ts := range m {
 				// Remove entries from map which have been there for more
-				// than a two minutes.
-				if currTs-ts >= int64(2*time.Minute) {
+				// than 10 seconds.
+				if currTs-ts >= int64(10*time.Second) {
 					delete(m, hash)
 				}
 			}

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -120,8 +120,7 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 		case <-cleanupTick.C:
 			currTs := time.Now().UnixNano()
 			for hash, ts := range m {
-				// Remove entries from map which have been there for more
-				// than 10 seconds.
+				// Remove entries from map which have been there for there more than 10 seconds.
 				if currTs-ts >= int64(10*time.Second) {
 					delete(m, hash)
 				}

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -122,7 +122,7 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 			for hash, ts := range m {
 				// Remove entries from map which have been there for more
 				// than a two minutes.
-				if currTs-ts >= 2*60*60 {
+				if currTs-ts >= int64(2*time.Minute) {
 					delete(m, hash)
 				}
 			}

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -117,15 +117,10 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 			currTs := time.Now().Unix()
 			for _, key := range *batch {
 				hash := z.MemHash(key)
-				elem, ok := m[hash]
-				if !ok {
-					// If this is a new key, add it and continue.
+				if elem := m[hash]; currTs-elem >= 10 {
+					// Key not present or Key present but last roll up was more than 10 sec ago.
+					// Add/Update map and rollup.
 					m[hash] = currTs
-					continue
-				}
-				// If this key has been in the map for more than 10 seconds, perform roll up.
-				if currTs-elem >= 10 {
-					delete(m, hash)
 					if err := ir.rollUpKey(writer, key); err != nil {
 						glog.Warningf("Error %v rolling up key %v\n", err, key)
 					}


### PR DESCRIPTION
FIXES - DGRAPH-1613

The incremental roll-up uses a `map` to keep track of the keys that should be rolled up.
The current implementation never clears the map which stores the keys. The existing algorithm is
```
If key is present or key was rolled up 10 seconds ago, perform roll up
```
we never clean up the map in the existing algorithm and as a result the map consumed a lot of memory
```
3.77GB 32.51% 32.51%     3.93GB 33.95%  github.com/dgraph-io/dgraph/posting.(*incrRollupi).Process
```
```
(pprof) list Process
Total: 11.59GB
ROUTINE ======================== github.com/dgraph-io/dgraph/posting.(*incrRollupi).Process in src/github.com/dgraph-io/dgraph/posting/mvcc.go
    3.77GB     3.93GB (flat, cum) 33.95% of Total
         .          .    118:			for _, key := range *batch {
         .          .    119:				hash := z.MemHash(key)
         .          .    120:				if elem := m[hash]; currTs-elem >= 10 {
         .          .    121:					// Key not present or Key present but last roll up was more than 10 sec ago.
         .          .    122:					// Add/Update map and rollup.
    3.77GB     3.77GB    123:					m[hash] = currTs
         .   170.89MB    124:					if err := ir.rollUpKey(writer, key); err != nil {
         .          .    125:						glog.Warningf("Error %v rolling up key %v\n", err, key)
         .          .    126:					}
         .          .    127:				}
         .          .    128:			}
         .          .    129:			// clear the batch and put it back in Sync keysPool

```

The proposed change will clean up the keys every 2 minutes and remove the keys that have not changed in the last minute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5599)
<!-- Reviewable:end -->
