### PR TITLE
fix(GraphQL): Hide info when performing mutation on id field with auth rule. (#6391)

### DIFF
--- a/graphql/e2e/auth/add_mutation_test.go
+++ b/graphql/e2e/auth/add_mutation_test.go
@@ -146,7 +146,7 @@ func TestAddDeepFilter(t *testing.T) {
 				Name: "project_add_2",
 				Roles: []*Role{{
 					Permission: "ADMIN",
-					AssignedTo: []*User{{
+					AssignedTo: []*common.User{{
 						Username: "user2",
 					}},
 				}},
@@ -162,12 +162,12 @@ func TestAddDeepFilter(t *testing.T) {
 				Name: "project_add_4",
 				Roles: []*Role{{
 					Permission: "ADMIN",
-					AssignedTo: []*User{{
+					AssignedTo: []*common.User{{
 						Username: "user6",
 					}},
 				}, {
 					Permission: "VIEW",
-					AssignedTo: []*User{{
+					AssignedTo: []*common.User{{
 						Username: "user6",
 					}},
 				}},
@@ -212,7 +212,7 @@ func TestAddDeepFilter(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Column{}, "ColID")
@@ -249,7 +249,7 @@ func TestAddOrRBACFilter(t *testing.T) {
 			Name: "project_add_2",
 			Roles: []*Role{{
 				Permission: "ADMIN",
-				AssignedTo: []*User{{
+				AssignedTo: []*common.User{{
 					Username: "user2",
 				}},
 			}},
@@ -262,12 +262,12 @@ func TestAddOrRBACFilter(t *testing.T) {
 			Name: "project_add_3",
 			Roles: []*Role{{
 				Permission: "ADMIN",
-				AssignedTo: []*User{{
+				AssignedTo: []*common.User{{
 					Username: "user7",
 				}},
 			}, {
 				Permission: "VIEW",
-				AssignedTo: []*User{{
+				AssignedTo: []*common.User{{
 					Username: "user7",
 				}},
 			}},
@@ -308,7 +308,7 @@ func TestAddOrRBACFilter(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Project{}, "ProjID")
@@ -329,13 +329,13 @@ func TestAddAndRBACFilterMultiple(t *testing.T) {
 		result: `{"addIssue": {"issue":[{"msg":"issue_add_5"}, {"msg":"issue_add_6"}, {"msg":"issue_add_7"}]}}`,
 		variables: map[string]interface{}{"issues": []*Issue{{
 			Msg:   "issue_add_5",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}, {
 			Msg:   "issue_add_6",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}, {
 			Msg:   "issue_add_7",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}}},
 	}, {
 		user:   "user8",
@@ -343,13 +343,13 @@ func TestAddAndRBACFilterMultiple(t *testing.T) {
 		result: ``,
 		variables: map[string]interface{}{"issues": []*Issue{{
 			Msg:   "issue_add_8",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}, {
 			Msg:   "issue_add_9",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}, {
 			Msg:   "issue_add_10",
-			Owner: &User{Username: "user9"},
+			Owner: &common.User{Username: "user9"},
 		}}},
 	}}
 
@@ -386,7 +386,7 @@ func TestAddAndRBACFilterMultiple(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Issue{}, "Id")
@@ -407,7 +407,7 @@ func TestAddAndRBACFilter(t *testing.T) {
 		result: `{"addIssue": {"issue":[{"msg":"issue_add_1"}]}}`,
 		variables: map[string]interface{}{"issue": &Issue{
 			Msg:   "issue_add_1",
-			Owner: &User{Username: "user7"},
+			Owner: &common.User{Username: "user7"},
 		}},
 	}, {
 		user:   "user7",
@@ -415,7 +415,7 @@ func TestAddAndRBACFilter(t *testing.T) {
 		result: ``,
 		variables: map[string]interface{}{"issue": &Issue{
 			Msg:   "issue_add_2",
-			Owner: &User{Username: "user8"},
+			Owner: &common.User{Username: "user8"},
 		}},
 	}, {
 		user:   "user7",
@@ -423,7 +423,7 @@ func TestAddAndRBACFilter(t *testing.T) {
 		result: ``,
 		variables: map[string]interface{}{"issue": &Issue{
 			Msg:   "issue_add_3",
-			Owner: &User{Username: "user7"},
+			Owner: &common.User{Username: "user7"},
 		}},
 	}}
 
@@ -460,7 +460,7 @@ func TestAddAndRBACFilter(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Issue{}, "Id")
@@ -522,7 +522,7 @@ func TestAddComplexFilter(t *testing.T) {
 			RegionsAvailable: []*Region{{
 				Name:   "add_region_2",
 				Global: false,
-				Users: []*User{{
+				Users: []*common.User{{
 					Username: "user8",
 				}},
 			}},
@@ -563,7 +563,7 @@ func TestAddComplexFilter(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Movie{}, "Id")
@@ -628,7 +628,7 @@ func TestAddRBACFilter(t *testing.T) {
 
 		err := json.Unmarshal([]byte(tcase.result), &expected)
 		require.NoError(t, err)
-		err = json.Unmarshal([]byte(gqlResponse.Data), &result)
+		err = json.Unmarshal(gqlResponse.Data, &result)
 		require.NoError(t, err)
 
 		opt := cmpopts.IgnoreFields(Log{}, "Id")

--- a/graphql/e2e/auth/debug_off/debug_off_test.go
+++ b/graphql/e2e/auth/debug_off/debug_off_test.go
@@ -89,6 +89,39 @@ func TestAddGQL(t *testing.T) {
 	}
 }
 
+func TestAddMutationWithXid(t *testing.T) {
+	mutation := `
+	mutation addTweets($tweet: AddTweetsInput!){
+      addTweets(input: [$tweet]) {
+        numUids
+      }
+    }
+	`
+
+	tweet := common.Tweets{
+		Id:        "tweet1",
+		Text:      "abc",
+		Timestamp: "2020-10-10",
+	}
+	user := "foo"
+	addTweetsParams := &common.GraphQLParams{
+		Headers:   common.GetJWT(t, user, "", metaInfo),
+		Query:     mutation,
+		Variables: map[string]interface{}{"tweet": tweet},
+	}
+
+	// Add the tweet for the first time.
+	gqlResponse := addTweetsParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+
+	// Re-adding the tweet should fail.
+	gqlResponse = addTweetsParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+
+	// Clear the tweet.
+	tweet.DeleteByID(t, user, metaInfo)
+}
+
 func TestMain(m *testing.M) {
 	schemaFile := "../schema.graphql"
 	schema, err := ioutil.ReadFile(schemaFile)

--- a/graphql/e2e/auth/delete_mutation_test.go
+++ b/graphql/e2e/auth/delete_mutation_test.go
@@ -374,11 +374,11 @@ func TestDeleteRBACRuleInverseField(t *testing.T) {
 	addTweetsParams := &common.GraphQLParams{
 		Headers: getJWT(t, "foo", ""),
 		Query:   mutation,
-		Variables: map[string]interface{}{"tweet": Tweets{
+		Variables: map[string]interface{}{"tweet": common.Tweets{
 			Id:        "tweet1",
 			Text:      "abc",
 			Timestamp: "2020-10-10",
-			User: User{
+			User: &common.User{
 				Username: "foo",
 			},
 		}},
@@ -390,10 +390,12 @@ func TestDeleteRBACRuleInverseField(t *testing.T) {
 	testCases := []TestCase{
 		{
 			user:   "foobar",
+			role:   "admin",
 			result: `{"deleteTweets":{"numUids":0,"tweets":[]}}`,
 		},
 		{
 			user:   "foo",
+			role:   "admin",
 			result: `{"deleteTweets":{"numUids":1,"tweets":[ {"text": "abc"}]}}`,
 		},
 	}

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -27,6 +27,7 @@ type User @auth(
 }
 
 type Tweets @auth (
+    query: { rule: "{$ROLE: { eq: \"admin\" } }"},
     add: { rule: "{$USER: { eq: \"foo\" } }"},
     delete: { rule: "{$USER: { eq: \"foo\" } }"},
     update: { rule: "{$USER: { eq: \"foo\" } }"}

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -100,6 +100,20 @@ type GraphQLResponse struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
+type Tweets struct {
+	Id        string `json:"id,omitempty"`
+	Text      string `json:"text,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+	User      *User  `json:"user,omitempty"`
+}
+
+type User struct {
+	Username string `json:"username,omitempty"`
+	Age      uint64 `json:"age,omitempty"`
+	IsPublic bool   `json:"isPublic,omitempty"`
+	Disabled bool   `json:"disabled,omitempty"`
+}
+
 type country struct {
 	ID     string   `json:"id,omitempty"`
 	Name   string   `json:"name,omitempty"`
@@ -176,6 +190,24 @@ type UserSecret struct {
 	Id      string `json:"id,omitempty"`
 	ASecret string `json:"aSecret,omitempty"`
 	OwnedBy string `json:"ownedBy,omitempty"`
+}
+
+func (twt *Tweets) DeleteByID(t *testing.T, user string, metaInfo *testutil.AuthMeta) {
+	getParams := &GraphQLParams{
+		Headers: GetJWT(t, user, "", metaInfo),
+		Query: `
+			mutation delTweets ($filter : TweetsFilter!){
+			  	deleteTweets (filter: $filter) {
+					numUids
+			  	}
+			}
+		`,
+		Variables: map[string]interface{}{"filter": map[string]interface{}{
+			"id": map[string]interface{}{"eq": twt.Id},
+		}},
+	}
+	gqlResponse := getParams.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
 }
 
 func (us *UserSecret) Delete(t *testing.T, user, role string, metaInfo *testutil.AuthMeta) {

--- a/graphql/resolve/auth_delete_test.yaml
+++ b/graphql/resolve/auth_delete_test.yaml
@@ -38,6 +38,7 @@
     }
   jwtvar:
     USER: "foo"
+    ROLE: "admin"
   dgmutations:
     - deletejson: |
         [
@@ -75,6 +76,8 @@
         }
       }
     }
+  jwtvar:
+    ROLE: "admin"
   dgmutations:
     - deletejson: |
         [

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -115,7 +115,7 @@ func (qr *queryRewriter) Rewrite(
 
 		// TODO: The only error that can occur in query rewriting is if an ID argument
 		// can't be parsed as a uid: e.g. the query was something like:
-		//
+		//UserSecret
 		// getT(id: "HI") { ... }
 		//
 		// But that's not a rewriting error!  It should be caught by validation

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -74,6 +74,11 @@ func (r *Response) WithError(err error) {
 	if !x.Config.GraphqlDebug && strings.Contains(err.Error(), "authorization failed") {
 		return
 	}
+
+	if !x.Config.GraphqlDebug && strings.Contains(err.Error(), "GraphQL debug:") {
+		return
+	}
+
 	r.Errors = append(r.Errors, AsGQLErrors(err)...)
 }
 


### PR DESCRIPTION
* Hide info when performing mutation on id field with auth rule.

(cherry picked from commit 5c33428fc9adc973590c7f5eb1f8ccd55eeb26f9)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6534)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5a3266d5af-95045.surge.sh)
<!-- Dgraph:end -->