### PR TITLE
fix(GraphQL): fix panic error when there is no @withSubscription directive on any type.

### DIFF
--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -97,6 +97,6 @@
   gqlvariables:
     { }
   errors:
-    [ { "message": "Cannot query field \"getAuthor\" on type \"subscription\".",
+    [ { "message": "Cannot query field \"getAuthor\" on type \"Subscription\".",
         "locations": [ { "line": 2, "column": 3 } ] } ]
 

--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -88,3 +88,15 @@
   errors:
     [ { "message": "must be defined",
       "path": [ "variable", "filter"] } ]
+-
+  name: "subscription on type without @withSubscription directive"
+  gqlrequest: |
+    subscription {
+      getAuthor(id: "0x1") { name }
+    }
+  gqlvariables:
+    { }
+  errors:
+    [ { "message": "Cannot query field \"getAuthor\" on type \"subscription\".",
+        "locations": [ { "line": 2, "column": 3 } ] } ]
+

--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -89,7 +89,7 @@
     [ { "message": "must be defined",
       "path": [ "variable", "filter"] } ]
 -
-  name: "subscription on type without @withSubscription directive"
+  name: "subscription on type without @withSubscription directive should retur error"
   gqlrequest: |
     subscription {
       getAuthor(id: "0x1") { name }

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -217,7 +217,12 @@ func TestSchema_Normal(t *testing.T) {
 			"index": true,
 			"tokenizer": ["exact"],
 			"list": true
-		}],
+		},
+        {
+             "predicate": "Person.name",
+			 "type": "string"
+        },
+     ],
 		"types": [{
 			"fields": [{
 				"name": "Author.name"
@@ -368,8 +373,6 @@ func TestSchema_Normal(t *testing.T) {
              "name": "People"
          },{
 			"fields": [{
-				"name": "Person.xid"
-			}, {
 				"name": "Person.name"
 			}],
 			"name": "Person"

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -217,11 +217,15 @@ func TestSchema_Normal(t *testing.T) {
 			"index": true,
 			"tokenizer": ["exact"],
 			"list": true
-		},
+		}, 
+        {
+             "predicate": "Person.id",
+			 "type": uid
+        },
         {
              "predicate": "Person.name",
 			 "type": "string"
-        },
+        }
      ],
 		"types": [{
 			"fields": [{

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -217,11 +217,7 @@ func TestSchema_Normal(t *testing.T) {
 			"index": true,
 			"tokenizer": ["exact"],
 			"list": true
-		}, 
-        {
-             "predicate": "Person.id",
-			 "type": uid
-        },
+		},
         {
              "predicate": "Person.name",
 			 "type": "string"

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -365,7 +365,13 @@ func TestSchema_Normal(t *testing.T) {
 			}, {
 				"name": "Student.taughtBy"
 			}],
-			"name": "Student"
+             {
+			"fields": [{
+				"name": "Person.xid"
+			}, {
+				"name": "Person.name"
+			}],
+			"name": "Person"
 		}, {
 			"fields": [{
 				"name": "dgraph.graphql.schema"

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -217,12 +217,12 @@ func TestSchema_Normal(t *testing.T) {
 			"index": true,
 			"tokenizer": ["exact"],
 			"list": true
-		},
-        {
-             "predicate": "Person.name",
+		},{
+                         "predicate": "Person.name",
 			 "type": "string"
-        }
-     ],
+                  
+                   }],
+
 		"types": [{
 			"fields": [{
 				"name": "Author.name"
@@ -351,7 +351,7 @@ func TestSchema_Normal(t *testing.T) {
 				"name": "People.name"
 			}],
 			"name": "People"
-		}, {
+		       }, {
 			"fields": [{
 				"name": "People.xid"
 			}, {
@@ -370,8 +370,8 @@ func TestSchema_Normal(t *testing.T) {
 			}, {
 				"name": "Student.taughtBy"
 			}],
-             "name": "People"
-         },{
+                        "name": "Student"
+                },{
 			"fields": [{
 				"name": "Person.name"
 			}],

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -365,7 +365,8 @@ func TestSchema_Normal(t *testing.T) {
 			}, {
 				"name": "Student.taughtBy"
 			}],
-             {
+             "name": "People"
+         },{
 			"fields": [{
 				"name": "Person.xid"
 			}, {

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -139,3 +139,7 @@ type Student implements People {
         taughtBy: [Teacher] @hasInverse(field: teaches)
 }
 
+type Person @withSubscription{
+    id: ID!
+    name: String!
+}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -572,7 +572,7 @@ func AsSchema(s *ast.Schema) (Schema, error) {
 	// vektah/gqlparser library doesn't validate subscriptions properly if s.Subscription == nil.
 	//s.Subscription is nil when there is no type with @withSubscription true, so we are handling that case.
 	if s.Subscription == nil {
-		s.Subscription = &ast.Definition{Name: "subscription"}
+		s.Subscription = &ast.Definition{Name: "Subscription"}
 	}
 	// Auth rules can't be effectively validated as part of the normal rules -
 	// because they need the fully generated schema to be checked against.

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -569,6 +569,8 @@ func customMappings(s *ast.Schema) map[string]map[string]*ast.Directive {
 // AsSchema wraps a github.com/vektah/gqlparser/ast.Schema.
 func AsSchema(s *ast.Schema) (Schema, error) {
 
+	// vektah/gqlparser library doesn't validate subscriptions properly if s.Subscription == nil.
+	//s.Subscription is nil when there is no type with @withSubscription true, so we are handling that case.
 	if s.Subscription == nil {
 		s.Subscription = &ast.Definition{Name: "subscription"}
 	}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -569,6 +569,9 @@ func customMappings(s *ast.Schema) map[string]map[string]*ast.Directive {
 // AsSchema wraps a github.com/vektah/gqlparser/ast.Schema.
 func AsSchema(s *ast.Schema) (Schema, error) {
 
+	if s.Subscription == nil {
+		s.Subscription = &ast.Definition{Name: "subscription"}
+	}
 	// Auth rules can't be effectively validated as part of the normal rules -
 	// because they need the fully generated schema to be checked against.
 	authRules, err := authRules(s)


### PR DESCRIPTION
This PR fixes panic error when there is no @withSubscription directive on any type.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5874)
<!-- Reviewable:end -->
