### PR TITLE
(release/v20.07-slash) Fix(Dgraph): Add a lock to backups to process …

### DIFF
--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"net/url"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/dgraph/posting"
@@ -75,6 +76,11 @@ func BackupGroup(ctx context.Context, in *pb.BackupRequest) (*pb.Status, error) 
 	return res, nil
 }
 
+// backupLock is used to synchronize backups to avoid more than one backup request
+// to be processed at the same time. Multiple requests could lead to multiple
+// backups with the same backupNum in their manifest.
+var backupLock sync.Mutex
+
 func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull bool) error {
 	if !EnterpriseEnabled() {
 		return errors.New("you must enable enterprise features first. " +
@@ -89,6 +95,10 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest, forceFull 
 		glog.Errorf("Backup canceled, not ready to accept requests: %s", err)
 		return err
 	}
+
+	// Grab the lock here to avoid more than one request to be processed at the same time.
+	backupLock.Lock()
+	defer backupLock.Unlock()
 
 	ts, err := Timestamps(ctx, &pb.Num{ReadOnly: true})
 	if err != nil {


### PR DESCRIPTION
…one request at a time.

It's possible that two requests reach the server around the same time
and send a requests to the alphas with the same backupNum. This could
lead to issues further down the line.

Related to DGRAPH-2295

(cherry picked from commit 5b7926018adc5ed2173d0df5b1ac5796517566ed)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6491)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-418c453b0d-94516.surge.sh)
<!-- Dgraph:end -->