### PR TITLE
Fix(docs): Fix subsection references in docs

### DIFF
--- a/wiki/content/clients/raw-http.md
+++ b/wiki/content/clients/raw-http.md
@@ -316,7 +316,7 @@ The result:
 ## Running read-only queries
 
 You can set the query parameter `ro=true` to `/query` to set it as a
-[read-only]({{< relref "#read-only-transactions" >}}) query.
+[read-only]({{< relref "clients/go.md#read-only-transactions" >}}) query.
 
 
 ```sh
@@ -333,7 +333,7 @@ $ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?ro
 ## Running best-effort queries
 
 You can set the query parameter `be=true` to `/query` to set it as a
-[best-effort]({{< relref "#read-only-transactions" >}}) query.
+[best-effort]({{< relref "clients/go.md#read-only-transactions" >}}) query.
 
 
 ```sh

--- a/wiki/content/deploy/cluster-checklist.md
+++ b/wiki/content/deploy/cluster-checklist.md
@@ -14,4 +14,4 @@ In setting up a cluster be sure the check the following.
 * Does each instance have a unique ID on startup?
 * Has `--bindall=true` been set for networked communication?
 
-See the [Production Checklist]({{< relref "production-checklist.md" >}}) docs for more info.
+See the [Production Checklist]({{< relref "deploy/production-checklist.md" >}}) docs for more info.

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -156,7 +156,7 @@ This stops the Alpha on which the command is executed and not the entire cluster
 
 ## Deleting database
 
-Individual triples, patterns of triples and predicates can be deleted as described in the [query languge docs](/query-language#delete).
+Individual triples, patterns of triples and predicates can be deleted as described in the [DQL docs]({{< relref "mutations/delete.md" >}}).
 
 To drop all data, you could send a `DropAll` request via `/alter` endpoint.
 
@@ -174,7 +174,7 @@ Doing periodic exports is always a good idea. This is particularly useful if you
 2. Ensure it is successful
 3. [Shutdown Dgraph]({{< relref "#shutting-down-database" >}}) and wait for all writes to complete
 4. Start a new Dgraph cluster using new data directories (this can be done by passing empty directories to the options `-p` and `-w` for Alphas and `-w` for Zeros)
-5. Reload the data via [bulk loader]({{< relref "#bulk-loader" >}})
+5. Reload the data via [bulk loader]({{< relref "deploy/fast-data-loading.md#bulk-loader" >}})
 6. Verify the correctness of the new Dgraph cluster. If all looks good, you can delete the old directories (export serves as an insurance)
 
 These steps are necessary because Dgraph's underlying data format could have changed, and reloading the export avoids encoding incompatibilities.
@@ -225,7 +225,7 @@ new type name and copy data from old predicate name to new predicate name for al
 are affected. Then, you can drop the old types and predicates from DB.
 
 {{% notice "note" %}}
-If you are upgrading from v1.0, please make sure you follow the schema migration steps described in [this section](/howto/#schema-types-scalar-uid-and-list-uid).
+If you are upgrading from v1.0, please make sure you follow the schema migration steps described in [this section]({{< relref "howto/migrate-dgraph-1-1.md" >}}).
 {{% /notice %}}
 
 ## Post Installation

--- a/wiki/content/deploy/dgraph-alpha.md
+++ b/wiki/content/deploy/dgraph-alpha.md
@@ -12,8 +12,8 @@ These HTTP endpoints are deprecated and will be removed in the next release. Ple
 {{% /notice %}}
 
 * `/health?all` returns information about the health of all the servers in the cluster.
-* `/admin/shutdown` initiates a proper [shutdown]({{< relref "#shutdown" >}}) of the Alpha.
-* `/admin/export` initiates a data [export]({{< relref "#export" >}}). The exported data will be
+* `/admin/shutdown` initiates a proper [shutdown]({{< relref "deploy/dgraph-administration.md#shutting-down-database" >}}) of the Alpha.
+* `/admin/export` initiates a data [export]({{< relref "deploy/dgraph-administration.md#exporting-database" >}}). The exported data will be
 encrypted if the alpha instance was configured with an encryption key file.
 
 By default the Alpha listens on `localhost` for admin actions (the loopback address only accessible from the same machine). The `--bindall=true` option binds to `0.0.0.0` and thus allows external connections.

--- a/wiki/content/deploy/fast-data-loading.md
+++ b/wiki/content/deploy/fast-data-loading.md
@@ -270,7 +270,8 @@ ending in .rdf, .rdf.gz, .json, and .json.gz will be loaded.
 `--format`: Specify file format (rdf or json) instead of getting it from
 filenames. This is useful if you need to define a strict format manually.
 
-`--store_xids`: Generate a xid edge for each node. It will store the XIDs (The identifier / Blank-nodes) in an attribute named `xid` in the entity itself. It is useful if you gonna use [External IDs](/mutations#external-ids).
+`--store_xids`: Generate a xid edge for each node. It will store the XIDs (The identifier / Blank-nodes) in an attribute named `xid` in the entity itself. It is useful if you gonna
+use [External IDs]({{< relref "mutations/external-ids.md" >}}).
 
 `--xidmap` (default: disabled. Need a path): Store xid to uid mapping to a directory. Dgraph will save all identifiers used in the load for later use in other data ingest operations. The mapping will be saved in the path you provide and you must indicate that same path in the next load. It is recommended to use this flag if you have full control over your identifiers (Blank-nodes). Because the identifier will be mapped to a specific UID.
 

--- a/wiki/content/deploy/kubernetes.md
+++ b/wiki/content/deploy/kubernetes.md
@@ -9,7 +9,7 @@ title = "Using Kubernetes"
 The following section covers running Dgraph with Kubernetes. We have tested Dgraph with Kubernetes versions 1.14 to 1.16 on [GKE](https://cloud.google.com/kubernetes-engine) and versions 1.14 to 1.17 on [EKS](https://aws.amazon.com/eks/).
 
 {{% notice "note" %}}These instructions are for running Dgraph alpha service without TLS configuration.
-Instructions for running Dgraph alpha service with TLS refer [TLS instructions]({{< relref "tls-configuration.md" >}}).{{% /notice %}}
+Instructions for running Dgraph alpha service with TLS refer [TLS instructions]({{< relref "deploy/tls-configuration.md" >}}).{{% /notice %}}
 
 * Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) which is used to deploy
   and manage applications on kubernetes.
@@ -231,7 +231,7 @@ helm install my-release dgraph/dgraph --set image.tag="v1.2.6"
 
 #### Dgraph Configuration Files
 
-You can supply a dgraph config files (see [Config]({{< relref "config.md" >}})) for alpha and zero with Helm chart configuration values:
+You can supply a dgraph config files (see [Config]({{< relref "deploy/config.md" >}})) for alpha and zero with Helm chart configuration values:
 
 ```yaml
 # my-config-values.yaml
@@ -363,7 +363,7 @@ upgrade the configuration in multiple steps following the steps below.
 
 #### Upgrade to HA cluster setup
 
-To upgrade to an [HA cluster setup]({{< relref "#ha-cluster-setup" >}}), ensure
+To upgrade to an [HA cluster setup]({{< relref "#ha-cluster-setup-using-kubernetes" >}}), ensure
 that the shard replication setting is more than 1. When `zero.shardReplicaCount`
 is not set to an HA configuration (3 or 5), follow the steps below:
 
@@ -661,7 +661,7 @@ configuration to be updated.
 ## Kubernetes and Bulk Loader
 
 You may want to initialize a new cluster with an existing data set such as data
-from the [Dgraph Bulk Loader]({{< relref "#bulk-loader" >}}). You can use [Init
+from the [Dgraph Bulk Loader]({{< relref "deploy/fast-data-loading.md#bulk-loader" >}}). You can use [Init
 Containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 to copy the data to the pod volume before the Alpha process runs.
 

--- a/wiki/content/deploy/multi-host-setup.md
+++ b/wiki/content/deploy/multi-host-setup.md
@@ -11,7 +11,7 @@ title = "Multi Host Setup"
 ### Cluster Setup Using Docker Swarm
 
 {{% notice "note" %}}These instructions are for running Dgraph Alpha without TLS config.
-Instructions for running with TLS refer [TLS instructions](#tls-configuration).{{% /notice %}}
+Instructions for running with TLS refer [TLS instructions]({{< relref "deploy/tls-configuration.md" >}}).{{% /notice %}}
 
 Here we'll go through an example of deploying 3 Dgraph Alpha nodes and 1 Zero on three different AWS instances using Docker Swarm with a replication factor of 3.
 

--- a/wiki/content/deploy/ports-usage.md
+++ b/wiki/content/deploy/ports-usage.md
@@ -23,9 +23,9 @@ Dgraph cluster nodes use different ports to communicate over gRPC and HTTP. User
        ratel      |  --Not Used--         | --Not Used--  |  8000
 
 
-<sup>1</sup>: Dgraph Zero's gRPC-internal port is used for internal communication within the cluster. It's also needed for the [fast data loading]({{< relref "#fast-data-loading" >}}) tools Dgraph Live Loader and Dgraph Bulk Loader.
+<sup>1</sup>: Dgraph Zero's gRPC-internal port is used for internal communication within the cluster. It's also needed for the [fast data loading]({{< relref "deploy/fast-data-loading.md" >}}) tools Dgraph Live Loader and Dgraph Bulk Loader.
 
-<sup>2</sup>: Dgraph Zero's HTTP-external port is used for [admin]({{< relref "#more-about-dgraph-zero" >}}) operations. Access to it is not required by clients.
+<sup>2</sup>: Dgraph Zero's HTTP-external port is used for [admin]({{< relref "deploy/dgraph-zero.md" >}}) operations. Access to it is not required by clients.
 
 Users have to modify security rules or open firewall ports depending up on their underlying network to allow communication between cluster nodes and between the Dgraph instances themselves and between Dgraph and a client. A general rule is to make *-external (gRPC/HTTP) ports wide open to clients and gRPC-internal ports open within the cluster nodes.
 

--- a/wiki/content/deploy/production-checklist.md
+++ b/wiki/content/deploy/production-checklist.md
@@ -107,7 +107,7 @@ We provide sample configs for both [Docker Compose](https://github.com/dgraph-io
 
 {{% load-img "/images/deploy-guide-1.png" "2-node cluster" %}}
 
-Configuration can be set either as command-line flags, environment variables, or in a config file (see [Config]({{< relref "deploy/_index.md#config" >}})).
+Configuration can be set either as command-line flags, environment variables, or in a config file (see [Config]({{< relref "deploy/config.md" >}})).
 
 Dgraph Zero:
 * The `--my` flag should be set to the address:port (the internal-gRPC port) that will be accessible to the Dgraph Alpha (default: `localhost:5080`).
@@ -130,7 +130,7 @@ We provide sample configs for both [Docker Compose](https://github.com/dgraph-io
 
 A Dgraph cluster can be configured in a high-availability setup with Dgraph Zero and Dgraph Alpha each set up with peers. These peers are part of Raft consensus groups, which elect a single leader amongst themselves. The non-leader peers are called followers. In the event that the peers cannot communicate with the leader (e.g., a network partition or a machine shuts down), the group automatically elects a new leader to continue.
 
-Configuration can be set either as command-line flags, environment variables, or in a config file (see [Config]({{< relref "deploy/_index.md#config" >}})).
+Configuration can be set either as command-line flags, environment variables, or in a config file (see [Config]({{< relref "deploy/config.md" >}})).
 
 In this setup, we assume the following hostnames are set:
 

--- a/wiki/content/deploy/single-host-setup.md
+++ b/wiki/content/deploy/single-host-setup.md
@@ -85,7 +85,7 @@ We will use [Docker Machine](https://docs.docker.com/machine/overview/). It is a
 * [Install Docker Machine](https://docs.docker.com/machine/install-machine/) on your machine.
 
 {{% notice "note" %}}These instructions are for running Dgraph Alpha without TLS config.
-Instructions for running with TLS refer [TLS instructions](#tls-configuration).{{% /notice %}}
+Instructions for running with TLS refer [TLS instructions]({{< relref "deploy/tls-configuration.md" >}}).{{% /notice %}}
 
 Here we'll go through an example of deploying Dgraph Zero, Alpha and Ratel on an AWS instance.
 

--- a/wiki/content/design-concepts/concepts.md
+++ b/wiki/content/design-concepts/concepts.md
@@ -17,7 +17,7 @@ Both the terminologies get used interchangeably in our code. Dgraph considers ed
 i.e. from `Subject -> Object`. This is the direction that the queries would be run.
 
 {{% notice "tip" %}}Dgraph can automatically generate a reverse edge. If the user wants to run
-queries in that direction, they would need to define the [reverse edge](/query-language#reverse-edges)
+queries in that direction, they would need to define the [reverse edge]({{< relref "query-language/schema.md#reverse-edges" >}})
 as part of the schema.{{% /notice %}}
 
 Internally, the RDF N-Quad gets parsed into this format.
@@ -157,7 +157,7 @@ Each group should typically be served by at least 3 servers, if available. In th
 failure, other servers serving the same group can still handle the load in that case.
 
 ## New Server and Discovery
-Dgraph cluster can detect new machines allocated to the [cluster](/deploy#cluster),
+Dgraph cluster can detect new machines allocated to the [cluster]({{< relref "deploy/cluster-setup.md" >}}),
 establish connections, and transfer a subset of existing predicates to it based on the groups served
 by the new machine.
 

--- a/wiki/content/dgraph-compared-to-other-databases/index.md
+++ b/wiki/content/dgraph-compared-to-other-databases/index.md
@@ -26,7 +26,7 @@ Graph databases optimize internal data representation to be able to do graph ope
 
 ### Language
 
-Dgraph supports [GraphQL+-]({{< relref "query-language/_index.md#graphql">}}),
+Dgraph supports [GraphQL+-]({{< relref "query-language/graphql-fundamentals.md">}}),
 a variation of [GraphQL](https://graphql.org/), a query language created by
 Facebook. 
 GraphQL+-, as GraphQL itself, allows results to be produced as subgraph rather than lists.

--- a/wiki/content/mutations/batch-mutations.md
+++ b/wiki/content/mutations/batch-mutations.md
@@ -13,4 +13,4 @@ Each mutation may contain multiple RDF triples. For large data uploads many such
 ```sh
 dgraph live --help
 ```
-See also [Fast Data Loading](/deploy#fast-data-loading).
+See also [Fast Data Loading]({{< relref "deploy/fast-data-loading.md" >}}).

--- a/wiki/content/mutations/json-mutation-format.md
+++ b/wiki/content/mutations/json-mutation-format.md
@@ -236,7 +236,7 @@ All edges for a predicate emanating from a single node can be deleted at once
 If no predicates are specified, then all of the node's known outbound edges (to
 other nodes and to literal values) are deleted (corresponding to deleting `S *
 *`). The predicates to delete are derived using the type system. Refer to the
-[RDF format]({{< relref "#delete" >}}) documentation and the section on the
+[RDF format]({{< relref "mutations/delete.md" >}}) documentation and the section on the
 [type system]({{< relref "query-language/type-system.md" >}}) for more
 information:
 

--- a/wiki/content/mutations/language-rdf-types.md
+++ b/wiki/content/mutations/language-rdf-types.md
@@ -46,4 +46,4 @@ The supported [RDF datatypes](https://www.w3.org/TR/rdf11-concepts/#section-Data
 | &#60;http&#58;//www.w3.org/2001/XMLSchema#float&#62;            | `float`          |
 
 
-See the section on [RDF schema types]({{< relref "#rdf-types" >}}) to understand how RDF types affect mutations and storage.
+See the section on [RDF schema types]({{< relref "query-language/schema/#rdf-types" >}}) to understand how RDF types affect mutations and storage.

--- a/wiki/content/mutations/language-rdf-types.md
+++ b/wiki/content/mutations/language-rdf-types.md
@@ -46,4 +46,4 @@ The supported [RDF datatypes](https://www.w3.org/TR/rdf11-concepts/#section-Data
 | &#60;http&#58;//www.w3.org/2001/XMLSchema#float&#62;            | `float`          |
 
 
-See the section on [RDF schema types]({{< relref "query-language/schema/#rdf-types" >}}) to understand how RDF types affect mutations and storage.
+See the section on [RDF schema types]({{< relref "query-language/schema.md#rdf-types" >}}) to understand how RDF types affect mutations and storage.

--- a/wiki/content/mutations/upsert-block.md
+++ b/wiki/content/mutations/upsert-block.md
@@ -195,7 +195,7 @@ curl -H "Content-Type: application/json" -X POST localhost:8080/mutate?commitNow
 ```
 
 If we want to execute the mutation only when the user exists, we could use
-[Conditional Upsert]({{< relref "#conditional-upsert" >}}).
+[Conditional Upsert]({{< relref "mutations/conditional-upsert.md" >}}).
 
 ## Example of `val` Function
 

--- a/wiki/content/query-language/aggregation.md
+++ b/wiki/content/query-language/aggregation.md
@@ -22,7 +22,7 @@ Schema Types:
 | `min` / `max`     | `int`, `float`, `string`, `dateTime`, `default`         |
 | `sum` / `avg`    | `int`, `float`       |
 
-Aggregation can only be applied to [value variables]({{< relref "#value-variables">}}).  An index is not required (the values have already been found and stored in the value variable mapping).
+Aggregation can only be applied to [value variables]({{< relref "query-language/value-variables.md">}}).  An index is not required (the values have already been found and stored in the value variable mapping).
 
 An aggregation is applied at the query block enclosing the variable definition.  As opposed to query variables and value variables, which are global, aggregation is computed locally.  For example:
 ```

--- a/wiki/content/query-language/count.md
+++ b/wiki/content/query-language/count.md
@@ -26,9 +26,9 @@ Query Example: The number of films acted in by each actor with `Orlando` in thei
 }
 {{< /runnable >}}
 
-Count can be used at root and [aliased]({{< relref "#alias">}}).
+Count can be used at root and [aliased]({{< relref "query-language/alias.md" >}}).
 
-Query Example: Count of directors who have directed more than five films.  When used at the query root, the [count index]({{< relref "#count-index">}}) is required.
+Query Example: Count of directors who have directed more than five films.  When used at the query root, the [count index]({{< relref "query-language/schema.md#count-index" >}}) is required.
 
 {{< runnable >}}
 {
@@ -39,7 +39,7 @@ Query Example: Count of directors who have directed more than five films.  When 
 {{< /runnable >}}
 
 
-Count can be assigned to a [value variable]({{< relref "#value-variables">}}).
+Count can be assigned to a [value variable]({{< relref "query-language/value-variables.md">}}).
 
 Query Example: The actors of Ang Lee's "Eat Drink Man Woman" ordered by the number of movies acted in.
 

--- a/wiki/content/query-language/expand-predicates.md
+++ b/wiki/content/query-language/expand-predicates.md
@@ -7,7 +7,7 @@ title = "Expand Predicates"
 +++
 
 The `expand()` function can be used to expand the predicates out of a node. To
-use `expand()`, the [type system]({{< relref "#type-system" >}}) is required.
+use `expand()`, the [type system]({{< relref "query-language/type-system.md" >}}) is required.
 Refer to the section on the type system to check how to set the types
 nodes. The rest of this section assumes familiarity with that section.
 
@@ -66,7 +66,7 @@ veterinarian
 
 {{% notice "note" %}}
 For `string` predicates, `expand` only returns values not tagged with a language
-(see [language preference]({{< relref "#language-support" >}})).  So it's often
+(see [language preference]({{< relref "query-language/graphql-fundamentals.md#language-support" >}})).  So it's often
 required to add `name@fr` or `name@.` as well to an expand query.
 {{% /notice  %}}
 

--- a/wiki/content/query-language/facets.md
+++ b/wiki/content/query-language/facets.md
@@ -120,7 +120,7 @@ All facets on an edge are queried with `@facets`.
 
 ## Facets i18n
 
-Facets keys and values can use language-specific characters directly when mutating. But facet keys need to be enclosed in angle brackets `<>` when querying. This is similar to predicates. See [Predicates i18n](#predicates-i18n) for more info.
+Facets keys and values can use language-specific characters directly when mutating. But facet keys need to be enclosed in angle brackets `<>` when querying. This is similar to predicates. See [Predicates i18n]({{< relref "query-language/schema.md#predicates-i18n" >}}) for more info.
 
 {{% notice "note" %}}Dgraph supports [Internationalized Resource Identifiers](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier) (IRIs) for facet keys when querying.{{% /notice  %}}
 
@@ -288,7 +288,7 @@ Charlie by their `rating` which is a facet.
 
 ## Assigning Facet values to a variable
 
-Facets on UID edges can be stored in [value variables]({{< relref "#value-variables" >}}).  The variable is a map from the edge target to the facet value.
+Facets on UID edges can be stored in [value variables]({{< relref "query-language/value-variables.md" >}}).  The variable is a map from the edge target to the facet value.
 
 Alice's friends reported by variables for `close` and `relative`.
 {{< runnable >}}
@@ -312,7 +312,7 @@ Alice's friends reported by variables for `close` and `relative`.
 
 ## Facets and Variable Propagation
 
-Facet values of `int` and `float` can be assigned to variables and thus the [values propagate]({{< relref "#variable-propagation" >}}).
+Facet values of `int` and `float` can be assigned to variables and thus the [values propagate]({{< relref "query-language/value-variables.md#variable-propagation" >}}).
 
 
 Alice, Bob and Charlie each rated every movie.  A value variable on facet `rating` maps movies to ratings.  A query that reaches a movie through multiple paths sums the ratings on each path.  The following sums Alice, Bob and Charlie's ratings for the three movies.

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -6,14 +6,14 @@ title = "Functions"
     weight = 2 
 +++
 
-Functions allow filtering based on properties of nodes or [variables]({{<relref "#value-variables">}}).  Functions can be applied in the query root or in filters.
+Functions allow filtering based on properties of nodes or [variables]({{<relref "query-language/value-variables.md">}}).  Functions can be applied in the query root or in filters.
 
 {{% notice "note" %}}Support for filters on non-indexed predicates was added with Dgraph `v1.2.0`.
 {{% /notice %}}
 
 Comparison functions (`eq`, `ge`, `gt`, `le`, `lt`) in the query root (aka `func:`) can only
-be applied on [indexed predicates]({{< relref "#indexing">}}). Since v1.2, comparison functions
-can now be used on [@filter]({{<relref "#applying-filters">}}) directives even on predicates
+be applied on [indexed predicates]({{< relref "query-language/schema.md#indexing" >}}). Since v1.2, comparison functions
+can now be used on [@filter]({{<relref "query-language/graphql-fundamentals.md#applying-filters" >}}) directives even on predicates
 that have not been indexed.
 Filtering on non-indexed predicates can be slow for large datasets, as they require
 iterating over all of the possible values at the level where the filter is being used.
@@ -76,7 +76,7 @@ Index Required: `term`
 Matches strings that have any of the specified terms in any order; case insensitive.
 #### Usage at root
 
-Query Example: All nodes that have a `name` containing either `poison` or `peacock`.  Many of the returned nodes are movies, but people like Joan Peacock also meet the search terms because without a [cascade directive]({{< relref "#cascade-directive">}}) the query doesn't require a genre.
+Query Example: All nodes that have a `name` containing either `poison` or `peacock`.  Many of the returned nodes are movies, but people like Joan Peacock also meet the search terms because without a [cascade directive]({{< relref "query-language/cascade-directive.md">}}) the query doesn't require a genre.
 
 {{< runnable >}}
 {
@@ -364,7 +364,7 @@ Query Example: Movies with directors with `Steven` in `name` and have directed m
 
 
 
-Query Example: A movie in each genre that has over 30000 movies.  Because there is no order specified on genres, the order will be by UID.  The [count index]({{< relref "#count-index">}}) records the number of edges out of nodes and makes such queries more .
+Query Example: A movie in each genre that has over 30000 movies.  Because there is no order specified on genres, the order will be by UID.  The [count index]({{< relref "query-language/schema.md#count-index">}}) records the number of edges out of nodes and makes such queries more .
 
 {{< runnable >}}
 {

--- a/wiki/content/query-language/graphql-fundamentals.md
+++ b/wiki/content/query-language/graphql-fundamentals.md
@@ -194,7 +194,7 @@ above.
 
 ---
 
-In [full-text search functions]({{< relref "#full-text-search" >}})
+In [full-text search functions]({{< relref "query-language/functions.md#full-text-search" >}})
 (`alloftext`, `anyoftext`), when no language is specified (untagged or `@.`),
 the default (English) full-text tokenizer is used. This does not mean that
 the value with the `en` tag will be searched when querying the untagged value,

--- a/wiki/content/query-language/kshortest-path-quries.md
+++ b/wiki/content/query-language/kshortest-path-quries.md
@@ -100,7 +100,7 @@ curl -H "Content-Type: application/graphql+-" localhost:8080/query -XPOST -d $'{
 }' | python -m json.tool | less
 ```
 
-{{% notice "note" %}}In the query above, instead of using UID literals, we query both people using var blocks and the `uid()` function. You can also combine it with [GraphQL Variables]({{< relref "#graphql-variables" >}}).{{% /notice %}}
+{{% notice "note" %}}In the query above, instead of using UID literals, we query both people using var blocks and the `uid()` function. You can also combine it with [GraphQL Variables]({{< relref "query-language/graphql-variables.md" >}}).{{% /notice %}}
 
 Edges weights are included by using facets on the edges as follows.
 

--- a/wiki/content/query-language/pagination.md
+++ b/wiki/content/query-language/pagination.md
@@ -8,7 +8,7 @@ title = "Pagination"
 
 Pagination allows returning only a portion, rather than the whole, result set.  This can be useful for top-k style queries as well as to reduce the size of the result set for client side processing or to allow paged access to results.
 
-Pagination is often used with [sorting]({{< relref "#sorting">}}).
+Pagination is often used with [sorting]({{< relref "query-language/sorting.md">}}).
 
 {{% notice "note" %}}Without a sort order specified, the results are sorted by `uid`, which is assigned randomly. So the ordering, while deterministic, might not be what you expected.{{% /notice  %}}
 ## First

--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -258,7 +258,7 @@ email: string @index(exact) @noconflict .
 
 Dgraph supports a number of [RDF types in mutations]({{< relref "mutations/language-rdf-types.md" >}}).
 
-As well as implying a schema type for a [first mutation]({{< relref "#schema" >}}), an RDF type can override a schema type for storage.
+As well as implying a schema type for a [first mutation]({{< relref "query-language/schema.md" >}}), an RDF type can override a schema type for storage.
 
 If a predicate has a schema type and a mutation has an RDF type with a different underlying Dgraph type, the convertibility to schema type is checked, and an error is thrown if they are incompatible, but the value is stored in the RDF type's corresponding Dgraph type.  Query results are always returned in schema type.
 
@@ -355,7 +355,7 @@ output:
 
 ## Indexing
 
-{{% notice "note" %}}Filtering on a predicate by applying a [function]({{< relref "#functions" >}}) requires an index.{{% /notice %}}
+{{% notice "note" %}}Filtering on a predicate by applying a [function]({{< relref "query-language/functions.md" >}}) requires an index.{{% /notice %}}
 
 When filtering by applying a function, Dgraph uses the index to make the search through a potentially large dataset efficient.
 
@@ -446,8 +446,7 @@ score: [int] .
 * A set operation adds to the list of values. The order of the stored values is non-deterministic.
 * A delete operation deletes the value from the list.
 * Querying for these predicates would return the list in an array.
-* Indexes can be applied on predicates which have a list type and you can use [Functions]({{<ref
-  "#functions">}}) on them.
+* Indexes can be applied on predicates which have a list type and you can use [Functions]({{<relref "query-language/functions.md">}}) on them.
 * Sorting is not allowed using these predicates.
 
 ## Filtering on list

--- a/wiki/content/query-language/sorting.md
+++ b/wiki/content/query-language/sorting.md
@@ -18,9 +18,9 @@ Sortable Types: `int`, `float`, `String`, `dateTime`, `default`
 
 Results can be sorted in ascending order (`orderasc`) or descending order (`orderdesc`) by a predicate or variable.
 
-For sorting on predicates with [sortable indices]({{< relref "#sortable-indices">}}), Dgraph sorts on the values and with the index in parallel and returns whichever result is computed first.
+For sorting on predicates with [sortable indices]({{< relref "query-language/schema.md#sortable-indices">}}), Dgraph sorts on the values and with the index in parallel and returns whichever result is computed first.
 
-Sorted queries retrieve up to 1000 results by default. This can be changed with [first]({{< relref "#first">}}).
+Sorted queries retrieve up to 1000 results by default. This can be changed with [first]({{< relref "query-language/pagination.md#first">}}).
 
 
 Query Example: French director Jean-Pierre Jeunet's movies sorted by release date.

--- a/wiki/content/query-language/type-system.md
+++ b/wiki/content/query-language/type-system.md
@@ -146,5 +146,5 @@ err := c.Alter(context.Background(), &api.Operation{
 
 ## Expand queries and types
 
-Queries using [expand]({{< relref "#expand-predicates" >}}) (i.e.:
+Queries using [expand]({{< relref "query-language/expand-predicates.md" >}}) (i.e.:
 `expand(_all_)`) require that the nodes to be expanded have types.

--- a/wiki/content/query-language/value-variables.md
+++ b/wiki/content/query-language/value-variables.md
@@ -24,7 +24,7 @@ It is an error to define a value variable but not use it elsewhere in the query.
 
 Value variables are used by extracting the values with `val(var-name)`, or by extracting the UIDs with `uid(var-name)`.
 
-[Facet]({{< relref "#facets-edge-attributes">}}) values can be stored in value variables.
+[Facet]({{< relref "query-language/facets.md">}}) values can be stored in value variables.
 
 Query Example: The number of movie roles played by the actors of the 80's classic "The Princess Bride".  Query variable `pbActors` matches the UIDs of all actors from the movie.  Value variable `roles` is thus a map from actor UID to number of roles.  Value variable `roles` can be used in the `totalRoles` query block because that query block also matches the `pbActors` UIDs, so the actor to number of roles map is available.
 


### PR DESCRIPTION
Motivation:
With the splitting of docs into multiple pages work carried out in this PR: https://github.com/dgraph-io/dgraph/pull/6079 , many subsections had moved to different pages causing references to not redirect to the desired page.

This PR fixes those referencing bugs.

Tested locally.


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6439)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-3f6e3e6873-93047.surge.sh)
<!-- Dgraph:end -->