### PR TITLE
fix(GraphQL): incorrect generatedSchema in updateGQLSchema

### DIFF
--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -57,10 +57,8 @@ func resolveUpdateGQLSchema(ctx context.Context, m schema.Mutation) (*resolve.Re
 	if _, err = schema.FromString(schHandler.GQLSchema()); err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
-	newGQLSchema := input.Set.Schema
-	newDgraphSchema := schHandler.DGSchema()
 
-	resp, err := edgraph.UpdateGQLSchema(ctx, newGQLSchema, newDgraphSchema)
+	resp, err := edgraph.UpdateGQLSchema(ctx, input.Set.Schema, schHandler.DGSchema())
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
@@ -70,8 +68,8 @@ func resolveUpdateGQLSchema(ctx context.Context, m schema.Mutation) (*resolve.Re
 			m.Name(): map[string]interface{}{
 				"gqlSchema": map[string]interface{}{
 					"id":              query.UidToHex(resp.Uid),
-					"schema":          newGQLSchema,
-					"generatedSchema": newDgraphSchema,
+					"schema":          input.Set.Schema,
+					"generatedSchema": schHandler.GQLSchema(),
 				}}},
 		Field: m,
 		Err:   nil,

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -6,10 +6,6 @@ services:
     image: dgraph/dgraph:latest
     container_name: alpha1
     working_dir: /data/alpha1
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
     labels:
       cluster: test
     ports:
@@ -26,10 +22,6 @@ services:
     image: dgraph/dgraph:latest
     container_name: zero1
     working_dir: /data/zero1
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
     labels:
       cluster: test
     ports:

--- a/graphql/e2e/schema/generatedSchema.graphql
+++ b/graphql/e2e/schema/generatedSchema.graphql
@@ -1,0 +1,232 @@
+#######################
+# Input Schema
+#######################
+
+type Author {
+	id: ID!
+	name: String!
+}
+
+#######################
+# Extended Definitions
+#######################
+
+"""
+The Int64 scalar type represents a signed 64‐bit numeric non‐fractional value.
+Int64 can currently represent values in range [-(2^53)+1, (2^53)-1] without any error.
+Values out of this range but representable by a signed 64-bit integer, may get coercion error.
+"""
+scalar Int64
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	int64
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	introspectionHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete:AuthRule) on OBJECT
+directive @custom(http: CustomHTTP, dql: String) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE
+directive @cascade(fields: [String]) on FIELD
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input Int64Filter {
+	eq: Int64
+	le: Int64
+	lt: Int64
+	ge: Int64
+	gt: Int64
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	numUids: Int
+}
+
+type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	msg: String
+	numUids: Int
+}
+
+type UpdateAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AuthorHasFilter {
+	name
+}
+
+enum AuthorOrderable {
+	name
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddAuthorInput {
+	name: String!
+}
+
+input AuthorFilter {
+	id: [ID!]
+	has: AuthorHasFilter
+	and: AuthorFilter
+	or: AuthorFilter
+	not: AuthorFilter
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
+}
+
+input AuthorPatch {
+	name: String
+}
+
+input AuthorRef {
+	id: ID
+	name: String
+}
+
+input UpdateAuthorInput {
+	filter: AuthorFilter!
+	set: AuthorPatch
+	remove: AuthorPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
+}
+

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"testing"
 	"time"
@@ -365,6 +366,45 @@ func TestGQLSchemaAfterDropData(t *testing.T) {
 	// we should still get the schema we inserted earlier
 	require.Equal(t, schema, getGQLSchemaRequireId(t, groupOneAdminServer))
 
+}
+
+func TestUpdateGQLSchemaFields(t *testing.T) {
+	schema := `
+	type Author {
+		id: ID!
+		name: String!
+	}`
+
+	generatedSchema, err := ioutil.ReadFile("generatedSchema.graphql")
+	require.NoError(t, err)
+
+	req := &common.GraphQLParams{
+		Query: `mutation updateGQLSchema($sch: String!) {
+			updateGQLSchema(input: { set: { schema: $sch }}) {
+				gqlSchema {
+					schema
+					generatedSchema
+				}
+			}
+		}`,
+		Variables: map[string]interface{}{"sch": schema},
+	}
+	resp := req.ExecuteAsPost(t, groupOneAdminServer)
+	require.NotNil(t, resp)
+	require.Nilf(t, resp.Errors, "%s", resp.Errors)
+
+	var updateResp struct {
+		UpdateGQLSchema struct {
+			GQLSchema struct {
+				Schema          string
+				GeneratedSchema string
+			}
+		}
+	}
+	require.NoError(t, json.Unmarshal(resp.Data, &updateResp))
+
+	require.Equal(t, schema, updateResp.UpdateGQLSchema.GQLSchema.Schema)
+	require.Equal(t, string(generatedSchema), updateResp.UpdateGQLSchema.GQLSchema.GeneratedSchema)
 }
 
 func updateGQLSchema(t *testing.T, schema, url string) *common.GraphQLResponse {


### PR DESCRIPTION
This PR fixes the behaviour where Dgraph schema was being given as `generatedSchema` field in `updateGQLSchema` request. Now, the newly generated complete GraphQL schema is given as `generatedSchema`.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6349)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a820345247-90521.surge.sh)
<!-- Dgraph:end -->