### PR TITLE
fix(GraphQL):  Disallow  Subscription typename. (#6077)

### DIFF
--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2387,6 +2387,18 @@ invalid_schemas:
      "locations":[{"line":6, "column":5}]}
     ]
 
+  -
+    name: "Subscription typename should return error"
+    input: |
+      type Subscription {
+              name: String
+      }
+
+    errlist: [
+    {"message": "Subscription is a reserved word, so you can't declare a type with this name. Pick a different name for the type.", "locations": [{"line":1, "column":6}]},
+    ]
+
+
 valid_schemas:
   - name: "@auth on interface implementation"
     input: |

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1781,7 +1781,13 @@ func isReservedArgument(name string) bool {
 }
 
 func isReservedKeyWord(name string) bool {
-	if isScalar(name) || isQueryOrMutation(name) || name == "uid" {
+	reservedTypeNames := map[string]bool{
+		// Reserved Type names
+		"uid":          true,
+		"Subscription": true,
+	}
+
+	if isScalar(name) || isQueryOrMutation(name) || reservedTypeNames[name] {
 		return true
 	}
 


### PR DESCRIPTION
This PR disallow Subscription typename so that it doesn't conflict with Subscriptions generated.

(cherry picked from commit 601e837e39d6e796db8f5c46921413f63e02b3c2)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6173)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-05faf22c4b-85645.surge.sh)
<!-- Dgraph:end -->