### PR TITLE
fix: Set dgraph cert default duration to 1 year.

### DIFF
--- a/dgraph/cmd/cert/create.go
+++ b/dgraph/cmd/cert/create.go
@@ -25,16 +25,17 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 const (
 	defaultDir      = "tls"
-	defaultDays     = 1826
+	defaultDays     = 365
 	defaultCADays   = 3651
 	defaultCACert   = "ca.crt"
 	defaultCAKey    = "ca.key"

--- a/wiki/content/deploy/index.md
+++ b/wiki/content/deploy/index.md
@@ -1581,6 +1581,8 @@ $ dgraph cert -n localhost -c dgraphuser
 $ dgraph cert ls
 ```
 
+Node certificates by default are valid for 365 days. To adjust the validity duration, you can use the `--duration` option.
+
 #### File naming conventions
 
 To enable TLS you must specify the directory path to find certificates and keys. The default location where the _cert_ command stores certificates (and keys) is `tls` under the Dgraph working directory; where the data files are found. The default dir path can be overridden using the `--dir` option.
@@ -1623,33 +1625,36 @@ Example of command output:
 ```sh
 -rw-r--r-- ca.crt - Dgraph Root CA certificate
         Issuer: Dgraph Labs, Inc.
-           S/N: 043c4d8fdd347f06
-    Expiration: 02 Apr 29 16:56 UTC
-SHA-256 Digest: 4A2B0F0F 716BF5B6 C603E01A 6229D681 0B2AFDC5 CADF5A0D 17D59299 116119E5
+           S/N: 0b618b0771411b
+    Expiration: 13 Jul 30 20:12 UTC
+SHA-256 Digest: 92248D16 FC3368EA 9C2C2B57 CC1657BC F41CB095 AB808700 80ED1A9B 38C7E5F8
 
 -r-------- ca.key - Dgraph Root CA key
-SHA-256 Digest: 4A2B0F0F 716BF5B6 C603E01A 6229D681 0B2AFDC5 CADF5A0D 17D59299 116119E5
+     Algorithm: RSA 2048 bits (PKCS#1)
+SHA-256 Digest: 92248D16 FC3368EA 9C2C2B57 CC1657BC F41CB095 AB808700 80ED1A9B 38C7E5F8
 
--rw-r--r-- client.admin.crt - Dgraph client certificate: admin
+-rw-r--r-- client.dgraphuser.crt - Dgraph client certificate: dgraphuser
         Issuer: Dgraph Labs, Inc.
      CA Verify: PASSED
-           S/N: 297e4cb4f97c71f9
-    Expiration: 03 Apr 24 17:29 UTC
-SHA-256 Digest: D23EFB61 DE03C735 EB07B318 DB70D471 D3FE8556 B15D084C 62675857 788DF26C
+           S/N: 23012b9183fdf9f5
+    Expiration: 14 Jul 21 20:14 UTC
+SHA-256 Digest: 800798FA 2938CAB4 7AA1A655 A7EB3053 81CE6031 3147C12A 50DBA682 83FF85DA
 
--rw------- client.admin.key - Dgraph Client key
-SHA-256 Digest: D23EFB61 DE03C735 EB07B318 DB70D471 D3FE8556 B15D084C 62675857 788DF26C
+-rw------- client.dgraphuser.key - Dgraph Client key
+     Algorithm: RSA 2048 bits (PKCS#1)
+SHA-256 Digest: 800798FA 2938CAB4 7AA1A655 A7EB3053 81CE6031 3147C12A 50DBA682 83FF85DA
 
 -rw-r--r-- node.crt - Dgraph Node certificate
         Issuer: Dgraph Labs, Inc.
      CA Verify: PASSED
-           S/N: 795ff0e0146fdb2d
-    Expiration: 03 Apr 24 17:00 UTC
-         Hosts: 104.25.165.23, 2400:cb00:2048:1::6819:a417, localhost, dgraph.io
-SHA-256 Digest: 7E243ED5 3286AE71 B9B4E26C 5B2293DA D3E7F336 1B1AFFA7 885E8767 B1A84D28
+           S/N: 4241d25148e478bd
+    Expiration: 14 Jul 21 20:12 UTC
+         Hosts: localhost
+SHA-256 Digest: 23302165 DE675EFA 11ABAD0C 3B11CC6E BD5B33F1 7B4DB140 80224D21 F834853B
 
 -rw------- node.key - Dgraph Node key
-SHA-256 Digest: 7E243ED5 3286AE71 B9B4E26C 5B2293DA D3E7F336 1B1AFFA7 885E8767 B1A84D28
+     Algorithm: RSA 2048 bits (PKCS#1)
+SHA-256 Digest: 23302165 DE675EFA 11ABAD0C 3B11CC6E BD5B33F1 7B4DB140 80224D21 F834853B
 ```
 
 Important points:


### PR DESCRIPTION
Cherry-pick of #5986. For DGRAPH-1782.

Changes:

* fix: Set cert default duration to 1 year.
* docs(Deploy): Document default validity and update ls example.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6011)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d27b7323aa-80088.surge.sh)
<!-- Dgraph:end -->