### PR TITLE
(release/v1.2) fix(Dgraph): Stop forcing RAM mode for the write-ahead log.

### DIFF
--- a/worker/config.go
+++ b/worker/config.go
@@ -39,12 +39,16 @@ const (
 type Options struct {
 	// PostingDir is the path to the directory storing the postings..
 	PostingDir string
-	// BadgerTables is the name of the mode used to load the badger tables.
+	// BadgerTables is the name of the mode used to load the badger tables for the p directory.
 	BadgerTables string
-	// BadgerVlog is the name of the mode used to load the badger value log.
+	// BadgerVlog is the name of the mode used to load the badger value log for the p directory.
 	BadgerVlog string
 	// BadgerKeyFile is the file containing the key used for encryption. Enterprise only feature.
 	BadgerKeyFile string
+	// BadgerWalTables is the name of the mode used to load the badger tables for the w directory.
+	BadgerWalTables string
+	// BadgerWalVlog is the name of the mode used to load the badger value log for the w directory.
+	BadgerWalVlog string
 	// BadgerCompressionLevel is the ZSTD compression level used by badger. A
 	// higher value means more CPU intensive compression and better compression
 	// ratio.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -65,7 +65,7 @@ func InitServerState() {
 	x.WorkerConfig.ProposedGroupId = groupId
 }
 
-func setBadgerOptions(opt badger.Options) badger.Options {
+func setBadgerOptions(opt badger.Options, wal bool) badger.Options {
 	opt = opt.WithSyncWrites(false).
 		WithTruncate(true).
 		WithLogger(&x.ToGlog{}).
@@ -89,8 +89,20 @@ func setBadgerOptions(opt badger.Options) badger.Options {
 		opt.ZSTDCompressionLevel = Config.BadgerCompressionLevel
 	}
 
+	var badgerTables string
+	var badgerVlog string
+	if wal {
+		// Settings for the write-ahead log.
+		badgerTables = Config.BadgerWalTables
+		badgerVlog = Config.BadgerWalVlog
+	} else {
+		// Settings for the data directory.
+		badgerTables = Config.BadgerTables
+		badgerVlog = Config.BadgerVlog
+	}
+
 	glog.Infof("Setting Badger table load option: %s", Config.BadgerTables)
-	switch Config.BadgerTables {
+	switch badgerTables {
 	case "mmap":
 		opt.TableLoadingMode = options.MemoryMap
 	case "ram":
@@ -102,7 +114,7 @@ func setBadgerOptions(opt badger.Options) badger.Options {
 	}
 
 	glog.Infof("Setting Badger value log load option: %s", Config.BadgerVlog)
-	switch Config.BadgerVlog {
+	switch badgerVlog {
 	case "mmap":
 		opt.ValueLogLoadingMode = options.MemoryMap
 	case "disk":
@@ -131,16 +143,9 @@ func (s *ServerState) initStorage() {
 		// Write Ahead Log directory
 		x.Checkf(os.MkdirAll(Config.WALDir, 0700), "Error while creating WAL dir.")
 		opt := badger.LSMOnlyOptions(Config.WALDir)
-		opt = setBadgerOptions(opt)
+		opt = setBadgerOptions(opt, true)
 		opt.ValueLogMaxEntries = 10000 // Allow for easy space reclamation.
 		opt.MaxCacheSize = 10 << 20    // 10 mb of cache size for WAL.
-
-		// We should always force load LSM tables to memory, disregarding user settings, because
-		// Raft.Advance hits the WAL many times. If the tables are not in memory, retrieval slows
-		// down way too much, causing cluster membership issues. Because of prefix compression and
-		// value separation provided by Badger, this is still better than using the memory based WAL
-		// storage provided by the Raft library.
-		opt.TableLoadingMode = options.LoadToRAM
 
 		// Print the options w/o exposing key.
 		// TODO: Build a stringify interface in Badger options, which is used to print nicely here.
@@ -164,7 +169,7 @@ func (s *ServerState) initStorage() {
 			WithKeepBlockIndicesInCache(true).
 			WithKeepBlocksInCache(true).
 			WithMaxBfCacheSize(500 << 20) // 500 MB of bloom filter cache.
-		opt = setBadgerOptions(opt)
+		opt = setBadgerOptions(opt, false)
 
 		// Print the options w/o exposing key.
 		// TODO: Build a stringify interface in Badger options, which is used to print nicely here.


### PR DESCRIPTION
This change also adds a way to set the table and value log loading modes for the w directory
independently of the values for the p directory.

Fixes DGRAPH-1898.

(cherry picked from commit 5f5aa9c1ab7505122b6e394a8af24ce0d52d9823)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6261)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-22e3aac5a0-87721.surge.sh)
<!-- Dgraph:end -->