### PR TITLE
fix(Query): Fix wrong path response for k-shortest paths

### DIFF
--- a/query/shortest.go
+++ b/query/shortest.go
@@ -341,7 +341,10 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 			}
 
 			// Add path to list.
+			itemRoute := make([]pathInfo, len(*item.path.route))
+			copy(itemRoute, *item.path.route)
 			newRoute := item.path
+			newRoute.route = &itemRoute
 			newRoute.totalWeight = item.cost
 			kroutes = append(kroutes, newRoute)
 			if len(kroutes) == numPaths {

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -340,7 +340,9 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 				continue
 			}
 
-			// Add path to list.
+			// Add path to list after making a copy of the path in itemRoute. A copy of
+			// *item.path.route is required because it has to be put back in the sync pool and a
+			// future reuse can alter the item already present in kroute because it is a pointer.
 			itemRoute := make([]pathInfo, len(*item.path.route))
 			copy(itemRoute, *item.path.route)
 			newRoute := item.path


### PR DESCRIPTION
Fixes DGRAPH-2381

The k-shortest path query sometimes returns a wrong response. The cause
of this issue is inappropriate use of sync.pools. Whenever a valid path 
is found a new variable is assigned with this route and that variable is  
appended in the kroutes (which is then parsed to produce response). 
But the route is also put in the sync.pool. Since the route is a 
structure containing a pointer to slice along with other fields, when
it is fetched back from the pool in future then any mutation on this fetched 
route causes modification in the kroutes, resulting in garbage response. 

This issue is fixed by making a deep copy of the route struct rather
than just assigning it to a variable, which causes a shallow copy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6437)
<!-- Reviewable:end -->
