### PR TITLE
release/v20.07: fix(GRAPHQL): fix restoreStatusQuery

### DIFF
--- a/graphql/admin/restore_status_test.go
+++ b/graphql/admin/restore_status_test.go
@@ -1,0 +1,38 @@
+package admin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestoreStatus(t *testing.T) {
+	gqlSchema := test.LoadSchema(t, graphqlAdminSchema)
+	Query := `query restoreStatus($restoreId: Int!) {
+					restoreStatus(restoreId: $restoreId) {
+						status
+						errors
+					}
+				}`
+	variables := `{"restoreId": 2 }`
+	vars := make(map[string]interface{})
+	d := json.NewDecoder(strings.NewReader(variables))
+	d.UseNumber()
+	err := d.Decode(&vars)
+	require.NoError(t, err)
+
+	op, err := gqlSchema.Operation(
+		&schema.Request{
+			Query:     Query,
+			Variables: vars,
+		})
+	require.NoError(t, err)
+	gqlQuery := test.GetQuery(t, op)
+	v, err := getRestoreStatusInput(gqlQuery)
+	require.NoError(t, err)
+	require.IsType(t, int64(2), v, nil)
+}


### PR DESCRIPTION
Fixes GRAPHQL-642.

For this restoreStatus query using variable
```
query restoreStatus($restoreId: Int!) {
	restoreStatus(restoreId: $restoreId) {
		status
		errors
	}
}
```
was giving this panic
```
panic: interface conversion: interface {} is json.Number, not int64.
```
Whereas the expected result should be
```
{
  "data": {
    "restoreStatus": {
      "status": "UNKNOWN",
      "errors": []
    }
  },
  "extensions": {}
}
```
This PR fixes this panic, Now `resolveStatus` with or without variable works fine.

(cherry picked from commit 45afae9)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6424)
<!-- Reviewable:end -->
