### PR TITLE
feat(GraphQL): GraphQL health now reported by /probe/graphql (#5802)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -470,9 +470,18 @@ func setupServer(closer *y.Closer) {
 	// The global epoch is set to maxUint64 while exiting the server.
 	// By using this information polling goroutine terminates the subscription.
 	globalEpoch := uint64(0)
-	var mainServer web.IServeGraphQL
-	mainServer, adminServer = admin.NewServers(introspection, &globalEpoch, closer)
+	mainServer, adminServer, gqlHealthStore := admin.NewServers(introspection, &globalEpoch, closer)
 	http.Handle("/graphql", mainServer.HTTPHandler())
+	http.HandleFunc("/probe/graphql", func(w http.ResponseWriter, r *http.Request) {
+		healthStatus := gqlHealthStore.GetHealth()
+		httpStatusCode := http.StatusOK
+		if !healthStatus.Healthy {
+			httpStatusCode = http.StatusServiceUnavailable
+		}
+		w.WriteHeader(httpStatusCode)
+		w.Header().Set("Content-Type", "application/json")
+		x.Check2(w.Write([]byte(fmt.Sprintf(`{"status":"%s"}`, healthStatus.StatusMsg))))
+	})
 	http.Handle("/admin", allowedMethodsHandler(allowedMethods{
 		http.MethodGet:     true,
 		http.MethodPost:    true,

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -42,7 +42,7 @@ import (
 
 const touchedUidsHeader = "Graphql-TouchedUids"
 
-// An IServeGraphQL can serve a GraphQL endpoint (currently only ons http)
+// An IServeGraphQL can serve a GraphQL endpoint (currently only on http)
 type IServeGraphQL interface {
 
 	// After ServeGQL is called, this IServeGraphQL serves the new resolvers.


### PR DESCRIPTION
Fixes #GRAPHQL-507.

This PR adds /probe/graphql HTTP endpoint which returns HTTP status 200 OK, if the /graphql endpoint is up and running otherwise it returns HTTP status 503 Service Unavailable. It also returns a JSON body of the following form:

{"status":"init/up/updating schema"}
Status init is returned for 503, while the rest of the two statuses return 200 code.

(cherry picked from commit 072f6b29abd2e0d94a073b08066a49156bfd27eb)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5875)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-90682c3914-76256.surge.sh)
<!-- Dgraph:end -->