### PR TITLE
Only process restore request in the current alpha if it's the leader.

### DIFF
--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -83,7 +83,7 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) error {
 }
 
 func proposeRestoreOrSend(ctx context.Context, req *pb.RestoreRequest) error {
-	if groups().ServesGroup(req.GetGroupId()) {
+	if groups().ServesGroup(req.GetGroupId()) && groups().Node.AmLeader() {
 		_, err := (&grpcWorker{}).Restore(ctx, req)
 		return err
 	}


### PR DESCRIPTION
Requests for other groups are being sent to the leader but the request
for the group the received the request might not be sent to the leader.
Fix that by first checking if the alpha is the leader. If not, the
request is sent to the leader.

<!--
Please add a description with these things:
1. A good title
2. A good description explaining the problem and what you changed.
3. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
4. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
5. If this is a breaking change, please prefix the title with "[Breaking] ".
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5657)
<!-- Reviewable:end -->
