### PR TITLE
fix(dgraph): add retry mechanism for 21million test

### DIFF
--- a/systest/21million/run_test.go
+++ b/systest/21million/run_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 // JSON output can be hundreds of lines and diffs can scroll off the terminal before you
@@ -74,24 +73,28 @@ func TestQueries(t *testing.T) {
 
 			// The test query and expected result are separated by a delimiter.
 			bodies := strings.SplitN(contents, "\n---\n", 2)
+			for retry := 0; retry < 3; retry++ {
+				// If a query takes too long to run, it probably means dgraph is stuck and there's
+				// no point in waiting longer or trying more tests.
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				resp, err := dg.NewTxn().Query(ctx, bodies[0])
+				cancel()
+				if ctx.Err() == context.DeadlineExceeded {
+					t.Fatal("aborting test due to query timeout")
+				}
+				if retry < 2 && err != nil {
+					continue
+				}
 
-			// If a query takes too long to run, it probably means dgraph is stuck and there's
-			// no point in waiting longer or trying more tests.
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			resp, err := dg.NewTxn().Query(ctx, bodies[0])
-			cancel()
-			if ctx.Err() == context.DeadlineExceeded {
-				t.Fatal("aborting test due to query timeout")
-			}
-			require.NoError(t, err)
+				t.Logf("running %s", file.Name())
+				if *savedir != "" {
+					savepath = path.Join(*savedir, file.Name())
+				}
 
-			t.Logf("running %s", file.Name())
-			if *savedir != "" {
-				savepath = path.Join(*savedir, file.Name())
-			}
-
-			if !testutil.EqualJSON(t, bodies[1], string(resp.GetJson()), savepath, *quiet) {
-				diffs++
+				if !testutil.EqualJSON(t, bodies[1], string(resp.GetJson()), savepath, *quiet) {
+					diffs++
+				}
+				break
 			}
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Tiger <rbalajis25@gmail.com>

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5820)
<!-- Reviewable:end -->
