### PR TITLE
feat(Usability): /state endpoint explicitly show the default values (e.g. leader=false)

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -90,7 +90,7 @@ func (st *state) assign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m := jsonpb.Marshaler{}
+	m := jsonpb.Marshaler{EmitDefaults: true}
 	if err := m.Marshal(w, ids); err != nil {
 		x.SetStatus(w, x.ErrorNoData, err.Error())
 		return
@@ -225,7 +225,7 @@ func (st *state) getState(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	m := jsonpb.Marshaler{}
+	m := jsonpb.Marshaler{EmitDefaults: true}
 	if err := m.Marshal(w, mstate); err != nil {
 		x.SetStatus(w, x.ErrorNoData, err.Error())
 		return

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -881,7 +881,7 @@ func (s *Server) State(ctx context.Context) (*api.Response, error) {
 		return nil, errors.Errorf("No membership state found")
 	}
 
-	m := jsonpb.Marshaler{}
+	m := jsonpb.Marshaler{EmitDefaults: true}
 	var jsonState bytes.Buffer
 	if err := m.Marshal(&jsonState, ms); err != nil {
 		return nil, errors.Errorf("Error marshalling state information to JSON")


### PR DESCRIPTION
1. This PR enhances usability by not omitting default fields in `/state` and `/assign` endpoints.

Earlier:
```json
{
  "zeros": {
    "1": {
      "id": "1",
      "addr": "localhost:5080",
      "leader": true
    },
    "2": {
      "id": "2",
      "addr": "localhost:5081"
    }
  },
  "maxTxnTs": "10000",
  "maxRaftId": "2",
  "cid": "256a5894-c3d2-4d3c-9879-7c29ae2e9584",
  "license": {
    "maxNodes": "18446744073709551615",
    "expiryTs": "1597232998",
    "enabled": true
  }
}
```
Now:
```json
{
  "zeros": {
    "1": {
      "id": "1",
      "groupId": 0,
      "addr": "localhost:5080",
      "leader": true,
      "amDead": false,
      "lastUpdate": "0",
      "clusterInfoOnly": false,
      "forceGroupId": false
    },
    "2": {
      "id": "2",
      "groupId": 0,
      "addr": "localhost:5081",
      "leader": false,
      "amDead": false,
      "lastUpdate": "0",
      "clusterInfoOnly": false,
      "forceGroupId": false
    }
  },
  "maxLeaseId": "0",
  "maxTxnTs": "10000",
  "maxRaftId": "2",
  "removed": [],
  "cid": "cdcb1edb-8c81-4557-af99-ebed2b383e3c",
  "license": {
    "user": "",
    "maxNodes": "18446744073709551615",
    "expiryTs": "1597232699",
    "enabled": true
  }
}
```
**Note the extra default fields added.**
For /assign endpoint:
```json
{
  "startId": "1",
  "endId": "1000",
  "readOnly": "0"
}
```
`readOnly` field is added.

2. Addresses #5742 
3. Fixes DGRAPH-1786

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5966)
<!-- Reviewable:end -->
