### PR TITLE
docs(CHANGELOG): Fixed referenced issue for @cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project will adhere to [Calendar Versioning](https://calver.org/) start
 
 - GraphQL
   - Add Graphql-TouchedUids header in HTTP response. ([#5572][])
-  - Introduce `@cascade` in GraphQL. Fixes [#4789][]. ([#5179][])	
+  - Introduce `@cascade` in GraphQL. Fixes [#4789][]. ([#5511][])	
   - Add authentication feature and http admin endpoints. Fixes [#4758][]. ([#5162][])	
   - Support existing gqlschema nodes without xid. ([#5457][])
   - Add custom logic feature. ([#5004][])
@@ -129,7 +129,7 @@ and this project will adhere to [Calendar Versioning](https://calver.org/) start
 [#5682]: https://github.com/dgraph-io/dgraph/issues/5682
 [#5572]: https://github.com/dgraph-io/dgraph/issues/5572
 [#4789]: https://github.com/dgraph-io/dgraph/issues/4789
-[#5179]: https://github.com/dgraph-io/dgraph/issues/5179
+[#5511]: https://github.com/dgraph-io/dgraph/issues/5511
 [#4758]: https://github.com/dgraph-io/dgraph/issues/4758
 [#5162]: https://github.com/dgraph-io/dgraph/issues/5162
 [#5457]: https://github.com/dgraph-io/dgraph/issues/5457


### PR DESCRIPTION
The wrong issue was being referenced for the `@cascade` directive. #5179 is for authorization while #5511 is for `@cascade`
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5800)
<!-- Reviewable:end -->
