### PR TITLE
(release/v1.2) fix(Dgraph): add flag to set up compression in zero.

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -113,6 +113,8 @@ instances to achieve high-availability.
 	flag.String("badger.vlog", "mmap",
 		"[mmap, disk] Specifies how Badger Value log is stored for the write-ahead log directory "+
 			"log directory. mmap consumes more RAM, but provides better performance.")
+	flag.Int("badger.compression_level", 3,
+		"The compression level for Badger. A higher value uses more resources.")
 }
 
 func setupListener(addr string, port int, kind string) (listener net.Listener, err error) {
@@ -248,7 +250,12 @@ func run() {
 		WithIndexCacheSize(indexCacheSz).
 		WithLoadBloomsOnOpen(false)
 
-	kvOpt.ZSTDCompressionLevel = 3
+	compression_level := Zero.Conf.GetInt("badger.compression_level")
+	if compression_level > 0 {
+		// By default, compression is disabled in badger.
+		kvOpt.Compression = bopt.ZSTD
+		kvOpt.ZSTDCompressionLevel = compression_level
+	}
 
 	// Set loading mode options.
 	switch Zero.Conf.GetString("badger.tables") {


### PR DESCRIPTION
(cherry picked from commit 254bd2904fa236ef4527d8744f2246af27b61d9a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6357)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a9eaa8132b-90591.surge.sh)
<!-- Dgraph:end -->