### PR TITLE
Return content length header for queries

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -490,7 +490,7 @@ func WriteResponse(w http.ResponseWriter, r *http.Request, b []byte) (int, error
 	if err != nil {
 		return 0, err
 	}
-	w.Header().Set("Content-Length", strconv.FormatInt(int64(bytesWritten), 64))
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(bytesWritten), 10))
 	return bytesWritten, nil
 }
 

--- a/x/x.go
+++ b/x/x.go
@@ -486,7 +486,12 @@ func WriteResponse(w http.ResponseWriter, r *http.Request, b []byte) (int, error
 		out = gzw
 	}
 
-	return out.Write(b)
+	bytesWritten, err := out.Write(b)
+	if err != nil {
+		return 0, err
+	}
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(bytesWritten), 64))
+	return bytesWritten, nil
 }
 
 // Min returns the minimum of the two given numbers.


### PR DESCRIPTION
Fixes DGRAPH-1675

To test out this fix just start a Dgraph cluster and load some dummy data then run a query with curl:

e.g
```
curl  -v -H "Content-Type: application/graphql+-" localhost:8080/query -XPOST -d '
{
  result(func: has(director.film), first: 10) {
    uid
  }
}' | jq
```
The content length will be reported as follows:
<pre>
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /query HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.58.0
> Accept: */*
> Accept-Encoding: deflate, gzip
> Content-Type: application/graphql+-
> Content-Length: 64
>
} [64 bytes data]
* upload completely sent off: 64 out of 64 bytes
< HTTP/1.1 200 OK
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: X-Dgraph-AccessToken, Content-Type, Content-Length, Accept-Encoding, Cache-Control, X-CSRF-Token, X-Auth-Token, X-Requested-With
< Access-Control-Allow-Methods: POST, OPTIONS
< Access-Control-Allow-Origin: *
< Connection: close
< Content-Encoding: gzip
< Content-Type: application/json
< Dgraph-Toucheduids: 10
< Date: Wed, 16 Sep 2020 19:12:31 GMT
<strong>< Content-Length: 317</strong>
< 
{ [317 bytes data]
</pre>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6469)
<!-- Reviewable:end -->
