### PR TITLE
fix panicwrap parent check (#6264)

### DIFF
--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -181,9 +181,17 @@ func WrapPanics() {
 	if err != nil {
 		panic(err)
 	}
-	// If exitStatus >= 0, then we're the parent process and the panicwrap
-	// re-executed ourselves and completed. Just exit with the proper status.
-	if exitStatus >= 0 {
+
+	// Note: panicwrap.Wrap documentation states that exitStatus == -1
+	// should be used to determine whether the process is the child.
+	// However, this is not reliable. See https://github.com/mitchellh/panicwrap/issues/18
+	// we have found that exitStatus = -1 is returned even when
+	// the process is the parent. Likely due to panicwrap returning
+	// syscall.WaitStatus.ExitStatus() as the exitStatus, which _can_ be
+	// -1. Checking panicwrap.Wrapped(nil) is more reliable.
+	if !panicwrap.Wrapped(nil) {
+		// parent
 		os.Exit(exitStatus)
 	}
+	// child
 }


### PR DESCRIPTION
(cherry picked from commit 52e136fb4871434e67dd79106286452ab34df2c3)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6299)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-21d7f281c8-89184.surge.sh)
<!-- Dgraph:end -->