### PR TITLE
fix(docs): Fix error in language tags example table

### DIFF
--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -359,10 +359,10 @@ Here is the table with the syntax for various ways of making use of language tag
 | comment@. | Look for an untagged string, if not found, then return review in any language. But, this returns only a single value. |
 | comment@jp | Look for comment tagged `@jp`. If not found, the query returns nothing.|
 | comment@ru | Look for comment tagged `@ru`. If not found, the query returns nothing. |
-| name@jp:. | Look for comment tagged `@jp` first. If not found, then find the untagged comment. If that's not found too, return anyone comment in other languages. |
-| name@jp:ru | Look for comment tagged `@jp`, then `@ru`. If neither is found, it returns nothing. |
-| name@jp:ru:. | Look for comment tagged `@jp`, then `@ru`. If both not found, then find the untagged comment. If that's not found too, return any other comment if it exists. |
-| name@* | Return all the language tags, including the untagged. |
+| comment@jp:. | Look for comment tagged `@jp` first. If not found, then find the untagged comment. If that's not found too, return anyone comment in other languages. |
+| comment@jp:ru | Look for comment tagged `@jp`, then `@ru`. If neither is found, it returns nothing. |
+| comment@jp:ru:. | Look for comment tagged `@jp`, then `@ru`. If both not found, then find the untagged comment. If that's not found too, return any other comment if it exists. |
+| comment@* | Return all the language tags, including the untagged. |
 
 If you remember, we had initially added a Russian dish `Borscht` with its review in `Russian`.
 


### PR DESCRIPTION
In the language tags examples, the "comment" column has been erroneously listed as "name".

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6064)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e3141a36e6-82003.surge.sh)
<!-- Dgraph:end -->