### PR TITLE
release/v1.2: fix(readPostingList): Return error instead of panic (#5877)

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -190,7 +190,9 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 		case BitDeltaPosting:
 			err := item.Value(func(val []byte) error {
 				pl := &pb.PostingList{}
-				x.Check(pl.Unmarshal(val))
+				if err := pl.Unmarshal(val); err != nil {
+					return err
+				}
 				pl.CommitTs = item.Version()
 				for _, mpost := range pl.Postings {
 					// commitTs, startTs are meant to be only in memory, not


### PR DESCRIPTION
We've seen some panics like "proto: illegal wireType 6" on trying to read the
posting lists. We haven't found the fix yet. The issue could be because badger
is returning incorrect values for the posting list. Since we haven't been able
to reproduce it, this is a stop-gap solution to return an error instead of
crashing dgraph.

This is not the fix, this will return an error instead of
causing a panic.

Fixes DGRAPH-1778

(cherry picked from commit f2773c8eb362881928f3448c8ff109ef51c032ff)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5908)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->