### PR TITLE
fix(GraphQL): multiple queries in a single request should not share the same variables (#5953)

### DIFF
--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -629,6 +629,13 @@ func (f *field) ArgValue(name string) interface{} {
 	if f.arguments == nil {
 		// Compute and cache the map first time this function is called for a field.
 		f.arguments = f.field.ArgumentMap(f.op.vars)
+		// use a deep-copy only if the request uses variables, as a variable could be shared by
+		// multiple queries in a single request and internally in our code we may overwrite field
+		// arguments which may result in the shared value being overwritten for all queries in a
+		// request.
+		if f.op.vars != nil {
+			f.arguments = x.DeepCopyJsonMap(f.arguments)
+		}
 	}
 	return f.arguments[name]
 }

--- a/x/x.go
+++ b/x/x.go
@@ -998,3 +998,47 @@ func StoreSync(db DB, closer *y.Closer) {
 		}
 	}
 }
+
+// DeepCopyJsonMap returns a deep copy of the input map `m`.
+// `m` is supposed to be a map similar to the ones produced as a result of json unmarshalling. i.e.,
+// any value in `m` at any nested level should be of an inbuilt go type.
+func DeepCopyJsonMap(m map[string]interface{}) map[string]interface{} {
+	if m == nil {
+		return nil
+	}
+
+	mCopy := make(map[string]interface{})
+	for k, v := range m {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			mCopy[k] = DeepCopyJsonMap(val)
+		case []interface{}:
+			mCopy[k] = DeepCopyJsonArray(val)
+		default:
+			mCopy[k] = val
+		}
+	}
+	return mCopy
+}
+
+// DeepCopyJsonArray returns a deep copy of the input array `a`.
+// `a` is supposed to be an array similar to the ones produced as a result of json unmarshalling.
+// i.e., any value in `a` at any nested level should be of an inbuilt go type.
+func DeepCopyJsonArray(a []interface{}) []interface{} {
+	if a == nil {
+		return nil
+	}
+
+	aCopy := make([]interface{}, 0, len(a))
+	for _, v := range a {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			aCopy = append(aCopy, DeepCopyJsonMap(val))
+		case []interface{}:
+			aCopy = append(aCopy, DeepCopyJsonArray(val))
+		default:
+			aCopy = append(aCopy, val)
+		}
+	}
+	return aCopy
+}


### PR DESCRIPTION
Fixes GraphQL-570.

Earlier, sending a query like this:
```
query ($filter: CountryFilter!){
  qc0: queryCountry(filter: $filter) {
    id
    name
  }
  qc1: queryCountry(filter: $filter) {
    id
    name
  }
}
```
where $filter is a GraphQL variable as below:
```
{
	"filter": {
		"id": [
			"0x0"
		]
	}
}
```
would fetch you results like this:
```
"data": {
    "qc0": [
      {
        "id": "0x2711",
        "name": "India"
      },
      {
        "id": "0x2712",
        "name": "Australia"
      },
      {
        "id": "0x2713",
        "name": "US"
      }
    ],
    "qc1": []
  }
```
While you should have got empty results for both the queries as `0x0` is not a uid that exists.

This PR fixes the above bug by doing a deep-copy of field arguments if variables are provided, so avoiding sharing the same memory address across all the queries in a request. Hence, avoiding any bugs that could be caused as a result of modification of that shared memory address.

(cherry picked from commit 58e90aad1f1d85bf8201e6942100e9f993292674)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6158)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c53589cfad-85121.surge.sh)
<!-- Dgraph:end -->