### PR TITLE
cherry-pick v20.07: docs: Update list documentation (#6455)

### DIFF
--- a/wiki/content/graphql/schema/types.md
+++ b/wiki/content/graphql/schema/types.md
@@ -11,7 +11,9 @@ This page describes how you use GraphQL types to set the Dgraph GraphQL schema.
 
 Dgraph GraphQL comes with the standard GraphQL scalars: `Int`, `Float`, `String`, `Boolean` and `ID`.  There's also a `DateTime` scalar - represented as a string in RFC3339 format.
 
-Scalars `Int`, `Float`, `String` and `DateTime` can be used in lists.  All scalars may be nullable or non-nullable.
+Scalars `Int`, `Float`, `String` and `DateTime` can be used in lists. Note that lists behave like an unordered set in Dgraph. For example: `["e1", "e1", "e2"]` may get stored as `["e2", "e1"]`, i.e., duplicate values will not be stored and order may not be preserved.
+
+All scalars may be nullable or non-nullable.
 
 The `ID` type is special.  IDs are auto-generated, immutable, and can be treated as strings.  Fields of type `ID` can be listed as nullable in a schema, but Dgraph will never return null. 
 

--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -435,8 +435,7 @@ For predicates with the `@count` Dgraph indexes the number of edges out of each 
 ## List Type
 
 Predicate with scalar types can also store a list of values if specified in the schema. The scalar
-type needs to be enclosed within `[]` to indicate that its a list type. These lists are like an
-unordered set.
+type needs to be enclosed within `[]` to indicate that its a list type.
 
 ```
 occupations: [string] .
@@ -449,6 +448,7 @@ score: [int] .
 * Indexes can be applied on predicates which have a list type and you can use [Functions]({{<ref
   "#functions">}}) on them.
 * Sorting is not allowed using these predicates.
+* These lists are like an unordered set. For example: `["e1", "e1", "e2"]` may get stored as `["e2", "e1"]`, i.e., duplicate values will not be stored and order may not be preserved.
 
 ## Filtering on list
 


### PR DESCRIPTION
Fixes GRAPHQL-657
Fixes [Discuss Issue](https://discuss.dgraph.io/t/documentation-that-arrays-work-as-a-set-not-storing-duplicates/9590)

(cherry picked from commit 07cff6f56303bce07828e6829b92f3ad7195b80b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6461)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b658e3314b-93842.surge.sh)
<!-- Dgraph:end -->