### PR TITLE
Fix(Dgraph): Fix how visited nodes are detected in recurse queries.

### DIFF
--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -79,7 +79,6 @@ func TestRecurseNestedError2(t *testing.T) {
 }
 
 func TestRecurseQuery(t *testing.T) {
-
 	query := `
 		{
 			me(func: uid(0x01)) @recurse {
@@ -90,7 +89,7 @@ func TestRecurseQuery(t *testing.T) {
 		}`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"name":"Michonne", "friend":[{"name":"Rick Grimes", "friend":[{"name":"Michonne"}]},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea", "friend":[{"name":"Glenn Rhee"}]}]}]}}`, js)
+		`{"data": {"me":[{"name":"Michonne", "friend":[{"name":"Rick Grimes", "friend":[{"name":"Michonne"}]},{"name":"Glenn Rhee"},{"name":"Daryl Dixon"},{"name":"Andrea"}]}]}}`, js)
 }
 
 func TestRecurseExpand(t *testing.T) {
@@ -132,7 +131,7 @@ func TestRecurseQueryOrder(t *testing.T) {
 		}`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"dob":"1910-01-01T00:00:00Z","friend":[{"dob":"1910-01-02T00:00:00Z","friend":[{"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1901-01-15T00:00:00Z","friend":[{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"name":"Andrea"}],"name":"Michonne"}]}}`,
+		`{"data": {"me":[{"dob":"1910-01-01T00:00:00Z","friend":[{"dob":"1910-01-02T00:00:00Z","friend":[{"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1901-01-15T00:00:00Z","name":"Andrea"}],"name":"Michonne"}]}}`,
 		js)
 }
 
@@ -147,7 +146,7 @@ func TestRecurseQueryAllowLoop(t *testing.T) {
 			}
 		}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"friend":[{"friend":[{"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"dob":"1910-01-02T00:00:00Z","name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"friend":[{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"}],"dob":"1901-01-15T00:00:00Z","name":"Andrea"}],"dob":"1910-01-01T00:00:00Z","name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"friend":[{"friend":[{"dob":"1910-01-01T00:00:00Z","name":"Michonne"}],"dob":"1910-01-02T00:00:00Z","name":"Rick Grimes"},{"dob":"1909-05-05T00:00:00Z","name":"Glenn Rhee"},{"dob":"1909-01-10T00:00:00Z","name":"Daryl Dixon"},{"dob":"1901-01-15T00:00:00Z","name":"Andrea"}],"dob":"1910-01-01T00:00:00Z","name":"Michonne"}]}}`, js)
 }
 
 func TestRecurseQueryAllowLoop2(t *testing.T) {

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -118,7 +118,7 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 				sg.updateUidMatrix()
 			}
 
-			for mIdx, _ := range sg.SrcUIDs.Uids {
+			for mIdx := range sg.SrcUIDs.Uids {
 				if allowLoop {
 					for _, ul := range sg.uidMatrix {
 						numEdges += uint64(len(ul.Uids))

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error {
-	// Note: Key format is - "attr|fromUID|toUID"
+	// Note: Key format is - "attr|toUID"
 	reachMap := make(map[string]struct{})
 	allowLoop := start.Params.RecurseArgs.AllowLoop
 	var numEdges uint64
@@ -118,15 +118,15 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 				sg.updateUidMatrix()
 			}
 
-			for mIdx, fromUID := range sg.SrcUIDs.Uids {
+			for mIdx, _ := range sg.SrcUIDs.Uids {
 				if allowLoop {
 					for _, ul := range sg.uidMatrix {
 						numEdges += uint64(len(ul.Uids))
 					}
 				} else {
 					algo.ApplyFilter(sg.uidMatrix[mIdx], func(uid uint64, i int) bool {
-						key := fmt.Sprintf("%s|%d|%d", sg.Attr, fromUID, uid)
-						_, seen := reachMap[key] // Combine fromUID here.
+						key := fmt.Sprintf("%s|%d", sg.Attr, uid)
+						_, seen := reachMap[key]
 						if seen {
 							return false
 						}


### PR DESCRIPTION
Currently a node is marked as visited if it's been visited before AND
has been visited from the same source UID. In dense graphs, the second
condition leads to exponential growth of the data and to other issues
such as responses that are too big to encode.  Removing this condition
fixes the issue.

Fixed tests and verified the new output makes sense.

Fixes DGRAPH-2337

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6272)
<!-- Reviewable:end -->
