### PR TITLE
chore: contrib k8s ha support dgraph alpha multiple zero support

### DIFF
--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -290,11 +290,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        # dgraph versions earlier than 1.2.3 can only support one zero:
+        # dgraph versions earlier than v1.2.3 and v20.03.0 can only support one zero:
         #  `dgraph alpha --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080`
-        # dgraph-alpha versions greater than or equal to 1.2.3 or 20.03.1 can support
-        #  a comma seperated list of zeros.  The value below has supports 3 zeros
-        #  (set acording to number of replicas)
+        # dgraph-alpha versions greater than or equal to v1.2.3 or v20.03.1 can support
+        #  a comma separated list of zeros.  The value below has supports 3 zeros
+        #  (set according to number of replicas)
         command:
           - bash
           - "-c"

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -290,12 +290,17 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        # dgraph versions earlier than 1.2.3 can only support one zero:
+        #  `dgraph alpha --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080`
+        # dgraph-alpha versions greater than or equal to 1.2.3 or 20.03.1 can support
+        #  a comma seperated list of zeros.  The value below has supports 3 zeros
+        #  (set acording to number of replicas)
         command:
           - bash
           - "-c"
           - |
             set -ex
-            dgraph alpha --my=$(hostname -f):7080 --lru_mb 2048 --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080
+            dgraph alpha --my=$(hostname -f):7080 --lru_mb 2048 --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080,dgraph-zero-1.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080,dgraph-zero-2.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080
         livenessProbe:
           httpGet:
             path: /health?live=1

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -293,7 +293,7 @@ spec:
         # dgraph versions earlier than v1.2.3 and v20.03.0 can only support one zero:
         #  `dgraph alpha --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080`
         # dgraph-alpha versions greater than or equal to v1.2.3 or v20.03.1 can support
-        #  a comma separated list of zeros.  The value below has supports 3 zeros
+        #  a comma separated list of zeros.  The value below supports 3 zeros
         #  (set according to number of replicas)
         command:
           - bash

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -293,7 +293,7 @@ spec:
         # dgraph versions earlier than v1.2.3 and v20.03.0 can only support one zero:
         #  `dgraph alpha --zero dgraph-zero-0.dgraph-zero.${POD_NAMESPACE}.svc.cluster.local:5080`
         # dgraph-alpha versions greater than or equal to v1.2.3 or v20.03.1 can support
-        #  a comma separated list of zeros.  The value below supports 3 zeros
+        #  a comma-separated list of zeros.  The value below supports 3 zeros
         #  (set according to number of replicas)
         command:
           - bash


### PR DESCRIPTION
This is change to k8s manifest `dgraph-ha.yaml` to support multiple zeros for `dgraph alpha` service and an inline comment for further explanation about the `--zero` option.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5973)
<!-- Reviewable:end -->
