### PR TITLE
chore: rename port names for consistency with helm chart

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -20,10 +20,10 @@ spec:
   ports:
   - port: 5080
     targetPort: 5080
-    name: zero-grpc
+    name: grpc-zero
   - port: 6080
     targetPort: 6080
-    name: zero-http
+    name: http-zero
   selector:
     app: dgraph-zero
 ---
@@ -39,10 +39,10 @@ spec:
   ports:
   - port: 8080
     targetPort: 8080
-    name: alpha-http
+    name: http-alpha
   - port: 9080
     targetPort: 9080
-    name: alpha-grpc
+    name: grpc-alpha
   selector:
     app: dgraph-alpha
 ---
@@ -57,7 +57,7 @@ spec:
   ports:
   - port: 8000
     targetPort: 8000
-    name: ratel-http
+    name: http-ratel
   selector:
     app: dgraph-ratel
 ---
@@ -73,7 +73,7 @@ spec:
   ports:
   - port: 5080
     targetPort: 5080
-    name: zero-grpc
+    name: grpc-zero
   clusterIP: None
   # We want all pods in the StatefulSet to have their addresses published for
   # the sake of the other Dgraph Zero pods even before they're ready, since they
@@ -94,7 +94,7 @@ spec:
   ports:
   - port: 7080
     targetPort: 7080
-    name: alpha-grpc-int
+    name: grpc-alpha-int
   clusterIP: None
   # We want all pods in the StatefulSet to have their addresses published for
   # the sake of the other Dgraph alpha pods even before they're ready, since they
@@ -137,9 +137,9 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5080
-          name: zero-grpc
+          name: grpc-zero
         - containerPort: 6080
-          name: zero-http
+          name: http-zero
         volumeMounts:
         - name: datadir
           mountPath: /dgraph
@@ -274,11 +274,11 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 7080
-          name: alpha-grpc-int
+          name: grpc-alpha-int
         - containerPort: 8080
-          name: alpha-http
+          name: http-alpha
         - containerPort: 9080
-          name: alpha-grpc
+          name: grpc-alpha
         volumeMounts:
         - name: datadir
           mountPath: /dgraph

--- a/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
+++ b/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
@@ -10,19 +10,19 @@ spec:
   ports:
   - port: 5080
     targetPort: 5080
-    name: zero-grpc
+    name: grpc-zero
   - port: 6080
     targetPort: 6080
-    name: zero-http
+    name: http-zero
   - port: 8080
     targetPort: 8080
-    name: alpha-http
+    name: http-alpha
   - port: 9080
     targetPort: 9080
-    name: alpha-grpc
+    name: grpc-alpha
   - port: 8000
     targetPort: 8000
-    name: ratel-http
+    name: http-ratel
   selector:
     app: dgraph
 ---
@@ -48,7 +48,7 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
-          name: ratel-http
+          name: http-ratel
         command:
           - dgraph-ratel
       - name: zero
@@ -56,9 +56,9 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 5080
-          name: zero-grpc
+          name: grpc-zero
         - containerPort: 6080
-          name: zero-http
+          name: http-zero
         volumeMounts:
         - name: datadir
           mountPath: /dgraph
@@ -73,9 +73,9 @@ spec:
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8080
-          name: alpha-http
+          name: http-alpha
         - containerPort: 9080
-          name: alpha-grpc
+          name: grpc-alpha
         volumeMounts:
         - name: datadir
           mountPath: /dgraph


### PR DESCRIPTION
This renames the port names used in `dgraph-ha.yaml` and `dgraph-single.yaml` Kubernetes manifests to be consistent with Helm chart port names.  The helm charts port names were changed to support older versions of Itsio naming conventions.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5972)
<!-- Reviewable:end -->
