### PR TITLE
(release/v1.2) fix(Dgraph): Add flags to set table and vlog loading m…

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/badger/v2"
+	bopt "github.com/dgraph-io/badger/v2/options"
 	"github.com/dgraph-io/badger/v2/y"
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -103,6 +104,15 @@ instances to achieve high-availability.
 	flag.Int64("cache_mb", 0, "Total size of cache (in MB) to be used in zero.")
 	flag.String("cache_percentage", "100,0",
 		"Cache percentages summing up to 100 for various caches (FORMAT: blockCache,indexCache).")
+
+	// Badger flags
+	flag.String("badger.tables", "mmap",
+		"[ram, mmap, disk] Specifies how Badger LSM tree is stored for write-ahead log directory "+
+			"write-ahead directory. Option sequence consume most to least RAM while providing "+
+			"best to worst read performance respectively")
+	flag.String("badger.vlog", "mmap",
+		"[mmap, disk] Specifies how Badger Value log is stored for the write-ahead log directory "+
+			"log directory. mmap consumes more RAM, but provides better performance.")
 }
 
 func setupListener(addr string, port int, kind string) (listener net.Listener, err error) {
@@ -239,6 +249,27 @@ func run() {
 		WithLoadBloomsOnOpen(false)
 
 	kvOpt.ZSTDCompressionLevel = 3
+
+	// Set loading mode options.
+	switch Zero.Conf.GetString("badger.tables") {
+	case "mmap":
+		kvOpt.TableLoadingMode = bopt.MemoryMap
+	case "ram":
+		kvOpt.TableLoadingMode = bopt.LoadToRAM
+	case "disk":
+		kvOpt.TableLoadingMode = bopt.FileIO
+	default:
+		x.Fatalf("Invalid Badger Tables options")
+	}
+	switch Zero.Conf.GetString("badger.vlog") {
+	case "mmap":
+		kvOpt.ValueLogLoadingMode = bopt.MemoryMap
+	case "disk":
+		kvOpt.ValueLogLoadingMode = bopt.FileIO
+	default:
+		x.Fatalf("Invalid Badger Value log options")
+	}
+	glog.Infof("Opening zero BadgerDB with options: %+v\n", kvOpt)
 
 	kv, err := badger.Open(kvOpt)
 	x.Checkf(err, "Error while opening WAL store")


### PR DESCRIPTION
…ode for zero.

Related to DGRAPH-2189

(cherry picked from commit bf799992473cf334947f8507b001883333ad2d88)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6344)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e2580514b9-90245.surge.sh)
<!-- Dgraph:end -->