### PR TITLE
test: Fix flakiness in online restore tests.

### DIFF
--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -96,7 +96,7 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 
 	// Wait for the client to exit draining mode. This is needed because the client might
 	// be connected to a follower and might be behind the leader in applying the restore.
-	// Waiting for three consecutive successful queries is done to prevent a situation in
+	// Waiting for five consecutive successful queries is done to prevent a situation in
 	// which the query succeeds at the first attempt because the follower is behind and
 	// has not started to apply the restore proposal.
 	numSuccess := 0
@@ -114,8 +114,8 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 			numSuccess = 0
 		}
 
-		if numSuccess == 3 {
-			// The server has been responsive three times in a row.
+		if numSuccess == 5 {
+			// The server has been responsive five times in a row.
 			break
 		}
 		time.Sleep(1 * time.Second)

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -81,6 +81,7 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 	b, err := json.Marshal(params)
 	require.NoError(t, err)
 
+	restoreDone := false
 	for i := 0; i < 15; i++ {
 		resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
 		require.NoError(t, err)
@@ -88,15 +89,16 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 		require.NoError(t, err)
 		sbuf := string(buf)
 		if strings.Contains(sbuf, "OK") {
-			return
+			restoreDone = true
+			break
 		}
 		time.Sleep(time.Second)
 	}
-	require.True(t, false, "restore operation did not complete after max number of retries")
+	require.True(t, restoreDone)
 
 	// Wait for the client to exit draining mode. This is needed because the client might
 	// be connected to a follower and might be behind the leader in applying the restore.
-	// Waiting for five consecutive successful queries is done to prevent a situation in
+	// Waiting for three consecutive successful queries is done to prevent a situation in
 	// which the query succeeds at the first attempt because the follower is behind and
 	// has not started to apply the restore proposal.
 	numSuccess := 0
@@ -114,8 +116,8 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 			numSuccess = 0
 		}
 
-		if numSuccess == 5 {
-			// The server has been responsive five times in a row.
+		if numSuccess == 3 {
+			// The server has been responsive three times in a row.
 			break
 		}
 		time.Sleep(1 * time.Second)

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -96,16 +96,28 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 
 	// Wait for the client to exit draining mode. This is needed because the client might
 	// be connected to a follower and might be behind the leader in applying the restore.
-	for i := 0; i < 10; i++ {
+	// Waiting for three consecutive successful queries is done to prevent a situation in
+	// which the query succeeds at the first attempt because the follower is behind and
+	// has not started to apply the restore proposal.
+	numSuccess := 0
+	for {
 		// This is a dummy query that returns no results.
 		_, err = dg.NewTxn().Query(context.Background(), `{
 		q(func: has(invalid_pred)) {
 			invalid_pred
 		}}`)
+
 		if err == nil {
+			numSuccess += 1
+		} else {
+			require.Contains(t, err.Error(), "the server is in draining mode")
+			numSuccess = 0
+		}
+
+		if numSuccess == 3 {
+			// The server has been responsive three times in a row.
 			break
 		}
-		require.Contains(t, err.Error(), "the server is in draining mode")
 		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
There's still some flakiness in the online restore tests caused by
the server being in draining mode. I suspect this happens when the
follower is behind and the check succeeds only for draining mode to be
enalbed right after. Previously the test checked that the alpha was
not in draining mode once. This change now requires the alpha to
have draining mode disabled three consecutive times before allowing
queries to be sent.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5853)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d225627ba1-76761.surge.sh)
<!-- Dgraph:end -->