### PR TITLE
fix: Allowing you to pass credentials to online restore

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -148,14 +148,13 @@ type loadFn func(reader io.Reader, groupId uint32, preds predicateSet) (uint64, 
 
 // LoadBackup will scan location l for backup files in the given backup series and load them
 // sequentially. Returns the maximum Since value on success, otherwise an error.
-func LoadBackup(location, backupId string, fn loadFn) LoadResult {
+func LoadBackup(location, backupId string, creds *Credentials, fn loadFn) LoadResult {
 	uri, err := url.Parse(location)
 	if err != nil {
 		return LoadResult{0, 0, err}
 	}
 
-	// TODO(martinmr): allow overriding credentials during restore.
-	h := getHandler(uri.Scheme, nil)
+	h := getHandler(uri.Scheme, creds)
 	if h == nil {
 		return LoadResult{0, 0, errors.Errorf("Unsupported URI: %v", uri)}
 	}

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -285,8 +285,17 @@ func getEncConfig(req *pb.RestoreRequest) (*viper.Viper, error) {
 	return config, nil
 }
 
+func getCredentialsFromRestoreRequest(req *pb.RestoreRequest) *Credentials {
+	return &Credentials{
+		AccessKey:    req.AccessKey,
+		SecretKey:    req.SecretKey,
+		SessionToken: req.SessionToken,
+		Anonymous:    req.Anonymous,
+	}
+}
+
 func writeBackup(ctx context.Context, req *pb.RestoreRequest) error {
-	res := LoadBackup(req.Location, req.BackupId,
+	res := LoadBackup(req.Location, req.BackupId, getCredentialsFromRestoreRequest(req),
 		func(r io.Reader, groupId uint32, preds predicateSet) (uint64, error) {
 			if groupId != req.GroupId {
 				// LoadBackup will try to call the backup function for every group.

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -43,7 +43,7 @@ func RunRestore(pdir, location, backupId string, key x.SensitiveByteSlice) LoadR
 
 	// Scan location for backup files and load them. Each file represents a node group,
 	// and we create a new p dir for each.
-	return LoadBackup(location, backupId,
+	return LoadBackup(location, backupId, nil,
 		func(r io.Reader, groupId uint32, preds predicateSet) (uint64, error) {
 
 			dir := filepath.Join(pdir, fmt.Sprintf("p%d", groupId))


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6295)
<!-- Reviewable:end -->
