### PR TITLE
fix(Dgraph): Parse Content-Type in headers properly

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime"
 	"net/http"
 	"sort"
 	"strconv"
@@ -177,18 +178,27 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		Query     string            `json:"query"`
 		Variables map[string]string `json:"variables"`
 	}
+
 	contentType := r.Header.Get("Content-Type")
-	switch strings.ToLower(contentType) {
+	mediaType, contentTypeParams, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		x.SetStatus(w, x.ErrorInvalidRequest, "Invalid Content-Type")
+	}
+	if charset, ok := contentTypeParams["charset"]; ok && strings.ToLower(charset) != "utf-8" {
+		x.SetStatus(w, x.ErrorInvalidRequest, "Unsupported charset. "+
+			"Supported charset is UTF-8")
+		return
+	}
+
+	switch mediaType {
 	case "application/json":
 		if err := json.Unmarshal(body, &params); err != nil {
 			jsonErr := convertJSONError(string(body), err)
 			x.SetStatus(w, x.ErrorInvalidRequest, jsonErr.Error())
 			return
 		}
-
 	case "application/graphql+-":
 		params.Query = string(body)
-
 	default:
 		x.SetStatus(w, x.ErrorInvalidRequest, "Unsupported Content-Type. "+
 			"Supported content types are application/json, application/graphql+-")
@@ -300,7 +310,17 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 
 	var req *api.Request
 	contentType := r.Header.Get("Content-Type")
-	switch strings.ToLower(contentType) {
+	mediaType, contentTypeParams, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		x.SetStatus(w, x.ErrorInvalidRequest, "Invalid Content-Type")
+	}
+	if charset, ok := contentTypeParams["charset"]; ok && strings.ToLower(charset) != "utf-8" {
+		x.SetStatus(w, x.ErrorInvalidRequest, "Unsupported charset. "+
+			"Supported charset is UTF-8")
+		return
+	}
+
+	switch mediaType {
 	case "application/json":
 		ms := make(map[string]*skipJSONUnmarshal)
 		if err := json.Unmarshal(body, &ms); err != nil {

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -955,3 +955,17 @@ func TestUrl(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, resp.StatusCode >= 200 && resp.StatusCode < 300)
 }
+
+func TestContentTypeCharset(t *testing.T) {
+	_, _, err := queryWithGz(`{"query": "schema {}"}`, "application/json; charset=utf-8", "false", "", false, false)
+	require.NoError(t, err)
+
+	_, _, err = queryWithGz(`{"query": "schema {}"}`, "application/json; charset=latin1", "false", "", false, false)
+	require.True(t, err != nil && strings.Contains(err.Error(), "Unsupported charset"))
+
+	_, err = mutationWithTs(`{}`, "application/rdf; charset=utf-8", false, true, 0)
+	require.NoError(t, err)
+
+	_, err = mutationWithTs(`{}`, "application/rdf; charset=latin1", false, true, 0)
+	require.True(t, err != nil && strings.Contains(err.Error(), "Unsupported charset"))
+}


### PR DESCRIPTION
Fixes DGRAPH-2227.

A request sent to a query or mutation handler with the header `Content-Type: application/json; charset=utf-8` fails even though it is perfectly valid. This PR fixes parsing of the `Content-Type` header.

Currently, I've added a check - `charset`, if defined, must be `utf-8`. We may or may not want to remove that check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6370)
<!-- Reviewable:end -->
