### PR TITLE
docs: add whitelisting issue error in troubleshoot page to help the community

### DIFF
--- a/wiki/content/deploy/troubleshooting.md
+++ b/wiki/content/deploy/troubleshooting.md
@@ -20,8 +20,16 @@ You could also decrease memory usage of Dgraph by setting `--badger.vlog=disk`.
 
 ### Too many open files
 
-If you see an log error messages saying `too many open files`, you should increase the per-process file descriptors limit.
+If you see a log error messages saying `too many open files`, you should increase the per-process file descriptors limit.
 
 During normal operations, Dgraph must be able to open many files. Your operating system may set by default a open file descriptor limit lower than what's needed for a database such as Dgraph.
 
 On Linux and Mac, you can check the file descriptor limit with `ulimit -n -H` for the hard limit and `ulimit -n -S` for the soft limit. The soft limit should be set high enough for Dgraph to run properly. A soft limit of 65535 is a good lower bound for a production setup. You can adjust the limit as needed.
+
+### Unauthorized IP address: X.X.X.X
+
+To ensure security around admin operations, the default behaviour of admin operations has been changed.
+ 
+Now by default, all the admin operations will be restricted from the alpha machine itself. Any admin operations outside the alpha environment will be rejected with unauthorized access error. 
+
+You can use the `--whitelist` option to specify whitelisted IP addresses or ranges for hosts from which admin operations can be initiated. More about whitelisting IPs can be found [here]({{< relref "dgraph-administration.md" >}}).


### PR DESCRIPTION
Fixes DGRAPH-2317. Issue is with v20.07 we restrict the admin operations from alpha instances only. But this hasn't been mentioned during the deployment process in any examples. Hence community is running into issues like Unauthorized IP address X.X.X.X. This doc addition in troubleshoot page will help the community members if they run into this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6422)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-cbcd6b45a4-92572.surge.sh)
<!-- Dgraph:end -->