### PR TITLE
chore: Modify test to remove flakiness caused by explicit uids (#6080)

### DIFF
--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v2/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -76,10 +76,7 @@ func TestLoaderXidmap(t *testing.T) {
 			location
 			friend{
 				name
-
-
-		"data": {
-		}
+			}
 		}
 	}`
 	expected := `{"q":[{"age":"13","location":"Wonderland","friend":[{"name":"Bob"}]}]}`

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -79,7 +79,6 @@ func TestLoaderXidmap(t *testing.T) {
 
 
 		"data": {
-			}
 		}
 		}
 	}`


### PR DESCRIPTION
Fixes DGRAPH-1737
(cherry picked from commit a5c469d56741a4a6e2c668b5053dba17bbfa5860)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6084)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ffbda4f041-82692.surge.sh)
<!-- Dgraph:end -->