### PR TITLE
fix(worker): Cancel the context when opening connection to leader for streaming snapshot

### DIFF
--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,7 +50,9 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
-	ctx := n.ctx
+	ctx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -49,12 +49,12 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	con := pl.Get()
 	c := pb.NewWorkerClient(con)
 
-	// Set my RaftContext on the snapshot, so it's easier to locate me.
 	// We should absolutely cancel the context when we return from this function, that way, the
 	// leader who is sending the snapshot would stop sending.
 	ctx, cancel := context.WithCancel(n.ctx)
 	defer cancel()
 
+	// Set my RaftContext on the snapshot, so it's easier to locate me.
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,6 +50,8 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
+	// We should absolutely cancel the context when we return from this function, that way, the
+	// leader who is sending the snapshot would stop sending.
 	ctx, cancel := context.WithCancel(n.ctx)
 	defer cancel()
 


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

When we're done requesting a snapshot the context should be canceled so that the leader stops sending instead of continuing when there are errors.

Fixes DGRAPH-1942

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6033)
<!-- Reviewable:end -->
