### PR TITLE
fix(dgraph): Add flags for blockcache and bloomcache size in alpha

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -108,6 +108,10 @@ they form a Raft group and provide synchronous replication.
 			" mmap consumes more RAM, but provides better performance.")
 	flag.Int("badger.compression_level", 3,
 		"The compression level for Badger. A higher value uses more resources.")
+	flag.Int("badger.blockcache_mb", 1024,
+		"Size of block cache for posting dir badger in MB.")
+	flag.Int("badger.bloomcache_mb", 512,
+		"Size of bloom filter cache for posting dir badger in MB.")
 	flag.String("encryption_key_file", "",
 		"The file that stores the encryption key. The key size must be 16, 24, or 32 bytes long. "+
 			"The key size determines the corresponding block size for AES encryption "+
@@ -529,6 +533,8 @@ func run() {
 		BadgerVlog:             Alpha.Conf.GetString("badger.vlog"),
 		BadgerKeyFile:          Alpha.Conf.GetString("encryption_key_file"),
 		BadgerCompressionLevel: Alpha.Conf.GetInt("badger.compression_level"),
+		BlockCacheMB:           Alpha.Conf.GetInt("badger.blockcache_mb"),
+		BloomCacheMB:           Alpha.Conf.GetInt("badger.bloomcache_mb"),
 
 		PostingDir: Alpha.Conf.GetString("postings"),
 		WALDir:     Alpha.Conf.GetString("wal"),

--- a/worker/config.go
+++ b/worker/config.go
@@ -49,6 +49,10 @@ type Options struct {
 	// higher value means more CPU intensive compression and better compression
 	// ratio.
 	BadgerCompressionLevel int
+	// BlockCacheMB is the size of block cache for PostingDir Badger in MBs.
+	BlockCacheMB int
+	// BloomCacheMB is the size of bloom filter cache for PostingDir Badger in MBs.
+	BloomCacheMB int
 	// WALDir is the path to the directory storing the write-ahead log.
 	WALDir string
 	// MutationsMode is the mode used to handle mutation requests.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -160,10 +160,10 @@ func (s *ServerState) initStorage() {
 		opt := badger.DefaultOptions(Config.PostingDir).
 			WithValueThreshold(1 << 10 /* 1KB */).
 			WithNumVersionsToKeep(math.MaxInt32).
-			WithMaxCacheSize(1 << 30).
+			WithMaxCacheSize(int64(Config.BlockCacheMB * 1024 * 1024)).
 			WithKeepBlockIndicesInCache(true).
 			WithKeepBlocksInCache(true).
-			WithMaxBfCacheSize(500 << 20) // 500 MB of bloom filter cache.
+			WithMaxBfCacheSize(int64(Config.BloomCacheMB * 1024 * 1024))
 		opt = setBadgerOptions(opt)
 
 		// Print the options w/o exposing key.


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6185)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-998d88219b-85857.surge.sh)
<!-- Dgraph:end -->