### PR TITLE
fix(GraphQL): fixes panic in update mutation without set & remove

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -313,6 +313,7 @@ func RunAll(t *testing.T) {
 	t.Run("mutations have extensions", mutationsHaveExtensions)
 	t.Run("alias works for mutations", mutationsWithAlias)
 	t.Run("three level deep", threeLevelDeepMutation)
+	t.Run("update mutation without set & remove", updateMutationWithoutSetRemove)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -245,6 +245,18 @@ func (mr *dgraphResolver) rewriteAndExecute(ctx context.Context,
 		return emptyResult(schema.GQLWrapf(err, "couldn't rewrite mutation %s", mutation.Name())),
 			resolverFailed
 	}
+	if len(upserts) == 0 {
+		return &Resolved{
+			Data: map[string]interface{}{
+				mutation.Name(): map[string]interface{}{
+					schema.NumUid:                0,
+					mutation.QueryField().Name(): nil,
+				}},
+			Field:      mutation,
+			Err:        nil,
+			Extensions: ext,
+		}, resolverSucceeded
+	}
 
 	result := make(map[string]interface{})
 	req := &dgoapi.Request{}


### PR DESCRIPTION
FIxes GRAPHQL-589.
See [Discuss](https://discuss.dgraph.io/t/panic-when-update-with-filter-but-without-set-remove/8623) for more details.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6073)
<!-- Reviewable:end -->
