### PR TITLE
Cherry-pick fix(dgraph): Panic because of nil map in groups.go (#5999)

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -945,6 +945,9 @@ func (g *groupi) processOracleDeltaStream() {
 						return
 					}
 					batch++
+					if delta.GroupChecksums == nil {
+						delta.GroupChecksums = make(map[uint32]uint64)
+					}
 					delta.Txns = append(delta.Txns, more.Txns...)
 					delta.MaxAssigned = x.Max(delta.MaxAssigned, more.MaxAssigned)
 					for gid, checksum := range more.GroupChecksums {


### PR DESCRIPTION
Fixes DGRAPH-1935
(cherry picked from commit 3c46878bc98856e5129933b143668a07b4513903)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6007)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-40fb43b51a-80028.surge.sh)
<!-- Dgraph:end -->