### PR TITLE
Cherry-pick v20.07: fix(worker): Cancel the context when opening connection to leader for streaming snapshot

### DIFF
--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -50,7 +50,9 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	c := pb.NewWorkerClient(con)
 
 	// Set my RaftContext on the snapshot, so it's easier to locate me.
-	ctx := n.ctx
+	ctx, cancel := context.WithCancel(n.ctx)
+	defer cancel()
+
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -49,10 +49,12 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) (int, error) {
 	con := pl.Get()
 	c := pb.NewWorkerClient(con)
 
-	// Set my RaftContext on the snapshot, so it's easier to locate me.
+	// We should absolutely cancel the context when we return from this function, that way, the
+	// leader who is sending the snapshot would stop sending.
 	ctx, cancel := context.WithCancel(n.ctx)
 	defer cancel()
 
+	// Set my RaftContext on the snapshot, so it's easier to locate me.
 	snap.Context = n.RaftContext
 	stream, err := c.StreamSnapshot(ctx)
 	if err != nil {


### PR DESCRIPTION
Fixes DGRAPH-1942

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6045)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6f3202bae5-81131.surge.sh)
<!-- Dgraph:end -->