### PR TITLE
fix(GraphQL): Validate subscriptions in Operation function

### DIFF
--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -139,7 +139,7 @@ type Student implements People {
         taughtBy: [Teacher] @hasInverse(field: "teaches")
 }
 
-type Message {
+type Message @withSubscription {
     content: String! @dgraph(pred: "post")
     author: String @dgraph(pred: "<职业>")
 }

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -399,6 +399,13 @@ func TestManyMutationsWithError(t *testing.T) {
 	}
 }
 
+func TestSubscriptionErrorWhenNoneDefined(t *testing.T) {
+	gqlSchema := test.LoadSchemaFromString(t, testGQLSchema)
+	resp := resolveWithClient(gqlSchema, `subscription { foo }`, nil, nil)
+	test.RequireJSONEq(t, x.GqlErrorList{{Message: "Not resolving subscription because schema" +
+		" doesn't have any fields defined for subscription operation."}}, resp.Errors)
+}
+
 func resolve(gqlSchema schema.Schema, gqlQuery string, dgResponse string) *schema.Response {
 	return resolveWithClient(gqlSchema, gqlQuery, nil, &executor{resp: dgResponse})
 }

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -55,6 +55,12 @@ func (s *schema) Operation(req *Request) (Operation, error) {
 		return nil, listErr
 	}
 
+	if len(doc.Operations) == 1 && doc.Operations[0].Operation == ast.Subscription &&
+		s.schema.Subscription == nil {
+		return nil, errors.Errorf("Not resolving subscription because schema doesn't have any " +
+			"fields defined for subscription operation.")
+	}
+
 	if len(doc.Operations) > 1 && req.OperationName == "" {
 		return nil, errors.Errorf("Operation name must by supplied when query has more " +
 			"than 1 operation.")

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -568,12 +568,6 @@ func customMappings(s *ast.Schema) map[string]map[string]*ast.Directive {
 
 // AsSchema wraps a github.com/vektah/gqlparser/ast.Schema.
 func AsSchema(s *ast.Schema) (Schema, error) {
-
-	// vektah/gqlparser library doesn't validate subscriptions properly if s.Subscription == nil.
-	//s.Subscription is nil when there is no type with @withSubscription true, so we are handling that case.
-	if s.Subscription == nil {
-		s.Subscription = &ast.Definition{Name: "Subscription"}
-	}
 	// Auth rules can't be effectively validated as part of the normal rules -
 	// because they need the fully generated schema to be checked against.
 	authRules, err := authRules(s)


### PR DESCRIPTION
We realised that as a result of b40c63254cfc3b4a4f3af9cb36d3d4fb2cb18cad, introspection queries started failing in Insomnia because subscription didn't exist in the types. Instead of adding more hacks there, we add validation for this inside Operation. We already do something similar for Queries/Mutations. If queries/mutations are not defined (say only custom queries/mutation were), we return this error.

```
{
  "errors": [
    {
      "message": "yo was not executed because no suitable resolver could be found - this indicates a resolver or validation bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)"
    }]
}

```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5926)
<!-- Reviewable:end -->
