### PR TITLE
fix(rollups): rollup a batch if more than 2 seconds elapsed since last batch

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -83,16 +83,22 @@ func (ir *incrRollupi) rollUpKey(writer *TxnWriter, key []byte) error {
 	return writer.Write(&bpb.KVList{Kv: kvs})
 }
 
+var lastSentTs int64 // keep track of ts of last batch rolled up.
 func (ir *incrRollupi) addKeyToBatch(key []byte) {
 	batch := ir.keysPool.Get().(*[][]byte)
 	*batch = append(*batch, key)
-	if len(*batch) < 64 {
+	sent := atomic.LoadInt64(&lastSentTs)
+	now := time.Now().Unix()
+
+	// Rollup only if batch len is 64 or it has been more than 2 seconds since last batch.
+	if now-sent < 2 && len(*batch) < 64 {
 		ir.keysPool.Put(batch)
 		return
 	}
 
 	select {
 	case ir.keysCh <- batch:
+		atomic.StoreInt64(&lastSentTs, now)
 	default:
 		// Drop keys and build the batch again. Lossy behavior.
 		*batch = (*batch)[:0]

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -150,12 +150,12 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 		case <-forceRollupTick.C:
 			batch = ir.keysPool.Get().(*[][]byte)
 			if len(*batch) > 0 {
-				dorollup()
+				doRollup()
 			} else {
 				ir.keysPool.Put(batch)
 			}
 		case batch = <-ir.keysCh:
-			dorollup()
+			doRollup()
 			// throttle to 1 batch = 64 rollups per 100 ms.
 			<-limiter.C
 		}

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -117,7 +117,7 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 
 	var batch *[][]byte
 
-	dorollup := func() {
+	doRollup := func() {
 		currTs := time.Now().Unix()
 		for _, key := range *batch {
 			hash := z.MemHash(key)

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -25,6 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkIncrRollupAtomic(b *testing.B) {
+	buf := []byte("key")
+	for n := 0; n < b.N; n++ {
+		IncrRollup.addKeyToBatch(buf)
+	}
+}
+
 func TestRollupTimestamp(t *testing.T) {
 	key := x.DataKey("rollup", 1)
 	// 3 Delta commits.

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -25,13 +25,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkIncrRollupAtomic(b *testing.B) {
-	buf := []byte("key")
-	for n := 0; n < b.N; n++ {
-		IncrRollup.addKeyToBatch(buf)
-	}
-}
-
 func TestRollupTimestamp(t *testing.T) {
 	key := x.DataKey("rollup", 1)
 	// 3 Delta commits.


### PR DESCRIPTION
fix(rollup): rollup a batch every 2 seconds or 64 keys

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6118)
<!-- Reviewable:end -->
