### PR TITLE
Avoid panic in handleValuePostings

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -19,6 +19,7 @@ package worker
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -356,6 +357,16 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	}
 	if srcFn.n == 0 {
 		return nil
+	}
+
+	// srcFn.n should be equal to len(q.UidList.Uids) for below implementation(DivideAndRule and
+	// calculate) to work correctly. But we have seen some panics while forming DataKey in
+	// calculate(). panic is of the form "index out of range [4] with length 1". We have tried to
+	// reproduce this but couldn't find any edge case which will result in this panic. So for now
+	// we are just logging when srcFn.n != len(q.UidList.Uids) and returning error when this
+	// happens.
+	if srcFn.n != len(q.UidList.Uids) {
+		return fmt.Errorf()
 	}
 
 	// This function has small boilerplate as handleUidPostings, around how the code gets

--- a/worker/task.go
+++ b/worker/task.go
@@ -19,7 +19,6 @@ package worker
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -366,7 +365,8 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	// we are just logging when srcFn.n != len(q.UidList.Uids) and returning error when this
 	// happens.
 	if srcFn.n != len(q.UidList.Uids) {
-		return fmt.Errorf()
+		return errors.Errorf("srcFn.n: %d is not equal to len(q.UidList.Uids): %d, srcFn: %+v in "+
+			"handleValuePostings", srcFn.n, len(q.UidList.GetUids()), srcFn)
 	}
 
 	// This function has small boilerplate as handleUidPostings, around how the code gets

--- a/worker/task.go
+++ b/worker/task.go
@@ -360,10 +360,8 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 
 	// srcFn.n should be equal to len(q.UidList.Uids) for below implementation(DivideAndRule and
 	// calculate) to work correctly. But we have seen some panics while forming DataKey in
-	// calculate(). panic is of the form "index out of range [4] with length 1". We have tried to
-	// reproduce this but couldn't find any edge case which will result in this panic. So for now
-	// we are just logging when srcFn.n != len(q.UidList.Uids) and returning error when this
-	// happens.
+	// calculate(). panic is of the form "index out of range [4] with length 1". Hence return error
+	// from here when srcFn.n != len(q.UidList.Uids).
 	if srcFn.n != len(q.UidList.Uids) {
 		return errors.Errorf("srcFn.n: %d is not equal to len(q.UidList.Uids): %d, srcFn: %+v in "+
 			"handleValuePostings", srcFn.n, len(q.UidList.GetUids()), srcFn)


### PR DESCRIPTION
Fixes: DGRAPH-1608

`srcFn.n` should be equal to `len(q.UidList.Uids)` for implementation `DivideAndRule` and
`calculate` to work correctly. But we have seen some panics while forming `DataKey` in
`calculate()`. panic is of the form `"index out of range [4] with length 1"`. We have tried to
reproduce this but couldn't find any edge case which will result in this panic. So for now
we are just logging when `srcFn.n != len(q.UidList.Uids)` and returning error when this
happens.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5652)
<!-- Reviewable:end -->
