### PR TITLE
test: Deal with incomplete tests in Jepsen tool

### DIFF
--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -136,8 +136,9 @@ var (
 	doDownOnly = pflag.BoolP("down-only", "D", false, "Do --down and exit. Does not run tests.")
 	web        = pflag.Bool("web", true, "Open the test results page in the browser.")
 
-	// Options
-	refreshCluster = pflag.Bool("refresh-cluster", false, "Down and up the cluster before each test.")
+	// Option to run each test with a new cluster. This appears to mitigate flakiness.
+	refreshCluster = pflag.Bool("refresh-cluster", false,
+		"Down and up the cluster before each test.")
 
 	// Script flags
 	dryRun = pflag.BoolP("dry-run", "y", false,

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -477,6 +477,8 @@ func main() {
 					// Retry incomplete tests. Sometimes tests fail due to temporary errors.
 					tries++
 					if tries == maxRetries {
+						fmt.Fprintf(os.Stderr, "Test with workload %s and nemesis %s could not "+
+							"start after maximum number of retries", w, n)
 						defer os.Exit(1)
 						break retryLoop
 					} else {


### PR DESCRIPTION
This PR does two things:

1. Add an option `--refresh-cluster` to down and up the test cluster before each test. I noticed
   that most errors that lead to incomplete tests go away if this is done.
1. Retry incomplete tests. Most incomplete tests fail early so it's not very expensive to retry
    the test. The tool now only returns an exit code of 1 if there's a test failure or a test was incomplete
    even after retries.

Related to DGRAPH-971

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5804)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c06910c0db-76986.surge.sh)
<!-- Dgraph:end -->