### PR TITLE
fix(Flaky): TestLiveLoadExportedSchema

### DIFF
--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -201,13 +202,13 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 	time.Sleep(time.Second)
 
 	// copy the export files from docker
-	exportId := copyExportToLocalFs(t)
+	exportId, groupId := copyExportToLocalFs(t)
 
 	// then loading the exported files should work
 	pipeline := [][]string{
 		{testutil.DgraphBinaryPath(), "live",
-			"--schema", localExportPath + "/" + exportId + "/g01.schema.gz",
-			"--files", localExportPath + "/" + exportId + "/g01.rdf.gz",
+			"--schema", localExportPath + "/" + exportId + "/" + groupId + ".schema.gz",
+			"--files", localExportPath + "/" + exportId + "/" + groupId + ".rdf.gz",
 			"--encryption_key_file", testDataDir + "/../../../../ee/enc/test-fixtures/enc-key",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -218,7 +219,7 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 	require.NoError(t, os.RemoveAll(localExportPath), "Error removing export copy directory")
 }
 
-func copyExportToLocalFs(t *testing.T) string {
+func copyExportToLocalFs(t *testing.T) (string, string) {
 	require.NoError(t, os.RemoveAll(localExportPath), "Error removing directory")
 	require.NoError(t, testutil.DockerCp(alphaExportPath, localExportPath),
 		"Error copying files from docker container")
@@ -227,7 +228,13 @@ func copyExportToLocalFs(t *testing.T) string {
 	require.NoError(t, err, "Couldn't read local export copy directory")
 	require.True(t, len(childDirs) > 0, "Local export copy directory is empty!!!")
 
-	return childDirs[0].Name()
+	exportFiles, err := ioutil.ReadDir(localExportPath + "/" + childDirs[0].Name())
+	require.NoError(t, err, "Couldn't read child of local export copy directory")
+	require.True(t, len(exportFiles) > 0, "no exported files found!!!")
+
+	groupId := strings.Split(exportFiles[0].Name(), ".")[0]
+
+	return childDirs[0].Name(), groupId
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
This PR fixes flaky behavior in `TestLiveLoadExportedSchema`. It used to happen because of the export file naming. It was assumed that the exported file is always named `g01.schema.gz`, but it turns out that the initial prefix `g01` is based on group id, on which the request was executed. So, this PR changes the filename to be dynamically read at export time.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5903)
<!-- Reviewable:end -->
