### PR TITLE
(dgraph/release/v1.2) Use /tmp dir to store temporary index (#4766)

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"math"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -512,7 +513,8 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	// All the temp indexes go into the following directory. We delete the whole
 	// directory after the indexing step is complete. This deletes any other temp
 	// indexes that may have been left around in case defer wasn't executed.
-	tmpParentDir := "dgraph_index"
+	// TODO(Aman): If users are not happy, we could add a flag to choose this dir.
+	tmpParentDir := filepath.Join(os.TempDir(), "dgraph_index")
 
 	// We write the index in a temporary badger first and then,
 	// merge entries before writing them to p directory.


### PR DESCRIPTION
Fixes #4600
While running dgraph as systemd service, we may not have permissions
to create a folder in the current directory. Now, we instead use /tmp
dir to store the temporary index solving the permission denied error.

(cherry picked from commit 8bf90461f28fcc5683c4edffc12ba70ff711c59e)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5730)
<!-- Reviewable:end -->
