### PR TITLE
docs(Enterprise): fix typo for EE license application to Zero leader

### DIFF
--- a/wiki/content/enterprise-features/index.md
+++ b/wiki/content/enterprise-features/index.md
@@ -20,7 +20,7 @@ enterprise features.
 {{% /notice %}}
 
 When you have an enterprise license key, the license can be applied to the cluster by including it
-as the body of a POST request and calling `/enterpriseLicense` HTTP endpoint on any Zero server.
+as the body of a POST request and calling `/enterpriseLicense` HTTP endpoint on the leader Zero server.
 
 ```sh
 curl -X POST localhost:6080/enterpriseLicense --upload-file ./licensekey.txt


### PR DESCRIPTION
The POST request for applying the enterprise license key can only be sent to the leader zero endpoint.

```
$ curl -X POST http://10.0.0.10:6080/enterpriseLicense --upload-file licensekey.txt 
{"errors":[{"message":"while proposing enterprise license state to cluster: Not Zero leader. Aborting proposal: license:\u003cuser:\"User\" maxNodes:6 expiryTs:1594752958 \u003e ","extensions":{"code":"ErrorInvalidRequest"}}]}
$ curl -X POST http://10.0.0.11:6080/enterpriseLicense --upload-file licensekey.txt 
{"code": "Success", "message": "License applied."}
```

Fixed this typo in the docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5985)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-96d9a58154-79556.surge.sh)
<!-- Dgraph:end -->