### PR TITLE
build(Docker): Make Docker Build Self-Contained and Multi-Stage

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,9 +1,12 @@
-# This file is used to add the nightly Dgraph binaries and assets to Dgraph base
-# image.
+# Build the project
+FROM golang:1.14.1 as builder
 
-# This gets built as part of release.sh. Must be run from /tmp/build, with the linux binaries
-# already built and placed there.
+ENV GOPATH=/go
+WORKDIR /go/src/dgraph
+COPY . .
+RUN make install
 
+# Copy the built binary to the runtime container
 FROM ubuntu:latest
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
@@ -11,7 +14,7 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends ca-certificates curl iputils-ping && \
   rm -rf /var/lib/apt/lists/*
 
-ADD linux /usr/local/bin
+COPY --from=builder /go/bin/dgraph /usr/local/bin
 
 EXPOSE 8080
 EXPOSE 9080

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,4 +1,12 @@
+# Contributor Resources
+
 The `contrib` directory contains scripts, images, and other helpful things
 which are not part of the core dgraph distribution. Please note that they
 could be out of date, since they do not receive the same attention as the
 rest of the repository.
+
+## Building the Docker Image
+
+The docker image is meant to be built from the root directory of the project and can be built with the following command:
+
+    docker build -t dgraph/dgraph:latest --file contrib/Dockerfile .


### PR DESCRIPTION
The Docker image previously required building the project on the host machine and copying the built artifacts into the container. Now you just have to `docker build` from the project root and it would build the project and create the container by itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5764)
<!-- Reviewable:end -->
