### PR TITLE
docs: add docs for admin endpoint auth

### DIFF
--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2416,11 +2416,13 @@ This option is available in v20.03.1 and later.
 Each Dgraph Alpha exposes various administrative endpoints both over HTTP and GraphQL, for
  example endpoints to export data and to perform a clean shutdown. All such admin endpoints are
   protected by three layers of auth:
-  1. IP White-listing, if `--whitelist` flag is passed to alpha.
-  2. Poor-man's auth, if `--auth_token` flag is passed to alpha (means you will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while making the HTTP request if this is enabled).
-  3. Guardian only access, if ACL is enabled (means you need to pass the ACL JWT of a Guardian user as `X-Dgraph-AccessToken` header while making the HTTP request if this is enabled).
 
-Admin endpoint means any http endpoint which provides admin functionalities. Normally, the path starts with `/admin` for such endpoints, except a few. So, at present this list includes:
+1. IP White-listing, if `--whitelist` flag is passed to alpha.
+2. Poor-man's auth, if `--auth_token` flag is passed to alpha (means you will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while making the HTTP request).
+3. Guardian only access, if ACL is enabled (means you need to pass the ACL-JWT of a Guardian user as `X-Dgraph-AccessToken` header while making the HTTP request).
+
+Admin endpoint means any http endpoint which provides admin functionalities. Normally, the path starts with `/admin` for such endpoints, except a few. So, currently this list includes:
+
 * /admin
 * /admin/backup
 * /admin/config/lru_mb
@@ -2432,7 +2434,8 @@ Admin endpoint means any http endpoint which provides admin functionalities. Nor
 * /login
 
 There are a few exceptions to the general rule described above:
-1. `/login`: This endpoint logs-in an ACL user, and provides them with JWT. Only IP Whitelisting and Poor-man's auth checks are performed for this. As one won't be able to login using ACL if we mandate Guardian only access on this.
+
+1. `/login`: This endpoint logs-in an ACL user, and provides them with a JWT. Only IP Whitelisting and Poor-man's auth checks are performed for this. As one won't be able to login using ACL if we mandate Guardian only access on this.
 2. `/admin`: This endpoint provides GraphQL queries/mutations corresponding to the HTTP admin endpoints. All the queries/mutations on `/admin` have all the 3 auth checks, except for the following one:
    * `login (mutation)`: The same behavior as the above HTTP `login` endpoint.
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2413,7 +2413,28 @@ This option is available in v20.03.1 and later.
 
 ## Dgraph Administration
 
-Each Dgraph Alpha exposes administrative operations over HTTP to export data and to perform a clean shutdown.
+Each Dgraph Alpha exposes various administrative endpoints both over HTTP and GraphQL, for
+ example endpoints to export data and to perform a clean shutdown. All such admin endpoints are
+  protected by three layers of auth:
+  1. IP White-listing, if `--whitelist` flag is passed to alpha.
+  2. Poor-man's auth, if `--auth_token` flag is passed to alpha (means you will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while making the HTTP request if this is enabled).
+  3. Guardian only access, if ACL is enabled (means you need to pass the ACL JWT of a Guardian user as `X-Dgraph-AccessToken` header while making the HTTP request if this is enabled).
+
+Admin endpoint means any http endpoint which provides admin functionalities. Normally, the path starts with `/admin` for such endpoints, except a few. So, at present this list includes:
+* /admin
+* /admin/backup
+* /admin/config/lru_mb
+* /admin/draining
+* /admin/export
+* /admin/shutdown
+* /admin/schema
+* /alter
+* /login
+
+There are a few exceptions to the general rule described above:
+1. `/login`: This endpoint logs-in an ACL user, and provides them with JWT. Only IP Whitelisting and Poor-man's auth checks are performed for this. As one won't be able to login using ACL if we mandate Guardian only access on this.
+2. `/admin`: This endpoint provides GraphQL queries/mutations corresponding to the HTTP admin endpoints. All the queries/mutations on `/admin` have all the 3 auth checks, except for the following one:
+   * `login (mutation)`: The same behavior as the above HTTP `login` endpoint.
 
 ### Whitelisting Admin Operations
 

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -2417,8 +2417,8 @@ Each Dgraph Alpha exposes various administrative endpoints both over HTTP and Gr
  example endpoints to export data and to perform a clean shutdown. All such admin endpoints are
   protected by three layers of auth:
 
-1. IP White-listing, if `--whitelist` flag is passed to alpha.
-2. Poor-man's auth, if `--auth_token` flag is passed to alpha (means you will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while making the HTTP request).
+1. IP White-listing (use `--whitelist` flag in alpha to whitelist IPs other than localhost).
+2. Poor-man's auth, if alpha is started with the `--auth_token` flag (means you will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while making the HTTP request).
 3. Guardian only access, if ACL is enabled (means you need to pass the ACL-JWT of a Guardian user as `X-Dgraph-AccessToken` header while making the HTTP request).
 
 Admin endpoint means any http endpoint which provides admin functionalities. Normally, the path starts with `/admin` for such endpoints, except a few. So, currently this list includes:
@@ -2435,7 +2435,7 @@ Admin endpoint means any http endpoint which provides admin functionalities. Nor
 
 There are a few exceptions to the general rule described above:
 
-1. `/login`: This endpoint logs-in an ACL user, and provides them with a JWT. Only IP Whitelisting and Poor-man's auth checks are performed for this. As one won't be able to login using ACL if we mandate Guardian only access on this.
+1. `/login`: This endpoint logs-in an ACL user, and provides them with a JWT. Only IP Whitelisting and Poor-man's auth checks are performed for this.
 2. `/admin`: This endpoint provides GraphQL queries/mutations corresponding to the HTTP admin endpoints. All the queries/mutations on `/admin` have all the 3 auth checks, except for the following one:
    * `login (mutation)`: The same behavior as the above HTTP `login` endpoint.
 

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2531,6 +2531,10 @@ schema {}
 by curly braces. Also, schema queries and regular queries cannot be combined.
 {{% /notice %}}
 
+{{% notice "note" %}} If ACL is enabled, then the schema query returns only the predicates for
+ which the logged-in ACL user has read access.
+{{% /notice %}}
+
 You can query for particular schema fields in the query body.
 
 ```


### PR DESCRIPTION
Fixes #GRAPHQL-523.

This PR adds documentation about the required authentications to access the admin endpoints.
Please see this discuss post for more details: https://discuss.dgraph.io/t/authentication-for-admin-endpoints/6786
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5842)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f33f8f5a21-76488.surge.sh)
<!-- Dgraph:end -->