### PR TITLE
fix(GraphQL): Fix segmentation fault when calling the /admin/backup endpoint.

### DIFF
--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/web"
 
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
 )
 
 func init() {
@@ -55,6 +56,7 @@ func backupHandler(w http.ResponseWriter, r *http.Request, adminServer web.IServ
 			"forceFull":    r.FormValue("force_full") == "true",
 		}},
 	}
+	glog.Infof("gqlReq %+v, r %+v adminServer %+v", gqlReq, r, adminServer)
 	resp := resolveWithAdminServer(gqlReq, r, adminServer)
 	if resp.Errors != nil {
 		x.SetStatus(w, resp.Errors.Error(), "Backup failed.")

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -471,7 +471,10 @@ func setupServer(closer *y.Closer) {
 	// The global epoch is set to maxUint64 while exiting the server.
 	// By using this information polling goroutine terminates the subscription.
 	globalEpoch := uint64(0)
-	mainServer, adminServer, gqlHealthStore := admin.NewServers(introspection, &globalEpoch, closer)
+	var mainServer web.IServeGraphQL
+	var gqlHealthStore *admin.GraphQLHealthStore
+	// Do not use := notation here because adminServer is a global variable.
+	mainServer, adminServer, gqlHealthStore = admin.NewServers(introspection, &globalEpoch, closer)
 	http.Handle("/graphql", mainServer.HTTPHandler())
 	http.HandleFunc("/probe/graphql", func(w http.ResponseWriter, r *http.Request) {
 		healthStatus := gqlHealthStore.GetHealth()

--- a/systest/backup/minio-large/backup_test.go
+++ b/systest/backup/minio-large/backup_test.go
@@ -16,13 +16,12 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -141,26 +140,11 @@ func addTriples(t *testing.T, dg *dgo.Dgraph, numTriples int) {
 }
 
 func runBackup(t *testing.T) {
-	backupRequest := `mutation backup($dst: String!) {
-		backup(input: {destination: $dst}) {
-			response {
-				code
-				message
-			}
-		}
-	}`
-
-	adminUrl := "http://localhost:8180/admin"
-	params := testutil.GraphQLParams{
-		Query: backupRequest,
-		Variables: map[string]interface{}{
-			"dst": backupDestination,
-		},
-	}
-	b, err := json.Marshal(params)
-	require.NoError(t, err)
-
-	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
+	// Using the old /admin/backup endpoint to ensure it works. Change back to using
+	// the GraphQL endpoint at /admin once this endpoint is deprecated.
+	resp, err := http.PostForm("http://localhost:8180/admin/backup", url.Values{
+		"destination": []string{backupDestination},
+	})
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	buf, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
PR #5802 introduced a bug that caused the adminServer global variable to
never be set, which in turned caused a segmentation fault when the
/admin/backup endpoint was called. This PR fixes the bug and changes the
minio-large test to use the /admin/backup endpoint to act as a
regression test.

Fixes DGRAPH-1938.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6042)
<!-- Reviewable:end -->
