### PR TITLE
feat(mutations): Introducte mutatoinsNquadLimit

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -193,6 +193,8 @@ they form a Raft group and provide synchronous replication.
 	flag.Uint64("normalize_node_limit", 1e4,
 		"Limit for the maximum number of nodes that can be returned in a query that uses the "+
 			"normalize directive.")
+	flag.Uint64("mutations_nquad_limit", 1e6,
+		"Limit for the maximum number of nquads that can be inserted in a mutation request")
 
 	// TLS configurations
 	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
@@ -733,6 +735,7 @@ func run() {
 	x.Config.PortOffset = Alpha.Conf.GetInt("port_offset")
 	x.Config.QueryEdgeLimit = cast.ToUint64(Alpha.Conf.GetString("query_edge_limit"))
 	x.Config.NormalizeNodeLimit = cast.ToInt(Alpha.Conf.GetString("normalize_node_limit"))
+	x.Config.MutationsNQuadLimit = cast.ToInt(Alpha.Conf.GetString("mutations_nquad_limit"))
 	x.Config.PollInterval = Alpha.Conf.GetDuration("graphql_poll_interval")
 	x.Config.GraphqlExtension = Alpha.Conf.GetBool("graphql_extensions")
 	x.Config.GraphqlDebug = Alpha.Conf.GetBool("graphql_debug")

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -450,7 +450,9 @@ func (s *Server) doMutate(ctx context.Context, qc *queryContext, resp *api.Respo
 	}
 
 	// update mutations from the query results before assigning UIDs
-	updateMutations(qc)
+	if err := updateMutations(qc); err != nil {
+		return err
+	}
 
 	newUids, err := query.AssignUids(ctx, qc.gmuList)
 	if err != nil {
@@ -599,7 +601,7 @@ func buildUpsertQuery(qc *queryContext) string {
 // updateMutations updates the mutation and replaces uid(var) and val(var) with
 // their values or a blank node, in case of an upsert.
 // We use the values stored in qc.uidRes and qc.valRes to update the mutation.
-func updateMutations(qc *queryContext) {
+func updateMutations(qc *queryContext) error {
 	for i, condVar := range qc.condVars {
 		gmu := qc.gmuList[i]
 		if len(condVar) != 0 {
@@ -611,9 +613,15 @@ func updateMutations(qc *queryContext) {
 			}
 		}
 
-		updateUIDInMutations(gmu, qc)
-		updateValInMutations(gmu, qc)
+		if err := updateUIDInMutations(gmu, qc); err != nil {
+			return err
+		}
+		if err := updateValInMutations(gmu, qc); err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
 // findMutationVars finds all the variables used in mutation block and stores them
@@ -733,20 +741,26 @@ func updateValInNQuads(nquads []*api.NQuad, qc *queryContext, isSet bool) []*api
 
 		newNQuads = append(newNQuads, nq)
 	}
+	qc.nquadsCount += len(newNQuads)
 	return newNQuads
 }
 
 // updateValInMutations does following transformations:
 // 0x123 <amount> val(v) -> 0x123 <amount> 13.0
-func updateValInMutations(gmu *gql.Mutation, qc *queryContext) {
+func updateValInMutations(gmu *gql.Mutation, qc *queryContext) error {
 	gmu.Del = updateValInNQuads(gmu.Del, qc, false)
 	gmu.Set = updateValInNQuads(gmu.Set, qc, true)
+	if qc.nquadsCount > x.Config.MutationsNQuadLimit {
+		return errors.Errorf("NQuad count in the request: %d, is more that threshold: %d",
+			qc.nquadsCount, x.Config.MutationsNQuadLimit)
+	}
+	return nil
 }
 
 // updateUIDInMutations does following transformations:
 //   * uid(v) -> 0x123     -- If v is defined in query block
 //   * uid(v) -> _:uid(v)  -- Otherwise
-func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) {
+func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) error {
 	// usedMutationVars keeps track of variables that are used in mutations.
 	getNewVals := func(s string) []string {
 		if strings.HasPrefix(s, "uid(") {
@@ -788,9 +802,15 @@ func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) {
 				}
 
 				gmuDel = append(gmuDel, getNewNQuad(nq, s, o))
+				qc.nquadsCount++
+			}
+			if qc.nquadsCount > x.Config.MutationsNQuadLimit {
+				return errors.Errorf("NQuad count in the request: %d, is more that threshold: %d",
+					qc.nquadsCount, x.Config.MutationsNQuadLimit)
 			}
 		}
 	}
+
 	gmu.Del = gmuDel
 
 	// Update the values in mutation block from the query block.
@@ -799,6 +819,12 @@ func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) {
 		newSubs := getNewVals(nq.Subject)
 		newObs := getNewVals(nq.ObjectId)
 
+		qc.nquadsCount += len(newSubs) * len(newObs)
+		if qc.nquadsCount > x.Config.MutationsNQuadLimit {
+			return errors.Errorf("NQuad count in the request: %d, is more that threshold: %d",
+				qc.nquadsCount, x.Config.MutationsNQuadLimit)
+		}
+
 		for _, s := range newSubs {
 			for _, o := range newObs {
 				gmuSet = append(gmuSet, getNewNQuad(nq, s, o))
@@ -806,6 +832,7 @@ func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) {
 		}
 	}
 	gmu.Set = gmuSet
+	return nil
 }
 
 // queryContext is used to pass around all the variables needed
@@ -836,6 +863,11 @@ type queryContext struct {
 	span *trace.Span
 	// graphql indicates whether the given request is from graphql admin or not.
 	graphql bool
+	// nquadsCount maintains numbers of nquads which would be inserted as part of this request.
+	// In some cases(mostly upserts), numbers of nquads to be inserted can to huge(we have seen upto
+	// 1B) and resulting in OOM. We are limiting number of nquads which can be inserted in
+	// a single request.
+	nquadsCount int
 }
 
 // Health handles /health and /health?all requests.

--- a/x/config.go
+++ b/x/config.go
@@ -30,6 +30,9 @@ type Options struct {
 	QueryEdgeLimit uint64
 	// NormalizeNodeLimit is the maximum number of nodes allowed in a normalize query.
 	NormalizeNodeLimit int
+	// MutationsNQuadLimit is maximum number of nquads that can be present in a single
+	// mutation request.
+	MutationsNQuadLimit int
 	// PollInterval is the polling interval for graphql subscription.
 	PollInterval time.Duration
 	// GraphqlExtension will be set to see extensions in graphql results


### PR DESCRIPTION
Currently we don't have any limitation on number of NQuads that can be present in single mutations request.
This is creating OOM issues in some case. Specially in case of upserts, where we combine results from queries and use them
in mutations. In some case we have seen numbers of NQuads after expansion to be as large as 1 billion.
This PR introduces as way to limit those via option called `mutations_nquad_limit`. Default value for it is 1M.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6561)
<!-- Reviewable:end -->
