### PR TITLE
Cherry-pick v20.07: feat(vault): support kv v1 and decode base64 key (#5708)

### DIFF
--- a/ee/enc/util_ee_test.go
+++ b/ee/enc/util_ee_test.go
@@ -41,8 +41,9 @@ func resetConfig(config *viper.Viper) {
 	config.Set(vaultAddr, "http://localhost:8200")
 	config.Set(vaultRoleIDFile, "")
 	config.Set(vaultSecretIDFile, "")
-	config.Set(vaultPath, "dgraph")
+	config.Set(vaultPath, "secret/data/dgraph")
 	config.Set(vaultField, "enc_key")
+	config.Set(vaultFormat, "base64")
 }
 
 // TODO: The function below allows instantiating a real Vault server. But results in go.mod issues.
@@ -116,6 +117,15 @@ func TestNewKeyReader(t *testing.T) {
 	k, err = kr.readKey()
 	require.Nil(t, k)
 	require.Error(t, err)
+
+	// Bad vault_format. Must be raw or base64.
+	resetConfig(config)
+	config.Set(vaultRoleIDFile, "./test-fixtures/dummy_role_id_file")
+	config.Set(vaultSecretIDFile, "./test-fixtures/dummy_secret_id_file")
+	config.Set(vaultFormat, "foo") // error.
+	kr, err = newKeyReader(config)
+	require.Error(t, err)
+	require.Nil(t, kr)
 
 	// RoleID and SecretID given but RoleID file and SecretID file exists and is valid.
 	resetConfig(config)


### PR DESCRIPTION
Fixes DGRAPH-1722
Fixes DGRAPH-1723

This PR adds support for Vault kv v1 in addition to v2. Also, it allows for Base64 encoded or raw keys fetched from vault.

(cherry picked from commit eff3dd9bb0e2fa20d5d20b992bc36f5829245461)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5725)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-486cf25853-72796.surge.sh)
<!-- Dgraph:end -->