### PR TITLE
fix: Return 404 status on non-existent API calls

### DIFF
--- a/dgraph/cmd/alpha/dashboard.go
+++ b/dgraph/cmd/alpha/dashboard.go
@@ -34,6 +34,10 @@ type keywords struct {
 }
 
 func homeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.Error(w, "404 page not found", http.StatusNotFound)
+		return
+	}
 	x.Check2(w.Write([]byte(
 		"Dgraph browser is available for running separately using the dgraph-ratel binary")))
 }

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -929,3 +929,26 @@ func TestOptionsForUiKeywords(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
 }
+
+func TestNonExistentPath(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/non-existent-url", addr), nil)
+	require.NoError(t, err)
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode == 404)
+	require.True(t, resp.Status == "404 Not Found")
+}
+
+func TestUrl(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, addr, nil)
+	require.NoError(t, err)
+
+	client := &http.Client{}
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
+}

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -938,8 +938,8 @@ func TestNonExistentPath(t *testing.T) {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	require.True(t, resp.StatusCode == 404)
-	require.True(t, resp.Status == "404 Not Found")
+	require.Equal(t, resp.StatusCode, 404)
+	require.Equal(t, resp.Status, "404 Not Found")
 }
 
 func TestUrl(t *testing.T) {


### PR DESCRIPTION
**Motivation**

Currently, making an API call to a non-existent path on alpha HTTP server such as "/admin/test" returns status as 200 (OK). As the path does not exist, status should be 404.
Related discuss issue: https://discuss.dgraph.io/t/dgraph-should-return-404-on-non-existent-api-paths/9574

**Components affected by this PR**
Dgraph alpha http server

**Does this PR break backwards compatibility?**:
No

**Testing**
Added two unit tests in dgraph/cmd/alpha/http_test.go .

This Pull Request fixes this.

**Fixes**
DGRAPH-2335

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6296)
<!-- Reviewable:end -->
