### PR TITLE
docs: add missing predicates in alter schema

### DIFF
--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -168,6 +168,8 @@ curl "localhost:8080/alter" -XPOST -d $'
   release_date: datetime @index(year) .
   revenue: float .
   running_time: int .
+  starring: uid .
+  director: uid .
 
   type Person {
     name


### PR DESCRIPTION
Current schema fails with the error: `"message": "Schema does not contain a matching predicate for field starring in type Film",
`
 This PR fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6390)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-938d122813-91672.surge.sh)
<!-- Dgraph:end -->