### PR TITLE
Pause rollups during snapshot streaming.

### DIFF
--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -253,6 +253,13 @@ func doStreamSnapshot(snap *pb.Snapshot, out pb.Worker_StreamSnapshotServer) err
 }
 
 func (w *grpcWorker) StreamSnapshot(stream pb.Worker_StreamSnapshotServer) error {
+	// Pause rollups during snapshot streaming.
+	closer, err := groups().Node.startTask(opSnapshot)
+	if err != nil {
+		return err
+	}
+	defer closer.Done()
+
 	n := groups().Node
 	if n == nil || n.Raft() == nil {
 		return conn.ErrNoNode


### PR DESCRIPTION
Possible fix for DGRAPH-2349. I think rollups happening in the leader while the snapshot
streaming is happening might be causing issues. Rollups cause previous versions to be
marked as discarded.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6282)
<!-- Reviewable:end -->
