### PR TITLE
fix(GraphQL): Remote schema introspection for single remote endpoint

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -237,7 +237,17 @@ func TestCustomNameForwardHeaders(t *testing.T) {
 }
 
 func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+		type Country @remote {
+			code: String
+			name: String
+		}
+
+		input CountryInput {
+			code: String!
+			name: String!
+		}
+		
 		type Query {
 			myCustom(yo: CountryInput!): [Country!]!
 			  @custom(
@@ -1181,7 +1191,19 @@ func TestForInvalidCustomQuery(t *testing.T) {
 }
 
 func TestForInvalidArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
 	type Query {
 		getCountry1(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/invalidargument",
@@ -1199,7 +1221,19 @@ func TestForInvalidArgument(t *testing.T) {
 }
 
 func TestForInvalidType(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+    }
+
+    type State @remote {
+        code: String
+        name: String
+        country: Country
+    }
 	type Query {
 		getCountry1(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/invalidtype",
@@ -1216,14 +1250,18 @@ func TestForInvalidType(t *testing.T) {
 }
 
 func TestCustomLogicGraphql(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+	}
+	
 	type Query {
 		getCountry1(id: ID!): Country!
 		  @custom(
 			http: {
 			  url: "http://mock:8888/validcountry"
 			  method: "POST"
-			  forwardHeaders: ["Content-Type"]
 			  graphql: "query($id: ID!) { country(code: $id) }"
 			}
 		  )
@@ -1247,7 +1285,12 @@ func TestCustomLogicGraphql(t *testing.T) {
 }
 
 func TestCustomLogicGraphqlWithArgumentsOnFields(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code(size: Int!): String
+      name: String
+	}
+	
 	type Query {
 		getCountry2(id: ID!): Country!
 		  @custom(
@@ -1278,7 +1321,30 @@ func TestCustomLogicGraphqlWithArgumentsOnFields(t *testing.T) {
 }
 
 func TestCustomLogicGraphqlWithError(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+      }
 	type Query {
 		getCountryOnlyErr(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/validcountrywitherror",
@@ -1305,7 +1371,12 @@ func TestCustomLogicGraphqlWithError(t *testing.T) {
 }
 
 func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+	}
+	
 	type Query {
 		getCountries(id: ID!): [Country]
 		  @custom(
@@ -1335,7 +1406,30 @@ func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
 }
 
 func TestCustomLogicWithErrorResponse(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+      }
 	type Query {
 		getCountriesErr(id: ID!): [Country] @custom(http: {
 			url: "http://mock:8888/graphqlerr",
@@ -1951,7 +2045,31 @@ func TestCustomGraphqlArgTypeMismatchForBatchedField(t *testing.T) {
 }
 
 func TestCustomGraphqlMissingRequiredArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+      states: [State]
+      std: Int
+    }
+
+    type State @remote {
+      code: String
+      name: String
+      country: Country
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+      states: [StateInput]
+    }
+
+    input StateInput {
+      code: String!
+      name: String!
+	}
+	
 	type Mutation {
 		addCountry1(input: CountryInput!): Country! @custom(http: {
 										url: "http://mock:8888/setCountry",
@@ -1990,7 +2108,31 @@ func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
 
 // this one accepts an object and returns an object
 func TestCustomGraphqlMutation1(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+      states: [State]
+      std: Int
+    }
+
+    type State @remote {
+      code: String
+      name: String
+      country: Country
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+      states: [StateInput]
+    }
+
+    input StateInput {
+      code: String!
+      name: String!
+	}
+	
 	type Mutation {
 		addCountry1(input: CountryInput!): Country!
 		  @custom(
@@ -2059,7 +2201,31 @@ func TestCustomGraphqlMutation1(t *testing.T) {
 
 // this one accepts multiple scalars and returns a list of objects
 func TestCustomGraphqlMutation2(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+	  }
+	  
 	type Mutation {
 		updateCountries(name: String, std: Int): [Country!]! @custom(http: {
 								url: "http://mock:8888/updateCountries",
@@ -2104,14 +2270,23 @@ func TestCustomGraphqlMutation2(t *testing.T) {
 }
 
 func TestForValidInputArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+	}
+	
 	type Query {
 		myCustom(yo: CountryInput!): [Country!]!
 		  @custom(
 			http: {
 			  url: "http://mock:8888/validinputfield"
 			  method: "POST"
-			  forwardHeaders: ["Content-Type"]
 			  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 			}
 		  )
@@ -2145,19 +2320,68 @@ func TestForValidInputArgument(t *testing.T) {
 }
 
 func TestForInvalidInputObject(t *testing.T) {
-	schema := customTypes + `
-	type Query {
-		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/invalidfield", method: "POST",forwardHeaders: ["Content-Type"], graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
-    }
+	schema := `
+	 type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: Int!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+	 }
+
+		type Query {
+			myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/invalidfield", method: "POST", graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
+		}
 	 `
 	res := updateSchema(t, schema)
 	require.Contains(t, res.Errors.Error(), "expected type for the field code is Int! but got String! in type CountryInput")
 }
 
 func TestForNestedInvalidInputObject(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+    }
+
+    type State @remote {
+        code: String
+        name: String
+        country: Country
+    }
+
+    input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+    }
+
+    input StateInput {
+        code: String!
+        name: Int!
+    }
+
 	type Query {
-		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/nestedinvalid", method: "POST",forwardHeaders: ["Content-Type"], graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
+		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/nestedinvalid", method: "POST",
+		graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
     }
 	 `
 	res := updateSchema(t, schema)

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -254,7 +254,6 @@ func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
 				http: {
 				  url: "http://mock:8888/validatesecrettoken"
 				  method: "POST"
-				  forwardHeaders: ["Content-Type"]
 				  secretHeaders: ["GITHUB-API-TOKEN"]
 				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 				}
@@ -2110,10 +2109,10 @@ func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
 func TestCustomGraphqlMutation1(t *testing.T) {
 	schema := `
 	type Country @remote {
-      code: String
-      name: String
-      states: [State]
-      std: Int
+		code: String
+		name: String
+		states: [State]
+		std: Int
     }
 
     type State @remote {
@@ -2134,14 +2133,11 @@ func TestCustomGraphqlMutation1(t *testing.T) {
 	}
 	
 	type Mutation {
-		addCountry1(input: CountryInput!): Country!
-		  @custom(
-			http: {
-			  url: "http://mock:8888/setCountry"
-			  method: "POST"
-			  graphql: "mutation($input: CountryInput!) { setCountry(country: $input) }"
-			}
-		  )
+		addCountry1(input: CountryInput!): Country! @custom(http: {
+					url: "http://mock:8888/setCountry"
+					method: "POST"
+					graphql: "mutation($input: CountryInput!) { setCountry(country: $input) }"
+			})
 	  }`
 	updateSchemaRequireNoGQLErrors(t, schema)
 	time.Sleep(2 * time.Second)

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -1040,20 +1040,19 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 		verifyData(t, users, teachers, schools)
 	})
 
-	// TODO when Introspection is fixed for multiple endpoints uncomment this
-	// t.Run("graphql single operation mode", func(t *testing.T) {
-	// 	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	// 	schema := readFile(t, "schemas/single-mode-graphql.graphql")
-	// 	updateSchemaRequireNoGQLErrors(t, schema)
-	// 	verifyData(t, users, teachers, schools)
-	// })
+	t.Run("graphql single operation mode", func(t *testing.T) {
+		// update schema to single mode where fields are resolved using GraphQL endpoints.
+		schema := readFile(t, "schemas/single-mode-graphql.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
+		verifyData(t, users, teachers, schools)
+	})
 
-	// t.Run("graphql batch operation mode", func(t *testing.T) {
-	// 	// update schema to single mode where fields are resolved using GraphQL endpoints.
-	// 	schema := readFile(t, "schemas/batch-mode-graphql.graphql")
-	// 	updateSchemaRequireNoGQLErrors(t, schema)
-	// 	verifyData(t, users, teachers, schools)
-	// })
+	t.Run("graphql batch operation mode", func(t *testing.T) {
+		// update schema to single mode where fields are resolved using GraphQL endpoints.
+		schema := readFile(t, "schemas/batch-mode-graphql.graphql")
+		updateSchemaRequireNoGQLErrors(t, schema)
+		verifyData(t, users, teachers, schools)
+	})
 
 	// Fields are fetched through a combination of REST/GraphQL and single/batch mode.
 	t.Run("mixed mode", func(t *testing.T) {
@@ -1079,6 +1078,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			  method: "POST"
 			  mode: SINGLE
 			  graphql: "query($id: ID!) { userName(id: $id) }"
+			  skipIntrospection: true
 			}
 		  )
 		age: Int! @search
@@ -1090,6 +1090,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			  mode: BATCH
 			  graphql: "query($input: [UserInput]) { cars(input: $input) }"
 			  body: "{ id: $id, age: $age}"
+			  skipIntrospection: true
 			}
 		  )
 	}`

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -1040,19 +1040,20 @@ func TestCustomFieldsShouldBeResolved(t *testing.T) {
 		verifyData(t, users, teachers, schools)
 	})
 
-	t.Run("graphql single operation mode", func(t *testing.T) {
-		// update schema to single mode where fields are resolved using GraphQL endpoints.
-		schema := readFile(t, "schemas/single-mode-graphql.graphql")
-		updateSchemaRequireNoGQLErrors(t, schema)
-		verifyData(t, users, teachers, schools)
-	})
+	// TODO when Introspection is fixed for multiple endpoints uncomment this
+	// t.Run("graphql single operation mode", func(t *testing.T) {
+	// 	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	// 	schema := readFile(t, "schemas/single-mode-graphql.graphql")
+	// 	updateSchemaRequireNoGQLErrors(t, schema)
+	// 	verifyData(t, users, teachers, schools)
+	// })
 
-	t.Run("graphql batch operation mode", func(t *testing.T) {
-		// update schema to single mode where fields are resolved using GraphQL endpoints.
-		schema := readFile(t, "schemas/batch-mode-graphql.graphql")
-		updateSchemaRequireNoGQLErrors(t, schema)
-		verifyData(t, users, teachers, schools)
-	})
+	// t.Run("graphql batch operation mode", func(t *testing.T) {
+	// 	// update schema to single mode where fields are resolved using GraphQL endpoints.
+	// 	schema := readFile(t, "schemas/batch-mode-graphql.graphql")
+	// 	updateSchemaRequireNoGQLErrors(t, schema)
+	// 	verifyData(t, users, teachers, schools)
+	// })
 
 	// Fields are fetched through a combination of REST/GraphQL and single/batch mode.
 	t.Run("mixed mode", func(t *testing.T) {
@@ -2330,13 +2331,13 @@ func TestForInvalidInputObject(t *testing.T) {
         country: Country
       }
 
-      input CountryInput {
-        code: Int!
+      input CountryInput @remote {
+        code: String!
         name: String!
         states: [StateInput]
       }
 
-      input StateInput {
+      input StateInput @remote {
         code: String!
         name: String!
 	 }
@@ -2364,15 +2365,15 @@ func TestForNestedInvalidInputObject(t *testing.T) {
         country: Country
     }
 
-    input CountryInput {
+    input CountryInput @remote {
         code: String!
         name: String!
         states: [StateInput]
     }
 
-    input StateInput {
+    input StateInput @remote {
         code: String!
-        name: Int!
+        name: String!
     }
 
 	type Query {

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -39,6 +39,8 @@ func validateUrl(rawURL string) error {
 		return fmt.Errorf("POST method cannot have query parameters in url: %s", rawURL)
 	}
 	return nil
+type IntrospectionRequest struct {
+	Query     string `json:"query"`
 }
 
 // introspectRemoteSchema introspectes remote schema
@@ -46,7 +48,7 @@ func introspectRemoteSchema(url string, headers http.Header) (*introspectedSchem
 	if err := validateUrl(url); err != nil {
 		return nil, err
 	}
-	param := &Request{
+	param := &IntrospectionRequest{
 		Query: introspectionQuery,
 	}
 

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -359,14 +359,14 @@ func matchDeepTypes(remoteType *gqlType, remoteTypes map[string]*types,
 	if err != nil {
 		return err
 	}
+	if len(expandedTypes) == 0 {
+		return nil
+	}
 	return matchRemoteTypes(expandedTypes, localSchema)
 }
 
 func matchRemoteTypes(expandedTypes map[string][]*gqlField, schema *ast.Schema) error {
 	for typeName, def := range schema.Types {
-		if len(expandedTypes) == 0 {
-			return nil
-		}
 		origTyp := schema.Types[typeName]
 		remoteDir := origTyp.Directives.ForName(remoteDirective)
 		if remoteDir != nil {

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -85,7 +85,6 @@ func introspectRemoteSchema(url string, headers http.Header) (*introspectedSchem
 const (
 	list        = "LIST"
 	nonNull     = "NON_NULL"
-	object = string(ast.Object)
 	inputObject = string(ast.InputObject)
 )
 
@@ -379,6 +378,7 @@ func matchRemoteTypes(schema *ast.Schema, remoteTypes map[string]*types) error {
 				}
 				remoteFields := remoteType.Fields
 				if remoteFields == nil {
+					// Get fields for INPUT_OBJECT
 					remoteFields = remoteType.InputFields
 				}
 				for _, field := range fields {

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -380,9 +380,9 @@ func matchRemoteTypes(expandedTypes map[string][]*gqlField, schema *ast.Schema) 
 			}
 			for _, field := range fields {
 				var remoteField *gqlField = nil
-				for _, it := range remoteType {
-					if it.Name == field.Name {
-						remoteField = it
+				for _, rf := range remoteType {
+					if rf.Name == field.Name {
+						remoteField = rf
 					}
 				}
 				if remoteField == nil {
@@ -547,7 +547,7 @@ func expandTypeRecursively(typenameToExpand string, param *expandTypeParams) err
 	param.expandedTypes[typenameToExpand] = struct{}{}
 	typeFound := false
 	for _, typ := range param.remoteTypes {
-		if typ.Name == typenameToExpand {
+		if typ.Name == typenameToExpand && typ.Kind != "INPUT_OBJECT"{
 			typeFound = true
 			param.typesToFields[typ.Name] = make([]*gqlField, 0,
 				len(typ.Fields)+len(typ.InputFields))
@@ -565,6 +565,9 @@ func expandTypeRecursively(typenameToExpand string, param *expandTypeParams) err
 					}
 				}
 			}
+		} 
+		if (typ.Kind != "INPUT_OBJECT") {
+			typeFound = true
 		}
 	}
 	if !typeFound {


### PR DESCRIPTION
Fixes GRAPHQL-503
This PR fixes remote schema introspection for custom logic in GraphQL for a single remote endpoint. Enabling validation for types that are part of custom logic query/mutation/field in our GraphQL schema against the remote schema .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5710)
<!-- Reviewable:end -->
