### PR TITLE
feat(bulk): Allow encrypted input with unencrypted output in bulk.

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -67,6 +67,7 @@ type options struct {
 	NewUids          bool
 	ClientDir        string
 	Encrypted        bool
+	EncryptedOut     bool
 
 	MapShards    int
 	ReduceShards int

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -142,12 +142,17 @@ func (r *reducer) createBadgerInternal(dir string, compression bool) *badger.DB 
 		}
 	}
 
+	key := r.opt.EncryptionKey
+	if !r.opt.EncryptedOut {
+		key = nil
+	}
+
 	opt := badger.DefaultOptions(dir).
 		WithSyncWrites(false).
 		WithTableLoadingMode(bo.MemoryMap).
 		WithValueThreshold(1 << 10 /* 1 KB */).
 		WithLogger(nil).
-		WithEncryptionKey(r.opt.EncryptionKey).
+		WithEncryptionKey(key).
 		WithBlockCacheSize(r.opt.BlockCacheSize).
 		WithIndexCacheSize(r.opt.IndexCacheSize)
 

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -61,10 +61,10 @@ func init() {
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
 		"Flag to indicate whether schema and data files are encrypted. "+
-			"Must be specified with --encryption_key_file or vault options.")
+			"Must be specified with --encryption_key_file or vault option(s).")
 	flag.Bool("encrypted_out", false,
 		"Flag to indicate whether to encrypt the output. "+
-			"Must be specified with --encryption_key_file or vault options.")
+			"Must be specified with --encryption_key_file or vault option(s).")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -180,10 +180,10 @@ func run() {
 		requiredFlags := Bulk.Cmd.Flags().Changed("encrypted") &&
 			Bulk.Cmd.Flags().Changed("encrypted_out")
 		if !requiredFlags {
-			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted_out.\n")
+			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted_out when providing encryption key.\n")
 			os.Exit(1)
 		}
-		if !opt.Encrypted || !opt.EncryptedOut {
+		if !opt.Encrypted && !opt.EncryptedOut {
 			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true when providing encryption key.\n")
 			os.Exit(1)
 		}

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -60,9 +60,11 @@ func init() {
 	flag.String("format", "",
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
-		"Flag to indicate whether schema and data files are encrypted.")
+		"Flag to indicate whether schema and data files are encrypted." + 
+		"Must be specified with --encryption_key_file or vault options")
 	flag.Bool("encrypted_out", false,
-		"Flag to indicate whether to encrypt the output.")
+		"Flag to indicate whether to encrypt the output." + 
+		"Must be specified with --encryption_key_file or vault option.")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -169,18 +171,27 @@ func run() {
 		fmt.Printf("unable to read key %v", err)
 		return
 	}
-	if len(opt.EncryptionKey) > 0 && !opt.Encrypted && !opt.EncryptedOut {
-		opt.Encrypted = true
-		opt.EncryptedOut = true
+
+	if len(opt.EncryptionKey) == 0 {
+		if opt.Encrypted || opt.EncryptedOut {
+			fmt.Fprint(os.Stderr, "Must use --encryption_key_file or vault option(s).\n")
+			os.Exit(1)
+		}
+	} else {
+		requiredFlags := Bulk.Cmd.Flags().Changed("encrypted") &&
+			Bulk.Cmd.Flags().Changed("encrypted_out")
+		if !requiredFlags {
+			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted_out.\n")
+			os.Exit(1)
+		}
+		if !opt.Encrypted || !opt.EncryptedOut {
+			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true.\n")
+			os.Exit(1)
+		}
 	}
-	if opt.Encrypted && len(opt.EncryptionKey) == 0 {
-		fmt.Printf("Must use --encryption_key_file or vault option(s) with --encrypted option.\n")
-		os.Exit(1)
-	}
-	if opt.EncryptedOut && len(opt.EncryptionKey) == 0 {
-		fmt.Printf("Must use --encryption_key_file or vault option(s) with --encrypted_out option.\n")
-		os.Exit(1)
-	}
+
+	fmt.Printf("Input is encrytped? %v, Output will be encrypted? %v\n", opt.Encrypted, opt.EncryptedOut)
+
 	if opt.SchemaFile == "" {
 		fmt.Fprint(os.Stderr, "Schema file must be specified.\n")
 		os.Exit(1)

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -61,6 +61,8 @@ func init() {
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
 		"Flag to indicate whether schema and data files are encrypted.")
+	flag.Bool("encrypted_out", false,
+		"Flag to indicate whether to encrypt the output.")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -122,6 +124,7 @@ func run() {
 		SchemaFile:       Bulk.Conf.GetString("schema"),
 		GqlSchemaFile:    Bulk.Conf.GetString("graphql_schema"),
 		Encrypted:        Bulk.Conf.GetBool("encrypted"),
+		EncryptedOut:     Bulk.Conf.GetBool("encrypted_out"),
 		OutDir:           Bulk.Conf.GetString("out"),
 		ReplaceOutDir:    Bulk.Conf.GetBool("replace_out"),
 		TmpDir:           Bulk.Conf.GetString("tmp"),
@@ -166,8 +169,16 @@ func run() {
 		fmt.Printf("unable to read key %v", err)
 		return
 	}
+	if len(opt.EncryptionKey) > 0 && !opt.Encrypted && !opt.EncryptedOut {
+		fmt.Printf("Must use --encrypted/--encrypted_out with --encryption_key_file option.\n")
+		os.Exit(1)		
+	} 
 	if opt.Encrypted && len(opt.EncryptionKey) == 0 {
 		fmt.Printf("Must use --encryption_key_file or vault option(s) with --encrypted option.\n")
+		os.Exit(1)
+	}
+	if opt.EncryptedOut && len(opt.EncryptionKey) == 0 {
+		fmt.Printf("Must use --encryption_key_file or vault option(s) with --encrypted_out option.\n")
 		os.Exit(1)
 	}
 	if opt.SchemaFile == "" {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -60,11 +60,11 @@ func init() {
 	flag.String("format", "",
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
-		"Flag to indicate whether schema and data files are encrypted." + 
-		"Must be specified with --encryption_key_file or vault options")
+		"Flag to indicate whether schema and data files are encrypted. "+
+			"Must be specified with --encryption_key_file or vault options.")
 	flag.Bool("encrypted_out", false,
-		"Flag to indicate whether to encrypt the output." + 
-		"Must be specified with --encryption_key_file or vault option.")
+		"Flag to indicate whether to encrypt the output. "+
+			"Must be specified with --encryption_key_file or vault options.")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -171,7 +171,6 @@ func run() {
 		fmt.Printf("unable to read key %v", err)
 		return
 	}
-
 	if len(opt.EncryptionKey) == 0 {
 		if opt.Encrypted || opt.EncryptedOut {
 			fmt.Fprint(os.Stderr, "Must use --encryption_key_file or vault option(s).\n")
@@ -185,12 +184,11 @@ func run() {
 			os.Exit(1)
 		}
 		if !opt.Encrypted || !opt.EncryptedOut {
-			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true.\n")
+			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true when providing encryption key.\n")
 			os.Exit(1)
 		}
 	}
-
-	fmt.Printf("Input is encrytped? %v, Output will be encrypted? %v\n", opt.Encrypted, opt.EncryptedOut)
+	fmt.Printf("Input Encrypted: %v; Output Encrypted: %v\n", opt.Encrypted, opt.EncryptedOut)
 
 	if opt.SchemaFile == "" {
 		fmt.Fprint(os.Stderr, "Schema file must be specified.\n")

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -170,9 +170,9 @@ func run() {
 		return
 	}
 	if len(opt.EncryptionKey) > 0 && !opt.Encrypted && !opt.EncryptedOut {
-		fmt.Printf("Must use --encrypted/--encrypted_out with --encryption_key_file option.\n")
-		os.Exit(1)		
-	} 
+		opt.Encrypted = true
+		opt.EncryptedOut = true
+	}
 	if opt.Encrypted && len(opt.EncryptionKey) == 0 {
 		fmt.Printf("Must use --encryption_key_file or vault option(s) with --encrypted option.\n")
 		os.Exit(1)

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -188,7 +188,7 @@ func run() {
 			os.Exit(1)
 		}
 	}
-	fmt.Printf("Input Encrypted: %v; Output Encrypted: %v\n", opt.Encrypted, opt.EncryptedOut)
+	fmt.Printf("Encrypted input: %v; Encrypted output: %v\n", opt.Encrypted, opt.EncryptedOut)
 
 	if opt.SchemaFile == "" {
 		fmt.Fprint(os.Stderr, "Schema file must be specified.\n")


### PR DESCRIPTION
Fixes DGRAPH-2135

All UT pass.

This adds a new flag `--encrypted_out` to bulk loader. Now, when bulk loading with encryption input or output, you must set both the `--encrypted` and `--encrypted_out` flags along with the encryption key. Otherwise, it's an error.

For example, to bulk load encrypted input data and output unencrypted data:

    dgraph bulk -f g01.rdf.gz -s g01.schema.gz --encryption_key_file ./enc-key --encrypted=true --encrypted_out=false

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6541)
<!-- Reviewable:end -->
