### PR TITLE
fix(GraphQL): fix  restoreStatus query with query variables

### DIFF
--- a/graphql/admin/restore_status.go
+++ b/graphql/admin/restore_status.go
@@ -41,8 +41,12 @@ func unknownStatus(q schema.Query, err error) *resolve.Resolved {
 }
 
 func resolveRestoreStatus(ctx context.Context, q schema.Query) *resolve.Resolved {
-	restoreId := int(q.ArgValue("restoreId").(int64))
-	status, err := worker.ProcessRestoreStatus(ctx, restoreId)
+	restoreId, err := q.ArgValue("restoreId").(json.Number).Int64()
+	if err != nil {
+		return unknownStatus(q, err)
+	}
+
+	status, err := worker.ProcessRestoreStatus(ctx, int(restoreId))
 	if err != nil {
 		return unknownStatus(q, err)
 	}

--- a/graphql/admin/restore_status.go
+++ b/graphql/admin/restore_status.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
@@ -40,12 +41,24 @@ func unknownStatus(q schema.Query, err error) *resolve.Resolved {
 	}
 }
 
+func getRestoreStatusInput(q schema.Query) (int64, error) {
+	restoreId := q.ArgValue("restoreId")
+	switch v := restoreId.(type) {
+	case int64:
+		return v, nil
+	case json.Number:
+		return v.Int64()
+	default:
+		return -1, fmt.Errorf("Invalid value of restoreId")
+	}
+
+}
+
 func resolveRestoreStatus(ctx context.Context, q schema.Query) *resolve.Resolved {
-	restoreId, err := q.ArgValue("restoreId").(json.Number).Int64()
+	restoreId, err := getRestoreStatusInput(q)
 	if err != nil {
 		return unknownStatus(q, err)
 	}
-
 	status, err := worker.ProcessRestoreStatus(ctx, int(restoreId))
 	if err != nil {
 		return unknownStatus(q, err)

--- a/graphql/admin/restore_status_test.go
+++ b/graphql/admin/restore_status_test.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+)
+
+func TestRestoreStatus(t *testing.T) {
+	gqlSchema := test.LoadSchema(t, graphqlAdminSchema)
+	gqlQuery := `query restoreStatus($restoreId: Int!) {
+					restoreStatus(restoreId: $restoreId) {
+						status
+						errors
+					}
+				}`
+	variables := `{"restoreId": 2 }`
+	vars := make(map[string]interface{})
+	d := json.NewDecoder(strings.NewReader(variables))
+	d.UseNumber()
+	err := d.Decode(&vars)
+	require.NoError(t, err)
+
+	op, err:= gqlSchema.Operation(
+		&schema.Request{
+			Query: gqlQuery,
+			Variables: vars,
+		})
+	require.NoError(t, err)
+	GQLQuery:= test.GetQuery(t, op)
+	resolved:= resolveRestoreStatus(context.Background(), GQLQuery)
+	require.NoError(t, resolved.Err)
+}

--- a/graphql/admin/restore_status_test.go
+++ b/graphql/admin/restore_status_test.go
@@ -1,13 +1,13 @@
 package admin
 
 import (
-	"context"
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/graphql/test"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
 )
 
 func TestRestoreStatus(t *testing.T) {
@@ -25,13 +25,13 @@ func TestRestoreStatus(t *testing.T) {
 	err := d.Decode(&vars)
 	require.NoError(t, err)
 
-	op, err:= gqlSchema.Operation(
+	op, err := gqlSchema.Operation(
 		&schema.Request{
-			Query: gqlQuery,
+			Query:     gqlQuery,
 			Variables: vars,
 		})
 	require.NoError(t, err)
-	GQLQuery:= test.GetQuery(t, op)
-	resolved:= resolveRestoreStatus(context.Background(), GQLQuery)
-	require.NoError(t, resolved.Err)
+	GQLQuery := test.GetQuery(t, op)
+	_, err = getRestoreStatusInput(GQLQuery)
+	require.NoError(t, err)
 }

--- a/graphql/admin/restore_status_test.go
+++ b/graphql/admin/restore_status_test.go
@@ -32,6 +32,7 @@ func TestRestoreStatus(t *testing.T) {
 		})
 	require.NoError(t, err)
 	GQLQuery := test.GetQuery(t, op)
-	_, err = getRestoreStatusInput(GQLQuery)
+	v, err := getRestoreStatusInput(GQLQuery)
 	require.NoError(t, err)
+	require.IsType(t, int64(2), v, nil)
 }

--- a/graphql/admin/restore_status_test.go
+++ b/graphql/admin/restore_status_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRestoreStatus(t *testing.T) {
 	gqlSchema := test.LoadSchema(t, graphqlAdminSchema)
-	gqlQuery := `query restoreStatus($restoreId: Int!) {
+	Query := `query restoreStatus($restoreId: Int!) {
 					restoreStatus(restoreId: $restoreId) {
 						status
 						errors
@@ -27,12 +27,12 @@ func TestRestoreStatus(t *testing.T) {
 
 	op, err := gqlSchema.Operation(
 		&schema.Request{
-			Query:     gqlQuery,
+			Query:     Query,
 			Variables: vars,
 		})
 	require.NoError(t, err)
-	GQLQuery := test.GetQuery(t, op)
-	v, err := getRestoreStatusInput(GQLQuery)
+	gqlQuery := test.GetQuery(t, op)
+	v, err := getRestoreStatusInput(gqlQuery)
 	require.NoError(t, err)
 	require.IsType(t, int64(2), v, nil)
 }


### PR DESCRIPTION
Fixes GRAPHQL-642.

For this restoreStatus query using variable
```
query restoreStatus($restoreId: Int!) {
	restoreStatus(restoreId: $restoreId) {
		status
		errors
	}
}
```
was giving this panic
```
panic: interface conversion: interface {} is json.Number, not int64.
```
Whereas expected result should be
```
{
  "data": {
    "restoreStatus": {
      "status": "UNKNOWN",
      "errors": []
    }
  },
  "extensions": {}
}
```
This PR fixes this panic, Now `resolveStatus` with or without variable works fine.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6414)
<!-- Reviewable:end -->
