### PR TITLE
chore(version): Add release codename to version output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)
 
-MODIFIED = $(shell git diff-index --quiet HEAD || (echo "-mod"))
+MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
 SUBDIRS = dgraph
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 #
 
 BUILD          ?= $(shell git rev-parse --short HEAD)
-BUILD_CODENAME ?=
+BUILD_CODENAME  = unnamed
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@
 # limitations under the License.
 #
 
-BUILD         ?= $(shell git rev-parse --short HEAD)
-BUILD_DATE    ?= $(shell git log -1 --format=%ci)
-BUILD_BRANCH  ?= $(shell git rev-parse --abbrev-ref HEAD)
-BUILD_VERSION ?= $(shell git describe --always --tags)
+BUILD          ?= $(shell git rev-parse --short HEAD)
+BUILD_CODENAME ?=
+BUILD_DATE     ?= $(shell git log -1 --format=%ci)
+BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
+BUILD_VERSION  ?= $(shell git describe --always --tags)
 
 SUBDIRS = dgraph
 
@@ -35,6 +36,7 @@ oss:
 version:
 	@echo Dgraph ${BUILD_VERSION}
 	@echo Build: ${BUILD}
+	@echo Codename: ${BUILD_CODENAME}
 	@echo Build date: ${BUILD_DATE}
 	@echo Branch: ${BUILD_BRANCH}
 	@echo Go version: $(shell go version)

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)
 
+MODIFIED = $(shell git diff-index --quiet HEAD || (echo "-mod"))
+
 SUBDIRS = dgraph
 
 ###############
@@ -36,7 +38,7 @@ oss:
 version:
 	@echo Dgraph ${BUILD_VERSION}
 	@echo Build: ${BUILD}
-	@echo Codename: ${BUILD_CODENAME}
+	@echo Codename: ${BUILD_CODENAME}${MODIFIED}
 	@echo Build date: ${BUILD_DATE}
 	@echo Branch: ${BUILD_BRANCH}
 	@echo Go version: $(shell go version)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -29,7 +29,7 @@ export GO111MODULE := on
 
 # Build-time Go variables
 dgraphVersion	= github.com/dgraph-io/dgraph/x.dgraphVersion
-dgraphCodename  = github.com/dgraph-io/dgraph/x.dgraphCodename
+dgraphCodename	= github.com/dgraph-io/dgraph/x.dgraphCodename
 gitBranch	= github.com/dgraph-io/dgraph/x.gitBranch
 lastCommitSHA	= github.com/dgraph-io/dgraph/x.lastCommitSHA
 lastCommitTime	= github.com/dgraph-io/dgraph/x.lastCommitTime

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -58,7 +58,7 @@ endif
 all: $(BIN)
 
 $(BIN): clean
-	go build $(BUILD_FLAGS) -o $(BIN)
+	@go build $(BUILD_FLAGS) -o $(BIN)
 
 clean:
 	@rm -f $(BIN)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -16,12 +16,14 @@
 
 BIN             = dgraph
 BUILD          ?= $(shell git rev-parse --short HEAD)
-BUILD_CODENAME ?=
+BUILD_CODENAME  = unnamed
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)
 BUILD_TAGS     ?=
 GOPATH         ?= $(shell go env GOPATH)
+
+MODIFIED = $(shell git diff-index --quiet HEAD || (echo "-mod"))
 
 export GO111MODULE := on
 
@@ -32,7 +34,7 @@ gitBranch	= github.com/dgraph-io/dgraph/x.gitBranch
 lastCommitSHA	= github.com/dgraph-io/dgraph/x.lastCommitSHA
 lastCommitTime	= github.com/dgraph-io/dgraph/x.lastCommitTime
 
-BUILD_FLAGS   ?= -ldflags '-X ${lastCommitSHA}=${BUILD} -X "${lastCommitTime}=${BUILD_DATE}" -X "${dgraphVersion}=${BUILD_VERSION}" -X "${dgraphCodename}=${BUILD_CODENAME}" -X ${gitBranch}=${BUILD_BRANCH}'
+BUILD_FLAGS   ?= -ldflags '-X ${lastCommitSHA}=${BUILD} -X "${lastCommitTime}=${BUILD_DATE}" -X "${dgraphVersion}=${BUILD_VERSION}" -X "${dgraphCodename}=${BUILD_CODENAME}${MODIFIED}" -X ${gitBranch}=${BUILD_BRANCH}'
 
 # Insert build tags if specified
 ifneq ($(strip $(BUILD_TAGS)),)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -14,23 +14,25 @@
 # limitations under the License.
 #
 
-BIN            = dgraph
-BUILD         ?= $(shell git rev-parse --short HEAD)
-BUILD_DATE    ?= $(shell git log -1 --format=%ci)
-BUILD_BRANCH  ?= $(shell git rev-parse --abbrev-ref HEAD)
-BUILD_VERSION ?= $(shell git describe --always --tags)
-BUILD_TAGS    ?=
-GOPATH        ?= $(shell go env GOPATH)
+BIN             = dgraph
+BUILD          ?= $(shell git rev-parse --short HEAD)
+BUILD_CODENAME ?=
+BUILD_DATE     ?= $(shell git log -1 --format=%ci)
+BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
+BUILD_VERSION  ?= $(shell git describe --always --tags)
+BUILD_TAGS     ?=
+GOPATH         ?= $(shell go env GOPATH)
 
 export GO111MODULE := on
 
 # Build-time Go variables
-dgraphVersion  = github.com/dgraph-io/dgraph/x.dgraphVersion
-gitBranch      = github.com/dgraph-io/dgraph/x.gitBranch
-lastCommitSHA  = github.com/dgraph-io/dgraph/x.lastCommitSHA
-lastCommitTime = github.com/dgraph-io/dgraph/x.lastCommitTime
+dgraphVersion	= github.com/dgraph-io/dgraph/x.dgraphVersion
+dgraphCodename  = github.com/dgraph-io/dgraph/x.dgraphCodename
+gitBranch	= github.com/dgraph-io/dgraph/x.gitBranch
+lastCommitSHA	= github.com/dgraph-io/dgraph/x.lastCommitSHA
+lastCommitTime	= github.com/dgraph-io/dgraph/x.lastCommitTime
 
-BUILD_FLAGS   ?= -ldflags '-X ${lastCommitSHA}=${BUILD} -X "${lastCommitTime}=${BUILD_DATE}" -X "${dgraphVersion}=${BUILD_VERSION}" -X ${gitBranch}=${BUILD_BRANCH}'
+BUILD_FLAGS   ?= -ldflags '-X ${lastCommitSHA}=${BUILD} -X "${lastCommitTime}=${BUILD_DATE}" -X "${dgraphVersion}=${BUILD_VERSION}" -X "${dgraphCodename}=${BUILD_CODENAME}" -X ${gitBranch}=${BUILD_BRANCH}'
 
 # Insert build tags if specified
 ifneq ($(strip $(BUILD_TAGS)),)
@@ -54,7 +56,7 @@ endif
 all: $(BIN)
 
 $(BIN): clean
-	@go build $(BUILD_FLAGS) -o $(BIN)
+	go build $(BUILD_FLAGS) -o $(BIN)
 
 clean:
 	@rm -f $(BIN)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -28,11 +28,11 @@ MODIFIED = $(shell git diff-index --quiet HEAD || (echo "-mod"))
 export GO111MODULE := on
 
 # Build-time Go variables
-dgraphVersion	= github.com/dgraph-io/dgraph/x.dgraphVersion
-dgraphCodename	= github.com/dgraph-io/dgraph/x.dgraphCodename
-gitBranch	= github.com/dgraph-io/dgraph/x.gitBranch
-lastCommitSHA	= github.com/dgraph-io/dgraph/x.lastCommitSHA
-lastCommitTime	= github.com/dgraph-io/dgraph/x.lastCommitTime
+dgraphVersion   = github.com/dgraph-io/dgraph/x.dgraphVersion
+dgraphCodename  = github.com/dgraph-io/dgraph/x.dgraphCodename
+gitBranch       = github.com/dgraph-io/dgraph/x.gitBranch
+lastCommitSHA   = github.com/dgraph-io/dgraph/x.lastCommitSHA
+lastCommitTime  = github.com/dgraph-io/dgraph/x.lastCommitTime
 
 BUILD_FLAGS   ?= -ldflags '-X ${lastCommitSHA}=${BUILD} -X "${lastCommitTime}=${BUILD_DATE}" -X "${dgraphVersion}=${BUILD_VERSION}" -X "${dgraphCodename}=${BUILD_CODENAME}${MODIFIED}" -X ${gitBranch}=${BUILD_BRANCH}'
 

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -23,7 +23,7 @@ BUILD_VERSION  ?= $(shell git describe --always --tags)
 BUILD_TAGS     ?=
 GOPATH         ?= $(shell go env GOPATH)
 
-MODIFIED = $(shell git diff-index --quiet HEAD || (echo "-mod"))
+MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
 export GO111MODULE := on
 

--- a/x/init.go
+++ b/x/init.go
@@ -76,14 +76,9 @@ func BuildDetails() string {
 			"Community License"
 	}
 
-	var versionCodename string
-	versionCodename = fmt.Sprintf("%v", dgraphVersion)
-	if dgraphCodename != "" {
-		versionCodename = fmt.Sprintf("%v (%v)", dgraphVersion, dgraphCodename)
-	}
-
 	return fmt.Sprintf(`
 Dgraph version   : %v
+Dgraph codename  : %v
 Dgraph SHA-256   : %x
 Commit SHA-1     : %v
 Commit timestamp : %v
@@ -97,7 +92,7 @@ For discussions about Dgraph     , visit https://discuss.dgraph.io.
 Copyright 2015-2020 Dgraph Labs, Inc.
 
 `,
-		versionCodename, ExecutableChecksum(), lastCommitSHA, lastCommitTime, gitBranch,
+		dgraphVersion, dgraphCodename, ExecutableChecksum(), lastCommitSHA, lastCommitTime, gitBranch,
 		runtime.Version(), licenseInfo)
 }
 

--- a/x/init.go
+++ b/x/init.go
@@ -34,6 +34,7 @@ var (
 
 	// These variables are set using -ldflags
 	dgraphVersion  string
+	dgraphCodename string
 	gitBranch      string
 	lastCommitSHA  string
 	lastCommitTime string
@@ -74,6 +75,13 @@ func BuildDetails() string {
 		licenseInfo = "Licensed variously under the Apache Public License 2.0 and Dgraph " +
 			"Community License"
 	}
+
+	var versionCodename string
+	versionCodename = fmt.Sprintf("%v", dgraphVersion)
+	if dgraphCodename != "" {
+		versionCodename = fmt.Sprintf("%v (%v)", dgraphVersion, dgraphCodename)
+	}
+
 	return fmt.Sprintf(`
 Dgraph version   : %v
 Dgraph SHA-256   : %x
@@ -89,7 +97,7 @@ For discussions about Dgraph     , visit https://discuss.dgraph.io.
 Copyright 2015-2020 Dgraph Labs, Inc.
 
 `,
-		dgraphVersion, ExecutableChecksum(), lastCommitSHA, lastCommitTime, gitBranch,
+		versionCodename, ExecutableChecksum(), lastCommitSHA, lastCommitTime, gitBranch,
 		runtime.Version(), licenseInfo)
 }
 

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -112,6 +112,7 @@ func ConfigureSentryScope(subcmd string) {
 		scope.SetTag("commit", lastCommitSHA)
 		scope.SetTag("commit_ts", lastCommitTime)
 		scope.SetTag("branch", gitBranch)
+		scope.SetTag("codename", dgraphCodename)
 		scope.SetLevel(sentry.LevelFatal)
 	})
 


### PR DESCRIPTION
This adds a codename field to the `dgraph version` output. The codename
is set explicitly in the Makefiles for Dgraph. The codename is also
pushed to Sentry.

Additionally, this updates the Makefile to check if the working
directory has any uncommitted changes. If so, the codename is suffixed
with "-mod" to indicate that the binary was created with uncommitted
modified changes.

Changes
* Update dgraph version output with the codename
* Update build Makefiles to include the codename and "-mod" suffix
* Update Sentry reporting

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6113)
<!-- Reviewable:end -->
