### PR TITLE
Adds multiple zero addresses to docker-compose files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /contrib
 /wiki
 /.git
+/.github

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -5,7 +5,7 @@
 # already built and placed there.
 
 FROM ubuntu:latest
-MAINTAINER Dgraph Labs <contact@dgraph.io>
+LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
 RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates curl iputils-ping && \

--- a/contrib/config/docker/docker-compose-ha.yml
+++ b/contrib/config/docker/docker-compose-ha.yml
@@ -70,7 +70,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws01
-    command: dgraph alpha --my=alpha1:7080 --lru_mb=2048 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082
   alpha2:
     image: dgraph/dgraph:latest
     hostname: "alpha2"
@@ -86,7 +86,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws02
-    command: dgraph alpha --my=alpha2:7081 --lru_mb=2048 --zero=zero1:5080 -o 1
+    command: dgraph alpha --my=alpha2:7081 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082 -o 1
   alpha3:
     image: dgraph/dgraph:latest
     hostname: "alpha3"
@@ -102,7 +102,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws03
-    command: dgraph alpha --my=alpha3:7082 --lru_mb=2048 --zero=zero1:5080 -o 2
+    command: dgraph alpha --my=alpha3:7082 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082 -o 2
   alpha4:
     image: dgraph/dgraph:latest
     hostname: "alpha4"
@@ -117,7 +117,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws04
-    command: dgraph alpha --my=alpha4:7083 --lru_mb=2048 --zero=zero1:5080 -o 3
+    command: dgraph alpha --my=alpha4:7083 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082 -o 3
   alpha5:
     image: dgraph/dgraph:latest
     hostname: "alpha5"
@@ -132,7 +132,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws05
-    command: dgraph alpha --my=alpha5:7084 --lru_mb=2048 --zero=zero1:5080 -o 4
+    command: dgraph alpha --my=alpha5:7084 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082 -o 4
   alpha6:
     image: dgraph/dgraph:latest
     hostname: "alpha6"
@@ -147,7 +147,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws06
-    command: dgraph alpha --my=alpha6:7085 --lru_mb=2048 --zero=zero1:5080 -o 5
+    command: dgraph alpha --my=alpha6:7085 --lru_mb=2048 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
   ratel:
     image: dgraph/dgraph:latest
     hostname: "ratel"

--- a/contrib/embargo/embargo.yml
+++ b/contrib/embargo/embargo.yml
@@ -61,7 +61,7 @@ containers:
     expose:
       - 8180
       - 9180
-    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080 -o 100 --expose_trace  --trace 1.0 --logtostderr -v=3
+    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace  --trace 1.0 --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -76,7 +76,7 @@ containers:
       - 8182
       - 9182
     start_delay: 8
-    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5080 -o 102 --expose_trace  --trace 1.0 --logtostderr -v=3
+    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace  --trace 1.0 --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -91,7 +91,7 @@ containers:
       - 8183
       - 9183
     start_delay: 16
-    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080 -o 103 --expose_trace  --trace 1.0 --logtostderr -v=3
+    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace  --trace 1.0 --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - 9180:9180
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 --logtostderr --mutations=disallow
+    command: /gobin/dgraph alpha --my=dg1:7180 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 100 --logtostderr --mutations=disallow
 
   dg2:
     image: dgraph/dgraph:latest
@@ -83,7 +83,7 @@ services:
       - 9182:9182
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 --logtostderr --mutations=strict
+    command: /gobin/dgraph alpha --my=dg2:7182 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 102 --logtostderr --mutations=strict
 
   dg3:
     image: dgraph/dgraph:latest
@@ -101,4 +101,4 @@ services:
       - 9183:9183
     labels:
       cluster: test
-    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 --logtostderr --mutations=strict
+    command: /gobin/dgraph alpha --my=dg3:7183 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 103 --logtostderr --mutations=strict

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16  --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 100 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16  --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   alpha2:
     image: dgraph/dgraph:latest
@@ -105,7 +105,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 102 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   alpha3:
     image: dgraph/dgraph:latest
@@ -132,7 +132,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 103 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   alpha4:
     image: dgraph/dgraph:latest
@@ -159,7 +159,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7184 --lru_mb=1024 --zero=zero1:5180 -o 104 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7184 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 104 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   alpha5:
     image: dgraph/dgraph:latest
@@ -186,7 +186,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7185 --lru_mb=1024 --zero=zero1:5180 -o 105 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7185 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 105 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   alpha6:
     image: dgraph/dgraph:latest
@@ -213,7 +213,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7186 --lru_mb=1024 --zero=zero1:5180 -o 106 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7186 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 -o 106 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --acl_cache_ttl 5s
 
   minio1:
     image: minio/minio:latest

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=1 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 102 --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 102 --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=2 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   alpha3:
@@ -66,7 +66,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 103 --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 103 --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=3 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   alpha4:
@@ -89,7 +89,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 104 --my=alpha4:7184 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 104 --my=alpha4:7184 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=4 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   alpha5:
@@ -112,7 +112,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 105 --my=alpha5:7185 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 105 --my=alpha5:7185 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=5 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   alpha6:
@@ -135,7 +135,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha -o 106 --my=alpha6:7186 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph alpha -o 106 --my=alpha6:7186 --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183
       --logtostderr -v=2 --idx=6 --acl_secret_file=/secret/hmac --acl_access_ttl 300s
       --acl_cache_ttl 500s
   zero1:

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 102 --my=alpha2:7182
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   alpha3:
     image: dgraph/dgraph:latest
     container_name: alpha3
@@ -54,7 +54,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 103 --my=alpha3:7183
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   alpha4:
     image: dgraph/dgraph:latest
     container_name: alpha4
@@ -72,7 +72,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 104 --my=alpha4:7184
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   alpha5:
     image: dgraph/dgraph:latest
     container_name: alpha5
@@ -90,7 +90,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 105 --my=alpha5:7185
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   alpha6:
     image: dgraph/dgraph:latest
     container_name: alpha6
@@ -108,7 +108,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 106 --my=alpha6:7186
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   jaeger:
     image: jaegertracing/all-in-one:latest
     container_name: jaeger

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 -o 100 --my=alpha1:7180
-      --lru_mb=1024 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
+      --lru_mb=1024 --zero=zero1:5180,zero2:5182,zero3:5183 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --snapshot_after 100
   alpha2:
     image: dgraph/dgraph:latest
     container_name: alpha2


### PR DESCRIPTION
This avoids the possibility of Dgraph not knowing where the Zero leader is in the event of a new election.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5653)
<!-- Reviewable:end -->
