### PR TITLE
Initialize posting list in moveToNextPart

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -184,6 +184,7 @@ func (it *pIterator) moveToNextPart() error {
 	}
 	it.plist = plist
 
+	it.uidPosting = &pb.Posting{}
 	it.dec = &codec.Decoder{Pack: it.plist.Pack}
 	// codec.SeekCurrent makes sure we skip returning afterUid during seek.
 	it.uids = it.dec.Seek(it.afterUid, codec.SeekCurrent)


### PR DESCRIPTION
If `deleteBelowTs` is not zero `it.uidPosting` won't be intialized in `pitr.init()`. This could cause panic when we are doing `pitr.posting()`. Our assumption was that `piter.valid()` would return false in such cases. This assumption might not always be true. If `it.uids` is empty, we try to move to next valid part of the list. In the function `moveToNextPart` we are intitializing many components of pIterator but not `uidPosting`. If `it.uids` is filled here, `piter.valid()` would become true and we
would end up into a panic at `pitr.posting()`.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6560)
<!-- Reviewable:end -->
