### PR TITLE
docs: added alpha ts metric

### DIFF
--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -61,6 +61,7 @@ The health metrics let you track to check the availability of an Dgraph Alpha in
  Metrics                          | Description
  -------                          | -----------
  `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha is ready to accept requests; otherwise 0.
+ `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This will show the latest max assigned timestamp. All alphas (within the same alpha group) should show the same timestamp if they are in sync.
 
 ## Go Metrics
 


### PR DESCRIPTION
added `dgraph_max_assigned_ts` metric to the list of metrics availalbe in `prometheus_metrics` endpoint

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6140)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-93b8a6b991-84382.surge.sh)
<!-- Dgraph:end -->