### PR TITLE
fix(shutdown): Force exit if CTRL-C is caught before initialization

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -770,6 +770,7 @@ func run() {
 		edgraph.ResetAcl(updaters)
 		edgraph.RefreshAcls(updaters)
 		edgraph.ResetCors(updaters)
+		atomic.AddUint32(&initDone, 1)
 		// Update the accepted cors origins.
 		for updaters.Ctx().Err() == nil {
 			origins, err := edgraph.GetCorsOrigins(updaters.Ctx())
@@ -780,7 +781,6 @@ func run() {
 			x.UpdateCorsOrigins(origins)
 			return
 		}
-		atomic.AddUint32(&initDone, 1)
 	}()
 	// Listen for any new cors origin update.
 	go listenForCorsUpdate(updaters)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -765,12 +765,13 @@ func run() {
 	updaters := y.NewCloser(4)
 	go func() {
 		worker.StartRaftNodes(worker.State.WALstore, bindall)
+		atomic.AddUint32(&initDone, 1)
+
 		// initialization of the admin account can only be done after raft nodes are running
 		// and health check passes
 		edgraph.ResetAcl(updaters)
 		edgraph.RefreshAcls(updaters)
 		edgraph.ResetCors(updaters)
-		atomic.AddUint32(&initDone, 1)
 		// Update the accepted cors origins.
 		for updaters.Ctx().Err() == nil {
 			origins, err := edgraph.GetCorsOrigins(updaters.Ctx())


### PR DESCRIPTION
Forcefully kill alpha if CTRL-C is caught before node initialization
has completed.

Fixes DGRAPH-2377


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6359)
<!-- Reviewable:end -->
