### PR TITLE
fix(bulk loader): Remove redundant compressionLevel option set

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -117,7 +117,7 @@ func (r *reducer) createBadger(i int) *badger.DB {
 	opt := badger.DefaultOptions(r.opt.shardOutputDirs[i]).WithSyncWrites(false).
 		WithTableLoadingMode(bo.MemoryMap).WithValueThreshold(1 << 10 /* 1 KB */).
 		WithLogger(nil).WithMaxCacheSize(1 << 20).
-		WithEncryptionKey(r.opt.EncryptionKey).WithCompression(bo.None)
+		WithEncryptionKey(r.opt.EncryptionKey)
 
 	// Overwrite badger options based on the options provided by the user.
 	r.setBadgerOptions(&opt)


### PR DESCRIPTION
The compression level is set in the `setBadgerOptions` function and setting `compressionLevel` before calling that function is a no-op since we will overwrite the value in the `setBadgerOptions` function.
https://github.com/dgraph-io/dgraph/blob/5e39c8aa8b4091d7fffcf8b2f18a98d712544539/dgraph/cmd/bulk/reduce.go#L135-L142
This PR removes the redundant setting of the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6119)
<!-- Reviewable:end -->
