### PR TITLE
fix(dgraph): ludicrous mode mutation error (#5701)

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -435,9 +435,6 @@ func (s *Server) doMutate(ctx context.Context, qc *queryContext, resp *api.Respo
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
-	if x.WorkerConfig.LudicrousMode {
-		qc.req.StartTs = worker.State.GetTimestamp(false)
-	}
 
 	start := time.Now()
 	defer func() {

--- a/systest/21million/docker-compose-ludicrous.yml
+++ b/systest/21million/docker-compose-ludicrous.yml
@@ -1,0 +1,78 @@
+# Auto-generated with: [./compose -a 3 -z 1 -r 1 -d data -w]
+#
+version: "3.5"
+services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+    - 8180:8180
+    - 9180:9180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=1 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --ludicrous_mode
+  alpha2:
+    image: dgraph/dgraph:latest
+    container_name: alpha2
+    working_dir: /data/alpha2
+    depends_on:
+    - alpha1
+    labels:
+      cluster: test
+    ports:
+    - 8182:8182
+    - 9182:9182
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 102 --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --ludicrous_mode
+  alpha3:
+    image: dgraph/dgraph:latest
+    container_name: alpha3
+    working_dir: /data/alpha3
+    depends_on:
+    - alpha2
+    labels:
+      cluster: test
+    ports:
+    - 8183:8183
+    - 9183:9183
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph alpha -o 103 --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180
+      --logtostderr -v=2 --idx=3 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --ludicrous_mode
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+    - 5180:5180
+    - 6180:6180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data:/data
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=1 --logtostderr
+      -v=2 --bindall --ludicrous_mode
+volumes:
+  data:

--- a/systest/21million/test-21million.sh
+++ b/systest/21million/test-21million.sh
@@ -18,10 +18,13 @@ function Info {
 function DockerCompose {
     docker-compose -p dgraph "$@"
 }
+function DgraphLive {
+    dgraph live "$@"
+}
 
-HELP= LOADER=bulk CLEANUP= SAVEDIR= LOAD_ONLY= QUIET=
+HELP= LOADER=bulk CLEANUP= SAVEDIR= LOAD_ONLY= QUIET= MODE=
 
-ARGS=$(/usr/bin/getopt -n$ME -o"h" -l"help,loader:,cleanup:,savedir:,load-only,quiet" -- "$@") || exit 1
+ARGS=$(/usr/bin/getopt -n$ME -o"h" -l"help,loader:,cleanup:,savedir:,load-only,quiet,mode:" -- "$@") || exit 1
 eval set -- "$ARGS"
 while true; do
     case "$1" in
@@ -31,6 +34,7 @@ while true; do
         --savedir)      SAVEDIR=${2,,}; shift  ;;
         --load-only)    LOAD_ONLY=yes          ;;
         --quiet)        QUIET=yes              ;;
+        --mode)         MODE=${2,,}; shift  ;;
         --)             shift; break           ;;
     esac
     shift
@@ -38,7 +42,7 @@ done
 
 if [[ $HELP ]]; then
     cat <<EOF
-usage: $ME [-h|--help] [--loader=<bulk|live|none>] [--cleanup=<all|none|servers>] [--savedir=path]
+usage: $ME [-h|--help] [--loader=<bulk|live|none>] [--cleanup=<all|none|servers>] [--savedir=path] [--mode=<normal|ludicrous|none>]
 
 options:
 
@@ -52,6 +56,9 @@ options:
                     for easier post-test review
     --load-only     load data but do not run tests
     --quiet         just report which queries differ, without a diff
+    --mode          normal = run dgraph in normal mode
+                    none = run dgraph in normal mode
+                    ludicrous = run dgraph in ludicrous mode
 EOF
     exit 0
 fi
@@ -65,6 +72,17 @@ fi
 # if already re-using it from a previous run
 if [[ $LOADER == none && -z $CLEANUP ]]; then
     CLEANUP=servers
+fi
+
+if [[ $MODE == ludicrous ]]; then
+    Info "removing old data (if any)"
+    DockerCompose down -v --remove-orphans
+    function DockerCompose {
+        docker-compose -f docker-compose-ludicrous.yml -p dgraph "$@"
+    }
+    function DgraphLive {
+        dgraph live --ludicrous_mode "$@"
+    }
 fi
 
 # default to cleaning up both services and volume
@@ -123,9 +141,13 @@ sleep 10
 
 if [[ $LOADER == live ]]; then
     Info "live loading data set"
-    dgraph live --schema=$SCHEMA_FILE --files=$DATA_FILE \
-                --format=rdf --zero=:5180 --alpha=:9180 --logtostderr
+    DgraphLive --schema=$SCHEMA_FILE --files=$DATA_FILE \
+                --format=rdf --zero=:5180 --alpha=:9180 --logtostderr --ludicrous_mode
+    if [[ $MODE == ludicrous ]]; then
+        sleep 300
+    fi
 fi
+
 
 if [[ $LOAD_ONLY ]]; then
     Info "exiting after data load"

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -643,6 +643,10 @@ func (n *node) processApplyCh() {
 			psz := proposal.Size()
 			totalSize += int64(psz)
 
+			if x.WorkerConfig.LudicrousMode && proposal.Mutations != nil && proposal.Mutations.StartTs == 0 {
+				proposal.Mutations.StartTs = State.GetTimestamp(false)
+			}
+
 			var perr error
 			p, ok := previous[proposal.Key]
 			if ok && p.err == nil && p.size == psz {


### PR DESCRIPTION
Fixes out of order commit in ludicrous mode.
DGRAPH-1612

(cherry picked from commit 2a8c17f56660a2b7481f63391dfcd7543faeb14c)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5915)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d4a51dc7c6-78854.surge.sh)
<!-- Dgraph:end -->