### PR TITLE
[stale] fix(encoder): Use EncoderAlloc for manual allocations

### DIFF
--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -330,8 +330,6 @@ func BenchmarkListIntersectRandom(b *testing.B) {
 		if j < len(dst2.Uids) {
 			b.Errorf("Unexpected error in intersection")
 		}
-
-		codec.FreePack(compressedUids)
 	}
 
 	randomTests(10240, 0.3)
@@ -397,8 +395,6 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 			if j < len(dst2.Uids) {
 				b.Errorf("Unexpected error in intersection")
 			}
-
-			codec.FreePack(compressedUids)
 		}
 	}
 
@@ -468,7 +464,6 @@ func TestIntersectCompressedWithLinJump(t *testing.T) {
 			actual := make([]uint64, 0)
 			IntersectCompressedWithLinJump(&dec, otherNums, &actual)
 			require.Equal(t, commonNums, actual)
-			codec.FreePack(pack)
 		}
 	}
 }
@@ -493,7 +488,6 @@ func TestIntersectCompressedWithBin(t *testing.T) {
 			actual := make([]uint64, 0)
 			IntersectCompressedWithBin(&dec, otherNums, &actual)
 			require.Equal(t, commonNums, actual)
-			codec.FreePack(pack)
 		}
 	}
 }
@@ -519,7 +513,6 @@ func TestIntersectCompressedWithBinMissingSize(t *testing.T) {
 			actual := make([]uint64, 0)
 			IntersectCompressedWithBin(&dec, otherNums, &actual)
 			require.Equal(t, commonNums, actual)
-			codec.FreePack(pack)
 		}
 	}
 }

--- a/codec/benchmark/benchmark.go
+++ b/codec/benchmark/benchmark.go
@@ -121,8 +121,7 @@ func benchmarkPack(trials int, chunks *chunks) int {
 	for i := range times {
 		start := time.Now()
 		for _, c := range chunks.data {
-			pack := codec.Encode(c, 256)
-			codec.FreePack(pack)
+			codec.Encode(c, 256)
 			// bp128.DeltaPack(c)
 		}
 		times[i] = int(time.Since(start).Nanoseconds())

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -47,8 +47,7 @@ func TestUidPack(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
 
 	// Some edge case tests.
-	pack := Encode([]uint64{}, 128)
-	FreePack(pack)
+	Encode([]uint64{}, 128)
 	require.Equal(t, 0, ApproxLen(&pb.UidPack{}))
 	require.Equal(t, 0, len(Decode(&pb.UidPack{}, 0)))
 
@@ -64,7 +63,6 @@ func TestUidPack(t *testing.T) {
 		require.Equal(t, len(expected), ExactLen(pack))
 		actual := Decode(pack, 0)
 		require.Equal(t, expected, actual)
-		FreePack(pack)
 	}
 }
 
@@ -75,7 +73,6 @@ func TestSeek(t *testing.T) {
 		enc.Add(uint64(i))
 	}
 	pack := enc.Done()
-	defer FreePack(pack)
 	dec := Decoder{Pack: pack}
 
 	tests := []struct {
@@ -124,7 +121,6 @@ func TestLinearSeek(t *testing.T) {
 		enc.Add(uint64(i))
 	}
 	pack := enc.Done()
-	defer FreePack(pack)
 	dec := Decoder{Pack: pack}
 
 	for i := 0; i < 2*N; i += 10 {
@@ -154,7 +150,6 @@ func TestDecoder(t *testing.T) {
 		expected = append(expected, uint64(i))
 	}
 	pack := enc.Done()
-	defer FreePack(pack)
 
 	dec := Decoder{Pack: pack}
 	for i := 3; i < N; i += 3 {
@@ -220,7 +215,6 @@ func benchmarkUidPackEncode(b *testing.B, blockSize int) {
 	for i := 0; i < b.N; i++ {
 		pack := Encode(uids, blockSize)
 		out, err := pack.Marshal()
-		FreePack(pack)
 		if err != nil {
 			b.Fatalf("Error marshaling uid pack: %s", err.Error())
 		}
@@ -255,7 +249,6 @@ func benchmarkUidPackDecode(b *testing.B, blockSize int) {
 
 	pack := Encode(uids, blockSize)
 	data, err := pack.Marshal()
-	defer FreePack(pack)
 	x.Check(err)
 	b.Logf("Output size: %s. Compression: %.2f",
 		humanize.Bytes(uint64(len(data))),
@@ -308,7 +301,6 @@ func newUidPack(data []uint64) *pb.UidPack {
 
 func TestCopyUidPack(t *testing.T) {
 	pack := newUidPack([]uint64{1, 2, 3, 4, 5})
-	defer FreePack(pack)
 	copy := CopyUidPack(pack)
 	require.Equal(t, Decode(pack, 0), Decode(copy, 0))
 }

--- a/dgraph/cmd/bulk/count_index.go
+++ b/dgraph/cmd/bulk/count_index.go
@@ -91,7 +91,7 @@ func (c *countIndexer) writeIndex(pred string, rev bool, counts map[int][]uint64
 		sort.Slice(uids, func(i, j int) bool { return uids[i] < uids[j] })
 
 		var pl pb.PostingList
-		pl.Pack = codec.Encode(uids, 256)
+		pl.Pack = codec.EncodeAlloc(uids, 256)
 		data, err := pl.Marshal()
 		x.Check(err)
 		codec.FreePack(pl.Pack)

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -668,8 +668,7 @@ func (r *reducer) toList(req *encodeRequest) []*countIndexEntry {
 		})
 
 		// Use a manually allocated block.
-		enc := codec.EncoderAlloc{}
-		enc.BlockSize = 256
+		enc := codec.Encoder{BlockSize: 256, ManualAlloc: true}
 		var lastUid uint64
 		for _, offset := range currentBatch {
 			me := MapEntry(cbuf.Slice(offset))

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -667,7 +667,9 @@ func (r *reducer) toList(req *encodeRequest) []*countIndexEntry {
 			return less(lhs, rhs)
 		})
 
-		enc := codec.Encoder{BlockSize: 256}
+		// Use a manually allocated block.
+		enc := codec.EncoderAlloc{}
+		enc.BlockSize = 256
 		var lastUid uint64
 		for _, offset := range currentBatch {
 			me := MapEntry(cbuf.Slice(offset))

--- a/posting/list.go
+++ b/posting/list.go
@@ -942,7 +942,7 @@ func (l *List) encode(out *rollupOutput, readTs uint64, split bool) error {
 	var plist *pb.PostingList
 	var startUid, endUid uint64
 	var splitIdx int
-	enc := codec.Encoder{BlockSize: blockSize}
+	enc := codec.Encoder{BlockSize: blockSize, ManualAlloc: true}
 
 	// Method to properly initialize the variables above
 	// when a multi-part list boundary is crossed.

--- a/posting/list.go
+++ b/posting/list.go
@@ -1578,7 +1578,7 @@ func FromBackupPostingList(bl *pb.BackupPostingList) *pb.PostingList {
 		return &l
 	}
 
-	l.Pack = codec.Encode(bl.Uids, blockSize)
+	l.Pack = codec.EncodeAlloc(bl.Uids, blockSize)
 	l.Postings = bl.Postings
 	l.CommitTs = bl.CommitTs
 	l.Splits = bl.Splits

--- a/posting/list.go
+++ b/posting/list.go
@@ -947,7 +947,7 @@ func (l *List) encode(out *rollupOutput, readTs uint64, split bool) error {
 	// Method to properly initialize the variables above
 	// when a multi-part list boundary is crossed.
 	initializeSplit := func() {
-		enc = codec.Encoder{BlockSize: blockSize}
+		enc = codec.Encoder{BlockSize: blockSize, ManualAlloc: true}
 
 		// Load the corresponding part and set endUid to correctly detect the end of the list.
 		startUid = l.plist.Splits[splitIdx]

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -28,6 +28,7 @@ import (
 	bpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/pkg/errors"
 
+	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -169,6 +170,7 @@ func loadFromBackup(db *badger.DB, r io.Reader, preds predicateSet) (uint64, err
 					// compatibility. New backups are not affected because there was a change
 					// to roll up lists into a single one.
 					restoreVal, err := pl.Marshal()
+					codec.FreePack(pl.Pack)
 					if err != nil {
 						return 0, errors.Wrapf(err, "while converting backup posting list")
 					}
@@ -180,6 +182,7 @@ func loadFromBackup(db *badger.DB, r io.Reader, preds predicateSet) (uint64, err
 				} else {
 					// This is a complete list. It should be rolled up to avoid writing
 					// a list that is too big to be read back from disk.
+					// Rollup will take ownership of the Pack and will free the memory.
 					l := posting.NewList(restoreKey, pl, kv.Version)
 					kvs, err := l.Rollup()
 					if err != nil {

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -28,7 +28,6 @@ import (
 	bpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/pkg/errors"
 
-	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -170,7 +170,6 @@ func loadFromBackup(db *badger.DB, r io.Reader, preds predicateSet) (uint64, err
 					// compatibility. New backups are not affected because there was a change
 					// to roll up lists into a single one.
 					restoreVal, err := pl.Marshal()
-					codec.FreePack(pl.Pack)
 					if err != nil {
 						return 0, errors.Wrapf(err, "while converting backup posting list")
 					}
@@ -182,7 +181,6 @@ func loadFromBackup(db *badger.DB, r io.Reader, preds predicateSet) (uint64, err
 				} else {
 					// This is a complete list. It should be rolled up to avoid writing
 					// a list that is too big to be read back from disk.
-					// Rollup will take ownership of the Pack and will free the memory.
 					l := posting.NewList(restoreKey, pl, kv.Version)
 					kvs, err := l.Rollup()
 					if err != nil {


### PR DESCRIPTION
The `codec.Encoder` type and `codec.Encode()` function is used at many places in dgraph and using manually allocated memory in these functions would require all the callers to call `FreePack`. 

This PR creates a new `EncoderAlloc` type and `EncodeAlloc()` function that can be used by the bulk loader to manually allocate memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6327)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-168f8dd865-89897.surge.sh)
<!-- Dgraph:end -->