### PR TITLE
fix(GraphQL): Typename for types should be filled in query for schema introspection queries

### DIFF
--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -40,7 +40,9 @@ const (
             }
 		],
 		"enumValues":[]
-	} }`
+	},
+	  "__typename" : "Query"
+	}`
 
 	expectedForType = `
 	{ "__type": {
@@ -75,7 +77,7 @@ const (
             }
 		],
 		"enumValues":[]
-	} }`
+	}, "__typename" : "Query" }`
 
 	expectedForEnum = `
 	{ "__type": {
@@ -98,7 +100,7 @@ const (
             }
 		],
 		"fields":[]
-    } }`
+    }, "__typename" : "Query" }`
 )
 
 func SchemaTest(t *testing.T, expectedDgraphSchema string) {
@@ -138,6 +140,7 @@ func graphQLDescriptions(t *testing.T) {
 				description
 			}
 		}
+		__typename
 	}`
 
 	for testName, tCase := range testCases {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -235,6 +235,10 @@ func (rf *resolverFactory) WithSchemaIntrospection() ResolverFactory {
 		WithQueryResolver("__type",
 			func(q schema.Query) QueryResolver {
 				return QueryResolverFunc(resolveIntrospection)
+			}).
+		WithQueryResolver("__typename",
+			func(q schema.Query) QueryResolver {
+				return QueryResolverFunc(resolveIntrospection)
 			})
 }
 

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -164,7 +164,6 @@ func (ec *executionContext) handleQuery(sel ast.Selection) []byte {
 		}
 		ec.writeKey(field.Alias)
 		switch field.Name {
-		// TODO - Add tests for __typename.
 		case Typename:
 			x.Check2(ec.b.WriteString(`"Query"`))
 		case "__type":
@@ -327,7 +326,7 @@ func (ec *executionContext) handleType(sel ast.SelectionSet, obj *introspection.
 		ec.writeKey(field.Alias)
 		switch field.Name {
 		case Typename:
-			x.Check2(ec.b.WriteString(`"__Type`))
+			x.Check2(ec.b.WriteString(`"__Type"`))
 		case "kind":
 			ec.writeStringValue(obj.Kind())
 		case "name":

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -25,7 +25,7 @@ import (
 // Introspect performs an introspection query given a query that's expected to be either
 // __schema or __type.
 func Introspect(q Query) (json.RawMessage, error) {
-	if q.Name() != "__schema" && q.Name() != "__type" {
+	if q.Name() != "__schema" && q.Name() != "__type" && q.Name() != Typename {
 		return nil, errors.New("call to introspect for field that isn't an introspection query " +
 			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}

--- a/graphql/schema/introspection_test.go
+++ b/graphql/schema/introspection_test.go
@@ -143,7 +143,7 @@ func TestIntrospectionQueryMissingNameArg(t *testing.T) {
 		schema {
 			query: TestType
 		}
-	
+
 		type TestType {
 			testField: String
 		}

--- a/graphql/schema/introspection_test.go
+++ b/graphql/schema/introspection_test.go
@@ -359,7 +359,7 @@ func TestFullIntrospectionQuery(t *testing.T) {
 	require.NotNil(t, op)
 	oper := &operation{op: op,
 		vars:     map[string]interface{}{},
-		query:    string(introspectionQuery),
+		query:    string(testIntrospectionQuery),
 		doc:      doc,
 		inSchema: &schema{schema: sch},
 	}

--- a/graphql/schema/introspection_test.go
+++ b/graphql/schema/introspection_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -220,6 +221,122 @@ func TestIntrospectionQueryWithVars(t *testing.T) {
 	testutil.CompareJSON(t, string(expectedBuf), string(resp))
 }
 
+const (
+	testIntrospectionQuery = `query {
+		__schema {
+		  __typename
+		  queryType {
+			name
+			__typename
+		  }
+		  mutationType {
+			name
+			__typename
+		  }
+		  subscriptionType {
+			name
+			__typename
+		  }
+		  types {
+			...FullType
+		  }
+		  directives {
+			__typename
+			name
+			locations
+			args {
+			  ...InputValue
+			}
+		  }
+		}
+	  }
+	  fragment FullType on __Type {
+		kind
+		name
+		fields(includeDeprecated: true) {
+		  __typename
+		  name
+		  args {
+			...InputValue
+			__typename
+		  }
+		  type {
+			...TypeRef
+			__typename
+		  }
+		  isDeprecated
+		  deprecationReason
+		}
+		inputFields {
+		  ...InputValue
+		  __typename
+		}
+		interfaces {
+		  ...TypeRef
+		  __typename
+		}
+		enumValues(includeDeprecated: true) {
+		  name
+		  isDeprecated
+		  deprecationReason
+		  __typename
+		}
+		possibleTypes {
+		  ...TypeRef
+		  __typename
+		}
+		__typename
+	  }
+	  fragment InputValue on __InputValue {
+		__typename
+		name
+		type {
+		  ...TypeRef
+		}
+		defaultValue
+	  }
+	  fragment TypeRef on __Type {
+		kind
+		name
+		ofType {
+		  kind
+		  name
+		  ofType {
+			kind
+			name
+			ofType {
+			  kind
+			  name
+			  ofType {
+				kind
+				name
+				ofType {
+				  kind
+				  name
+				  ofType {
+					kind
+					name
+					ofType {
+					  kind
+					  name
+					  __typename
+					}
+					__typename
+				  }
+				  __typename
+				}
+				__typename
+			  }
+			  __typename
+			}
+			__typename
+		  }
+		  __typename
+		}
+		__typename
+	  }`
+)
+
 func TestFullIntrospectionQuery(t *testing.T) {
 	sch := gqlparser.MustLoadSchema(
 		&ast.Source{Name: "schema.graphql", Input: `
@@ -232,7 +349,7 @@ func TestFullIntrospectionQuery(t *testing.T) {
 	}
 `})
 
-	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: introspectionQuery})
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: testIntrospectionQuery})
 	require.Nil(t, gqlErr)
 
 	listErr := validator.Validate(sch, doc)
@@ -249,6 +366,7 @@ func TestFullIntrospectionQuery(t *testing.T) {
 
 	queries := oper.Queries()
 	resp, err := Introspect(queries[0])
+	fmt.Println(string(resp))
 	require.NoError(t, err)
 
 	expectedBuf, err := ioutil.ReadFile("testdata/introspection/output/full_query.json")

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -89,58 +89,69 @@ const (
 )
 
 const introspectionQuery = `
-	query {
-	  __schema {
-		queryType { name }
-		mutationType { name }
-		subscriptionType { name }
-		types {
-		  ...FullType
-		}
-		directives {
-		  name
-		  locations
-		  args {
-			...InputValue
-		  }
-		}
-	  }
-	}
-	fragment FullType on __Type {
-	  kind
-	  name
-	  fields(includeDeprecated: true) {
+  query {
+	__schema {
+	  queryType {
 		name
+	  }
+	  mutationType {
+		name
+	  }
+	  subscriptionType {
+		name
+	  }
+	  types {
+		...FullType
+	  }
+	  directives {
+		name
+		locations
 		args {
 		  ...InputValue
 		}
-		type {
-		  ...TypeRef
-		}
-		isDeprecated
-		deprecationReason
 	  }
-	  inputFields {
+	}
+  }
+  fragment FullType on __Type {
+	kind
+	name
+	fields(includeDeprecated: true) {
+	  name
+	  args {
 		...InputValue
 	  }
-	  interfaces {
+	  type {
 		...TypeRef
 	  }
-	  enumValues(includeDeprecated: true) {
-		name
-		isDeprecated
-		deprecationReason
-	  }
-	  possibleTypes {
-		...TypeRef
-	  }
+	  isDeprecated
+	  deprecationReason
 	}
-	fragment InputValue on __InputValue {
+	inputFields {
+	  ...InputValue
+	}
+	interfaces {
+	  ...TypeRef
+	}
+	enumValues(includeDeprecated: true) {
 	  name
-	  type { ...TypeRef }
-	  defaultValue
+	  isDeprecated
+	  deprecationReason
 	}
-	fragment TypeRef on __Type {
+	possibleTypes {
+	  ...TypeRef
+	}
+  }
+  fragment InputValue on __InputValue {
+	name
+	type {
+	  ...TypeRef
+	}
+	defaultValue
+  }
+  fragment TypeRef on __Type {
+	kind
+	name
+	ofType {
 	  kind
 	  name
 	  ofType {
@@ -161,10 +172,6 @@ const introspectionQuery = `
 				ofType {
 				  kind
 				  name
-				  ofType {
-					kind
-					name
-				  }
 				}
 			  }
 			}
@@ -172,7 +179,7 @@ const introspectionQuery = `
 		}
 	  }
 	}
-  `
+  }`
 
 // remoteGraphqlMetadata represents the minimal set of data that is required to validate the graphql
 // given in @custom->http->graphql with the remote server

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -89,69 +89,65 @@ const (
 )
 
 const introspectionQuery = `
-  query {
-	__schema {
-	  queryType {
-		name
-	  }
-	  mutationType {
-		name
-	  }
-	  subscriptionType {
-		name
-	  }
-	  types {
-		...FullType
-	  }
-	  directives {
-		name
-		locations
-		args {
-		  ...InputValue
+	query {
+	  __schema {
+		queryType { name __typename }
+		mutationType { name __typename }
+		subscriptionType { name __typename }
+		types {
+		  ...FullType
+		}
+		directives {
+		  name
+		  locations
+		  args {
+			...InputValue
+		  }
 		}
 	  }
 	}
-  }
-  fragment FullType on __Type {
-	kind
-	name
-	fields(includeDeprecated: true) {
+	fragment FullType on __Type {
+	  kind
 	  name
-	  args {
+	  fields(includeDeprecated: true) {
+		name
+		args {
+		  ...InputValue
+		  __typename
+		}
+		type {
+		  ...TypeRef
+		  __typename
+		}
+		isDeprecated
+		deprecationReason
+	  }
+	  inputFields {
 		...InputValue
+		__typename
 	  }
-	  type {
+	  interfaces {
 		...TypeRef
+		__typename
 	  }
-	  isDeprecated
-	  deprecationReason
+	  enumValues(includeDeprecated: true) {
+		name
+		isDeprecated
+		deprecationReason
+		__typename
+	  }
+	  possibleTypes {
+		...TypeRef
+		__typename
+	  }
+	  __typename
 	}
-	inputFields {
-	  ...InputValue
-	}
-	interfaces {
-	  ...TypeRef
-	}
-	enumValues(includeDeprecated: true) {
+	fragment InputValue on __InputValue {
 	  name
-	  isDeprecated
-	  deprecationReason
+	  type { ...TypeRef }
+	  defaultValue
 	}
-	possibleTypes {
-	  ...TypeRef
-	}
-  }
-  fragment InputValue on __InputValue {
-	name
-	type {
-	  ...TypeRef
-	}
-	defaultValue
-  }
-  fragment TypeRef on __Type {
-	kind
-	name
-	ofType {
+	fragment TypeRef on __Type {
 	  kind
 	  name
 	  ofType {
@@ -172,14 +168,26 @@ const introspectionQuery = `
 				ofType {
 				  kind
 				  name
+				  ofType {
+					kind
+					name
+					__typename
+				  }
+				  __typename
 				}
+				__typename
 			  }
+			  __typename
 			}
+			__typename
 		  }
+		  __typename
 		}
+		__typename
 	  }
+	  __typename
 	}
-  }`
+  `
 
 // remoteGraphqlMetadata represents the minimal set of data that is required to validate the graphql
 // given in @custom->http->graphql with the remote server

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -91,9 +91,9 @@ const (
 const introspectionQuery = `
 	query {
 	  __schema {
-		queryType { name __typename }
-		mutationType { name __typename }
-		subscriptionType { name __typename }
+		queryType { name }
+		mutationType { name }
+		subscriptionType { name }
 		types {
 		  ...FullType
 		}
@@ -113,34 +113,27 @@ const introspectionQuery = `
 		name
 		args {
 		  ...InputValue
-		  __typename
 		}
 		type {
 		  ...TypeRef
-		  __typename
 		}
 		isDeprecated
 		deprecationReason
 	  }
 	  inputFields {
 		...InputValue
-		__typename
 	  }
 	  interfaces {
 		...TypeRef
-		__typename
 	  }
 	  enumValues(includeDeprecated: true) {
 		name
 		isDeprecated
 		deprecationReason
-		__typename
 	  }
 	  possibleTypes {
 		...TypeRef
-		__typename
 	  }
-	  __typename
 	}
 	fragment InputValue on __InputValue {
 	  name
@@ -171,21 +164,13 @@ const introspectionQuery = `
 				  ofType {
 					kind
 					name
-					__typename
 				  }
-				  __typename
 				}
-				__typename
 			  }
-			  __typename
 			}
-			__typename
 		  }
-		  __typename
 		}
-		__typename
 	  }
-	  __typename
 	}
   `
 

--- a/graphql/schema/testdata/introspection/output/full_query.json
+++ b/graphql/schema/testdata/introspection/output/full_query.json
@@ -1,864 +1,982 @@
 {
     "__schema": {
+        "directives": [
+            {
+                "args": [
+                    {
+                        "defaultValue": "\"No longer supported\"",
+                        "name": "reason",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    }
+                ],
+                "locations": [
+                    "ENUM_VALUE",
+                    "FIELD_DEFINITION"
+                ],
+                "name": "deprecated"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "name": "if",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "include"
+            },
+            {
+                "args": [
+                    {
+                        "defaultValue": null,
+                        "name": "if",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "name": "skip"
+            }
+        ],
+        "mutationType": null,
         "queryType": {
+            "__typename": "__Type",
             "name": "TestType"
         },
-        "mutationType": null,
         "subscriptionType": null,
         "types": [
             {
-                "kind": "SCALAR",
-                "name": "Float",
+                "__typename": "__Type",
+                "enumValues": [],
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "TestType",
-                "fields": [
-                    {
-                        "name": "testField",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "SCALAR",
-                "name": "ID",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "SCALAR",
-                "name": "String",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
                 "possibleTypes": []
             },
             {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "SCALAR",
+                "name": "Float",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "SCALAR",
+                "name": "ID",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
                 "kind": "SCALAR",
                 "name": "Int",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
-                "enumValues": [],
+                "kind": "SCALAR",
+                "name": "String",
                 "possibleTypes": []
             },
             {
-                "kind": "OBJECT",
-                "name": "__Schema",
+                "__typename": "__Type",
+                "enumValues": [],
                 "fields": [
                     {
-                        "name": "types",
                         "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "__Type",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        },
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "queryType",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "mutationType",
-                        "args": [],
-                        "type": {
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "subscriptionType",
-                        "args": [],
-                        "type": {
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "directives",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "__Directive",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "__Type",
-                "fields": [
-                    {
-                        "name": "kind",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "ENUM",
-                                "name": "__TypeKind",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "name",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "description",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "fields",
-                        "args": [
-                            {
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                },
-                                "defaultValue": "false"
-                            }
-                        ],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Field",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "interfaces",
-                        "args": [],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "possibleTypes",
-                        "args": [],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "enumValues",
-                        "args": [
-                            {
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                },
-                                "defaultValue": "false"
-                            }
-                        ],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__EnumValue",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "inputFields",
-                        "args": [],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__InputValue",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ofType",
-                        "args": [],
-                        "type": {
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "ENUM",
-                "name": "__TypeKind",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [
-                    {
-                        "name": "SCALAR",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INTERFACE",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "UNION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ENUM",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INPUT_OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "LIST",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "NON_NULL",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "__Field",
-                "fields": [
-                    {
-                        "name": "name",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "description",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
                         "name": "args",
-                        "args": [],
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
+                                "__typename": "__Type",
                                 "kind": "LIST",
                                 "name": null,
                                 "ofType": {
+                                    "__typename": "__Type",
                                     "kind": "NON_NULL",
                                     "name": null,
                                     "ofType": {
+                                        "__typename": "__Type",
                                         "kind": "OBJECT",
                                         "name": "__InputValue",
                                         "ofType": null
                                     }
                                 }
                             }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
+                        }
                     },
                     {
-                        "name": "type",
                         "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
-                        },
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "name": "deprecationReason",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
                     },
                     {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
                         "name": "isDeprecated",
-                        "args": [],
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
+                                "__typename": "__Type",
                                 "kind": "SCALAR",
                                 "name": "Boolean",
                                 "ofType": null
                             }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
+                        }
                     },
                     {
-                        "name": "deprecationReason",
                         "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "__InputValue",
-                "fields": [
-                    {
                         "name": "name",
-                        "args": [],
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
+                                "__typename": "__Type",
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
                             }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
+                        }
                     },
                     {
-                        "name": "description",
                         "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
                         "name": "type",
-                        "args": [],
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
+                                "__typename": "__Type",
                                 "kind": "OBJECT",
                                 "name": "__Type",
                                 "ofType": null
                             }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "defaultValue",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
+                        }
                     }
                 ],
                 "inputFields": [],
                 "interfaces": [],
-                "enumValues": [],
+                "kind": "OBJECT",
+                "name": "__Field",
                 "possibleTypes": []
             },
             {
-                "kind": "OBJECT",
-                "name": "__EnumValue",
-                "fields": [
-                    {
-                        "name": "name",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "description",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "isDeprecated",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "deprecationReason",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
+                "__typename": "__Type",
                 "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "__Directive",
                 "fields": [
                     {
-                        "name": "name",
                         "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "args",
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "description",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "locations",
-                        "args": [],
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
+                                "__typename": "__Type",
                                 "kind": "LIST",
                                 "name": null,
                                 "ofType": {
+                                    "__typename": "__Type",
                                     "kind": "NON_NULL",
                                     "name": null,
                                     "ofType": {
+                                        "__typename": "__Type",
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "locations",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "__typename": "__Type",
                                         "kind": "ENUM",
                                         "name": "__DirectiveLocation",
                                         "ofType": null
                                     }
                                 }
                             }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
+                        }
                     },
                     {
-                        "name": "args",
                         "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "name",
                         "type": {
+                            "__typename": "__Type",
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Directive",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "defaultValue",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "type",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__InputValue",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "deprecationReason",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "isDeprecated",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            }
+                        }
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__EnumValue",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "description",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "inputFields",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "OBJECT",
+                                    "name": "__InputValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "interfaces",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "kind",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "ENUM",
+                                "name": "__TypeKind",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "name",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "ofType",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "possibleTypes",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "defaultValue": "false",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "__typename": "__Type",
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "enumValues",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "OBJECT",
+                                    "name": "__EnumValue",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "defaultValue": "false",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "__typename": "__Type",
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            }
+                        ],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "fields",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "OBJECT",
+                                    "name": "__Field",
+                                    "ofType": null
+                                }
+                            }
+                        }
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Type",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [],
+                "fields": [
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "directives",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
                                 "kind": "LIST",
                                 "name": null,
                                 "ofType": {
+                                    "__typename": "__Type",
                                     "kind": "NON_NULL",
                                     "name": null,
                                     "ofType": {
+                                        "__typename": "__Type",
                                         "kind": "OBJECT",
-                                        "name": "__InputValue",
+                                        "name": "__Directive",
                                         "ofType": null
                                     }
                                 }
                             }
-                        },
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "name": "mutationType",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "queryType",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null
+                            }
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "subscriptionType",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null
+                        }
+                    },
+                    {
+                        "args": [],
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "types",
+                        "type": {
+                            "__typename": "__Type",
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "__typename": "__Type",
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "__typename": "__Type",
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "__typename": "__Type",
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null
+                                    }
+                                }
+                            }
+                        }
                     }
                 ],
                 "inputFields": [],
                 "interfaces": [],
+                "kind": "OBJECT",
+                "name": "__Schema",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
                 "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "ENUM",
-                "name": "__DirectiveLocation",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [
+                "fields": [
                     {
-                        "name": "QUERY",
+                        "args": [],
+                        "deprecationReason": null,
                         "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "MUTATION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SUBSCRIPTION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FIELD",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FRAGMENT_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FRAGMENT_SPREAD",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INLINE_FRAGMENT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SCHEMA",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SCALAR",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FIELD_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ARGUMENT_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INTERFACE",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "UNION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ENUM",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ENUM_VALUE",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INPUT_OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INPUT_FIELD_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "possibleTypes": []
-            }
-        ],
-        "directives": [
-            {
-                "name": "include",
-                "locations": [
-                    "FIELD",
-                    "FRAGMENT_SPREAD",
-                    "INLINE_FRAGMENT"
-                ],
-                "args": [
-                    {
-                        "name": "if",
+                        "name": "testField",
                         "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        },
-                        "defaultValue": null
-                    }
-                ]
-            },
-            {
-                "name": "skip",
-                "locations": [
-                    "FIELD",
-                    "FRAGMENT_SPREAD",
-                    "INLINE_FRAGMENT"
-                ],
-                "args": [
-                    {
-                        "name": "if",
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        },
-                        "defaultValue": null
-                    }
-                ]
-            },
-            {
-                "name": "deprecated",
-                "locations": [
-                    "FIELD_DEFINITION",
-                    "ENUM_VALUE"
-                ],
-                "args": [
-                    {
-                        "name": "reason",
-                        "type": {
+                            "__typename": "__Type",
                             "kind": "SCALAR",
                             "name": "String",
                             "ofType": null
-                        },
-                        "defaultValue": "\"No longer supported\""
+                        }
                     }
-                ]
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "OBJECT",
+                "name": "TestType",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "ARGUMENT_DEFINITION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "ENUM_VALUE"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "FIELD"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "FIELD_DEFINITION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_DEFINITION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "FRAGMENT_SPREAD"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INLINE_FRAGMENT"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INPUT_FIELD_DEFINITION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "MUTATION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "QUERY"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "SCHEMA"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "SUBSCRIPTION"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "ENUM",
+                "name": "__DirectiveLocation",
+                "possibleTypes": []
+            },
+            {
+                "__typename": "__Type",
+                "enumValues": [
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "ENUM"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INPUT_OBJECT"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "INTERFACE"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "LIST"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "NON_NULL"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "OBJECT"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "SCALAR"
+                    },
+                    {
+                        "__typename": "__EnumValue",
+                        "deprecationReason": null,
+                        "isDeprecated": false,
+                        "name": "UNION"
+                    }
+                ],
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "kind": "ENUM",
+                "name": "__TypeKind",
+                "possibleTypes": []
             }
         ]
     }

--- a/graphql/schema/testdata/introspection/output/full_query.json
+++ b/graphql/schema/testdata/introspection/output/full_query.json
@@ -1,982 +1,1022 @@
 {
     "__schema": {
-        "directives": [
-            {
-                "args": [
-                    {
-                        "defaultValue": "\"No longer supported\"",
-                        "name": "reason",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    }
-                ],
-                "locations": [
-                    "ENUM_VALUE",
-                    "FIELD_DEFINITION"
-                ],
-                "name": "deprecated"
-            },
-            {
-                "args": [
-                    {
-                        "defaultValue": null,
-                        "name": "if",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "locations": [
-                    "FIELD",
-                    "FRAGMENT_SPREAD",
-                    "INLINE_FRAGMENT"
-                ],
-                "name": "include"
-            },
-            {
-                "args": [
-                    {
-                        "defaultValue": null,
-                        "name": "if",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "locations": [
-                    "FIELD",
-                    "FRAGMENT_SPREAD",
-                    "INLINE_FRAGMENT"
-                ],
-                "name": "skip"
-            }
-        ],
-        "mutationType": null,
+        "__typename": "__Schema",
         "queryType": {
-            "__typename": "__Type",
-            "name": "TestType"
+            "name": "TestType",
+            "__typename": "__Type"
         },
+        "mutationType": null,
         "subscriptionType": null,
         "types": [
             {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
                 "kind": "SCALAR",
                 "name": "Float",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
-                "kind": "SCALAR",
-                "name": "ID",
-                "possibleTypes": []
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
-                "__typename": "__Type",
-                "enumValues": [],
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
-                "kind": "SCALAR",
-                "name": "Int",
-                "possibleTypes": []
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "SCALAR",
-                "name": "String",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "args",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "kind": "OBJECT",
-                                        "name": "__InputValue",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "deprecationReason",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "description",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "isDeprecated",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "name",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "type",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__Field",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "args",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "kind": "OBJECT",
-                                        "name": "__InputValue",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "description",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "locations",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "kind": "ENUM",
-                                        "name": "__DirectiveLocation",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "name",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__Directive",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "defaultValue",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "description",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "name",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "type",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__InputValue",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "deprecationReason",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "description",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "isDeprecated",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "name",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__EnumValue",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "description",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "inputFields",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "OBJECT",
-                                    "name": "__InputValue",
-                                    "ofType": null
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "interfaces",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "kind",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "ENUM",
-                                "name": "__TypeKind",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "name",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "ofType",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "possibleTypes",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            {
-                                "__typename": "__InputValue",
-                                "defaultValue": "false",
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "__typename": "__Type",
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                }
-                            }
-                        ],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "enumValues",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "OBJECT",
-                                    "name": "__EnumValue",
-                                    "ofType": null
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [
-                            {
-                                "__typename": "__InputValue",
-                                "defaultValue": "false",
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "__typename": "__Type",
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                }
-                            }
-                        ],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "fields",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "OBJECT",
-                                    "name": "__Field",
-                                    "ofType": null
-                                }
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__Type",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "directives",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "kind": "OBJECT",
-                                        "name": "__Directive",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "mutationType",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "queryType",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "subscriptionType",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
-                        }
-                    },
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "types",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "__typename": "__Type",
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "__typename": "__Type",
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "__typename": "__Type",
-                                        "kind": "OBJECT",
-                                        "name": "__Type",
-                                        "ofType": null
-                                    }
-                                }
-                            }
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "kind": "OBJECT",
-                "name": "__Schema",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [],
-                "fields": [
-                    {
-                        "args": [],
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "testField",
-                        "type": {
-                            "__typename": "__Type",
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        }
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
                 "kind": "OBJECT",
                 "name": "TestType",
-                "possibleTypes": []
-            },
-            {
-                "__typename": "__Type",
-                "enumValues": [
+                "fields": [
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "testField",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "ARGUMENT_DEFINITION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "ENUM"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "ENUM_VALUE"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "FIELD"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "FIELD_DEFINITION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "FRAGMENT_DEFINITION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "FRAGMENT_SPREAD"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "INLINE_FRAGMENT"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "INPUT_FIELD_DEFINITION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "INPUT_OBJECT"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "INTERFACE"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "MUTATION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "OBJECT"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "QUERY"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "SCALAR"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "SCHEMA"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "SUBSCRIPTION"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "UNION"
+                        "deprecationReason": null
                     }
                 ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "SCALAR",
+                "name": "ID",
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
-                "kind": "ENUM",
-                "name": "__DirectiveLocation",
-                "possibleTypes": []
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
-                "__typename": "__Type",
-                "enumValues": [
+                "kind": "OBJECT",
+                "name": "__Schema",
+                "fields": [
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "types",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Type",
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "ENUM"
+                        "deprecationReason": null
                     },
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "queryType",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "INPUT_OBJECT"
+                        "deprecationReason": null
                     },
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "mutationType",
+                        "args": [],
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "INTERFACE"
+                        "deprecationReason": null
                     },
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "subscriptionType",
+                        "args": [],
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "LIST"
+                        "deprecationReason": null
                     },
                     {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
+                        "__typename": "__Field",
+                        "name": "directives",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__Directive",
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
                         "isDeprecated": false,
-                        "name": "NON_NULL"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "OBJECT"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "SCALAR"
-                    },
-                    {
-                        "__typename": "__EnumValue",
-                        "deprecationReason": null,
-                        "isDeprecated": false,
-                        "name": "UNION"
+                        "deprecationReason": null
                     }
                 ],
-                "fields": [],
                 "inputFields": [],
                 "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "__InputValue",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "description",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "type",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "defaultValue",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
                 "kind": "ENUM",
                 "name": "__TypeKind",
-                "possibleTypes": []
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [
+                    {
+                        "name": "SCALAR",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INTERFACE",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "UNION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ENUM",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INPUT_OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "LIST",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "NON_NULL",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    }
+                ],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "SCALAR",
+                "name": "Int",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "__Field",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "description",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "args",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "type",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "isDeprecated",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "deprecationReason",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "ENUM",
+                "name": "__DirectiveLocation",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [
+                    {
+                        "name": "QUERY",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "MUTATION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SUBSCRIPTION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FIELD",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FRAGMENT_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FRAGMENT_SPREAD",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INLINE_FRAGMENT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SCHEMA",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SCALAR",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FIELD_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ARGUMENT_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INTERFACE",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "UNION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ENUM",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ENUM_VALUE",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INPUT_OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INPUT_FIELD_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    }
+                ],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "SCALAR",
+                "name": "String",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "kind",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "ENUM",
+                                "name": "__TypeKind",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "description",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "fields",
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "defaultValue": "false"
+                            }
+                        ],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Field",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "interfaces",
+                        "args": [],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "possibleTypes",
+                        "args": [],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "enumValues",
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "defaultValue": "false"
+                            }
+                        ],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__EnumValue",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "inputFields",
+                        "args": [],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__InputValue",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "ofType",
+                        "args": [],
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "__EnumValue",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "description",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "isDeprecated",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "deprecationReason",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "__Directive",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "description",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "locations",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "ENUM",
+                                        "name": "__DirectiveLocation",
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "args",
+                        "args": [],
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "__InputValue",
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            }
+        ],
+        "directives": [
+            {
+                "__typename": "__Directive",
+                "name": "skip",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "args": [
+                    {
+                        "__typename": "__InputValue",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "defaultValue": null
+                    }
+                ]
+            },
+            {
+                "__typename": "__Directive",
+                "name": "deprecated",
+                "locations": [
+                    "FIELD_DEFINITION",
+                    "ENUM_VALUE"
+                ],
+                "args": [
+                    {
+                        "__typename": "__InputValue",
+                        "name": "reason",
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "defaultValue": "\"No longer supported\""
+                    }
+                ]
+            },
+            {
+                "__typename": "__Directive",
+                "name": "include",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "args": [
+                    {
+                        "__typename": "__InputValue",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "defaultValue": null
+                    }
+                ]
             }
         ]
     }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1107,7 +1107,7 @@ func queryType(name string, custom *ast.Directive) QueryType {
 		return HTTPQuery
 	case strings.HasPrefix(name, "get"):
 		return GetQuery
-	case name == "__schema" || name == "__type":
+	case name == "__schema" || name == "__type" || name == "__typename":
 		return SchemaQuery
 	case strings.HasPrefix(name, "query"):
 		return FilterQuery


### PR DESCRIPTION
There was a missing `"` in the `__typename` that was filled in for types in schema introspection queries. That resulted in JSON parsing errors, we have fixed it and modified the existing test to test for it. Fixes #5792. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5827)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0aaf3fb33b-76313.surge.sh)
<!-- Dgraph:end -->