### PR TITLE
feat(querylang): language support for term tokenization

### DIFF
--- a/tok/tok.go
+++ b/tok/tok.go
@@ -19,6 +19,7 @@ package tok
 import (
 	"encoding/binary"
 	"plugin"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -275,7 +276,9 @@ func (t HourTokenizer) IsSortable() bool { return true }
 func (t HourTokenizer) IsLossy() bool    { return true }
 
 // TermTokenizer generates term tokens from string data.
-type TermTokenizer struct{}
+type TermTokenizer struct {
+	lang string
+}
 
 func (t TermTokenizer) Name() string { return "term" }
 func (t TermTokenizer) Type() string { return "string" }
@@ -284,8 +287,19 @@ func (t TermTokenizer) Tokens(v interface{}) ([]string, error) {
 	if !ok || str == "" {
 		return []string{str}, nil
 	}
-	tokens := termAnalyzer.Analyze([]byte(str))
-	return uniqueTerms(tokens), nil
+	lang := LangBase(t.lang)
+	switch lang {
+	case "zh", "ja", "th", "lo", "my", "bo", "km", "kxm":
+		// Chinese, Japanese, Thai, Lao, Burmese, Tibetan and Khmer (km, kxm) do not use spaces as delimiters. We simply split by space.
+		tokens := strings.Split(str, " ")
+		return x.RemoveDuplicates(tokens), nil
+	case "":
+		fallthrough
+	default:
+		tokens := termAnalyzer.Analyze([]byte(str))
+		return uniqueTerms(tokens), nil
+	}
+
 }
 func (t TermTokenizer) Identifier() byte { return IdentTerm }
 func (t TermTokenizer) IsSortable() bool { return false }

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -293,8 +293,6 @@ func (t TermTokenizer) Tokens(v interface{}) ([]string, error) {
 		// Chinese, Japanese, Thai, Lao, Burmese, Tibetan and Khmer (km, kxm) do not use spaces as delimiters. We simply split by space.
 		tokens := strings.Split(str, " ")
 		return x.RemoveDuplicates(tokens), nil
-	case "":
-		fallthrough
 	default:
 		tokens := termAnalyzer.Analyze([]byte(str))
 		return uniqueTerms(tokens), nil

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -152,6 +152,18 @@ func TestTermTokenizer(t *testing.T) {
 	require.Equal(t, 2, len(tokens))
 	id := tokenizer.Identifier()
 	require.Equal(t, []string{encodeToken("tokenizer", id), encodeToken("works", id)}, tokens)
+
+	// TEMPORARILY COMMENTED OUT AS THIS IS THE IDEAL BEHAVIOUR. WE ARE NOT THERE YET.
+	/*
+		tokens, err = BuildTokens("Barack Obama made Obamacare", tokenizer)
+		require.NoError(t, err)
+		require.Equal(t, 3, len(tokens))
+		require.Equal(t, []string{
+			encodeToken("barack obama", id),
+			encodeToken("made", id),
+			encodeToken("obamacare", id),
+		})
+	*/
 }
 
 func TestTrigramTokenizer(t *testing.T) {

--- a/tok/tok_test.go
+++ b/tok/tok_test.go
@@ -285,6 +285,24 @@ func TestFullTextTokenizerCJKJapanese(t *testing.T) {
 	checkSortedAndUnique(t, got)
 }
 
+func TestTermTokenizeCJKChinese(t *testing.T) {
+	tokenizer, ok := GetTokenizer("term")
+	require.True(t, ok)
+	require.NotNil(t, tokenizer)
+
+	got, err := BuildTokens("第一轮 第二轮 第一轮", GetTokenizerForLang(tokenizer, "zh"))
+	require.NoError(t, err)
+
+	id := tokenizer.Identifier()
+	wantToks := []string{
+		encodeToken("第一轮", id),
+		encodeToken("第二轮", id),
+	}
+	require.Equal(t, wantToks, got)
+	checkSortedAndUnique(t, got)
+
+}
+
 func checkSortedAndUnique(t *testing.T, tokens []string) {
 	if !sort.StringsAreSorted(tokens) {
 		t.Error("tokens were not sorted")
@@ -298,4 +316,8 @@ func checkSortedAndUnique(t *testing.T, tokens []string) {
 		}
 		set[tok] = struct{}{}
 	}
+}
+
+func BenchmarkTermTokenizer(b *testing.B) {
+	b.Skip() // tmp
 }

--- a/tok/tokens.go
+++ b/tok/tokens.go
@@ -36,6 +36,8 @@ func GetTokenizerForLang(t Tokenizer, lang string) Tokenizer {
 		// We must return a new instance because another goroutine might be calling this
 		// with a different lang.
 		return FullTextTokenizer{lang: lang}
+	case TermTokenizer:
+		return TermTokenizer{lang: lang}
 	case ExactTokenizer:
 		langTag, err := language.Parse(lang)
 		// We default to english if the language is not supported.


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
The current tokenization method breaks the use of `anyofterms` and `allofterms` for languages like Chinese or Japanese. The issue was first raised [here](https://discuss.dgraph.io/t/anyofterms-doesn-t-work-as-expected-with-chinese-characters/9373), where tokenization in a language where the space character isn't used to delimit words (e.g. Chinese). 

This PR fixes that as a first step to removing Bleve in term tokenization.

Additional language support to the `TermTokenizer` is added, so that `GetTokenizerByLang` works when `TermTokenizer` gets passed in. If it's a language in which we know doesn't use space to delimit words, then a simple `strings.Split` is called.

# Issues That Require Resolution
 Currently no attempt is made to clean up punctuations and symbols. The reason for this is that it gets quite complicated with language specific punctuation. 

An example: `"﹏封神演義﹏"` is a valid string term, where the `"﹏"`, although a punctuation, is really more of a kind of "capitalization" in Chinese.

Another example: `"贝拉克·奥巴马"` (Barack Obama in Chinese), has a middle dot, which is part of the string term for formal names. In English, the *correct* tokenization of  "Barack Obama" would be one word. Currently our tokenizer does NOT do the correct thing for such cases. In Chinese, this is made a lot easier by means off having the middle dot. 

Another example: `"사과(沙果)는"` is one word in Korean (it means apple). Because the rules of Korean is agglutinative, if you split the word up into tokens `"사과", "沙果", "는"` that's wrong, because "沙果" isn't hangul, and "는" marks that the parens is part of the word

One way we can do this is to parse out all punctuation marks and replace them with spaces, then `strings.Split` would simply produce the same semantic results as the English tokenizer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6269)
<!-- Reviewable:end -->
