### PR TITLE
fix(docs): Allow more levels for right toc

### DIFF
--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -17,7 +17,7 @@ style = "vs"
 tabWidth = 4
 
 [markup.tableOfContents]
-endLevel = 3
+endLevel = 4
 ordered = false
 startLevel = 2
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6477)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-37dd329db8-94267.surge.sh)
<!-- Dgraph:end -->