### PR TITLE
Fix(GraphQL): fix object Linking with `hasInverse`

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -362,6 +362,7 @@ func RunAll(t *testing.T) {
 	t.Run("deep XID mutations", deepXIDMutations)
 	t.Run("three level xid", testThreeLevelXID)
 	t.Run("nested add mutation with @hasInverse", nestedAddMutationWithHasInverse)
+	t.Run("add mutation with @hasInverse overrides correctly", addMutationWithHasInverseOverridesCorrectly)
 	t.Run("error in multiple mutations", addMultipleMutationWithOneError)
 	t.Run("dgraph directive with reverse edge adds data correctly",
 		addMutationWithReverseDgraphEdge)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -3815,5 +3815,10 @@ func addMutationWithHasInverseOverridesCorrectly(t *testing.T) {
 		}
 	  }`
 	testutil.CompareJSON(t, expected, string(gqlResponse.Data))
-	deleteGqlType(t, "Country", map[string]interface{}{}, 4, nil)
+	filter := map[string]interface{}{"name": map[string]interface{}{"eq": "A country"}}
+	deleteCountry(t, filter, 1, nil)
+	filter = map[string]interface{}{"xcode": map[string]interface{}{"eq": "abc"}}
+	deleteState(t, filter, 1, nil)
+	filter = map[string]interface{}{"xcode": map[string]interface{}{"eq": "def"}}
+	deleteState(t, filter, 1, nil)
 }

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -3746,3 +3746,74 @@ func nestedAddMutationWithHasInverse(t *testing.T) {
 	// cleanup
 	deleteGqlType(t, "Person1", map[string]interface{}{}, 3, nil)
 }
+
+func addMutationWithHasInverseOverridesCorrectly(t *testing.T) {
+	params := &GraphQLParams{
+		Query: `mutation addCountry($input: [AddCountryInput!]!) {
+			addCountry(input: $input) {
+			  country {
+				name
+				states{
+				  xcode
+				  name
+				  country{
+					name
+				  }
+				}
+			  }
+			}
+		  }`,
+
+		Variables: map[string]interface{}{
+			"input": []interface{}{
+				map[string]interface{}{
+					"name": "A country",
+					"states": []interface{}{
+						map[string]interface{}{
+							"xcode": "abc",
+							"name":  "Alphabet",
+						},
+						map[string]interface{}{
+							"xcode": "def",
+							"name":  "Vowel",
+							"country": map[string]interface{}{
+								"name": "B country",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	gqlResponse := postExecutor(t, GraphqlURL, params)
+	RequireNoGQLErrors(t, gqlResponse)
+
+	expected := `{
+		"addCountry": {
+		  "country": [
+			{
+			  "name": "A country",
+			  "states": [
+				{
+				  "country": {
+					"name": "A country"
+				  },
+				  "name": "Alphabet",
+				  "xcode": "abc"
+				},
+				{
+				  "country": {
+					"name": "A country"
+				  },
+				  "name": "Vowel",
+				  "xcode": "def"
+				}
+			  ]
+			}
+		  ]
+		}
+	  }`
+	testutil.CompareJSON(t, expected, string(gqlResponse.Data))
+	deleteGqlType(t, "Country", map[string]interface{}{}, 4, nil)
+}

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -1600,7 +1600,7 @@
     {
       "auth": {
         "name": "A.N. Author",
-        "posts": [ { "postID": "0x456" } ]
+        "posts": [ { "postID": "0x456" }, {"title": "New Post", "author": {"name": "Abhimanyu"}} ]
       }
     }
   dgmutations:
@@ -1612,6 +1612,12 @@
           "Author.posts": [
             {
               "uid": "0x456",
+              "Post.author": { "uid": "_:Author1" }
+            },
+            {
+              "uid": "_:Post4",
+              "dgraph.type": "Post",
+              "Post.title": "New Post",
               "Post.author": { "uid": "_:Author1" }
             }
           ]

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -1716,21 +1716,7 @@
             {
               "uid": "uid(State3)",
               "State.country": { "uid": "_:Country1" }
-            }
-          ]
-        }
-      deletejson: |
-        [
-          {
-            "uid": "uid(Country4)",
-            "Country.states": [ { "uid": "uid(State3)" } ]
-          }
-        ]
-      cond: "@if(eq(len(State3), 1))"
-    - setjson: |
-        {
-          "uid" : "_:Country1",
-          "Country.states": [
+            },
             {
               "uid": "uid(State6)",
               "State.country": { "uid": "_:Country1" }
@@ -1740,11 +1726,15 @@
       deletejson: |
         [
           {
+            "uid": "uid(Country4)",
+            "Country.states": [ { "uid": "uid(State3)" } ]
+          },
+          {
             "uid": "uid(Country7)",
             "Country.states": [ { "uid": "uid(State6)" } ]
           }
         ]
-      cond: "@if(eq(len(State6), 1))"
+      cond: "@if(eq(len(State3), 1) AND eq(len(State6), 1))"
 
 - name: "Deep XID 4 level deep"
   gqlmutation: |

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -1616,7 +1616,7 @@
             },
             {
               "uid": "_:Post4",
-              "dgraph.type": "Post",
+              "dgraph.type": ["Post"],
               "Post.title": "New Post",
               "Post.author": { "uid": "_:Author1" }
             }
@@ -1653,13 +1653,19 @@
     {
       "inp": {
         "name": "A Country",
-        "states": [ { "code": "abc", "name": "Alphabet" } ]
+        "states": [
+          { "code": "abc", "name": "Alphabet" },
+          { "code": "def", "name": "Vowel", "country": { "name": "B country" } }
+        ]
       }
     }
 
   dgquery: |-
     query {
       State3 as State3(func: eq(State.code, "abc")) @filter(type(State)) {
+        uid
+      }
+      State6 as State6(func: eq(State.code, "def")) @filter(type(State)) {
         uid
       }
     }
@@ -1674,6 +1680,16 @@
           "uid": "_:State3"
         }
       cond: "@if(eq(len(State3), 0))"
+    - setjson: |
+        {
+          "State.code": "def",
+          "State.name": "Vowel",
+          "dgraph.type": [
+            "State"
+          ],
+          "uid": "_:State6"
+        }
+      cond: "@if(eq(len(State6), 0))"
 
   dgquerysec: |-
     query {
@@ -1682,6 +1698,12 @@
       }
       var(func: uid(State3)) {
         Country4 as State.country
+      }
+      State6 as State6(func: eq(State.code, "def")) @filter(type(State)) {
+        uid
+      }
+      var(func: uid(State6)) {
+        Country7 as State.country
       }
     }
   dgmutationssec:
@@ -1705,6 +1727,24 @@
           }
         ]
       cond: "@if(eq(len(State3), 1))"
+    - setjson: |
+        {
+          "uid" : "_:Country1",
+          "Country.states": [
+            {
+              "uid": "uid(State6)",
+              "State.country": { "uid": "_:Country1" }
+            }
+          ]
+        }
+      deletejson: |
+        [
+          {
+            "uid": "uid(Country7)",
+            "Country.states": [ { "uid": "uid(State6)" } ]
+          }
+        ]
+      cond: "@if(eq(len(State6), 1))"
 
 - name: "Deep XID 4 level deep"
   gqlmutation: |

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1064,6 +1064,10 @@ func rewriteObject(
 			// So for example if we had the addAuthor mutation which is also adding nested
 			// posts, then we add the link _:Post Post.author AuthorUID(srcUID) here.
 			addInverseLink(newObj, srcField, srcUID)
+			// If this object had an overwritten value for the inverse field, then we don't want to
+			// use that value as we have already added the link to the inverse field in the above
+			// function call with the parent of this object
+			deleteInverseObject(obj, srcField)
 		}
 	} else {
 		myUID = srcUID
@@ -1633,6 +1637,15 @@ func attachChild(res map[string]interface{}, parent schema.Type, child schema.Fi
 			[]interface{}{map[string]interface{}{"uid": childUID}}
 	} else {
 		res[parent.DgraphPredicate(child.Name())] = map[string]interface{}{"uid": childUID}
+	}
+}
+
+func deleteInverseObject(obj map[string]interface{}, srcField schema.FieldDefinition) {
+	if srcField != nil {
+		invField := srcField.Inverse()
+		if invField != nil && invField.Type().ListType() == nil {
+			delete(obj, invField.Name())
+		}
 	}
 }
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -996,6 +996,8 @@ func rewriteObject(
 		if xid != nil && xidString != "" {
 			xidFrag = asXIDReference(ctx, srcField, srcUID, typ, xid.Name(), xidString,
 				variable, withAdditionalDeletes, varGen, xidMetadata)
+			deleteInverseObject(obj, srcField)
+
 			if deepXID > 2 {
 				// Here we link the already existing node with an xid to the parent whose id is
 				// passed in srcUID. We do this linking only if there is a hasInverse relationship


### PR DESCRIPTION
Fixes GRAPHQL-335.

This PR fixes incorrect linking of objects with `hasInverse`. For example
For this schema, `type Country` has field `state` with `hasInverse` predicate.
```
type Country {
        id: ID!
        name: String! @search(by: [trigram, hash])
        states: [State] @hasInverse(field: country)
}

type State {
        id: ID!
        xcode: String! @id @search(by: [regexp])
        name: String!
	capital: String
	country: Country
}
```
And for the following mutation
```
mutation addCountry($input: [AddCountryInput!]!) {
			addCountry(input: $input) {
			  country {
				name
				states{
				  xcode
				  name
				  country{
					name
				  }
				}
			  }
			}
		  }
```
with `input`:
```
{
	"input": {
		"name": "A Country",
		"states": [
			{
				"xcode": "abc",
				"name": "Alphabet"
			},
			{
				"xcode": "def",
				"name": "Vowel",
				"country": {
					"name": "B country"
				}
			}
		]
	}
}
``` 
should result in 
```
{
		"addCountry": {
		  "country": [
			{
			  "name": "A country",
			  "states": [
				{
				  "country": {
					"name": "A country"
				  },
				  "name": "Alphabet",
				  "xcode": "abc"
				},
				{
				  "country": {
					"name": "A country"
				  },
				  "name": "Vowel",
				  "xcode": "def"
				}
			  ]
			}
		  ]
		}
	  }`
```
whereas the incorrect output was 
```
{
		"addCountry": {
		  "country": [
			{
			  "name": "A country",
			  "states": [
				{
				  "country": {
					"name": "A country"
				  },
				  "name": "Alphabet",
				  "xcode": "abc"
				},
				{
				  "country": {
					"name": "B country"
				  },
				  "name": "Vowel",
				  "xcode": "def"
				}
			  ]
			}
		  ]
		}
	  }`
```
This PR fixes this issue.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6557)
<!-- Reviewable:end -->
