### PR TITLE
chore(contrib): Expose pprof in bank test.

### DIFF
--- a/contrib/integration/bank/main.go
+++ b/contrib/integration/bank/main.go
@@ -27,6 +27,8 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"net/http"
+	_ "net/http/pprof" // http profiler
 	"sort"
 	"strings"
 	"sync"
@@ -49,6 +51,8 @@ var (
 	verbose    = flag.Bool("verbose", true, "Output all logs in verbose mode.")
 	login      = flag.Bool("login", true, "Login as groot. Used for ACL-enabled cluster.")
 	slashToken = flag.String("slash-token", "", "Slash GraphQL API token")
+	debugHttp  = flag.String("http", "localhost:6060",
+		"Address to serve http (pprof).")
 )
 
 var startBal = 10
@@ -340,6 +344,10 @@ func grpcConnection(one string) (*grpc.ClientConn, error) {
 
 func main() {
 	flag.Parse()
+	go func() {
+		log.Printf("Listening for /debug HTTP requests at address: %v\n", *debugHttp)
+		log.Fatal(http.ListenAndServe(*debugHttp, nil))
+	}()
 
 	all := strings.Split(*alpha, ",")
 	x.AssertTrue(len(all) > 0)


### PR DESCRIPTION
This exposes an HTTP port for pprof information in the bank test. This is configurable via the `-http` config option. By default, it is set to localhost:6060.

When the bank test starts, it will first log the address/port for pprof:

```
2020/09/23 14:25:06 Listening for /debug HTTP requests at address: localhost:6060
```

Using `go tool pprof`, you can collect pprof information during the bank test.

CPU profile for 10 seconds (save to file and spit out `-text` output):

```text
$ go tool pprof -text 'localhost:6060/debug/pprof/profile?seconds=10s'       
Fetching profile over HTTP from http://localhost:6060/debug/pprof/profile?seconds=10s
Saved profile in /home/dmai/pprof/pprof.bank.samples.cpu.002.pb.gz
File: bank
Build ID: f273cd7e6dbe3988ad3ec0c578ea5a2ca0d22640
Type: cpu
Time: Sep 23, 2020 at 2:45pm (PDT)
Duration: 30s, Total samples = 2.20s ( 7.33%)
Showing nodes accounting for 1.84s, 83.64% of 2.20s total
...
```

CPU profile for 30 seconds (default) (interactive pprof shell):
<pre>
$ <strong>go tool pprof localhost:6060/debug/pprof/profile</strong>
Fetching profile over HTTP from http://localhost:6060/debug/pprof/profile
<strong>Saved profile in /home/dmai/pprof/pprof.bank.samples.cpu.001.pb.gz</strong>
File: bank
Build ID: f273cd7e6dbe3988ad3ec0c578ea5a2ca0d22640
Type: cpu
Time: Sep 23, 2020 at 2:25pm (PDT)
Duration: 30.04s, Total samples = 3.97s (13.21%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) <strong>top</strong>
Showing nodes accounting for 2380ms, 59.95% of 3970ms total
Dropped 105 nodes (cum <= 19.85ms)
Showing top 10 nodes out of 218
      flat  flat%   sum%        cum   cum%
     680ms 17.13% 17.13%      870ms 21.91%  syscall.Syscall
     600ms 15.11% 32.24%      600ms 15.11%  runtime.futex
     320ms  8.06% 40.30%      320ms  8.06%  runtime.epollwait
     250ms  6.30% 46.60%      250ms  6.30%  runtime.usleep
     150ms  3.78% 50.38%      150ms  3.78%  runtime.runqgrab
     140ms  3.53% 53.90%     1110ms 27.96%  runtime.findrunnable
      80ms  2.02% 55.92%      100ms  2.52%  runtime.heapBitsSetType
      60ms  1.51% 57.43%       60ms  1.51%  runtime.lock
      60ms  1.51% 58.94%      420ms 10.58%  runtime.netpoll
      40ms  1.01% 59.95%       50ms  1.26%  encoding/json.indirect
(pprof) <strong>list runTransaction</strong>
Total: 3.97s
ROUTINE ======================== main.(*state).runTransaction in /home/dmai/go/src/github.com/dgraph-io/dgraph/contrib/integration/bank/main.go
         0      280ms (flat, cum)  7.05% of Total
         .          .    210:		if sk != sd {
         .          .    211:			break
         .          .    212:		}
         .          .    213:	}
         .          .    214:
         .       80ms    215:	src, err := s.findAccount(txn, sk)
         .          .    216:	if err != nil {
         .          .    217:		return err
         .          .    218:	}
         .       40ms    219:	dst, err := s.findAccount(txn, sd)
...
</pre>

You can also fetch the profiling information via curl and inspect it later via `go tool pprof`:

CPU profile:
```sh
$ curl -o cpu.pprof http://localhost:6060/debug/pprof/profile
```
```sh
$ go tool pprof ./cpu.pprof
```

Memory profile:
```
$ curl -o heap.pprof http://localhost:6060/debug/pprof/heap
```
```sh
$ go tool pprof ./heap.pprof
```

More info:
https://blog.golang.org/pprof
https://dgraph.io/docs/howto/retrieving-debug-information/#profiling-information

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6563)
<!-- Reviewable:end -->
