### PR TITLE
feat(GraphQL): @custom HTTP body now supports hardcoded scalars

### DIFF
--- a/graphql/e2e/custom_logic/cmd/main.go
+++ b/graphql/e2e/custom_logic/cmd/main.go
@@ -281,7 +281,7 @@ func postFavMoviesWithBodyHandler(w http.ResponseWriter, r *http.Request) {
 	err := verifyRequest(r, expectedRequest{
 		method:    http.MethodPost,
 		urlSuffix: "/0x123?name=Author",
-		body:      `{"id":"0x123","name":"Author"}`,
+		body:      `{"id":"0x123","movie_type":"space","name":"Author"}`,
 		headers:   nil,
 	})
 	if err != nil {

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -165,7 +165,7 @@ func TestCustomPostQueryWithBody(t *testing.T) {
 	 type Query {
 		 myFavoriteMoviesPost(id: ID!, name: String!, num: Int): [Movie] @custom(http: {
 				 url: "http://mock:8888/favMoviesPostWithBody/$id?name=$name",
-                 body:"{id:$id,name:$name,num:$num}"
+                 body:"{id:$id,name:$name,num:$num,movie_type:\"space\"}"
 				 method: "POST"
 		 })
 	 }`

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -852,13 +852,7 @@ func resolveCustomField(f schema.Field, vals []interface{}, mu *sync.RWMutex, er
 			}
 
 			mu.RLock()
-			if err := schema.SubstituteVarsInBody(&temp, vals[i].(map[string]interface{})); err != nil {
-				errCh <- x.GqlErrorf("Evaluation of custom field failed while substituting "+
-					"variables into body for remote endpoint with an error: %s for field: %s "+
-					"within type: %s.", err, f.Name(), f.GetObjectName()).WithLocations(f.Location())
-				mu.RUnlock()
-				return
-			}
+			schema.SubstituteVarsInBody(&temp, vals[i].(map[string]interface{}))
 			mu.RUnlock()
 			inputs[i] = temp
 		}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2662,7 +2662,7 @@ valid_schemas:
         getAuthorsForCountry(country_code: String!): [Author] @custom(http: {
             url: "http://blah.com"
             method: "POST"
-            body: "{country_code: $country_code, version: 1}"
+            body: "{country_code: $country_code, version: 1, tag: \"temp\"}"
         })
       }
       type Mutation {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2636,7 +2636,7 @@ valid_schemas:
       }
 
   -
-    name: "Query, Mutation in initial schema with @custom directive"
+    name: "initial schema with @custom directive"
     input: |
       type Author {
         id: ID!

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -1179,7 +1179,7 @@ invalid_schemas:
         })
       }
     errlist: [
-    {"message": "Type Query; Field getAuthor1; body template inside @custom directive could not be parsed.",
+    {"message": "Type Query; Field getAuthor1; body template inside @custom directive could not be parsed: found unexpected value: name",
      "locations":[{"line":10, "column":12}]},
     ]
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -1175,7 +1175,7 @@ invalid_schemas:
         getAuthor1(id: ID): Author! @custom(http: {
           url: "http://google.com/",
           method: "POST",
-          body: "{id: $id, name: \"name\"}",
+          body: "{id: $id, name: name}",
         })
       }
     errlist: [
@@ -2645,9 +2645,25 @@ valid_schemas:
       input AuthorUpdate {
         id: ID!
       }
+      type Country {
+        country_code: String! @id
+        authors: [Author] @custom(http: {
+             url: "http://blah.com",
+             method: "POST"
+             graphql: "query ($input: [AuthorInput]) { authors(input: $input) }"
+             body: "{country_code: $country_code, version: ONE}"
+             mode: BATCH
+             skipIntrospection: true
+        })
+      }
 
       type Query {
         getMyAuthor(id: ID): Author! @custom(http: {url: "http://blah.com", method: "GET"})
+        getAuthorsForCountry(country_code: String!): [Author] @custom(http: {
+            url: "http://blah.com"
+            method: "POST"
+            body: "{country_code: $country_code, version: 1}"
+        })
       }
       type Mutation {
         updateMyAuthor(input: AuthorUpdate!): Author! @custom(http: {url: "http://blah.com",

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1418,7 +1418,11 @@ func customDirectiveValidation(sch *ast.Schema,
 	// 8. Validating body
 	var requiredFields map[string]bool
 	if body != nil {
-		_, requiredFields, err = parseBodyTemplate(body.Raw)
+		strictJSON := true
+		if graphql != nil {
+			strictJSON = false
+		}
+		_, requiredFields, err = parseBodyTemplate(body.Raw, strictJSON)
 		if err != nil {
 			errs = append(errs, gqlerror.ErrorPosf(body.Position,
 				"Type %s; Field %s; body template inside @custom directive could not be parsed.",
@@ -1564,7 +1568,7 @@ func customDirectiveValidation(sch *ast.Schema,
 					bodyBuilder.WriteString(comma)
 				}
 				bodyBuilder.WriteString("}")
-				_, requiredVars, err := parseBodyTemplate(bodyBuilder.String())
+				_, requiredVars, err := parseBodyTemplate(bodyBuilder.String(), false)
 				if err != nil {
 					errs = append(errs, gqlerror.ErrorPosf(graphql.Position,
 						"Type %s; Field %s: inside graphql in @custom directive, "+

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1418,15 +1418,11 @@ func customDirectiveValidation(sch *ast.Schema,
 	// 8. Validating body
 	var requiredFields map[string]bool
 	if body != nil {
-		strictJSON := true
-		if graphql != nil {
-			strictJSON = false
-		}
-		_, requiredFields, err = parseBodyTemplate(body.Raw, strictJSON)
+		_, requiredFields, err = parseBodyTemplate(body.Raw, graphql == nil)
 		if err != nil {
 			errs = append(errs, gqlerror.ErrorPosf(body.Position,
-				"Type %s; Field %s; body template inside @custom directive could not be parsed.",
-				typ.Name, field.Name))
+				"Type %s; Field %s; body template inside @custom directive could not be parsed: %s",
+				typ.Name, field.Name, err.Error()))
 		}
 		// Validating params to body template for Query/Mutation types. For other types the
 		// validation is performed later along with graphql.

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -689,12 +689,8 @@ func (f *field) HasCustomDirective() (bool, map[string]bool) {
 	bodyArg := httpArg.Value.Children.ForName("body")
 	graphqlArg := httpArg.Value.Children.ForName("graphql")
 	if bodyArg != nil {
-		strictJSON := true
-		if graphqlArg != nil {
-			strictJSON = false
-		}
 		bodyTemplate := bodyArg.Raw
-		_, rf, _ = parseBodyTemplate(bodyTemplate, strictJSON)
+		_, rf, _ = parseBodyTemplate(bodyTemplate, graphqlArg == nil)
 	}
 
 	if rf == nil {
@@ -1863,6 +1859,8 @@ func parseAsJSONTemplate(value *ast.Value, vars map[string]bool, strictJSON bool
 // would return
 // { "author" : "$id", "post": { "id": "$postID" }} and { "id": true, "postID": true}
 // If the final result is not a valid JSON, then an error is returned.
+//
+// In strictJSON mode block strings and enums are invalid and throw an error.
 // strictJSON should be false when the body template is being used for custom graphql arg parsing,
 // otherwise it should be true.
 func parseBodyTemplate(body string, strictJSON bool) (*interface{}, map[string]bool, error) {


### PR DESCRIPTION
Fixes #5641
Fixes GRAPHQL-508
Fixes [Discuss Issue](https://discuss.dgraph.io/t/custom-mutation-underscores-within-post-body/8622)

This PR adds support for parsing hardcoded scalar values in `@custom` HTTP body.
This also adds support for allowing `_` in key names in the body template.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6157)
<!-- Reviewable:end -->
