### PR TITLE
Change groupId from int to uint32.

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -171,7 +171,7 @@ type predicateSet map[string]struct{}
 // loadFn is a function that will receive the current file being read.
 // A reader, the backup groupId, and a map whose keys are the predicates to restore
 // are passed as arguments.
-type loadFn func(reader io.Reader, groupId int, preds predicateSet) (uint64, error)
+type loadFn func(reader io.Reader, groupId uint32, preds predicateSet) (uint64, error)
 
 // LoadBackup will scan location l for backup files in the given backup series and load them
 // sequentially. Returns the maximum Since value on success, otherwise an error.

--- a/worker/file_handler.go
+++ b/worker/file_handler.go
@@ -171,7 +171,7 @@ func (h *fileHandler) Load(uri *url.URL, backupId string, fn loadFn) LoadResult 
 			// of the last backup.
 			predSet := manifests[len(manifests)-1].getPredsInGroup(gid)
 
-			groupMaxUid, err := fn(fp, int(gid), predSet)
+			groupMaxUid, err := fn(fp, gid, predSet)
 			if err != nil {
 				return LoadResult{0, 0, err}
 			}

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -44,7 +44,7 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 	// Scan location for backup files and load them. Each file represents a node group,
 	// and we create a new p dir for each.
 	return LoadBackup(location, backupId,
-		func(r io.Reader, groupId int, preds predicateSet) (uint64, error) {
+		func(r io.Reader, groupId uint32, preds predicateSet) (uint64, error) {
 
 			dir := filepath.Join(pdir, fmt.Sprintf("p%d", groupId))
 			r, err := enc.GetReader(keyfile, r)

--- a/worker/s3_handler.go
+++ b/worker/s3_handler.go
@@ -318,7 +318,7 @@ func (h *s3Handler) Load(uri *url.URL, backupId string, fn loadFn) LoadResult {
 			// of the last backup.
 			predSet := manifests[len(manifests)-1].getPredsInGroup(gid)
 
-			groupMaxUid, err := fn(reader, int(gid), predSet)
+			groupMaxUid, err := fn(reader, gid, predSet)
 			if err != nil {
 				return LoadResult{0, 0, err}
 			}


### PR DESCRIPTION
This change removes the need to convert between int and uint32.
Group IDs are always uint32.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->
