### PR TITLE
feat(GraphQL): GraphQL health now reported by /probe/graphql

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -470,9 +470,13 @@ func setupServer(closer *y.Closer) {
 	// The global epoch is set to maxUint64 while exiting the server.
 	// By using this information polling goroutine terminates the subscription.
 	globalEpoch := uint64(0)
-	var mainServer web.IServeGraphQL
-	mainServer, adminServer = admin.NewServers(introspection, &globalEpoch, closer)
+	mainServer, adminServer, mainHealth := admin.NewServers(introspection, &globalEpoch, closer)
 	http.Handle("/graphql", mainServer.HTTPHandler())
+	http.HandleFunc("/probe/graphql", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(mainHealth.HttpStatusCode)
+		w.Header().Set("Content-Type", "application/json")
+		x.Check2(w.Write([]byte(fmt.Sprintf(`{"status": "%s"}`, mainHealth.StatusMsg))))
+	})
 	http.Handle("/admin", allowedMethodsHandler(allowedMethods{
 		http.MethodGet:     true,
 		http.MethodPost:    true,

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -473,9 +473,10 @@ func setupServer(closer *y.Closer) {
 	mainServer, adminServer, mainHealth := admin.NewServers(introspection, &globalEpoch, closer)
 	http.Handle("/graphql", mainServer.HTTPHandler())
 	http.HandleFunc("/probe/graphql", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(mainHealth.HttpStatusCode)
+		statusCode, StatusMsg := mainHealth.Status()
+		w.WriteHeader(statusCode)
 		w.Header().Set("Content-Type", "application/json")
-		x.Check2(w.Write([]byte(fmt.Sprintf(`{"status": "%s"}`, mainHealth.StatusMsg))))
+		x.Check2(w.Write([]byte(fmt.Sprintf(`{"status":"%s"}`, StatusMsg))))
 	})
 	http.Handle("/admin", allowedMethodsHandler(allowedMethods{
 		http.MethodGet:     true,

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -333,21 +333,22 @@ var (
 		"deleteGroup": {resolve.IpWhitelistingMW4Mutation},
 	}
 	// mainHealth tracks the health of the main GraphQL server.
-	// It is required for kubernetes probing.
-	mainHealth = &graphQLHealth{HttpStatusCode: http.StatusServiceUnavailable, StatusMsg: "init"}
+	mainHealth = &GraphQLHealth{HttpStatusCode: http.StatusServiceUnavailable, StatusMsg: "init"}
 )
 
-type graphQLHealth struct {
+// GraphQLHealth is used to report the health status of a GraphQL server.
+// It is required for kubernetes probing.
+type GraphQLHealth struct {
 	HttpStatusCode int
 	StatusMsg      string
 }
 
-func (g *graphQLHealth) up() {
+func (g *GraphQLHealth) up() {
 	g.HttpStatusCode = http.StatusOK
 	g.StatusMsg = "up"
 }
 
-func (g *graphQLHealth) updatingSchema() {
+func (g *GraphQLHealth) updatingSchema() {
 	g.HttpStatusCode = http.StatusOK
 	g.StatusMsg = "updating schema"
 }
@@ -380,7 +381,7 @@ type adminServer struct {
 // NewServers initializes the GraphQL servers.  It sets up an empty server for the
 // main /graphql endpoint and an admin server.  The result is mainServer, adminServer.
 func NewServers(withIntrospection bool, globalEpoch *uint64, closer *y.Closer) (web.IServeGraphQL,
-	web.IServeGraphQL, *graphQLHealth) {
+	web.IServeGraphQL, *GraphQLHealth) {
 	gqlSchema, err := schema.FromString("")
 	if err != nil {
 		x.Panic(err)

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -333,24 +333,37 @@ var (
 		"deleteGroup": {resolve.IpWhitelistingMW4Mutation},
 	}
 	// mainHealth tracks the health of the main GraphQL server.
-	mainHealth = &GraphQLHealth{HttpStatusCode: http.StatusServiceUnavailable, StatusMsg: "init"}
+	mainHealth = &GraphQLHealth{httpStatusCode: http.StatusServiceUnavailable, statusMsg: "init"}
 )
 
 // GraphQLHealth is used to report the health status of a GraphQL server.
 // It is required for kubernetes probing.
 type GraphQLHealth struct {
-	HttpStatusCode int
-	StatusMsg      string
+	httpStatusCode int
+	statusMsg      string
+	// mux protects GraphQLHealth from simultaneous read/write, as an instance of this type could be
+	// used by multiple Go-routines
+	mux sync.RWMutex
+}
+
+func (g *GraphQLHealth) Status() (int, string) {
+	g.mux.RLock()
+	defer g.mux.RUnlock()
+	return g.httpStatusCode, g.statusMsg
 }
 
 func (g *GraphQLHealth) up() {
-	g.HttpStatusCode = http.StatusOK
-	g.StatusMsg = "up"
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.httpStatusCode = http.StatusOK
+	g.statusMsg = "up"
 }
 
 func (g *GraphQLHealth) updatingSchema() {
-	g.HttpStatusCode = http.StatusOK
-	g.StatusMsg = "updating schema"
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	g.httpStatusCode = http.StatusOK
+	g.statusMsg = "updating schema"
 }
 
 type gqlSchema struct {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -18,7 +18,6 @@ package admin
 
 import (
 	"context"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -326,36 +325,36 @@ var (
 		"deleteGroup": {resolve.IpWhitelistingMW4Mutation},
 	}
 	// mainHealth tracks the health of the main GraphQL server.
-	mainHealth = &GraphQLHealth{httpStatusCode: http.StatusServiceUnavailable, statusMsg: "init"}
+	mainHealth = &GraphQLHealth{healthy: false, statusMsg: "init"}
 )
 
 // GraphQLHealth is used to report the health status of a GraphQL server.
 // It is required for kubernetes probing.
 type GraphQLHealth struct {
-	httpStatusCode int
-	statusMsg      string
+	healthy   bool
+	statusMsg string
 	// mux protects GraphQLHealth from simultaneous read/write, as an instance of this type could be
 	// used by multiple Go-routines
 	mux sync.RWMutex
 }
 
-func (g *GraphQLHealth) Status() (int, string) {
+func (g *GraphQLHealth) Status() (bool, string) {
 	g.mux.RLock()
 	defer g.mux.RUnlock()
-	return g.httpStatusCode, g.statusMsg
+	return g.healthy, g.statusMsg
 }
 
 func (g *GraphQLHealth) up() {
 	g.mux.Lock()
 	defer g.mux.Unlock()
-	g.httpStatusCode = http.StatusOK
+	g.healthy = true
 	g.statusMsg = "up"
 }
 
 func (g *GraphQLHealth) updatingSchema() {
 	g.mux.Lock()
 	defer g.mux.Unlock()
-	g.httpStatusCode = http.StatusOK
+	g.healthy = true
 	g.statusMsg = "updating schema"
 }
 

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -42,7 +42,7 @@ import (
 
 const touchedUidsHeader = "Graphql-TouchedUids"
 
-// An IServeGraphQL can serve a GraphQL endpoint (currently only ons http)
+// An IServeGraphQL can serve a GraphQL endpoint (currently only on http)
 type IServeGraphQL interface {
 
 	// After ServeGQL is called, this IServeGraphQL serves the new resolvers.


### PR DESCRIPTION
Fixes #GRAPHQL-507.

This PR adds `/probe/graphql` HTTP endpoint which returns HTTP status 200 OK, if the `/graphql` endpoint is up and running otherwise it returns HTTP status 503 Service Unavailable. It also returns a JSON body of the following form:
```
{"status":"init/up/updating schema"}
```
Status `init` is returned for 503, while rest of the two statuses return 200 code.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5802)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ee9f26feeb-75202.surge.sh)
<!-- Dgraph:end -->