### PR TITLE
Cherry-pick v20.03: feat(graphql+-): support for paramterized @cascade

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -67,7 +67,7 @@ type GraphQuery struct {
 	Recurse          bool
 	RecurseArgs      RecurseArgs
 	ShortestPathArgs ShortestPathArgs
-	Cascade          bool
+	Cascade          []string
 	IgnoreReflex     bool
 	Facets           *pb.FacetParams
 	FacetsFilter     *FilterTree
@@ -961,7 +961,9 @@ L:
 			case "normalize":
 				gq.Normalize = true
 			case "cascade":
-				gq.Cascade = true
+				if err := parseCascade(it, gq); err != nil {
+					return nil, err
+				}
 			case "groupby":
 				gq.IsGroupby = true
 				if err := parseGroupby(it, gq); err != nil {
@@ -2091,6 +2093,69 @@ func tryParseFacetList(it *lex.ItemIterator) (res facetRes, parseOk bool, err er
 	}
 }
 
+// parseCascade parses the cascade directive.
+// Two formats:
+// 	1. @cascade
+//  2. @cascade(pred1, pred2, ...)
+func parseCascade(it *lex.ItemIterator, gq *GraphQuery) error {
+	item := it.Item()
+	items, err := it.Peek(1)
+	if err != nil {
+		return item.Errorf("Unable to peek lexer after cascade")
+	}
+
+	// check if it is without any args:
+	// 1. @cascade {
+	// 2. @cascade }
+	// 3. @cascade @
+	// 4. @cascade\n someOtherPred
+	if items[0].Typ == itemLeftCurl || items[0].Typ == itemRightCurl || items[0].
+		Typ == itemAt || items[0].Typ == itemName {
+		// __all__ implies @cascade i.e.  implies values for all the children are mandatory.
+		gq.Cascade = append(gq.Cascade, "__all__")
+		return nil
+	}
+
+	count := 0
+	expectArg := true
+	it.Next()
+	item = it.Item()
+	if item.Typ != itemLeftRound {
+		return item.Errorf("Expected a left round after cascade, got: %s", item.String())
+	}
+
+loop:
+	for it.Next() {
+		item := it.Item()
+		switch item.Typ {
+		case itemRightRound:
+			break loop
+		case itemComma:
+			if expectArg {
+				return item.Errorf("Expected a predicate but got comma")
+			}
+			expectArg = true
+		case itemName:
+			if !expectArg {
+				return item.Errorf("Expected a comma or right round but got: %v", item.Val)
+			}
+			gq.Cascade = append(gq.Cascade, collectName(it, item.Val))
+			count++
+			expectArg = false
+		default:
+			return item.Errorf("Unexpected item while parsing: %v", item.Val)
+		}
+	}
+	if expectArg {
+		// use the initial item to report error line and column numbers
+		return item.Errorf("Unnecessary comma in cascade()")
+	}
+	if count == 0 {
+		return item.Errorf("At least one predicate required in parameterized cascade()")
+	}
+	return nil
+}
+
 // parseGroupby parses the groupby directive.
 func parseGroupby(it *lex.ItemIterator, gq *GraphQuery) error {
 	count := 0
@@ -2427,7 +2492,9 @@ func parseDirective(it *lex.ItemIterator, curp *GraphQuery) error {
 			return item.Errorf("Facets parsing failed.")
 		}
 	case item.Val == "cascade":
-		curp.Cascade = true
+		if err := parseCascade(it, curp); err != nil {
+			return err
+		}
 	case item.Val == "normalize":
 		curp.Normalize = true
 	case peek[0].Typ == itemLeftRound:

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -5238,3 +5238,86 @@ func TestFilterWithEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, gq.Query[0].Filter.Func.Args[0].Value, "")
 }
+
+func TestCascade(t *testing.T) {
+	query := `{
+		names(func: has(name)) @cascade {
+		  name
+		}
+	  }`
+	gq, err := Parse(Request{
+		Str: query,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gq.Query[0].Cascade[0], "__all__")
+}
+
+func TestCascadeParameterized(t *testing.T) {
+	query := `{
+		names(func: has(name)) @cascade(name, age) {
+		  name
+		  age
+		  dob
+		}
+	  }`
+	gq, err := Parse(Request{
+		Str: query,
+	})
+	require.NoError(t, err)
+	require.Equal(t, gq.Query[0].Cascade[0], "name")
+	require.Equal(t, gq.Query[0].Cascade[1], "age")
+}
+
+func TestBadCascadeParameterized(t *testing.T) {
+	badQueries := []string{
+		`{
+			names(func: has(name)) @cascade( {
+			  name
+			  age
+			  dob
+			}
+		  }`,
+		`{
+			names(func: has(name)) @cascade) {
+			  name
+			  age
+			  dob
+			}
+		 }`,
+		`{
+			names(func: has(name)) @cascade() {
+			  name
+			  age
+			  dob
+			}
+		  }`,
+		`{
+			names(func: has(name)) @cascade(,) {
+			  name
+			  age
+			  dob
+			}
+		  }`,
+		`{
+			names(func: has(name)) @cascade(name,) {
+			  name
+			  age
+			  dob
+			}
+		  }`,
+		`{
+			names(func: has(name)) @cascade(,name) {
+			  name
+			  age
+			  dob
+			}
+		  }`,
+	}
+
+	for _, query := range badQueries {
+		_, err := Parse(Request{
+			Str: query,
+		})
+		require.Error(t, err)
+	}
+}

--- a/query/query.go
+++ b/query/query.go
@@ -156,8 +156,10 @@ type params struct {
 	Recurse bool
 	// RecurseArgs stores the arguments passed to the @recurse directive.
 	RecurseArgs gql.RecurseArgs
-	// Cascade is true if the @cascade directive is specified.
-	Cascade bool
+	// Cascade is the list of predicates to apply @cascade to.
+	// __all__ is special to mean @cascade i.e. all the children of this subgraph are mandatory
+	// and should have values otherwise the node will be excluded.
+	Cascade []string
 	// IgnoreReflex is true if the @ignorereflex directive is specified.
 	IgnoreReflex bool
 
@@ -532,7 +534,6 @@ func treeCopy(gq *gql.GraphQuery, sg *SubGraph) error {
 
 		args := params{
 			Alias:        gchild.Alias,
-			Cascade:      gchild.Cascade || sg.Params.Cascade,
 			Expand:       gchild.Expand,
 			Facet:        gchild.Facets,
 			FacetsOrder:  gchild.FacetsOrder,
@@ -547,6 +548,15 @@ func treeCopy(gq *gql.GraphQuery, sg *SubGraph) error {
 			GroupbyAttrs: gchild.GroupbyAttrs,
 			IsGroupBy:    gchild.IsGroupby,
 			IsInternal:   gchild.IsInternal,
+		}
+
+		// If parent has @cascade (with or without params), inherit @cascade (with no params)
+		if len(sg.Params.Cascade) > 0 {
+			args.Cascade = append(args.Cascade, "__all__")
+		}
+		// Allow over-riding at this level.
+		if len(gchild.Cascade) > 0 {
+			args.Cascade = gchild.Cascade
 		}
 
 		if gchild.IsCount {
@@ -1296,6 +1306,13 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 	if sg.DestUIDs == nil || sg.IsGroupBy() {
 		return nil
 	}
+
+	cascadeArgMap := make(map[string]bool)
+	for _, pred := range sg.Params.Cascade {
+		cascadeArgMap[pred] = true
+	}
+	cascadeAllPreds := cascadeArgMap["__all__"]
+
 	out := make([]uint64, 0, len(sg.DestUIDs.Uids))
 	if sg.Params.Alias == "shortest" {
 		goto AssignStep
@@ -1311,7 +1328,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 			return err
 		}
 		sgPath = sgPath[:len(sgPath)-1] // Backtrack
-		if !child.Params.Cascade {
+		if len(child.Params.Cascade) == 0 {
 			continue
 		}
 
@@ -1320,7 +1337,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 		child.updateUidMatrix()
 	}
 
-	if !sg.Params.Cascade {
+	if len(sg.Params.Cascade) == 0 {
 		goto AssignStep
 	}
 
@@ -1336,7 +1353,8 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 
 			// If the length of child UID list is zero and it has no valid value, then the
 			// current UID should be removed from this level.
-			if !child.IsInternal() &&
+			if (cascadeAllPreds || cascadeArgMap[child.Attr]) &&
+				!child.IsInternal() &&
 				// Check len before accessing index.
 				(len(child.valueMatrix) <= i || len(child.valueMatrix[i].Values) == 0) &&
 				(len(child.counts) <= i) &&


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5763)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-99fc1c8e05-73881.surge.sh)
<!-- Dgraph:end -->