### PR TITLE
cherry-pick v20.07-slash: fix(GraphQL): incorrect generatedSchema in updateGQLSchema (#6349)

### DIFF
--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -57,10 +57,8 @@ func resolveUpdateGQLSchema(ctx context.Context, m schema.Mutation) (*resolve.Re
 	if _, err = schema.FromString(schHandler.GQLSchema()); err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
-	newGQLSchema := input.Set.Schema
-	newDgraphSchema := schHandler.DGSchema()
 
-	resp, err := edgraph.UpdateGQLSchema(ctx, newGQLSchema, newDgraphSchema)
+	resp, err := edgraph.UpdateGQLSchema(ctx, input.Set.Schema, schHandler.DGSchema())
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
@@ -70,8 +68,8 @@ func resolveUpdateGQLSchema(ctx context.Context, m schema.Mutation) (*resolve.Re
 			m.Name(): map[string]interface{}{
 				"gqlSchema": map[string]interface{}{
 					"id":              query.UidToHex(resp.Uid),
-					"schema":          newGQLSchema,
-					"generatedSchema": newDgraphSchema,
+					"schema":          input.Set.Schema,
+					"generatedSchema": schHandler.GQLSchema(),
 				}}},
 		Field: m,
 		Err:   nil,

--- a/graphql/e2e/schema/generatedSchema.graphql
+++ b/graphql/e2e/schema/generatedSchema.graphql
@@ -1,0 +1,209 @@
+#######################
+# Input Schema
+#######################
+
+type Author {
+	id: ID!
+	name: String!
+}
+
+#######################
+# Extended Definitions
+#######################
+
+scalar DateTime
+
+enum DgraphIndex {
+	int
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	introspectionHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete:AuthRule) on OBJECT
+directive @custom(http: CustomHTTP, dql: String) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE
+directive @cascade on FIELD
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	le: String
+	lt: String
+	ge: String
+	gt: String
+}
+
+input StringHashFilter {
+	eq: String
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	numUids: Int
+}
+
+type DeleteAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	msg: String
+	numUids: Int
+}
+
+type UpdateAuthorPayload {
+	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum AuthorOrderable {
+	name
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddAuthorInput {
+	name: String!
+}
+
+input AuthorFilter {
+	id: [ID!]
+	not: AuthorFilter
+}
+
+input AuthorOrder {
+	asc: AuthorOrderable
+	desc: AuthorOrderable
+	then: AuthorOrder
+}
+
+input AuthorPatch {
+	name: String
+}
+
+input AuthorRef {
+	id: ID
+	name: String
+}
+
+input UpdateAuthorInput {
+	filter: AuthorFilter!
+	set: AuthorPatch
+	remove: AuthorPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getAuthor(id: ID!): Author
+	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
+	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
+	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
+}
+


### PR DESCRIPTION
This PR fixes the behaviour where Dgraph schema was being given as generatedSchema field in updateGQLSchema request. Now, the newly generated complete GraphQL schema is given as generatedSchema.

(cherry picked from commit 0b8681cdca27b1032aa645ee6c0e6851ae82b154)

\# Conflicts:
\#	graphql/e2e/schema/schema_test.go

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6368)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9a56f1a2f4-90807.surge.sh)
<!-- Dgraph:end -->