### PR TITLE
fix(Dgraph): allow compression level to be set for both p and w.

### DIFF
--- a/worker/config.go
+++ b/worker/config.go
@@ -48,10 +48,15 @@ type Options struct {
 	// BadgerWalVlog is the name of the mode used to load the badger value log for the w directory.
 	BadgerWalVlog string
 
-	// BadgerCompressionLevel is the ZSTD compression level used by badger. A
+	// BadgerCompressionLevel is the ZSTD compression level used by the p directory. A
 	// higher value means more CPU intensive compression and better compression
 	// ratio.
 	BadgerCompressionLevel int
+	// BadgerCompressionLevel is the ZSTD compression level used by the p directory. A
+	// higher value means more CPU intensive compression and better compression
+	// ratio.
+	BadgerWalCompressionLevel int
+
 	// WALDir is the path to the directory storing the write-ahead log.
 	WALDir string
 	// MutationsMode is the mode used to handle mutation requests.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -83,9 +83,12 @@ func setBadgerOptions(opt badger.Options, wal bool) badger.Options {
 		// Settings for the write-ahead log.
 		badgerTables = Config.BadgerWalTables
 		badgerVlog = Config.BadgerWalVlog
-		// Disable compression for WAL as it is supposed to be fast. Compression makes it a
-		// little slow (Though we save some disk space but it is not worth the slowness).
-		opt.Compression = options.None
+		// Disable compression for WAL by default as it is supposed to be fast. Compression
+		// makes it a little slow (Though we save some disk space but it is not worth the slowness).
+		if Config.BadgerWalCompressionLevel != 0 {
+			opt.Compression = options.ZSTD
+			opt.ZSTDCompressionLevel = Config.BadgerWalCompressionLevel
+		}
 	} else {
 		// Settings for the data directory.
 		badgerTables = Config.BadgerTables


### PR DESCRIPTION
Related to DGRAPH-2189

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6404)
<!-- Reviewable:end -->
