### PR TITLE
fix(GraphQl): fix errors from authorization examples given in docs.

### DIFF
--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -27,15 +27,17 @@ type Todo @auth(
 ){
     id: ID!
     text: String! @search(by: [term])
-    owner: String!
+    owner: String! @search(by: [hash])
 }
 ```
+
+In addition to above schema, details of authentication provider should be given in the last line of schema, as discussed in last chapter.
 
 Here we define a type `Todo`, that's got an `id`, the `text` of the todo and the username of the `owner` of the todo.  What todos can a user query?  Any `Todo` that the `query` rule would also return.
 
 The `query` rule in this case expects the JWT to contain a claim `"USER": "..."` giving the username of the logged in user, and says: you can query any todo that has your username as the owner.
 
-In this example we use the `queryTodo` query that will be auto generated after uploading this schema. When using a query in a rule, you can only use the `queryTypeName` query. Where `TypeName` matches the name of where the `@auth` directive is attached. In other words, we could not have used the `getTodo` query in our rule above to query by id only.
+In this example we use the `queryTodo` query that will be auto generated after uploading this schema. When using a query in a rule, you can only use the `queryTypeName` query. Where `TypeName` matches the name of the type, where the `@auth` directive is attached. In other words, we could not have used the `getTodo` query in our rule above to query by id only.
 
 This rule is applied automatically at query time.  For example, the query
 

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -31,7 +31,7 @@ type Todo @auth(
 }
 ```
 
-In addition to above schema, details of authentication provider should be given in the last line of schema, as discussed in last chapter.
+In addition to it, details of the authentication provider should be given in the last line of the schema, as discussed in section  [authorization-overview](/graphql/authorization/authorization-overview).
 
 Here we define a type `Todo`, that's got an `id`, the `text` of the todo and the username of the `owner` of the todo.  What todos can a user query?  Any `Todo` that the `query` rule would also return.
 

--- a/wiki/content/graphql/authorization/mutations.md
+++ b/wiki/content/graphql/authorization/mutations.md
@@ -24,12 +24,11 @@ type Todo @auth(
             } 
         }"""
     }
-){{
+){
     id: ID!
     text: String!
     owner: User
 }
-
 type User {
     username: String! @id
     todos: [Todo]
@@ -58,7 +57,7 @@ type Todo @auth(
         },
         { rule:  "{$ROLE: { eq: \"ADMIN\" } }"}
     ]}
-){{
+){
     id: ID!
     text: String! @search(by: [term])
     owner: User


### PR DESCRIPTION
This PR fix errors from authorization examples given in docs.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6330)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-7997c5b7af-90396.surge.sh)
<!-- Dgraph:end -->