### PR TITLE
chore: fix prometheus.yaml to select correct dgraph services

### DIFF
--- a/contrib/config/monitoring/prometheus/prometheus.yaml
+++ b/contrib/config/monitoring/prometheus/prometheus.yaml
@@ -53,7 +53,7 @@ spec:
     matchLabels:
       monitor: alpha-dgraph-io
   endpoints:
-  - port: alpha-http
+  - port: http-alpha
     path: /debug/prometheus_metrics
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -70,7 +70,7 @@ spec:
     matchLabels:
       monitor: zero.dgraph-io
   endpoints:
-  - port: zero-http
+  - port: http-zero
     path: /debug/prometheus_metrics
 ---
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
This is a bug fix for prometheus.yaml that works in conjunction to the dgraph helm chart.  The zero and alpha port names were renamed, which broke the ServiceMonitor CRD manifest. Fixed it so that it will match the correct labels.
