### PR TITLE
docs: How-to article on concurrent modifications and txn aborts.

### DIFF
--- a/wiki/content/howto/concurrent-modification-java-multithreaded.md
+++ b/wiki/content/howto/concurrent-modification-java-multithreaded.md
@@ -5,9 +5,10 @@ title = "Concurrent mutations and conflicts"
     parent = "howto"
     weight = 12
 +++
-This how-to guide provides an example on how to handle concurrent modifications using a multi-threaded Java Program.
+This how-to guide provides an example on how to handle concurrent modifications using a multi-threaded Java Program. The example demonstrates [transaction]({{< relref "clients/overview.md#transactions" >}}) conflicts in Dgraph.
 
-Steps to run this example are as follows.<br>
+Steps to run this example are as follows.
+
 Step 1: Start a new terminal and launch Dgraph with the following command line.
 ```sh
 docker run -it -p 8080:8080 -p 9080:9080 dgraph/standalone:master
@@ -22,39 +23,44 @@ Step 3: On running the example, the program initializes Dgraph with the followin
 <name>: string @index(exact) .
 ```
 Step 4: The program also initializes user "Alice" with a 'clickCount' of value '1', and then proceeds to increment 'clickCount' concurrently in two threads. Dgraph throws an exception if a transaction is updating a given predicate that is being concurrently modified. As part of the exception handling logic, the program sleeps for 1 second on receiving a concurrent modification exception (“TxnConflictException”), and then retries. 
-<br> The logs below show that two threads are increasing clickCount for the same user named Alice (note the same uid). Thread #1 succeeds immediately, and Dgraph throws a concurrent modification conflict on Thread 2. Thread 2 sleeps for 1 second and retries, and this time succeeds. 
+<br> The logs below show that two threads are increasing clickCount for the same user named Alice (note the same uid). Thread #1 succeeds immediately, and Dgraph throws a concurrent modification conflict on Thread 2. Thread 2 sleeps for 1 second and retries, and this time succeeds.
+ 
 <-timestamp-> <-log->
 ```sh
-1599628015260 Thread #2 increasing clickCount for uid0xe ,Name: Alice
-1599628015260 Thread #1 increasing clickCount for uid0xe ,Name: Alice
+1599628015260 Thread #2 increasing clickCount for uid 0xe, Name: Alice
+1599628015260 Thread #1 increasing clickCount for uid 0xe, Name: Alice
 1599628015291 Thread #1 succeeded after 0 retries
 1599628015297 Thread #2 found a concurrent modification conflict, sleeping for 1 second...
 1599628016297 Thread #2 resuming
-1599628016310 Thread #2 increasing clickCount for uid0xe ,Name: Alice
+1599628016310 Thread #2 increasing clickCount for uid 0xe, Name: Alice
 1599628016333 Thread #2 succeeded after 1 retries
 ```
 Step 5: Please note that the final value of clickCount is 3 (initial value was 1), which is correct. 
 Query:
-```:graphql
+```json
 {
-      Alice(func: has(<name>)) @filter(eq(name,"Alice" )) {        
-        uid
-        name
-        clickCount
-      }
-    }
+  Alice(func: has(<name>)) @filter(eq(name,"Alice" )) {        
+    uid
+    name
+    clickCount
+  }
+}
 ```
 Response:
-```:json
-"data": {
+```json
+{
+  "data": {
     "Alice": [
       {
-        "uid": "0x8",
+        "uid": "0xe",
         "name": "Alice",
         "clickCount": 3
       }
     ]
   }
+}
 ```
-***Summary*** <br> 
+
+***Summary***
+
 Concurrent modifications to the same predicate causes the "TxnConflictException" exception. When several transactions hit the same node's predicate at the same time, the first one succeeds, while the other will get the “TxnConflictException”. Upon constantly retrying, the transactions begin to succeed one after another, and given enough retries, correctly completes its work.

--- a/wiki/content/howto/concurrent-modification-java-multithreaded.md
+++ b/wiki/content/howto/concurrent-modification-java-multithreaded.md
@@ -57,4 +57,4 @@ Response:
   }
 ```
 ***Summary*** <br> 
-Concurrent modifications to the same predicate causes the TxnConflictException. When several transactions hit the same node's predicate at the same time, the first one succeeds, while the other will get the “TxnConflictException”. Upon constantly retrying, the transactions begin to succeed one after another, and given enough retries, correctly completes its work.
+Concurrent modifications to the same predicate causes the "TxnConflictException" exception. When several transactions hit the same node's predicate at the same time, the first one succeeds, while the other will get the “TxnConflictException”. Upon constantly retrying, the transactions begin to succeed one after another, and given enough retries, correctly completes its work.

--- a/wiki/content/howto/concurrent-modification-java-multithreaded.md
+++ b/wiki/content/howto/concurrent-modification-java-multithreaded.md
@@ -1,0 +1,60 @@
++++
+date = "2017-09-10T22:25:17+11:00"
+title = "Concurrent mutations and conflicts"
+[menu.main]
+    parent = "howto"
+    weight = 12
++++
+This how-to guide provides an example on how to handle concurrent modifications using a multi-threaded Java Program.
+
+Steps to run this example are as follows.<br>
+Step 1: Start a new terminal and launch Dgraph with the following command line.
+```sh
+docker run -it -p 8080:8080 -p 9080:9080 dgraph/standalone:master
+```
+Step 2: Checkout the source code from the 'samples' directory in dgraph4j repository (https://github.com/dgraph-io/dgraph4j). This particular example can found at the path "samples/concurrent-modification". In order to run this example, execute the following maven command from the 'concurrent-modification' folder.
+```sh
+mvn clean install exec:java
+```
+Step 3: On running the example, the program initializes Dgraph with the following schema.
+```sh
+<clickCount>: int @index(int) .
+<name>: string @index(exact) .
+```
+Step 4: The program also initializes user "Alice" with a 'clickCount' of value '1', and then proceeds to increment 'clickCount' concurrently in two threads. Dgraph throws an exception if a transaction is updating a given predicate that is being concurrently modified. As part of the exception handling logic, the program sleeps for 1 second on receiving a concurrent modification exception (“TxnConflictException”), and then retries. 
+<br> The logs below show that two threads are increasing clickCount for the same user named Alice (note the same uid). Thread #1 succeeds immediately, and Dgraph throws a concurrent modification conflict on Thread 2. Thread 2 sleeps for 1 second and retries, and this time succeeds. 
+<-timestamp-> <-log->
+```sh
+1599628015260 Thread #2 increasing clickCount for uid0xe ,Name: Alice
+1599628015260 Thread #1 increasing clickCount for uid0xe ,Name: Alice
+1599628015291 Thread #1 succeeded after 0 retries
+1599628015297 Thread #2 found a concurrent modification conflict, sleeping for 1 second...
+1599628016297 Thread #2 resuming
+1599628016310 Thread #2 increasing clickCount for uid0xe ,Name: Alice
+1599628016333 Thread #2 succeeded after 1 retries
+```
+Step 5: Please note that the final value of clickCount is 3 (initial value was 1), which is correct. 
+Query:
+```:graphql
+{
+      Alice(func: has(<name>)) @filter(eq(name,"Alice" )) {        
+        uid
+        name
+        clickCount
+      }
+    }
+```
+Response:
+```:json
+"data": {
+    "Alice": [
+      {
+        "uid": "0x8",
+        "name": "Alice",
+        "clickCount": 3
+      }
+    ]
+  }
+```
+***Summary*** <br> 
+Concurrent modifications to the same predicate causes the TxnConflictException. When several transactions hit the same node's predicate at the same time, the first one succeeds, while the other will get the “TxnConflictException”. Upon constantly retrying, the transactions begin to succeed one after another, and given enough retries, correctly completes its work.


### PR DESCRIPTION
This PR adds a how-to article on concurrent modifications using Java

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6438)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-bfbe2101f0-93791.surge.sh)
<!-- Dgraph:end -->