### PR TITLE
docs(build): Set v20.07 docs as latest.

### DIFF
--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -29,9 +29,9 @@ NEW_THEME="master"
 # and then the older versions in descending order, such that the
 # build script can place the artifact in an appropriate location.
 
-
 # these versions use new theme
 NEW_VERSIONS=(
+        'v20.07'
 	'master'
 )
 


### PR DESCRIPTION
This updates the build script to publish v20.07 docs from the release/v20.07 branch.

Needs #6131 to be merged first into release/v20.07 to build the new split-page structure for the docs.

Now docs are built for v20.07 release series only, NOT for every patch release (e.g., v20.07.0, v20.07.1, and so on).
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6132)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f1e8e8311f-84122.surge.sh)
<!-- Dgraph:end -->