### PR TITLE
(release/v1.2) Changes to reduce backup memory.

### DIFF
--- a/ee/backup/backup.go
+++ b/ee/backup/backup.go
@@ -276,25 +276,24 @@ func (pr *Processor) toBackupList(key []byte, itr *badger.Iterator) (*bpb.KVList
 		if err != nil {
 			return nil, errors.Wrapf(err, "while reading posting list")
 		}
-		kvs, err := l.Rollup()
+
+		kv, err := l.SingleListRollup()
 		if err != nil {
 			return nil, errors.Wrapf(err, "while rolling up list")
 		}
 
-		for _, kv := range kvs {
-			backupKey, err := toBackupKey(kv.Key)
-			if err != nil {
-				return nil, err
-			}
-			kv.Key = backupKey
-
-			backupPl, err := pr.toBackupPostingList(kv.Value, itr.ThreadId)
-			if err != nil {
-				return nil, err
-			}
-			kv.Value = backupPl
+		backupKey, err := toBackupKey(kv.Key)
+		if err != nil {
+			return nil, err
 		}
-		list.Kv = append(list.Kv, kvs...)
+		kv.Key = backupKey
+
+		backupPl, err := pr.toBackupPostingList(kv.Value, itr.ThreadId)
+		if err != nil {
+			return nil, err
+		}
+		kv.Value = backupPl
+		list.Kv = append(list.Kv, kv)
 	case posting.BitSchemaPosting:
 		valCopy, err := item.ValueCopy(nil)
 		if err != nil {

--- a/posting/list.go
+++ b/posting/list.go
@@ -972,10 +972,10 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		}
 	}
 
+	out.newMinTs = maxCommitTs
 	if split {
 		// Check if the list (or any of it's parts if it's been previously split) have
 		// become too big. Split the list if that is the case.
-		out.newMinTs = maxCommitTs
 		out.recursiveSplit()
 		out.removeEmptySplits()
 	} else {

--- a/posting/list.go
+++ b/posting/list.go
@@ -780,7 +780,7 @@ func (l *List) Rollup() ([]*bpb.KV, error) {
 
 	l.RLock()
 	defer l.RUnlock()
-	out, err := l.rollup(math.MaxUint64)
+	out, err := l.rollup(math.MaxUint64, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed when calling List.rollup")
 	}
@@ -813,6 +813,30 @@ func (l *List) Rollup() ([]*bpb.KV, error) {
 	})
 
 	return kvs, nil
+}
+
+// SingleListRollup works like rollup but generates a single list with no splits.
+// It's used during backup so that each backed up posting list is stored in a single key.
+func (l *List) SingleListRollup() (*bpb.KV, error) {
+	l.RLock()
+	defer l.RUnlock()
+
+	out, err := l.rollup(math.MaxUint64, false)
+	if err != nil {
+		return nil, err
+	}
+	// out is only nil when the list's minTs is greater than readTs but readTs
+	// is math.MaxUint64 so that's not possible. Assert that's true.
+	x.AssertTrue(out != nil)
+
+	kv := &bpb.KV{}
+	kv.Version = out.newMinTs
+	kv.Key = l.key
+	val, meta := marshalPostingList(out.plist)
+	kv.UserMeta = []byte{meta}
+	kv.Value = val
+
+	return kv, nil
 }
 
 func (out *rollupOutput) marshalPostingListPart(
@@ -854,7 +878,7 @@ type rollupOutput struct {
 // Merge all entries in mutation layer with commitTs <= l.commitTs into
 // immutable layer. Note that readTs can be math.MaxUint64, so do NOT use it
 // directly. It should only serve as the read timestamp for iteration.
-func (l *List) rollup(readTs uint64) (*rollupOutput, error) {
+func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	l.AssertRLock()
 
 	// Pick all committed entries
@@ -880,8 +904,7 @@ func (l *List) rollup(readTs uint64) (*rollupOutput, error) {
 	initializeSplit := func() {
 		enc = codec.Encoder{BlockSize: blockSize}
 
-		// Otherwise, load the corresponding part and set endUid to correctly
-		// detect the end of the list.
+		// Load the corresponding part and set endUid to correctly detect the end of the list.
 		startUid = l.plist.Splits[splitIdx]
 		if splitIdx+1 == len(l.plist.Splits) {
 			endUid = math.MaxUint64
@@ -893,7 +916,7 @@ func (l *List) rollup(readTs uint64) (*rollupOutput, error) {
 	}
 
 	// If not a multi-part list, all UIDs go to the same encoder.
-	if len(l.plist.Splits) == 0 {
+	if len(l.plist.Splits) == 0 || !split {
 		plist = out.plist
 		endUid = math.MaxUint64
 	} else {
@@ -901,7 +924,7 @@ func (l *List) rollup(readTs uint64) (*rollupOutput, error) {
 	}
 
 	err := l.iterate(readTs, 0, func(p *pb.Posting) error {
-		if p.Uid > endUid {
+		if p.Uid > endUid && split {
 			plist.Pack = enc.Done()
 			out.parts[startUid] = plist
 
@@ -946,11 +969,16 @@ func (l *List) rollup(readTs uint64) (*rollupOutput, error) {
 		}
 	}
 
-	// Check if the list (or any of it's parts if it's been previously split) have
-	// become too big. Split the list if that is the case.
-	out.newMinTs = maxCommitTs
-	out.splitUpList()
-	out.removeEmptySplits()
+	if split {
+		// Check if the list (or any of it's parts if it's been previously split) have
+		// become too big. Split the list if that is the case.
+		out.newMinTs = maxCommitTs
+		out.splitUpList()
+		out.removeEmptySplits()
+	} else {
+		out.plist.Splits = nil
+	}
+
 	return out, nil
 }
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1243,7 +1243,8 @@ func TestSingleListRollup(t *testing.T) {
 	ol, commits := createMultiPartList(t, size, true)
 
 	// Roll list into a single list.
-	kv, err := ol.SingleListRollup()
+	kv := &bpb.KV{}
+	err := ol.SingleListRollup(kv)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(kv.UserMeta))
 	require.Equal(t, BitCompletePosting, kv.UserMeta[0])


### PR DESCRIPTION
This PR includes related commits to bring up branch release/v1.2 up to
date and introduce the memory savings in master. None of the changes
are breaking.

For simplicity, I am opening a single PR but the commits can be rebased
to the branch when they are approved.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5649)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-75bc709625-70578.surge.sh)
<!-- Dgraph:end -->