### PR TITLE
(release/v20.07) fix(Dgraph): Stop forcing RAM mode for the write-ahead log.

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -104,13 +104,17 @@ they form a Raft group and provide synchronous replication.
 	flag.StringP("postings", "p", "p", "Directory to store posting lists.")
 
 	// Options around how to set up Badger.
-	flag.String("badger.tables", "mmap",
-		"[ram, mmap, disk] Specifies how Badger LSM tree is stored. "+
-			"Option sequence consume most to least RAM while providing best to worst read "+
-			"performance respectively.")
-	flag.String("badger.vlog", "mmap",
-		"[mmap, disk] Specifies how Badger Value log is stored."+
-			" mmap consumes more RAM, but provides better performance.")
+	flag.String("badger.tables", "mmap,mmap",
+		"[ram, mmap, disk] Specifies how Badger LSM tree is stored for the postings and "+
+			"write-ahead directory. Option sequence consume most to least RAM while providing "+
+			"best to worst read performance respectively. If you pass two values separated by a "+
+			"comma, the first value will be used for the postings directory and the second for "+
+			"the write-ahead log directory.")
+	flag.String("badger.vlog", "mmap,mmap",
+		"[mmap, disk] Specifies how Badger Value log is stored for the postings and write-ahead "+
+			"log directory. mmap consumes more RAM, but provides better performance. If you pass "+
+			"two values separated by a comma the first value will be used for the postings "+
+			"directory and the second for the w directory.")
 	flag.Int("badger.compression_level", 3,
 		"The compression level for Badger. A higher value uses more resources.")
 	enc.RegisterFlags(flag)
@@ -573,8 +577,6 @@ func run() {
 	bindall = Alpha.Conf.GetBool("bindall")
 
 	opts := worker.Options{
-		BadgerTables:           Alpha.Conf.GetString("badger.tables"),
-		BadgerVlog:             Alpha.Conf.GetString("badger.vlog"),
 		BadgerCompressionLevel: Alpha.Conf.GetInt("badger.compression_level"),
 		PostingDir:             Alpha.Conf.GetString("postings"),
 		WALDir:                 Alpha.Conf.GetString("wal"),
@@ -582,6 +584,32 @@ func run() {
 		MutationsMode:  worker.AllowMutations,
 		AuthToken:      Alpha.Conf.GetString("auth_token"),
 		AllottedMemory: Alpha.Conf.GetFloat64("lru_mb"),
+	}
+
+	badgerTables := strings.Split(Alpha.Conf.GetString("badger.tables"), ",")
+	if len(badgerTables) != 1 && len(badgerTables) != 2 {
+		glog.Fatalf("Unable to read badger.tables options. Expected single value or two "+
+			"comma-separated values. Got %s", Alpha.Conf.GetString("badger.tables"))
+	}
+	if len(badgerTables) == 1 {
+		opts.BadgerTables = badgerTables[0]
+		opts.BadgerWalTables = badgerTables[0]
+	} else {
+		opts.BadgerTables = badgerTables[0]
+		opts.BadgerWalTables = badgerTables[1]
+	}
+
+	badgerVlog := strings.Split(Alpha.Conf.GetString("badger.vlog"), ",")
+	if len(badgerVlog) != 1 && len(badgerVlog) != 2 {
+		glog.Fatalf("Unable to read badger.vlog options. Expected single value or two "+
+			"comma-separated values. Got %s", Alpha.Conf.GetString("badger.vlog"))
+	}
+	if len(badgerVlog) == 1 {
+		opts.BadgerVlog = badgerVlog[0]
+		opts.BadgerWalVlog = badgerVlog[0]
+	} else {
+		opts.BadgerVlog = badgerVlog[0]
+		opts.BadgerWalVlog = badgerVlog[1]
 	}
 
 	secretFile := Alpha.Conf.GetString("acl_secret_file")

--- a/worker/config.go
+++ b/worker/config.go
@@ -39,10 +39,15 @@ const (
 type Options struct {
 	// PostingDir is the path to the directory storing the postings..
 	PostingDir string
-	// BadgerTables is the name of the mode used to load the badger tables.
+	// BadgerTables is the name of the mode used to load the badger tables for the p directory.
 	BadgerTables string
-	// BadgerVlog is the name of the mode used to load the badger value log.
+	// BadgerVlog is the name of the mode used to load the badger value log for the p directory.
 	BadgerVlog string
+	// BadgerWalTables is the name of the mode used to load the badger tables for the w directory.
+	BadgerWalTables string
+	// BadgerWalVlog is the name of the mode used to load the badger value log for the w directory.
+	BadgerWalVlog string
+
 	// BadgerCompressionLevel is the ZSTD compression level used by badger. A
 	// higher value means more CPU intensive compression and better compression
 	// ratio.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -62,7 +62,7 @@ func InitServerState() {
 	x.WorkerConfig.ProposedGroupId = groupId
 }
 
-func setBadgerOptions(opt badger.Options) badger.Options {
+func setBadgerOptions(opt badger.Options, wal bool) badger.Options {
 	opt = opt.WithSyncWrites(false).WithTruncate(true).WithLogger(&x.ToGlog{}).
 		WithEncryptionKey(x.WorkerConfig.EncryptionKey)
 
@@ -84,8 +84,20 @@ func setBadgerOptions(opt badger.Options) badger.Options {
 		opt.ZSTDCompressionLevel = Config.BadgerCompressionLevel
 	}
 
+	var badgerTables string
+	var badgerVlog string
+	if wal {
+		// Settings for the write-ahead log.
+		badgerTables = Config.BadgerWalTables
+		badgerVlog = Config.BadgerWalVlog
+	} else {
+		// Settings for the data directory.
+		badgerTables = Config.BadgerTables
+		badgerVlog = Config.BadgerVlog
+	}
+
 	glog.Infof("Setting Badger table load option: %s", Config.BadgerTables)
-	switch Config.BadgerTables {
+	switch badgerTables {
 	case "mmap":
 		opt.TableLoadingMode = options.MemoryMap
 	case "ram":
@@ -97,7 +109,7 @@ func setBadgerOptions(opt badger.Options) badger.Options {
 	}
 
 	glog.Infof("Setting Badger value log load option: %s", Config.BadgerVlog)
-	switch Config.BadgerVlog {
+	switch badgerVlog {
 	case "mmap":
 		opt.ValueLogLoadingMode = options.MemoryMap
 	case "disk":
@@ -126,16 +138,9 @@ func (s *ServerState) initStorage() {
 		// Write Ahead Log directory
 		x.Checkf(os.MkdirAll(Config.WALDir, 0700), "Error while creating WAL dir.")
 		opt := badger.LSMOnlyOptions(Config.WALDir)
-		opt = setBadgerOptions(opt)
+		opt = setBadgerOptions(opt, true)
 		opt.ValueLogMaxEntries = 10000 // Allow for easy space reclamation.
 		opt.MaxCacheSize = 10 << 20    // 10 mb of cache size for WAL.
-
-		// We should always force load LSM tables to memory, disregarding user settings, because
-		// Raft.Advance hits the WAL many times. If the tables are not in memory, retrieval slows
-		// down way too much, causing cluster membership issues. Because of prefix compression and
-		// value separation provided by Badger, this is still better than using the memory based WAL
-		// storage provided by the Raft library.
-		opt.TableLoadingMode = options.LoadToRAM
 
 		// Print the options w/o exposing key.
 		// TODO: Build a stringify interface in Badger options, which is used to print nicely here.
@@ -159,7 +164,7 @@ func (s *ServerState) initStorage() {
 			WithKeepBlockIndicesInCache(true).
 			WithKeepBlocksInCache(true).
 			WithMaxBfCacheSize(500 << 20) // 500 MB of bloom filter cache.
-		opt = setBadgerOptions(opt)
+		opt = setBadgerOptions(opt, false)
 
 		// Print the options w/o exposing key.
 		// TODO: Build a stringify interface in Badger options, which is used to print nicely here.


### PR DESCRIPTION
This change also adds a way to set the table and value log loading modes for the w directory
independently of the values for the p directory.

Fixes DGRAPH-1898.

(cherry picked from commit 5f5aa9c1ab7505122b6e394a8af24ce0d52d9823)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6259)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0ab83ca1b4-87706.surge.sh)
<!-- Dgraph:end -->