### PR TITLE
feat(GraphQL): Allow more control over custom logic header names

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -295,6 +295,26 @@ func verifyHeadersHandler(w http.ResponseWriter, r *http.Request) {
 	check2(w.Write([]byte(`[{"id":"0x3","name":"Star Wars"}]`)))
 }
 
+func verifyCustomNameHeadersHandler(w http.ResponseWriter, r *http.Request) {
+	err := verifyRequest(r, expectedRequest{
+		method:    http.MethodGet,
+		urlSuffix: "/verifyCustomNameHeaders",
+		body:      "",
+		headers: map[string][]string{
+			"X-App-Token":      {"app-token"},
+			"X-User-Id":        {"123"},
+			"Authorization": {"random-fake-token"},
+			"Accept-Encoding":  nil,
+			"User-Agent":       nil,
+		},
+	})
+	if err != nil {
+		check2(w.Write([]byte(err.Error())))
+		return
+	}
+	check2(w.Write([]byte(`[{"id":"0x3","name":"Star Wars"}]`)))
+}
+
 func twitterFollwerHandler(w http.ResponseWriter, r *http.Request) {
 	err := verifyRequest(r, expectedRequest{
 		method:    http.MethodGet,
@@ -1114,6 +1134,7 @@ func main() {
 	http.HandleFunc("/favMovies/", getFavMoviesHandler)
 	http.HandleFunc("/favMoviesPost/", postFavMoviesHandler)
 	http.HandleFunc("/verifyHeaders", verifyHeadersHandler)
+	http.HandleFunc("/verifyCustomNameHeaders", verifyCustomNameHeadersHandler)
 	http.HandleFunc("/twitterfollowers", twitterFollwerHandler)
 
 	// for mutations

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1613,9 +1613,13 @@ func customDirectiveValidation(sch *ast.Schema,
 		headers := http.Header{}
 		if secretHeaders != nil {
 			for _, h := range secretHeaders.Children {
+				key := strings.Split(h.Value.Raw, ":")
+				if len(key) != 2 {
+					continue
+				}
 				// We try and fetch the value from the stored secrets.
-				val := secrets[h.Value.Raw]
-				headers.Add(h.Value.Raw, string(val))
+				val := secrets[key[1]]
+				headers.Add(key[0], string(val))
 			}
 		}
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1617,10 +1617,10 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(key) == 1 {
 					key = []string{h.Value.Raw, h.Value.Raw}
 				} else if len(key) > 2 {
-					return gqlerror.ErrorPosf(graphql.Position,
+					return append(errs, gqlerror.ErrorPosf(graphql.Position,
 						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw)
+						typ.Name, field.Name, h.Value.Raw))
 				}
 				// We try and fetch the value from the stored secrets.
 				val := secrets[key[1]]

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1604,6 +1604,32 @@ func customDirectiveValidation(sch *ast.Schema,
 		}
 	}
 
+	forwardHeaders := httpArg.Value.Children.ForName("forwardHeaders")
+	if forwardHeaders != nil {
+		for _, h := range forwardHeaders.Children {
+			key := strings.Split(h.Value.Raw, ":")
+			if len(key) > 2 {
+				return append(errs, gqlerror.ErrorPosf(graphql.Position,
+					"Type %s; Field %s; forwardHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+						", found: `%s`.",
+					typ.Name, field.Name, h.Value.Raw))
+			}
+		}
+	}
+
+	secretHeaders := httpArg.Value.Children.ForName("secretHeaders")
+	if secretHeaders != nil {
+		for _, h := range secretHeaders.Children {
+			key := strings.Split(h.Value.Raw, ":")
+			if len(key) > 2 {
+				return append(errs, gqlerror.ErrorPosf(graphql.Position,
+					"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+						", found: `%s`.",
+					typ.Name, field.Name, h.Value.Raw))
+			}
+		}
+	}
+
 	if errs != nil {
 		return errs
 	}
@@ -1616,11 +1642,6 @@ func customDirectiveValidation(sch *ast.Schema,
 				key := strings.Split(h.Value.Raw, ":")
 				if len(key) == 1 {
 					key = []string{h.Value.Raw, h.Value.Raw}
-				} else if len(key) > 2 {
-					return append(errs, gqlerror.ErrorPosf(graphql.Position,
-						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
-							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw))
 				}
 				// We try and fetch the value from the stored secrets.
 				val := secrets[key[1]]

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1614,12 +1614,17 @@ func customDirectiveValidation(sch *ast.Schema,
 		if secretHeaders != nil {
 			for _, h := range secretHeaders.Children {
 				key := strings.Split(h.Value.Raw, ":")
-				if len(key) != 2 {
+				if len(key) == 1 {
 					key = []string{h.Value.Raw, h.Value.Raw}
+				} else if len(key) > 2 {
+					return gqlerror.ErrorPosf(graphql.Position,
+						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+							", found: `%s`.",
+						typ.Name, field.Name, h.Value.Raw)
 				}
 				// We try and fetch the value from the stored secrets.
-				val := secrets[key[0]]
-				headers.Add(key[1], string(val))
+				val := secrets[key[1]]
+				headers.Add(key[0], string(val))
 			}
 		}
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1615,11 +1615,11 @@ func customDirectiveValidation(sch *ast.Schema,
 			for _, h := range secretHeaders.Children {
 				key := strings.Split(h.Value.Raw, ":")
 				if len(key) != 2 {
-					continue
+					key = []string{h.Value.Raw, h.Value.Raw}
 				}
 				// We try and fetch the value from the stored secrets.
-				val := secrets[key[1]]
-				headers.Add(key[0], string(val))
+				val := secrets[key[0]]
+				headers.Add(key[1], string(val))
 			}
 		}
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -262,8 +262,6 @@ func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
-			} else if len(key) > 2 {
-				continue
 			}
 			headers[key[1]] = struct{}{}
 		}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -261,7 +261,7 @@ func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
 		for _, h := range forwardHeaders.Children {
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) != 2 {
-				continue
+				key = []string{h.Value.Raw, h.Value.Raw}
 			}
 			headers[key[1]] = struct{}{}
 		}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -259,7 +259,11 @@ func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
 			return
 		}
 		for _, h := range forwardHeaders.Children {
-			headers[h.Value.Raw] = struct{}{}
+			key := strings.Split(h.Value.Raw, ":")
+			if len(key) != 2 {
+				continue
+			}
+			headers[key[1]] = struct{}{}
 		}
 	}
 

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -260,8 +260,10 @@ func getAllowedHeaders(sch *ast.Schema, definitions []string) string {
 		}
 		for _, h := range forwardHeaders.Children {
 			key := strings.Split(h.Value.Raw, ":")
-			if len(key) != 2 {
+			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
+			} else if len(key) > 2 {
+				continue
 			}
 			headers[key[1]] = struct{}{}
 		}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -850,8 +850,6 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
-			} else if len(key) > 2 {
-				continue
 			}
 			val := string(hc.secrets[key[1]])
 			fconf.ForwardHeaders.Set(key[0], val)
@@ -866,8 +864,6 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
-			} else if len(key) > 2 {
-				continue
 			}
 			reqHeaderVal := f.op.header.Get(key[1])
 			fconf.ForwardHeaders.Set(key[0], reqHeaderVal)

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -849,7 +849,7 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 		for _, h := range secretHeaders.Children {
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) != 2 {
-				continue
+				key = []string{h.Value.Raw, h.Value.Raw}
 			}
 			val := string(hc.secrets[key[1]])
 			fconf.ForwardHeaders.Set(key[0], val)
@@ -863,7 +863,7 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 			// We would override the header if it was also specified as part of secretHeaders.
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) != 2 {
-				continue
+				key = []string{h.Value.Raw, h.Value.Raw}
 			}
 			reqHeaderVal := f.op.header.Get(key[1])
 			fconf.ForwardHeaders.Set(key[0], reqHeaderVal)

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -847,8 +847,12 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 	if secretHeaders != nil {
 		hc.RLock()
 		for _, h := range secretHeaders.Children {
-			val := string(hc.secrets[h.Value.Raw])
-			fconf.ForwardHeaders.Set(h.Value.Raw, val)
+			key := strings.Split(h.Value.Raw, ":")
+			if len(key) != 2 {
+				continue
+			}
+			val := string(hc.secrets[key[1]])
+			fconf.ForwardHeaders.Set(key[0], val)
 		}
 		hc.RUnlock()
 	}
@@ -857,8 +861,12 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 	if forwardHeaders != nil {
 		for _, h := range forwardHeaders.Children {
 			// We would override the header if it was also specified as part of secretHeaders.
-			reqHeaderVal := f.op.header.Get(h.Value.Raw)
-			fconf.ForwardHeaders.Set(h.Value.Raw, reqHeaderVal)
+			key := strings.Split(h.Value.Raw, ":")
+			if len(key) != 2 {
+				continue
+			}
+			reqHeaderVal := f.op.header.Get(key[1])
+			fconf.ForwardHeaders.Set(key[0], reqHeaderVal)
 		}
 	}
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -848,8 +848,10 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 		hc.RLock()
 		for _, h := range secretHeaders.Children {
 			key := strings.Split(h.Value.Raw, ":")
-			if len(key) != 2 {
+			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
+			} else if len(key) > 2 {
+				continue
 			}
 			val := string(hc.secrets[key[1]])
 			fconf.ForwardHeaders.Set(key[0], val)
@@ -862,8 +864,10 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 		for _, h := range forwardHeaders.Children {
 			// We would override the header if it was also specified as part of secretHeaders.
 			key := strings.Split(h.Value.Raw, ":")
-			if len(key) != 2 {
+			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}
+			} else if len(key) > 2 {
+				continue
 			}
 			reqHeaderVal := f.op.header.Get(key[1])
 			fconf.ForwardHeaders.Set(key[0], reqHeaderVal)


### PR DESCRIPTION
Add support for declaring headers with custom name like -
 secretHeaders: ["Authorization:Github-Api-Token"] where "Authorization" is send as the header name to GitHub and "Github-Api-Token" is used internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5600)
<!-- Reviewable:end -->
