### PR TITLE
fix(GraphQL): Fix case where Dgraph type was not generated for GraphQL interface (#5738)

### DIFF
--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -244,6 +244,49 @@ schemas:
       C.dob: dateTime .
 
   -
+    name: "interface using other interface generate type in dgraph"
+    input: |
+      interface A {
+        id: ID!
+        data: [D]
+      }
+      type C implements A {
+          lname: String
+      }
+      interface B {
+          name: String! @id
+          fname: String!
+      }
+      type D implements B {
+        link: A 
+        correct: Boolean!
+      }
+    output: |
+      type A {
+        A.data
+      }
+      A.data: [uid] .
+      type C {
+        A.data
+        C.lname
+      }
+      C.lname: string .
+      type B {
+        B.name
+        B.fname
+      }
+      B.name: string @index(hash) @upsert .
+      B.fname: string .
+      type D {
+        B.name
+        B.fname
+        D.link
+        D.correct
+      }
+      D.link: uid .
+      D.correct: bool .
+
+  -
     name: "Schema with @dgraph directive."
     input: |
       type A @dgraph(type: "dgraph.type.A") {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -421,7 +421,7 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 
 				var typStr string
 				switch gqlSch.Types[f.Type.Name()].Kind {
-				case ast.Object:
+				case ast.Object,ast.Interface:
 					typStr = fmt.Sprintf("%suid%s", prefix, suffix)
 
 					if parentInt == nil {


### PR DESCRIPTION
Fixes #5311
Fixes #GRAPHQL-419
Previously when Dgraph schema was generated the GraphQL interface was getting skipped and hence it was not present in the generated Dgraph schema. This PR fixes that and hence now all the queries/mutations will work as expected.

(cherry picked from commit c6a0dfa4c6f87ab8d3708701027e2ef5859eb2d4)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5828)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-1190b0a47c-75336.surge.sh)
<!-- Dgraph:end -->