### PR TITLE
(releave/v20.07) Queue keys for rollup during mutation.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -326,6 +326,14 @@ func (l *List) updateMutationLayer(mpost *pb.Posting, singleUidUpdate bool) erro
 	l.AssertLock()
 	x.AssertTrue(mpost.Op == Set || mpost.Op == Del)
 
+	// Keys are added to the rollup batches here instead of at the point at which the
+	// transaction is committed because the transaction context does not keep track
+	// of the badger keys touched by mutations. It's useful to roll up lists even if
+	// the transaction is eventually aborted.
+	if len(l.mutationMap) > 0 {
+		IncrRollup.addKeyToBatch(l.key)
+	}
+
 	// If we have a delete all, then we replace the map entry with just one.
 	if hasDeleteAll(mpost) {
 		plist := &pb.PostingList{}


### PR DESCRIPTION
Right now, keys are only added for rollups during queries. Keys that
only receive queries will not be rolled up until they are queried, which
can cause issues and slowness.

Fixes DGRAPH-2202

(cherry picked from commit 3ea5efe5bd94936fcbcc402a330b49e4a6870a2a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6151)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c77038a5ba-84722.surge.sh)
<!-- Dgraph:end -->