### PR TITLE
fix(GraphQL): fix internal error when doing GraphQL schema introspection after drop all

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -769,7 +769,7 @@ func (as *adminServer) resetSchema(gqlSchema schema.Schema) {
 	mainHealthStore.updatingSchema()
 
 	var resolverFactory resolve.ResolverFactory
-	// If schema is nil (which becomes aftyer drop_all) then do not attach Resolver for
+	// If schema is nil (which becomes after drop_all) then do not attach Resolver for
 	// introspection operations, and set GQL schema to empty.
 	if gqlSchema == nil {
 		resolverFactory = resolverFactoryWithErrorMsg(errNoGraphQLSchema)

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -768,13 +768,18 @@ func (as *adminServer) resetSchema(gqlSchema schema.Schema) {
 	// set status as updating schema
 	mainHealthStore.updatingSchema()
 
-	resolverFactory := resolverFactoryWithErrorMsg(errResolverNotFound)
-	// it is nil after drop_all
-	if gqlSchema != nil {
-		resolverFactory = resolverFactory.WithConventionResolvers(gqlSchema, as.fns)
-	}
-	if as.withIntrospection {
-		resolverFactory.WithSchemaIntrospection()
+	var resolverFactory resolve.ResolverFactory
+	// If schema is nil (which becomes aftyer drop_all) then do not attach Resolver for
+	// introspection operations, and set GQL schema to empty.
+	if gqlSchema == nil {
+		resolverFactory = resolverFactoryWithErrorMsg(errNoGraphQLSchema)
+		gqlSchema, _ = schema.FromString("")
+	} else {
+		resolverFactory = resolverFactoryWithErrorMsg(errResolverNotFound).
+			WithConventionResolvers(gqlSchema, as.fns)
+		if as.withIntrospection {
+			resolverFactory.WithSchemaIntrospection()
+		}
 	}
 
 	// Increment the Epoch when you get a new schema. So, that subscription's local epoch

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -279,6 +279,33 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
 	require.Equal(t, finalGraphQLSchema, resp.GqlSchema[0].Schema)
 }
 
+// TestIntrospectionQueryAfterDropAll make sure that Introspection query after drop_all doesn't give any internal error
+func TestIntrospectionQueryAfterDropAll(t *testing.T) {
+	// First Do the drop_all operation
+	dg, err := testutil.DgraphClient(groupOnegRPC)
+	require.NoError(t, err)
+	testutil.DropAll(t, dg)
+
+	introspectionQuery := `
+	query{
+		__schema{
+		   types{
+			 name
+		   }
+		}
+	}`
+	introspect := &common.GraphQLParams{
+		Query: introspectionQuery,
+	}
+
+	// On doing Introspection Query Now, We should get the Expected Error Message, not the Internal Error.
+	introspectionResult := introspect.ExecuteAsPost(t, groupOneServer)
+	require.Len(t, introspectionResult.Errors, 1)
+	gotErrorMessage := introspectionResult.Errors[0].Message
+	expectedErrorMessage := "Not resolving __schema. There's no GraphQL schema in Dgraph.  Use the /admin API to add a GraphQL schema"
+	require.Equal(t, expectedErrorMessage, gotErrorMessage)
+}
+
 // TestUpdateGQLSchemaAfterDropAll makes sure that updating the GraphQL schema after drop_all works
 func TestUpdateGQLSchemaAfterDropAll(t *testing.T) {
 	updateGQLSchemaRequireNoErrors(t, `
@@ -305,6 +332,20 @@ func TestUpdateGQLSchemaAfterDropAll(t *testing.T) {
 	updateGQLSchemaRequireNoErrors(t, schema, groupOneAdminServer)
 	// we should get the schema we expect
 	require.Equal(t, schema, getGQLSchemaRequireId(t, groupOneAdminServer))
+}
+
+// TestGQSchemaAfterDropAll checks for empty schema after drop_all
+func TestGQLSchemaAfterDropAll(t *testing.T) {
+	// First Do the drop_all operation
+	dg, err := testutil.DgraphClient(groupOnegRPC)
+	require.NoError(t, err)
+	testutil.DropAll(t, dg)
+
+	// need to wait a bit
+	time.Sleep(time.Second)
+	// Query Schema and ensure that it should be empty
+	schema := getGQLSchemaRequireId(t, groupOneAdminServer)
+	require.Empty(t, schema)
 }
 
 // TestGQLSchemaAfterDropData checks whether if the schema still exists after drop_data

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -285,6 +285,8 @@ func TestIntrospectionQueryAfterDropAll(t *testing.T) {
 	dg, err := testutil.DgraphClient(groupOnegRPC)
 	require.NoError(t, err)
 	testutil.DropAll(t, dg)
+	// wait for a bit
+	time.Sleep(time.Second)
 
 	introspectionQuery := `
 	query{

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -336,20 +336,6 @@ func TestUpdateGQLSchemaAfterDropAll(t *testing.T) {
 	require.Equal(t, schema, getGQLSchemaRequireId(t, groupOneAdminServer))
 }
 
-// TestGQSchemaAfterDropAll checks for empty schema after drop_all
-func TestGQLSchemaAfterDropAll(t *testing.T) {
-	// First Do the drop_all operation
-	dg, err := testutil.DgraphClient(groupOnegRPC)
-	require.NoError(t, err)
-	testutil.DropAll(t, dg)
-
-	// need to wait a bit
-	time.Sleep(time.Second)
-	// Query Schema and ensure that it should be empty
-	schema := getGQLSchemaRequireId(t, groupOneAdminServer)
-	require.Empty(t, schema)
-}
-
 // TestGQLSchemaAfterDropData checks whether if the schema still exists after drop_data
 func TestGQLSchemaAfterDropData(t *testing.T) {
 	schema := `


### PR DESCRIPTION
This PR fixes the "Internal error" response when querying the GraphQL schema after performing drop_all operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6268)
<!-- Reviewable:end -->
