### PR TITLE
docs: cluster_checklist doc update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /dgraph-bulk-loader
 /osx-docker-gopath
 
+# docs
+/public
+
 # fuzzing output
 gql/gql-fuzz.zip
 gql/fuzz-data/crashers

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -13,7 +13,7 @@ We use [Hugo](https://gohugo.io/) for our documentation.
 2. From within the `wiki` folder, run the command below to get the theme.
 
 ```
-cd themes && git clone https://github.com/dgraph-io/hugo-docs
+pushd themes && git clone https://github.com/dgraph-io/hugo-docs && popd
 ```
 
 3. Run `./scripts/local.sh` within the `wiki` folder and visit `http://localhost:1313` to see the
@@ -21,7 +21,7 @@ documentation site.
 
 (Optional) To run queries *within* the documentation using a different Dgraph instance, set the `DGRAPH_ENDPOINT` environment variable before starting the local web server:
 ```
-DGRAPH_ENDPOINT="http://localhost:8080/query?latency=true" ./local.sh
+DGRAPH_ENDPOINT="http://localhost:8080/query?latency=true" ./scripts/local.sh
 ```
 
 Now you can make changes to the docs and see them being updated instantly thanks to Hugo.

--- a/wiki/content/deploy/cluster-checklist.md
+++ b/wiki/content/deploy/cluster-checklist.md
@@ -14,4 +14,4 @@ In setting up a cluster be sure the check the following.
 * Does each instance have a unique ID on startup?
 * Has `--bindall=true` been set for networked communication?
 
-See the [Production Checklist]({{< relref "#production-checklist" >}}) docs for more info.
+See the [Production Checklist]({{< relref "production-checklist.md" >}}) docs for more info.


### PR DESCRIPTION
Minor Doc Updates

* cluster_checklist has relative link that goes nowhere, fixed it so it goes to production_checklist
* update README.md instructions
* put `/public` in git ignore, as these shouldn't be checked into master commit


