### PR TITLE
release/v20.03 - fix(task): Return error on closed DB (#6075)

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -361,6 +361,9 @@ func ReadPostingList(key []byte, it *badger.Iterator) (*List, error) {
 }
 
 func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
+	if pstore.IsClosed() {
+		return nil, badger.ErrDBClosed
+	}
 	txn := pstore.NewTransactionAt(readTs, false)
 	defer txn.Discard()
 


### PR DESCRIPTION
Fixes DGRAPH-2181

The queries in dgraph are processed in separate goroutines. The pstore badger DB
could be closed while the query was being processed. This causes panics such as
```
panic: runtime error: invalid memory address or nil pointer dereference
	panic: Unclosed iterator at time of Txn.Discard.
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x11d2311]

goroutine 19298 [running]:
github.com/dgraph-io/badger/v2.(*Txn).Discard(0xc05586bc20)
	/go/pkg/mod/github.com/dgraph-io/badger/v2@v2.0.1-rc1.0.20200718033852-37ee16d8ad1c/txn.go:517 +0xc1
panic(0x19e26a0, 0x2988560)
	/usr/local/go/src/runtime/panic.go:969 +0x166
github.com/dgraph-io/badger/v2/skl.(*Skiplist).IncrRef(...)
```
This PR attempts to reduce the number of such crashes. This PR doesn't fix the actual
issue but it tries to reduce the probability of such crashes by checking if badger is not
closed before accessing it.

An ideal fix would be to stop all the goroutines started by dgraph while closing DB so
that we don't try to read from a closed badger DB.

(cherry picked from commit 3cea0fe26c27d62e9ebc5f9574cdc9ba2e31fa13)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6321)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c34625d413-89723.surge.sh)
<!-- Dgraph:end -->