### PR TITLE
feat(vault): support kv v1 and decode base64 key

### DIFF
--- a/ee/enc/util_ee_test.go
+++ b/ee/enc/util_ee_test.go
@@ -41,8 +41,9 @@ func resetConfig(config *viper.Viper) {
 	config.Set(vaultAddr, "http://localhost:8200")
 	config.Set(vaultRoleIDFile, "")
 	config.Set(vaultSecretIDFile, "")
-	config.Set(vaultPath, "dgraph")
+	config.Set(vaultPath, "secret/data/dgraph")
 	config.Set(vaultField, "enc_key")
+	config.Set(vaultFormat, "base64")
 }
 
 // TODO: The function below allows instantiating a real Vault server. But results in go.mod issues.
@@ -116,6 +117,15 @@ func TestNewKeyReader(t *testing.T) {
 	k, err = kr.readKey()
 	require.Nil(t, k)
 	require.Error(t, err)
+
+	// Bad vault_format. Must be raw or base64.
+	resetConfig(config)
+	config.Set(vaultRoleIDFile, "./test-fixtures/dummy_role_id_file")
+	config.Set(vaultSecretIDFile, "./test-fixtures/dummy_secret_id_file")
+	config.Set(vaultFormat, "foo") // error.
+	kr, err = newKeyReader(config)
+	require.Error(t, err)
+	require.Nil(t, kr)
 
 	// RoleID and SecretID given but RoleID file and SecretID file exists and is valid.
 	resetConfig(config)

--- a/ee/enc/vault_ee.go
+++ b/ee/enc/vault_ee.go
@@ -54,7 +54,7 @@ func registerVaultFlags(flag *pflag.FlagSet) {
 	flag.String(vaultField, "enc_key",
 		"Vault kv store field whose value is the Base64 encoded encryption key.")
 	flag.String(vaultFormat, "base64",
-		"Vault field format. raw|base64")
+		"Vault field format. raw or base64")
 }
 
 // vaultKeyReader implements the KeyReader interface. It reads the key from vault server.
@@ -151,7 +151,7 @@ func (vkr *vaultKeyReader) readKey() (x.SensitiveByteSlice, error) {
 		return nil, errors.Errorf("secret key not found at %v", vkr.field)
 	}
 	kbyte := []byte(kVal.(string))
-	if vkr.field == "base64" {
+	if vkr.format == "base64" {
 		kbyte, err = base64.StdEncoding.DecodeString(kVal.(string))
 		if err != nil {
 			return nil, errors.Errorf("Unable to decode the Base64 Encoded key: err %v", err)

--- a/ee/enc/vault_ee.go
+++ b/ee/enc/vault_ee.go
@@ -142,8 +142,7 @@ func (vkr *vaultKeyReader) readKey() (x.SensitiveByteSlice, error) {
 	var m map[string]interface{}
 	m, ok := secret.Data["data"].(map[string]interface{})
 	if !ok {
-		glog.Infof("kv store read response from vault is bad. Trying kv v1.")
-		// try kv v1
+		glog.Infof("Unable to extract key from kv v2 response. Trying kv v1.")
 		m = secret.Data
 	}
 	kVal, ok := m[vkr.field]


### PR DESCRIPTION
Fixes DGRAPH-1722
Fixes DGRAPH-1723

This PR adds support for Vault kv v1 in addition to v2. Also, it allows for Base64 encoded or raw keys fetched from vault. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5708)
<!-- Reviewable:end -->
