### PR TITLE
(release/v20.07) fix(Dgraph): Perform rollups more aggresively.

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -86,7 +86,7 @@ func (ir *incrRollupi) rollUpKey(writer *TxnWriter, key []byte) error {
 func (ir *incrRollupi) addKeyToBatch(key []byte) {
 	batch := ir.keysPool.Get().(*[][]byte)
 	*batch = append(*batch, key)
-	if len(*batch) < 64 {
+	if len(*batch) < 16 {
 		ir.keysPool.Put(batch)
 		return
 	}
@@ -112,7 +112,7 @@ func (ir *incrRollupi) Process(closer *y.Closer) {
 	defer limiter.Stop()
 	cleanupTick := time.NewTicker(5 * time.Minute)
 	defer cleanupTick.Stop()
-	forceRollupTick := time.NewTicker(2 * time.Second)
+	forceRollupTick := time.NewTicker(500 * time.Millisecond)
 	defer forceRollupTick.Stop()
 
 	var batch *[][]byte


### PR DESCRIPTION
- Reduce batch size to 16.
- Force a rollup to happen every 500ms instead of 2s.

Related to DGRAPH-2202

(cherry picked from commit fa013db935cdc64ca5eb31139057528d83751a3b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6146)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d28a35d5a7-84545.surge.sh)
<!-- Dgraph:end -->