### PR TITLE
fix(readPostingList): Return error instead of panic

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -317,7 +317,9 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 		case BitDeltaPosting:
 			err := item.Value(func(val []byte) error {
 				pl := &pb.PostingList{}
-				x.Check(pl.Unmarshal(val))
+				if err := pl.Unmarshal(val); err != nil {
+					return err
+				}
 				pl.CommitTs = item.Version()
 				for _, mpost := range pl.Postings {
 					// commitTs, startTs are meant to be only in memory, not


### PR DESCRIPTION
We've seen some panics like `proto: illegal wireType 6` on trying to read the posting lists. We haven't found the fix yet. The issue could be because badger is returning incorrect values for the posting list. Since we haven't been able to reproduce it, this is a stop-gap solution to return an error instead of crashing dgraph. This is not the fix, this will return an error instead of causing a panic.

Fixes DGRAPH-1778

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5877)
<!-- Reviewable:end -->
