### PR TITLE
ci: fixes systest  - posting/size_test.sh to return fail for failed test

### DIFF
--- a/posting/size_test.sh
+++ b/posting/size_test.sh
@@ -1,17 +1,30 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
+TEST_FAIL=1
 # get the p directory
-wget https://storage.googleapis.com/dgraph-datasets/21million/p/p.tar.gz
+GCS_URL=https://storage.googleapis.com/dgraph-datasets/21million/p/p.tar.gz
+wget $GCS_URL || { echo "ERROR: Download from '$GCS_URL' falied." >&2; exit 2; }
 
 #untar it
-tar -xvf p.tar.gz 
+[[ -f p.tar.gz ]] || { echo "ERROR: File 'p.tar.gz' does not exist. Exiting" >&2; exit 2; }
+tar -xf p.tar.gz
+
 # get the profiling and size
 go test -run Test21MillionDataSet$ -v -manual=true
+[[ $? -ne 0 ]] && TEST_FAIL=1
 
 # compare our calculation with the profile
 go test -run Test21MillionDataSetSize$ -v -manual=true
+[[ $? -ne 0 ]] && TEST_FAIL=1
 
-rm mem.out
-rm size.data
-rm -rf p 
-rm  p.tar.gz
+# cleanup (idempotent)
+rm -f mem.out
+rm -f size.data
+rm -rf p
+rm -f p.tar.gz
+
+# report to calling script that test passed or failed
+if [[ $TEST_FAIL -ne 0 ]]; then
+  exit 1
+else
+  exit 0
+fi

--- a/posting/size_test.sh
+++ b/posting/size_test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-TEST_FAIL=1
+TEST_FAIL=0
 # get the p directory
 GCS_URL=https://storage.googleapis.com/dgraph-datasets/21million/p/p.tar.gz
-wget $GCS_URL || { echo "ERROR: Download from '$GCS_URL' falied." >&2; exit 2; }
+wget --quiet $GCS_URL || { echo "ERROR: Download from '$GCS_URL' falied." >&2; exit 2; }
 
 #untar it
 [[ -f p.tar.gz ]] || { echo "ERROR: File 'p.tar.gz' does not exist. Exiting" >&2; exit 2; }

--- a/posting/size_test.sh
+++ b/posting/size_test.sh
@@ -2,7 +2,7 @@
 TEST_FAIL=0
 # get the p directory
 GCS_URL=https://storage.googleapis.com/dgraph-datasets/21million/p/p.tar.gz
-wget --quiet $GCS_URL || { echo "ERROR: Download from '$GCS_URL' falied." >&2; exit 2; }
+wget --quiet $GCS_URL || { echo "ERROR: Download from '$GCS_URL' failed." >&2; exit 2; }
 
 #untar it
 [[ -f p.tar.gz ]] || { echo "ERROR: File 'p.tar.gz' does not exist. Exiting" >&2; exit 2; }


### PR DESCRIPTION
**Description** Currently when running `./test.sh -F` or the `cd posting && ./size_test.sh`, test failures will be reported as passing.  This is because the underlying test script `posting/size_test.sh`, doesn't return an exit code of 1 when the test fails.  

The test script is a shell script wrapper to setup data, instead of using the go test framework.  Unlike the go test framework it returns exit code of 1 when a test fails, and exit code of 0 when test succeeds.  The `size_test.sh` always returns a 0 when the test passes of fails.

**Solution**

* return exit of 1 if any tests fails (2 tests wrapped in this script)
* return exit of 2 setup fails, such as GCS file not available or file not available.
* do not report error if `rm` on file that doesn't exist
* use `/usr/bin/env` to execute bash, as bash can be located in different paths (standard best practices)
* quiet status progress from wget (not useful of test output results)
* quiet tar verbose progress (not useful in scope of test output results)

Fixes #5713 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5714)
<!-- Reviewable:end -->
