### PR TITLE
(release/v20.03) fix(Dgraph): make backups cancel other tasks

### DIFF
--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -49,6 +49,11 @@ func backupCurrentGroup(ctx context.Context, req *pb.BackupRequest) (*pb.Status,
 		return nil, err
 	}
 
+	closer, err := g.Node.startTask(opBackup)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot start backup operation")
+	}
+	defer closer.Done()
 	bp := NewBackupProcessor(pstore, req)
 	return bp.WriteBackup(ctx)
 }


### PR DESCRIPTION
Backups should be added to the list of tasks (rollups, snapshots, etc)
that are managed by Dgraph so that rollups and other tasks are paused
during the backup.

(cherry picked from commit ea15b664aa8659c0722e31a499c598698377215f)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6244)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f84dfa78b7-89642.surge.sh)
<!-- Dgraph:end -->