### PR TITLE
test: add --build option for docker-compose up in test script

### DIFF
--- a/contrib/scripts/functions.sh
+++ b/contrib/scripts/functions.sh
@@ -37,7 +37,7 @@ function restartCluster {
   fi
 
   docker ps -a --filter label="cluster=test" --format "{{.Names}}" | xargs -r docker rm -f
-  GOPATH=$docker_compose_gopath docker-compose -p dgraph -f $compose_file up --force-recreate --remove-orphans -d || exit 1
+  GOPATH=$docker_compose_gopath docker-compose -p dgraph -f $compose_file up --force-recreate --build --remove-orphans -d || exit 1
   popd >/dev/null
 
   $basedir/contrib/wait-for-it.sh -t 60 localhost:6180 || exit 1


### PR DESCRIPTION
Fixes DGRAPH-2356
This PR fixes random GraphQL custom logic e2e test failures in TeamCity by requiring docker-compose to always build images before starting the containers, as the mock server in custom logic tests can change any time.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6348)
<!-- Reviewable:end -->
