### PR TITLE
Do not allow enabling compression without cache

### DIFF
--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -118,7 +118,7 @@ instances to achieve high-availability.
 	flag.String("badger.vlog", "mmap",
 		"[mmap, disk] Specifies how Badger Value log is stored for the write-ahead log directory "+
 			"log directory. mmap consumes more RAM, but provides better performance.")
-	flag.Int("badger.compression_level", 3,
+	flag.Int("badger.compression_level", 0,
 		"The compression level for Badger. A higher value uses more resources.")
 }
 
@@ -275,6 +275,11 @@ func run() {
 		// By default, compression is disabled in badger.
 		kvOpt.Compression = bopt.ZSTD
 		kvOpt.ZSTDCompressionLevel = compression_level
+	}
+
+	if compression_level > 0 && blockCacheSz == 0 {
+		log.Fatal("Cache is required with Compression. " +
+			"Please set --cache_mb and --cache_percentage flags.")
 	}
 
 	// Set loading mode options.


### PR DESCRIPTION
Alpha/zero should not be used if compression/encryption is enabled. This
PR adds checks so that we don't start alpha/zero if compression or
encryption is enabled.

**This PR also sets cache size for alpha to 2GB and disables compression for Zero.**

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6497)
<!-- Reviewable:end -->
