### PR TITLE
cherry-pick v20.07: fix(GraphQL): don't generate orderable enum value for list fields (#6…

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -955,7 +955,7 @@ func addTypeOrderable(schema *ast.Schema, defn *ast.Definition) {
 	}
 
 	for _, fld := range defn.Fields {
-		if orderable[fld.Type.Name()] {
+		if fld.Type.NamedType != "" && orderable[fld.Type.NamedType] {
 			order.EnumValues = append(order.EnumValues,
 				&ast.EnumValueDefinition{Name: fld.Name})
 		}

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -180,9 +180,6 @@ enum PostOrderable {
 	title
 	titleByEverything
 	text
-	tags
-	tagsHash
-	tagsExact
 	publishByYear
 	publishByMonth
 	publishByDay


### PR DESCRIPTION
…392)

Fixes GRAPHQL-650.

For this user schema:
```
type Starship {
        id: ID!
        name: String! @search(by: [term])
        length: Int64
        tags: [String]
        createdAt: DateTime
}
```
we were generating complete GraphQL schema with StarshipOrderable as:
```
enum StarshipOrderable {
  name
  length
  tags
  createdAt
}
```
that would cause a DQL query to be formed which errors out, see this GraphQL query:
```
query {
  queryStarship(order: {asc: tags}) {
    id
    name
    length
    tags
  }
}
```
It gives back:
```
{
  "errors": [
    {
      "message": "Dgraph query failed because Dgraph execution failed because : Sorting not supported on attr: Starship.tags of type: [scalar]"
    }
  ],
  "data": {
    "queryStarship": []
  }
}
```
which means we should not allow even list of scalar along with object types in orderable. Only scalar field should be allowed in orderable. So, the correct orderable should be without tags field:
```
enum StarshipOrderable {
  name
  length
  createdAt
}
```

This PR fixes the above bug.

(cherry picked from commit dc66617abf96a87595cc1a677e9aaa4f97e076f5)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6413)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-7c29a15dc4-92245.surge.sh)
<!-- Dgraph:end -->