### PR TITLE
fix(GraphQL): Custom Claim will be parsed as JSON if it is encoded as a string

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -152,8 +152,14 @@ func (c *CustomClaims) UnmarshalJSON(data []byte) error {
 	}
 
 	// Unmarshal the auth variables for a particular namespace.
-	if authVariables, ok := result[metainfo.Namespace]; ok {
-		c.AuthVariables, _ = authVariables.(map[string]interface{})
+	if authValue, ok := result[metainfo.Namespace]; ok {
+		if authJson, ok := authValue.(string); ok {
+			if err := json.Unmarshal([]byte(authJson), &c.AuthVariables); err != nil {
+				return err
+			}
+		} else {
+			c.AuthVariables, _ = authValue.(map[string]interface{})
+		}
 	}
 	return nil
 }

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/grpc/metadata"
+
 	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
@@ -149,6 +151,31 @@ func (ex *authExecutor) Execute(ctx context.Context, req *dgoapi.Request) (*dgoa
 
 func (ex *authExecutor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
 	return nil
+}
+
+func TestStringCustomClaim(t *testing.T) {
+	sch, err := ioutil.ReadFile("../e2e/auth/schema.graphql")
+	require.NoError(t, err, "Unable to read schema file")
+
+	authSchema, err := testutil.AppendAuthInfo(sch, authorization.HMAC256, "")
+	require.NoError(t, err)
+
+	test.LoadSchemaFromString(t, string(authSchema))
+
+	// Token with string custom claim
+	// "https://xyz.io/jwt/claims": "{\"USER\": \"50950b40-262f-4b26-88a7-cbbb780b2176\", \"ROLE\": \"ADMIN\"}",
+	token := "eyJraWQiOiIyRWplN2tIRklLZS92MFRVT3JRYlVJWWJxSWNNUHZ2TFBjM3RSQ25EclBBPSIsImFsZyI6IkhTMjU2In0.eyJzdWIiOiI1MDk1MGI0MC0yNjJmLTRiMjYtODhhNy1jYmJiNzgwYjIxNzYiLCJjb2duaXRvOmdyb3VwcyI6WyJBRE1JTiJdLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiaXNzIjoiaHR0cHM6Ly9jb2duaXRvLWlkcC5hcC1zb3V0aGVhc3QtMi5hbWF6b25hd3MuY29tL2FwLXNvdXRoZWFzdC0yX0dmbWVIZEZ6NCIsImNvZ25pdG86dXNlcm5hbWUiOiI1MDk1MGI0MC0yNjJmLTRiMjYtODhhNy1jYmJiNzgwYjIxNzYiLCJodHRwczovL3h5ei5pby9qd3QvY2xhaW1zIjoie1wiVVNFUlwiOiBcIjUwOTUwYjQwLTI2MmYtNGIyNi04OGE3LWNiYmI3ODBiMjE3NlwiLCBcIlJPTEVcIjogXCJBRE1JTlwifSIsImF1ZCI6IjYzZG8wcTE2bjZlYmpna3VtdTA1a2tlaWFuIiwiZXZlbnRfaWQiOiIzMWM5ZDY4NC0xZDQ1LTQ2ZjctOGMyYi1jYzI3YjFmNmYwMWIiLCJ0b2tlbl91c2UiOiJpZCIsImF1dGhfdGltZSI6MTU5MDMzMzM1NiwibmFtZSI6IkRhdmlkIFBlZWsiLCJleHAiOjk1OTAzNzYwMzIsImlhdCI6MTU5MDM3MjQzMiwiZW1haWwiOiJkYXZpZEB0eXBlam9pbi5jb20ifQ.whgQ9QVMOa0jFYBKhCytlm25-dJiIxcfUFligjav0K0"
+	md := metadata.New(map[string]string{"authorizationJwt": token})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	authVar, err := authorization.ExtractAuthVariables(ctx)
+	require.NoError(t, err)
+
+	result := map[string]interface{}{
+		"ROLE": "ADMIN",
+		"USER": "50950b40-262f-4b26-88a7-cbbb780b2176",
+	}
+	require.Equal(t, authVar, result)
 }
 
 // Tests showing that the query rewriter produces the expected Dgraph queries


### PR DESCRIPTION
#5668 Cherrypicking to release/v20.07 branch

* If JWT custom claim field is string, parse as JSON

Co-authored-by: David Peek <mail@dpeek.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5862)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f3ecf01458-76063.surge.sh)
<!-- Dgraph:end -->