### PR TITLE
Fix: Change tablet size calculation to not depend on the right key.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1240,8 +1240,27 @@ func (n *node) calculateTabletSizes() {
 	}
 	var total int64
 	tablets := make(map[string]*pb.Tablet)
+	updateSize := func(pred string, size int64) {
+		if pred == "" {
+			return
+		}
+
+		glog.Infof("Adding %v to table %v", size, pred)
+		if tablet, ok := tablets[pred]; ok {
+			tablet.Space += size
+		} else {
+			tablets[pred] = &pb.Tablet{
+				GroupId:   n.gid,
+				Predicate: pred,
+				Space:     size,
+			}
+		}
+		total += size
+	}
 
 	tableInfos := pstore.Tables(false)
+	previousLeft := ""
+	var previousSize int64
 	glog.V(2).Infof("Calculating tablet sizes. Found %d tables\n", len(tableInfos))
 	for _, tinfo := range tableInfos {
 		left, err := x.Parse(tinfo.Left)
@@ -1249,29 +1268,26 @@ func (n *node) calculateTabletSizes() {
 			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
-		right, err := x.Parse(tinfo.Right)
-		if err != nil {
-			glog.V(3).Infof("Unable to parse key: %v", err)
-			continue
-		}
-		if left.Attr != right.Attr {
-			// Skip all tables not fully owned by one predicate.
+
+		if previousLeft != "" && left.Attr != previousLeft {
+			// Dgraph cannot depend on the right end of the table to know if the table belongs
+			// to a single predicate because there might be Badger-specific keys.
+			// Instead, Dgraph only counts the previous table if the current one belongs to the
+			// same predicate.
 			// We could later specifically iterate over these tables to get their estimated sizes.
+			previousLeft = left.Attr
+			previousSize = int64(tinfo.EstimatedSz)
 			glog.V(3).Info("Skipping table not owned by one predicate")
 			continue
 		}
-		pred := left.Attr
-		if tablet, ok := tablets[pred]; ok {
-			tablet.Space += int64(tinfo.EstimatedSz)
-		} else {
-			tablets[pred] = &pb.Tablet{
-				GroupId:   n.gid,
-				Predicate: pred,
-				Space:     int64(tinfo.EstimatedSz),
-			}
-		}
-		total += int64(tinfo.EstimatedSz)
+
+		updateSize(previousLeft, previousSize)
+		previousLeft = left.Attr
+		previousSize = int64(tinfo.EstimatedSz)
 	}
+	// The last table has not been counted. Assign it to the predicate at the left of the table.
+	updateSize(previousLeft, previousSize)
+
 	if len(tablets) == 0 {
 		glog.V(2).Infof("No tablets found.")
 		return

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1245,7 +1245,6 @@ func (n *node) calculateTabletSizes() {
 			return
 		}
 
-		glog.Infof("Adding %v to table %v", size, pred)
 		if tablet, ok := tablets[pred]; ok {
 			tablet.Space += size
 		} else {
@@ -1269,19 +1268,17 @@ func (n *node) calculateTabletSizes() {
 			continue
 		}
 
-		if previousLeft != "" && left.Attr != previousLeft {
+		if left.Attr == previousLeft {
 			// Dgraph cannot depend on the right end of the table to know if the table belongs
 			// to a single predicate because there might be Badger-specific keys.
 			// Instead, Dgraph only counts the previous table if the current one belongs to the
 			// same predicate.
 			// We could later specifically iterate over these tables to get their estimated sizes.
-			previousLeft = left.Attr
-			previousSize = int64(tinfo.EstimatedSz)
-			glog.V(3).Info("Skipping table not owned by one predicate")
+			updateSize(previousLeft, previousSize)
 			continue
+		} else {
+			glog.V(3).Info("Skipping table not owned by one predicate")
 		}
-
-		updateSize(previousLeft, previousSize)
 		previousLeft = left.Attr
 		previousSize = int64(tinfo.EstimatedSz)
 	}


### PR DESCRIPTION
In badger, the right key might be a badger specific key that Dgraph
cannot understand. To deal with these keys, a table is included in
the size calculation if the next table starts with the same key.

Related to DGRAPH-1358 and #5408.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5656)
<!-- Reviewable:end -->
