### PR TITLE
fix(dgraph):  Badger iterator key copy in count index query

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -2182,7 +2182,8 @@ func (qs *queryState) evaluate(cp countParams, out *pb.Result) error {
 
 	for itr.Seek(countKey); itr.Valid(); itr.Next() {
 		item := itr.Item()
-		pl, err := qs.cache.Get(item.Key())
+		key := append(make([]byte, 0), item.Key()...)
+		pl, err := qs.cache.Get(key)
 		if err != nil {
 			return err
 		}

--- a/worker/task.go
+++ b/worker/task.go
@@ -2182,8 +2182,8 @@ func (qs *queryState) evaluate(cp countParams, out *pb.Result) error {
 
 	for itr.Seek(countKey); itr.Valid(); itr.Next() {
 		item := itr.Item()
-		key := append(make([]byte, 0, len(item.Key())), item.Key()...)
-		pl, err := qs.cache.Get(key)
+		var key []byte
+		pl, err := qs.cache.Get(item.KeyCopy(key))
 		if err != nil {
 			return err
 		}

--- a/worker/task.go
+++ b/worker/task.go
@@ -2182,7 +2182,7 @@ func (qs *queryState) evaluate(cp countParams, out *pb.Result) error {
 
 	for itr.Seek(countKey); itr.Valid(); itr.Next() {
 		item := itr.Item()
-		key := append(make([]byte, 0), item.Key()...)
+		key := append(make([]byte, len(item.Key())), item.Key()...)
 		pl, err := qs.cache.Get(key)
 		if err != nil {
 			return err

--- a/worker/task.go
+++ b/worker/task.go
@@ -2182,7 +2182,7 @@ func (qs *queryState) evaluate(cp countParams, out *pb.Result) error {
 
 	for itr.Seek(countKey); itr.Valid(); itr.Next() {
 		item := itr.Item()
-		key := append(make([]byte, len(item.Key())), item.Key()...)
+		key := append(make([]byte, 0, len(item.Key())), item.Key()...)
 		pl, err := qs.cache.Get(key)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes DGRAPH-998
Fixes #4689

When we run ./systest/21million/test-21million.sh --loader live, 
This query fails.
```
{                                                                                                                                                                                                                                                                                                                          
  directors(func: gt(count(director.film), 5)) {                                                                                                                                                                                                                                                                           
    totalDirectors : count(uid)                                                                                                                                                                                                                                                                                            
 }                                                                                                                                                                                                                                                                                                                        
}    
```                                                                                                                                                                                                                                                                                                                       
 The result should be 7712, but we were giving the wrong answer. 

After investigation, I found out that there was a race condition due to memory leak. For the count index, we would iterate on all the keys. When we fetch a key, we would see if the posting list to that key has Delta>0, and call rollup on it. The rollup is called in another thread, but we pass the same key. We keep on iterating on the keys, which change the key being used in the rollup function, causing the error. A simple fix was to send a new copy of the key which doesn't get changed. 



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5689)
<!-- Reviewable:end -->
