### PR TITLE
test(restore): Fix flakiness in online restore tests.

### DIFF
--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -36,7 +37,7 @@ import (
 	"github.com/dgraph-io/dgraph/testutil"
 )
 
-func sendRestoreRequest(t *testing.T, backupId string) {
+func sendRestoreRequest(t *testing.T, backupId string, dg *dgo.Dgraph) {
 	restoreRequest := fmt.Sprintf(`mutation restore() {
 		 restore(input: {location: "/data/backup", backupId: "%s",
 		 	encryptionKeyFile: "/data/keys/enc_key"}) {
@@ -59,6 +60,21 @@ func sendRestoreRequest(t *testing.T, backupId string) {
 	buf, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.Contains(t, string(buf), "Restore completed.")
+
+	// Wait for the client to exit draining mode. This is needed because the client might
+	// be connected to a follower and might be behind the leader in applying the restore.
+	for i := 0; i < 10; i++ {
+		// This is a dummy query that returns no results.
+		_, err = dg.NewTxn().Query(context.Background(), `{
+		q(func: has(invalid_pred)) {
+			invalid_pred
+		}}`)
+		if err == nil {
+			break
+		}
+		require.Contains(t, err.Error(), "the server is in draining mode")
+		time.Sleep(250 * time.Millisecond)
+	}
 }
 
 // disableDraining disables draining mode before each test for increased reliability.
@@ -163,7 +179,7 @@ func TestBasicRestore(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 
-	sendRestoreRequest(t, "youthful_rhodes3")
+	sendRestoreRequest(t, "youthful_rhodes3", dg)
 	runQueries(t, dg, false)
 	runMutations(t, dg)
 }
@@ -178,12 +194,12 @@ func TestMoveTablets(t *testing.T) {
 	ctx := context.Background()
 	require.NoError(t, dg.Alter(ctx, &api.Operation{DropAll: true}))
 
-	sendRestoreRequest(t, "youthful_rhodes3")
+	sendRestoreRequest(t, "youthful_rhodes3", dg)
 	runQueries(t, dg, false)
 
 	// Send another restore request with a different backup. This backup has some of the
 	// same predicates as the previous one but they are stored in different groups.
-	sendRestoreRequest(t, "blissful_hermann1")
+	sendRestoreRequest(t, "blissful_hermann1", dg)
 
 	resp, err := dg.NewTxn().Query(context.Background(), `{
 	  q(func: has(name), orderasc: name) {

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -73,7 +73,7 @@ func sendRestoreRequest(t *testing.T, backupId string, dg *dgo.Dgraph) {
 			break
 		}
 		require.Contains(t, err.Error(), "the server is in draining mode")
-		time.Sleep(250 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 	}
 }
 


### PR DESCRIPTION
The tests are flaky because the test waits for the leaders to complete the request. However,
the followers might be behind and the client can be connected to a follower. The fix is
to check that the client has exited draining mode before doing any queries.

Fixes DGRAPH-1740
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5724)
<!-- Reviewable:end -->
