### PR TITLE
(release/v1.2) Document --encryption_key_file option in dgraph restore command.

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -179,6 +179,10 @@ backups built on top of it. Each time a new full backup is created, a new backup
 series with a different ID is started. The backup series ID is stored in each
 `manifest.json` file stored in every backup folder.
 
+The `--encryption_key_file` flag is required if you took the backup in an
+encrypted cluster and should point to the location of the same key used to
+run the cluster.
+
 The restore feature will create a cluster with as many groups as the original
 cluster had at the time of the last backup. For each group, `dgraph restore`
 creates a posting directory `p<N>` corresponding to the backup group ID. For


### PR DESCRIPTION
<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5646)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d74e79af7d-70528.surge.sh)
<!-- Dgraph:end -->