### PR TITLE
fix(GraphQL): Prevent empty values in fields having `id` directive.

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -2213,3 +2213,49 @@
         uid
       }
     }
+
+-
+  name: "Add mutation error on @id field for empty value"
+  gqlmutation: |
+    mutation addState($input: AddStateInput!) {
+      addState(input: [$input]) {
+        state {
+          name
+        }
+      }
+    }
+  gqlvariables: |
+    { "input":
+      {
+        "code": "",
+        "name": "NSW",
+        "country": { "id": "0x12" }
+      }
+    }
+  explanation: "The add mutation should not be allowed since value of @id field is empty."
+  error:
+    { "message": "failed to rewrite mutation payload because encountered an empty value for @id field `State.code`" }
+
+-
+  name: "Add mutation error on @id field for empty value (Nested)"
+  gqlmutation: |
+    mutation addCountry($input: AddCountryInput!) {
+      addCountry(input: [$input]) {
+        country {
+          name
+        }
+      }
+    }
+  gqlvariables: |
+    { "input":
+      {
+        "name": "Dgraph Land",
+        "states": [ {
+          "code": "",
+          "name": "Dgraph"
+        } ]
+      }
+    }
+  explanation: "The add mutation should not be allowed since value of @id field is empty."
+  error:
+    { "message": "failed to rewrite mutation payload because encountered an empty value for @id field `State.code`" }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1154,6 +1154,13 @@ func rewriteObject(
 				//   e.g. to remove the text or
 				//   { "friends": null, ... }
 				//   to remove all friends
+
+				// Fields with `id` directive cannot have empty values.
+				if fieldDef.HasIDDirective() && val == "" {
+					errFrag := newFragment(nil)
+					errFrag.err = fmt.Errorf("encountered an empty value for @id field `%s`", fieldName)
+					return &mutationRes{secondPass: []*mutationFragment{errFrag}}
+				}
 				frags = &mutationRes{secondPass: []*mutationFragment{newFragment(val)}}
 			}
 

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -1348,6 +1348,30 @@
       }
     }
 
+- name: "Update mutation error on @id field for empty value"
+  gqlmutation: |
+    mutation updateCountry($patch: UpdateCountryInput!) {
+      updateCountry(input: $patch) {
+        country {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "patch": {
+        "filter": {
+          "id": ["0x123"]
+        },
+        "set": {
+          "states": [ { "code": "", "name": "Alphabet" } ]
+        }
+      }
+    }
+  explanation: "The update mutation should not be allowed since value of @id field is empty."
+  error:
+    { "message": "failed to rewrite mutation payload because encountered an empty value for @id field `State.code`" }
+
 - name: "Additional Deletes - Update references existing node by XID (updt single edge)"
   gqlmutation: |
     mutation updateComputerOwner($patch: UpdateComputerOwnerInput!) {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -185,6 +185,7 @@ type FieldDefinition interface {
 	Name() string
 	Type() Type
 	IsID() bool
+	HasIDDirective() bool
 	Inverse() FieldDefinition
 	// TODO - It might be possible to get rid of ForwardEdge and just use Inverse() always.
 	ForwardEdge() FieldDefinition
@@ -1356,6 +1357,13 @@ func (fd *fieldDefinition) Name() string {
 
 func (fd *fieldDefinition) IsID() bool {
 	return isID(fd.fieldDef)
+}
+
+func (fd *fieldDefinition) HasIDDirective() bool {
+	if fd.fieldDef == nil {
+		return false
+	}
+	return hasIDDirective(fd.fieldDef)
 }
 
 func hasIDDirective(fd *ast.FieldDefinition) bool {


### PR DESCRIPTION
Fixes GRAPHQL-458

Schema:
```
type Post {
    id: ID!
    title: String! @id
    text: String!
}
```

Mutation:
```
mutation AP {
   addPost(input: [{title: "", text: "TextHello" }]) {
    post{
      id
      title
      text
    }
    numUids
  }
}
```

This PR errors out on the following mutation which was previously allowed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6177)
<!-- Reviewable:end -->
