### PR TITLE
feat(GraphQL): Turn on subscriptions and adds directive to control Subscription generation. (#5715)

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -562,9 +562,6 @@ func generateGQLSchema(sch *gqlSchema) (*schema.Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Disable subscription.
-	schHandler.DisableSubscription()
-
 	sch.GeneratedSchema = schHandler.GQLSchema()
 	generatedSchema, err := schema.FromString(sch.GeneratedSchema)
 	if err != nil {

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -53,8 +53,6 @@ func resolveUpdateGQLSchema(ctx context.Context, m schema.Mutation) (*resolve.Re
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
-	// Disable subscription.
-	schHandler.DisableSubscription()
 
 	if _, err = schema.FromString(schHandler.GQLSchema()); err != nil {
 		return resolve.EmptyResult(m, err), false

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -308,9 +308,8 @@ func TestServerShouldAllowForwardHeaders(t *testing.T) {
 }
 
 func TestCustomFieldsInSubscription(t *testing.T) {
-	t.Skip()
 	updateSchemaRequireNoGQLErrors(t, `
-	type Teacher {
+	type Teacher @withSubscription {
 		tid: ID!
 		age: Int!
 		name: String
@@ -338,7 +337,6 @@ func TestCustomFieldsInSubscription(t *testing.T) {
 }
 
 func TestSubscriptionInNestedCustomField(t *testing.T) {
-	t.Skip()
 	updateSchemaRequireNoGQLErrors(t, `
 	type Episode {
 		name: String! @id
@@ -350,7 +348,7 @@ func TestSubscriptionInNestedCustomField(t *testing.T) {
 				})
 	}
 
-	type Character {
+	type Character @withSubscription {
 		name: String! @id
 		lastName: String @custom(http: {
 						url: "http://mock:8888/userNames",

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -500,7 +500,6 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 
 // ValidateSubscription will check the given subscription query is valid or not.
 func (r *RequestResolver) ValidateSubscription(req *schema.Request) error {
-	return errors.New("Subscriptions are not supported")
 	op, err := r.schema.Operation(req)
 	if err != nil {
 		return err

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -1991,6 +1991,28 @@ invalid_schemas:
      "locations":[{"line":1, "column":6}]},
     ]
 
+  - name: "@withSubscription and @remote directive on type"
+    input: |
+      type Class @withSubscription @remote  {
+        id: ID!
+        name: String!
+        numStudents: Int!
+      }
+
+      type School {
+        id: ID!
+        established: String!
+        name: String! @custom(http: {
+                url: "http://mock:8888/schoolNames/$id/$established",
+                method: "POST",
+                body: "{sid: $id}"
+                })
+      }
+    errlist: [
+    {"message": "Type Class; cannot have both @withSubscription and @remote directive",
+     "locations":[{"line":1, "column":6}]},
+    ]
+
   -
     name: "@custom directive on field where graphql uses a field without a variable definition"
     input: |

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -450,7 +450,7 @@ func collectFieldNames(idFields []*ast.FieldDefinition) (string, []gqlerror.Loca
 }
 
 func conflictingDirectiveValidation(schema *ast.Schema, typ *ast.Definition) gqlerror.List {
-	var hasAuth, hasRemote bool
+	var hasAuth, hasRemote, hasSubscription bool
 	for _, dir := range typ.Directives {
 		if dir.Name == authDirective {
 			hasAuth = true
@@ -458,10 +458,17 @@ func conflictingDirectiveValidation(schema *ast.Schema, typ *ast.Definition) gql
 		if dir.Name == remoteDirective {
 			hasRemote = true
 		}
+		if dir.Name == SubscriptionDirective {
+			hasSubscription = true
+		}
 	}
 	if hasAuth && hasRemote {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(typ.Position, `Type %s; cannot have both @%s and @%s directive`,
 			typ.Name, authDirective, remoteDirective)}
+	}
+	if hasSubscription && hasRemote {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(typ.Position, `Type %s; cannot have both @%s and @%s directive`,
+			typ.Name, SubscriptionDirective, remoteDirective)}
 	}
 	return nil
 }

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -37,7 +37,6 @@ import (
 type Handler interface {
 	DGSchema() string
 	GQLSchema() string
-	DisableSubscription()
 }
 
 type handler struct {
@@ -71,10 +70,6 @@ func (s *handler) GQLSchema() string {
 
 func (s *handler) DGSchema() string {
 	return s.dgraphSchema
-}
-
-func (s *handler) DisableSubscription() {
-	s.completeSchema.Subscription = nil
 }
 
 func parseSecrets(sch string) (map[string]string, error) {

--- a/graphql/schema/testdata/schemagen/input/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/input/hasInverse_withSubscription.graphql
@@ -1,0 +1,9 @@
+type Post {
+  id: ID!
+  author: Author! @hasInverse(field: "posts")
+}
+
+type Author @withSubscription{
+  id: ID!
+  posts: [Post!]! @hasInverse(field: "author")
+}

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -75,6 +75,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -297,13 +298,3 @@ type Mutation {
 	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getTodo(id: ID!): Todo
-	queryTodo(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo]
-	getUser(username: String!): User
-	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-}

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -80,6 +80,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -238,12 +239,3 @@ type Mutation {
 	deleteT(filter: TFilter!): DeleteTPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	queryI(order: IOrder, first: Int, offset: Int): [I]
-	getT(id: ID!): T
-	queryT(filter: TFilter, order: TOrder, first: Int, offset: Int): [T]
-}

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -68,6 +68,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -209,11 +210,3 @@ type Mutation {
 	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getUser(id: ID!): User
-	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-}

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -85,6 +85,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -69,6 +69,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -210,11 +211,3 @@ type Mutation {
 	deleteCar(filter: CarFilter!): DeleteCarPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getCar(id: ID!): Car
-	queryCar(filter: CarFilter, order: CarOrder, first: Int, offset: Int): [Car]
-}

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -68,6 +68,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -64,6 +64,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -205,11 +206,3 @@ type Mutation {
 	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getUser(id: ID!): User
-	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-}

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -64,6 +64,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -178,10 +179,3 @@ type Mutation {
 	addAtype(input: [AddAtypeInput!]!): AddAtypePayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	queryAtype(order: AtypeOrder, first: Int, offset: Int): [Atype]
-}

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -78,6 +78,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -325,15 +326,3 @@ type Mutation {
 	deleteDirector(filter: DirectorFilter!): DeleteDirectorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getMovie(id: ID!): Movie
-	queryMovie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
-	getOscarMovie(id: ID!): OscarMovie
-	queryOscarMovie(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie]
-	getDirector(id: ID!): Director
-	queryDirector(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director]
-}

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -78,6 +78,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -324,15 +325,3 @@ type Mutation {
 	deleteDirector(filter: DirectorFilter!): DeleteDirectorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getMovie(id: ID!): Movie
-	queryMovie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
-	getOscarMovie(id: ID!): OscarMovie
-	queryOscarMovie(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie]
-	getDirector(id: ID!): Director
-	queryDirector(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director]
-}

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -77,6 +77,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -330,15 +331,3 @@ type Mutation {
 	deleteGenre(filter: GenreFilter!): DeleteGenrePayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getPost(postID: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	getAuthor(id: ID, name: String): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getGenre(name: String!): Genre
-	queryGenre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
-}

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -71,6 +71,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -270,13 +271,3 @@ type Mutation {
 	deleteMovieDirector(filter: MovieDirectorFilter!): DeleteMovieDirectorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getMovie(id: ID!): Movie
-	queryMovie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
-	getMovieDirector(id: ID!): MovieDirector
-	queryMovieDirector(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector]
-}

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -88,6 +88,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -420,17 +421,3 @@ type Mutation {
 	deleteAnswer(filter: AnswerFilter!): DeleteAnswerPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	getQuestion(id: ID!): Question
-	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
-	getAnswer(id: ID!): Answer
-	queryAnswer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
-}

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -89,6 +89,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -424,17 +425,3 @@ type Mutation {
 	deleteAnswer(filter: AnswerFilter!): DeleteAnswerPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	getQuestion(id: ID!): Question
-	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
-	getAnswer(id: ID!): Answer
-	queryAnswer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
-}

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -88,6 +88,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -420,17 +421,3 @@ type Mutation {
 	deleteAnswer(filter: AnswerFilter!): DeleteAnswerPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	getQuestion(id: ID!): Question
-	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
-	getAnswer(id: ID!): Answer
-	queryAnswer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
-}

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -69,6 +69,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -239,13 +240,3 @@ type Mutation {
 	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, first: Int, offset: Int): [Post]
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, first: Int, offset: Int): [Author]
-}

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -2,18 +2,14 @@
 # Input Schema
 #######################
 
-interface LibraryItem {
-	refID: String! @id
+type Post {
+	id: ID!
+	author(filter: AuthorFilter): Author! @hasInverse(field: "posts")
 }
 
-type Book implements LibraryItem {
-	refID: String! @id
-	title: String
-	author: String
-}
-
-type Library {
-	items(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
+type Author @withSubscription {
+	id: ID!
+	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
 }
 
 #######################
@@ -138,108 +134,86 @@ input StringHashFilter {
 # Generated Types
 #######################
 
-type AddBookPayload {
-	book(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
+type AddAuthorPayload {
+	author(filter: AuthorFilter, first: Int, offset: Int): [Author]
 	numUids: Int
 }
 
-type AddLibraryPayload {
-	library(first: Int, offset: Int): [Library]
+type AddPostPayload {
+	post(filter: PostFilter, first: Int, offset: Int): [Post]
 	numUids: Int
 }
 
-type DeleteBookPayload {
+type DeleteAuthorPayload {
 	msg: String
 	numUids: Int
 }
 
-type DeleteLibraryItemPayload {
+type DeletePostPayload {
 	msg: String
 	numUids: Int
 }
 
-type UpdateBookPayload {
-	book(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
+type UpdateAuthorPayload {
+	author(filter: AuthorFilter, first: Int, offset: Int): [Author]
 	numUids: Int
 }
 
-#######################
-# Generated Enums
-#######################
-
-enum BookOrderable {
-	refID
-	title
-	author
-}
-
-enum LibraryItemOrderable {
-	refID
+type UpdatePostPayload {
+	post(filter: PostFilter, first: Int, offset: Int): [Post]
+	numUids: Int
 }
 
 #######################
 # Generated Inputs
 #######################
 
-input AddBookInput {
-	refID: String!
-	title: String
-	author: String
+input AddAuthorInput {
+	posts: [PostRef!]!
 }
 
-input AddLibraryInput {
-	items: [LibraryItemRef]
+input AddPostInput {
+	author: AuthorRef!
 }
 
-input BookFilter {
-	refID: StringHashFilter
-	and: BookFilter
-	or: BookFilter
-	not: BookFilter
+input AuthorFilter {
+	id: [ID!]
+	not: AuthorFilter
 }
 
-input BookOrder {
-	asc: BookOrderable
-	desc: BookOrderable
-	then: BookOrder
+input AuthorPatch {
+	posts: [PostRef!]
 }
 
-input BookPatch {
-	title: String
-	author: String
+input AuthorRef {
+	id: ID
+	posts: [PostRef!]
 }
 
-input BookRef {
-	refID: String
-	title: String
-	author: String
+input PostFilter {
+	id: [ID!]
+	not: PostFilter
 }
 
-input LibraryItemFilter {
-	refID: StringHashFilter
-	and: LibraryItemFilter
-	or: LibraryItemFilter
-	not: LibraryItemFilter
+input PostPatch {
+	author: AuthorRef
 }
 
-input LibraryItemOrder {
-	asc: LibraryItemOrderable
-	desc: LibraryItemOrderable
-	then: LibraryItemOrder
+input PostRef {
+	id: ID
+	author: AuthorRef
 }
 
-input LibraryItemRef {
-	refID: String! @id
+input UpdateAuthorInput {
+	filter: AuthorFilter!
+	set: AuthorPatch
+	remove: AuthorPatch
 }
 
-input LibraryRef {
-	items: [LibraryItemRef]
-}
-
-input UpdateBookInput {
-	filter: BookFilter!
-	set: BookPatch
-	remove: BookPatch
+input UpdatePostInput {
+	filter: PostFilter!
+	set: PostPatch
+	remove: PostPatch
 }
 
 #######################
@@ -247,11 +221,10 @@ input UpdateBookInput {
 #######################
 
 type Query {
-	getLibraryItem(refID: String!): LibraryItem
-	queryLibraryItem(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
-	getBook(refID: String!): Book
-	queryBook(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
-	queryLibrary(first: Int, offset: Int): [Library]
+	getPost(id: ID!): Post
+	queryPost(filter: PostFilter, first: Int, offset: Int): [Post]
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, first: Int, offset: Int): [Author]
 }
 
 #######################
@@ -259,10 +232,19 @@ type Query {
 #######################
 
 type Mutation {
-	deleteLibraryItem(filter: LibraryItemFilter!): DeleteLibraryItemPayload
-	addBook(input: [AddBookInput!]!): AddBookPayload
-	updateBook(input: UpdateBookInput!): UpdateBookPayload
-	deleteBook(filter: BookFilter!): DeleteBookPayload
-	addLibrary(input: [AddLibraryInput!]!): AddLibraryPayload
+	addPost(input: [AddPostInput!]!): AddPostPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
+	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }
 
+#######################
+# Generated Subscriptions
+#######################
+
+type Subscription {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, first: Int, offset: Int): [Author]
+}

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -71,6 +71,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -224,11 +225,3 @@ type Mutation {
 	deleteProduct(filter: ProductFilter!): DeleteProductPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getProduct(id: ID!): Product
-	queryProduct(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
-}

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -73,6 +73,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -222,12 +223,3 @@ type Mutation {
 	addUser(input: [AddUserInput!]!): AddUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	queryMessage(order: MessageOrder, first: Int, offset: Int): [Message]
-	queryQuestion(order: QuestionOrder, first: Int, offset: Int): [Question]
-	queryUser(order: UserOrder, first: Int, offset: Int): [User]
-}

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -95,6 +95,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -444,20 +445,3 @@ type Mutation {
 	deleteStarship(filter: StarshipFilter!): DeleteStarshipPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getCharacter(id: ID!): Character
-	checkCharacterPassword(id: ID!, password: String!): Character
-	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	getHuman(id: ID!): Human
-	checkHumanPassword(id: ID!, password: String!): Human
-	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
-	getDroid(id: ID!): Droid
-	checkDroidPassword(id: ID!, password: String!): Droid
-	queryDroid(filter: DroidFilter, order: DroidOrder, first: Int, offset: Int): [Droid]
-	getStarship(id: ID!): Starship
-	queryStarship(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
-}

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -95,6 +95,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -434,17 +435,3 @@ type Mutation {
 	deleteStarship(filter: StarshipFilter!): DeleteStarshipPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getCharacter(id: ID!): Character
-	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	getHuman(id: ID!): Human
-	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
-	getDroid(id: ID!): Droid
-	queryDroid(filter: DroidFilter, order: DroidOrder, first: Int, offset: Int): [Droid]
-	getStarship(id: ID!): Starship
-	queryStarship(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
-}

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -63,6 +63,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -203,10 +204,3 @@ type Mutation {
 	deletePost(filter: PostFilter!): DeletePostPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-}

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -75,6 +75,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -272,13 +273,3 @@ type Mutation {
 	addGenre(input: [AddGenreInput!]!): AddGenrePayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	queryPost(order: PostOrder, first: Int, offset: Int): [Post]
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	queryGenre(order: GenreOrder, first: Int, offset: Int): [Genre]
-}

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -64,6 +64,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -212,12 +213,3 @@ type Mutation {
 	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAuthor(name: String!): Author
-	checkAuthorPassword(name: String!, pwd: String!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-}

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -73,6 +73,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -296,13 +297,3 @@ type Mutation {
 	deletePost(filter: PostFilter!): DeletePostPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-	getPost(postID: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-}

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -90,6 +90,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -359,11 +360,3 @@ type Mutation {
 	deletePost(filter: PostFilter!): DeletePostPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getPost(postID: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-}

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -72,6 +72,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -219,11 +220,3 @@ type Mutation {
 	deletePost(filter: PostFilter!): DeletePostPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-}

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -66,6 +66,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -214,11 +215,3 @@ type Mutation {
 	deleteMessage(filter: MessageFilter!): DeleteMessagePayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getMessage(id: ID!): Message
-	queryMessage(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
-}

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -79,6 +79,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -296,14 +297,3 @@ type Mutation {
 	deleteHuman(filter: HumanFilter!): DeleteHumanPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getCharacter(id: ID!): Character
-	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	queryEmployee(order: EmployeeOrder, first: Int, offset: Int): [Employee]
-	getHuman(id: ID!): Human
-	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
-}

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -71,6 +71,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -272,13 +273,3 @@ type Mutation {
 	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getPost(id: ID!): Post
-	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	getAuthor(id: ID!): Author
-	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
-}

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -72,6 +72,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -267,13 +268,3 @@ type Mutation {
 	deleteMessage(filter: MessageFilter!): DeleteMessagePayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getAbstract(id: ID!): Abstract
-	queryAbstract(filter: AbstractFilter, order: AbstractOrder, first: Int, offset: Int): [Abstract]
-	getMessage(id: ID!): Message
-	queryMessage(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
-}

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -71,6 +71,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -269,13 +270,3 @@ type Mutation {
 	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getCar(id: ID!): Car
-	queryCar(filter: CarFilter, order: CarOrder, first: Int, offset: Int): [Car]
-	getUser(id: ID!): User
-	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-}

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -71,6 +71,7 @@ directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
 directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
 directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @auth(
 	query: AuthRule,
@@ -215,11 +216,3 @@ type Mutation {
 	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 
-#######################
-# Generated Subscriptions
-#######################
-
-type Subscription {
-	getUser(id: ID!): User
-	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
-}


### PR DESCRIPTION
This PR enables GraphQL subscriptions (the code was previously completed but disabled) and adds an @withSubscription directive to types that controls which types get subscriptions generated - previously all types got subscriptions generated.

(cherry picked from commit 64e8518292beaf9e59e22267a97975953510b647)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5856)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-01c42b8f61-75788.surge.sh)
<!-- Dgraph:end -->