### PR TITLE
fix(Debug): Do not calculate min max versions upfront

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -797,8 +797,9 @@ func run() {
 		return
 	}
 
-	min, max := getMinMax(db, opt.readTs)
-	fmt.Printf("Min commit: %d. Max commit: %d, w.r.t %d\n", min, max, opt.readTs)
+	// Commenting the following out because on large Badger DBs, this can take a LONG time.
+	// min, max := getMinMax(db, opt.readTs)
+	// fmt.Printf("Min commit: %d. Max commit: %d, w.r.t %d\n", min, max, opt.readTs)
 
 	switch {
 	case len(opt.keyLookup) > 0:

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,7 +50,9 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
-	ctx := n.ctx
+	ctx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,6 +50,8 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
+	// We should absolutely cancel the context when we return from this function, that way, the
+	// leader who is sending the snapshot would stop sending.
 	ctx, cancel := context.WithCancel(n.ctx)
 	defer cancel()
 

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,9 +50,7 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
-	ctx, cancel := context.WithCancel(n.ctx)
-	defer cancel()
-
+	ctx := n.ctx
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,8 +50,6 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
-	// We should absolutely cancel the context when we return from this function, that way, the
-	// leader who is sending the snapshot would stop sending.
 	ctx, cancel := context.WithCancel(n.ctx)
 	defer cancel()
 


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

Calculating min and max versions upfront requires iterating over the entire Badger DB. For larger DBs, this can take up significant amount of time and compute power. And it is not useful outside of Jepsen testing which calculates min-max anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6031)
<!-- Reviewable:end -->
