### PR TITLE
fix(DGraph): Increased timeout for rebalancing alpha nodes from 20m to 2h

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	predicateMoveTimeout = 20 * time.Minute
+	predicateMoveTimeout = 120 * time.Minute
 )
 
 /*


### PR DESCRIPTION
DGraph zero always times out when it tries to rebalance across alpha nodes for very large nodes. This PR increases the timeout from 20 minutes to 2 hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6388)
<!-- Reviewable:end -->
