### PR TITLE
release/v1.2 - Fix(Alpha): MASA: Make Alpha Shutdown Again (#6313)

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -346,5 +346,10 @@ func run() {
 
 	glog.Infoln("Running Dgraph Zero...")
 	st.zero.closer.Wait()
-	glog.Infoln("All done.")
+	glog.Infoln("Closer closed.")
+
+	err = kv.Close()
+	glog.Infof("Badger closed with err: %v\n", err)
+
+	glog.Infoln("All done. Goodbye!")
 }

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -41,7 +41,7 @@ func (s *Server) Login(ctx context.Context,
 }
 
 // ResetAcl is an empty method since ACL is only supported in the enterprise version.
-func ResetAcl() {
+func ResetAcl(closer *y.Closer) {
 	// do nothing
 }
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -297,14 +297,14 @@ func authorizeUser(ctx context.Context, userid string, password string) (
 
 // RefreshAcls queries for the ACL triples and refreshes the ACLs accordingly.
 func RefreshAcls(closer *y.Closer) {
-	defer closer.Done()
+	defer func() {
+		glog.Infoln("RefreshAcls closed")
+		closer.Done()
+	}()
 	if len(worker.Config.HmacSecret) == 0 {
 		// the acl feature is not turned on
 		return
 	}
-
-	ticker := time.NewTicker(worker.Config.AclRefreshInterval)
-	defer ticker.Stop()
 
 	// retrieve the full data set of ACLs from the corresponding alpha server, and update the
 	// aclCachePtr
@@ -315,9 +315,7 @@ func RefreshAcls(closer *y.Closer) {
 			ReadOnly: true,
 		}
 
-		ctx := context.Background()
-		var err error
-		queryResp, err := (&Server{}).doQuery(ctx, &queryRequest, NoAuthorize)
+		queryResp, err := (&Server{}).doQuery(closer.Ctx(), &queryRequest, NoAuthorize)
 		if err != nil {
 			return errors.Errorf("unable to retrieve acls: %v", err)
 		}
@@ -331,14 +329,16 @@ func RefreshAcls(closer *y.Closer) {
 		return nil
 	}
 
+	ticker := time.NewTicker(worker.Config.AclRefreshInterval)
+	defer ticker.Stop()
 	for {
 		select {
-		case <-closer.HasBeenClosed():
-			return
 		case <-ticker.C:
 			if err := retrieveAcls(); err != nil {
-				glog.Errorf("Error while retrieving acls:%v", err)
+				glog.Errorf("Error while retrieving acls: %v", err)
 			}
+		case <-closer.HasBeenClosed():
+			return
 		}
 	}
 }
@@ -353,7 +353,12 @@ const queryAcls = `
 `
 
 // ResetAcl clears the aclCachePtr and upserts the Groot account.
-func ResetAcl() {
+func ResetAcl(closer *y.Closer) {
+	defer func() {
+		glog.Infof("ResetAcl closed")
+		closer.Done()
+	}()
+
 	if len(worker.Config.HmacSecret) == 0 {
 		// The acl feature is not turned on.
 		return
@@ -420,8 +425,8 @@ func ResetAcl() {
 		return nil
 	}
 
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	for closer.Ctx().Err() == nil {
+		ctx, cancel := context.WithTimeout(closer.Ctx(), time.Minute)
 		defer cancel()
 		if err := upsertGuardians(ctx); err != nil {
 			glog.Infof("Unable to upsert the guardian group. Error: %v", err)
@@ -431,8 +436,8 @@ func ResetAcl() {
 		break
 	}
 
-	for {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	for closer.Ctx().Err() == nil {
+		ctx, cancel := context.WithTimeout(closer.Ctx(), time.Minute)
 		defer cancel()
 		if err := upsertGroot(ctx); err != nil {
 			glog.Infof("Unable to upsert the groot account. Error: %v", err)

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -130,7 +130,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		_, err := query.ApplyMutations(ctx, m)
 
 		// recreate the admin account after a drop all operation
-		ResetAcl()
+		ResetAcl(nil)
 		return empty, err
 	}
 
@@ -143,7 +143,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		_, err := query.ApplyMutations(ctx, m)
 
 		// recreate the admin account after a drop data operation
-		ResetAcl()
+		ResetAcl(nil)
 		return empty, err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/blevesearch/segment v0.0.0-20160915185041-762005e7a34f // indirect
 	github.com/blevesearch/snowballstem v0.0.0-20180110192139-26b06a2c243d // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462
+	github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4
 	github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6
 	github.com/dgraph-io/ristretto v0.0.4-0.20200904131139-4dec2770af66
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,9 @@ require (
 	github.com/blevesearch/segment v0.0.0-20160915185041-762005e7a34f // indirect
 	github.com/blevesearch/snowballstem v0.0.0-20180110192139-26b06a2c243d // indirect
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4
+	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462
 	github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6
-	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de
+	github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/dgryski/go-groupvarint v0.0.0-20190318181831-5ce5df8ca4e1

--- a/go.sum
+++ b/go.sum
@@ -62,12 +62,11 @@ github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462 h1:5A3xbCP8emF/lJ1btFdvMZ/oBaVpF9Ncldbop5MFcwM=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462/go.mod h1:EdVb0qoPSOGlrBrHSG4ArQTao3rVHe14qaVx1qqO7Vk=
+github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4 h1:DUDFTVgqZysKplH39/ya0aI4+zGm91L9QttXgITT2YE=
+github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6 h1:5leDFqGys055YO3TbghBhk/QdRPEwyLPdgsSJfiR20I=
 github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6/go.mod h1:LJCkLxm5fUMcU+yb8gHFjHt7ChgNuz3YnQQ6MQkmscI=
-github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b h1:/g8jOqvD1UzHTOwENtkqcLmMLzTcN18P3ut8aSUZ45g=
-github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.0.4-0.20200904131139-4dec2770af66 h1:ectpJv2tGhTudyk0JhqE/53o/ObH30u5yt/yThsAn3I=
 github.com/dgraph-io/ristretto v0.0.4-0.20200904131139-4dec2770af66/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/go.sum
+++ b/go.sum
@@ -62,12 +62,12 @@ github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4 h1:DUDFTVgqZysKplH39/ya0aI4+zGm91L9QttXgITT2YE=
-github.com/dgraph-io/badger/v2 v2.2007.2-0.20200827131741-d5a25b83fbf4/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462 h1:5A3xbCP8emF/lJ1btFdvMZ/oBaVpF9Ncldbop5MFcwM=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20200828220306-806a325a0462/go.mod h1:EdVb0qoPSOGlrBrHSG4ArQTao3rVHe14qaVx1qqO7Vk=
 github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6 h1:5leDFqGys055YO3TbghBhk/QdRPEwyLPdgsSJfiR20I=
 github.com/dgraph-io/dgo/v2 v2.1.1-0.20191127085444-c7a02678e8a6/go.mod h1:LJCkLxm5fUMcU+yb8gHFjHt7ChgNuz3YnQQ6MQkmscI=
-github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
-github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b h1:/g8jOqvD1UzHTOwENtkqcLmMLzTcN18P3ut8aSUZ45g=
+github.com/dgraph-io/ristretto v0.0.4-0.20200820164438-623d8ef1614b/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -43,9 +43,6 @@ import (
 
 type groupi struct {
 	x.SafeMutex
-	// TODO: Is this context being used?
-	ctx          context.Context
-	cancel       context.CancelFunc
 	state        *pb.MembershipState
 	Node         *node
 	gid          uint32
@@ -74,8 +71,6 @@ func groups() *groupi {
 // This function triggers RAFT nodes to be created, and is the entrance to the RAFT
 // world from main.go.
 func StartRaftNodes(walStore *badger.DB, bindall bool) {
-	gr.ctx, gr.cancel = context.WithCancel(context.Background())
-
 	if x.WorkerConfig.MyAddr == "" {
 		x.WorkerConfig.MyAddr = fmt.Sprintf("localhost:%d", workerPort())
 	} else {
@@ -124,7 +119,7 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 			continue
 		}
 		zc := pb.NewZeroClient(pl.Get())
-		connState, err = zc.Connect(gr.ctx, m)
+		connState, err = zc.Connect(gr.Ctx(), m)
 		if err == nil || x.ShouldCrash(err) {
 			break
 		}
@@ -162,6 +157,14 @@ func StartRaftNodes(walStore *badger.DB, bindall bool) {
 
 	gr.informZeroAboutTablets()
 	gr.proposeInitialSchema()
+}
+
+func (g *groupi) Ctx() context.Context {
+	return g.closer.Ctx()
+}
+
+func (g *groupi) IsClosed() bool {
+	return g.closer.Ctx().Err() != nil
 }
 
 func (g *groupi) informZeroAboutTablets() {
@@ -216,7 +219,7 @@ func (g *groupi) upsertSchema(sch *pb.SchemaUpdate) {
 	// Propose schema mutation.
 	var m pb.Mutations
 	// schema for a reserved predicate is not changed once set.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(g.Ctx(), 10*time.Second)
 	ts, err := Timestamps(ctx, &pb.Num{Val: 1})
 	cancel()
 	if err != nil {
@@ -230,7 +233,7 @@ func (g *groupi) upsertSchema(sch *pb.SchemaUpdate) {
 	// This would propose the schema mutation and make sure some node serves this predicate
 	// and has the schema defined above.
 	for {
-		_, err := MutateOverNetwork(gr.ctx, &m)
+		_, err := MutateOverNetwork(gr.Ctx(), &m)
 		if err == nil {
 			break
 		}
@@ -347,8 +350,7 @@ func (g *groupi) applyState(state *pb.MembershipState) {
 						}
 					}
 
-					if err := g.Node.ProposePeerRemoval(
-						context.Background(), member.GetId()); err != nil {
+					if err := g.Node.ProposePeerRemoval(g.Ctx(), member.GetId()); err != nil {
 						glog.Errorf("Error while proposing node removal: %+v", err)
 					}
 				}()
@@ -415,7 +417,7 @@ func (g *groupi) BelongsToReadOnly(key string, ts uint64) (uint32, error) {
 		Predicate: key,
 		ReadOnly:  true,
 	}
-	out, err := zc.ShouldServe(context.Background(), tablet)
+	out, err := zc.ShouldServe(g.Ctx(), tablet)
 	if err != nil {
 		glog.Errorf("Error while ShouldServe grpc call %v", err)
 		return 0, err
@@ -459,7 +461,7 @@ func (g *groupi) Tablet(key string) (*pb.Tablet, error) {
 	zc := pb.NewZeroClient(pl.Get())
 
 	tablet = &pb.Tablet{GroupId: g.groupId(), Predicate: key}
-	out, err := zc.ShouldServe(context.Background(), tablet)
+	out, err := zc.ShouldServe(g.Ctx(), tablet)
 	if err != nil {
 		glog.Errorf("Error while ShouldServe grpc call %v", err)
 		return nil, err
@@ -613,7 +615,7 @@ func (g *groupi) connToZeroLeader() *conn.Pool {
 	glog.V(1).Infof("No healthy Zero leader found. Trying to find a Zero leader...")
 
 	getLeaderConn := func(zc pb.ZeroClient) *conn.Pool {
-		ctx, cancel := context.WithTimeout(g.ctx, 10*time.Second)
+		ctx, cancel := context.WithTimeout(g.Ctx(), 10*time.Second)
 		defer cancel()
 
 		connState, err := zc.Connect(ctx, &pb.Member{ClusterInfoOnly: true})
@@ -633,6 +635,10 @@ func (g *groupi) connToZeroLeader() *conn.Pool {
 	delay := connBaseDelay
 	maxHalfDelay := time.Second
 	for i := 0; ; i++ { // Keep on retrying. See: https://github.com/dgraph-io/dgraph/issues/2289
+		if g.IsClosed() {
+			return nil
+		}
+
 		time.Sleep(delay)
 		if delay <= maxHalfDelay {
 			delay *= 2
@@ -685,7 +691,7 @@ func (g *groupi) doSendMembership(tablets map[string]*pb.Tablet) error {
 		return errNoConnection
 	}
 	c := pb.NewZeroClient(pl.Get())
-	ctx, cancel := context.WithTimeout(g.ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(g.Ctx(), 10*time.Second)
 	defer cancel()
 	reply, err := c.UpdateMembership(ctx, group)
 	if err != nil {
@@ -700,7 +706,10 @@ func (g *groupi) doSendMembership(tablets map[string]*pb.Tablet) error {
 // sendMembershipUpdates sends the membership update to Zero leader. If this Alpha is the leader, it
 // would also calculate the tablet sizes and send them to Zero.
 func (g *groupi) sendMembershipUpdates() {
-	defer g.closer.Done() // CLOSER:1
+	defer func() {
+		glog.Infoln("Closing sendMembershipUpdates")
+		g.closer.Done() // CLOSER:1
+	}()
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -744,7 +753,10 @@ func (g *groupi) sendMembershipUpdates() {
 // connection which tells Alpha about the state of the cluster, including the latest Zero leader.
 // All the other connections to Zero, are only made only to the leader.
 func (g *groupi) receiveMembershipUpdates() {
-	defer g.closer.Done() // CLOSER:1
+	defer func() {
+		glog.Infoln("Closing receiveMembershipUpdates")
+		g.closer.Done() // CLOSER:1
+	}()
 
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
@@ -766,7 +778,7 @@ START:
 	glog.Infof("Got address of a Zero leader: %s", pl.Addr)
 
 	c := pb.NewZeroClient(pl.Get())
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(g.Ctx())
 	stream, err := c.StreamMembership(ctx, &api.Payload{})
 	if err != nil {
 		cancel()
@@ -839,7 +851,10 @@ OUTER:
 // processOracleDeltaStream is used to process oracle delta stream from Zero.
 // Zero sends information about aborted/committed transactions and maxPending.
 func (g *groupi) processOracleDeltaStream() {
-	defer g.closer.Done() // CLOSER:1
+	defer func() {
+		glog.Infoln("Closing processOracleDeltaStream")
+		g.closer.Done() // CLOSER:1
+	}()
 
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
@@ -851,6 +866,9 @@ func (g *groupi) processOracleDeltaStream() {
 		pl := g.connToZeroLeader()
 		if pl == nil {
 			glog.Warningln("Oracle delta stream: No Zero leader known.")
+			if g.IsClosed() {
+				return
+			}
 			time.Sleep(time.Second)
 			return
 		}
@@ -861,8 +879,9 @@ func (g *groupi) processOracleDeltaStream() {
 		// batching. Once a batch is created, it gets proposed. Thus, we can reduce the number of
 		// times proposals happen, which is a great optimization to have (and a common one in our
 		// code base).
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(g.Ctx())
 		defer cancel()
+
 		c := pb.NewZeroClient(pl.Get())
 		stream, err := c.Oracle(ctx, &api.Payload{})
 		if err != nil {
@@ -976,7 +995,7 @@ func (g *groupi) processOracleDeltaStream() {
 			for {
 				// Block forever trying to propose this. Also this proposal should not be counted
 				// towards num pending proposals and be proposed right away.
-				err := g.Node.proposeAndWait(context.Background(), &pb.Proposal{Delta: delta})
+				err := g.Node.proposeAndWait(g.Ctx(), &pb.Proposal{Delta: delta})
 				if err == nil {
 					break
 				}
@@ -1007,30 +1026,25 @@ func EnterpriseEnabled() bool {
 	}
 	g := groups()
 	if g.state == nil {
-		return askZeroForEE()
+		return g.askZeroForEE()
 	}
 	g.RLock()
 	defer g.RUnlock()
 	return g.state.GetLicense().GetEnabled()
 }
 
-func askZeroForEE() bool {
+func (g *groupi) askZeroForEE() bool {
 	var err error
 	var connState *pb.ConnectionState
 
-	grp := &groupi{}
-
 	createConn := func() bool {
-		grp.ctx, grp.cancel = context.WithCancel(context.Background())
-		defer grp.cancel()
-
-		pl := grp.connToZeroLeader()
+		pl := g.connToZeroLeader()
 		if pl == nil {
 			return false
 		}
 		zc := pb.NewZeroClient(pl.Get())
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(g.Ctx(), 10*time.Second)
 		defer cancel()
 
 		connState, err = zc.Connect(ctx, &pb.Member{ClusterInfoOnly: true})
@@ -1046,7 +1060,7 @@ func askZeroForEE() bool {
 		return false
 	}
 
-	for {
+	for !g.IsClosed() {
 		if createConn() {
 			break
 		}
@@ -1056,34 +1070,51 @@ func askZeroForEE() bool {
 }
 
 // SubscribeForUpdates will listen for updates for the given group.
-func SubscribeForUpdates(prefixes [][]byte, cb func(kvs *badgerpb.KVList), group uint32) {
-	for {
+func SubscribeForUpdates(prefixes [][]byte, cb func(kvs *badgerpb.KVList),
+	group uint32, closer *y.Closer) {
+
+	var prefix []byte
+	if len(prefixes) > 0 {
+		prefix = prefixes[0]
+	}
+	defer func() {
+		glog.Infof("SubscribeForUpdates closing for prefix: %q\n", prefix)
+		closer.Done()
+	}()
+
+	listen := func() error {
 		// Connect to any of the group 1 nodes.
 		members := groups().AnyTwoServers(group)
 		// There may be a lag while starting so keep retrying.
 		if len(members) == 0 {
-			continue
+			return fmt.Errorf("Unable to find any servers for group: %d", group)
 		}
 		pool := conn.GetPools().Connect(members[0])
 		client := pb.NewWorkerClient(pool.Get())
 
 		// Get Subscriber stream.
-		stream, err := client.Subscribe(context.Background(), &pb.SubscriptionRequest{
-			Prefixes: prefixes,
-		})
+		stream, err := client.Subscribe(closer.Ctx(), &pb.SubscriptionRequest{Prefixes: prefixes})
 		if err != nil {
-			glog.Errorf("Error from alpha client subscribe: %v", err)
-			continue
+			return errors.Wrapf(err, "error from client.subscribe")
 		}
-	receiver:
 		for {
 			// Listen for updates.
 			kvs, err := stream.Recv()
 			if err != nil {
-				glog.Errorf("Error from worker subscribe stream: %v", err)
-				break receiver
+				return errors.Wrapf(err, "while receiving from stream")
 			}
 			cb(kvs)
 		}
+	}
+
+	for {
+		if err := listen(); err != nil {
+			glog.Errorf("Error during SubscribeForUpdates for prefix %q: %v. closer err: %v\n",
+				prefix, err, closer.Ctx().Err())
+		}
+		if closer.Ctx().Err() != nil {
+			return
+		}
+		time.Sleep(time.Second)
 	}
 }

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -212,20 +212,28 @@ func (s *ServerState) fillTimestampRequests() {
 		maxDelay  = time.Second
 	)
 
+	defer func() {
+		glog.Infoln("Exiting fillTimestampRequests")
+	}()
+
 	var reqs []tsReq
 	for {
 		// Reset variables.
 		reqs = reqs[:0]
 		delay := initDelay
 
-		req := <-s.needTs
-	slurpLoop:
-		for {
-			reqs = append(reqs, req)
-			select {
-			case req = <-s.needTs:
-			default:
-				break slurpLoop
+		select {
+		case <-s.gcCloser.HasBeenClosed():
+			return
+		case req := <-s.needTs:
+		slurpLoop:
+			for {
+				reqs = append(reqs, req)
+				select {
+				case req = <-s.needTs:
+				default:
+					break slurpLoop
+				}
 			}
 		}
 
@@ -241,7 +249,10 @@ func (s *ServerState) fillTimestampRequests() {
 
 		// Execute the request with infinite retries.
 	retry:
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		if s.gcCloser.Ctx().Err() != nil {
+			return
+		}
+		ctx, cancel := context.WithTimeout(s.gcCloser.Ctx(), 10*time.Second)
 		ts, err := Timestamps(ctx, num)
 		cancel()
 		if err != nil {


### PR DESCRIPTION
This PR removes the usage of context.Background() in groups.go and ensures that all the various goroutines exit as intended.

Changes:
* Shutdown SubscribeForUpdates correctly.
* Fix up all the closing conditions.
* Consolidate updaters into one closer
* Update Badger to master
* fix(build): Update ResetAcl args for OSS build.
* chore: Remove TODO comment.

Co-authored-by: Daniel Mai <daniel@dgraph.io>
(cherry picked from commit f1941b3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6406)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e3fac85fe5-91937.surge.sh)
<!-- Dgraph:end -->