### PR TITLE
fix(ServeTask): Return error if server is not ready

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -1858,6 +1858,12 @@ func (w *grpcWorker) ServeTask(ctx context.Context, q *pb.Query) (*pb.Result, er
 		return nil, ctx.Err()
 	}
 
+	// It could be possible that the server isn't ready but a peer sends a
+	// request. In that case we should check for the health here.
+	if err := x.HealthCheck(); err != nil {
+		return nil, err
+	}
+
 	gid, err := groups().BelongsToReadOnly(q.Attr, q.ReadTs)
 	switch {
 	case err != nil:


### PR DESCRIPTION
The grpcWorker.ServeTask function is called when a request is received
over the network (sent by a peer). This function doesn't consider the
health of the node before starting the processing of the request. If we
process a request before the node is ready, we might end up seeing
crashes similar to https://dgraph.atlassian.net/browse/DGRAPH-1934

Fixes DGRAPH-1934

I ran jepsen bank test with all nemesis and don't see any panics
```
./jepsen --jepsen-root $GOPATH/src/github.com/dgraph-io/jepsen -w bank -n "kill-alpha,kill-zero,partition-ring,move-tablet"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6019)
<!-- Reviewable:end -->
