### PR TITLE
fix(Export/Import): Live load exported schema

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -118,6 +118,7 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			defer x.StartProfile(Live.Conf).Stop()
 			if err := run(); err != nil {
+				x.Check2(fmt.Fprintf(os.Stderr, "%s", err.Error()))
 				os.Exit(1)
 			}
 		},

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -533,10 +533,25 @@ func LoadTypesFromDb() error {
 	return nil
 }
 
-// InitialTypes returns the schema updates to insert at the begining of
-// Dgraph's execution. It looks at the schema state to determine which
+// InitialTypes returns the type updates to insert at the beginning of
+// Dgraph's execution. It looks at the worker options to determine which
 // types to insert.
 func InitialTypes() []*pb.TypeUpdate {
+	return initialTypesInternal(false)
+}
+
+// CompleteInitialTypes returns all the type updates regardless of the worker
+// options. This is useful in situations where the worker options are not known
+// in advance or it is required to consider all initial pre-defined types. An
+// example of such situation is while allowing type updates to go through during
+// alter if they are same as existing pre-defined types. This is useful for
+// live loading a previously exported schema.
+func CompleteInitialTypes() []*pb.TypeUpdate {
+	return initialTypesInternal(true)
+}
+
+// NOTE: whenever defining a new type here, please also add it in x/keys.go: preDefinedTypeMap
+func initialTypesInternal(all bool) []*pb.TypeUpdate {
 	var initialTypes []*pb.TypeUpdate
 	initialTypes = append(initialTypes,
 		&pb.TypeUpdate{
@@ -553,7 +568,7 @@ func InitialTypes() []*pb.TypeUpdate {
 			},
 		})
 
-	if x.WorkerConfig.AclEnabled {
+	if all || x.WorkerConfig.AclEnabled {
 		// These type definitions are required for deleteUser and deleteGroup GraphQL API to work
 		// properly.
 		initialTypes = append(initialTypes, &pb.TypeUpdate{
@@ -682,22 +697,50 @@ func initialSchemaInternal(all bool) []*pb.SchemaUpdate {
 	return initialSchema
 }
 
-// IsPreDefinedPredicateChanged returns true if the initial update for the pre-defined
-// predicate pred is different than the passed update.
-func IsPreDefinedPredicateChanged(pred string, update *pb.SchemaUpdate) bool {
+// IsPreDefPredChanged returns true if the initial update for the pre-defined
+// predicate is different than the passed update.
+//If the passed update is not a pre-defined predicate then it just returns false.
+func IsPreDefPredChanged(update *pb.SchemaUpdate) bool {
 	// Return false for non-pre-defined predicates.
-	if !x.IsPreDefinedPredicate(pred) {
+	if !x.IsPreDefinedPredicate(update.Predicate) {
 		return false
 	}
 
 	initialSchema := CompleteInitialSchema()
 	for _, original := range initialSchema {
-		if original.Predicate != pred {
+		if original.Predicate != update.Predicate {
 			continue
 		}
 		return !proto.Equal(original, update)
 	}
 	return true
+}
+
+// IsPreDefTypeChanged returns true if the initial update for the pre-defined
+// type is different than the passed update.
+// If the passed update is not a pre-defined type than it just returns false.
+func IsPreDefTypeChanged(update *pb.TypeUpdate) bool {
+	// Return false for non-pre-defined types.
+	if !x.IsPreDefinedType(update.TypeName) {
+		return false
+	}
+
+	initialTypes := CompleteInitialTypes()
+	for _, original := range initialTypes {
+		if original.TypeName != update.TypeName {
+			continue
+		}
+		if len(original.Fields) != len(update.Fields) {
+			return true
+		}
+		for i, field := range original.Fields {
+			if field.Predicate != update.Fields[i].Predicate {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func reset() {

--- a/x/keys.go
+++ b/x/keys.go
@@ -552,6 +552,13 @@ var internalPredicateMap = map[string]struct{}{
 	"uid": {},
 }
 
+var preDefinedTypeMap = map[string]struct{}{
+	"dgraph.graphql":    {},
+	"dgraph.type.User":  {},
+	"dgraph.type.Group": {},
+	"dgraph.type.Rule":  {},
+}
+
 // IsGraphqlReservedPredicate returns true if it is the predicate is reserved by graphql.
 func IsGraphqlReservedPredicate(pred string) bool {
 	_, ok := graphqlReservedPredicate[pred]
@@ -630,8 +637,26 @@ func IsInternalPredicate(pred string) bool {
 // We reserve `dgraph.` as the namespace for the types/predicates we may create in future.
 // So, users are not allowed to create a type under this namespace.
 // Hence, we should always define internal types under `dgraph.` namespace.
+//
+// Pre-defined types are subset of reserved types.
+//
+// When critical, use IsPreDefinedType(typ string) to find out whether the typ was
+// actually defined internally or not.
 func IsReservedType(typ string) bool {
 	return isReservedName(typ)
+}
+
+// IsPreDefinedType returns true only if the typ has been defined by dgraph internally.
+// For example, `dgraph.graphql` or ACL types are defined in the initial internal types.
+//
+// We reserve `dgraph.` as the namespace for the types/predicates we may create in future.
+// So, users are not allowed to create a predicate under this namespace.
+// Hence, we should always define internal types under `dgraph.` namespace.
+//
+// Pre-defined types are subset of reserved types.
+func IsPreDefinedType(typ string) bool {
+	_, ok := preDefinedTypeMap[typ]
+	return ok
 }
 
 // isReservedName returns true if the given name is prefixed with `dgraph.`


### PR DESCRIPTION
This PR fixes the issue where live loader was not able to import the schema exported using export request. It does so, by allowing the alter schema request for pre-defined types to go through if the type in the request is same as the initial internal type.

This issue was introduced as a result of #5185.

This PR also disallows a pre-defined type from being dropped.

Fixes #DGRAPH-1694.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5696)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-18797adf5e-71945.surge.sh)
<!-- Dgraph:end -->