### PR TITLE
feat(Upgrade): Users can now upgrade to v20.07.0 (#5634)

### DIFF
--- a/upgrade/change_list.go
+++ b/upgrade/change_list.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package upgrade
+
+func init() {
+	allChanges = changeList{
+		{
+			introducedIn: &version{major: 20, minor: 3, patch: 0},
+			changes: []*change{{
+				name: "Upgrade ACL Rules",
+				description: "This updates the ACL nodes to use the new ACL model introduced in" +
+					" v20.03.0. This is applied while upgrading from v1.2.2+ to v20.03.0+",
+				minFromVersion: &version{major: 1, minor: 2, patch: 2},
+				applyFunc:      upgradeACLRules,
+			}},
+		},
+		{
+			introducedIn: &version{major: 20, minor: 7, patch: 0},
+			changes: []*change{
+				{
+					name: "Upgrade ACL Type names",
+					description: "This updates the ACL nodes to use the new type names for the" +
+						" types User, Group and Rule. They are now dgraph.type.User, " +
+						"dgraph.type.Group, and dgraph.type.Rule. This change was introduced in " +
+						"v20.07.0, and is applied while upgrading from v20.03.0+ to v20.07.0+. " +
+						"For more info, see: https://github.com/dgraph-io/dgraph/pull/5185",
+					minFromVersion: &version{major: 20, minor: 3, patch: 0},
+					applyFunc:      upgradeAclTypeNames,
+				},
+				// another change in 20.07.0 version is if someone was having types/predicates in
+				// reserved namespace, then data should be migrated for such cases,
+				// to not use the reserved namespace. Migration is expected to be done by the user,
+				// and we will only provide a documentation mentioning the steps to be taken.
+				// This is not being automated because:
+				// 	1. There is very less chance that someone was using the reserved namespace,
+				//	so this automation may not be used at all.
+				// 	2. The data migration can be huge, if needed to migrate. The automated code
+				//	can't handle every scenario. So, it is best to let the user do it.
+			},
+		},
+	}
+}

--- a/upgrade/change_v20.03.0.go
+++ b/upgrade/change_v20.03.0.go
@@ -17,20 +17,16 @@
 package upgrade
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
-	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
-	"google.golang.org/grpc"
 )
 
 const (
-	oldACLQuery = `
+	queryACLGroupsBefore_v20_03_0 = `
 		{
-			rules(func: type(dgraph.type.Group)) {
+			rules(func: type(Group)) @filter(has(dgraph.group.acl)) {
 				uid
 				dgraph.group.acl
 			}
@@ -51,48 +47,26 @@ type rule struct {
 type rules []rule
 
 func upgradeACLRules() error {
-	alpha := Upgrade.Conf.GetString("alpha")
-	userName := Upgrade.Conf.GetString("user")
-	password := Upgrade.Conf.GetString("password")
-	deleteOld := Upgrade.Conf.GetBool("deleteOld")
-
-	// TODO(Aman): add TLS configuration.
-	conn, err := grpc.Dial(alpha, grpc.WithInsecure())
+	dg, conn, err := getDgoClient(true)
 	if err != nil {
-		return fmt.Errorf("unable to connect to Dgraph cluster: %w", err)
+		return fmt.Errorf("error getting dgo client: %w", err)
 	}
 	defer conn.Close()
 
-	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-
-	// login to cluster
-	if err := dg.Login(ctx, userName, password); err != nil {
-		return fmt.Errorf("unable to login to Dgraph cluster: %w", err)
-	}
-
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	resp, err := dg.NewReadOnlyTxn().Query(ctx, oldACLQuery)
-	if err != nil {
-		return fmt.Errorf("unable to query old ACL rules: %w", err)
-	}
-
 	data := make(map[string][]group)
-	if err := json.Unmarshal(resp.Json, &data); err != nil {
-		return fmt.Errorf("unable to unmarshal old ACLs: %w", err)
+	if err = getQueryResult(dg, queryACLGroupsBefore_v20_03_0, &data); err != nil {
+		return fmt.Errorf("error querying old ACL rules: %w", err)
 	}
 
 	groups, ok := data["rules"]
 	if !ok {
-		return fmt.Errorf("unable to parse ACLs: %v", string(resp.Json))
+		return fmt.Errorf("unable to parse ACLs: %v", data)
 	}
 
 	counter := 1
 	var nquads []*api.NQuad
 	for _, group := range groups {
-		if len(group.ACL) == 0 {
+		if group.ACL == "" {
 			continue
 		}
 
@@ -104,11 +78,8 @@ func upgradeACLRules() error {
 		for _, r := range rs {
 			newRuleStr := fmt.Sprintf("_:newrule%d", counter)
 			nquads = append(nquads, []*api.NQuad{
-				{
-					Subject:   newRuleStr,
-					Predicate: "dgraph.type",
-					ObjectId:  "dgraph.type.Rule",
-				},
+				// the name of the type was Rule in v20.03.0
+				getTypeNquad(newRuleStr, "Rule"),
 				{
 					Subject:   newRuleStr,
 					Predicate: "dgraph.rule.predicate",
@@ -136,18 +107,18 @@ func upgradeACLRules() error {
 
 	// Nothing to do.
 	if len(nquads) == 0 {
-		return fmt.Errorf("no old rules found in the cluster")
+		fmt.Println("nothing to do: no old rules found in the cluster")
+		return nil
 	}
 
-	if err := mutateACL(dg, nquads); err != nil {
+	if err := mutateWithClient(dg, &api.Mutation{Set: nquads}); err != nil {
 		return fmt.Errorf("error upgrading ACL rules: %w", err)
 	}
 	fmt.Println("Successfully upgraded ACL rules.")
 
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	deleteOld := Upgrade.Conf.GetBool("deleteOld")
 	if deleteOld {
-		err = dg.Alter(ctx, &api.Operation{
+		err = alterWithClient(dg, &api.Operation{
 			DropOp:    api.Operation_ATTR,
 			DropValue: "dgraph.group.acl",
 		})
@@ -158,25 +129,4 @@ func upgradeACLRules() error {
 	}
 
 	return nil
-}
-
-func mutateACL(dg *dgo.Dgraph, nquads []*api.NQuad) error {
-	var err error
-	for i := 0; i < 3; i++ {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		_, err = dg.NewTxn().Mutate(ctx, &api.Mutation{
-			Set:       nquads,
-			CommitNow: true,
-		})
-		if err != nil {
-			fmt.Printf("error in running mutation, retrying: %v\n", err)
-			continue
-		}
-
-		return nil
-	}
-
-	return err
 }

--- a/upgrade/change_v20.07.0.go
+++ b/upgrade/change_v20.07.0.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package upgrade
+
+import (
+	"fmt"
+
+	"github.com/dgraph-io/dgo/v200"
+	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/protos/pb"
+)
+
+const (
+	queryACLUsersBefore_v20_07_0 = `
+		{
+			nodes(func: type(User)) @filter(has(dgraph.xid)) {
+				uid
+			}
+		}
+	`
+	queryACLGroupsBefore_v20_07_0 = `
+		{
+			nodes(func: type(Group)) @filter(has(dgraph.xid)) {
+				uid
+			}
+		}
+	`
+	queryACLRulesBefore_v20_07_0 = `
+		{
+			nodes(func: type(Rule)) @filter(has(dgraph.rule.predicate)) {
+				uid
+			}
+		}
+	`
+	typeCountQuery = `
+		{
+			nodes(func: type(%s)) {
+				count(uid)
+			}
+		}
+	`
+	typeSchemaQuery = `schema (type: %s) {}`
+)
+
+type uidNodeQueryResp struct {
+	Nodes []*struct {
+		Uid string `json:"uid"`
+	} `json:"nodes"`
+}
+
+type countNodeQueryResp struct {
+	Nodes []*struct {
+		Count int `json:"count"`
+	} `json:"nodes"`
+}
+
+type schemaTypeField struct {
+	Name string `json:"name"`
+}
+
+type schemaTypeNode struct {
+	Name   string             `json:"name"`
+	Fields []*schemaTypeField `json:"fields"`
+}
+
+type schemaQueryResp struct {
+	Schema []*pb.SchemaNode  `json:"schema"`
+	Types  []*schemaTypeNode `json:"types"`
+}
+
+type updateTypeNameInfo struct {
+	oldTypeName              string
+	newTypeName              string
+	oldUidNodeQuery          string
+	dropOldTypeIfUnused      bool
+	predsToRemoveFromOldType map[string]struct{}
+}
+
+func upgradeAclTypeNames() error {
+	deleteOld := Upgrade.Conf.GetBool("deleteOld")
+	// prepare upgrade info for ACL type names
+	aclTypeNameInfo := []*updateTypeNameInfo{
+		{
+			oldTypeName:         "User",
+			newTypeName:         "dgraph.type.User",
+			oldUidNodeQuery:     queryACLUsersBefore_v20_07_0,
+			dropOldTypeIfUnused: deleteOld,
+			predsToRemoveFromOldType: map[string]struct{}{
+				"dgraph.xid":        {},
+				"dgraph.password":   {},
+				"dgraph.user.group": {},
+			},
+		},
+		{
+			oldTypeName:         "Group",
+			newTypeName:         "dgraph.type.Group",
+			oldUidNodeQuery:     queryACLGroupsBefore_v20_07_0,
+			dropOldTypeIfUnused: deleteOld,
+			predsToRemoveFromOldType: map[string]struct{}{
+				"dgraph.xid":      {},
+				"dgraph.acl.rule": {},
+			},
+		},
+		{
+			oldTypeName:         "Rule",
+			newTypeName:         "dgraph.type.Rule",
+			oldUidNodeQuery:     queryACLRulesBefore_v20_07_0,
+			dropOldTypeIfUnused: deleteOld,
+			predsToRemoveFromOldType: map[string]struct{}{
+				"dgraph.rule.predicate":  {},
+				"dgraph.rule.permission": {},
+			},
+		},
+	}
+
+	// get dgo client
+	dg, conn, err := getDgoClient(true)
+	if err != nil {
+		return fmt.Errorf("error getting dgo client: %w", err)
+	}
+	defer conn.Close()
+
+	// apply upgrades for old ACL type names, one by one.
+	for _, typeNameInfo := range aclTypeNameInfo {
+		if err = typeNameInfo.updateTypeName(dg); err != nil {
+			return fmt.Errorf("error upgrading ACL type name from `%s` to `%s`: %w",
+				typeNameInfo.oldTypeName, typeNameInfo.newTypeName, err)
+		}
+		if err = typeNameInfo.updateTypeSchema(dg); err != nil {
+			return fmt.Errorf("error upgrading schema for old ACL type `%s`: %w",
+				typeNameInfo.oldTypeName, err)
+		}
+	}
+
+	return nil
+}
+
+// updateTypeName changes the name of the given type from old name to new name for all the nodes of
+// that type.
+func (t *updateTypeNameInfo) updateTypeName(dg *dgo.Dgraph) error {
+	if t == nil {
+		return nil
+	}
+
+	// query nodes for old type, using the provided query
+	var oldQueryRes uidNodeQueryResp
+	if err := getQueryResult(dg, t.oldUidNodeQuery, &oldQueryRes); err != nil {
+		return fmt.Errorf("unable to query old type `%s`: %w", t.oldTypeName, err)
+	}
+
+	// build NQuads for changing old type name to new name
+	var setNQuads, delNQuads []*api.NQuad
+	for _, node := range oldQueryRes.Nodes {
+		setNQuads = append(setNQuads, getTypeNquad(node.Uid, t.newTypeName))
+		delNQuads = append(delNQuads, getTypeNquad(node.Uid, t.oldTypeName))
+	}
+
+	// send the mutation to change the old type name to new name
+	if len(oldQueryRes.Nodes) > 0 {
+		if err := mutateWithClient(dg, &api.Mutation{Set: setNQuads, Del: delNQuads}); err != nil {
+			return fmt.Errorf("error upgrading data for old type `%s`: %w",
+				t.oldTypeName, err)
+		}
+	}
+
+	return nil
+}
+
+// updateTypeSchema drops the old type from schema if it is not being used by any node and it is
+// allowed to drop the type. Otherwise, it just alters the schema of old type to remove the old
+// predicates.
+func (t *updateTypeNameInfo) updateTypeSchema(dg *dgo.Dgraph) error {
+	if t == nil {
+		return nil
+	}
+
+	// find the number of nodes using old type name as their type
+	var countQueryRes countNodeQueryResp
+	if err := getQueryResult(dg, fmt.Sprintf(typeCountQuery, t.oldTypeName),
+		&countQueryRes); err != nil {
+		return fmt.Errorf("unable to query node count for type `%s`: %w", t.oldTypeName, err)
+	}
+	if len(countQueryRes.Nodes) != 1 {
+		return fmt.Errorf("unable to find number of nodes for type `%s`", t.oldTypeName)
+	}
+
+	// if the old type was not being used by any nodes, and if it is allowed to drop the old type,
+	// then drop it from schema
+	if countQueryRes.Nodes[0].Count == 0 && t.dropOldTypeIfUnused {
+		if err := alterWithClient(dg, &api.Operation{
+			DropOp:    api.Operation_TYPE,
+			DropValue: t.oldTypeName,
+		}); err != nil {
+			return fmt.Errorf("unable to drop old type `%s` from schema: %w", t.oldTypeName, err)
+		}
+	} else if (len(t.predsToRemoveFromOldType)) > 0 {
+		// otherwise just alter the schema of type to remove the old predicates
+
+		// query the schema for type
+		var schemaTypeQueryResp schemaQueryResp
+		if err := getQueryResult(dg, fmt.Sprintf(typeSchemaQuery, t.oldTypeName),
+			&schemaTypeQueryResp); err != nil || len(schemaTypeQueryResp.Types) != 1 {
+			return fmt.Errorf("unable to query schema for type `%s`: %w", t.oldTypeName, err)
+		}
+		// rewrite the schema to remove old predicates
+		schema := getTypeSchemaString(t.oldTypeName, schemaTypeQueryResp.Types[0], nil,
+			t.predsToRemoveFromOldType)
+		// overwrite the schema for type with alter
+		if err := alterWithClient(dg, &api.Operation{Schema: schema}); err != nil {
+			return fmt.Errorf("unable to update schema for type `%s`: %w", t.oldTypeName, err)
+		}
+	}
+
+	return nil
+}

--- a/upgrade/doc.go
+++ b/upgrade/doc.go
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package upgrade provides the upgrade functionality which can be used while upgrading dgraph to a
+// new version from an old version.
+//
+// The code in this package is very much dependent on dgraph version. Please be very careful while
+// modifying any files in this package. It is expected that only new files will be added over
+// time in this package, and any change in existing files in not expected, as they would have been
+// correct for the version of dgraph for which they were introduced. So, please double check whether
+// you really need to modify any existing files.
+//
+// When adding upgrade capability for a new dgraph release version, follow these steps:
+// 	1. Create a file named `change_<release_version>.go`. For example: change_v20.07.0.go
+// 	2. For any change that needs to be introduced in that version, create a function of the form
+//	`func() error` that applies that change, in the newly created file.
+// 	3. Add that function to change_list.go inside the changes for the change set introduced in
+//	that version. Also add a short name and some meaningful description with it.
+//
+// Points to keep in mind:
+// 	1. Upgrade is expected only for breaking changes which go in as part of the breaking releases.
+// 	2. Look at the upgrade algorithm in upgrade.go to understand how & when a change is applied.
+// 	3. There are many re-usable functions in utils.go for the upgrade process, look at them too.
+// 	4. Thoroughly test your upgrade to make sure that it works correctly while upgrading from
+//	previous versions to the new release version, as an upgrade is very critical process.
+package upgrade

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -18,7 +18,11 @@ package upgrade
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
@@ -27,32 +31,293 @@ import (
 var (
 	// Upgrade is the sub-command used to upgrade dgraph cluster.
 	Upgrade x.SubCommand
+	// zeroVersion represents &version{major: 0, minor: 0, patch: 0}
+	zeroVersion = &version{}
+	// allChanges contains all the changes ever introduced since the beginning of dgraph in the form
+	// of a list of change sets.
+	allChanges changeList
 )
+
+type versionComparisonResult uint8
+
+const (
+	acl       = "acl"
+	dryRun    = "dry-run"
+	alpha     = "alpha"
+	user      = "user"
+	password  = "password"
+	deleteOld = "deleteOld"
+	from      = "from"
+	to        = "to"
+
+	versionFmtBeforeCalVer = "v%d.%d.%d"
+	versionFmtAfterCalVer  = "v%d.%02d.%d"
+
+	less versionComparisonResult = iota
+	equal
+	greater
+)
+
+// version represents a mainstream release version
+// for eg: for v20.03.1, major = 20, minor = 3, patch = 1
+type version struct {
+	major int
+	minor int
+	patch int
+}
+
+func (v *version) String() string {
+	if v == nil {
+		v = zeroVersion
+	}
+
+	versionFmt := versionFmtAfterCalVer
+	if v.major < 20 {
+		versionFmt = versionFmtBeforeCalVer
+	}
+
+	return fmt.Sprintf(versionFmt, v.major, v.minor, v.patch)
+}
+
+// Compare compares v with other version, and tells if v is equal, less, or greater than other.
+// It interprets nil as &version{major: 0, minor: 0, patch: 0}
+func (v *version) Compare(other *version) versionComparisonResult {
+	if v == nil {
+		v = zeroVersion
+	}
+	if other == nil {
+		other = zeroVersion
+	}
+
+	switch {
+	case v.major > other.major:
+		return greater
+	case v.major < other.major:
+		return less
+	case v.minor > other.minor:
+		return greater
+	case v.minor < other.minor:
+		return less
+	case v.patch > other.patch:
+		return greater
+	case v.patch < other.patch:
+		return less
+	}
+
+	return equal
+}
+
+// change represents the action that needs to be taken during upgrade as a result of some breaking
+// change
+type change struct {
+	name        string // a short name to identify the change
+	description string // longer description
+	// The minimum from version, upgrading from which this change can be applied.
+	// For a version less than this value, this change is not applicable
+	minFromVersion *version
+	applyFunc      func() error // function which applies the change
+}
+
+// changeSet represents a set of changes that were introduced in some version
+type changeSet struct {
+	introducedIn *version // the version in which the changes were introduced
+	// the list of changes that were introduced in the above version
+	// it should contain changes in sorted order, based on their order of introduction as they would
+	// be applied in the order they are present in this list
+	changes []*change
+}
+
+// changeList represents a list of changeSet, i.e., a list of all the changes that were ever
+// introduced since the beginning of Dgraph.
+//The changeSets in this list are supposed to be in sorted order based on when they were introduced.
+type changeList []*changeSet
+
+type commandInput struct {
+	fromVersion *version
+	toVersion   *version
+}
 
 func init() {
 	Upgrade.Cmd = &cobra.Command{
 		Use:   "upgrade",
 		Short: "Run the Dgraph upgrade tool",
+		Long: "This tool is supported only for the mainstream release versions of Dgraph, " +
+			"not for the beta releases.",
 		Run: func(cmd *cobra.Command, args []string) {
 			run()
 		},
 	}
 
 	flag := Upgrade.Cmd.Flags()
-	flag.Bool("acl", false, "upgrade ACL from v1.2.2 to >v20.03.0")
-	flag.StringP("alpha", "a", "127.0.0.1:9080", "Dgraph Alpha gRPC server address")
-	flag.StringP("user", "u", "", "Username if login is required.")
-	flag.StringP("password", "p", "", "Password of the user.")
-	flag.BoolP("deleteOld", "d", true, "Delete the older ACL predicates")
+	flag.Bool(acl, false, "upgrade ACL from v1.2.2 to >=v20.03.0")
+	flag.Bool(dryRun, false, "dry-run the upgrade")
+	flag.StringP(alpha, "a", "127.0.0.1:9080", "Dgraph Alpha gRPC server address")
+	flag.StringP(user, "u", "", "Username of ACL user")
+	flag.StringP(password, "p", "", "Password of ACL user")
+	flag.BoolP(deleteOld, "d", true, "Delete the older ACL types/predicates")
+	flag.StringP(from, "f", "", "The version string from which to upgrade, e.g.: v1.2.2")
+	flag.StringP(to, "t", "", "The version string till which to upgrade, e.g.: v20.03.0")
 }
 
 func run() {
-	if !Upgrade.Conf.GetBool("acl") {
-		fmt.Fprint(os.Stderr, "Error! we only support acl upgrade as of now.\n")
+	cmdInput, err := validateAndParseInput()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return
 	}
 
-	if err := upgradeACLRules(); err != nil {
-		fmt.Fprintln(os.Stderr, "Error in upgrading ACL!", err)
+	applyChangeList(cmdInput, allChanges)
+}
+
+func validateAndParseInput() (*commandInput, error) {
+	if !Upgrade.Conf.GetBool(acl) {
+		return nil, formatAsFlagParsingError(acl,
+			fmt.Errorf("we only support acl upgrade as of now"))
 	}
+
+	_, _, err := net.SplitHostPort(strings.TrimSpace(Upgrade.Conf.GetString(alpha)))
+	if err != nil {
+		return nil, formatAsFlagParsingError(alpha, err)
+	}
+
+	if strings.TrimSpace(Upgrade.Conf.GetString(user)) == "" {
+		return nil, formatAsFlagRequiredError(user)
+	}
+
+	if strings.TrimSpace(Upgrade.Conf.GetString(password)) == "" {
+		return nil, formatAsFlagRequiredError(password)
+	}
+
+	fromVersionParsed, err := parseVersionFromString(Upgrade.Conf.GetString(from))
+	if err != nil {
+		return nil, formatAsFlagParsingError(from, err)
+	}
+
+	toVersionParsed, err := parseVersionFromString(Upgrade.Conf.GetString(to))
+	if err != nil {
+		return nil, formatAsFlagParsingError(to, err)
+	}
+
+	if fromVersionParsed.Compare(toVersionParsed) != less {
+		return nil, fmt.Errorf("error: `%s` must be less than `%s`", from, to)
+	}
+
+	return &commandInput{fromVersion: fromVersionParsed, toVersion: toVersionParsed}, nil
+}
+
+func formatAsFlagParsingError(flag string, err error) error {
+	return fmt.Errorf("error parsing flag `%s`: %w", flag, err)
+}
+
+func formatAsFlagRequiredError(flag string) error {
+	return formatAsFlagParsingError(flag, fmt.Errorf("`%s` is required", flag))
+}
+
+// parseVersionFromString parses a version given as string to internal representation.
+// Some examples for input and output:
+// 	1. input : v1.2.2
+// 	   output: &version{major: 1, minor: 2, patch: 2}, nil
+// 	2. input : v20.03.0-beta.20200320
+// 	   output: &version{major: 20, minor: 3, patch: 0}, nil
+// 	3. input : 1.2.2
+// 	   output: nil, error
+// 	4. input : v1.2.2s
+// 	   output: nil, error
+func parseVersionFromString(v string) (*version, error) {
+	v = strings.TrimSpace(v)
+	if v == "" || v[:1] != "v" {
+		return nil, fmt.Errorf("version can't be empty and must start with `v`. E.g.: v1.2.2")
+	}
+
+	versionSplit := strings.Split(v[1:], ".")
+	result := &version{}
+	var err error
+
+	result.major, err = strconv.Atoi(versionSplit[0])
+	if err != nil {
+		return nil, fmt.Errorf("error parsing major version: %w", err)
+	}
+
+	result.minor, err = strconv.Atoi(versionSplit[1])
+	if err != nil {
+		return nil, fmt.Errorf("error parsing minor version: %w", err)
+	}
+
+	// the third part of split might contain some extra things like `beta` appended with -,
+	// so split again and take the first part as patch
+	patchSplit := strings.Split(versionSplit[2], "-")
+	result.patch, err = strconv.Atoi(patchSplit[0])
+	if err != nil {
+		return nil, fmt.Errorf("error parsing patch version: %w", err)
+	}
+
+	return result, nil
+}
+
+func applyChangeList(cmdInput *commandInput, list changeList) {
+	fmt.Println("**********************************************")
+	fmt.Println("Version to upgrade from:", cmdInput.fromVersion)
+	fmt.Println("Version to upgrade to  :", cmdInput.toVersion)
+	fmt.Println("**********************************************")
+	// sort the changeList based on the version the changes were introduced in
+	sort.SliceStable(list, func(i, j int) bool {
+		iVersion := list[i].introducedIn
+		jVersion := list[j].introducedIn
+		return iVersion.Compare(jVersion) == less
+	})
+
+	isInitialFromVersion := true
+
+	for j, changeSet := range list {
+		// apply the change set only if the version in which it was introduced is <= the version
+		// to which we want to upgrade and also >= the version from which we want to upgrade.
+		// If cmdInput.fromVersion hasn't been changed by us yet, then make sure that it is always
+		// less than the introduced version, ignore equality. So, if upgrading from version x to
+		// some other version, then the changes introduced in version x don't get applied.
+		fromConditionSatisfied := false
+		if isInitialFromVersion {
+			fromConditionSatisfied = cmdInput.fromVersion.Compare(changeSet.introducedIn) == less
+		} else {
+			fromConditionSatisfied = cmdInput.fromVersion.Compare(changeSet.introducedIn) != greater
+		}
+		if cmdInput.toVersion.Compare(changeSet.introducedIn) != less && fromConditionSatisfied {
+			fmt.Printf("\n%d. Applying the change set introduced in version: %s\n", j+1,
+				changeSet.introducedIn)
+			// Go over every change in the change set and check if it should be applied. If yes,
+			// apply it, otherwise skip it.
+			for i, change := range changeSet.changes {
+				fmt.Println(fmt.Sprintf(""+
+					"\tApplying change %d:\n"+
+					"\t\tName       : %s\n"+
+					"\t\tDescription: %s", i+1, change.name, change.description))
+				// apply the change only if the min version from which it should be applied
+				// is <= the version from which we want to upgrade
+				if cmdInput.fromVersion.Compare(change.minFromVersion) != less {
+					var err error
+					if !Upgrade.Conf.GetBool(dryRun) {
+						err = change.applyFunc()
+					}
+					if err != nil {
+						fmt.Println("\t\tStatus     : Error")
+						fmt.Println("\t\tError      :", err)
+						fmt.Println("\t\tCan't continue. Exiting!!!")
+						os.Exit(1)
+					} else {
+						fmt.Println("\t\tStatus     : Successful")
+					}
+				} else {
+					fmt.Println("\t\tStatus     : Skipped (min version mismatch)")
+				}
+			}
+			// update the fromVersion to reflect the version till which DB has been upgraded,
+			// so that minFromVersion check is satisfied for the changes in next changeSets
+			cmdInput.fromVersion = changeSet.introducedIn
+			isInitialFromVersion = false
+			fmt.Println("\tDB state now upgraded to:", cmdInput.fromVersion)
+		} else {
+			fmt.Println("Skipping the change set introduced in version:", changeSet.introducedIn)
+		}
+	}
+
+	fmt.Println("\nUpgrade finished!")
 }

--- a/upgrade/upgrade_test.go
+++ b/upgrade/upgrade_test.go
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package upgrade
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/dgraph-io/dgo/v200/protos/api"
+)
+
+func Test_version_String(t *testing.T) {
+	tests := []struct {
+		name    string
+		version *version
+		want    string
+	}{
+		{
+			name:    "nil version",
+			version: nil,
+			want:    "v0.0.0",
+		}, {
+			name:    "zero version",
+			version: &version{},
+			want:    "v0.0.0",
+		}, {
+			name:    "prior to CalVer versioning",
+			version: &version{major: 1, minor: 2, patch: 1},
+			want:    "v1.2.1",
+		}, {
+			name:    "CalVer versioning",
+			version: &version{major: 20, minor: 3, patch: 1},
+			want:    "v20.03.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.version.String(); got != tt.want {
+				t.Errorf("String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_version_Compare(t *testing.T) {
+	v1 := &version{major: 20, minor: 3, patch: 1}
+	v2 := &version{major: 20, minor: 3, patch: 2}
+	v3 := &version{major: 20, minor: 7, patch: 0}
+	v4 := &version{major: 1, minor: 2, patch: 0}
+
+	tests := []struct {
+		name  string
+		this  *version
+		other *version
+		want  versionComparisonResult
+	}{
+		{
+			name:  "v1 == v1, reflexive",
+			this:  v1,
+			other: v1,
+			want:  equal,
+		}, {
+			name:  "v1 < v2, by patch",
+			this:  v1,
+			other: v2,
+			want:  less,
+		}, {
+			name:  "v2 > v1, by patch",
+			this:  v2,
+			other: v1,
+			want:  greater,
+		}, {
+			name:  "v2 < v3, by minor",
+			this:  v2,
+			other: v3,
+			want:  less,
+		}, {
+			name:  "v1 < v3, transitive, by minor",
+			this:  v1,
+			other: v3,
+			want:  less,
+		}, {
+			name:  "v1 > v4, by major",
+			this:  v1,
+			other: v4,
+			want:  greater,
+		}, {
+			name:  "this is nil",
+			this:  nil,
+			other: v3,
+			want:  less,
+		}, {
+			name:  "other is nil",
+			this:  v1,
+			other: nil,
+			want:  greater,
+		}, {
+			name:  "both are nil",
+			this:  nil,
+			other: nil,
+			want:  equal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.this.Compare(tt.other); got != tt.want {
+				t.Errorf("Compare() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_parseVersionFromString(t *testing.T) {
+	tests := []struct {
+		name       string
+		versionStr string
+		want       *version
+		wantErr    bool
+	}{
+		{
+			name:       "parse mainstream version successfully",
+			versionStr: "v1.2.2",
+			want:       &version{major: 1, minor: 2, patch: 2},
+			wantErr:    false,
+		}, {
+			name:       "parse beta version successfully",
+			versionStr: "v20.03.0-beta.20200320",
+			want:       &version{major: 20, minor: 3, patch: 0},
+			wantErr:    false,
+		}, {
+			name:       "error if version doesn't start with v",
+			versionStr: "1.2.2",
+			want:       nil,
+			wantErr:    true,
+		}, {
+			name:       "error parsing patch version",
+			versionStr: "v1.2.2s",
+			want:       nil,
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseVersionFromString(tt.versionStr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseVersionFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseVersionFromString() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test(t *testing.T) {
+	nq := &api.NQuad{
+		Subject:   "0x1",
+		Predicate: "dgraph.type",
+		ObjectValue: &api.Value{
+			Val: &api.Value_StrVal{StrVal: "Post"},
+		},
+	}
+	fmt.Println(nq)
+	fmt.Println(nq.String())
+	b, err := nq.Marshal()
+	fmt.Println(string(b))
+	fmt.Println(err)
+
+}

--- a/upgrade/utils.go
+++ b/upgrade/utils.go
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dgraph-io/dgo/v200"
+	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/x"
+	"google.golang.org/grpc"
+)
+
+// getDgoClient creates a gRPC connection and uses that to create a new dgo client.
+// The gRPC.ClientConn returned by this must be closed after use.
+func getDgoClient(withLogin bool) (*dgo.Dgraph, *grpc.ClientConn, error) {
+	alpha := Upgrade.Conf.GetString(alpha)
+
+	// TODO(Aman): add TLS configuration.
+	conn, err := grpc.Dial(alpha, grpc.WithInsecure())
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to connect to Dgraph cluster: %w", err)
+	}
+
+	dg := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+
+	if withLogin {
+		userName := Upgrade.Conf.GetString(user)
+		password := Upgrade.Conf.GetString(password)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		// login to cluster
+		if err = dg.Login(ctx, userName, password); err != nil {
+			x.Check(conn.Close())
+			return nil, nil, fmt.Errorf("unable to login to Dgraph cluster: %w", err)
+		}
+	}
+
+	return dg, conn, nil
+}
+
+// getQueryResult executes the given query and unmarshals the result in given pointer queryResPtr.
+// If any error is encountered, it returns the error.
+func getQueryResult(dg *dgo.Dgraph, query string, queryResPtr interface{}) error {
+	var resp *api.Response
+	var err error
+
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		resp, err = dg.NewReadOnlyTxn().Query(ctx, query)
+		if err != nil {
+			fmt.Println("error in query, retrying:", err)
+			continue
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(resp.GetJson(), queryResPtr)
+}
+
+// mutateWithClient uses the given dgraph client to execute the given mutation.
+// It retries max 3 times before returning failure error, if any.
+func mutateWithClient(dg *dgo.Dgraph, mutation *api.Mutation) error {
+	if mutation == nil {
+		return nil
+	}
+
+	mutation.CommitNow = true
+
+	var err error
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err = dg.NewTxn().Mutate(ctx, mutation)
+		if err != nil {
+			fmt.Println("error in mutation, retrying:", err)
+			continue
+		}
+
+		return nil
+	}
+
+	return err
+}
+
+// alterWithClient uses the given dgraph client to execute the given alter operation.
+// It retries max 3 times before returning failure error, if any.
+func alterWithClient(dg *dgo.Dgraph, operation *api.Operation) error {
+	if operation == nil {
+		return nil
+	}
+
+	var err error
+	for i := 0; i < 3; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		err = dg.Alter(ctx, operation)
+		if err != nil {
+			fmt.Println("error in alter, retrying:", err)
+			continue
+		}
+
+		return nil
+	}
+
+	return err
+}
+
+// getTypeSchemaString generates a string which can be used to alter a type in schema.
+// It generates the type string using new type and predicate names. So, if this type
+// previously had a predicate for which we got a new name, then the generated string
+// will contain the new name for that predicate. Also, if some predicates need to be
+// removed from the type, then they can be supplied in predsToRemove. For example:
+// initialType:
+// 	type Person {
+// 		name
+// 		age
+// 		unnecessaryEdge
+// 	}
+// also,
+// 	newTypeName = "Human"
+// 	newPredNames = {
+// 		"age": "ageOnEarth'
+// 	}
+// 	predsToRemove = {
+// 		"unnecessaryEdge": {}
+// 	}
+// then returned type string will be:
+// 	type Human {
+// 		name
+// 		ageOnEarth
+// 	}
+func getTypeSchemaString(newTypeName string, typeNode *schemaTypeNode,
+	newPredNames map[string]string, predsToRemove map[string]struct{}) string {
+	var builder strings.Builder
+	builder.WriteString("type ")
+	builder.WriteString(newTypeName)
+	builder.WriteString(" {\n")
+
+	for _, oldPred := range typeNode.Fields {
+		if _, ok := predsToRemove[oldPred.Name]; ok {
+			continue
+		}
+
+		builder.WriteString("  ")
+		newPredName, ok := newPredNames[oldPred.Name]
+		if ok {
+			builder.WriteString(newPredName)
+		} else {
+			builder.WriteString(oldPred.Name)
+		}
+		builder.WriteString("\n")
+	}
+
+	builder.WriteString("}\n")
+
+	return builder.String()
+}
+
+func getTypeNquad(uid, typeName string) *api.NQuad {
+	return &api.NQuad{
+		Subject:   uid,
+		Predicate: "dgraph.type",
+		ObjectValue: &api.Value{
+			Val: &api.Value_StrVal{StrVal: typeName},
+		},
+	}
+}

--- a/upgrade/utils_test.go
+++ b/upgrade/utils_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v200/protos/api"
+)
+
+func Test_getTypeSchemaString(t *testing.T) {
+	type args struct {
+		newTypeName   string
+		typeNode      *schemaTypeNode
+		newPredNames  map[string]string
+		predsToRemove map[string]struct{}
+	}
+
+	testSchemaTypeNode := &schemaTypeNode{
+		Name: "dgraph.User",
+		Fields: []*schemaTypeField{
+			{Name: "name"},
+			{Name: "dgraph.xid"},
+			{Name: "age"},
+			{Name: "unnecessaryEdge"},
+		},
+	}
+
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "only change type name",
+			args: args{
+				newTypeName:   "User",
+				typeNode:      testSchemaTypeNode,
+				newPredNames:  nil,
+				predsToRemove: nil,
+			},
+			want: "type User {\n  name\n  dgraph.xid\n  age\n  unnecessaryEdge\n}\n",
+		},
+		{
+			name: "change type name + change name for a predicate + remove another predicate",
+			args: args{
+				newTypeName:   "User",
+				typeNode:      testSchemaTypeNode,
+				newPredNames:  map[string]string{"dgraph.xid": "xid"},
+				predsToRemove: map[string]struct{}{"unnecessaryEdge": {}},
+			},
+			want: "type User {\n  name\n  xid\n  age\n}\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getTypeSchemaString(tt.args.newTypeName, tt.args.typeNode,
+				tt.args.newPredNames, tt.args.predsToRemove); got != tt.want {
+				t.Errorf("getTypeSchemaString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getTypeNquad(t *testing.T) {
+	uid := "0x1"
+	typeName := "Post"
+
+	wantNQuad := &api.NQuad{
+		Subject:   uid,
+		Predicate: "dgraph.type",
+		ObjectValue: &api.Value{
+			Val: &api.Value_StrVal{StrVal: typeName},
+		},
+	}
+
+	require.Equal(t, wantNQuad, getTypeNquad(uid, typeName))
+}


### PR DESCRIPTION
Fixes #DGRAPH-1617.

This PR adds the capability to upgrade to v20.07.0 from v20.03.0+
It has only considered the breaking changes introduced in #5185.

It also introduces a generic system to handle upgrades.

At present, upgrade tool expects to handle only breaking ACL changes, and does not expect to handle badger data format changes. The way it is supposed to work is by updating the Dgraph binary to new version, start Dgraph cluster with existing data directories (which could also have been restored by enterprise backup/restore), and then running the upgrade tool by specifying the version you want to upgrade from and the version you want to upgrade to.

(cherry picked from commit d5892dc0c233970bab85b2aa39e865df57c45fc5)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5830)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-aae350b322-75358.surge.sh)
<!-- Dgraph:end -->