### PR TITLE
fix(Documentation): fixes sampling rate in tracing documentation

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2344,7 +2344,7 @@ Go's built-in metrics may also be useful to measure for memory usage and garbage
 
 Dgraph is integrated with [OpenCensus](https://opencensus.io/zpages/) to collect distributed traces from the Dgraph cluster.
 
-Trace data is always collected within Dgraph. You can adjust the trace sampling rate for Dgraph queries with the `--trace` option for Dgraph Alphas. By default, `--trace` is set to 1 to trace 100% of queries.
+Trace data is always collected within Dgraph. You can adjust the trace sampling rate for Dgraph queries with the `--trace` option for Dgraph Alphas. By default, `--trace` is set to 0.01 to trace 1% of queries.
 
 ### Examining Traces with zPages
 


### PR DESCRIPTION
Fix sampling rate for tracing in the documentation.
See [default value for --trace](https://github.com/dgraph-io/dgraph/blob/master/dgraph/cmd/alpha/run.go#L128)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5806)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-aaa05c8b69-75041.surge.sh)
<!-- Dgraph:end -->