### PR TITLE
fix: Don't allow idx flag to be set to 0 on dgraph zero (#6156)

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -80,7 +80,7 @@ instances to achieve high-availability.
 		"addr:port of this server, so other Dgraph alphas can talk to this.")
 	flag.IntP("port_offset", "o", 0,
 		"Value added to all listening port numbers. [Grpc=5080, HTTP=6080]")
-	flag.Uint64("idx", 1, "Unique node index for this server.")
+	flag.Uint64("idx", 1, "Unique node index for this server. idx cannot be 0.")
 	flag.Int("replicas", 1, "How many replicas to run per data shard."+
 		" The count includes the original shard.")
 	flag.String("peer", "", "Address of another dgraphzero server.")
@@ -168,6 +168,10 @@ func run() {
 		peer:              Zero.Conf.GetString("peer"),
 		w:                 Zero.Conf.GetString("wal"),
 		rebalanceInterval: Zero.Conf.GetDuration("rebalance_interval"),
+	}
+
+	if opts.nodeId == 0 {
+		log.Fatalf("ERROR: Cannot idx flag cannot be 0. Please try again with idx as a positive integer")
 	}
 
 	if opts.numReplicas < 0 || opts.numReplicas%2 == 0 {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -171,7 +171,7 @@ func run() {
 	}
 
 	if opts.nodeId == 0 {
-		log.Fatalf("ERROR: Cannot idx flag cannot be 0. Please try again with idx as a positive integer")
+		log.Fatalf("ERROR: idx flag cannot be 0. Please try again with idx as a positive integer")
 	}
 
 	if opts.numReplicas < 0 || opts.numReplicas%2 == 0 {


### PR DESCRIPTION
**Cherry pick**
* Fix DGRAPH-2185

* Update the help message for idx flag in dgraph zero

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6193)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-18b17ed871-86163.surge.sh)
<!-- Dgraph:end -->