### PR TITLE
fix(GraphQL): Linking of xids for deep mutations (#6172)

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -127,7 +127,7 @@
         {
           "PostSecret.title": "ps1",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret4"
         }
@@ -136,7 +136,7 @@
         {
           "PostSecret.title": "ps2",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret7"
         }
@@ -145,7 +145,7 @@
         {
           "PostSecret.title": "ps3",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret10"
         }
@@ -154,7 +154,7 @@
         {
           "PostSecret.title": "ps4",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret13"
         }
@@ -163,7 +163,7 @@
         {
           "PostSecret.title": "ps5",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret16"
         }
@@ -172,7 +172,7 @@
         {
           "PostSecret.title": "ps6",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret19"
         }
@@ -181,7 +181,7 @@
         {
           "PostSecret.title": "ps7",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret22"
         }
@@ -190,7 +190,7 @@
         {
           "PostSecret.title": "ps8",
           "dgraph.type": [
-            "PostSecret" 
+            "PostSecret"
             ],
           "uid": "_:PostSecret25"
         }
@@ -392,7 +392,7 @@
   name: "Add Multiple Mutations with embedded value"
   gqlmutation: |
     mutation addAuthor {
-      addAuthor(input: [{ name: "A.N. Author", posts: []}, 
+      addAuthor(input: [{ name: "A.N. Author", posts: []},
                         { name: "Different Author", posts: []}]) {
         author {
           name
@@ -1564,19 +1564,19 @@
 # Additional Deletes
 #
 # If we have
-# 
+#
 # type Post { ... author: Author @hasInverse(field: posts) ... }
 # type Author { ... posts: [Post] ... }
 #
 # and existing edge
-# 
+#
 # Post1 --- author --> Author1
-# 
+#
 # there must also exist edge
-# 
+#
 # Author1 --- posts --> Post1
 #
-# So if we did an add Author2 and connect the author to Post1, that changes the 
+# So if we did an add Author2 and connect the author to Post1, that changes the
 # author of Post1 to Author2, we need to
 #  * add edge Post1 --- author --> Author2 (done by asIDReference/asXIDReference)
 #  * add edge Author2 --- posts --> Post1 (done by addInverseLink)
@@ -1597,7 +1597,7 @@
       }
     }
   gqlvariables: |
-    { 
+    {
       "auth": {
         "name": "A.N. Author",
         "posts": [ { "postID": "0x456" } ]
@@ -1605,7 +1605,7 @@
     }
   dgmutations:
     - setjson: |
-        { 
+        {
           "uid":"_:Author1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
@@ -2060,7 +2060,7 @@
             code
             name
             cities {
-              name 
+              name
               district {
                 code
                 name
@@ -2071,7 +2071,7 @@
       }
     }
   gqlvariables: |
-    { 
+    {
       "city": {
         "name": "c1",
         "district":{
@@ -2150,10 +2150,10 @@
       }
     }
   gqlvariables: |
-    { 
+    {
       "auth": {
         "name": "A.N. Author",
-        "country": { 
+        "country": {
           "name": "A Country",
           "states": [ { "code": "abc", "name": "Alphabet" } ]
         }
@@ -2173,7 +2173,7 @@
 
   dgmutationssec:
     - setjson: |
-        { 
+        {
           "uid":"_:Author1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
@@ -2213,3 +2213,90 @@
         uid
       }
     }
+
+- name: "Deep mutation three level xid"
+  gqlmutation: |
+    mutation($auth: AddPost1Input!) {
+      addPost1(input: [$auth]) {
+        post1 {
+          id
+          comments {
+            id
+            replies {
+              id
+            }
+          }
+        }
+      }
+    }
+
+  gqlvariables: |
+    {
+      "auth": {
+        "id": "post1",
+        "comments": [{
+          "id": "comment1",
+          "replies": [{
+            "id": "reply1"
+          }]
+        }]
+      }
+    }
+  dgquery: |-
+    query {
+      Comment14 as Comment14(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
+        uid
+      }
+      Comment16 as Comment16(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "Comment1.id": "comment1",
+          "dgraph.type": [
+            "Comment1"
+          ],
+          "uid": "_:Comment14"
+        }
+      cond: "@if(eq(len(Comment14), 0))"
+    - setjson: |
+        {
+          "Comment1.id": "reply1",
+          "dgraph.type": [
+            "Comment1"
+          ],
+          "uid": "_:Comment16"
+        }
+      cond: "@if(eq(len(Comment16), 0) AND eq(len(Comment14), 0))"
+    - setjson: |
+        {"uid":"_:Comment14", "Comment1.replies": [{"uid": "uid(Comment16)"}]}
+      cond: "@if(eq(len(Comment16), 1) AND eq(len(Comment14), 0))"
+    - setjson: |
+        {"uid":"_:Comment14", "Comment1.replies": [{"uid": "_:Comment16"}]}
+      cond: "@if(eq(len(Comment16), 0) AND eq(len(Comment14), 0))"
+    - setjson: |
+        {"uid":"uid(Comment16)"}
+      cond: "@if(eq(len(Comment16), 1) AND eq(len(Comment14), 0))"
+  dgquerysec: |-
+    query {
+      Post12 as Post12(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
+        uid
+      }
+      Comment14 as Comment14(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
+        uid
+      }
+    }
+  dgmutationssec:
+    - setjson: |
+        {
+          "Post1.comments":
+            [{
+              "uid":"uid(Comment14)"
+            }],
+          "Post1.id":"post1",
+          "dgraph.type":["Post1"],
+          "uid":"_:Post12"
+        }
+      cond: "@if(eq(len(Post12), 0) AND eq(len(Comment14), 1))"

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -276,7 +276,7 @@ func (mrw *AddRewriter) Rewrite(ctx context.Context, m schema.Mutation) ([]*Upse
 
 	for _, i := range val {
 		obj := i.(map[string]interface{})
-		frag := rewriteObject(ctx, mutatedType, nil, "", varGen, true, obj, 0, xidMd)
+		frag := rewriteObject(ctx, nil, mutatedType, nil, "", varGen, true, obj, 0, xidMd)
 		mrw.frags = append(mrw.frags, frag.secondPass)
 
 		mutationsAll = buildMutations(mutationsAll, queries, frag.firstPass)
@@ -497,7 +497,7 @@ func (urw *UpdateRewriter) Rewrite(
 	var setFragF, setFragS, delFragF, delFragS []*mutationFragment
 
 	if setArg != nil {
-		setFrag := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, true,
+		setFrag := rewriteObject(ctx, nil, mutatedType, nil, srcUID, varGen, true,
 			setArg.(map[string]interface{}), 0, xidMd)
 
 		setFragF = setFrag.firstPass
@@ -505,7 +505,7 @@ func (urw *UpdateRewriter) Rewrite(
 	}
 
 	if delArg != nil {
-		delFrag := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, false,
+		delFrag := rewriteObject(ctx, nil, mutatedType, nil, srcUID, varGen, false,
 			delArg.(map[string]interface{}), 0, xidMd)
 		delFragF = delFrag.firstPass
 		delFragS = delFrag.secondPass
@@ -907,6 +907,7 @@ type mutationRes struct {
 // to secondPass, and then to make those links ourselves.
 func rewriteObject(
 	ctx context.Context,
+	parentTyp schema.Type,
 	typ schema.Type,
 	srcField schema.FieldDefinition,
 	srcUID string,
@@ -983,16 +984,21 @@ func rewriteObject(
 
 	var parentFrags []*mutationFragment
 
-	if !atTopLevel { // top level is never a reference - it's adding/updating
+	if !atTopLevel { // top level is never a reference - it's a new addition.
+		// this is the case of a lower level having xid which is a reference.
 		if xid != nil && xidString != "" {
 			xidFrag = asXIDReference(ctx, srcField, srcUID, typ, xid.Name(), xidString,
 				variable, withAdditionalDeletes, varGen, xidMetadata)
 			if deepXID > 2 {
-				// We need to link the parent to the already existing child
+				// Here we link the already existing node with an xid to the parent whose id is
+				// passed in srcUID. We do this linking only if there is a hasInverse relationship
+				// between the two.
+				// So for example if we had the addAuthor mutation which is also adding nested
+				// posts, then we link the authorUid(srcUID) - Author.posts - uid(Post) here.
+
 				res := make(map[string]interface{}, 1)
 				res["uid"] = srcUID
-				addInverseLink(res, srcField.Inverse(), fmt.Sprintf("uid(%s)", variable))
-
+				attachChild(res, parentTyp, srcField, fmt.Sprintf("uid(%s)", variable))
 				parentFrag := newFragment(res)
 				parentFrag.conditions = append(parentFrag.conditions, xidFrag.conditions...)
 				parentFrags = append(parentFrags, parentFrag)
@@ -1046,6 +1052,10 @@ func rewriteObject(
 		myUID = fmt.Sprintf("_:%s", variable)
 
 		if xid == nil || deepXID > 2 {
+			// Lets link the new node that we are creating with the parent if a @hasInverse
+			// exists between the two.
+			// So for example if we had the addAuthor mutation which is also adding nested
+			// posts, then we add the link _:Post Post.author AuthorUID(srcUID) here.
 			addInverseLink(newObj, srcField, srcUID)
 		}
 	} else {
@@ -1075,7 +1085,8 @@ func rewriteObject(
 
 	if xid != nil && !atTopLevel {
 		if deepXID <= 2 { // elements in firstPass or not
-			// duplicate query in elements >= 2, as the pair firstPass element would already have the same query.
+			// duplicate query in elements >= 2, as the pair firstPass element would already have
+			// the same query.
 			frag.queries = []*gql.GraphQuery{
 				xidQuery(variable, xidString, xid.Name(), typ),
 			}
@@ -1083,7 +1094,8 @@ func rewriteObject(
 			// We need to link the parent to the element we are just creating
 			res := make(map[string]interface{}, 1)
 			res["uid"] = srcUID
-			addInverseLink(res, srcField.Inverse(), fmt.Sprintf("_:%s", variable))
+			this := fmt.Sprintf("_:%s", variable)
+			attachChild(res, parentTyp, srcField, this)
 
 			parentFrag := newFragment(res)
 			parentFrag.conditions = append(parentFrag.conditions, frag.conditions...)
@@ -1127,7 +1139,7 @@ func rewriteObject(
 				// { "title": "...", "author": { "username": "new user", "dob": "...", ... }
 				//          like here ^^
 				frags =
-					rewriteObject(ctx, fieldDef.Type(), fieldDef, myUID, varGen,
+					rewriteObject(ctx, typ, fieldDef.Type(), fieldDef, myUID, varGen,
 						withAdditionalDeletes, val, deepXID, xidMetadata)
 
 			case []interface{}:
@@ -1143,7 +1155,7 @@ func rewriteObject(
 				//   { "title": "...", "scores": [10.5, 9.3, ... ]
 				//            like here ^^
 				frags =
-					rewriteList(ctx, fieldDef.Type(), fieldDef, myUID, varGen,
+					rewriteList(ctx, typ, fieldDef.Type(), fieldDef, myUID, varGen,
 						withAdditionalDeletes, val, deepXID, xidMetadata)
 			default:
 				// This field is either:
@@ -1156,9 +1168,10 @@ func rewriteObject(
 				//   to remove all friends
 				frags = &mutationRes{secondPass: []*mutationFragment{newFragment(val)}}
 			}
-
 			childrenFirstPass = appendFragments(childrenFirstPass, frags.firstPass)
-			results.secondPass = squashFragments(squashIntoObject(fieldName), results.secondPass, frags.secondPass)
+
+			results.secondPass = squashFragments(squashIntoObject(fieldName), results.secondPass,
+				frags.secondPass)
 		}
 	}
 
@@ -1174,6 +1187,7 @@ func rewriteObject(
 	for _, i := range results.firstPass {
 		conditions = append(conditions, i.conditions...)
 	}
+
 	for _, i := range childrenFirstPass {
 		i.conditions = append(i.conditions, conditions...)
 	}
@@ -1581,17 +1595,23 @@ func authCheck(chk resultChecker, qry string) resultChecker {
 	}
 }
 
+func attachChild(res map[string]interface{}, parent schema.Type, child schema.FieldDefinition, childUID string) {
+	if parent == nil {
+		return
+	}
+	if child.Type().ListType() != nil {
+		res[parent.DgraphPredicate(child.Name())] =
+			[]interface{}{map[string]interface{}{"uid": childUID}}
+	} else {
+		res[parent.DgraphPredicate(child.Name())] = map[string]interface{}{"uid": childUID}
+	}
+}
+
 func addInverseLink(obj map[string]interface{}, srcField schema.FieldDefinition, srcUID string) {
 	if srcField != nil {
 		invField := srcField.Inverse()
 		if invField != nil {
-			if invField.Type().ListType() != nil {
-				obj[srcField.Type().DgraphPredicate(invField.Name())] =
-					[]interface{}{map[string]interface{}{"uid": srcUID}}
-			} else {
-				obj[srcField.Type().DgraphPredicate(invField.Name())] =
-					map[string]interface{}{"uid": srcUID}
-			}
+			attachChild(obj, srcField.Type(), invField, srcUID)
 		}
 	}
 }
@@ -1615,6 +1635,7 @@ func xidQuery(xidVariable, xidString, xidPredicate string, typ schema.Type) *gql
 
 func rewriteList(
 	ctx context.Context,
+	parentTyp schema.Type,
 	typ schema.Type,
 	srcField schema.FieldDefinition,
 	srcUID string,
@@ -1631,7 +1652,8 @@ func rewriteList(
 	for _, obj := range objects {
 		switch obj := obj.(type) {
 		case map[string]interface{}:
-			frag := rewriteObject(ctx, typ, srcField, srcUID, varGen, withAdditionalDeletes, obj, deepXID, xidMetadata)
+			frag := rewriteObject(ctx, parentTyp, typ, srcField, srcUID, varGen,
+				withAdditionalDeletes, obj, deepXID, xidMetadata)
 			if len(frag.secondPass) != 0 {
 				foundSecondPass = true
 			}

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -240,6 +240,23 @@ type Y implements X @auth(
   userRole: String @search(by: [hash])
 }
 
+type Post1 {
+  id: String! @id
+  content: String
+  comments: [Comment1]
+}
+
+type Person1 {
+  id: String! @id
+  name: String
+}
+
+type Comment1 {
+  id: String! @id
+  message: String
+  replies: [Comment1]
+}
+
 type Tweets {
     id: String! @id
     score: Int


### PR DESCRIPTION
For nested add mutations, the linking of nodes for xids wasn't working properly. Level 1 and 2 are linked properly but level 2 and beyond were not. This PR aims to fix that.
See https://discuss.dgraph.io/t/grandchild-is-not-attached-to-child-when-using-addtype/9224 for more details.

(cherry picked from commit 806a8dfb51818d6baa63129df4cf34788f41b59e)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6203)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-17a344b48d-86482.surge.sh)
<!-- Dgraph:end -->