### PR TITLE
fix(GraphQL): Remove github issues link from the error messages. (#6036)

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -43,8 +43,7 @@ const (
 	errNoGraphQLSchema = "Not resolving %s. There's no GraphQL schema in Dgraph.  " +
 		"Use the /admin API to add a GraphQL schema"
 	errResolverNotFound = "%s was not executed because no suitable resolver could be found - " +
-		"this indicates a resolver or validation bug " +
-		"(Please let us know : https://github.com/dgraph-io/dgraph/issues)"
+		"this indicates a resolver or validation bug. Please let us know by filing an issue."
 
 	// GraphQL schema for /admin endpoint.
 	graphqlAdminSchema = `

--- a/graphql/api/panics.go
+++ b/graphql/api/panics.go
@@ -34,6 +34,6 @@ func PanicHandler(fn func(error)) {
 
 		fn(errors.Errorf("Internal Server Error - a panic was trapped.  " +
 			"This indicates a bug in the GraphQL server.  A stack trace was logged.  " +
-			"Please let us know : https://github.com/dgraph-io/dgraph/issues."))
+			"Please let us know by filing an issue with the stack trace."))
 	}
 }

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -253,7 +253,7 @@ func panicCatcher(t *testing.T) {
 			require.Equal(t, x.GqlErrorList{
 				{Message: fmt.Sprintf("Internal Server Error - a panic was trapped.  " +
 					"This indicates a bug in the GraphQL server.  A stack trace was logged.  " +
-					"Please let us know : https://github.com/dgraph-io/dgraph/issues.")}},
+					"Please let us know by filing an issue with the stack trace.")}},
 				gqlResponse.Errors)
 
 			require.Nil(t, gqlResponse.Data, string(gqlResponse.Data))

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -666,8 +666,7 @@ func completeDgraphResult(
 		glog.Errorf("Could not process Dgraph result : \n%s", string(dgResult))
 		return nullResponse(
 			x.GqlErrorf("Couldn't process the result from Dgraph.  " +
-				"This probably indicates a bug in the Dgraph GraphQL layer.  " +
-				"Please let us know : https://github.com/dgraph-io/dgraph/issues.").
+				"This probably indicates a bug in Dgraph. Please let us know by filing an issue.").
 				WithLocations(field.Location()))
 	}
 

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -27,25 +27,25 @@ import (
 func Introspect(q Query) (json.RawMessage, error) {
 	if q.Name() != "__schema" && q.Name() != "__type" && q.Name() != Typename {
 		return nil, errors.New("call to introspect for field that isn't an introspection query " +
-			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
+			"this indicates bug. Please let us know by filing an issue.")
 	}
 
 	sch, ok := q.Operation().Schema().(*schema)
 	if !ok {
 		return nil, errors.New("couldn't convert schema to internal type " +
-			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
+			"this indicates bug. Please let us know by filing an issue.")
 	}
 
 	op, ok := q.Operation().(*operation)
 	if !ok {
 		return nil, errors.New("couldn't convert operation to internal type " +
-			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
+			"this indicates bug. Please let us know by filing an issue.")
 	}
 
 	qu, ok := q.(*query)
 	if !ok {
 		return nil, errors.New("couldn't convert query to internal type " +
-			"this indicates bug (Please let us know : https://github.com/dgraph-io/dgraph/issues)")
+			"this indicates bug. Please let us know by filing an issue.")
 	}
 
 	reqCtx := &requestContext{

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -1,0 +1,86 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+      - 5180:5180
+      - 6180:6180
+    command: /gobin/dgraph zero --cwd=/data/zero1 --my=zero1:5180 -o 100 --bindall --logtostderr -v=0 --replicas 3
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    env_file:
+      - export.env
+    labels:
+      cluster: test
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    ports:
+      - 8180:8180
+      - 9180:9180
+    command: /gobin/dgraph alpha --cwd=/data/alpha1 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180 -o 100 -v=0 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+  alpha2:
+    image: dgraph/dgraph:latest
+    container_name: alpha2
+    working_dir: /data/alpha2
+    env_file:
+      - export.env
+    labels:
+      cluster: test
+    depends_on:
+      - alpha1
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    ports:
+      - 8182:8182
+      - 9182:9182
+    command: /gobin/dgraph alpha --cwd=/data/alpha2 --my=alpha2:7182 --lru_mb=1024 --zero=zero1:5180 -o 102 -v=0 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+  alpha3:
+    image: dgraph/dgraph:latest
+    container_name: alpha3
+    working_dir: /data/alpha3
+    env_file:
+      - export.env
+    labels:
+      cluster: test
+    depends_on:
+      - alpha2
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    ports:
+      - 8183:8183
+      - 9183:9183
+    command: /gobin/dgraph alpha --cwd=/data/alpha3 --my=alpha3:7183 --lru_mb=1024 --zero=zero1:5180 -o 103 -v=0 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+
+  minio1:
+    image: minio/minio:latest
+    container_name: minio1
+    env_file:
+      - export.env
+    ports:
+      - 9001:9001
+    labels:
+      cluster: test
+    command: minio server /data/minio --address :9001

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -30,9 +30,8 @@ import (
 const (
 	errGraphQLSchemaCommitFailed = "error occurred updating GraphQL schema, please retry"
 	ErrGraphQLSchemaAlterFailed  = "succeeded in saving GraphQL schema but failed to alter Dgraph" +
-		" schema - this indicates a bug in Dgraph schema generation. Please let us know : " +
-		"https://github.com/dgraph-io/dgraph/issues. " +
-		"Don't forget to post your old and new schemas in the issue description."
+		" schema - this indicates a bug in Dgraph schema generation. Please let us know by" +
+		" filing an issue. Don't forget to post your old and new schemas in the issue description."
 
 	GqlSchemaPred    = "dgraph.graphql.schema"
 	gqlSchemaXidPred = "dgraph.graphql.xid"


### PR DESCRIPTION
Since we don't use GitHub issues anymore, error messages should not link to them. Updating the error messages to say so.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6183)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-777cd253ad-85809.surge.sh)
<!-- Dgraph:end -->