### PR TITLE
fix(shutdown): Fix negative waitgroup error

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -1089,8 +1089,6 @@ func (g *groupi) askZeroForEE() bool {
 // SubscribeForUpdates will listen for updates for the given group.
 func SubscribeForUpdates(prefixes [][]byte, cb func(kvs *badgerpb.KVList), group uint32,
 	closer *z.Closer) {
-	defer closer.Done()
-
 	var prefix []byte
 	if len(prefixes) > 0 {
 		prefix = prefixes[0]


### PR DESCRIPTION
Fixes DGRAPH-2466

We were calling closer.Done() twice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6551)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b524e3fdc5-95420.surge.sh)
<!-- Dgraph:end -->