### PR TITLE
fix(dgraph): Panic because of nil map in groups.go

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -924,6 +924,7 @@ func (g *groupi) processOracleDeltaStream() {
 
 		for {
 			var delta *pb.OracleDelta
+			delta.GroupChecksums = make(map[uint32]uint64)
 			var batch int
 			select {
 			case delta = <-deltaCh:
@@ -955,9 +956,6 @@ func (g *groupi) processOracleDeltaStream() {
 					batch++
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
-					if delta.GroupChecksums == nil {
-						delta.GroupChecksums = make(map[uint32]uint64)
-					}
 					for gid, checksum := range more.GroupChecksums {
 						delta.GroupChecksums[gid] = checksum
 					}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -924,7 +924,6 @@ func (g *groupi) processOracleDeltaStream() {
 
 		for {
 			var delta *pb.OracleDelta
-			delta.GroupChecksums = make(map[uint32]uint64)
 			var batch int
 			select {
 			case delta = <-deltaCh:
@@ -954,6 +953,9 @@ func (g *groupi) processOracleDeltaStream() {
 						return
 					}
 					batch++
+					if delta.GroupChecksums == nil {
+						delta.GroupChecksums = make(map[uint32]uint64)
+					}
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
 					for gid, checksum := range more.GroupChecksums {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -955,6 +955,9 @@ func (g *groupi) processOracleDeltaStream() {
 					batch++
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
+					if delta.GroupChecksums == nil {
+						delta.GroupChecksums = make(map[uint32]uint64)
+					}
 					for gid, checksum := range more.GroupChecksums {
 						delta.GroupChecksums[gid] = checksum
 					}


### PR DESCRIPTION
Fixes DGRAPH-1935

delta.GroupChecksums is nil at this point in the code, so copying keys to this map causes the code to panic with message:
`assignment to entry in nil map`

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/5999)
<!-- Reviewable:end -->
