### PR TITLE
docs: Update Hugo config for v1.1.1 (#5337)

### DIFF
--- a/wiki/config.toml
+++ b/wiki/config.toml
@@ -2,6 +2,12 @@ baseurl = "http://localhost:1313/"
 languageCode = "en-us"
 theme = "hugo-docs"
 
+[markup.goldmark.renderer]
+unsafe = true
+
+[markup.highlight]
+noClasses = false
+
 # set by build script: title, baseurl
 title = "Dgraph Documentation"
 

--- a/wiki/scripts/build.sh
+++ b/wiki/scripts/build.sh
@@ -10,7 +10,13 @@ set -e
 
 GREEN='\033[32;1m'
 RESET='\033[0m'
-HOST=https://docs.dgraph.io
+HOST="${HOST:-https://dgraph.io/docs}"
+# Name of output public directory
+PUBLIC="${PUBLIC:-public}"
+# LOOP true makes this script run in a loop to check for updates
+LOOP="${LOOP:-true}"
+# Binary of hugo command to run.
+HUGO="${HUGO:-hugo}"
 
 # TODO - Maybe get list of released versions from Github API and filter
 # those which have docs.


### PR DESCRIPTION
These changes make docs work with Hugo v0.69.2 (the current
latest version).

Starting with Hugo v0.60.0 and later, setting
markup.goldmark.renderer.unsafe = true is required to use inline
HTML. Otherwise, inline HTML in Markdown documents is replaced
with <!-- raw HTML omitted -->. We use raw HTML in some places of
the docs (e.g., on the front page).

Changes

* Set canonifyURLs to true and set the base URL to dgraph.io/docs
* Set the Markdown renderer to unsafe mode to render inline HTML
* Set [markdown.highlight] noClasses = false to keep the same
  syntax highlighting.

(cherry picked from commit 0b3018502f823654096c31cb1d1a2f2d1e21c9be)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6513)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://)
<!-- Dgraph:end -->