### PR TITLE
fix(GraphQL): don't generate orderable enum value for list fields

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1020,7 +1020,7 @@ func addTypeOrderable(schema *ast.Schema, defn *ast.Definition) {
 	}
 
 	for _, fld := range defn.Fields {
-		if orderable[fld.Type.Name()] {
+		if fld.Type.NamedType != "" && orderable[fld.Type.NamedType] {
 			order.EnumValues = append(order.EnumValues,
 				&ast.EnumValueDefinition{Name: fld.Name})
 		}

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -227,9 +227,6 @@ enum PostOrderable {
 	title
 	titleByEverything
 	text
-	tags
-	tagsHash
-	tagsExact
 	publishByYear
 	publishByMonth
 	publishByDay


### PR DESCRIPTION
Fixes GRAPHQL-650.

For this user schema:
```
type Starship {
        id: ID!
        name: String! @search(by: [term])
        length: Int64
        tags: [String]
        createdAt: DateTime
}
```
we were generating complete GraphQL schema with StarshipOrderable as:
```
enum StarshipOrderable {
  name
  length
  tags
  createdAt
}
```
that would cause a DQL query to be formed which errors out, see this GraphQL query:
```
query {
  queryStarship(order: {asc: tags}) {
    id
    name
    length
    tags
  }
}
```
It gives back:
```
{
  "errors": [
    {
      "message": "Dgraph query failed because Dgraph execution failed because : Sorting not supported on attr: Starship.tags of type: [scalar]"
    }
  ],
  "data": {
    "queryStarship": []
  }
}
```
which means we should not allow even list of scalar along with object types in orderable. Only scalar field should be allowed in orderable. So, the correct orderable should be without tags field:
```
enum StarshipOrderable {
  name
  length
  createdAt
}
```

This PR fixes the above bug.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6392)
<!-- Reviewable:end -->
