### PR TITLE
fix(GraphQL): Fix getType queries when id was used as a name for types other than ID (#6130)

### DIFF
--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1326,7 +1326,7 @@
         }
       }
     }
-  dgquery: |
+  dgquery: |-
     query {
       getPost(func: uid(0x1)) @filter(type(Post)) {
         postID : uid
@@ -1337,5 +1337,21 @@
           id : uid
           url : Comment.url
         }
+      }
+    }
+- name: "getType by id should work"
+  gqlquery: |-
+    query {
+      getTweets(id: "1286891968727982081") {
+        score
+        id
+      }
+    }
+  dgquery: |-
+    query {
+      getTweets(func: eq(Tweets.id, "1286891968727982081")) @filter(type(Tweets)) {
+        score : Tweets.score
+        id : Tweets.id
+        dgraph.uid : uid
       }
     }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -239,3 +239,8 @@ type Y implements X @auth(
 ){
   userRole: String @search(by: [hash])
 }
+
+type Tweets {
+    id: String! @id
+    score: Int
+}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -87,7 +87,6 @@ const (
 	HTTPMutation         MutationType = "http"
 	NotSupportedMutation MutationType = "notsupported"
 	IDType                            = "ID"
-	IDArgName                         = "id"
 	InputArgName                      = "input"
 	FilterArgName                     = "filter"
 )
@@ -731,8 +730,17 @@ func (f *field) HasCustomDirective() (bool, map[string]bool) {
 func (f *field) XIDArg() string {
 	xidArgName := ""
 	passwordField := f.Type().PasswordField()
-	for _, arg := range f.field.Arguments {
-		if arg.Name != IDArgName && (passwordField == nil ||
+
+	args := f.field.Definition.Arguments
+	if len(f.field.Definition.Arguments) == 0 {
+		// For acl endpoints like getCurrentUser which redirects to getUser resolver, the field
+		// definition doesn't change and hence we can't find the arguments for getUser. As a
+		// fallback, we get the args from the query field arguments in that case.
+		args = f.op.inSchema.schema.Query.Fields.ForName(f.Name()).Arguments
+	}
+
+	for _, arg := range args {
+		if arg.Type.Name() != IDType && (passwordField == nil ||
 			arg.Name != passwordField.Name()) {
 			xidArgName = arg.Name
 		}
@@ -1608,7 +1616,7 @@ func (t *astType) Interfaces() []string {
 // satisfy a valid post.
 func (t *astType) EnsureNonNulls(obj map[string]interface{}, exclusion string) error {
 	for _, fld := range t.inSchema.schema.Types[t.Name()].Fields {
-		if fld.Type.NonNull && !isID(fld) && !(fld.Name == exclusion) {
+		if fld.Type.NonNull && !isID(fld) && fld.Name != exclusion {
 			if val, ok := obj[fld.Name]; !ok || val == nil {
 				return errors.Errorf(
 					"type %s requires a value for field %s, but no value present",


### PR DESCRIPTION
For the schema

type Tweets {
	id: String! @id
	score: Int
}

getTweets query was not being properly re-written. This is because we were using the name id to signify that a field is of type ID instead of the type ID itself. That has been fixed now. So getTweets would work if the field was named anything.

query MyQuery {
  getTweets(id: "1286891968727982081") {
    score
    id
  }
}

(cherry picked from commit bb8e4b9d5456cc05a1abd15933b95881ca8e156b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6180)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-722e428c44-85760.surge.sh)
<!-- Dgraph:end -->