### PR TITLE
(release/v1.2) fix(Dgraph): Don't store start_ts in postings.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -516,6 +516,9 @@ func (l *List) getMutation(startTs uint64) []byte {
 	l.RLock()
 	defer l.RUnlock()
 	if pl, ok := l.mutationMap[startTs]; ok {
+		for _, p := range pl.GetPostings() {
+			p.StartTs = 0
+		}
 		data, err := pl.Marshal()
 		x.Check(err)
 		return data
@@ -586,6 +589,7 @@ func (l *List) pickPostings(readTs uint64) (uint64, []*pb.Posting) {
 					deleteBelowTs = effectiveTs
 					continue
 				}
+				mpost.StartTs = startTs
 				posts = append(posts, mpost)
 			}
 		}


### PR DESCRIPTION
Clear out the start_ts field in the postings of deltas before they are
marshalled to avoid storing that field in disk. This field is only meant
to be used during in-memory processing.

Related to https://discuss.dgraph.io/t/start-ts-not-being-cleared-before-postings-are-written-to-disk/9146

(cherry picked from commit 9d7fc94c4c1e712cf6090581e7d35290c77b6d18)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6136)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cac185c935-84194.surge.sh)
<!-- Dgraph:end -->