### PR TITLE
fix(bulk-schema flaky test): Add sleep time to wait for clusters before querying for schema in the test (#5826)

### DIFF
--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -243,6 +243,7 @@ pushd dir2 >/dev/null
 StartZero
 BulkLoadExportedData
 StartAlpha "./out/0/p"
+sleep 5
 QuerySchema
 StopServers
 
@@ -258,6 +259,7 @@ pushd dir3 >/dev/null
 StartZero
 BulkLoadFixtureData
 StartAlpha "./out/0/p"
+sleep 5
 QuerySchema
 StopServers
 


### PR DESCRIPTION
Add sleep to prevent query on unhealthy cluster

(cherry picked from commit b537eff70da0fe884106f6c00ec49e642d2cda24)

Partially
Fixes DGRAPH-1643
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5932)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-4020b5e3dc-77910.surge.sh)
<!-- Dgraph:end -->