### PR TITLE
fix(GraphQL): correct GraphQL variable propagation to custom-dql

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -2748,7 +2748,11 @@ func TestCustomDQL(t *testing.T) {
 
 	params = &common.GraphQLParams{
 		Query: `
-		query {
+		query ($count: Int!) {
+		  queryWithVar: getFirstUserByFollowerCount(count: $count) {
+			screen_name
+			followers
+		  }
 		  getFirstUserByFollowerCount(count: 10) {
 			screen_name
 			followers
@@ -2764,12 +2768,17 @@ func TestCustomDQL(t *testing.T) {
 			tweetCount
 		  }
 		}`,
+		Variables: map[string]interface{}{"count": 5},
 	}
 
 	result = params.ExecuteAsPost(t, alphaURL)
 	common.RequireNoGQLErrors(t, result)
 
 	require.JSONEq(t, `{
+		"queryWithVar": {
+		  "screen_name": "abhimanyu",
+		  "followers": 5
+		},
 		"getFirstUserByFollowerCount": {
 		  "screen_name": "pawan",
 		  "followers": 10

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -188,6 +188,8 @@ func convertScalarToString(val interface{}) (string, error) {
 		str = strconv.FormatInt(v, 10)
 	case float64:
 		str = strconv.FormatFloat(v, 'f', -1, 64)
+	case json.Number:
+		str = v.String()
 	case nil:
 		str = ""
 	default:


### PR DESCRIPTION
Fixes GRAPHQL-680
Fixes [Discuss Issue](https://discuss.dgraph.io/t/int-type-parameter-of-custom-dql-is-wrong/10142)
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6433)
<!-- Reviewable:end -->
