### PR TITLE
perf(GraphQL): Fix filter order with UID (#5928)

### DIFF
--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -19,7 +19,7 @@
         uid
       }
       UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret)) @filter(uid(0x123))
+      UserSecret1 as var(func: uid(0x123)) @filter(type(UserSecret))
       UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   uids: |
@@ -50,7 +50,7 @@
         uid
       }
       ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: type(Column)) @filter(uid(0x123))
+      Column1 as var(func: uid(0x123)) @filter(type(Column))
       ColumnAuth2 as var(func: uid(Column1)) @cascade {
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
@@ -117,7 +117,7 @@
         uid
       }
       ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: type(Column)) @filter(uid(0x123))
+      Column1 as var(func: uid(0x123)) @filter(type(Column))
       ColumnAuth2 as var(func: uid(Column1)) @cascade {
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
@@ -187,7 +187,7 @@
         uid
       }
       ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: type(Column)) @filter(uid(0x123))
+      Column1 as var(func: uid(0x123)) @filter(type(Column))
       ColumnAuth2 as var(func: uid(Column1)) @cascade {
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
@@ -254,7 +254,7 @@
         uid
       }
       ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: type(Column)) @filter(uid(0x123))
+      Column1 as var(func: uid(0x123)) @filter(type(Column))
       ColumnAuth2 as var(func: uid(Column1)) @cascade {
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
@@ -322,7 +322,7 @@
         uid
       }
       TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket)) @filter(uid(0x123))
+      Ticket1 as var(func: uid(0x123)) @filter(type(Ticket))
       TicketAuth2 as var(func: uid(Ticket1)) @cascade {
         onColumn : Ticket.onColumn {
           inProject : Column.inProject {
@@ -391,7 +391,7 @@
         uid
       }
       TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket)) @filter(uid(0x123))
+      Ticket1 as var(func: uid(0x123)) @filter(type(Ticket))
       TicketAuth2 as var(func: uid(Ticket1)) @cascade {
         onColumn : Ticket.onColumn {
           inProject : Column.inProject {
@@ -487,7 +487,7 @@
         uid
       }
       LogRoot as var(func: uid(Log1))
-      Log1 as var(func: type(Log)) @filter(uid(0x123))
+      Log1 as var(func: uid(0x123)) @filter(type(Log))
     }
 
 - name: "Update with top level OR RBAC false."
@@ -515,7 +515,7 @@
         uid
       }
       ProjectRoot as var(func: uid(Project1)) @filter(uid(ProjectAuth2))
-      Project1 as var(func: type(Project)) @filter(uid(0x123))
+      Project1 as var(func: uid(0x123)) @filter(type(Project))
       ProjectAuth2 as var(func: uid(Project1)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -550,7 +550,7 @@
         uid
       }
       ProjectRoot as var(func: uid(Project1))
-      Project1 as var(func: type(Project)) @filter(uid(0x123))
+      Project1 as var(func: uid(0x123)) @filter(type(Project))
     }
 
 - name: "Update with top level And RBAC true."
@@ -578,7 +578,7 @@
         uid
       }
       IssueRoot as var(func: uid(Issue1)) @filter(uid(IssueAuth2))
-      Issue1 as var(func: type(Issue)) @filter(uid(0x123))
+      Issue1 as var(func: uid(0x123)) @filter(type(Issue))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
         dgraph.uid : uid
@@ -634,7 +634,7 @@
         uid
       }
       ComplexLogRoot as var(func: uid(ComplexLog1))
-      ComplexLog1 as var(func: type(ComplexLog)) @filter(uid(0x123))
+      ComplexLog1 as var(func: uid(0x123)) @filter(type(ComplexLog))
     }
 
 - name: "Update with top level not RBAC false."

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -616,7 +616,7 @@ func checkResult(frags []*mutationFragment, result map[string]interface{}) error
 	return err
 }
 
-func extractFilter(m schema.Mutation) map[string]interface{} {
+func extractMutationFilter(m schema.Mutation) map[string]interface{} {
 	var filter map[string]interface{}
 	mutationType := m.MutationType()
 	if mutationType == schema.UpdateMutation {
@@ -653,13 +653,13 @@ func RewriteUpsertQueryFromMutation(m schema.Mutation, authRw *authRewriter) *gq
 	})
 
 	// TODO - Cache this instead of this being a loop to find the IDField.
-	if ids := idFilter(m, m.MutatedType().IDField()); ids != nil {
+	filter := extractMutationFilter(m)
+	if ids := idFilter(filter, m.MutatedType().IDField()); ids != nil {
 		addUIDFunc(dgQuery, ids)
 	} else {
 		addTypeFunc(dgQuery, m.MutatedType().DgraphName())
 	}
 
-	filter := extractFilter(m)
 	addFilter(dgQuery, m.MutatedType(), filter)
 
 	dgQuery = authRw.addAuthQueries(m.MutatedType(), dgQuery, rbac)

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -236,7 +236,7 @@ func rewriteAsQueryByIds(field schema.Field, uids []uint64, authRw *authRewriter
 		UID:  uids,
 	}
 
-	if ids := idFilter(field, field.Type().IDField()); ids != nil {
+	if ids := idFilter(extractQueryFilter(field), field.Type().IDField()); ids != nil {
 		addUIDFunc(dgQuery, intersection(ids, uids))
 	}
 
@@ -375,7 +375,7 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) *gql.GraphQuery {
 			authRw.varName = ""
 			authRw.filterByUid = false
 		}
-	} else if ids := idFilter(field, field.Type().IDField()); ids != nil {
+	} else if ids := idFilter(extractQueryFilter(field), field.Type().IDField()); ids != nil {
 		addUIDFunc(dgQuery, ids)
 	} else {
 		addTypeFunc(dgQuery, field.Type().DgraphName())
@@ -872,9 +872,13 @@ func convertIDs(idsSlice []interface{}) []uint64 {
 	return ids
 }
 
-func idFilter(field schema.Field, idField schema.FieldDefinition) []uint64 {
-	filter, ok := field.ArgValue("filter").(map[string]interface{})
-	if !ok || idField == nil {
+func extractQueryFilter(f schema.Field) map[string]interface{} {
+	filter, _ := f.ArgValue("filter").(map[string]interface{})
+	return filter
+}
+
+func idFilter(filter map[string]interface{}, idField schema.FieldDefinition) []uint64 {
+	if filter == nil || idField == nil {
 		return nil
 	}
 

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -27,7 +27,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124)) {
+      x as updatePost(func: uid(0x123, 0x124)) @filter(type(Post)) {
         uid
       }
     }
@@ -61,7 +61,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124)) {
+      x as updatePost(func: uid(0x123, 0x124)) @filter(type(Post)) {
         uid
       }
     }
@@ -95,7 +95,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updatePost(func: type(Post)) @filter(uid(0x123, 0x124)) {
+      x as updatePost(func: uid(0x123, 0x124)) @filter(type(Post)) {
         uid
       }
     }
@@ -137,7 +137,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateHuman(func: type(Human)) @filter(uid(0x123)) {
+      x as updateHuman(func: uid(0x123)) @filter(type(Human)) {
         uid
       }
     }
@@ -162,7 +162,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateCharacter(func: type(Character)) @filter(uid(0x123)) {
+      x as updateCharacter(func: uid(0x123)) @filter(type(Character)) {
         uid
       }
     }
@@ -289,7 +289,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateEditor(func: type(Editor)) @filter((eq(Editor.code, "editor") AND uid(0x1, 0x2))) {
+      x as updateEditor(func: uid(0x1, 0x2)) @filter((eq(Editor.code, "editor") AND type(Editor))) {
         uid
       }
     }
@@ -334,7 +334,7 @@
       cond: "@if(eq(len(Post3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
@@ -452,7 +452,7 @@
       cond: "@if(eq(len(Post3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x124)) @filter(type(Post)) {
@@ -494,7 +494,7 @@
       cond: "@if(eq(len(Post3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
@@ -555,7 +555,7 @@
       cond: "@if(eq(len(Post6), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
@@ -614,7 +614,7 @@
       cond: "@if(eq(len(Post3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
@@ -660,7 +660,7 @@
       cond: "@if(gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
     }
@@ -728,7 +728,7 @@
       cond: "@if(eq(len(State5), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       State5 as State5(func: eq(State.code, "dg")) @filter(type(State)) {
@@ -737,7 +737,7 @@
     }
   dgquerysec: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       State5 as State5(func: eq(State.code, "dg")) @filter(type(State)) {
@@ -799,7 +799,7 @@
       cond: "@if(eq(len(State5), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       State5 as State5(func: eq(State.code, "dg")) @filter(type(State)) {
@@ -855,7 +855,7 @@
       cond: "@if(eq(len(House3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateOwner(func: type(Owner)) @filter(uid(0x123)) {
+      x as updateOwner(func: uid(0x123)) @filter(type(Owner)) {
         uid
       }
       House3 as House3(func: uid(0x456)) @filter(type(House)) {
@@ -901,7 +901,7 @@
       cond: "@if(eq(len(Movie3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateMovieDirector(func: type(MovieDirector)) @filter(uid(0x123)) {
+      x as updateMovieDirector(func: uid(0x123)) @filter(type(MovieDirector)) {
         uid
       }
       Movie3 as Movie3(func: uid(0x456)) @filter(type(Movie)) {
@@ -941,7 +941,7 @@
       cond: "@if(eq(len(Movie3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateMovieDirector(func: type(MovieDirector)) @filter(uid(0x123)) {
+      x as updateMovieDirector(func: uid(0x123)) @filter(type(MovieDirector)) {
         uid
       }
       Movie3 as Movie3(func: uid(0x456)) @filter(type(Movie)) {
@@ -982,7 +982,7 @@
   is same, it should not return error."
   dgquery: |-
     query {
-      x as updateStudent(func: type(Student)) @filter(uid(0x123)) {
+      x as updateStudent(func: uid(0x123)) @filter(type(Student)) {
         uid
       }
       Teacher4 as Teacher4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
@@ -991,7 +991,7 @@
     }
   dgquerysec: |-
     query {
-      x as updateStudent(func: type(Student)) @filter(uid(0x123)) {
+      x as updateStudent(func: uid(0x123)) @filter(type(Student)) {
         uid
       }
       Teacher4 as Teacher4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
@@ -1217,7 +1217,7 @@
       cond: "@if(eq(len(Post3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateAuthor(func: type(Author)) @filter(uid(0x123)) {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
@@ -1267,7 +1267,7 @@
       cond: "@if(eq(len(Author3), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updatePost(func: type(Post)) @filter(uid(0x123)) {
+      x as updatePost(func: uid(0x123)) @filter(type(Post)) {
         uid
       }
       Author3 as Author3(func: uid(0x456)) @filter(type(Author)) {
@@ -1328,7 +1328,7 @@
       cond: "@if(eq(len(State4), 1) AND gt(len(x), 0))"
   dgquery: |-
     query {
-      x as updateCountry(func: type(Country)) @filter(uid(0x123)) {
+      x as updateCountry(func: uid(0x123)) @filter(type(Country)) {
         uid
       }
       State4 as State4(func: eq(State.code, "abc")) @filter(type(State)) {
@@ -1337,7 +1337,7 @@
     }
   dgquerysec: |-
     query {
-      x as updateCountry(func: type(Country)) @filter(uid(0x123)) {
+      x as updateCountry(func: uid(0x123)) @filter(type(Country)) {
         uid
       }
       State4 as State4(func: eq(State.code, "abc")) @filter(type(State)) {


### PR DESCRIPTION
There were cases that get rewritten like `updateStudent(func: type(Student)) @filter(uid(0x123)) { ... }`. This PR changes them to get rewritten like `updateStudent(func: uid(0x123)) @filter(type(Student)) { ... }` because, having `uid` as root func is more efficient than having `type` as root func.

(cherry picked from commit 64ce93bf6890eb20b09017453ae78fb63b3bf80e)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6159)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b202a7c9e9-85127.surge.sh)
<!-- Dgraph:end -->