### PR TITLE
Removed slack references from tutorial pages

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -300,4 +300,3 @@ communicate with Dgraph from your application.
 feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues)
 if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).

--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -291,7 +291,7 @@ We have defined 4 environments:
 
 **dev-oss / dev-enterprise**: These are events seen on non-released / local developer builds.
 
-**prod-oss/prod-enterprise**: These are events on released version such as v20.03.0.
+**prod-oss/prod-enterprise**: These are events on released version such as v20.03.0. Events in this category are also sent on a slack channel private to Dgraph
 
 **Tags:**
 

--- a/wiki/content/howto/index.md
+++ b/wiki/content/howto/index.md
@@ -291,7 +291,7 @@ We have defined 4 environments:
 
 **dev-oss / dev-enterprise**: These are events seen on non-released / local developer builds.
 
-**prod-oss/prod-enterprise**: These are events on released version such as v20.03.0. Events in this category are also sent on a slack channel private to Dgraph
+**prod-oss/prod-enterprise**: These are events on released version such as v20.03.0.
 
 **Tags:**
 

--- a/wiki/content/tutorial-2/index.md
+++ b/wiki/content/tutorial-2/index.md
@@ -377,4 +377,3 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 * Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).

--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -398,7 +398,6 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 * Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-5/index.md
+++ b/wiki/content/tutorial-5/index.md
@@ -581,7 +581,6 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 * Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-6/index.md
+++ b/wiki/content/tutorial-6/index.md
@@ -384,4 +384,3 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 * Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).

--- a/wiki/content/tutorials/index.md
+++ b/wiki/content/tutorials/index.md
@@ -125,4 +125,3 @@ with Dgraph from your application.
 
 * Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
 * Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
-* You can also join our [Slack channel](http://slack.dgraph.io).


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5965)
<!-- Reviewable:end -->
