### PR TITLE
chore(Docs): Update graph-links.md to remove a duplicate word

### DIFF
--- a/wiki/content/graphql/schema/graph-links.md
+++ b/wiki/content/graphql/schema/graph-links.md
@@ -48,7 +48,7 @@ type Post {
 }
 ```
 
-Then, the schema says that an author has a list of posts and a post has an author.  But, that GraphQL schema doesn't doesn't say that every post in the list of posts for an author has the same author as their `author`.  For example, it's perfectly valid for author `a1` to have a `posts` edge to post `p1`, that has an `author` edge to author `a2`.  Here, we'd expect an author to be the author of all their posts, but that's not what GraphQL enforces.  In GraphQL, it's left up to the implementation to make two-way connections in cases that make sense.  That's just part of how GraphQL works.
+Then, the schema says that an author has a list of posts and a post has an author.  But, that GraphQL schema doesn't say that every post in the list of posts for an author has the same author as their `author`.  For example, it's perfectly valid for author `a1` to have a `posts` edge to post `p1`, that has an `author` edge to author `a2`.  Here, we'd expect an author to be the author of all their posts, but that's not what GraphQL enforces.  In GraphQL, it's left up to the implementation to make two-way connections in cases that make sense.  That's just part of how GraphQL works.
 
 In Dgraph, the directive `@hasInverse` is used to create a two-way edge.  
 


### PR DESCRIPTION
remove duplicate word "doesn't" from description of two-way edges.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6378)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5c80007d4e-91182.surge.sh)
<!-- Dgraph:end -->