### PR TITLE
chore: Prometheus helm chart values

### DIFF
--- a/contrib/config/monitoring/grafana/dgraph-kubernetes-grafana-dashboard.json
+++ b/contrib/config/monitoring/grafana/dgraph-kubernetes-grafana-dashboard.json
@@ -1,0 +1,1194 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "$$hashKey": "object:315",
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 1,
+    "iteration": 1585706329057,
+    "links": [],
+    "panels": [
+      {
+        "cacheTimeout": null,
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 2,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "hideTimeOverride": false,
+        "id": 30,
+        "links": [],
+        "options": {
+          "colorMode": "background",
+          "fieldOptions": {
+            "calcs": [
+              "max"
+            ],
+            "defaults": {
+              "mappings": [
+                {
+                  "id": 0,
+                  "op": "=",
+                  "text": "N/A",
+                  "type": 1,
+                  "value": "null"
+                }
+              ],
+              "nullValueMode": "connected",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  }
+                ]
+              },
+              "title": "Health Status -",
+              "unit": "short"
+            },
+            "overrides": [],
+            "values": false
+          },
+          "graphMode": "none",
+          "justifyMode": "center",
+          "orientation": "vertical"
+        },
+        "pluginVersion": "6.7.1",
+        "targets": [
+          {
+            "expr": "dgraph_alpha_health_status{pod=~'$Pod'}-1",
+            "format": "heatmap",
+            "hide": false,
+            "instant": false,
+            "intervalFactor": 1,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_active_mutations_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "Zero and Alpha",
+        "transparent": true,
+        "type": "stat"
+      },
+      {
+        "datasource": "Prometheus",
+        "gridPos": {
+          "h": 3,
+          "w": 24,
+          "x": 0,
+          "y": 2
+        },
+        "id": 34,
+        "links": [],
+        "options": {
+          "fieldOptions": {
+            "calcs": [
+              "last"
+            ],
+            "defaults": {
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "title": "Memory in use",
+              "unit": "decbytes"
+            },
+            "limit": 3,
+            "overrides": [],
+            "values": false
+          },
+          "orientation": "auto",
+          "showThresholdLabels": false,
+          "showThresholdMarkers": true
+        },
+        "pluginVersion": "6.7.1",
+        "targets": [
+          {
+            "expr": "(dgraph_memory_idle_bytes{pod=~'$Pod'}+dgraph_memory_inuse_bytes{pod=~'$Pod'})",
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "Alpha",
+            "metric": "dgraph_memory_idle_bytes",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "timeFrom": null,
+        "timeShift": null,
+        "title": "",
+        "transparent": true,
+        "type": "gauge"
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 9,
+          "w": 24,
+          "x": 0,
+          "y": 5
+        },
+        "hiddenSeries": false,
+        "id": 1,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": false,
+          "avg": false,
+          "current": false,
+          "max": true,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_memory_inuse_bytes+dgraph_memory_idle_bytes{pod=~'$Pod'}",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "Inuse+Idle ({{pod}})",
+            "metric": "dgraph_memory_idle_bytes",
+            "refId": "A",
+            "step": 2
+          },
+          {
+            "expr": "dgraph_memory_proc_bytes{pod=~'$Pod'}",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "Proc ({{pod}})",
+            "metric": "dgraph_memory_proc_bytes",
+            "refId": "B",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Total memory",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "bytes",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 14
+        },
+        "hiddenSeries": false,
+        "id": 17,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "max": true,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_active_mutations_total{pod=~'$Pod'}",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_active_mutations_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Active mutations",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 14
+        },
+        "hiddenSeries": false,
+        "id": 5,
+        "isNew": true,
+        "legend": {
+          "alignAsTable": true,
+          "avg": true,
+          "current": true,
+          "hideEmpty": false,
+          "hideZero": false,
+          "max": false,
+          "min": false,
+          "rightSide": false,
+          "show": true,
+          "total": true,
+          "values": true
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.6.1",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_pending_proposals_total{pod=~'$Pod'}",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_pending_proposals_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Pending Proposals",
+        "tooltip": {
+          "shared": true,
+          "sort": 1,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": "",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 21
+        },
+        "hiddenSeries": false,
+        "id": 14,
+        "isNew": true,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_memory_idle_bytes{pod=~'$Pod'}",
+            "interval": "",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_memory_idle_bytes",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Memory Heap Idle",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "bytes",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 21
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "isNew": true,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(go_gc_duration_seconds_sum{pod=~'$Pod'}[5m])",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "go_gc_duration_seconds_sum",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "GC second sum rate(30s)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "description": "goroutines used by go.",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 24,
+          "x": 0,
+          "y": 28
+        },
+        "hiddenSeries": false,
+        "hideTimeOverride": false,
+        "id": 35,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.6.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "go_goroutines{pod=~'$Pod'}",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_active_mutations_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "goroutines",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:595",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:596",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 35
+        },
+        "hiddenSeries": false,
+        "hideTimeOverride": false,
+        "id": 23,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.6.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_num_queries_total",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "",
+            "metric": "dgraph_active_mutations_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Processed Queries",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 35
+        },
+        "hiddenSeries": false,
+        "id": 16,
+        "isNew": true,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_pending_queries_total{pod=~'$Pod'}",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_pending_queries_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Pending Queries",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "cacheTimeout": null,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 0,
+          "y": 42
+        },
+        "hiddenSeries": false,
+        "hideTimeOverride": false,
+        "id": 31,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pluginVersion": "6.6.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_raft_applied_index{pod=~'$Pod'}",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_active_mutations_total",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Raft Applied Index",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "Prometheus",
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+          "h": 7,
+          "w": 12,
+          "x": 12,
+          "y": 42
+        },
+        "hiddenSeries": false,
+        "id": 18,
+        "isNew": true,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+          "dataLinks": []
+        },
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "dgraph_alpha_health_status{pod=~'$Pod'}",
+            "intervalFactor": 2,
+            "legendFormat": "{{pod}}",
+            "metric": "dgraph_alpha_health_status",
+            "refId": "A",
+            "step": 2
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Server Health",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 22,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": "Prometheus",
+          "definition": "label_values(pod)",
+          "hide": 0,
+          "includeAll": true,
+          "index": -1,
+          "label": null,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "Pod",
+          "options": [],
+          "query": "label_values(pod)",
+          "refresh": 1,
+          "regex": "/dgraph-.*-[0-9]*$/",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": {
+      "from": "now-12h",
+      "to": "now"
+    },
+    "timepicker": {
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Dgraph-Kubernetes",
+    "uid": "d0cZK8i6M",
+    "variables": {
+      "list": []
+    },
+    "version": 4
+  }

--- a/contrib/config/monitoring/prometheus/README.md
+++ b/contrib/config/monitoring/prometheus/README.md
@@ -1,0 +1,22 @@
+## Prometheus Metrics
+
+[Prometheus](https://prometheus.io/) platform for gathering metric and triggering alerts.  This can be used to monitor Dgraph deployed on the Kubernetes platform.
+
+You can install [Prometheus](https://prometheus.io/) using either of these options:
+
+* Kubernetes manifests (this directory)
+  * Instructions: [Deploy: Monitoring in Kubernetes](https://dgraph.io/docs/deploy/#monitoring-in-kubernetes)
+* Helm Chart Values - This will install [Prometheus](https://prometheus.io/), [AlertManager](https://prometheus.io/docs/alerting/latest/alertmanager/), and [Grafana](https://grafana.com/).
+  * Instructions: [README.md](chart-values/README.md)
+  
+## Kubernetes Manifests Details
+
+These manifests require the [prometheus-operator](https://coreos.com/blog/the-prometheus-operator.html) to be installed before using these (see [instructions](https://dgraph.io/docs/deploy/#monitoring-in-kubernetes)).
+
+This will contain the following files:
+
+* `prometheus.yaml` - Prometheus service and Dgraph service monitors to keep the configuration synchronized Dgraph configuration changes.  The service monitor use service discovery, such as Kubernetes labels and namespaces, to discover Dgraph.  Should you have multiple Dgraph installations installed, such as a dev-test and production, you can tailor these narrow the scope of which Dgraph version you would want to track.
+* `alertmanager-config.yaml` - This is a secret you can create when installing `alertmanager.yaml`.  Here you can specify where to direct alerts, such as Slack or PagerDuty.
+* `alertmanager.yaml` - AlertManager service to trigger alerts if metrics fall over a threshold specified in alert rules.
+* `alert-rules.yaml` - These are rules that can trigger alerts. Adjust these as they make sense for your Dgraph deployment.
+

--- a/contrib/config/monitoring/prometheus/chart-values/README.md
+++ b/contrib/config/monitoring/prometheus/chart-values/README.md
@@ -1,0 +1,8 @@
+# Helm Chart Values
+
+## Usage
+
+```bash
+helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm install my-prometheus-release --values dgraph-prometheus-operator.yaml stable/prometheus-operator 
+```

--- a/contrib/config/monitoring/prometheus/chart-values/README.md
+++ b/contrib/config/monitoring/prometheus/chart-values/README.md
@@ -1,8 +1,37 @@
 # Helm Chart Values
 
+You can install [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/) using this helm chart and supplied helm chart values. 
+
 ## Usage
 
 ```bash
 helm repo add stable https://kubernetes-charts.storage.googleapis.com
-helm install my-prometheus-release --values dgraph-prometheus-operator.yaml stable/prometheus-operator 
+helm install my-prometheus-release \
+  --values dgraph-prometheus-operator.yaml \
+  --set grafana.adminPassword='<put-complete-password-here>' \ 
+  stable/prometheus-operator 
 ```
+
+## Grafana Dashboards
+
+You can import [Grafana](https://grafana.com/) Dashboards from within the web consoles.  
+
+There's an example dash board for some metrics that you can use to monitor Dgraph on Kubernetes:
+
+* [dgraph-kubernetes-grafana-dashboard.json](../../grafana/dgraph-kubernetes-grafana-dashboard.json)
+
+## Helm Chart Values
+
+Here are some Helm chart values you may want to configure depending on your environment.
+
+## General
+
+* `grafana.service.type` - set to `LoadBalancer` if you would like to expose this port.
+* `grafana.service.annotations` - add annotations to configure a `LoadBalancer` such as if it is internal or external facing, DNS name with external-dns, etc.
+* `prometheus.service.type` - set to `LoadBalancer` if you would like to expose this port.
+* `prometheus.service.annotations` - add annotations to configure a `LoadBalancer` such as if it is internal or external facing, DNS name with external-dns, etc.
+
+## Dgraph Service Monitors
+
+* `prometheus.additionalServiceMonitors.namespaceSelector.matchNames` - if you want to match a dgraph installed into a specific namespace.
+* `prometheus.additionalServiceMonitors.selector.matchLabels` - if you want to match through a specific labels in your dgraph deployment.  Currently matches `monitor: zero.dgraph-io` and `monitor: alpha.dgraph-io`, which si the default for [Dgraph helm chart](https://github.com/dgraph-io/charts).

--- a/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
+++ b/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
@@ -64,7 +64,7 @@ prometheus:
           - default
       selector:
         matchLabels:
-          monitor: zero.dgraph-io
+          monitor: zero-dgraph-io
     - name: alpha-dgraph-io
       additionalLabels:
         app: dgraph-io
@@ -77,7 +77,7 @@ prometheus:
           - default
       selector:
         matchLabels:
-          monitor: alpha.dgraph-io
+          monitor: alpha-dgraph-io
 
 additionalPrometheusRules:
   - name: prometheus-rules-dgraph-io

--- a/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
+++ b/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
@@ -1,17 +1,28 @@
-# This supresses warnings about helm2 hook
-# Comment this out if using helm2
 prometheusOperator:
   createCustomResource: false
 
-nameOverride: dgraph-io
-commonLabels:
-  prometheus: dgraph-io
+grafana:
+  enabled: true
+  persistence:
+    enabled: true
+    accessModes: ["ReadWriteOnce"]
+    size: 5Gi
+  defaultDashboardsEnabled: true
+  service:
+    type: ClusterIP
 
 alertmanager:
   service:
     labels:
       app: dgraph-io
   alertmanagerSpec:
+    storage:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 5Gi
     replicas: 1
     logLevel: debug
   config:
@@ -31,117 +42,36 @@ alertmanager:
     - name: 'null'
 
 prometheus:
+  service:
+      type: ClusterIP
   serviceAccount:
     create: true
     name: prometheus-dgraph-io
+
   prometheusSpec:
-    alertingEndpoints:
-    - namespace: default
-      name: alertmanager-dgraph-io
-      port: web
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 25Gi
     resources:
       requests:
         memory: 400Mi
-    serviceMonitorSelector:
-      matchLabels:
-        app: dgraph-io
-    ruleSelector:
-      matchLabels:
-        app: dgraph-io
-        prometheus: dgraph-io
-        role: alert-rules
     enableAdminAPI: false
   additionalServiceMonitors:
     - name: zero-dgraph-io
-      additionalLabels:
-        app: dgraph-io
-        prometheus: dgraph-io
       endpoints:
         - port: http-zero
           path: /debug/prometheus_metrics
-      namespaceSelector:
-        matchNames:
-          - default
       selector:
         matchLabels:
           monitor: zero-dgraph-io
     - name: alpha-dgraph-io
-      additionalLabels:
-        app: dgraph-io
-        prometheus: dgraph-io
       endpoints:
         - port: http-alpha
           path: /debug/prometheus_metrics
-      namespaceSelector:
-        matchNames:
-          - default
       selector:
         matchLabels:
           monitor: alpha-dgraph-io
-
-additionalPrometheusRules:
-  - name: prometheus-rules-dgraph-io
-    groups:
-    - name: ./dgraph-alert.rules
-      interval: 30s
-      rules:
-      - alert: AlphaNotReady
-        expr: dgraph_alpha_health_status{job="dgraph-alpha-public"}
-          == 0
-        for: 3m
-        annotations:
-          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has been
-            down for more than 3 minutes.'
-          summary: Instance {{ $labels.instance }} down
-        labels:
-          severity: medium
-      - alert: AlphaDead
-        expr: dgraph_alpha_health_status{job="dgraph-alpha-public"}
-          == 0
-        for: 10m
-        annotations:
-          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has been
-            down for more than 10 minutes.'
-          summary: Instance {{ $labels.instance }} down
-        labels:
-          severity: high
-      - alert: HighPendingQueriesCount
-        expr: (sum
-          by(instance, cluster) (dgraph_pending_queries_total{job="dgraph-alpha-public"}))
-          > 1000
-        for: 5m
-        annotations:
-          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has
-            a high number of pending quries({{ $value }} in last 5m).'
-          summary: Instance {{ $labels.instance }} is experiencing high pending query rates.
-        labels:
-          severity: medium
-      - alert: HighAlphaOpenFDCount
-        expr: process_open_fds{job="dgraph-alpha-public"}
-          / process_max_fds{job="dgraph-alpha-public"} > 0.75
-        for: 10m
-        annotations:
-          description: 'Too many open file descriptors on alpha instance {{ $labels.instance }}: {{ $value
-            }} fraction used.'
-          summary: 'Alpha instance {{ $labels.instance }} have too many open file descriptors.'
-        labels:
-          severity: high
-      - alert: HighZeroOpenFDCount
-        expr: process_open_fds{job="dgraph-zero-public"}
-          / process_max_fds{job="dgraph-zero-public"} > 0.75
-        for: 10m
-        annotations:
-          description: 'Too many open file descriptors on zero instance {{ $labels.instance }}: {{ $value
-            }} fraction used.'
-          summary: 'Zero instance {{ $labels.instance }} have too many open file descriptors.'
-        labels:
-          severity: high
-      - alert: FollowerBehindTs
-        expr: (max
-          by(cluster) (dgraph_max_assigned_ts)) - (min by(cluster) (dgraph_max_assigned_ts))
-          > 1000
-        for: 30s
-        annotations:
-          description: A follower is behind the leader's latest applied timestamp by {{ $value }}.
-        labels:
-          severity: medium

--- a/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
+++ b/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
@@ -1,0 +1,147 @@
+# This supresses warnings about helm2 hook
+# Comment this out if using helm2
+prometheusOperator:
+  createCustomResource: false
+
+nameOverride: dgraph-io
+commonLabels:
+  prometheus: dgraph-io
+
+alertmanager:
+  service:
+    labels:
+      app: dgraph-io
+  alertmanagerSpec:
+    replicas: 1
+    logLevel: debug
+  config:
+    global:
+      resolve_timeout: 2m
+    route:
+      group_by: ['job']
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 12h
+      receiver: 'null'
+      routes:
+      - match:
+          alertname: Watchdog
+        receiver: 'null'
+    receivers:
+    - name: 'null'
+
+prometheus:
+  serviceAccount:
+    create: true
+    name: prometheus-dgraph-io
+  prometheusSpec:
+    alertingEndpoints:
+    - namespace: default
+      name: alertmanager-dgraph-io
+      port: web
+    resources:
+      requests:
+        memory: 400Mi
+    serviceMonitorSelector:
+      matchLabels:
+        app: dgraph-io
+    ruleSelector:
+      matchLabels:
+        app: dgraph-io
+        prometheus: dgraph-io
+        role: alert-rules
+    enableAdminAPI: false
+  additionalServiceMonitors:
+    - name: zero-dgraph-io
+      additionalLabels:
+        app: dgraph-io
+        prometheus: dgraph-io
+      endpoints:
+        - port: http-zero
+          path: /debug/prometheus_metrics
+      namespaceSelector:
+        matchNames:
+          - default
+      selector:
+        matchLabels:
+          monitor: zero.dgraph-io
+    - name: alpha-dgraph-io
+      additionalLabels:
+        app: dgraph-io
+        prometheus: dgraph-io
+      endpoints:
+        - port: http-alpha
+          path: /debug/prometheus_metrics
+      namespaceSelector:
+        matchNames:
+          - default
+      selector:
+        matchLabels:
+          monitor: alpha.dgraph-io
+
+additionalPrometheusRules:
+  - name: prometheus-rules-dgraph-io
+    groups:
+    - name: ./dgraph-alert.rules
+      interval: 30s
+      rules:
+      - alert: AlphaNotReady
+        expr: dgraph_alpha_health_status{job="dgraph-alpha-public"}
+          == 0
+        for: 3m
+        annotations:
+          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has been
+            down for more than 3 minutes.'
+          summary: Instance {{ $labels.instance }} down
+        labels:
+          severity: medium
+      - alert: AlphaDead
+        expr: dgraph_alpha_health_status{job="dgraph-alpha-public"}
+          == 0
+        for: 10m
+        annotations:
+          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has been
+            down for more than 10 minutes.'
+          summary: Instance {{ $labels.instance }} down
+        labels:
+          severity: high
+      - alert: HighPendingQueriesCount
+        expr: (sum
+          by(instance, cluster) (dgraph_pending_queries_total{job="dgraph-alpha-public"}))
+          > 1000
+        for: 5m
+        annotations:
+          description: '{{ $labels.instance }} for cluster {{ $labels.cluster }} has
+            a high number of pending quries({{ $value }} in last 5m).'
+          summary: Instance {{ $labels.instance }} is experiencing high pending query rates.
+        labels:
+          severity: medium
+      - alert: HighAlphaOpenFDCount
+        expr: process_open_fds{job="dgraph-alpha-public"}
+          / process_max_fds{job="dgraph-alpha-public"} > 0.75
+        for: 10m
+        annotations:
+          description: 'Too many open file descriptors on alpha instance {{ $labels.instance }}: {{ $value
+            }} fraction used.'
+          summary: 'Alpha instance {{ $labels.instance }} have too many open file descriptors.'
+        labels:
+          severity: high
+      - alert: HighZeroOpenFDCount
+        expr: process_open_fds{job="dgraph-zero-public"}
+          / process_max_fds{job="dgraph-zero-public"} > 0.75
+        for: 10m
+        annotations:
+          description: 'Too many open file descriptors on zero instance {{ $labels.instance }}: {{ $value
+            }} fraction used.'
+          summary: 'Zero instance {{ $labels.instance }} have too many open file descriptors.'
+        labels:
+          severity: high
+      - alert: FollowerBehindTs
+        expr: (max
+          by(cluster) (dgraph_max_assigned_ts)) - (min by(cluster) (dgraph_max_assigned_ts))
+          > 1000
+        for: 30s
+        annotations:
+          description: A follower is behind the leader's latest applied timestamp by {{ $value }}.
+        labels:
+          severity: medium


### PR DESCRIPTION
This updates the Prometheus section in contribution.  The following items were added:

* Docs for existing Prometheseus manifests
* Helm Chart Values for prometheus-operator including Grafana install.
* Grafana dashboard adjusted for Kubernetes, e.g. using pods instead of instances.

Additionally, tested the usability of the Grafana dashboard on GKE and EKS using 21million data set to generate some traffic.  

Not included in this PR:

* Add alert rules
* Add dgraph grafana dash board automatically
* Documentation for in deploy wiki for new helm chart

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6128)
<!-- Reviewable:end -->
