### PR TITLE
feat(dgraph): Allow parent's cascade (with or w/o param) to trickle to child until overridden explicitly

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -553,9 +553,9 @@ func treeCopy(gq *gql.GraphQuery, sg *SubGraph) error {
 			IsInternal:   gchild.IsInternal,
 		}
 
-		// If parent has @cascade (with or without params), inherit @cascade (with no params)
+		// Inherit from the parent.
 		if len(sg.Params.Cascade) > 0 {
-			args.Cascade = append(args.Cascade, "__all__")
+			args.Cascade = append(args.Cascade, sg.Params.Cascade...)
 		}
 		// Allow over-riding at this level.
 		if len(gchild.Cascade) > 0 {

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -1147,18 +1147,28 @@ func CascadeParams(t *testing.T, c *dgo.Dgraph) {
 			out: `
 			{
 				"q": [
-				  {
-					"name": "Alice 1",
-					"age": "23"
-				  },
-				  {
-					"name": "Alice 2"
-				  },
-				  {
-					"name": "Alice 3",
-					"age": "32"
-				  }
-				]
+					{
+					  "name": "Alice 1",
+					  "age": "23",
+					  "friend": [
+						{
+						  "name": "Bob"
+						}
+					  ]
+					},
+					{
+					  "name": "Alice 2",
+					  "friend": [
+						{
+						  "name": "Chris"
+						}
+					  ]
+					},
+					{
+					  "name": "Alice 3",
+					  "age": "32"
+					}
+				  ]
 			}
 			`,
 		},


### PR DESCRIPTION
Fixes DGRAPH-1279

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6283)
<!-- Reviewable:end -->
