### PR TITLE
fix(GraphQL): fix for deletion on interfaces with no non Id field

### DIFF
--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -266,3 +266,29 @@
     query {
       x as deleteX()
     }
+
+-
+  name: "Deleting an interface with just a field with @id directive"
+  gqlmutation: |
+    mutation{
+      deleteA(filter:{name:{eq: "xyz"}}){
+        a{
+          name
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      x as deleteA(func: type(A)) @filter(eq(A.name, "xyz")) {
+        uid
+      }
+      a(func: uid(x)) {
+        dgraph.type
+        name : A.name
+        dgraph.uid : uid
+      }
+    }
+  dgmutations:
+    - deletejson: |
+        [{ "uid": "uid(x)"}]
+

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -282,3 +282,7 @@ type ThingTwo implements Thing {
     prop: String @dgraph(pred: "prop")
     owner: String
 }
+
+interface A {
+    name: String! @id
+}

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -518,10 +518,10 @@ func mutatedTypeMapping(s *schema,
 		}
 		// This is a convoluted way of getting the type for mutatedTypeName. We get the definition
 		// for UpdateTPayload and get the type from the first field. There is no direct way to get
-		// the type from the definition of an object. We use Update and not Add here because
-		// Interfaces only have Update.
+		// the type from the definition of an object. We use Delete and not Update or Add here because
+		// Interfaces can't have Add and if there is no non Id field then Update also will not be there.
 		var def *ast.Definition
-		if def = s.schema.Types["Update"+mutatedTypeName+"Payload"]; def == nil {
+		if def = s.schema.Types["Delete"+mutatedTypeName+"Payload"]; def == nil {
 			def = s.schema.Types["Add"+mutatedTypeName+"Payload"]
 		}
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -521,8 +521,8 @@ func mutatedTypeMapping(s *schema,
 		// the type from the definition of an object. We use Delete and not Update or Add here because
 		// Interfaces can't have Add and if there is no non Id field then Update also will not be there.
 		var def *ast.Definition
-		if def = s.schema.Types["Delete"+mutatedTypeName+"Payload"]; def == nil {
-			def = s.schema.Types["Add"+mutatedTypeName+"Payload"]
+		if def = s.schema.Types["Add"+mutatedTypeName+"Payload"]; def == nil {
+			def = s.schema.Types["Delete"+mutatedTypeName+"Payload"]
 		}
 
 		if def == nil {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -517,9 +517,9 @@ func mutatedTypeMapping(s *schema,
 		default:
 		}
 		// This is a convoluted way of getting the type for mutatedTypeName. We get the definition
-		// for UpdateTPayload and get the type from the first field. There is no direct way to get
-		// the type from the definition of an object. We use Delete and not Update or Add here because
-		// Interfaces can't have Add and if there is no non Id field then Update also will not be there.
+		// for AddTPayload and get the type from the first field. There is no direct way to get
+		// the type from the definition of an object. Interfaces can't have Add and if there is no non Id
+		// field then Update also will not be there, so we use Delete if there is no AddTPayload.
 		var def *ast.Definition
 		if def = s.schema.Types["Add"+mutatedTypeName+"Payload"]; def == nil {
 			def = s.schema.Types["Delete"+mutatedTypeName+"Payload"]


### PR DESCRIPTION
Fixes GRAPHQL-655.

For this user schema (interface have no non-Id field):

```
interface A {
   name: String! @id
}

type B implements A {
  age: Int!
}
```
the following delete mutation 
```
mutation{
  deleteA(filter:{name:{eq: "xyz"}}){
    a{
      name
    }
  }
}
```
was resulting in the following error:
```
{
  "errors": [
    {
      "message": "Internal Server Error - a panic was trapped.  This indicates a bug in the GraphQL server.  A stack trace was logged.  Please let us know by filing an issue with the stack trace."
    }
  ]
}
```
This PR fixes this bug and now deleting can be performed successfully.


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6387)
<!-- Reviewable:end -->
