### PR TITLE
update dgraph-single.yaml for security

### DIFF
--- a/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
+++ b/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: dgraph
 spec:
-  type: LoadBalancer
+  type: ClusterIP
   ports:
   - port: 5080
     targetPort: 5080


### PR DESCRIPTION
Minor fix to dgraph-single.yaml for security purposes.

Overview:
* changes from service type form `LoadBalancer` to `ClusterIP`. 
* default should be secure, not exposed to public Internet.

Fixes  #5768

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5772)
<!-- Reviewable:end -->
