### PR TITLE
feat: Live Loader Now Supports Slash GraphQL

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -142,7 +142,10 @@ func init() {
 		"Number of N-Quads to send as part of a mutation.")
 	flag.StringP("xidmap", "x", "", "Directory to store xid to uid mapping")
 	flag.StringP("auth_token", "t", "",
-		"The auth token passed to the server for Alter operation of the schema file")
+		"The auth token passed to the server for Alter operation of the schema file. If used with --slash_grpc_endpoint, then this "+
+			"should be set to the API token issued by Slash GraphQL")
+	flag.String("slash_grpc_endpoint", "", "Path to Slash GraphQL GRPC endpoint. If --slash_grpc_endpoint is set, "+
+		"all other TLS options and connection options will be ignored")
 	flag.BoolP("use_compression", "C", false,
 		"Enable compression on connection to alpha server")
 	flag.Bool("new_uids", false,

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -383,12 +383,12 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 	}
 
 	dialOpts := []grpc.DialOption{}
-	if conf.IsSet("slash_grpc_endpoint") && conf.IsSet("auth_token") {
+	if conf.GetString("slash_grpc_endpoint") != "" && conf.IsSet("auth_token") {
 		dialOpts = append(dialOpts, x.WithAuthorizationCredentials(conf.GetString("auth_token")))
 	}
 
 	var tlsConfig *tls.Config = nil
-	if conf.IsSet("slash_grpc_endpoint") {
+	if conf.GetString("slash_grpc_endpoint") != "" {
 		var tlsErr error
 		tlsConfig, tlsErr = x.SlashTLSConfig(conf.GetString("slash_grpc_endpoint"))
 		x.Checkf(tlsErr, "Unable to generate TLS Cert Pool")
@@ -421,7 +421,7 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 
 func run() error {
 	var zero string
-	if Live.Conf.IsSet("slash_grpc_endpoint") {
+	if Live.Conf.GetString("slash_grpc_endpoint") != "" {
 		zero = Live.Conf.GetString("slash_grpc_endpoint")
 	} else {
 		zero = Live.Conf.GetString("zero")

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -89,7 +89,7 @@ func SlashTLSConfig(endpoint string) (*tls.Config, error) {
 
 // LoadClientTLSConfig loads the TLS config into the client with the given parameters.
 func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	if v.IsSet("slash_grpc_endpoint") {
+	if v.GetString("slash_grpc_endpoint") != "" {
 		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
 	}
 

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -53,8 +53,6 @@ func RegisterClientTLSFlags(flag *pflag.FlagSet) {
 	flag.String("tls_cert", "", "(optional) The Cert file provided by the client to the server.")
 	flag.String("tls_key", "", "(optional) The private key file "+
 		"provided by the client to the server.")
-	flag.String("slash_grpc_endpoint", "", "Path to Slash GraphQL GRPC endpoint. If this is set, "+
-		"all other TLS options and connection options will be ignored")
 }
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
@@ -75,12 +73,13 @@ func LoadServerTLSConfig(v *viper.Viper, tlsCertFile string, tlsKeyFile string) 
 }
 
 // SlashTLSConfig returns the TLS config appropriate for SlashGraphQL
+// This assumes that endpoint is not empty, and in the format "domain.grpc.cloud.dg.io:443"
 func SlashTLSConfig(endpoint string) (*tls.Config, error) {
 	pool, err := generateCertPool("", true)
-	hostWithoutPort := strings.Split(endpoint, ":")[0]
 	if err != nil {
 		return nil, err
 	}
+	hostWithoutPort := strings.Split(endpoint, ":")[0]
 	return &tls.Config{
 		RootCAs:    pool,
 		ServerName: hostWithoutPort,

--- a/x/x.go
+++ b/x/x.go
@@ -740,7 +740,7 @@ func DivideAndRule(num int) (numGo, width int) {
 }
 
 // SetupConnection starts a secure gRPC connection to the given host.
-func SetupConnection(host string, tlsCfg *tls.Config, useGz bool) (*grpc.ClientConn, error) {
+func SetupConnection(host string, tlsCfg *tls.Config, useGz bool, dialOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	callOpts := append([]grpc.CallOption{},
 		grpc.MaxCallRecvMsgSize(GrpcMaxSize),
 		grpc.MaxCallSendMsgSize(GrpcMaxSize))
@@ -750,7 +750,7 @@ func SetupConnection(host string, tlsCfg *tls.Config, useGz bool) (*grpc.ClientC
 		callOpts = append(callOpts, grpc.UseCompressor(gzip.Name))
 	}
 
-	dialOpts := append([]grpc.DialOption{},
+	dialOpts = append(dialOpts,
 		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
 		grpc.WithDefaultCallOptions(callOpts...),
 		grpc.WithBlock())
@@ -815,13 +815,38 @@ type CredOpt struct {
 	PasswordOpt string
 }
 
+type authorizationCredentials struct {
+	token string
+}
+
+func (a *authorizationCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
+	return map[string]string{"Authorization": a.token}, nil
+}
+
+func (a *authorizationCredentials) RequireTransportSecurity() bool {
+	return true
+}
+
+// WithAuthorizationCredentials adds Authorization: <api-token> to every GRPC request
+// This is mostly used by Slash GraphQL to authenticate requests
+func WithAuthorizationCredentials(authToken string) grpc.DialOption {
+	return grpc.WithPerRPCCredentials(&authorizationCredentials{authToken})
+}
+
 // GetDgraphClient creates a Dgraph client based on the following options in the configuration:
+// --slash_grpc_endpoint specifies the grpc endpoint for slash. It takes precedence over --alpha and TLS
 // --alpha specifies a comma separated list of endpoints to connect to
 // --tls_cacert, --tls_cert, --tls_key etc specify the TLS configuration of the connection
 // --retries specifies how many times we should retry the connection to each endpoint upon failures
 // --user and --password specify the credentials we should use to login with the server
 func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
-	alphas := conf.GetString("alpha")
+	var alphas string
+	if conf.IsSet("slash_grpc_endpoint") {
+		alphas = conf.GetString("slash_grpc_endpoint")
+	} else {
+		alphas = conf.GetString("alpha")
+	}
+
 	if len(alphas) == 0 {
 		glog.Fatalf("The --alpha option must be set in order to connect to Dgraph")
 	}
@@ -842,10 +867,15 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 		}
 	}
 
+	dialOpts := []grpc.DialOption{}
+	if conf.IsSet("slash_grpc_endpoint") && conf.IsSet("auth_token") {
+		dialOpts = append(dialOpts, WithAuthorizationCredentials(conf.GetString("auth_token")))
+	}
+
 	for _, d := range ds {
 		var conn *grpc.ClientConn
 		for i := 0; i < retries; i++ {
-			conn, err = SetupConnection(d, tlsCfg, false)
+			conn, err = SetupConnection(d, tlsCfg, false, dialOpts...)
 			if err == nil {
 				break
 			}

--- a/x/x.go
+++ b/x/x.go
@@ -841,7 +841,7 @@ func WithAuthorizationCredentials(authToken string) grpc.DialOption {
 // --user and --password specify the credentials we should use to login with the server
 func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 	var alphas string
-	if conf.IsSet("slash_grpc_endpoint") {
+	if conf.GetString("slash_grpc_endpoint") != "" {
 		alphas = conf.GetString("slash_grpc_endpoint")
 	} else {
 		alphas = conf.GetString("alpha")
@@ -868,7 +868,7 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 	}
 
 	dialOpts := []grpc.DialOption{}
-	if conf.IsSet("slash_grpc_endpoint") && conf.IsSet("auth_token") {
+	if conf.GetString("slash_grpc_endpoint") != "" && conf.IsSet("auth_token") {
 		dialOpts = append(dialOpts, WithAuthorizationCredentials(conf.GetString("auth_token")))
 	}
 


### PR DESCRIPTION
Live Loader can now support Slash GraphQL

Here is an example: 
```
./dgraph live --slash_grpc_endpoint=defiant-curve-2926.grpc.us-east-1.aws.thegaas.com:443 -f /path/to/file.json.gz -t api-token
```

Why introduce a new flag, `--slash_grpc_endpoint`?
* Connections to zero didn't support TLS, so we'd need a new flag to indicate this
* There was no way to start TLS, but use the system CA pool (--tls_ca_cert had to be a valid path). This is not needed for public auth
* Passing in the --alpha --zero and --tls_server_name with the same value felt clunky
* In Slash GraphQL, the GRPC authentication is passed in via `Authentication` metadata to all endpoints, as opposed to only passing in `X-Dgraph-AuthToken` to alter alone

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6117)
<!-- Reviewable:end -->
