### PR TITLE
chore(docs): Make the link for badger on docs an absolute link

### DIFF
--- a/wiki/content/_index.md
+++ b/wiki/content/_index.md
@@ -153,7 +153,7 @@ Designed from the ground up to be run in production, Dgraph is the native GraphQ
       <div class="col-12 col-sm-6">
         <div class="section-item">
           <div class="section-name">
-            <a href="/docs/badger/">
+            <a href="https://dgraph.io/docs/badger">
               Badger
             </a>
           </div>


### PR DESCRIPTION
The current absolute link doesn't work on master, so making it an absolute link for the docs.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6429)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a148921d4c-92859.surge.sh)
<!-- Dgraph:end -->