### PR TITLE
feat(Telemetry): Cleaning up telemetry for custom service

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -47,7 +47,7 @@ type Telemetry struct {
 	NumGraphQL   uint64 `json:",omitempty"`
 }
 
-const url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
+const url = "https://ping.dgraph.io"
 
 // NewZero returns a Telemetry struct that holds information about the state of zero server.
 func NewZero(ms *pb.MembershipState) *Telemetry {


### PR DESCRIPTION
Since we are sending telemetry to custom service now, we can remove the request path and also the auth header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6162)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-df571124d1-87236.surge.sh)
<!-- Dgraph:end -->