### PR TITLE
fix(GraphQL): Fix squashIntoObject so that results are correctly merged

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -329,6 +329,7 @@ func RunAll(t *testing.T) {
 	t.Run("add multiple mutations", testMultipleMutations)
 	t.Run("deep XID mutations", deepXIDMutations)
 	t.Run("three level xid", testThreeLevelXID)
+	t.Run("nested add mutation with @hasInverse", nestedAddMutationWithHasInverse)
 	t.Run("error in multiple mutations", addMultipleMutationWithOneError)
 	t.Run("dgraph directive with reverse edge adds data correctly",
 		addMutationWithReverseDgraphEdge)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -3721,26 +3721,26 @@ func nestedAddMutationWithHasInverse(t *testing.T) {
 
 	expected := `{
 		"addPerson1": {
-			"person1": [
+		  "person1": [
+			{
+			  "friends": [
 				{
-					"friends": [
-						{
-							"friends": [
-								{
-									"name": "Or"
-								},
-								{
-									"name": "Justin"
-								}
-							],
-							"name": "Michal"
-						}
-					],
-					"name": "Or"
+				  "friends": [
+					{
+					  "name": "Or"
+					},
+					{
+					  "name": "Justin"
+					}
+				  ],
+				  "name": "Michal"
 				}
-			]
+			  ],
+			  "name": "Or"
+			}
+		  ]
 		}
-	}`
+	  }`
 	testutil.CompareJSON(t, expected, string(gqlResponse.Data))
 
 	// cleanup

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -178,3 +178,9 @@ type post1{
     title: String! @id @search(by: [regexp])
     numLikes: Int64
 }
+
+type Person1 {
+    id: ID!
+    name: String!
+    friends: [Person1] @hasInverse(field: friends)
+}

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -69,6 +69,15 @@
             "upsert": true
         },
         {
+            "predicate": "Person1.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Person1.friends",
+            "type": "uid",
+            "list": true
+        },
+        {
             "predicate": "Post1.comments",
             "type": "uid",
             "list": true
@@ -456,6 +465,17 @@
                 }
             ],
             "name": "People"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Person1.name"
+                },
+                {
+                    "name": "Person1.friends"
+                }
+            ],
+            "name": "Person1"
         },
         {
             "fields": [

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -179,3 +179,9 @@ type post1{
         title: String! @id @search(by: [regexp])
         numLikes: Int64
 }
+
+type Person1 {
+    id: ID!
+    name: String!
+    friends: [Person1] @hasInverse(field: friends)
+}

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -151,6 +151,15 @@
             "type": "string"
         },
         {
+            "predicate": "Person1.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Person1.friends",
+            "type": "uid",
+            "list": true
+        },
+        {
             "predicate": "Post.author",
             "type": "uid"
         },
@@ -509,6 +518,17 @@
                 }
             ],
             "name": "Person"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Person1.name"
+                },
+                {
+                    "name": "Person1.friends"
+                }
+            ],
+            "name": "Person1"
         },
         {
             "fields": [

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -2413,3 +2413,61 @@
   explanation: "The add mutation should not be allowed since value of @id field is empty."
   error:
     { "message": "failed to rewrite mutation payload because encountered an empty value for @id field `State.code`" }
+
+-
+  name: "Add mutation for person with @hasInverse"
+  gqlmutation: |
+    mutation($input: [AddPersonInput!]!) {
+      addPerson(input: $input) {
+        person {
+          name
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "name": "Or",
+          "friends": [
+            { "name": "Michal", "friends": [{ "name": "Justin" }] }
+          ]
+        }
+      ]
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "Person.friends": [
+            {
+              "Person.friends": [
+                {
+                  "uid": "_:Person1"
+                },
+                {
+                  "Person.friends": [
+                    {
+                      "uid": "_:Person2"
+                    }
+                  ],
+                  "Person.name": "Justin",
+                  "dgraph.type": [
+                    "Person"
+                  ],
+                  "uid": "_:Person3"
+                }
+              ],
+              "Person.name": "Michal",
+              "dgraph.type": [
+                "Person"
+              ],
+              "uid": "_:Person2"
+            }
+          ],
+          "Person.name": "Or",
+          "dgraph.type": [
+            "Person"
+          ],
+          "uid": "_:Person1"
+        }
+

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1727,7 +1727,24 @@ func squashIntoObject(label string) func(interface{}, interface{}, bool) interfa
 			}
 			asObject = cpy
 		}
-		asObject[label] = v
+
+		val := v
+
+		// If there is an existing value for the label in the object, then we should append to it
+		// instead of overwriting it. This can happen when there is @hasInverse and we are doing
+		// nested adds.
+		existing := asObject[label]
+		switch ev := existing.(type) {
+		case []interface{}:
+			switch vv := v.(type) {
+			case []interface{}:
+				ev = append(ev, vv...)
+				val = ev
+			default:
+			}
+		default:
+		}
+		asObject[label] = val
 		return asObject
 	}
 }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1731,8 +1731,8 @@ func squashIntoObject(label string) func(interface{}, interface{}, bool) interfa
 		val := v
 
 		// If there is an existing value for the label in the object, then we should append to it
-		// instead of overwriting it. This can happen when there is @hasInverse and we are doing
-		// nested adds.
+		// instead of overwriting it if the existing value is a list. This can happen when there
+		// is @hasInverse and we are doing nested adds.
 		existing := asObject[label]
 		switch ev := existing.(type) {
 		case []interface{}:

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1740,6 +1740,9 @@ func squashIntoObject(label string) func(interface{}, interface{}, bool) interfa
 			case []interface{}:
 				ev = append(ev, vv...)
 				val = ev
+			case interface{}:
+				ev = append(ev, vv)
+				val = ev
 			default:
 			}
 		default:

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -282,3 +282,9 @@ type ThingTwo implements Thing {
     prop: String @dgraph(pred: "prop")
     owner: String
 }
+
+type Person {
+    id: ID!
+    name: String @search(by: [hash])
+    friends: [Person] @hasInverse(field: friends)
+}


### PR DESCRIPTION
While creating the add mutation, we weren't squashing different bits correctly which led to the incorrect mutation being sent to Dgraph. This change modifies the set to append for `[]interface{}` to fix that.

Fixes GRAPHQL-679

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6416)
<!-- Reviewable:end -->
