### PR TITLE
release/v1.2: fix(ServeTask): Return error if server is not ready (#6019)

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -1791,6 +1791,12 @@ func (w *grpcWorker) ServeTask(ctx context.Context, q *pb.Query) (*pb.Result, er
 		return &pb.Result{}, ctx.Err()
 	}
 
+	// It could be possible that the server isn't ready but a peer sends a
+	// request. In that case we should check for the health here.
+	if err := x.HealthCheck(); err != nil {
+		return nil, err
+	}
+
 	gid, err := groups().BelongsToReadOnly(q.Attr, q.ReadTs)
 	switch {
 	case err != nil:


### PR DESCRIPTION
The grpcWorker.ServeTask function is called when a request is received
over the network (sent by a peer). This function doesn't consider the
health of the node before starting the processing of the request. If we
process a request before the node is ready, we might end up seeing
crashes similar to https://dgraph.atlassian.net/browse/DGRAPH-1934

Fixes DGRAPH-1934

This bug was seen when running Jepsen bank test with
kill-alpha and kill-zero nemesis.

(cherry picked from commit 9293c97cf8641a6ecbdbe316a312d183065d44c7)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6022)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-2fd8b269f8-80364.surge.sh)
<!-- Dgraph:end -->