### PR TITLE
chore: Modify test to remove flakiness caused by explicit uids (#6080) 

### DIFF
--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -17,23 +17,26 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
+	"context"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
+// TestLoaderXidmap checks that live loader re-uses xidmap on loading data from two different files
 func TestLoaderXidmap(t *testing.T) {
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+	ctx := context.Background()
+	testutil.DropAll(t, dg)
 	tmpDir, err := ioutil.TempDir("", "loader_test")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpDir)
@@ -63,80 +66,23 @@ func TestLoaderXidmap(t *testing.T) {
 	liveCmd.Stderr = os.Stdout
 	require.NoError(t, liveCmd.Run())
 
-	exportRequest := `mutation {
-		export(input: {format: "rdf"}) {
-			response {
-				code
-				message
+	op := api.Operation{Schema: "name: string @index(exact) ."}
+	x.Check(dg.Alter(ctx, &op))
+
+	query := `
+	{
+		q(func: eq(name, "Alice")) {
+			age
+			location
+			friend{
+				name
 			}
 		}
 	}`
+	expected := `{"q":[{"age":"13","location":"Wonderland","friend":[{"name":"Bob"}]}]}`
 
-	adminUrl := "http://" + testutil.SockAddrHttp + "/admin"
-	params := testutil.GraphQLParams{
-		Query:     exportRequest,
-		Variables: map[string]interface{}{"format": "json"},
-	}
-	b, err := json.Marshal(params)
+	resp, err := dg.NewReadOnlyTxn().Query(ctx, query)
 	require.NoError(t, err)
-	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	b, err = ioutil.ReadAll(resp.Body)
-	require.NoError(t, err)
-	expected := `{
-		  "export": {
-			"response": {
-			  "code": "Success",
-			  "message": "Export completed."
-			}
-		  }
-		}`
-	res1 := &testutil.GraphQLResponse{}
-	err=json.Unmarshal(b,res1)
-	require.NoError(t, err)
-	require.JSONEq(t, expected, string(res1.Data))
+	testutil.CompareJSON(t, expected, string(resp.GetJson()))
 
-	require.NoError(t, copyExportFiles(tmpDir))
-
-	dataFile, err := findFile(filepath.Join(tmpDir, "export"), ".rdf.gz")
-	require.NoError(t, err)
-
-	cmd := fmt.Sprintf("gunzip -c %s | sort", dataFile)
-	out, err := exec.Command("sh", "-c", cmd).Output()
-	require.NoError(t, err)
-
-	expected = `<0x1> <age> "13" .
-<0x1> <friend> <0x2711> .
-<0x1> <location> "Wonderland" .
-<0x1> <name> "Alice" .
-<0x2711> <name> "Bob" .
-`
-	require.Equal(t, expected, string(out))
-}
-
-func copyExportFiles(tmpDir string) error {
-	exportPath := filepath.Join(tmpDir, "export")
-	if err := os.MkdirAll(exportPath, 0755); err != nil {
-		return err
-	}
-
-	srcPath := "alpha1:/data/alpha1/export"
-	dstPath := filepath.Join(tmpDir, "export")
-	return testutil.DockerCp(srcPath, dstPath)
-}
-
-func findFile(dir string, ext string) (string, error) {
-	var fp string
-	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if strings.HasSuffix(path, ext) {
-			fp = path
-			return nil
-		}
-		return nil
-	})
-	return fp, err
 }


### PR DESCRIPTION
DGRAPH-1737
(cherry picked from commit a5c469d56741a4a6e2c668b5053dba17bbfa5860)
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6085)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0541873cc1-82701.surge.sh)
<!-- Dgraph:end -->