### PR TITLE
fix(dgraph): Dgraph version picked from git tags on master

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -19,8 +19,14 @@ BUILD          ?= $(shell git rev-parse --short HEAD)
 BUILD_CODENAME  = unnamed
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
-# Set latest tag as BUILD_VERSION
-BUILD_VERSION ?= $(shell git for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1)
+
+# use a large version number v99 on master branch
+ifeq ($(BUILD_BRANCH),master)
+BUILD_VERSION ?= 'v20.11.0-'$(BUILD)
+else
+BUILD_VERSION ?= $(shell git describe --always --tags)
+endif
+
 BUILD_TAGS    ?=
 GOPATH        ?= $(shell go env GOPATH)
 

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -23,13 +23,15 @@ BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 # Use the next build version on master branch
 # NOTE: this needs to be updated with each new release
 ifeq ($(BUILD_BRANCH),master)
-BUILD_VERSION ?= 'v20.11.0-'$(BUILD)
+# Version on master is of the format <next-release-version>-g<commit-id>
+BUILD_VERSION ?= 'v20.11.0-g'$(BUILD)
 else
 BUILD_VERSION ?= $(shell git describe --always --tags)
 endif
 
 BUILD_TAGS    ?=
 GOPATH        ?= $(shell go env GOPATH)
+MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
 export GO111MODULE := on
 

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-<<<<<<< HEAD
 BIN             = dgraph
 BUILD          ?= $(shell git rev-parse --short HEAD)
 BUILD_CODENAME  = unnamed

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -20,7 +20,8 @@ BUILD_CODENAME  = unnamed
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 
-# use a large version number v99 on master branch
+# Use the next build version on master branch
+# NOTE: this needs to be updated with each new release
 ifeq ($(BUILD_BRANCH),master)
 BUILD_VERSION ?= 'v20.11.0-'$(BUILD)
 else

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -14,16 +14,16 @@
 # limitations under the License.
 #
 
+<<<<<<< HEAD
 BIN             = dgraph
 BUILD          ?= $(shell git rev-parse --short HEAD)
 BUILD_CODENAME  = unnamed
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
-BUILD_VERSION  ?= $(shell git describe --always --tags)
-BUILD_TAGS     ?=
-GOPATH         ?= $(shell go env GOPATH)
-
-MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
+# Set latest tag as BUILD_VERSION
+BUILD_VERSION ?= $(shell git for-each-ref refs/tags --sort=-taggerdate --format='%(refname:short)' --count=1)
+BUILD_TAGS    ?=
+GOPATH        ?= $(shell go env GOPATH)
 
 export GO111MODULE := on
 

--- a/query/query.go
+++ b/query/query.go
@@ -2639,7 +2639,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 	stop := x.SpanTimer(span, "query.ProcessQuery")
 	defer stop()
 
-	// doneVars stores the processed variables.
+	// Vars stores the processed variables.
 	req.Vars = make(map[string]varValue)
 	loopStart := time.Now()
 	queries := req.GqlQuery.Query


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
Fixes DGRAPH-1734
Use next release version as the dgraph version number for dgraph build on master branch. Refer: https://discuss.dgraph.io/t/health-endpoint-doesnt-show-a-version-when-built-from-master/8566/ for discussion about this.

Earlier `git describe` was being used to get the recent tag which is yielding `v2.0.0-rc1-503-g144685a84` on master. `git describe` finds the last ancestor commit which is shared with any tag and yield that tag. It's unclear why it's yielding an old tag on master. May be something wrong with the commit history somewhere.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5956)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-79bbaa9719-82639.surge.sh)
<!-- Dgraph:end -->