### PR TITLE
fix 20.7 use new timestamp instead of commited txn timestamp in (#5801)

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -1611,7 +1611,7 @@ upsert {
 func TestUpsertWithValueVar(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`amount: int .`))
-	res, err := mutationWithTs(`{ set { _:p <amount> "0" . } }`, "application/rdf", false, true, 0)
+	_, err := mutationWithTs(`{ set { _:p <amount> "0" . } }`, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
 	const (
@@ -1640,10 +1640,10 @@ upsert {
 	)
 
 	for count := 1; count < 3; count++ {
-		res, err = mutationWithTs(m, "application/rdf", false, true, 0)
+		_, err = mutationWithTs(m, "application/rdf", false, true, 0)
 		require.NoError(t, err)
 
-		got, _, err := queryWithTs(q, "application/graphql+-", "", res.startTs)
+		got, _, err := queryWithTs(q, "application/graphql+-", "", 0)
 		require.NoError(t, err)
 
 		require.JSONEq(t, fmt.Sprintf(`{"data":{"q":[{"amount":%d}]}}`, count), got)

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -49,7 +49,7 @@ function ErrorExit
 function StartZero
 {
   INFO "starting zero container"
-  DockerCompose -f $DOCKER_CONF up --force-recreate -d zero1
+  DockerCompose -f $DOCKER_CONF up --force-recreate --remove-orphans -d zero1
   TIMEOUT=10
   while [[ $TIMEOUT > 0 ]]; do
     if docker logs zero1 2>&1 | grep -q 'CID set'; then
@@ -67,7 +67,7 @@ function StartAlpha
   local p_dir=$1
 
   INFO "starting alpha container"
-  DockerCompose -f $DOCKER_CONF up --force-recreate --no-start alpha1
+  DockerCompose -f $DOCKER_CONF up --force-recreate --remove-orphans --no-start alpha1
   if [[ $p_dir ]]; then
     docker cp $p_dir alpha1:/data/alpha1/
   fi


### PR DESCRIPTION
TestUpsertWithValueVar test

Signed-off-by: Tiger <rbalajis25@gmail.com>

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6108)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-6bfc00c88f-84317.surge.sh)
<!-- Dgraph:end -->