### PR TITLE
fix(GraphQL): Remote schema introspection for single remote endpoint (#5710)

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -237,14 +237,23 @@ func TestCustomNameForwardHeaders(t *testing.T) {
 }
 
 func TestSchemaIntrospectionForCustomQueryShouldForwardHeaders(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+		type Country @remote {
+			code: String
+			name: String
+		}
+
+		input CountryInput {
+			code: String!
+			name: String!
+		}
+		
 		type Query {
 			myCustom(yo: CountryInput!): [Country!]!
 			  @custom(
 				http: {
 				  url: "http://mock:8888/validatesecrettoken"
 				  method: "POST"
-				  forwardHeaders: ["Content-Type"]
 				  secretHeaders: ["GITHUB-API-TOKEN"]
 				  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 				}
@@ -1071,6 +1080,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			  method: "POST"
 			  mode: SINGLE
 			  graphql: "query($id: ID!) { userName(id: $id) }"
+			  skipIntrospection: true
 			}
 		  )
 		age: Int! @search
@@ -1082,6 +1092,7 @@ func TestCustomFieldResolutionShouldPropagateGraphQLErrors(t *testing.T) {
 			  mode: BATCH
 			  graphql: "query($input: [UserInput]) { cars(input: $input) }"
 			  body: "{ id: $id, age: $age}"
+			  skipIntrospection: true
 			}
 		  )
 	}`
@@ -1183,7 +1194,19 @@ func TestForInvalidCustomQuery(t *testing.T) {
 }
 
 func TestForInvalidArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
 	type Query {
 		getCountry1(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/invalidargument",
@@ -1201,7 +1224,19 @@ func TestForInvalidArgument(t *testing.T) {
 }
 
 func TestForInvalidType(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+    }
+
+    type State @remote {
+        code: String
+        name: String
+        country: Country
+    }
 	type Query {
 		getCountry1(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/invalidtype",
@@ -1218,14 +1253,18 @@ func TestForInvalidType(t *testing.T) {
 }
 
 func TestCustomLogicGraphql(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+	}
+	
 	type Query {
 		getCountry1(id: ID!): Country!
 		  @custom(
 			http: {
 			  url: "http://mock:8888/validcountry"
 			  method: "POST"
-			  forwardHeaders: ["Content-Type"]
 			  graphql: "query($id: ID!) { country(code: $id) }"
 			}
 		  )
@@ -1249,7 +1288,12 @@ func TestCustomLogicGraphql(t *testing.T) {
 }
 
 func TestCustomLogicGraphqlWithArgumentsOnFields(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code(size: Int!): String
+      name: String
+	}
+	
 	type Query {
 		getCountry2(id: ID!): Country!
 		  @custom(
@@ -1280,7 +1324,30 @@ func TestCustomLogicGraphqlWithArgumentsOnFields(t *testing.T) {
 }
 
 func TestCustomLogicGraphqlWithError(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+      }
 	type Query {
 		getCountryOnlyErr(id: ID!): Country! @custom(http: {
 			url: "http://mock:8888/validcountrywitherror",
@@ -1307,7 +1374,12 @@ func TestCustomLogicGraphqlWithError(t *testing.T) {
 }
 
 func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+	}
+	
 	type Query {
 		getCountries(id: ID!): [Country]
 		  @custom(
@@ -1337,7 +1409,30 @@ func TestCustomLogicGraphQLValidArrayResponse(t *testing.T) {
 }
 
 func TestCustomLogicWithErrorResponse(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+      }
 	type Query {
 		getCountriesErr(id: ID!): [Country] @custom(http: {
 			url: "http://mock:8888/graphqlerr",
@@ -1951,7 +2046,31 @@ func TestCustomGraphqlArgTypeMismatchForBatchedField(t *testing.T) {
 }
 
 func TestCustomGraphqlMissingRequiredArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+      states: [State]
+      std: Int
+    }
+
+    type State @remote {
+      code: String
+      name: String
+      country: Country
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+      states: [StateInput]
+    }
+
+    input StateInput {
+      code: String!
+      name: String!
+	}
+	
 	type Mutation {
 		addCountry1(input: CountryInput!): Country! @custom(http: {
 										url: "http://mock:8888/setCountry",
@@ -1990,16 +2109,37 @@ func TestCustomGraphqlMissingRequiredArgumentForBatchedField(t *testing.T) {
 
 // this one accepts an object and returns an object
 func TestCustomGraphqlMutation1(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+		code: String
+		name: String
+		states: [State]
+		std: Int
+    }
+
+    type State @remote {
+      code: String
+      name: String
+      country: Country
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+      states: [StateInput]
+    }
+
+    input StateInput {
+      code: String!
+      name: String!
+	}
+	
 	type Mutation {
-		addCountry1(input: CountryInput!): Country!
-		  @custom(
-			http: {
-			  url: "http://mock:8888/setCountry"
-			  method: "POST"
-			  graphql: "mutation($input: CountryInput!) { setCountry(country: $input) }"
-			}
-		  )
+		addCountry1(input: CountryInput!): Country! @custom(http: {
+					url: "http://mock:8888/setCountry"
+					method: "POST"
+					graphql: "mutation($input: CountryInput!) { setCountry(country: $input) }"
+			})
 	  }`
 	updateSchemaRequireNoGQLErrors(t, schema)
 	time.Sleep(2 * time.Second)
@@ -2059,7 +2199,31 @@ func TestCustomGraphqlMutation1(t *testing.T) {
 
 // this one accepts multiple scalars and returns a list of objects
 func TestCustomGraphqlMutation2(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput {
+        code: String!
+        name: String!
+	  }
+	  
 	type Mutation {
 		updateCountries(name: String, std: Int): [Country!]! @custom(http: {
 								url: "http://mock:8888/updateCountries",
@@ -2104,14 +2268,23 @@ func TestCustomGraphqlMutation2(t *testing.T) {
 }
 
 func TestForValidInputArgument(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+      code: String
+      name: String
+    }
+
+    input CountryInput {
+      code: String!
+      name: String!
+	}
+	
 	type Query {
 		myCustom(yo: CountryInput!): [Country!]!
 		  @custom(
 			http: {
 			  url: "http://mock:8888/validinputfield"
 			  method: "POST"
-			  forwardHeaders: ["Content-Type"]
 			  graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"
 			}
 		  )
@@ -2145,19 +2318,68 @@ func TestForValidInputArgument(t *testing.T) {
 }
 
 func TestForInvalidInputObject(t *testing.T) {
-	schema := customTypes + `
-	type Query {
-		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/invalidfield", method: "POST",forwardHeaders: ["Content-Type"], graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
-    }
+	schema := `
+	 type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+      }
+
+      type State @remote {
+        code: String
+        name: String
+        country: Country
+      }
+
+      input CountryInput @remote {
+        code: String!
+        name: String!
+        states: [StateInput]
+      }
+
+      input StateInput @remote {
+        code: String!
+        name: String!
+	 }
+
+		type Query {
+			myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/invalidfield", method: "POST", graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
+		}
 	 `
 	res := updateSchema(t, schema)
 	require.Contains(t, res.Errors.Error(), "expected type for the field code is Int! but got String! in type CountryInput")
 }
 
 func TestForNestedInvalidInputObject(t *testing.T) {
-	schema := customTypes + `
+	schema := `
+	type Country @remote {
+        code: String
+        name: String
+        states: [State]
+        std: Int
+    }
+
+    type State @remote {
+        code: String
+        name: String
+        country: Country
+    }
+
+    input CountryInput @remote {
+        code: String!
+        name: String!
+        states: [StateInput]
+    }
+
+    input StateInput @remote {
+        code: String!
+        name: String!
+    }
+
 	type Query {
-		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/nestedinvalid", method: "POST",forwardHeaders: ["Content-Type"], graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
+		myCustom(yo: CountryInput!): [Country!]! @custom(http: {url: "http://mock:8888/nestedinvalid", method: "POST",
+		graphql: "query($yo: CountryInput!) {countries(filter: $yo)}"})
     }
 	 `
 	res := updateSchema(t, schema)

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -41,12 +41,16 @@ func validateUrl(rawURL string) error {
 	return nil
 }
 
+type IntrospectionRequest struct {
+	Query string `json:"query"`
+}
+
 // introspectRemoteSchema introspectes remote schema
 func introspectRemoteSchema(url string, headers http.Header) (*introspectedSchema, error) {
 	if err := validateUrl(url); err != nil {
 		return nil, err
 	}
-	param := &Request{
+	param := &IntrospectionRequest{
 		Query: introspectionQuery,
 	}
 
@@ -351,38 +355,55 @@ func missingRemoteTypeError(typName string) error {
 
 func matchDeepTypes(remoteType *gqlType, remoteTypes map[string]*types,
 	localSchema *ast.Schema) error {
-	expandedTypes, err := expandType(remoteType, remoteTypes)
+	_, err := expandType(remoteType, remoteTypes)
 	if err != nil {
 		return err
 	}
-	return matchRemoteTypes(expandedTypes, localSchema)
+	return matchRemoteTypes(localSchema, remoteTypes)
 }
 
-func matchRemoteTypes(expandedTypes map[string][]*gqlField, schema *ast.Schema) error {
-	for typeName, fields := range expandedTypes {
-		localType, ok := schema.Types[typeName]
-		if !ok {
-			return errors.Errorf(
-				"Unable to find remote type %s in the local schema",
-				typeName,
-			)
-		}
-		for _, field := range fields {
-			localField := localType.Fields.ForName(field.Name)
-			if localField == nil {
-				return errors.Errorf(
-					"%s field for the remote type %s is not present in the local type %s",
-					field.Name, localType.Name, localType.Name,
-				)
-			}
-			if localField.Type.String() != field.Type.String() {
-				return errors.Errorf(
-					"expected type for the field %s is %s but got %s in type %s",
-					field.Name,
-					field.Type.String(),
-					localField.Type.String(),
-					typeName,
-				)
+func matchRemoteTypes(schema *ast.Schema, remoteTypes map[string]*types) error {
+	for typeName, def := range schema.Types {
+		origTyp := schema.Types[typeName]
+		remoteDir := origTyp.Directives.ForName(remoteDirective)
+		if remoteDir != nil {
+			{
+				remoteType, ok := remoteTypes[def.Name]
+				fields := def.Fields
+				if !ok {
+					return errors.Errorf(
+						"Unable to find local type %s in the remote schema",
+						typeName,
+					)
+				}
+				remoteFields := remoteType.Fields
+				if remoteFields == nil {
+					// Get fields for INPUT_OBJECT
+					remoteFields = remoteType.InputFields
+				}
+				for _, field := range fields {
+					var remoteField *gqlField = nil
+					for _, rf := range remoteFields {
+						if rf.Name == field.Name {
+							remoteField = rf
+						}
+					}
+					if remoteField == nil {
+						return errors.Errorf(
+							"%s field for the local type %s is not present in the remote type %s",
+							field.Name, typeName, remoteType.Name,
+						)
+					}
+					if remoteField.Type.String() != field.Type.String() {
+						return errors.Errorf(
+							"expected type for the field %s is %s but got %s in type %s",
+							remoteField.Name,
+							remoteField.Type.String(),
+							field.Type.String(),
+							typeName,
+						)
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #GRAPHQL-503
This PR fixes remote schema introspection for custom logic in GraphQL for a single remote endpoint. Enabling validation for types that are part of custom logic query/mutation/field in our GraphQL schema against the remote schema .

(cherry picked from commit 55594de574cf67ec4305eba58c9b179b76a80ba3)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5824)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0fb4674860-75263.surge.sh)
<!-- Dgraph:end -->