### PR TITLE
(release/v20.07) fix(Dgraph): Sort manifests by BackupNum in file handler.

### DIFF
--- a/worker/file_handler.go
+++ b/worker/file_handler.go
@@ -139,6 +139,11 @@ func (h *fileHandler) GetManifests(uri *url.URL, backupId string) ([]*Manifest, 
 		return nil, err
 	}
 
+	// Sort manifests in the ascending order of their BackupNum so that the first
+	// manifest corresponds to the first full backup and so on.
+	sort.Slice(manifests, func(i, j int) bool {
+		return manifests[i].BackupNum < manifests[j].BackupNum
+	})
 	return manifests, nil
 }
 


### PR DESCRIPTION
This was being done in the S3 handler but not in the file handler.
By default the paths are sorted by the filename but sorting by backup
number is more robust.

(cherry picked from commit df63d6ca2076f059961892b9a6f192cb05f88e31)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6279)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5dcbfe6016-88687.surge.sh)
<!-- Dgraph:end -->