### PR TITLE
fix(GraphQL): fix interface conversion panic in v20.03

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -450,7 +450,7 @@ type graphQLSchemaNode struct {
 	Schema string `json:"dgraph.graphql.schema"`
 }
 
-type existingGQLSchemaQryResp struct {
+type gqlSchemaQryResp struct {
 	ExistingGQLSchema []graphQLSchemaNode `json:"ExistingGQLSchema"`
 }
 
@@ -517,7 +517,7 @@ func upsertEmptyGQLSchema() (*gqlSchema, error) {
 		return &gqlSchema{ID: uid}, nil
 	}
 
-	var result existingGQLSchemaQryResp
+	var result gqlSchemaQryResp
 	if err := json.Unmarshal(resp.GetJson(), &result); err != nil {
 		return nil, schema.GQLWrapf(err, "Couldn't unmarshal response from Dgraph mutation")
 	}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -24,14 +24,12 @@ import (
 	"time"
 
 	dgoapi "github.com/dgraph-io/dgo/v2/protos/api"
-	"github.com/dgraph-io/dgraph/gql"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
 	badgerpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/badger/v2/y"
-	"github.com/dgraph-io/dgraph/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/graphql/web"
@@ -446,32 +444,28 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 	return rf.WithSchemaIntrospection()
 }
 
+// graphQLSchemaNode represents the node which contains GraphQL schema
+type graphQLSchemaNode struct {
+	Uid    string `json:"uid"`
+	Schema string `json:"dgraph.graphql.schema"`
+}
+
+type existingGQLSchemaQryResp struct {
+	ExistingGQLSchema []graphQLSchemaNode `json:"ExistingGQLSchema"`
+}
+
 func upsertEmptyGQLSchema() (*gqlSchema, error) {
 	existingSchemaVar := "ExistingGQLSchema"
 	xidInSchemaVar := "XidInSchema"
 	gqlType := "dgraph.graphql"
-	/*
-	   query {
-	     ExistingGQLSchema as ExistingGQLSchema(func: type(dgraph.graphql)) {
+
+	qry := `query {
+	     ExistingGQLSchema as ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
 	       uid
 	       dgraph.graphql.schema
 	       XidInSchema as dgraph.graphql.xid
 	     }
-	   }
-	*/
-	qry := &gql.GraphQuery{
-		Attr: existingSchemaVar,
-		Var:  existingSchemaVar,
-		Func: &gql.Function{
-			Name: "type",
-			Args: []gql.Arg{{Value: gqlType}},
-		},
-		Children: []*gql.GraphQuery{
-			{Attr: "uid"},
-			{Attr: gqlSchemaPred},
-			{Attr: gqlSchemaXidKey, Var: xidInSchemaVar},
-		},
-	}
+	   }`
 	/*
 	   mutation @if(eq(len(ExistingGQLSchema),1) AND eq(len(XidInSchema),0)) {
 	      set {
@@ -512,7 +506,7 @@ func upsertEmptyGQLSchema() (*gqlSchema, error) {
 	}
 
 	resp, err := resolve.NewAdminExecutor().Execute(context.Background(),
-		&dgoapi.Request{Query: dgraph.AsString(qry), Mutations: mutations, CommitNow: true})
+		&dgoapi.Request{Query: qry, Mutations: mutations, CommitNow: true})
 	if err != nil {
 		return nil, err
 	}
@@ -523,16 +517,16 @@ func upsertEmptyGQLSchema() (*gqlSchema, error) {
 		return &gqlSchema{ID: uid}, nil
 	}
 
-	result := make(map[string]interface{})
+	var result existingGQLSchemaQryResp
 	if err := json.Unmarshal(resp.GetJson(), &result); err != nil {
 		return nil, schema.GQLWrapf(err, "Couldn't unmarshal response from Dgraph mutation")
 	}
 
 	// the Alphas which didn't create the gql schema node, will get the uid here.
-	gqlSchemaNode := result[existingSchemaVar].([]interface{})[0].(map[string]interface{})
+	gqlSchemaNode := result.ExistingGQLSchema[0]
 	return &gqlSchema{
-		ID:     gqlSchemaNode["uid"].(string),
-		Schema: gqlSchemaNode[gqlSchemaPred].(string),
+		ID:     gqlSchemaNode.Uid,
+		Schema: gqlSchemaNode.Schema,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes DGRAPH-1787.

This PR fixes an issue, where if some user accidentally deleted the `dgraph.type` edge for the GraphQL schema node and simultaneously added another GraphQL schema node with `dgraph.type` edge and restarted the alpha, it would end up crashing with a panic saying `panic: interface conversion: interface {} is nil, not string`.

Steps to reproduce:
* Start zero and alpha.
* Run following mutation:
  ```
  {
    set {
      _:newSchema <dgraph.type> "dgraph.graphql" .
    }
    delete {
      <0x1> <dgraph.type> * .
    }
  }
  ```
  Note that <0x1> is the uid of existing GraphQL schema node. What we did in this mutation is to remove the `dgraph.type` edge from the existing schema node, and add a new node with just `dgraph.type` edge.
* Restart alpha.
* It will panic, and crash.
The reason it happens is that the code in 20.03 used to do the initial GraphQL schema upsert using the type query, and when you restart the alpha, it will find the new node which doesn't have the `dgraph.graphql.schema` edge. So, it comes as nil in query, and hence the panic.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5857)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-98cbd4b970-75849.surge.sh)
<!-- Dgraph:end -->