### PR TITLE
fix(Query): Fix val queries when ACL is enabled

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -42,7 +42,7 @@ import (
 
 type predsAndvars struct {
 	preds []string
-	vars  map[string]struct{ predicate string }
+	vars  map[string]string
 }
 
 // Login handles login requests from clients.
@@ -689,13 +689,13 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 
 func parsePredsFromQuery(gqls []*gql.GraphQuery) predsAndvars {
 	predsMap := make(map[string]struct{})
-	varsMap := make(map[string]struct{ predicate string })
+	varsMap := make(map[string]string)
 	for _, gq := range gqls {
 		if gq.Func != nil {
 			predsMap[gq.Func.Attr] = struct{}{}
 		}
 		if len(gq.Var) > 0 {
-			varsMap[gq.Var] = struct{ predicate string }{predicate: gq.Attr}
+			varsMap[gq.Var] = gq.Attr
 		}
 		if len(gq.Attr) > 0 && gq.Attr != "uid" && gq.Attr != "expand" && gq.Attr != "val" {
 			predsMap[gq.Attr] = struct{}{}
@@ -781,7 +781,7 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 	// list of blocked predicates
 	predToVarsMap := make(map[string]string)
 	for k, v := range varsToPredMap {
-		predToVarsMap[v.predicate] = k
+		predToVarsMap[v] = k
 	}
 
 	doAuthorizeQuery := func() (map[string]struct{}, []string, error) {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -42,7 +42,7 @@ import (
 
 type predsAndvars struct {
 	preds []string
-	vars  []string
+	vars  map[string]struct{ predicate string }
 }
 
 // Login handles login requests from clients.
@@ -689,13 +689,13 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 
 func parsePredsFromQuery(gqls []*gql.GraphQuery) predsAndvars {
 	predsMap := make(map[string]struct{})
-	varsMap := make(map[string]struct{})
+	varsMap := make(map[string]struct{ predicate string })
 	for _, gq := range gqls {
 		if gq.Func != nil {
 			predsMap[gq.Func.Attr] = struct{}{}
 		}
 		if len(gq.Var) > 0 {
-			varsMap[gq.Var] = struct{}{}
+			varsMap[gq.Var] = struct{ predicate string }{predicate: gq.Attr}
 		}
 		if len(gq.Attr) > 0 && gq.Attr != "uid" && gq.Attr != "expand" && gq.Attr != "val" {
 			predsMap[gq.Attr] = struct{}{}
@@ -714,21 +714,18 @@ func parsePredsFromQuery(gqls []*gql.GraphQuery) predsAndvars {
 		for _, childPred := range childPredandVars.preds {
 			predsMap[childPred] = struct{}{}
 		}
-		for _, childVar := range childPredandVars.vars {
-			varsMap[childVar] = struct{}{}
+		for childVar := range childPredandVars.vars {
+			varsMap[childVar] = childPredandVars.vars[childVar]
 		}
 	}
 	preds := make([]string, 0, len(predsMap))
-	vars := make([]string, 0, len(varsMap))
 	for pred := range predsMap {
 		if _, found := varsMap[pred]; !found {
 			preds = append(preds, pred)
 		}
 	}
-	for variable := range varsMap {
-		vars = append(vars, variable)
-	}
-	pv := predsAndvars{preds: preds, vars: vars}
+
+	pv := predsAndvars{preds: preds, vars: varsMap}
 	return pv
 }
 
@@ -776,7 +773,17 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 
 	var userId string
 	var groupIds []string
-	preds := parsePredsFromQuery(parsedReq.Query).preds
+	predsAndvars := parsePredsFromQuery(parsedReq.Query)
+	preds := predsAndvars.preds
+	varsToPredMap := predsAndvars.vars
+
+	// Need this to efficiently identify blocked variables from the
+	// list of blocked predicates
+	predToVarsMap := make(map[string]string)
+	for k, v := range varsToPredMap {
+		predToVarsMap[v.predicate] = k
+	}
+
 	doAuthorizeQuery := func() (map[string]struct{}, []string, error) {
 		userData, err := extractUserAndGroups(ctx)
 		if err != nil {
@@ -826,7 +833,18 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 			// In query context ~predicate and predicate are considered different.
 			delete(blockedPreds, "~dgraph.user.group")
 		}
+
+		blockedVars := make(map[string]struct{})
+		for predicate := range blockedPreds {
+			if variable, found := predToVarsMap[predicate]; found {
+				// Add variables to blockedPreds to delete from Query
+				blockedPreds[variable] = struct{}{}
+				// Collect blocked Variables to remove from QueryVars
+				blockedVars[variable] = struct{}{}
+			}
+		}
 		parsedReq.Query = removePredsFromQuery(parsedReq.Query, blockedPreds)
+		parsedReq.QueryVars = removeVarsFromQueryVars(parsedReq.QueryVars, blockedVars)
 	}
 	for i := range parsedReq.Query {
 		parsedReq.Query[i].AllowedPreds = allowedPreds
@@ -1077,6 +1095,7 @@ func removePredsFromQuery(gqs []*gql.GraphQuery,
 	blockedPreds map[string]struct{}) []*gql.GraphQuery {
 
 	filteredGQs := gqs[:0]
+L:
 	for _, gq := range gqs {
 		if gq.Func != nil && len(gq.Func.Attr) > 0 {
 			if _, ok := blockedPreds[gq.Func.Attr]; ok {
@@ -1086,6 +1105,15 @@ func removePredsFromQuery(gqs []*gql.GraphQuery,
 		if len(gq.Attr) > 0 {
 			if _, ok := blockedPreds[gq.Attr]; ok {
 				continue
+			}
+			if gq.Attr == "val" {
+				// TODO (Anurag): If val supports multiple variables, this would
+				// need an upgrade
+				for _, variable := range gq.NeedsVar {
+					if _, ok := blockedPreds[variable.Name]; ok {
+						continue L
+					}
+				}
 			}
 		}
 
@@ -1104,6 +1132,30 @@ func removePredsFromQuery(gqs []*gql.GraphQuery,
 		filteredGQs = append(filteredGQs, gq)
 	}
 
+	return filteredGQs
+}
+
+func removeVarsFromQueryVars(gqs []*gql.Vars,
+	blockedVars map[string]struct{}) []*gql.Vars {
+
+	filteredGQs := gqs[:0]
+	for _, gq := range gqs {
+		var defines []string
+		var needs []string
+		for _, variable := range gq.Defines {
+			if _, ok := blockedVars[variable]; !ok {
+				defines = append(defines, variable)
+			}
+		}
+		for _, variable := range gq.Needs {
+			if _, ok := blockedVars[variable]; !ok {
+				needs = append(needs, variable)
+			}
+		}
+		gq.Defines = defines
+		gq.Needs = needs
+		filteredGQs = append(filteredGQs, gq)
+	}
 	return filteredGQs
 }
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1315,14 +1315,88 @@ func TestValQueryWithACLPermissions(t *testing.T) {
     q2(func: eq(val(v), "RandomGuy")) {
 		val(v)
 		val(a)
-    }}`
+	}}`
 
 	// Test that groot has access to all the predicates
 	resp, err := dg.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err, "Error while querying data")
-	// testutil.CompareJSON(t, `{"me":[{"name":"RandomGuy","age":23, "nickname":"RG"},{"name":"RandomGuy2","age":25, "nickname":"RG2"}]}`,
-	// 	string(resp.GetJson()))
-	fmt.Println(string(resp.GetJson()))
+	testutil.CompareJSON(t, `{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],"q2":[{"val(v)":"RandomGuy","val(a)":23}]}`,
+		string(resp.GetJson()))
+
+	// All test cases
+	tests := []struct {
+		input                  string
+		descriptionNoPerm      string
+		outputNoPerm           string
+		descriptionNamePerm    string
+		outputNamePerm         string
+		descriptionNameAgePerm string
+		outputNameAgePerm      string
+	}{
+		{
+			`
+			{
+				q1(func: has(name)) {
+					v as name
+					a as age
+				}
+				q2(func: eq(val(v), "RandomGuy")) {
+					val(v)
+					val(a)
+				}
+			}
+			`,
+			"alice doesn't have access to name or age",
+			`{}`,
+
+			`alice has access to name`,
+			`{"q1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],"q2":[{"val(v)":"RandomGuy"}]}`,
+
+			"alice has access to name and age",
+			`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],"q2":[{"val(v)":"RandomGuy","val(a)":23}]}`,
+		},
+		{
+			`{
+				q1(func: has(name) ) {
+					a as age
+				}
+				q2(func: has(name) ) {
+					val(a)
+				}
+			}`,
+			"alice doesn't have access to name or age",
+			`{}`,
+
+			`alice has access to name`,
+			`{"q1":[],"q2":[]}`,
+
+			"alice has access to name and age",
+			`{"q1":[{"age":23},{"age":25}],"q2":[{"val(a)":23},{"val(a)":25}]}`,
+		},
+		{
+			`{
+				f as q1(func: has(name) ) {
+					n as name
+					a as age
+				}
+				q2(func: uid(f), orderdesc: val(a) ) {
+					name
+					val(n)
+					val(a)
+				}
+			}`,
+			"alice doesn't have access to name or age",
+			`{"q2":[]}`,
+
+			`alice has access to name`,
+			`{"q1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],
+			"q2":[{"name":"RandomGuy","val(n)":"RandomGuy"},{"name":"RandomGuy2","val(n)":"RandomGuy2"}]}`,
+
+			"alice has access to name and age",
+			`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],
+			"q2":[{"name":"RandomGuy2","val(n)":"RandomGuy2","val(a)":25},{"name":"RandomGuy","val(n)":"RandomGuy","val(a)":23}]}`,
+		},
+	}
 
 	userClient, err := testutil.DgraphClient(testutil.SockAddr)
 	require.NoError(t, err)
@@ -1332,10 +1406,15 @@ func TestValQueryWithACLPermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Query via user when user has no permissions
-	resp, err = userClient.NewReadOnlyTxn().Query(ctx, query)
-	require.NoError(t, err, "Error while querying data")
-	// testutil.CompareJSON(t, `{}`, string(resp.GetJson()))
-	fmt.Println(string(resp.GetJson()))
+	for _, tc := range tests {
+		desc := tc.descriptionNoPerm
+		t.Run(desc, func(t *testing.T) {
+			resp, err := userClient.NewTxn().Query(ctx, tc.input)
+			require.NoError(t, err)
+			testutil.CompareJSON(t, tc.outputNoPerm, string(resp.Json))
+		})
+	}
+
 	// Login to groot to modify accesses (1)
 	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
 		Endpoint: adminEndpoint,
@@ -1344,14 +1423,18 @@ func TestValQueryWithACLPermissions(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-	// Give read access of <name>, write access of <age> to dev
+	// Give read access of <name> to dev
 	addRulesToGroup(t, accessJwt, devGroup, []rule{{"name", Read.Code}})
 	time.Sleep(6 * time.Second)
-	resp, err = userClient.NewReadOnlyTxn().Query(ctx, query)
-	require.NoError(t, err, "Error while querying data")
-	// testutil.CompareJSON(t, `{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
-	// string(resp.GetJson()))
-	fmt.Println(string(resp.GetJson()))
+
+	for _, tc := range tests {
+		desc := tc.descriptionNamePerm
+		t.Run(desc, func(t *testing.T) {
+			resp, err := userClient.NewTxn().Query(ctx, tc.input)
+			require.NoError(t, err)
+			testutil.CompareJSON(t, tc.outputNamePerm, string(resp.Json))
+		})
+	}
 
 	// Login to groot to modify accesses (1)
 	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
@@ -1364,11 +1447,15 @@ func TestValQueryWithACLPermissions(t *testing.T) {
 	// Give read access of <name> and <age> to dev
 	addRulesToGroup(t, accessJwt, devGroup, []rule{{"name", Read.Code}, {"age", Read.Code}})
 	time.Sleep(6 * time.Second)
-	resp, err = userClient.NewReadOnlyTxn().Query(ctx, query)
-	require.NoError(t, err, "Error while querying data")
-	// testutil.CompareJSON(t, `{"me":[{"name":"RandomGuy"},{"name":"RandomGuy2"}]}`,
-	// string(resp.GetJson()))
-	fmt.Println(string(resp.GetJson()))
+
+	for _, tc := range tests {
+		desc := tc.descriptionNameAgePerm
+		t.Run(desc, func(t *testing.T) {
+			resp, err := userClient.NewTxn().Query(ctx, tc.input)
+			require.NoError(t, err)
+			testutil.CompareJSON(t, tc.outputNameAgePerm, string(resp.Json))
+		})
+	}
 
 }
 func TestNewACLPredicates(t *testing.T) {


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

### Motivation
This PR partially fixes:

- DGRAPH-1711 -- `expand(_all_)` and `value variable` queries do not work with ACL turned on. This PR fixes the issues with `value variable` queries.

For a detailed discussion and repro examples refer [here.](https://github.com/dgraph-io/dgraph/issues/5687)

<!-- Besides the motivation itself, if applicable, you should add references. e.g public conversations (URL) in the community. This helps reviewers with context. You should also advocate for the PR if needed. You can ping Daniel, Karthic, Michel or Santo if you need help. -->

### Components affected by this PR <!-- (Optional) -->
`value variables` queries when ACL is enabled. <!-- Please, take a minute to think about what or who this PR affects. Does it need help for doing documentation? Does it affect third parties (Open Source or not) applications? Make it clear so we can track and fix it. --><!-- e.g. "It breaks/affects Ratel UI behavior." or You are working on documentation. Check if any links will be broken with your changes. -->

### Does this PR break backwards compatibility?  <!-- (Optional) -->
No.

### Testing <!-- (Optional) -->
See `TestValQueryWithACLPermissions` in `acl_test.go`.
Tests include various queries related to `val(variable)` under following circumstances:
1. User has access to no predicate
2. User has access to only one predicate 
3. User has access to all predicates.

### Fixes <!-- (Optional) -->
Partially
Fixes DGRAPH-1711

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5945)
<!-- Reviewable:end -->
