### PR TITLE
test: Retry due to connection issues in RetryMutations and RetryQuery.

### DIFF
--- a/testutil/client.go
+++ b/testutil/client.go
@@ -164,7 +164,10 @@ func DropAll(t *testing.T, dg *dgo.Dgraph) {
 func RetryQuery(dg *dgo.Dgraph, q string) (*api.Response, error) {
 	for {
 		resp, err := dg.NewTxn().Query(context.Background(), q)
-		if err != nil && strings.Contains(err.Error(), "Please retry") {
+		if err != nil && (strings.Contains(err.Error(), "Please retry") ||
+			strings.Contains(err.Error(), "connection closed")) {
+			// Retry connection issues because some tests (e.g TestSnapshot) are stopping and
+			// starting alphas.
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -199,7 +199,10 @@ func RetryMutation(dg *dgo.Dgraph, mu *api.Mutation) error {
 	for {
 		_, err := dg.NewTxn().Mutate(context.Background(), mu)
 		if err != nil && (strings.Contains(err.Error(), "Please retry") ||
-			strings.Contains(err.Error(), "Tablet isn't being served by this instance")) {
+			strings.Contains(err.Error(), "Tablet isn't being served by this instance") ||
+			strings.Contains(err.Error(), "connection closed")) {
+			// Retry connection issues because some tests (e.g TestSnapshot) are stopping and
+			// starting alphas.
 			time.Sleep(10 * time.Millisecond)
 			continue
 		}


### PR DESCRIPTION
Some tests down and up alphas so connection issues are expected and the
tests should retry until the alpha comes back up.

Fixes DGRAPH(1618)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5736)
<!-- Reviewable:end -->
