### PR TITLE
docs(Docker): Reword docker compose to show the need to change volume mount directories.

### DIFF
--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -2,7 +2,7 @@
 # and Alpha in different Docker containers.
 
 # It mounts /tmp/data on the host machine to /dgraph within the
-# container. You can change /tmp/data to a more appropriate location.
+# container. You will need to change /tmp/data to a more appropriate location.
 # Run `docker-compose up` to start Dgraph.
 
 version: "3.2"


### PR DESCRIPTION
Change wording to show the need to change the volume to something besides "/tmp/*"


Tested on AWS. If the mount directory of the volume is not changed away from tmp then the data will not persists even though the volume is persistent with EBS.

Figured this out by reading this topic on discourse: https://discuss.dgraph.io/t/dgraph-in-docker-unable-to-reload-data-on-restart/5927/4?u=amaster507
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5757)
<!-- Reviewable:end -->
