### PR TITLE
fix(GraphQL): Apply auth rules on type having @dgraph directive (#5702)

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -113,6 +113,11 @@ type Project struct {
 	Columns []*Column `json:"columns,omitempty"`
 }
 
+type Student struct {
+	Id    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+}
+
 type TestCase struct {
 	user      string
 	role      string
@@ -145,6 +150,87 @@ func getJWT(t *testing.T, user, role string) http.Header {
 	h := make(http.Header)
 	h.Add(metaInfo.Header, jwtToken)
 	return h
+}
+
+func (s Student) deleteByEmail(t *testing.T) {
+	getParams := &common.GraphQLParams{
+		Query: `
+			mutation delStudent ($filter : StudentFilter!){
+			  	deleteStudent (filter: $filter) {
+					numUids
+			  	}
+			}
+		`,
+		Variables: map[string]interface{}{"filter": map[string]interface{}{
+			"email": map[string]interface{}{"eq": s.Email},
+		}},
+	}
+	gqlResponse := getParams.ExecuteAsPost(t, graphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+}
+
+func (s Student) add(t *testing.T) {
+	mutation := &common.GraphQLParams{
+		Query: `
+		mutation addStudent($student : AddStudentInput!) {
+			addStudent(input: [$student]) {
+				numUids
+			}
+		}`,
+		Variables: map[string]interface{}{"student": s},
+	}
+	result := `{"addStudent":{"numUids": 1}}`
+	gqlResponse := mutation.ExecuteAsPost(t, graphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+	require.JSONEq(t, result, string(gqlResponse.Data))
+}
+
+func TestAuthWithDgraphDirective(t *testing.T) {
+	students := []Student{
+		{
+			Email: "user1@gmail.com",
+		},
+		{
+			Email: "user2@gmail.com",
+		},
+	}
+	for _, student := range students {
+		student.add(t)
+	}
+
+	testCases := []TestCase{{
+		user:   students[0].Email,
+		role:   "ADMIN",
+		result: `{"queryStudent":[{"email":"` + students[0].Email + `"}]}`,
+	}, {
+		user:   students[0].Email,
+		role:   "USER",
+		result: `{"queryStudent" : []}`,
+	}}
+
+	queryStudent := `
+	query {
+		queryStudent {
+			email
+		}
+	}`
+
+	for _, tcase := range testCases {
+		t.Run(tcase.role+"_"+tcase.user, func(t *testing.T) {
+			queryParams := &common.GraphQLParams{
+				Query:   queryStudent,
+				Headers: getJWT(t, tcase.user, tcase.role),
+			}
+			gqlResponse := queryParams.ExecuteAsPost(t, graphqlURL)
+			common.RequireNoGQLErrors(t, gqlResponse)
+			require.JSONEq(t, tcase.result, string(gqlResponse.Data))
+		})
+	}
+
+	// Clean up
+	for _, student := range students {
+		student.deleteByEmail(t)
+	}
 }
 
 func TestAuthRulesWithMissingJWT(t *testing.T) {

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -511,3 +511,14 @@ type Review @auth() {
     comment: String!
 }
 
+type Student @dgraph(type: "is7sowSm")
+@auth(query:  { and : [ {rule: """
+query($USER: String!) {
+    queryStudent(filter: {email: { eq: $USER}}) {
+        __typename
+    }
+}
+"""},{ rule: "{$ROLE: { eq: \"ADMIN\" }}"}]}) {
+    id: ID!
+    email: String! @dgraph(pred: "IOw80vnV") @search(by: [hash])
+}

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1,3 +1,34 @@
+- name: "Auth query with @dgraph pred."
+  gqlquery: |
+    query {
+      queryStudent {
+        email
+      }
+    }
+  role: "ADMIN"
+  dgquery: |-
+    query {
+      queryStudent(func: uid(Student1)) @filter(uid(Student2)) {
+        email : IOw80vnV
+        dgraph.uid : uid
+      }
+      Student1 as var(func: type(is7sowSm))
+      Student2 as var(func: uid(Student1)) @filter(eq(IOw80vnV, "user1")) @cascade
+    }
+
+- name: "Auth query with @dgraph pred (Test RBAC)."
+  gqlquery: |
+    query {
+      queryStudent {
+        email
+      }
+    }
+  role: "USER"
+  dgquery: |-
+    query {
+      queryStudent()
+    }
+
 - name: "Auth with deep get query."
   gqlquery: |
     query {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1284,7 +1284,7 @@ func (m *mutation) IsAuthQuery() bool {
 }
 
 func (t *astType) AuthRules() *TypeAuth {
-	return t.inSchema.authRules[t.Name()]
+	return t.inSchema.authRules[t.DgraphName()]
 }
 
 func (t *astType) Field(name string) FieldDefinition {


### PR DESCRIPTION
Auth rules were not applied on type having @dgraph directive because they were stored in authRules map corresponding to Graphql type name and was fetched with Dgraph type name when rewriting the query.

(cherry picked from commit 8562311a6e70eb7278abcb5c9c0c004196f206dd)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5863)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-69b991e011-76070.surge.sh)
<!-- Dgraph:end -->