### PR TITLE
feat(GraphQL): Add introspection headers to custom logic

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -205,6 +205,7 @@ func TestCustomNameForwardHeaders(t *testing.T) {
 				 method: "GET",
 				 forwardHeaders: ["X-App-Token:App", "X-User-Id"],
 				 secretHeaders: ["Authorization:Github-Api-Token"]
+				 introspectionHeaders: ["API:Github-Api-Token"]
 		 })
 	 }
 

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -246,6 +246,7 @@ func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
 				  method: "POST"
 				  forwardHeaders: ["Content-Type"]
 				  secretHeaders: ["GITHUB-API-TOKEN"]
+				  introspectionHeaders: ["GITHUB-API-TOKEN"]
 				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 				}
 			  )

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -245,7 +245,6 @@ func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
 				  url: "http://mock:8888/validatesecrettoken"
 				  method: "POST"
 				  forwardHeaders: ["Content-Type"]
-				  secretHeaders: ["GITHUB-API-TOKEN"]
 				  introspectionHeaders: ["GITHUB-API-TOKEN"]
 				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 				}

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -165,7 +165,7 @@ func TestCustomQueryShouldForwardHeaders(t *testing.T) {
 				 url: "http://mock:8888/verifyHeaders",
 				 method: "GET",
 				 forwardHeaders: ["X-App-Token", "X-User-Id"],
-				 secretHeaders: ["Github-Api-Token", "X-App-Token"]
+				 secretHeaders: ["Github-Api-Token"]
 		 })
 	 }
 	 
@@ -204,12 +204,11 @@ func TestCustomNameForwardHeaders(t *testing.T) {
 				 url: "http://mock:8888/verifyCustomNameHeaders",
 				 method: "GET",
 				 forwardHeaders: ["X-App-Token:App", "X-User-Id"],
-				 secretHeaders: ["Authorization:Github-Api-Token", "X-App-Token"]
+				 secretHeaders: ["Authorization:Github-Api-Token"]
 		 })
 	 }
 
 		 # Dgraph.Secret Github-Api-Token "random-fake-token"
-		 # Dgraph.Secret X-App-Token "should-be-overriden"
 	 `
 	updateSchemaRequireNoGQLErrors(t, schema)
 	time.Sleep(2 * time.Second)

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -106,6 +106,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1685,15 +1685,15 @@ func customDirectiveValidation(sch *ast.Schema,
 
 	if graphql != nil && !skip && graphqlOpDef != nil {
 		headers := http.Header{}
-		for k, v := range iHeaders {
+		for key, val := range iHeaders {
 			// We try and fetch the value from the stored secrets.
-			val, ok := secrets[v]
+			value, ok := secrets[val]
 			if !ok {
 				return append(errs, gqlerror.ErrorPosf(graphql.Position,
 					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file.",
-					typ.Name, field.Name, v,))
+					typ.Name, field.Name, val,))
 			}
-			headers.Add(k, string(val))
+			headers.Add(key, string(value))
 		}
 		if err := validateRemoteGraphql(&remoteGraphqlMetadata{
 			parentType:   typ,

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1698,9 +1698,9 @@ func customDirectiveValidation(sch *ast.Schema,
 				val, ok := secrets[key[1]]
 				if !ok {
 					return append(errs, gqlerror.ErrorPosf(graphql.Position,
-						"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value"+
+						"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file."+
 							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw))
+						typ.Name, field.Name, key[1], h.Value.Raw))
 				}
 				headers.Add(key[0], string(val))
 			}

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1698,7 +1698,7 @@ func customDirectiveValidation(sch *ast.Schema,
 				val, ok := secrets[key[1]]
 				if !ok {
 					return append(errs, gqlerror.ErrorPosf(graphql.Position,
-						"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file."+
+						"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file"+
 							", found: `%s`.",
 						typ.Name, field.Name, key[1], h.Value.Raw))
 				}

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -68,6 +68,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -73,6 +73,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -61,6 +61,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -78,6 +78,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 
@@ -161,4 +162,3 @@ type Query {
 type Mutation {
 	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"$input"})
 }
-

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -162,3 +162,4 @@ type Query {
 type Mutation {
 	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"$input"})
 }
+

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -62,6 +62,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -145,3 +145,4 @@ type Query {
 type Mutation {
 	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"{ data: $input }"})
 }
+

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -61,6 +61,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 
@@ -144,4 +145,3 @@ type Query {
 type Mutation {
 	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"{ data: $input }"})
 }
-

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -57,6 +57,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -57,6 +57,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -71,6 +71,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -71,6 +71,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -70,6 +70,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -81,6 +81,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -82,6 +82,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -81,6 +81,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -62,6 +62,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -62,6 +62,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -66,6 +66,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -66,6 +66,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -88,6 +88,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -88,6 +88,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -56,6 +56,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -68,6 +68,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -57,6 +57,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -66,6 +66,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -83,6 +83,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -65,6 +65,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -59,6 +59,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -72,6 +72,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -65,6 +65,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -64,6 +64,7 @@ input CustomHTTP {
 	mode: Mode
 	forwardHeaders: [String!]
 	secretHeaders: [String!]
+	introspectionHeaders: [String!]
 	skipIntrospection: Boolean
 }
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -864,7 +864,6 @@ func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, err
 	forwardHeaders := httpArg.Value.Children.ForName("forwardHeaders")
 	if forwardHeaders != nil {
 		for _, h := range forwardHeaders.Children {
-			// We would override the header if it was also specified as part of secretHeaders.
 			key := strings.Split(h.Value.Raw, ":")
 			if len(key) == 1 {
 				key = []string{h.Value.Raw, h.Value.Raw}

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -882,29 +882,6 @@ func TestCustomLogicHeaders(t *testing.T) {
 			errors.New("input:14: Type Query; Field user; secretHeaders and forwardHeaders in @custom directive cannot have overlapping headers, found: `Authorization`." + "\n"),
 		},
 		{
-			"check that header values can be shared across different types of headers",
-			`
-			type User @remote {
- 				description: String
-			}
-
-			type Query {
-			user(name: String!): User
-				@custom(
-				http: {
-					url: "http://mock:8888/verifyHeaders"
-					method: "POST"
-					forwardHeaders: ["Token:API-Token"]
-					secretHeaders: ["Authorization:API-Token"]
-					graphql: "query($name: String!) { getUser(name: $name) }"
-				}
-   	 			)
-				}
-				# Dgraph.Secret API-Token "random-fake-token"
-			`,
-			errors.New("input:14: Type Query; Field user: inside graphql in @custom directive, remote schema doesn't have any queries." + "\n"),
-		},
-		{
 			"check for header structure",
 			`
 			type User @remote {
@@ -930,11 +907,7 @@ func TestCustomLogicHeaders(t *testing.T) {
 	for _, test := range tcases {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := NewHandler(test.schemaStr)
-			if test.err != nil || err != nil {
-				require.EqualError(t, err, test.err.Error())
-				return
-			}
-			// require.NoError(t, err)
+			require.EqualError(t, err, test.err.Error())
 		})
 	}
 }

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -796,7 +796,6 @@ func TestGraphQLQueryInCustomHTTPConfig(t *testing.T) {
 }
 
 func TestAllowedHeadersList(t *testing.T) {
-	// TODO Add Custom logic forward headers tests
 	tcases := []struct {
 		name      string
 		schemaStr string
@@ -829,6 +828,86 @@ func TestAllowedHeadersList(t *testing.T) {
 			_, err := FromString(schHandler.GQLSchema())
 			require.NoError(t, err)
 			require.True(t, strings.Contains(hc.allowed, test.expected))
+		})
+	}
+}
+
+func TestCustomLogicHeaders(t *testing.T) {
+	tcases := []struct {
+		name      string
+		schemaStr string
+		err       error
+	}{
+		{
+			"check for introspection header to always use value from secrets",
+			`
+			type User @remote {
+ 				description: String
+			}
+
+			type Query {
+			user(name: String!): User
+				@custom(
+				http: {
+					url: "http://api:8888/graphql"
+					method: "POST"
+					introspectionHeaders: ["Authorization:Api-Token"]
+					graphql: "query($name: String!) { getUser(name: $name) }"
+				}
+   	 			)
+				}
+			`,
+			errors.New("input:13: Type Query; Field user; introspectionHeaders in @custom directive should use secrets to store the header value. " + "To do that specify `Api-Token` in this format '#Dgraph.Secret name value' at the bottom of your schema file, found: `Authorization:Api-Token`." + "\n"),
+		},
+		{
+			"check for secret and forward headers overlapping",
+			`
+			type User @remote {
+ 				description: String
+			}
+
+			type Query {
+			user(name: String!): User
+				@custom(
+				http: {
+					url: "http://api:8888/graphql"
+					method: "POST"
+					forwardHeaders: ["API-Token", "Authorization"]
+					secretHeaders: ["Authorization"]
+					graphql: "query($name: String!) { getUser(name: $name) }"
+				}
+   	 			)
+				}
+			`,
+			errors.New("input:14: Type Query; Field user; secretHeaders and forwardHeaders in @custom directive cannot have overlapping headers, found: `Authorization`." + "\n"),
+		},
+		{
+			"check for header structure",
+			`
+			type User @remote {
+ 				description: String
+			}
+
+			type Query {
+			user(name: String!): User
+				@custom(
+				http: {
+					url: "http://api:8888/graphql"
+					method: "POST"
+					forwardHeaders: ["API-Token",  "Content-Type"]
+					secretHeaders: ["Authorization:Auth:random"]
+					graphql: "query($name: String!) { getUser(name: $name) }"
+				}
+   	 			)
+				}
+			`,
+			errors.New("input:14: Type Query; Field user; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername', found: `Authorization:Auth:random`." + "\n"),
+		},
+	}
+	for _, test := range tcases {
+		t.Run(test.name, func(t *testing.T) {
+			_, errs := NewHandler(test.schemaStr)
+			require.EqualError(t, errs, test.err.Error())
 		})
 	}
 }

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -892,7 +892,7 @@ func TestCustomLogicHeaders(t *testing.T) {
 			user(name: String!): User
 				@custom(
 				http: {
-					url: "http://api:8888/graphql"
+					url: "http://mock:8888/verifyHeaders"
 					method: "POST"
 					forwardHeaders: ["Token:API-Token"]
 					secretHeaders: ["Authorization:API-Token"]
@@ -902,7 +902,7 @@ func TestCustomLogicHeaders(t *testing.T) {
 				}
 				# Dgraph.Secret API-Token "random-fake-token"
 			`,
-			errors.New("input:14: Type Query; Field user: inside graphql in @custom directive, Post \"http://api:8888/graphql\": dial tcp: lookup api: no such host" + "\n"),
+			errors.New("input:14: Type Query; Field user: inside graphql in @custom directive, remote schema doesn't have any queries." + "\n"),
 		},
 		{
 			"check for header structure",


### PR DESCRIPTION
Fixes GRAPHQL-510
This PR introduces `introspectionHeaders` for custom logic in GraphQL which will only be used for making the introspection query to the remote endpoint. Also `forwardHeaders` and `secretHeaders` cannot overlap.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5775)
<!-- Reviewable:end -->
