### PR TITLE
feat(GraphQL): Allow query of deleted nodes. (#5706)

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -76,8 +76,9 @@ type Issue struct {
 }
 
 type Log struct {
-	Id   string `json:"id,omitempty"`
-	Logs string `json:"logs,omitempty"`
+	Id     string `json:"id,omitempty"`
+	Logs   string `json:"logs,omitempty"`
+	Random string `json:"random,omitempty"`
 }
 
 type ComplexLog struct {

--- a/graphql/e2e/auth/delete_mutation_test.go
+++ b/graphql/e2e/auth/delete_mutation_test.go
@@ -173,13 +173,18 @@ func TestDeleteRootFilter(t *testing.T) {
 
 func TestDeleteRBACFilter(t *testing.T) {
 	testCases := []TestCase{
-		{role: "USER", result: `{"deleteLog": {"numUids": 0}}`},
-		{role: "ADMIN", result: `{"deleteLog": {"numUids": 2}}`}}
+		{role: "USER", result: `{"deleteLog":{"numUids":0, "msg":"No nodes were deleted", "log":[]}}`},
+		{role: "ADMIN", result: `{"deleteLog":{"numUids":2, "msg":"Deleted", "log":[{"logs":"Log1","random":"test"}, {"logs":"Log2","random":"test"}]}}`}}
 
 	query := `
 		mutation ($logs: [ID!]) {
 			deleteLog(filter: {id: $logs}) {
           		numUids
+				msg
+				log (order: { asc: logs }) {
+					logs
+					random
+				}
 		    }
 	    }
 	`
@@ -308,17 +313,24 @@ func TestDeleteNestedFilter(t *testing.T) {
 	testCases := []TestCase{{
 		user:   "user1",
 		role:   "USER",
-		result: `{"deleteMovie": {"numUids": 3}}`,
+		result: `{"deleteMovie":{"numUids":3,"movie":[{"content":"Movie2","regionsAvailable":[{"name":"Region1","global":null}]},{"content":"Movie3","regionsAvailable":[{"name":"Region1","global":null},{"name":"Region4","global":null}]},{"content":"Movie4","regionsAvailable":[{"name":"Region5","global":true}]}]}}`,
 	}, {
 		user:   "user2",
 		role:   "USER",
-		result: `{"deleteMovie": {"numUids": 4}}`,
+		result: `{"deleteMovie":{"numUids":4,"movie":[{"content":"Movie1","regionsAvailable":[{"name":"Region2","global":null},{"name":"Region3","global":null}]},{"content":"Movie2","regionsAvailable":[{"name":"Region1","global":null}]},{"content":"Movie3","regionsAvailable":[{"name":"Region1","global":null},{"name":"Region4","global":null}]},{"content":"Movie4","regionsAvailable":[{"name":"Region5","global":true}]}]}}`,
 	}}
 
 	query := `
 	    mutation ($ids: [ID!]) {
 		    deleteMovie(filter: {id: $ids}) {
 				numUids
+				movie (order: {asc: content}) {
+					content
+					regionsAvailable (order: {asc: name}) {
+						name
+						global
+					}
+				}
 		    }
 	    }
 	`

--- a/graphql/e2e/auth/test_data.json
+++ b/graphql/e2e/auth/test_data.json
@@ -118,11 +118,13 @@
 	{
 		"uid": "_:log1",
 		"dgraph.type": "Log",
+		"Log.random": "test",
 		"Log.logs": "Log1"
 	},
 	{
 		"uid": "_:log2",
 		"dgraph.type": "Log",
+		"Log.random": "test",
 		"Log.logs": "Log2"
 	},
 	{

--- a/graphql/resolve/auth_delete_test.yaml
+++ b/graphql/resolve/auth_delete_test.yaml
@@ -66,12 +66,138 @@
       }
     }
 
+
+- name: "Delete with deep query"
+  gqlquery: |
+    mutation deleteTicket($filter: TicketFilter!) {
+      deleteTicket(filter: $filter) {
+        msg
+        numUids
+        ticket {
+          title
+          onColumn {
+            inProject {
+              roles {
+                assignedTo {
+                  username
+                  age
+                }
+              }
+            }
+          }
+          assignedTo {
+            username
+            age
+            isPublic
+            disabled
+          }
+        }
+      }
+    }
+  variables: |
+    { "filter": { "title": { "anyofterms": "auth is applied" } } }
+  dgmutations:
+    - deletejson: |
+        [
+          { "uid": "uid(x)" },
+          {
+            "uid":"uid(Column3)",
+            "Column.tickets": [ { "uid":"uid(x)" } ]
+          },
+          {
+            "uid":"uid(User4)",
+            "User.tickets": [ { "uid":"uid(x)" } ]
+          }
+        ]
+  dgquery: |-
+    query {
+      x as deleteTicket(func: uid(Ticket1)) @filter(uid(Ticket2)) {
+        uid
+        Column3 as Ticket.onColumn
+        User4 as Ticket.assignedTo
+      }
+      Ticket1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
+      Ticket2 as var(func: uid(Ticket1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      ticket(func: uid(x)) @filter(uid(Ticket8)) {
+        title : Ticket.title
+        onColumn : Ticket.onColumn @filter(uid(Column6)) {
+          inProject : Column.inProject @filter(uid(Project5)) {
+            roles : Project.roles {
+              assignedTo : Role.assignedTo {
+                username : User.username
+                age : User.age
+                dgraph.uid : uid
+              }
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        assignedTo : Ticket.assignedTo {
+          username : User.username
+          age : User.age
+          isPublic : User.isPublic
+          disabled : User.disabled
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      Ticket7 as var(func: type(Ticket))
+      Ticket8 as var(func: uid(Ticket7)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      Project5 as var(func: type(Project)) @cascade {
+        roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+          assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      Column6 as var(func: type(Column)) @cascade {
+        inProject : Column.inProject {
+          roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+            assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
 - name: "Delete with top level RBAC true."
   gqlquery: |
     mutation($projs: [ID!]) {
       deleteProject (filter: { projID: $projs}) {
-          numUids
+        numUids
+        project {
+          name
+          random
         }
+      }
     }
   variables: |
     {
@@ -96,6 +222,11 @@
         uid
         Column2 as Project.columns
       }
+      project(func: uid(x)) {
+        name : Project.name
+        random : Project.random
+        dgraph.uid : uid
+      }
     }
 
 - name: "Delete with top level RBAC false."
@@ -103,6 +234,10 @@
     mutation deleteLog($filter: LogFilter!) {
       deleteLog(filter: $filter) {
         msg
+        log {
+          logs
+          random
+        }
       }
     }
   variables: |
@@ -120,6 +255,7 @@
   dgquery: |-
     query {
       x as deleteLog()
+      log()
     }
 
 - name: "multiple rule in delete mutation"

--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -29,6 +29,63 @@
     }
 
 -
+  name: "Delete with deep query in result"
+  gqlmutation: |
+    mutation deleteAuthor($filter: AuthorFilter!) {
+      deleteAuthor(filter: $filter) {
+        msg
+        numUids
+        author (filter: { name: { eq: "GraphQL" } }, order: { asc: name }, first: 10, offset: 10) {
+          id
+          name
+          country {
+            name
+            states (filter: { code: { eq: "GraphQL" } }, order: { asc: name }, first: 10, offset: 10) {
+              code
+              name
+              capital
+            }
+          }
+        }
+      }
+    }
+  gqlvariables: |
+    { "filter":
+      { "id": ["0x1", "0x2"] }
+    }
+  explanation: "The correct mutation and query should be built using variable and filters."
+  dgmutations:
+    - deletejson: |
+        [
+          { "uid": "uid(x)" },
+          {
+            "uid": "uid(Post2)",
+            "Post.author": { "uid": "uid(x)" }
+          }
+        ]
+  dgquery: |-
+    query {
+      x as deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author)) {
+        uid
+        Post2 as Author.posts
+      }
+      author(func: uid(x), orderasc: Author.name, first: 10, offset: 10) @filter(eq(Author.name, "GraphQL")) {
+        id : uid
+        name : Author.name
+        country : Author.country {
+          name : Country.name
+          states : Country.states @filter(eq(State.code, "GraphQL")) (orderasc: State.name, first: 10, offset: 10) {
+            code : State.code
+            name : State.name
+            capital : State.capital
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+      }
+    }
+
+-
   name: "Multiple filters including id"
   gqlmutation: |
     mutation deleteAuthor($filter: AuthorFilter!) {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -310,7 +310,14 @@ func (mr *dgraphResolver) rewriteAndExecute(ctx context.Context,
 	ext.TouchedUids += qryResp.GetMetrics().GetNumUids()[touchedUidsKey]
 	numUids := getNumUids(mutation, mutResp.Uids, result)
 
-	resolved := completeDgraphResult(ctx, mutation.QueryField(), qryResp.GetJson(), errs)
+	var qryResult []byte
+	if mutation.MutationType() == schema.DeleteMutation && mutation.QueryField().SelectionSet() != nil {
+		qryResult = mutResp.GetJson()
+	} else {
+		qryResult = qryResp.GetJson()
+	}
+
+	resolved := completeDgraphResult(ctx, mutation.QueryField(), qryResult, errs)
 	if resolved.Data == nil && resolved.Err != nil {
 		return &Resolved{
 			Data: map[string]interface{}{

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -563,13 +563,16 @@ func addTypeFilter(q *gql.GraphQuery, typ schema.Type) {
 			Args: []gql.Arg{{Value: typ.DgraphName()}},
 		},
 	}
+	addToFilterTree(q, thisFilter)
+}
 
+func addToFilterTree(q *gql.GraphQuery, filter *gql.FilterTree) {
 	if q.Filter == nil {
-		q.Filter = thisFilter
+		q.Filter = filter
 	} else {
 		q.Filter = &gql.FilterTree{
 			Op:    "and",
-			Child: []*gql.FilterTree{q.Filter, thisFilter},
+			Child: []*gql.FilterTree{q.Filter, filter},
 		}
 	}
 }

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -52,6 +52,7 @@ const (
 
 	deprecatedDirective = "deprecated"
 	NumUid              = "numUids"
+	Msg                 = "msg"
 
 	Typename = "__typename"
 
@@ -1021,18 +1022,26 @@ func addDeletePayloadType(schema *ast.Schema, defn *ast.Definition) {
 		return
 	}
 
+	qry := &ast.FieldDefinition{
+		Name: camelCase(defn.Name),
+		Type: ast.ListType(&ast.Type{
+			NamedType: defn.Name,
+		}, nil),
+	}
+
+	addFilterArgument(schema, qry)
+	addOrderArgument(schema, qry)
+	addPaginationArguments(qry)
+
+	msg := &ast.FieldDefinition{
+		Name: "msg",
+		Type: &ast.Type{NamedType: "String"},
+	}
+
 	schema.Types["Delete"+defn.Name+"Payload"] = &ast.Definition{
-		Kind: ast.Object,
-		Name: "Delete" + defn.Name + "Payload",
-		Fields: []*ast.FieldDefinition{
-			{
-				Name: "msg",
-				Type: &ast.Type{
-					NamedType: "String",
-				},
-			},
-			numUids,
-		},
+		Kind:   ast.Object,
+		Name:   "Delete" + defn.Name + "Payload",
+		Fields: []*ast.FieldDefinition{qry, msg, numUids},
 	}
 }
 

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -152,11 +152,13 @@ type AddUserPayload {
 }
 
 type DeleteTodoPayload {
+	todo(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo]
 	msg: String
 	numUids: Int
 }
 
 type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -152,6 +152,7 @@ type AddTPayload {
 }
 
 type DeleteTPayload {
+	t(filter: TFilter, order: TOrder, first: Int, offset: Int): [T]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -140,6 +140,7 @@ type AddUserPayload {
 }
 
 type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -141,6 +141,7 @@ type AddCarPayload {
 }
 
 type DeleteCarPayload {
+	car(filter: CarFilter, order: CarOrder, first: Int, offset: Int): [Car]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -136,6 +136,7 @@ type AddUserPayload {
 }
 
 type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -155,16 +155,19 @@ type AddOscarMoviePayload {
 }
 
 type DeleteDirectorPayload {
+	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director]
 	msg: String
 	numUids: Int
 }
 
 type DeleteMoviePayload {
+	movie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
 	msg: String
 	numUids: Int
 }
 
 type DeleteOscarMoviePayload {
+	oscarMovie(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -155,16 +155,19 @@ type AddOscarMoviePayload {
 }
 
 type DeleteDirectorPayload {
+	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director]
 	msg: String
 	numUids: Int
 }
 
 type DeleteMoviePayload {
+	movie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
 	msg: String
 	numUids: Int
 }
 
 type DeleteOscarMoviePayload {
+	oscarMovie(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -159,16 +159,19 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeleteGenrePayload {
+	genre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -148,11 +148,13 @@ type AddMoviePayload {
 }
 
 type DeleteMovieDirectorPayload {
+	movieDirector(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector]
 	msg: String
 	numUids: Int
 }
 
 type DeleteMoviePayload {
+	movie(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -170,21 +170,25 @@ type AddQuestionPayload {
 }
 
 type DeleteAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
 	msg: String
 	numUids: Int
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }
 
 type DeleteQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -171,21 +171,25 @@ type AddQuestionPayload {
 }
 
 type DeleteAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
 	msg: String
 	numUids: Int
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }
 
 type DeleteQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -170,21 +170,25 @@ type AddQuestionPayload {
 }
 
 type DeleteAnswerPayload {
+	answer(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer]
 	msg: String
 	numUids: Int
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }
 
 type DeleteQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -146,11 +146,13 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -146,11 +146,13 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -143,6 +143,7 @@ type AddProductPayload {
 }
 
 type DeleteProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -150,11 +150,13 @@ type AddLibraryPayload {
 }
 
 type DeleteBookPayload {
+	book(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
 	msg: String
 	numUids: Int
 }
 
 type DeleteLibraryItemPayload {
+	libraryItem(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -177,21 +177,25 @@ type AddStarshipPayload {
 }
 
 type DeleteCharacterPayload {
+	character(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	msg: String
 	numUids: Int
 }
 
 type DeleteDroidPayload {
+	droid(filter: DroidFilter, order: DroidOrder, first: Int, offset: Int): [Droid]
 	msg: String
 	numUids: Int
 }
 
 type DeleteHumanPayload {
+	human(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	msg: String
 	numUids: Int
 }
 
 type DeleteStarshipPayload {
+	starship(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -177,21 +177,25 @@ type AddStarshipPayload {
 }
 
 type DeleteCharacterPayload {
+	character(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	msg: String
 	numUids: Int
 }
 
 type DeleteDroidPayload {
+	droid(filter: DroidFilter, order: DroidOrder, first: Int, offset: Int): [Droid]
 	msg: String
 	numUids: Int
 }
 
 type DeleteHumanPayload {
+	human(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	msg: String
 	numUids: Int
 }
 
 type DeleteStarshipPayload {
+	starship(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -135,6 +135,7 @@ type AddPostPayload {
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -157,6 +157,7 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -136,6 +136,7 @@ type AddAuthorPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -150,11 +150,13 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -162,6 +162,7 @@ type AddPostPayload {
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -144,6 +144,7 @@ type AddPostPayload {
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -138,6 +138,7 @@ type AddMessagePayload {
 }
 
 type DeleteMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -151,11 +151,13 @@ type AddHumanPayload {
 }
 
 type DeleteCharacterPayload {
+	character(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	msg: String
 	numUids: Int
 }
 
 type DeleteHumanPayload {
+	human(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -148,11 +148,13 @@ type AddPostPayload {
 }
 
 type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	msg: String
 	numUids: Int
 }
 
 type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -144,11 +144,13 @@ type AddMessagePayload {
 }
 
 type DeleteAbstractPayload {
+	abstract(filter: AbstractFilter, order: AbstractOrder, first: Int, offset: Int): [Abstract]
 	msg: String
 	numUids: Int
 }
 
 type DeleteMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -148,11 +148,13 @@ type AddUserPayload {
 }
 
 type DeleteCarPayload {
+	car(filter: CarFilter, order: CarOrder, first: Int, offset: Int): [Car]
 	msg: String
 	numUids: Int
 }
 
 type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -143,6 +143,7 @@ type AddUserPayload {
 }
 
 type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1191,7 +1191,7 @@ func (m *mutation) SelectionSet() []Field {
 
 func (m *mutation) QueryField() Field {
 	for _, f := range m.SelectionSet() {
-		if f.Name() == NumUid || f.Name() == Typename {
+		if f.Name() == NumUid || f.Name() == Typename || f.Name() == Msg {
 			continue
 		}
 		// if @cascade was given on mutation itself, then it should get applied for the query which


### PR DESCRIPTION
Allows delete mutation requests to query the deleted objects.
Now delete payload looks as following:

type deleteTodoPayload {
  todo(...filter, page...etc) : [Todo]
  msg: String
  numUids: Int
}

(cherry picked from commit f29c5bbc026667c4bf6b5199ad8a9e124310ef47)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5864)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-7226c6e27f-76078.surge.sh)
<!-- Dgraph:end -->