### PR TITLE
fix(GraphQL): This PR adds documentation for Scalar DateTime type.

### DIFF
--- a/graphql/e2e/schema/generatedSchema.graphql
+++ b/graphql/e2e/schema/generatedSchema.graphql
@@ -18,6 +18,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -68,8 +68,10 @@ Int64 can currently represent values in range [-(2^53)+1, (2^53)-1] without any 
 Values out of this range but representable by a signed 64-bit integer, may get coercion error.
 """
 scalar Int64
+
 """
-The DateTime scalar type represent Date and time as a string in RFC3339 format.
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
 """
 scalar DateTime
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -68,7 +68,9 @@ Int64 can currently represent values in range [-(2^53)+1, (2^53)-1] without any 
 Values out of this range but representable by a signed 64-bit integer, may get coercion error.
 """
 scalar Int64
-
+"""
+The DateTime scalar type represent Date and time as a string in RFC3339 format.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -29,6 +29,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -34,6 +34,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -22,6 +22,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -39,6 +39,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -23,6 +23,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -22,6 +22,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -18,6 +18,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -18,6 +18,11 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -22,7 +22,6 @@ scalar Int64
 The DateTime scalar type represents date and time as a string in RFC3339 format.
 For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
 """
-
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -32,6 +32,11 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -36,7 +36,6 @@ scalar Int64
 The DateTime scalar type represents date and time as a string in RFC3339 format.
 For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
 """
-
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -32,6 +32,11 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -36,7 +36,6 @@ scalar Int64
 The DateTime scalar type represents date and time as a string in RFC3339 format.
 For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
 """
-
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -31,6 +31,11 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -35,7 +35,6 @@ scalar Int64
 The DateTime scalar type represents date and time as a string in RFC3339 format.
 For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
 """
-
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -25,6 +25,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -42,6 +42,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -43,6 +43,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -42,6 +42,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -23,6 +23,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -23,6 +23,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/hasfilter.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasfilter.graphql
@@ -26,6 +26,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -25,6 +25,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -32,6 +32,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -27,6 +27,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -27,6 +27,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -49,6 +49,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -49,6 +49,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -17,6 +17,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -29,6 +29,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -18,6 +18,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -27,6 +27,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -46,6 +46,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -26,6 +26,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -21,6 +21,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -33,6 +33,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -25,6 +25,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -26,6 +26,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -25,6 +25,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -25,6 +25,10 @@ Values out of this range but representable by a signed 64-bit integer, may get c
 """
 scalar Int64
 
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
 scalar DateTime
 
 enum DgraphIndex {


### PR DESCRIPTION
Fixes GRAPHQL-631
This PR adds documentation for Scalar DateTime type.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6373)
<!-- Reviewable:end -->
