### PR TITLE
fix: Report Raft heartbeat metrics for Zero v=3 logs and log read index.

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -624,7 +624,7 @@ func (n *Node) WaitLinearizableRead(ctx context.Context) error {
 	span := otrace.FromContext(ctx)
 	span.Annotate(nil, "WaitLinearizableRead")
 
-	if num := atomic.AddUint64(&readIndexTotal, 1); num%100 == 0 {
+	if num := atomic.AddUint64(&readIndexTotal, 1); num%1000 == 0 {
 		glog.V(2).Infof("ReadIndex Total: %d\n", num)
 	}
 	indexCh := make(chan uint64, 1)
@@ -642,7 +642,7 @@ func (n *Node) WaitLinearizableRead(ctx context.Context) error {
 		if index == 0 {
 			return errReadIndex
 		} else {
-			if num := atomic.AddUint64(&readIndexOk, 1); num%100 == 0 {
+			if num := atomic.AddUint64(&readIndexOk, 1); num%1000 == 0 {
 				glog.V(2).Infof("ReadIndex OK: %d\n", num)
 			}
 		}

--- a/conn/node.go
+++ b/conn/node.go
@@ -617,11 +617,16 @@ type linReadReq struct {
 var errReadIndex = errors.Errorf(
 	"Cannot get linearized read (time expired or no configured leader)")
 
+var readIndexOk, readIndexTotal uint64
+
 // WaitLinearizableRead waits until a linearizable read can be performed.
 func (n *Node) WaitLinearizableRead(ctx context.Context) error {
 	span := otrace.FromContext(ctx)
 	span.Annotate(nil, "WaitLinearizableRead")
 
+	if num := atomic.AddUint64(&readIndexTotal, 1); num%100 == 0 {
+		glog.V(2).Infof("ReadIndex Total: %d\n", num)
+	}
 	indexCh := make(chan uint64, 1)
 	select {
 	case n.requestCh <- linReadReq{indexCh: indexCh}:
@@ -636,6 +641,10 @@ func (n *Node) WaitLinearizableRead(ctx context.Context) error {
 		span.Annotatef(nil, "Received index: %d", index)
 		if index == 0 {
 			return errReadIndex
+		} else {
+			if num := atomic.AddUint64(&readIndexOk, 1); num%100 == 0 {
+				glog.V(2).Infof("ReadIndex OK: %d\n", num)
+			}
 		}
 		err := n.Applied.WaitForMark(ctx, index)
 		span.Annotatef(nil, "Error from Applied.WaitForMark: %v", err)

--- a/conn/node.go
+++ b/conn/node.go
@@ -134,7 +134,7 @@ func NewNode(rc *pb.RaftContext, store *raftwal.DiskStorage) *Node {
 		},
 		// processConfChange etc are not throttled so some extra delta, so that we don't
 		// block tick when applyCh is full
-		Applied:     y.WaterMark{Name: fmt.Sprintf("Applied watermark")},
+		Applied:     y.WaterMark{Name: "Applied watermark"},
 		RaftContext: rc,
 		Rand:        rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())}),
 		confChanges: make(map[uint64]chan error),
@@ -641,10 +641,8 @@ func (n *Node) WaitLinearizableRead(ctx context.Context) error {
 		span.Annotatef(nil, "Received index: %d", index)
 		if index == 0 {
 			return errReadIndex
-		} else {
-			if num := atomic.AddUint64(&readIndexOk, 1); num%1000 == 0 {
-				glog.V(2).Infof("ReadIndex OK: %d\n", num)
-			}
+		} else if num := atomic.AddUint64(&readIndexOk, 1); num%1000 == 0 {
+			glog.V(2).Infof("ReadIndex OK: %d\n", num)
 		}
 		err := n.Applied.WaitForMark(ctx, index)
 		span.Annotatef(nil, "Error from Applied.WaitForMark: %v", err)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -280,13 +280,11 @@ func (n *node) handleTabletProposal(tablet *pb.Tablet) error {
 		if tablet.Force {
 			originalGroup := state.Groups[prev.GroupId]
 			delete(originalGroup.Tablets, tablet.Predicate)
-		} else {
-			if prev.GroupId != tablet.GroupId {
-				glog.Infof(
-					"Tablet for attr: [%s], gid: [%d] already served by group: [%d]\n",
-					prev.Predicate, tablet.GroupId, prev.GroupId)
-				return errTabletAlreadyServed
-			}
+		} else if prev.GroupId != tablet.GroupId {
+			glog.Infof(
+				"Tablet for attr: [%s], gid: [%d] already served by group: [%d]\n",
+				prev.Predicate, tablet.GroupId, prev.GroupId)
+			return errTabletAlreadyServed
 		}
 	}
 	tablet.Force = false
@@ -442,7 +440,7 @@ func (n *node) triggerLeaderChange() {
 func (n *node) proposeNewCID() {
 	// Either this is a new cluster or can't find a CID in the entries. So, propose a new ID for the cluster.
 	// CID check is needed for the case when a leader assigns a CID to the new node and the new node is proposing a CID
-	for len(n.server.membershipState().Cid) == 0 {
+	for n.server.membershipState().Cid == "" {
 		id := uuid.New().String()
 		err := n.proposeAndWait(context.Background(), &pb.ZeroProposal{Cid: id})
 		if err == nil {

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -697,23 +697,6 @@ func (n *node) Run() {
 		go x.StoreSync(n.Store, closer)
 	}
 
-	// var readNum uint64
-	// getRead := func() {
-	// 	start := time.Now()
-	// 	dur := 20 * time.Millisecond
-	// 	ticker := time.NewTicker(dur)
-	// 	defer ticker.Stop()
-	// 	for range ticker.C {
-	// 		err := n.WaitLinearizableRead(context.Background())
-	// 		cnt := atomic.AddUint64(&readNum, 1)
-	// 		if err != nil || cnt%100 == 0 {
-	// 			glog.Infof("Got lin read for id: %d with err: %v. Num: %d. Expected: %d\n", n.Id, err, cnt, 2*time.Since(start)/dur)
-	// 		}
-	// 	}
-	// }
-	// go getRead()
-	// go getRead()
-
 	// We only stop runReadIndexLoop after the for loop below has finished interacting with it.
 	// That way we know sending to readStateCh will not deadlock.
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -674,8 +674,6 @@ func (n *node) trySnapshot(skip uint64) {
 func (n *node) Run() {
 	var leader bool
 	licenseApplied := false
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
 
 	// snapshot can cause select loop to block while deleting entries, so run
 	// it in goroutine
@@ -696,6 +694,22 @@ func (n *node) Run() {
 		closer.AddRunning(1)
 		go x.StoreSync(n.Store, closer)
 	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				n.Raft().Tick()
+			case <-n.closer.HasBeenClosed():
+				return
+			}
+		}
+	}()
 
 	// var readNum uint64
 	// getRead := func() {
@@ -722,10 +736,11 @@ func (n *node) Run() {
 	for {
 		select {
 		case <-n.closer.HasBeenClosed():
+			wg.Wait() // Wait to stop ticking.
 			n.Raft().Stop()
 			return
-		case <-ticker.C:
-			n.Raft().Tick()
+		// case <-ticker.C:
+		// 	n.Raft().Tick()
 		case rd := <-n.Raft().Ready():
 			num++
 			if num%1000 == 0 {

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -718,7 +718,6 @@ func (n *node) Run() {
 	// That way we know sending to readStateCh will not deadlock.
 
 	var timer x.Timer
-	var num uint64
 	for {
 		select {
 		case <-n.closer.HasBeenClosed():
@@ -727,11 +726,6 @@ func (n *node) Run() {
 		case <-ticker.C:
 			n.Raft().Tick()
 		case rd := <-n.Raft().Ready():
-			num++
-			if num%1000 == 0 {
-				glog.Infof("Got ready for id: %d: %d\n", n.Id, num)
-			}
-
 			timer.Start()
 			_, span := otrace.StartSpan(n.ctx, "Zero.RunLoop",
 				otrace.WithSampler(otrace.ProbabilitySampler(0.001)))

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -579,6 +579,7 @@ func (n *node) initAndStartNode() error {
 
 	go n.Run()
 	go n.BatchAndSendMessages()
+	go n.ReportRaftComms()
 	return nil
 }
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -696,7 +696,6 @@ func (n *node) Run() {
 		closer.AddRunning(1)
 		go x.StoreSync(n.Store, closer)
 	}
-
 	// We only stop runReadIndexLoop after the for loop below has finished interacting with it.
 	// That way we know sending to readStateCh will not deadlock.
 

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -568,6 +568,8 @@ func (w *DiskStorage) NumEntries() (int, error) {
 }
 
 func (w *DiskStorage) allEntries(lo, hi, maxSize uint64) (es []raftpb.Entry, rerr error) {
+	w.elog.Printf("AllEntries")
+	defer w.elog.Printf("Done")
 	err := w.db.View(func(txn *badger.Txn) error {
 		if hi-lo == 1 { // We only need one entry.
 			item, err := txn.Get(w.EntryKey(lo))

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -568,8 +568,6 @@ func (w *DiskStorage) NumEntries() (int, error) {
 }
 
 func (w *DiskStorage) allEntries(lo, hi, maxSize uint64) (es []raftpb.Entry, rerr error) {
-	w.elog.Printf("AllEntries")
-	defer w.elog.Printf("Done")
 	err := w.db.View(func(txn *badger.Txn) error {
 		if hi-lo == 1 { // We only need one entry.
 			item, err := txn.Get(w.EntryKey(lo))

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -41,6 +41,7 @@ type DiskStorage struct {
 	db   *badger.DB
 	id   uint64
 	gid  uint32
+	span *otrace.Span
 	elog trace.EventLog
 
 	cache          *sync.Map
@@ -68,6 +69,7 @@ func Init(db *badger.DB, id uint64, gid uint32) *DiskStorage {
 	go w.processIndexRange()
 
 	w.elog = trace.NewEventLog("Badger", "RaftStorage")
+	w.span = otrace.FromContext(context.Background())
 
 	snap, err := w.Snapshot()
 	x.Check(err)
@@ -570,8 +572,8 @@ func (w *DiskStorage) NumEntries() (int, error) {
 }
 
 func (w *DiskStorage) allEntries(lo, hi, maxSize uint64) (es []raftpb.Entry, rerr error) {
-	_, span := otrace.StartSpan(context.Background(), "raftwal.AllEntries")
-	defer span.End()
+	w.span.Annotatef(nil, "Started allEntries")
+	defer w.span.Annotatef(nil, "Done allEntries")
 	err := w.db.View(func(txn *badger.Txn) error {
 		if hi-lo == 1 { // We only need one entry.
 			item, err := txn.Get(w.EntryKey(lo))


### PR DESCRIPTION
When logging in v=3, the Zero heartbeat logs would show 0 heartbeats even when the quorum is healthy:

    RaftComm: [0x1] Heartbeats out: 0, in: 0

This change fixes the reporting for Zero instances by calling ReportRaftComms in Zero:

    RaftComm: [0x1] Heartbeats out: 28, in: 28

Also, this adds a log for read index to check for healthiness for read index calls.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6538)
<!-- Reviewable:end -->
