### PR TITLE
(release/v20.03) Fix: Change tablet size calculation to not depend on the right key

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1197,8 +1197,26 @@ func (n *node) calculateTabletSizes() {
 	}
 	var total int64
 	tablets := make(map[string]*pb.Tablet)
+	updateSize := func(pred string, size int64) {
+		if pred == "" {
+			return
+		}
+
+		if tablet, ok := tablets[pred]; ok {
+			tablet.Space += size
+		} else {
+			tablets[pred] = &pb.Tablet{
+				GroupId:   n.gid,
+				Predicate: pred,
+				Space:     size,
+			}
+		}
+		total += size
+	}
 
 	tableInfos := pstore.Tables(false)
+	previousLeft := ""
+	var previousSize int64
 	glog.V(2).Infof("Calculating tablet sizes. Found %d tables\n", len(tableInfos))
 	for _, tinfo := range tableInfos {
 		left, err := x.Parse(tinfo.Left)
@@ -1206,29 +1224,23 @@ func (n *node) calculateTabletSizes() {
 			glog.V(3).Infof("Unable to parse key: %v", err)
 			continue
 		}
-		right, err := x.Parse(tinfo.Right)
-		if err != nil {
-			glog.V(3).Infof("Unable to parse key: %v", err)
-			continue
-		}
-		if left.Attr != right.Attr {
-			// Skip all tables not fully owned by one predicate.
+
+		if left.Attr == previousLeft {
+			// Dgraph cannot depend on the right end of the table to know if the table belongs
+			// to a single predicate because there might be Badger-specific keys.
+			// Instead, Dgraph only counts the previous table if the current one belongs to the
+			// same predicate.
 			// We could later specifically iterate over these tables to get their estimated sizes.
-			glog.V(2).Info("Skipping table not owned by one predicate")
-			continue
-		}
-		pred := left.Attr
-		if tablet, ok := tablets[pred]; ok {
-			tablet.Space += int64(tinfo.EstimatedSz)
+			updateSize(previousLeft, previousSize)
 		} else {
-			tablets[pred] = &pb.Tablet{
-				GroupId:   n.gid,
-				Predicate: pred,
-				Space:     int64(tinfo.EstimatedSz),
-			}
+			glog.V(3).Info("Skipping table not owned by one predicate")
 		}
-		total += int64(tinfo.EstimatedSz)
+		previousLeft = left.Attr
+		previousSize = int64(tinfo.EstimatedSz)
 	}
+	// The last table has not been counted. Assign it to the predicate at the left of the table.
+	updateSize(previousLeft, previousSize)
+
 	if len(tablets) == 0 {
 		glog.V(2).Infof("No tablets found.")
 		return


### PR DESCRIPTION
In badger, the right key might be a badger specific key that Dgraph
cannot understand. To deal with these keys, a table is included in
the size calculation if the next table starts with the same key.

Related to DGRAPH-1358 and #5408.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5665)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-785ee0ceb9-71149.surge.sh)
<!-- Dgraph:end -->