### PR TITLE
docs: checkpwd using val()

### DIFF
--- a/wiki/content/tips/index.md
+++ b/wiki/content/tips/index.md
@@ -117,3 +117,25 @@ Example: Get all unique genres from all of the movies directed by Steven Spielbe
   }
 }
 {{< /runnable >}}
+
+## Usage of checkpwd boolean
+
+Store the result of `checkpwd` in a query variable and then match it against `1` (`checkpwd` is `true`) or `0` (`checkpwd` is `false`).
+
+{{< runnable >}}
+{  
+  exampleData(func: has(email)) {
+    uid
+    email
+    check as checkpwd(pass, "1bdfhJHb!fd")
+  }
+  userMatched(func: eq(val(check), 1)) {
+    uid
+    email
+  }
+  userIncorrect(func: eq(val(check), 0)) {
+    uid
+    email
+  }
+}
+{{< /runnable >}}


### PR DESCRIPTION
`checkpwd` boolean becomes a `0` or `1` when used with `val()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5631)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-472648e9ee-70031.surge.sh)
<!-- Dgraph:end -->