### PR TITLE
don't propose trail license if the licences is provided by the user.

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -458,7 +458,7 @@ func (n *node) proposeNewCID() {
 	}
 
 	// Apply trial license only if not already licensed.
-	if n.server.license() == nil {
+	if n.server.license() == nil && Zero.Conf.GetString("enterprise_license") == "" {
 		if err := n.proposeTrialLicense(); err != nil {
 			glog.Errorf("while proposing trial license to cluster: %v", err)
 		}

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -457,7 +457,7 @@ func (n *node) proposeNewCID() {
 		time.Sleep(3 * time.Second)
 	}
 
-	// Apply trial license only if not already licensed.
+	// Apply trial license only if not already licensed and no enterprise license provided.
 	if n.server.license() == nil && Zero.Conf.GetString("enterprise_license") == "" {
 		if err := n.proposeTrialLicense(); err != nil {
 			glog.Errorf("while proposing trial license to cluster: %v", err)


### PR DESCRIPTION
because, raft ready already proposing enterprise license. So, avoiding
the race condition.

Signed-off-by: பாலாஜி <balaji@dgraph.io>

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6367)
<!-- Reviewable:end -->
