### PR TITLE
docs: update kubernetes section

### DIFF
--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -286,7 +286,7 @@ helm install my-release dgraph/dgraph --set alpha.service.type="LoadBalancer" --
 
 ##### LoadBalancer (Private Internal Network)
 
-An external load balancer can be configured to face internally to a private subnet rather the public Internet.  This way it can be accessed securely by clients on the same network, or through a VPN or a jump server. In Kubernetes, this is often configured through service annotations by the provider.  Here's a small list of  of annotations:
+An external load balancer can be configured to face internally to a private subnet rather the public Internet.  This way it can be accessed securely by clients on the same network, through a VPN, or from a jump server. In Kubernetes, this is often configured through service annotations by the provider.  Here's a small list of annotations from cloud providers:
 
 |Provider    | Documentation Reference   | Annotation |
 |------------|---------------------------|------------|

--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -319,9 +319,9 @@ helm install my-release dgraph/dgraph --values my-config-values.yaml
 
 ##### Ingress Resource
 
-You can expose alpha and ratel using an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resource that can route traffic to services resources.  Before using this option you may need to install an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) first, as is the case with [AKS](https://docs.microsoft.com/azure/aks/) and [EKS](https://aws.amazon.com/eks/), while in the case of [GKE](https://cloud.google.com/kubernetes-engine), this comes bundled with a default ingress controller.  When routing traffic based on the `hostname`, you may want to integrate an addon like [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) so that DNS records can be registered automatically when deploying dgraph.
+You can expose alpha and ratel using an [ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) resource that can route traffic to service resources.  Before using this option you may need to install an [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) first, as is the case with [AKS](https://docs.microsoft.com/azure/aks/) and [EKS](https://aws.amazon.com/eks/), while in the case of [GKE](https://cloud.google.com/kubernetes-engine), this comes bundled with a default ingress controller.  When routing traffic based on the `hostname`, you may want to integrate an addon like [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) so that DNS records can be registered automatically when deploying dgraph.
 
-As an examples, you can configure a single ingress resourse that uses [ingress-nginx](https://github.com/kubernetes/ingress-nginx) for alpha and ratel services, by creating Helm chart confgiuration values like this below:
+As an examples, you can configure a single ingress resource that uses [ingress-nginx](https://github.com/kubernetes/ingress-nginx) for alpha and ratel services, by creating Helm chart configuration values like this below:
 
 ```yaml
 # my-config-values.yaml

--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -227,8 +227,7 @@ The above command will install a recent version of the dgraph docker image. You 
 helm install my-release dgraph/dgraph --set image.tag="v1.2.6"
 ```
 
-{{% notice "note" %}}When configuring dgraph image tag, be careful not to use `latest` or `master` on a production system.{{% /notice %}}
-
+{{% notice "warning" %}}When configuring dgraph image tag, be careful not to use `latest` or `master` in a production environment. These tags may have the dgraph version change causing mixed version dgraph cluster that can lead to outage and potential data loss.{{% /notice %}}
 
 #### Dgraph Configuration Files
 

--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -8,8 +8,8 @@ title = "Using Kubernetes"
 
 The following section covers running Dgraph with Kubernetes. We have tested Dgraph with Kubernetes versions 1.14 to 1.16 on [GKE](https://cloud.google.com/kubernetes-engine) and versions 1.14 to 1.17 on [EKS](https://aws.amazon.com/eks/).
 
-{{% notice "note" %}}These instructions are for running Dgraph Alpha without TLS configuration.
-Instructions for running with TLS refer [TLS instructions]({{< relref "tls-configuration.md" >}}).{{% /notice %}}
+{{% notice "note" %}}These instructions are for running Dgraph alpha service without TLS configuration.
+Instructions for running Dgraph alpha service with TLS refer [TLS instructions]({{< relref "tls-configuration.md" >}}).{{% /notice %}}
 
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) which is used to deploy
   and manage applications on kubernetes.
@@ -17,10 +17,9 @@ Instructions for running with TLS refer [TLS instructions]({{< relref "tls-confi
   * For Amazon [EKS](https://aws.amazon.com/eks/), you can use [eksctl](https://eksctl.io/) to quickly provision a new cluster. If you are new to this, Amazon has an article [Getting started with eksctl](https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html).
   * For Google Cloud [GKE](https://cloud.google.com/kubernetes-engine), you can use [Google Cloud SDK](https://cloud.google.com/sdk/install) and the `gcloud container clusters create` command to quickly provision a new cluster.
 
-On Amazon [EKS](https://aws.amazon.com/eks/), you would see something like this:
+Verify that you have your cluster up and running using `kubectl get nodes`. If you used `eksctl` or `gcloud container clusters create` with the default options, you should have 2-3 worker nodes ready.
 
-Verify that you have your cluster up and running using `kubectl get nodes`. If you used `kops` with
-the default options, you should have a master and two worker nodes ready.
+On Amazon [EKS](https://aws.amazon.com/eks/), you would see something like this:
 
 ```sh
 ➜  kubernetes git:(master) ✗ kubectl get nodes
@@ -177,8 +176,8 @@ dgraph-zero-2         1/1     Running   0          5m6s
 
 {{% notice "tip" %}}You can check the logs for the containers in the pod using `kubectl logs --follow dgraph-alpha-0` and `kubectl logs --follow dgraph-zero-0`.{{% /notice %}}
 
-### Test Dgraph HA Cluster Setup
 
+### Test Dgraph HA Cluster Setup
 Port forward from your local machine to the pod
 
 ```sh
@@ -345,7 +344,7 @@ helm install my-release dgraph/dgraph --values my-config-values.yaml
 Afterward you can run `kubectl get ingress` to see the status and access these through their hostname, such as `http://alpha.<my-domain-name>` and `http://ratel.<my-domain-name>`
 
 
-{{% notice "note" %}}Ingress controllers will likely have an option to configure access for private internal networks.  Consult documentation from the ingress controller provider for further information.{{% /notice %}}
+{{% notice "tip" %}}Ingress controllers will likely have an option to configure access for private internal networks.  Consult documentation from the ingress controller provider for further information.{{% /notice %}}
 
 
 

--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -227,7 +227,7 @@ The above command will install a recent version of the dgraph docker image. You 
 helm install my-release dgraph/dgraph --set image.tag="v1.2.6"
 ```
 
-{{% notice "warning" %}}When configuring dgraph image tag, be careful not to use `latest` or `master` in a production environment. These tags may have the dgraph version change causing mixed version dgraph cluster that can lead to outage and potential data loss.{{% /notice %}}
+{{% notice "warning" %}}When configuring dgraph image tag, be careful not to use `latest` or `master` in a production environment. These tags may have the dgraph version change, causing a mixed version dgraph cluster that can lead to an outage and potential data loss.{{% /notice %}}
 
 #### Dgraph Configuration Files
 
@@ -264,7 +264,7 @@ helm install my-release dgraph/dgraph --values my-config-values.yaml
 By default zero and alpha services are exposed only within the kubernetes cluster as
 kubernetes service type `ClusterIP`.
 
-In order to expose the alpha service and ratel service publicly you can use kubernetes service type `LoadBalancer`, or an Ingress resource.
+In order to expose the alpha service and ratel service publicly you can use kubernetes service type `LoadBalancer` or an Ingress resource.
 
 ##### LoadBalancer (Public Internet)
 


### PR DESCRIPTION
Kubernetes Update
* Kubernetes
  * reconciled missing or lost content from prior PRs due to split
  * adjustment for clarity
* Helm Chart
  * reconciled missing or lost content from prior PRs due to split
    * From Previous PR: removed harm chart config values (redundant) and an incorrect command
  * added section on dgraph config
  * expanded load balancer to loadbalancer public and private and ingress.
  * warning about `latest` and `master` tags

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6254)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-db5e162810-88080.surge.sh)
<!-- Dgraph:end -->