### PR TITLE
(release/v20.03) test: Handle kB units in size_test.go

### DIFF
--- a/posting/size_test.go
+++ b/posting/size_test.go
@@ -218,7 +218,8 @@ func Test21MillionDataSetSize(t *testing.T) {
 func filterUnit(line string) (string, error) {
 	words := strings.Split(line, " ")
 	for _, word := range words {
-		if strings.Contains(word, "MB") || strings.Contains(word, "GB") {
+		if strings.Contains(word, "MB") || strings.Contains(word, "GB") ||
+			strings.Contains(word, "kB") {
 			return strings.TrimSpace(word), nil
 		}
 	}
@@ -227,6 +228,13 @@ func filterUnit(line string) (string, error) {
 
 // convertToBytes converts the unit into bytes.
 func convertToBytes(unit string) (uint32, error) {
+	if strings.Contains(unit, "kB") {
+		kb, err := strconv.ParseFloat(unit[0:len(unit)-2], 64)
+		if err != nil {
+			return 0, err
+		}
+		return uint32(kb * 1024.0), nil
+	}
 	if strings.Contains(unit, "MB") {
 		mb, err := strconv.ParseFloat(unit[0:len(unit)-2], 64)
 		if err != nil {


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5900)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f95e22ed05-76945.surge.sh)
<!-- Dgraph:end -->