### PR TITLE
fix v20.07 fix(dgraph): ignore minTs warning in bank upsert test. (#5821)

### DIFF
--- a/contrib/integration/acctupsert/main.go
+++ b/contrib/integration/acctupsert/main.go
@@ -149,8 +149,12 @@ func tryUpsert(c *dgo.Dgraph, acc account) error {
 		}
 	`, acc.first, acc.last, acc.age)
 	resp, err := txn.Query(ctx, q)
+	if err != nil &&
+		(strings.Contains(err.Error(), "Transaction is too old") ||
+			strings.Contains(err.Error(), "less than minTs")) {
+		return err
+	}
 	x.Check(err)
-
 	decode := struct {
 		Get []struct {
 			Uid *string


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6102)
<!-- Reviewable:end -->
