### PR TITLE
fix(GraphQL): Typename for types should be filled in query for schema introspection queries (#5827)

### DIFF
--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -40,7 +40,9 @@ const (
             }
 		],
 		"enumValues":[]
-	} }`
+	},
+	  "__typename" : "Query"
+	}`
 
 	expectedForType = `
 	{ "__type": {
@@ -75,7 +77,7 @@ const (
             }
 		],
 		"enumValues":[]
-	} }`
+	}, "__typename" : "Query" }`
 
 	expectedForEnum = `
 	{ "__type": {
@@ -98,7 +100,7 @@ const (
             }
 		],
 		"fields":[]
-    } }`
+    }, "__typename" : "Query" }`
 )
 
 func SchemaTest(t *testing.T, expectedDgraphSchema string) {
@@ -138,6 +140,7 @@ func graphQLDescriptions(t *testing.T) {
 				description
 			}
 		}
+		__typename
 	}`
 
 	for testName, tCase := range testCases {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -237,6 +237,10 @@ func (rf *resolverFactory) WithSchemaIntrospection() ResolverFactory {
 		WithQueryResolver("__type",
 			func(q schema.Query) QueryResolver {
 				return QueryResolverFunc(resolveIntrospection)
+			}).
+		WithQueryResolver("__typename",
+			func(q schema.Query) QueryResolver {
+				return QueryResolverFunc(resolveIntrospection)
 			})
 }
 

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -25,7 +25,7 @@ import (
 // Introspect performs an introspection query given a query that's expected to be either
 // __schema or __type.
 func Introspect(q Query) (json.RawMessage, error) {
-	if q.Name() != "__schema" && q.Name() != "__type" {
+	if q.Name() != "__schema" && q.Name() != "__type" && q.Name() != Typename {
 		return nil, errors.New("call to introspect for field that isn't an introspection query " +
 			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
 	}
@@ -164,7 +164,6 @@ func (ec *executionContext) handleQuery(sel ast.Selection) []byte {
 		}
 		ec.writeKey(field.Alias)
 		switch field.Name {
-		// TODO - Add tests for __typename.
 		case Typename:
 			x.Check2(ec.b.WriteString(`"Query"`))
 		case "__type":
@@ -327,7 +326,7 @@ func (ec *executionContext) handleType(sel ast.SelectionSet, obj *introspection.
 		ec.writeKey(field.Alias)
 		switch field.Name {
 		case Typename:
-			x.Check2(ec.b.WriteString(`"__Type`))
+			x.Check2(ec.b.WriteString(`"__Type"`))
 		case "kind":
 			ec.writeStringValue(obj.Kind())
 		case "name":

--- a/graphql/schema/introspection_test.go
+++ b/graphql/schema/introspection_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -143,7 +144,7 @@ func TestIntrospectionQueryMissingNameArg(t *testing.T) {
 		schema {
 			query: TestType
 		}
-	
+
 		type TestType {
 			testField: String
 		}
@@ -220,6 +221,122 @@ func TestIntrospectionQueryWithVars(t *testing.T) {
 	testutil.CompareJSON(t, string(expectedBuf), string(resp))
 }
 
+const (
+	testIntrospectionQuery = `query {
+		__schema {
+		  __typename
+		  queryType {
+			name
+			__typename
+		  }
+		  mutationType {
+			name
+			__typename
+		  }
+		  subscriptionType {
+			name
+			__typename
+		  }
+		  types {
+			...FullType
+		  }
+		  directives {
+			__typename
+			name
+			locations
+			args {
+			  ...InputValue
+			}
+		  }
+		}
+	  }
+	  fragment FullType on __Type {
+		kind
+		name
+		fields(includeDeprecated: true) {
+		  __typename
+		  name
+		  args {
+			...InputValue
+			__typename
+		  }
+		  type {
+			...TypeRef
+			__typename
+		  }
+		  isDeprecated
+		  deprecationReason
+		}
+		inputFields {
+		  ...InputValue
+		  __typename
+		}
+		interfaces {
+		  ...TypeRef
+		  __typename
+		}
+		enumValues(includeDeprecated: true) {
+		  name
+		  isDeprecated
+		  deprecationReason
+		  __typename
+		}
+		possibleTypes {
+		  ...TypeRef
+		  __typename
+		}
+		__typename
+	  }
+	  fragment InputValue on __InputValue {
+		__typename
+		name
+		type {
+		  ...TypeRef
+		}
+		defaultValue
+	  }
+	  fragment TypeRef on __Type {
+		kind
+		name
+		ofType {
+		  kind
+		  name
+		  ofType {
+			kind
+			name
+			ofType {
+			  kind
+			  name
+			  ofType {
+				kind
+				name
+				ofType {
+				  kind
+				  name
+				  ofType {
+					kind
+					name
+					ofType {
+					  kind
+					  name
+					  __typename
+					}
+					__typename
+				  }
+				  __typename
+				}
+				__typename
+			  }
+			  __typename
+			}
+			__typename
+		  }
+		  __typename
+		}
+		__typename
+	  }`
+)
+
 func TestFullIntrospectionQuery(t *testing.T) {
 	sch := gqlparser.MustLoadSchema(
 		&ast.Source{Name: "schema.graphql", Input: `
@@ -232,7 +349,7 @@ func TestFullIntrospectionQuery(t *testing.T) {
 	}
 `})
 
-	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: introspectionQuery})
+	doc, gqlErr := parser.ParseQuery(&ast.Source{Input: testIntrospectionQuery})
 	require.Nil(t, gqlErr)
 
 	listErr := validator.Validate(sch, doc)
@@ -242,13 +359,14 @@ func TestFullIntrospectionQuery(t *testing.T) {
 	require.NotNil(t, op)
 	oper := &operation{op: op,
 		vars:     map[string]interface{}{},
-		query:    string(introspectionQuery),
+		query:    string(testIntrospectionQuery),
 		doc:      doc,
 		inSchema: &schema{schema: sch},
 	}
 
 	queries := oper.Queries()
 	resp, err := Introspect(queries[0])
+	fmt.Println(string(resp))
 	require.NoError(t, err)
 
 	expectedBuf, err := ioutil.ReadFile("testdata/introspection/output/full_query.json")

--- a/graphql/schema/testdata/introspection/output/full_query.json
+++ b/graphql/schema/testdata/introspection/output/full_query.json
@@ -1,7 +1,9 @@
 {
     "__schema": {
+        "__typename": "__Schema",
         "queryType": {
-            "name": "TestType"
+            "name": "TestType",
+            "__typename": "__Type"
         },
         "mutationType": null,
         "subscriptionType": null,
@@ -13,46 +15,8 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "OBJECT",
-                "name": "TestType",
-                "fields": [
-                    {
-                        "name": "testField",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "SCALAR",
-                "name": "ID",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "SCALAR",
-                "name": "String",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "SCALAR",
@@ -61,22 +25,49 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "OBJECT",
+                "name": "TestType",
+                "fields": [
+                    {
+                        "__typename": "__Field",
+                        "name": "testField",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    }
+                ],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "SCALAR",
-                "name": "Int",
+                "name": "ID",
                 "fields": [],
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
                 "name": "__Schema",
                 "fields": [
                     {
+                        "__typename": "__Field",
                         "name": "types",
                         "args": [],
                         "type": {
@@ -91,15 +82,20 @@
                                     "ofType": {
                                         "kind": "OBJECT",
                                         "name": "__Type",
-                                        "ofType": null
-                                    }
-                                }
-                            }
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "queryType",
                         "args": [],
                         "type": {
@@ -108,35 +104,42 @@
                             "ofType": {
                                 "kind": "OBJECT",
                                 "name": "__Type",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "mutationType",
                         "args": [],
                         "type": {
                             "kind": "OBJECT",
                             "name": "__Type",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "subscriptionType",
                         "args": [],
                         "type": {
                             "kind": "OBJECT",
                             "name": "__Type",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "directives",
                         "args": [],
                         "type": {
@@ -151,10 +154,14 @@
                                     "ofType": {
                                         "kind": "OBJECT",
                                         "name": "__Directive",
-                                        "ofType": null
-                                    }
-                                }
-                            }
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -163,171 +170,71 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
-                "name": "__Type",
+                "name": "__InputValue",
                 "fields": [
                     {
-                        "name": "kind",
+                        "__typename": "__Field",
+                        "name": "name",
                         "args": [],
                         "type": {
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
-                                "kind": "ENUM",
-                                "name": "__TypeKind",
-                                "ofType": null
-                            }
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
-                        "name": "name",
-                        "args": [],
-                        "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
+                        "__typename": "__Field",
                         "name": "description",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
-                        "name": "fields",
-                        "args": [
-                            {
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                },
-                                "defaultValue": "false"
-                            }
-                        ],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Field",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "interfaces",
+                        "__typename": "__Field",
+                        "name": "type",
                         "args": [],
                         "type": {
-                            "kind": "LIST",
+                            "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
+                                "kind": "OBJECT",
+                                "name": "__Type",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
-                        "name": "possibleTypes",
+                        "__typename": "__Field",
+                        "name": "defaultValue",
                         "args": [],
                         "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__Type",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "enumValues",
-                        "args": [
-                            {
-                                "name": "includeDeprecated",
-                                "type": {
-                                    "kind": "SCALAR",
-                                    "name": "Boolean",
-                                    "ofType": null
-                                },
-                                "defaultValue": "false"
-                            }
-                        ],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__EnumValue",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "inputFields",
-                        "args": [],
-                        "type": {
-                            "kind": "LIST",
-                            "name": null,
-                            "ofType": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "__InputValue",
-                                    "ofType": null
-                                }
-                            }
-                        },
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ofType",
-                        "args": [],
-                        "type": {
-                            "kind": "OBJECT",
-                            "name": "__Type",
-                            "ofType": null
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -336,7 +243,8 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "ENUM",
@@ -348,51 +256,71 @@
                     {
                         "name": "SCALAR",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "OBJECT",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "INTERFACE",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "UNION",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "ENUM",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "INPUT_OBJECT",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "LIST",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     },
                     {
                         "name": "NON_NULL",
                         "isDeprecated": false,
-                        "deprecationReason": null
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
                     }
                 ],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "SCALAR",
+                "name": "Int",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
                 "name": "__Field",
                 "fields": [
                     {
+                        "__typename": "__Field",
                         "name": "name",
                         "args": [],
                         "type": {
@@ -401,24 +329,29 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "String",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "description",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "args",
                         "args": [],
                         "type": {
@@ -433,15 +366,20 @@
                                     "ofType": {
                                         "kind": "OBJECT",
                                         "name": "__InputValue",
-                                        "ofType": null
-                                    }
-                                }
-                            }
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "type",
                         "args": [],
                         "type": {
@@ -450,13 +388,16 @@
                             "ofType": {
                                 "kind": "OBJECT",
                                 "name": "__Type",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "isDeprecated",
                         "args": [],
                         "type": {
@@ -465,19 +406,23 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "Boolean",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "deprecationReason",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -486,60 +431,334 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "ENUM",
+                "name": "__DirectiveLocation",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [
+                    {
+                        "name": "QUERY",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "MUTATION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SUBSCRIPTION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FIELD",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FRAGMENT_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FRAGMENT_SPREAD",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INLINE_FRAGMENT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SCHEMA",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "SCALAR",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "FIELD_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ARGUMENT_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INTERFACE",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "UNION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ENUM",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "ENUM_VALUE",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INPUT_OBJECT",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    },
+                    {
+                        "name": "INPUT_FIELD_DEFINITION",
+                        "isDeprecated": false,
+                        "deprecationReason": null,
+                        "__typename": "__EnumValue"
+                    }
+                ],
+                "possibleTypes": [],
+                "__typename": "__Type"
+            },
+            {
+                "kind": "SCALAR",
+                "name": "String",
+                "fields": [],
+                "inputFields": [],
+                "interfaces": [],
+                "enumValues": [],
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
-                "name": "__InputValue",
+                "name": "__Type",
                 "fields": [
                     {
-                        "name": "name",
+                        "__typename": "__Field",
+                        "name": "kind",
                         "args": [],
                         "type": {
                             "kind": "NON_NULL",
                             "name": null,
                             "ofType": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            }
+                                "kind": "ENUM",
+                                "name": "__TypeKind",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
+                        "name": "name",
+                        "args": [],
+                        "type": {
+                            "kind": "SCALAR",
+                            "name": "String",
+                            "ofType": null,
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
                         "name": "description",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
-                        "name": "type",
-                        "args": [],
+                        "__typename": "__Field",
+                        "name": "fields",
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "defaultValue": "false"
+                            }
+                        ],
                         "type": {
-                            "kind": "NON_NULL",
+                            "kind": "LIST",
                             "name": null,
                             "ofType": {
-                                "kind": "OBJECT",
-                                "name": "__Type",
-                                "ofType": null
-                            }
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Field",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
-                        "name": "defaultValue",
+                        "__typename": "__Field",
+                        "name": "interfaces",
                         "args": [],
                         "type": {
-                            "kind": "SCALAR",
-                            "name": "String",
-                            "ofType": null
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "possibleTypes",
+                        "args": [],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__Type",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "enumValues",
+                        "args": [
+                            {
+                                "__typename": "__InputValue",
+                                "name": "includeDeprecated",
+                                "type": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "defaultValue": "false"
+                            }
+                        ],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__EnumValue",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "inputFields",
+                        "args": [],
+                        "type": {
+                            "kind": "LIST",
+                            "name": null,
+                            "ofType": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "__InputValue",
+                                    "ofType": null,
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "isDeprecated": false,
+                        "deprecationReason": null
+                    },
+                    {
+                        "__typename": "__Field",
+                        "name": "ofType",
+                        "args": [],
+                        "type": {
+                            "kind": "OBJECT",
+                            "name": "__Type",
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -548,13 +767,15 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
                 "name": "__EnumValue",
                 "fields": [
                     {
+                        "__typename": "__Field",
                         "name": "name",
                         "args": [],
                         "type": {
@@ -563,24 +784,29 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "String",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "description",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "isDeprecated",
                         "args": [],
                         "type": {
@@ -589,19 +815,23 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "Boolean",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "deprecationReason",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -610,13 +840,15 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             },
             {
                 "kind": "OBJECT",
                 "name": "__Directive",
                 "fields": [
                     {
+                        "__typename": "__Field",
                         "name": "name",
                         "args": [],
                         "type": {
@@ -625,24 +857,29 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "String",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "description",
                         "args": [],
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "locations",
                         "args": [],
                         "type": {
@@ -657,15 +894,20 @@
                                     "ofType": {
                                         "kind": "ENUM",
                                         "name": "__DirectiveLocation",
-                                        "ofType": null
-                                    }
-                                }
-                            }
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
                     },
                     {
+                        "__typename": "__Field",
                         "name": "args",
                         "args": [],
                         "type": {
@@ -680,10 +922,14 @@
                                     "ofType": {
                                         "kind": "OBJECT",
                                         "name": "__InputValue",
-                                        "ofType": null
-                                    }
-                                }
-                            }
+                                        "ofType": null,
+                                        "__typename": "__Type"
+                                    },
+                                    "__typename": "__Type"
+                                },
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "isDeprecated": false,
                         "deprecationReason": null
@@ -692,134 +938,13 @@
                 "inputFields": [],
                 "interfaces": [],
                 "enumValues": [],
-                "possibleTypes": []
-            },
-            {
-                "kind": "ENUM",
-                "name": "__DirectiveLocation",
-                "fields": [],
-                "inputFields": [],
-                "interfaces": [],
-                "enumValues": [
-                    {
-                        "name": "QUERY",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "MUTATION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SUBSCRIPTION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FIELD",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FRAGMENT_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FRAGMENT_SPREAD",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INLINE_FRAGMENT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SCHEMA",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "SCALAR",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "FIELD_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ARGUMENT_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INTERFACE",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "UNION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ENUM",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "ENUM_VALUE",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INPUT_OBJECT",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    },
-                    {
-                        "name": "INPUT_FIELD_DEFINITION",
-                        "isDeprecated": false,
-                        "deprecationReason": null
-                    }
-                ],
-                "possibleTypes": []
+                "possibleTypes": [],
+                "__typename": "__Type"
             }
         ],
         "directives": [
             {
-                "name": "include",
-                "locations": [
-                    "FIELD",
-                    "FRAGMENT_SPREAD",
-                    "INLINE_FRAGMENT"
-                ],
-                "args": [
-                    {
-                        "name": "if",
-                        "type": {
-                            "kind": "NON_NULL",
-                            "name": null,
-                            "ofType": {
-                                "kind": "SCALAR",
-                                "name": "Boolean",
-                                "ofType": null
-                            }
-                        },
-                        "defaultValue": null
-                    }
-                ]
-            },
-            {
+                "__typename": "__Directive",
                 "name": "skip",
                 "locations": [
                     "FIELD",
@@ -828,6 +953,7 @@
                 ],
                 "args": [
                     {
+                        "__typename": "__InputValue",
                         "name": "if",
                         "type": {
                             "kind": "NON_NULL",
@@ -835,14 +961,17 @@
                             "ofType": {
                                 "kind": "SCALAR",
                                 "name": "Boolean",
-                                "ofType": null
-                            }
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
                         },
                         "defaultValue": null
                     }
                 ]
             },
             {
+                "__typename": "__Directive",
                 "name": "deprecated",
                 "locations": [
                     "FIELD_DEFINITION",
@@ -850,13 +979,42 @@
                 ],
                 "args": [
                     {
+                        "__typename": "__InputValue",
                         "name": "reason",
                         "type": {
                             "kind": "SCALAR",
                             "name": "String",
-                            "ofType": null
+                            "ofType": null,
+                            "__typename": "__Type"
                         },
                         "defaultValue": "\"No longer supported\""
+                    }
+                ]
+            },
+            {
+                "__typename": "__Directive",
+                "name": "include",
+                "locations": [
+                    "FIELD",
+                    "FRAGMENT_SPREAD",
+                    "INLINE_FRAGMENT"
+                ],
+                "args": [
+                    {
+                        "__typename": "__InputValue",
+                        "name": "if",
+                        "type": {
+                            "kind": "NON_NULL",
+                            "name": null,
+                            "ofType": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null,
+                                "__typename": "__Type"
+                            },
+                            "__typename": "__Type"
+                        },
+                        "defaultValue": null
                     }
                 ]
             }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1102,7 +1102,7 @@ func queryType(name string, custom *ast.Directive) QueryType {
 		return HTTPQuery
 	case strings.HasPrefix(name, "get"):
 		return GetQuery
-	case name == "__schema" || name == "__type":
+	case name == "__schema" || name == "__type" || name == "__typename":
 		return SchemaQuery
 	case strings.HasPrefix(name, "query"):
 		return FilterQuery


### PR DESCRIPTION


There was a missing " in the __typename that was filled in for types in schema introspection queries. That resulted in JSON parsing errors, we have fixed it and modified the existing test to test for it. Fixes #5792.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5891)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5f8d263489-76705.surge.sh)
<!-- Dgraph:end -->