### PR TITLE
fix(GraphQL): Dgraph directive with reverse edge should work smoothly with interfaces (#5911)

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1308,6 +1308,13 @@ func getFieldsWithoutIDType(schema *ast.Schema, defn *ast.Definition) ast.FieldL
 			continue
 		}
 
+		// Remove edges which have a reverse predicate as they should only be updated through their
+		// forward edge.
+		fname := fieldName(fld, defn.Name)
+		if strings.HasPrefix(fname, "~") || strings.HasPrefix(fname, "<~") {
+			continue
+		}
+
 		// see also comment in getNonIDFields
 		if schema.Types[fld.Type.Name()].Kind == ast.Interface &&
 			(!hasID(schema.Types[fld.Type.Name()]) && !hasXID(schema.Types[fld.Type.Name()])) {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -657,6 +657,56 @@ invalid_schemas:
     ]
 
   -
+    name: "Dgraph directive with reverse pred argument matching with wrong type implementing an interface produces an error"
+    input: |
+      type Z {
+        f1: String!
+      }
+      type X {
+        f1: [Z] @dgraph(pred: "f1")
+      }
+
+      interface Person {
+        id: ID!
+      }
+
+      type Y implements Person {
+        f1: [X] @dgraph(pred: "~f1")
+      }
+    errlist: [
+      {"message": "Type X; Field f1: should be any of types Y or Person to be compatible with @dgraph reverse
+      directive but is of type Z.",
+      "locations":[{"line":5, "column":12}]}
+    ]
+
+  -
+    name: "Dgraph directive with reverse pred argument matching with wrong type implementing multiple interfaces produces an error"
+    input: |
+      type Z {
+        f1: String!
+      }
+      type X {
+        f1: [Z] @dgraph(pred: "f1")
+      }
+
+      interface Person {
+        id: ID!
+      }
+
+      interface Student {
+        ids: String! @id
+      }
+
+      type Y implements Person & Student {
+        f1: [X] @dgraph(pred: "~f1")
+      }
+    errlist: [
+      {"message": "Type X; Field f1: should be any of types Y, Person or Student to be compatible with @dgraph reverse
+      directive but is of type Z.",
+      "locations":[{"line":5, "column":12}]}
+    ]
+
+  -
     name: "Field with a dgraph directive with reverse pred argument should be a list"
     input: |
       type X {
@@ -2451,9 +2501,13 @@ valid_schemas:
     name: "dgraph directive with correct reverse field works"
     input: |
       type X {
+        id: ID!
+        name: String
         f1: [Y] @dgraph(pred: "~f1")
       }
       type Y {
+        id: ID!
+        name: String
         f1: [X] @dgraph(pred: "f1")
       }
 
@@ -2604,4 +2658,23 @@ valid_schemas:
           method: "POST",
           body: "{sid: $id}"
           })
+      }
+
+  -
+    name: "dgraph directive with reverse edges should work with interfaces"
+    input: |
+      type Object {
+        id: ID!
+        name: String
+        ownedBy: Person @dgraph(pred: "Object.owner")
+      }
+
+      type BusinessMan implements Person {
+        companyName: String
+      }
+
+      interface Person {
+        id: ID!
+        name: String
+        owns: [Object] @dgraph(pred: "~Object.owner")
       }

--- a/graphql/schema/testdata/schemagen/input/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/input/interface-with-dgraph-pred.graphql
@@ -1,0 +1,15 @@
+type Object {
+  id: ID!
+  name: String
+  ownedBy: Person @dgraph(pred: "Object.owner")
+}
+
+type BusinessMan implements Person {
+  companyName: String
+}
+
+interface Person {
+  id: ID!
+  name: String
+  owns: [Object] @dgraph(pred: "~Object.owner")
+}

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -210,7 +210,6 @@ enum OscarMovieOrderable {
 
 input AddDirectorInput {
 	name: String!
-	directed: [OscarMovieRef]
 }
 
 input AddOscarMovieInput {
@@ -237,7 +236,6 @@ input DirectorPatch {
 input DirectorRef {
 	id: ID
 	name: String
-	directed: [OscarMovieRef]
 }
 
 input MovieFilter {

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -215,7 +215,6 @@ input AddDirectorInput {
 
 input AddOscarMovieInput {
 	name: String!
-	director: [DirectorRef]
 	year: Int!
 }
 
@@ -279,7 +278,6 @@ input OscarMoviePatch {
 input OscarMovieRef {
 	id: ID
 	name: String
-	director: [DirectorRef]
 	year: Int
 }
 

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -192,7 +192,6 @@ input AddMovieDirectorInput {
 
 input AddMovieInput {
 	name: String!
-	director: [MovieDirectorRef]
 }
 
 input MovieDirectorFilter {
@@ -235,7 +234,6 @@ input MoviePatch {
 input MovieRef {
 	id: ID
 	name: String
-	director: [MovieDirectorRef]
 }
 
 input UpdateMovieDirectorInput {

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -1,0 +1,329 @@
+#######################
+# Input Schema
+#######################
+
+type Object {
+	id: ID!
+	name: String
+	ownedBy(filter: PersonFilter): Person @dgraph(pred: "Object.owner")
+}
+
+type BusinessMan implements Person {
+	id: ID!
+	name: String
+	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
+	companyName: String
+}
+
+interface Person {
+	id: ID!
+	name: String
+	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	introspectionHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete:AuthRule) on OBJECT
+directive @custom(http: CustomHTTP) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddBusinessManPayload {
+	businessMan(filter: BusinessManFilter, order: BusinessManOrder, first: Int, offset: Int): [BusinessMan]
+	numUids: Int
+}
+
+type AddObjectPayload {
+	object(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object]
+	numUids: Int
+}
+
+type DeleteBusinessManPayload {
+	businessMan(filter: BusinessManFilter, order: BusinessManOrder, first: Int, offset: Int): [BusinessMan]
+	msg: String
+	numUids: Int
+}
+
+type DeleteObjectPayload {
+	object(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object]
+	msg: String
+	numUids: Int
+}
+
+type DeletePersonPayload {
+	person(filter: PersonFilter, order: PersonOrder, first: Int, offset: Int): [Person]
+	msg: String
+	numUids: Int
+}
+
+type UpdateBusinessManPayload {
+	businessMan(filter: BusinessManFilter, order: BusinessManOrder, first: Int, offset: Int): [BusinessMan]
+	numUids: Int
+}
+
+type UpdateObjectPayload {
+	object(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object]
+	numUids: Int
+}
+
+type UpdatePersonPayload {
+	person(filter: PersonFilter, order: PersonOrder, first: Int, offset: Int): [Person]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum BusinessManOrderable {
+	name
+	companyName
+}
+
+enum ObjectOrderable {
+	name
+}
+
+enum PersonOrderable {
+	name
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddBusinessManInput {
+	name: String
+	companyName: String
+}
+
+input AddObjectInput {
+	name: String
+	ownedBy: PersonRef
+}
+
+input BusinessManFilter {
+	id: [ID!]
+	not: BusinessManFilter
+}
+
+input BusinessManOrder {
+	asc: BusinessManOrderable
+	desc: BusinessManOrderable
+	then: BusinessManOrder
+}
+
+input BusinessManPatch {
+	name: String
+	companyName: String
+}
+
+input BusinessManRef {
+	id: ID
+	name: String
+	companyName: String
+}
+
+input ObjectFilter {
+	id: [ID!]
+	not: ObjectFilter
+}
+
+input ObjectOrder {
+	asc: ObjectOrderable
+	desc: ObjectOrderable
+	then: ObjectOrder
+}
+
+input ObjectPatch {
+	name: String
+	ownedBy: PersonRef
+}
+
+input ObjectRef {
+	id: ID
+	name: String
+	ownedBy: PersonRef
+}
+
+input PersonFilter {
+	id: [ID!]
+	not: PersonFilter
+}
+
+input PersonOrder {
+	asc: PersonOrderable
+	desc: PersonOrderable
+	then: PersonOrder
+}
+
+input PersonPatch {
+	name: String
+}
+
+input PersonRef {
+	id: ID!
+}
+
+input UpdateBusinessManInput {
+	filter: BusinessManFilter!
+	set: BusinessManPatch
+	remove: BusinessManPatch
+}
+
+input UpdateObjectInput {
+	filter: ObjectFilter!
+	set: ObjectPatch
+	remove: ObjectPatch
+}
+
+input UpdatePersonInput {
+	filter: PersonFilter!
+	set: PersonPatch
+	remove: PersonPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getObject(id: ID!): Object
+	queryObject(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object]
+	getBusinessMan(id: ID!): BusinessMan
+	queryBusinessMan(filter: BusinessManFilter, order: BusinessManOrder, first: Int, offset: Int): [BusinessMan]
+	getPerson(id: ID!): Person
+	queryPerson(filter: PersonFilter, order: PersonOrder, first: Int, offset: Int): [Person]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addObject(input: [AddObjectInput!]!): AddObjectPayload
+	updateObject(input: UpdateObjectInput!): UpdateObjectPayload
+	deleteObject(filter: ObjectFilter!): DeleteObjectPayload
+	addBusinessMan(input: [AddBusinessManInput!]!): AddBusinessManPayload
+	updateBusinessMan(input: UpdateBusinessManInput!): UpdateBusinessManPayload
+	deleteBusinessMan(filter: BusinessManFilter!): DeleteBusinessManPayload
+	updatePerson(input: UpdatePersonInput!): UpdatePersonPayload
+	deletePerson(filter: PersonFilter!): DeletePersonPayload
+}
+


### PR DESCRIPTION
Fixes #5744 and GRAPHQL-558

There was another bug where field which map to reverse edges in Dgraph where generated as part of AddTypeInput and TypeRef. They have been excluded now as we can't perform a mutation along them. They would earlier have given an error at runtime while doing mutations in Dgraph about predicate being incorrect because it starts with ~. Apart, from that to fix #5744, we also allow interfaces implemented by the current type in the check.

(cherry picked from commit ecec0714e5a49ca24ef763c132bd4671ac5df46a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5982)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-501fae9641-79369.surge.sh)
<!-- Dgraph:end -->