### PR TITLE
docs: Document backupNum field in restore endpoint.

### DIFF
--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -71,7 +71,7 @@ const adminTypes = `
 
 		"""
 		Number of the backup within the backup series to be restored. Backups with a greater value
-		will be ignored. If the value is missing, the entire series will be restored.
+		will be ignored. If the value is zero or missing, the entire series will be restored.
 		"""
 		backupNum: Int
 

--- a/wiki/content/enterprise-features/binary-backups.md
+++ b/wiki/content/enterprise-features/binary-backups.md
@@ -318,6 +318,12 @@ input RestoreInput {
 		If missing, it defaults to the latest series.
 		"""
 		backupId: String
+        
+		"""
+		Number of the backup within the backup series to be restored. Backups with a greater value
+		will be ignored. If the value is zero or is missing, the entire series will be restored.
+		"""
+		backupNum: Int
 
 		"""
 		Path to the key file needed to decrypt the backup. This file should be accessible


### PR DESCRIPTION
Related to DGRAPH-1648.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6471)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-dbd9403eb8-94131.surge.sh)
<!-- Dgraph:end -->