### PR TITLE
fix v1.1 use new timestamp instead of commited txn timestamp in (#5801)

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1611,7 +1611,7 @@ upsert {
 func TestUpsertWithValueVar(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`amount: int .`))
-	res, err := mutationWithTs(`{ set { _:p <amount> "0" . } }`, "application/rdf", false, true, 0)
+	_, err := mutationWithTs(`{ set { _:p <amount> "0" . } }`, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 	b, _ := json.MarshalIndent(res, "", "  ")
 	fmt.Printf("%s\n", b)
@@ -1642,10 +1642,10 @@ upsert {
 	)
 
 	for count := 1; count < 3; count++ {
-		res, err = mutationWithTs(m, "application/rdf", false, true, 0)
+		_, err = mutationWithTs(m, "application/rdf", false, true, 0)
 		require.NoError(t, err)
 
-		got, _, err := queryWithTs(q, "application/graphql+-", "", res.startTs)
+		got, _, err := queryWithTs(q, "application/graphql+-", "", 0)
 		require.NoError(t, err)
 
 		require.JSONEq(t, fmt.Sprintf(`{"data":{"q":[{"amount":%d}]}}`, count), got)


### PR DESCRIPTION
TestUpsertWithValueVar test

Signed-off-by: Tiger <rbalajis25@gmail.com>

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6106)
<!-- Reviewable:end -->
