### PR TITLE
fix(Dgraph): Don't store start_ts in postings.

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -385,14 +385,10 @@ func history(lookup []byte, itr *badger.Iterator) {
 		if meta&posting.BitDeltaPosting > 0 {
 			plist := &pb.PostingList{}
 			x.Check(plist.Unmarshal(val))
-
-			fmt.Fprintf(&buf, " postings: %+v ", plist.Postings)
-
 			for _, p := range plist.Postings {
 				appendPosting(&buf, p)
 			}
 		}
-
 		if meta&posting.BitCompletePosting > 0 {
 			var plist pb.PostingList
 			x.Check(plist.Unmarshal(val))

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -385,10 +385,14 @@ func history(lookup []byte, itr *badger.Iterator) {
 		if meta&posting.BitDeltaPosting > 0 {
 			plist := &pb.PostingList{}
 			x.Check(plist.Unmarshal(val))
+
+			fmt.Fprintf(&buf, " postings: %+v ", plist.Postings)
+
 			for _, p := range plist.Postings {
 				appendPosting(&buf, p)
 			}
 		}
+
 		if meta&posting.BitCompletePosting > 0 {
 			var plist pb.PostingList
 			x.Check(plist.Unmarshal(val))

--- a/posting/list.go
+++ b/posting/list.go
@@ -592,6 +592,7 @@ func (l *List) pickPostings(readTs uint64) (uint64, []*pb.Posting) {
 					deleteBelowTs = effectiveTs
 					continue
 				}
+				mpost.StartTs = startTs
 				posts = append(posts, mpost)
 			}
 		}

--- a/posting/list.go
+++ b/posting/list.go
@@ -521,6 +521,10 @@ func (l *List) getMutation(startTs uint64) []byte {
 	l.RLock()
 	defer l.RUnlock()
 	if pl, ok := l.mutationMap[startTs]; ok {
+		for _, p := range pl.GetPostings() {
+			p.StartTs = 0
+			p.CommitTs = 0
+		}
 		data, err := pl.Marshal()
 		x.Check(err)
 		return data

--- a/posting/list.go
+++ b/posting/list.go
@@ -523,7 +523,6 @@ func (l *List) getMutation(startTs uint64) []byte {
 	if pl, ok := l.mutationMap[startTs]; ok {
 		for _, p := range pl.GetPostings() {
 			p.StartTs = 0
-			p.CommitTs = 0
 		}
 		data, err := pl.Marshal()
 		x.Check(err)


### PR DESCRIPTION
Clear out the start_ts field in the postings of deltas before they are
marshalled to avoid storing that field in disk. This field is only meant
to be used during in-memory processing.

Related to https://discuss.dgraph.io/t/start-ts-not-being-cleared-before-postings-are-written-to-disk/9146

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6127)
<!-- Reviewable:end -->
