### PR TITLE
docs: document upgrade and internal type/predicate namespace

### DIFF
--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -208,12 +208,16 @@ dgraph upgrade --acl -a localhost:9080 -u groot -p password
 5. [Restore]({{< relref "enterprise-features/binary-backups.md#restore-from-backup">}}) from the backups using upgraded `dgraph` binary
 6. Start a new Dgraph cluster using the restored data directories
 7. Upgrade ACL data using the following command:
-
-```
-dgraph upgrade --acl -a localhost:9080 -u groot -p password -f v20.03.0 -t v20.07.0
-```
-
-You can use `--dry-run` option in `dgraph upgrade` command to see what the upgrade command will do.
+    ```
+    dgraph upgrade --acl -a localhost:9080 -u groot -p password -f v20.03.0 -t v20.07.0
+    ```
+    You can use `--dry-run` option in `dgraph upgrade` command to see a dry run of what the upgrade
+    command will do.
+8. If you have introduced types or predicates in your schema whose names start with `dgraph.`, then
+you would need to manually alter schema to change their names to something else which isn't
+prefixed with `dgraph.`, and also do mutations to change the value of `dgraph.type` edge to the
+new type name and copy data from old predicate name to new predicate name for all the nodes which
+are affected. Then, you can drop the old types and predicates from DB.
 
 {{% notice "note" %}}
 If you are upgrading from v1.0, please make sure you follow the schema migration steps described in [this section](/howto/#schema-types-scalar-uid-and-list-uid).

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -200,6 +200,21 @@ When the new cluster (that uses the upgraded version of Dgraph) is up and runnin
 dgraph upgrade --acl -a localhost:9080 -u groot -p password
 ```
 
+### Upgrading from v20.03.0 to v20.07.0 for Enterprise Customers
+1. Use [binary]({{< relref "enterprise-features/binary-backups.md">}}) backup to export data from old cluster
+2. Ensure it is successful
+3. [Shutdown Dgraph]({{< relref "#shutting-down-database" >}}) and wait for all writes to complete
+4. Upgrade `dgraph` binary to `v20.07.0`
+5. [Restore]({{< relref "enterprise-features/binary-backups.md#restore-from-backup">}}) from the backups using upgraded `dgraph` binary
+6. Start a new Dgraph cluster using the restored data directories
+7. Upgrade ACL data using the following command:
+
+```
+dgraph upgrade --acl -a localhost:9080 -u groot -p password -f v20.03.0 -t v20.07.0
+```
+
+You can use `--dry-run` option in `dgraph upgrade` command to see what the upgrade command will do.
+
 {{% notice "note" %}}
 If you are upgrading from v1.0, please make sure you follow the schema migration steps described in [this section](/howto/#schema-types-scalar-uid-and-list-uid).
 {{% /notice %}}

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -211,9 +211,14 @@ dgraph upgrade --acl -a localhost:9080 -u groot -p password
     ```
     dgraph upgrade --acl -a localhost:9080 -u groot -p password -f v20.03.0 -t v20.07.0
     ```
+    This is required because previously the type-names `User`, `Group` and `Rule` were used by ACL.
+    They have now been renamed as `dgraph.type.User`, `dgraph.type.Group` and `dgraph.type.Rule`, to
+    keep them in dgraph's internal namespace. This upgrade just changes the type-names for the ACL
+    nodes to the new type-names.
+    
     You can use `--dry-run` option in `dgraph upgrade` command to see a dry run of what the upgrade
     command will do.
-8. If you have introduced types or predicates in your schema whose names start with `dgraph.`, then
+8. If you have types or predicates in your schema whose names start with `dgraph.`, then
 you would need to manually alter schema to change their names to something else which isn't
 prefixed with `dgraph.`, and also do mutations to change the value of `dgraph.type` edge to the
 new type name and copy data from old predicate name to new predicate name for all the nodes which

--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -82,6 +82,10 @@ If data exists and new indices are specified in a schema mutation, any index not
 
 Reverse edges are also computed if specified by a schema mutation.
 
+{{% notice "note" %}}You can't define predicate names starting with `dgraph.`, it is reserved as the
+namespace for Dgraph's internal types/predicates. For example, defining `dgraph.name` as a
+predicate is invalid.{{% /notice  %}}
+
 
 ## Indexes in Background
 

--- a/wiki/content/query-language/type-system.md
+++ b/wiki/content/query-language/type-system.md
@@ -23,6 +23,10 @@ type Student {
 }
 ```
 
+{{% notice "note" %}}You can't define type names starting with `dgraph.`, it is reserved as the
+namespace for Dgraph's internal types/predicates. For example, defining `dgraph.Student` as a
+type is invalid.{{% /notice  %}}
+
 Types are declared along with the schema using the Alter endpoint. In order to
 properly support the above type, a predicate for each of the attributes
 in the type is also needed, such as:


### PR DESCRIPTION
Fixes DGRAPH-1714.
This PR adds documentation for upgrading from `v20.03.x` to `v20.07.0`. It also adds documentation for the reserved `dgraph.` namespace for internal types and predicates.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6149)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-eaf7d05835-85181.surge.sh)
<!-- Dgraph:end -->