### PR TITLE
fix(badger): Update badger to v20.07.0-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/blevesearch/segment v0.0.0-20160915185041-762005e7a34f // indirect
 	github.com/blevesearch/snowballstem v0.0.0-20180110192139-26b06a2c243d // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200609141616-14386ac9b764
+	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200711090415-0dfb8b45d4a4
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453
-	github.com/dgraph-io/ristretto v0.0.2
+	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/dgryski/go-groupvarint v0.0.0-20190318181831-5ce5df8ca4e1

--- a/go.sum
+++ b/go.sum
@@ -78,13 +78,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200609141616-14386ac9b764 h1:cWmYs+E7F/w4KWIkVrV3VLUJkqolRa7y5G2LLMPQVQs=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200609141616-14386ac9b764/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200711090415-0dfb8b45d4a4 h1:M85aROJxDOXmp8mZQN6x04EraKDGOF2RL3ox/6LZdjo=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200711090415-0dfb8b45d4a4/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453 h1:DTgOrw91nMIukDm/WEvdobPLl0LgeDd/JE66+24jBks=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200401175452-e463f9234453/go.mod h1:Co+FwJrnndSrPORO8Gdn20dR7FPTfmXr0W/su0Ve/Ig=
-github.com/dgraph-io/ristretto v0.0.2-0.20200115201040-8f368f2f2ab3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
-github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -170,6 +170,9 @@ func (s *ServerState) initStorage() {
 		glog.Infof("Opening postings BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
 
+		// Disable conflict detection in badger since dgraph performs its own conflict detection.
+		opt.DetectConflicts = false
+
 		s.Pstore, err = badger.OpenManaged(opt)
 		x.Checkf(err, "Error while creating badger KV posting store")
 

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -170,9 +170,6 @@ func (s *ServerState) initStorage() {
 		glog.Infof("Opening postings BadgerDB with options: %+v\n", opt)
 		opt.EncryptionKey = key
 
-		// Disable conflict detection in badger since dgraph performs its own conflict detection.
-		opt.DetectConflicts = false
-
 		s.Pstore, err = badger.OpenManaged(opt)
 		x.Checkf(err, "Error while creating badger KV posting store")
 


### PR DESCRIPTION
Fixes https://github.com/dgraph-io/dgraph/issues/5573

This commit brings the following new changes from badger.

This description was generated using this script:
```sh
#!/bin/bash

set -e
GHORG=${GHORG:-dgraph-io}
GHREPO=${GHREPO:-badger}
cat <<EOF
This description was generated using this script:
\`\`\`sh
`cat $0`
\`\`\`
Invoked as:

    `echo GHORG=${GHORG} GHREPO=${GHREPO} $(basename $0) ${@:1}`

EOF
git log --oneline --reverse ${@:1} \
  | sed -E "s/^(\S{7}\s)//g" \
  | sed -E "s/([\s|\(| ])#([0-9]+)/\1${GHORG}\/${GHREPO}#\2/g" \
```
Invoked as:

    GHORG=dgraph-io GHREPO=badger changes.sh 14386ac9b76...0dfb8b45d4a4

Fix assert in background compression and encryption. (dgraph-io/badger#1366)
Avoid panic in filltables() (dgraph-io/badger#1365)
Force KeepL0InMemory to be true when InMemory is true (dgraph-io/badger#1375)
Tests: Use t.Parallel in TestIteratePrefix tests  (dgraph-io/badger#1377)
Remove second initialization of writech in Open (dgraph-io/badger#1382)
Increase default valueThreshold from 32B to 1KB (dgraph-io/badger#1346)
pre allocate cache key for the block cache and the bloom filter cache (dgraph-io/badger#1371)
Rework DB.DropPrefix (dgraph-io/badger#1381)
Update head while replaying value log (dgraph-io/badger#1372)
Update ristretto to commit f66de99 (dgraph-io/badger#1391)
Enable cross-compiled 32bit tests on TravisCI (dgraph-io/badger#1392)
Avoid panic on multiple closer.Signal calls (dgraph-io/badger#1401)
Add a contribution guide (dgraph-io/badger#1379)
add assert to check integer overflow for table size (dgraph-io/badger#1402)
return error if the vlog writes exceeds more that 4GB. (dgraph-io/badger#1400)
Revert "add assert to check integer overflow for table size (dgraph-io/badger#1402)" (dgraph-io/badger#1406)
Revert "fix: Fix race condition in block.incRef (dgraph-io/badger#1337)" (dgraph-io/badger#1407)
Revert "Buffer pool for decompression (dgraph-io/badger#1308)" (dgraph-io/badger#1408)
Revert "Compress/Encrypt Blocks in the background (dgraph-io/badger#1227)" (dgraph-io/badger#1409)
Add missing changelog for v2.0.3 (dgraph-io/badger#1410)
Changelog for v20.07.0 (dgraph-io/badger#1411)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5939)
<!-- Reviewable:end -->
