### PR TITLE
fix(raft): Only leader should check the quorum

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -61,15 +61,16 @@ func (n *node) amLeader() bool {
 
 func (n *node) AmLeader() bool {
 	// Return false if the node is not the leader. Otherwise, check the lastQuorum as well.
-	return n.amLeader() && func() bool {
-		// This node must be the leader, but must also be an active member of
-		// the cluster, and not hidden behind a partition. Basically, if this
-		// node was the leader and goes behind a partition, it would still
-		// think that it is indeed the leader for the duration mentioned below.
-		n.mu.RLock()
-		defer n.mu.RUnlock()
-		return time.Since(n.lastQuorum) <= 5*time.Second
-	}()
+	if !n.amLeader() {
+		return false
+	}
+	// This node must be the leader, but must also be an active member of
+	// the cluster, and not hidden behind a partition. Basically, if this
+	// node was the leader and goes behind a partition, it would still
+	// think that it is indeed the leader for the duration mentioned below.
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return time.Since(n.lastQuorum) <= 5*time.Second
 }
 
 func (n *node) uniqueKey() string {


### PR DESCRIPTION
The Checkquorum() function is used by the leader to determine if it is
still a leader and not behind a network partition (split-head situation).

The current code would checkquorum even for followers which isn't necessary.
This PR removes the quorum check for followers.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6323)
<!-- Reviewable:end -->
