### PR TITLE
fix(GraphQL): GraphQL schema is preserved after drop_data

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -129,7 +129,7 @@ func PeriodicallyPostTelemetry() {
 
 // GetGQLSchema queries for the GraphQL schema node, and returns the uid and the GraphQL schema.
 // If multiple schema nodes were found, it returns an error.
-func GetGQLSchema() (uid string, graphQLSchema string, err error) {
+func GetGQLSchema() (uid, graphQLSchema string, err error) {
 	resp, err := (&Server{}).Query(context.WithValue(context.Background(), Authorize, false),
 		&api.Request{
 			Query: `

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -127,6 +127,41 @@ func PeriodicallyPostTelemetry() {
 	}
 }
 
+// GetGQLSchema queries for the GraphQL schema node, and returns the uid and the GraphQL schema.
+// If multiple schema nodes were found, it returns an error.
+func GetGQLSchema() (uid string, graphQLSchema string, err error) {
+	resp, err := (&Server{}).Query(context.Background(),
+		&api.Request{
+			Query: `
+			query {
+			  ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
+				uid
+				dgraph.graphql.schema
+			  }
+			}`})
+	if err != nil {
+		return "", "", err
+	}
+
+	result := make(map[string]interface{})
+	if err := json.Unmarshal(resp.GetJson(), &result); err != nil {
+		return "", "", errors.Wrap(err, "Couldn't unmarshal response from Dgraph query")
+	}
+
+	existingGQLSchema := result["ExistingGQLSchema"].([]interface{})
+	if len(existingGQLSchema) == 0 {
+		// no schema has been stored yet in Dgraph
+		return "", "", nil
+	} else if len(existingGQLSchema) == 1 {
+		// we found an existing GraphQL schema
+		gqlSchemaNode := existingGQLSchema[0].(map[string]interface{})
+		return gqlSchemaNode["uid"].(string), gqlSchemaNode[worker.GqlSchemaPred].(string), nil
+	}
+
+	// found multiple GraphQL schema nodes, this should never happen
+	return "", "", worker.ErrMultipleGraphQLSchemaNodes
+}
+
 // UpdateGQLSchema updates the GraphQL and Dgraph schemas using the given inputs.
 // It first validates and parses the dgraphSchema given in input. If that fails,
 // it returns an error. All this is done on the alpha on which the update request is received.
@@ -271,7 +306,12 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 
 		m.DropOp = pb.Mutations_ALL
 		_, err := query.ApplyMutations(ctx, m)
+		if err != nil {
+			return empty, err
+		}
 
+		// insert empty GraphQL schema, so all alphas get notified to reset their in-memory schema
+		_, err = UpdateGQLSchema(ctx, "", "")
 		// recreate the admin account after a drop all operation
 		ResetAcl()
 		return empty, err
@@ -282,9 +322,20 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 			return empty, errors.Errorf("If DropOp is set to DATA, DropValue must be empty")
 		}
 
-		m.DropOp = pb.Mutations_DATA
-		_, err := query.ApplyMutations(ctx, m)
+		// query the GraphQL schema and keep it in memory, so it can be inserted again
+		_, graphQLSchema, err := GetGQLSchema()
+		if err != nil {
+			return empty, err
+		}
 
+		m.DropOp = pb.Mutations_DATA
+		_, err = query.ApplyMutations(ctx, m)
+		if err != nil {
+			return empty, err
+		}
+
+		// just reinsert the GraphQL schema, no need to alter dgraph schema as this was drop_data
+		_, err = UpdateGQLSchema(ctx, graphQLSchema, "")
 		// recreate the admin account after a drop data operation
 		ResetAcl()
 		return empty, err

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -155,7 +155,17 @@ func GetGQLSchema() (uid, graphQLSchema string, err error) {
 	} else if len(existingGQLSchema) == 1 {
 		// we found an existing GraphQL schema
 		gqlSchemaNode := existingGQLSchema[0].(map[string]interface{})
-		return gqlSchemaNode["uid"].(string), gqlSchemaNode[worker.GqlSchemaPred].(string), nil
+		uid, ok := gqlSchemaNode["uid"].(string)
+		if !ok {
+			// this should never happen
+			return "", "", errors.New("didn't find uid in ExistingGQLSchema node")
+		}
+		graphQLSchema, ok := gqlSchemaNode[worker.GqlSchemaPred].(string)
+		if !ok {
+			// this should never happen
+			return "", "", errors.New("didn't find dgraph.graphql.schema in ExistingGQLSchema node")
+		}
+		return uid, graphQLSchema, nil
 	}
 
 	// found multiple GraphQL schema nodes, this should never happen

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -130,7 +130,7 @@ func PeriodicallyPostTelemetry() {
 // GetGQLSchema queries for the GraphQL schema node, and returns the uid and the GraphQL schema.
 // If multiple schema nodes were found, it returns an error.
 func GetGQLSchema() (uid string, graphQLSchema string, err error) {
-	resp, err := (&Server{}).Query(context.Background(),
+	resp, err := (&Server{}).Query(context.WithValue(context.Background(), Authorize, false),
 		&api.Request{
 			Query: `
 			query {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -18,14 +18,13 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/dgraph/query"
+	"github.com/dgraph-io/dgraph/edgraph"
 
-	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/query"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -48,8 +47,6 @@ const (
 	errResolverNotFound = "%s was not executed because no suitable resolver could be found - " +
 		"this indicates a resolver or validation bug " +
 		"(Please let us know : https://github.com/dgraph-io/dgraph/issues)"
-
-	gqlSchemaPred = "dgraph.graphql.schema"
 
 	// GraphQL schema for /admin endpoint.
 	graphqlAdminSchema = `
@@ -406,7 +403,7 @@ func newAdminResolver(
 		globalEpoch:       epoch,
 	}
 
-	prefix := x.DataKey(gqlSchemaPred, 0)
+	prefix := x.DataKey(worker.GqlSchemaPred, 0)
 	// Remove uid from the key, to get the correct prefix
 	prefix = prefix[:len(prefix)-8]
 	// Listen for graphql schema changes in group 1.
@@ -443,10 +440,14 @@ func newAdminResolver(
 			Schema: string(pl.Postings[0].Value),
 		}
 
-		gqlSchema, err := generateGQLSchema(newSchema)
-		if err != nil {
-			glog.Errorf("Error processing GraphQL schema: %s.  ", err)
-			return
+		var gqlSchema schema.Schema
+		// on drop_all, we will receive an empty string as the schema update
+		if newSchema.Schema != "" {
+			gqlSchema, err = generateGQLSchema(newSchema)
+			if err != nil {
+				glog.Errorf("Error processing GraphQL schema: %s.  ", err)
+				return
+			}
 		}
 
 		glog.Infof("Successfully updated GraphQL schema. Serving New GraphQL API.")
@@ -455,7 +456,7 @@ func newAdminResolver(
 		defer server.mux.Unlock()
 
 		server.schema = newSchema
-		server.resetSchema(*gqlSchema)
+		server.resetSchema(gqlSchema)
 	}, 1, closer)
 
 	go server.initServer()
@@ -518,42 +519,15 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 }
 
 func getCurrentGraphQLSchema() (*gqlSchema, error) {
-	resp, err := resolve.NewAdminExecutor().Execute(context.Background(),
-		&dgoapi.Request{
-			Query: `
-			query {
-			  ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
-				uid
-				dgraph.graphql.schema
-			  }
-			}`})
+	uid, graphQLSchema, err := edgraph.GetGQLSchema()
 	if err != nil {
 		return nil, err
 	}
 
-	result := make(map[string]interface{})
-	if err := json.Unmarshal(resp.GetJson(), &result); err != nil {
-		return nil, schema.GQLWrapf(err, "Couldn't unmarshal response from Dgraph query")
-	}
-
-	existingGQLSchema := result["ExistingGQLSchema"].([]interface{})
-	if len(existingGQLSchema) == 0 {
-		// no schema has been stored yet in Dgraph
-		return &gqlSchema{}, nil
-	} else if len(existingGQLSchema) == 1 {
-		// we found an existing GraphQL schema
-		gqlSchemaNode := existingGQLSchema[0].(map[string]interface{})
-		return &gqlSchema{
-			ID:     gqlSchemaNode["uid"].(string),
-			Schema: gqlSchemaNode[gqlSchemaPred].(string),
-		}, nil
-	}
-
-	// found multiple GraphQL schema nodes, this should never happen
-	return nil, worker.ErrMultipleGraphQLSchemaNodes
+	return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
 }
 
-func generateGQLSchema(sch *gqlSchema) (*schema.Schema, error) {
+func generateGQLSchema(sch *gqlSchema) (schema.Schema, error) {
 	schHandler, err := schema.NewHandler(sch.Schema)
 	if err != nil {
 		return nil, err
@@ -564,7 +538,7 @@ func generateGQLSchema(sch *gqlSchema) (*schema.Schema, error) {
 		return nil, err
 	}
 
-	return &generatedSchema, nil
+	return generatedSchema, nil
 }
 
 func (as *adminServer) initServer() {
@@ -609,7 +583,7 @@ func (as *adminServer) initServer() {
 
 		glog.Infof("Successfully loaded GraphQL schema.  Serving GraphQL API.")
 
-		as.resetSchema(*generatedSchema)
+		as.resetSchema(generatedSchema)
 
 		break
 	}
@@ -735,9 +709,12 @@ func resolverFactoryWithErrorMsg(msg string) resolve.ResolverFactory {
 }
 
 func (as *adminServer) resetSchema(gqlSchema schema.Schema) {
+	resolverFactory := resolverFactoryWithErrorMsg(errResolverNotFound)
 
-	resolverFactory := resolverFactoryWithErrorMsg(errResolverNotFound).
-		WithConventionResolvers(gqlSchema, as.fns)
+	// it is nil after drop_all
+	if gqlSchema != nil {
+		resolverFactory = resolverFactory.WithConventionResolvers(gqlSchema, as.fns)
+	}
 	if as.withIntrospection {
 		resolverFactory.WithSchemaIntrospection()
 	}

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -294,8 +294,8 @@ func TestUpdateGQLSchemaAfterDropAll(t *testing.T) {
 	// need to wait a bit, because the update notification takes time to reach the alpha
 	time.Sleep(time.Second)
 	// now retrieving the GraphQL schema should report no schema
-	gqlSchema := getGQLSchema(t, groupOneAdminServer)
-	require.Nil(t, gqlSchema)
+	gqlSchema := getGQLSchemaRequireId(t, groupOneAdminServer)
+	require.Empty(t, gqlSchema)
 
 	// updating the schema now should work
 	schema := `

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -291,6 +291,8 @@ func TestUpdateGQLSchemaAfterDropAll(t *testing.T) {
 	require.NoError(t, err)
 	testutil.DropAll(t, dg)
 
+	// need to wait a bit, because the update notification takes time to reach the alpha
+	time.Sleep(time.Second)
 	// now retrieving the GraphQL schema should report no schema
 	gqlSchema := getGQLSchema(t, groupOneAdminServer)
 	require.Nil(t, gqlSchema)
@@ -318,6 +320,9 @@ func TestGQLSchemaAfterDropData(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, dg.Alter(context.Background(), &api.Operation{DropOp: api.Operation_DATA}))
 
+	// lets wait a bit to be sure that the update notification has reached the alpha,
+	// otherwise we are anyways gonna get the previous schema from the in-memory schema
+	time.Sleep(time.Second)
 	// we should still get the schema we inserted earlier
 	require.Equal(t, schema, getGQLSchemaRequireId(t, groupOneAdminServer))
 

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -380,6 +380,7 @@ func getGQLSchema(t *testing.T, url string) gqlSchema {
 func getGQLSchemaRequireId(t *testing.T, url string) string {
 	schema := getGQLSchema(t, url)
 	require.NotEmpty(t, schema.Id, "Got empty ID in getGQLSchema")
+	return schema.Schema
 }
 
 func getDgraphSchema(t *testing.T, dg *dgo.Dgraph) string {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -72,6 +72,8 @@ const (
 		"probably a mismatch between the GraphQL and Dgraph/remote schemas. " +
 		"The value was resolved as null (which may trigger GraphQL error propagation) " +
 		"and as much other data as possible returned."
+
+	errInternal = "Internal error"
 )
 
 // A ResolverFactory finds the right resolver for a query/mutation.
@@ -375,12 +377,12 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 
 	if r == nil {
 		glog.Errorf("Call to Resolve with nil RequestResolver")
-		return schema.ErrorResponse(errors.New("Internal error"))
+		return schema.ErrorResponse(errors.New(errInternal))
 	}
 
 	if r.schema == nil {
 		glog.Errorf("Call to Resolve with no schema")
-		return schema.ErrorResponse(errors.New("Internal error"))
+		return schema.ErrorResponse(errors.New(errInternal))
 	}
 
 	startTime := time.Now()
@@ -500,6 +502,11 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 
 // ValidateSubscription will check the given subscription query is valid or not.
 func (r *RequestResolver) ValidateSubscription(req *schema.Request) error {
+	if r.schema == nil {
+		glog.Errorf("Call to Resolve with no schema")
+		return errors.New(errInternal)
+	}
+
 	op, err := r.schema.Operation(req)
 	if err != nil {
 		return err

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -503,7 +503,7 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 // ValidateSubscription will check the given subscription query is valid or not.
 func (r *RequestResolver) ValidateSubscription(req *schema.Request) error {
 	if r.schema == nil {
-		glog.Errorf("Call to Resolve with no schema")
+		glog.Errorf("Call to ValidateSubscription with no schema")
 		return errors.New(errInternal)
 	}
 


### PR DESCRIPTION
Fixes #GRAPHQL-370.

This PR makes sure that the GraphQL schema is preserved after `drop_data` operation. It also makes sure that the `getGQLSchema` GraphQL admin resolver reports empty schema after `drop_all`.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5790)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cd8ca67f67-74641.surge.sh)
<!-- Dgraph:end -->