### PR TITLE
docs: clarify how to turn off encryption with live loader

### DIFF
--- a/wiki/content/enterprise-features/encryption-at-rest.md
+++ b/wiki/content/enterprise-features/encryption-at-rest.md
@@ -21,7 +21,7 @@ encryption at rest as an enterprise feature. If encryption is enabled, Dgraph us
 algorithm to encrypt the data and secure it.
 
 Prior to v20.07.0, the encryption key file must be present on the local file system.
-Starting with [v20.07.0] (https://github.com/dgraph-io/dgraph/releases/tag/v20.07.0), 
+Starting with [v20.07.0] (https://github.com/dgraph-io/dgraph/releases/tag/v20.07.0),
 we have added support for encryption keys sitting on Vault servers. This allows an alternate
 way to configure the encryption keys needed for encrypting the data at rest.
 
@@ -38,7 +38,7 @@ desired key size):
 dd if=/dev/random bs=1 count=32 of=enc_key_file
 ```
 
-Alternatively, you can use the `--vault_*` options to enable encrption as explained below. 
+Alternatively, you can use the `--vault_*` options to enable encrption as explained below.
 
 ## Turn on Encryption
 
@@ -76,8 +76,11 @@ restart successfully.
 
 ## Turn off Encryption
 
-If you wish to turn off encryption from an existing Alpha, then you can export your data and import it
-into a new Dgraph instance without encryption enabled.
+If you wish to turn off encryption from an existing Alpha, then you can export your data and import it (using [live loader](https://dgraph.io/docs/deploy/fast-data-loading/#live-loader) into a new Dgraph instance without encryption enabled. You will have to use the `--encryption_key_file` flag while importing.
+
+```
+dgraph live -f <path-to-gzipped-RDF-or-JSON-file> -s <path-to-schema> --encryption_key_file <path-to-enc_key_file> -a <dgraph-alpha-address:grpc_port> -z <dgraph-zero-address:grpc_port>
+```
 
 ## Change Encryption Key
 


### PR DESCRIPTION
Currently, docs state the following about turning of encryption:

> If you wish to turn off encryption from an existing Alpha, then you can export your data and import it into a new Dgraph instance without encryption enabled.

This is not enough clear, therefore this doc PR to clarify that in this case, one has to load data with live loader and pass the `--encryption_key_file` + example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6548)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-57ddc7cbc1-95380.surge.sh)
<!-- Dgraph:end -->