### PR TITLE
feat(GraphQL): Support authorization with jwk_url

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,5 +72,6 @@ require (
 	google.golang.org/grpc v1.23.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.13.1 // indirect
 	gopkg.in/ini.v1 v1.48.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -206,7 +206,6 @@ func SetAuthMeta(m *AuthMeta) {
 	authMeta.Algo = m.Algo
 	authMeta.Audience = m.Audience
 	authMeta.ticker.Reset(m.RefreshTime)
-
 }
 
 // AttachAuthorizationJwt adds any incoming JWT authorization data into the grpc context metadata.
@@ -316,7 +315,6 @@ func validateJWTCustomClaims(jwtStr string) (*CustomClaims, error) {
 			}, jwt.WithoutAudienceValidation())
 
 	} else {
-
 		if authMeta.Algo == "" {
 			return nil, fmt.Errorf(
 				"jwt token cannot be validated because verification algorithm is not set")
@@ -343,7 +341,6 @@ func validateJWTCustomClaims(jwtStr string) (*CustomClaims, error) {
 				}
 				return nil, errors.Errorf("couldn't parse signing method from token header: %s", algo)
 			}, jwt.WithoutAudienceValidation())
-
 	}
 
 	if err != nil {
@@ -421,7 +418,6 @@ func (a *AuthMeta) RefreshJWK() {
 				}
 				time.Sleep(60 * time.Second)
 			}
-
 		}
 	}
 }

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -406,6 +406,7 @@ func (a *AuthMeta) fetchJWKs() error {
 // Refresh the JWKs on ticking the Ticker, but only if the
 // RefreshTime is non-zero, else stop.
 func (a *AuthMeta) RefreshJWK() {
+	// If there is no jwkUrl then just return
 	if a.JWKUrl == "" {
 		return
 	}
@@ -413,6 +414,8 @@ func (a *AuthMeta) RefreshJWK() {
 	for {
 		select {
 		case <-a.ticker.C:
+			// refreshTime = 0 means that we couldn't parse any valid value for token
+			// expiry time. In that case, it just ends the process of regular refresh
 			if a.refreshTime == 0 {
 				return
 			}

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -73,7 +73,7 @@ func (a *AuthMeta) validate() error {
 	// they are needed only if JWKUrl is not present there.
 	if a.JWKUrl != "" {
 		if a.VerificationKey != "" || a.Algo != "" {
-			return fmt.Errorf("Expecting either JWKUrl or (VerificationKey, Algo), both were given")
+			return fmt.Errorf("expecting either JWKUrl or (VerificationKey, Algo), both were given")
 		}
 	} else {
 		if a.VerificationKey == "" {
@@ -387,12 +387,15 @@ func (a *AuthMeta) FetchJWKs() error {
 	}
 	a.jwkSet = &jose.JSONWebKeySet{Keys: make([]jose.JSONWebKey, len(jwkArray.JWKs))}
 	for i, jwk := range jwkArray.JWKs {
-		a.jwkSet.Keys[i].UnmarshalJSON(jwk)
+		err = a.jwkSet.Keys[i].UnmarshalJSON(jwk)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Try to Parse the Remaining time in the expiry of signing keys
 	// from the `max-age` directive in the `Cache-Control` Header
-	maxAge := int64(0)
+	var maxAge int64
 
 	if resp.Header["Cache-Control"] != nil {
 		maxAge, err = ParseMaxAge(resp.Header["Cache-Control"][0])

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -398,30 +398,18 @@ func (a *AuthMeta) fetchJWKs() error {
 		maxAge, err = ParseMaxAge(resp.Header["Cache-Control"][0])
 	}
 	a.RefreshTime = time.Duration(maxAge) * time.Second
-	// // Reinitialise ticker if get a non zero maxAge value which
-	// // means we need to refresh the JWK keys
-	// if maxAge != 0 {
-	// 	if a.ticker == nil {
-	// 		a.ticker = time.NewTicker(a.RefreshTime)
-	// 	} else {
-	// 		a.ticker.Reset(a.RefreshTime)
-	// 	}
-	// 	fmt.Println("Ticker changed")
-	// }
 	return nil
 }
 
 // Refresh the JWKs on ticking the Ticker, but only if the
-// RefreshTime is non-zero, else skip.
+// RefreshTime is non-zero, else stop.
 func (a *AuthMeta) RefreshJWK() {
 	for {
 		select {
 		case <-a.ticker.C:
-			fmt.Println("Tick Tick")
 			if a.RefreshTime == 0 {
-				continue
+				return
 			}
-
 			// Try to Continuosly Refetch the Keys until it doesn't result in error
 			// Take a minute's gap in refetching after a failure.
 			for {
@@ -439,10 +427,6 @@ func (a *AuthMeta) RefreshJWK() {
 }
 
 func init() {
-	// Initialize ticker to a High Value
-	fmt.Println("ticker Init := ", authMeta.ticker)
 	authMeta.ticker = time.NewTicker(10 * time.Second)
-	fmt.Println(authMeta.ticker)
-	fmt.Println("Ticker Defined")
 	go authMeta.RefreshJWK()
 }

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -205,7 +205,9 @@ func SetAuthMeta(m *AuthMeta) {
 	authMeta.Namespace = m.Namespace
 	authMeta.Algo = m.Algo
 	authMeta.Audience = m.Audience
-	authMeta.ticker = time.NewTicker(m.refreshTime)
+	if m.refreshTime > 0 {
+		authMeta.ticker = time.NewTicker(m.refreshTime)
+	}
 }
 
 // AttachAuthorizationJwt adds any incoming JWT authorization data into the grpc context metadata.

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -205,7 +205,7 @@ func SetAuthMeta(m *AuthMeta) {
 	authMeta.Namespace = m.Namespace
 	authMeta.Algo = m.Algo
 	authMeta.Audience = m.Audience
-	authMeta.ticker.Reset(m.refreshTime)
+	authMeta.ticker = time.NewTicker(m.refreshTime)
 }
 
 // AttachAuthorizationJwt adds any incoming JWT authorization data into the grpc context metadata.

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -54,7 +54,7 @@ var (
 type AuthMeta struct {
 	VerificationKey string
 	JWKUrl          string
-	JWKSet          jose.JSONWebKeySet
+	JWKSet          *jose.JSONWebKeySet
 	RSAPublicKey    *rsa.PublicKey `json:"-"` // Ignoring this field
 	Header          string
 	Namespace       string
@@ -155,7 +155,7 @@ func ParseAuthMeta(schema string) (*AuthMeta, error) {
 		return nil, err
 	}
 
-	// fetch and Store the
+	// fetch and Store the keys from JWKUrl
 	if metaInfo.JWKUrl != "" {
 		metaInfo.JWKSet, err = fetchJWKs(metaInfo.JWKUrl)
 		if err != nil {
@@ -357,15 +357,15 @@ func validateJWTCustomClaims(jwtStr string) (*CustomClaims, error) {
 	return claims, nil
 }
 
-func fetchJWKs(jwkUrl string) (jose.JSONWebKeySet, error) {
+func fetchJWKs(jwkUrl string) (*jose.JSONWebKeySet, error) {
 	req, err := http.NewRequest("GET", jwkUrl, nil)
 	if err != nil {
-		return jose.JSONWebKeySet{}, err
+		return nil, err
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return jose.JSONWebKeySet{}, err
+		return nil, err
 	}
 
 	data, _ := ioutil.ReadAll(resp.Body)
@@ -381,5 +381,5 @@ func fetchJWKs(jwkUrl string) (jose.JSONWebKeySet, error) {
 	for i, jwk := range jwkArray.JWKs {
 		keySet.Keys[i].UnmarshalJSON(jwk)
 	}
-	return keySet, nil
+	return &keySet, nil
 }

--- a/graphql/authorization/utils.go
+++ b/graphql/authorization/utils.go
@@ -8,23 +8,24 @@ import (
 	"github.com/pkg/errors"
 )
 
-func ParseMaxAge(CacheControlHeaderStr string) (int, error) {
+func ParseMaxAge(CacheControlHeaderStr string) (int64, error) {
 	splittedHeaderStr := strings.Split(CacheControlHeaderStr, ",")
 	for _, str := range splittedHeaderStr {
 		strTrimSpace := strings.TrimSpace(str)
 		if strings.HasPrefix(strTrimSpace, "max-age") || strings.HasPrefix(strTrimSpace, "s-maxage") {
-			return strconv.Atoi(strings.Split(str, "=")[1])
+			maxAge, err := strconv.Atoi(strings.Split(str, "=")[1])
+			return int64(maxAge), err
 		}
 	}
 	return 0, errors.Errorf("Couldn't Parse max-age")
 }
 
-func ParseExpires(ExpiresHeaderStr string) (int, error) {
+func ParseExpires(ExpiresHeaderStr string) (int64, error) {
 	expDate, err := time.Parse(time.RFC1123, ExpiresHeaderStr)
 	if err != nil {
 		return 0, err
 	}
 	currDate := time.Now().Round(time.Second)
 	diff := expDate.Sub(currDate).Seconds()
-	return int(diff), nil
+	return int64(diff), nil
 }

--- a/graphql/authorization/utils.go
+++ b/graphql/authorization/utils.go
@@ -1,0 +1,30 @@
+package authorization
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func ParseMaxAge(CacheControlHeaderStr string) (int, error) {
+	splittedHeaderStr := strings.Split(CacheControlHeaderStr, ",")
+	for _, str := range splittedHeaderStr {
+		strTrimSpace := strings.TrimSpace(str)
+		if strings.HasPrefix(strTrimSpace, "max-age") || strings.HasPrefix(strTrimSpace, "s-maxage") {
+			return strconv.Atoi(strings.Split(str, "=")[1])
+		}
+	}
+	return 0, errors.Errorf("Couldn't Parse max-age")
+}
+
+func ParseExpires(ExpiresHeaderStr string) (int, error) {
+	expDate, err := time.Parse(time.RFC1123, ExpiresHeaderStr)
+	if err != nil {
+		return 0, err
+	}
+	currDate := time.Now().Round(time.Second)
+	diff := expDate.Sub(currDate).Seconds()
+	return int(diff), nil
+}

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -260,7 +260,6 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 	authSchema, err := testutil.AppendAuthInfoWithJWKUrl(sch)
 	require.NoError(t, err)
 	test.LoadSchemaFromString(t, string(authSchema))
-	testutil.SetAuthMeta(string(authSchema))
 
 	// Verify that authorization information is set correctly.
 	metainfo := authorization.GetAuthMeta()
@@ -274,7 +273,7 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 		name  string
 		token string
 	}{
-		name:  `Token without expiry value`,
+		name:  `Expired Token`,
 		token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE2NzUwM2UwYWVjNTJkZGZiODk2NTIxYjkxN2ZiOGUyMGMxZjMzMDAiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZmlyLXByb2plY3QxLTI1OWU3IiwiYXVkIjoiZmlyLXByb2plY3QxLTI1OWU3IiwiYXV0aF90aW1lIjoxNjAxNDQ0NjM0LCJ1c2VyX2lkIjoiMTdHb3h2dU5CWlc5YTlKU3Z3WXhROFc0bjE2MyIsInN1YiI6IjE3R294dnVOQlpXOWE5SlN2d1l4UThXNG4xNjMiLCJpYXQiOjE2MDE0NDQ2MzQsImV4cCI6MTYwMTQ0ODIzNCwiZW1haWwiOiJtaW5oYWpAZGdyYXBoLmlvIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7ImVtYWlsIjpbIm1pbmhhakBkZ3JhcGguaW8iXX0sInNpZ25faW5fcHJvdmlkZXIiOiJwYXNzd29yZCJ9fQ.q5YmOzOUkZHNjlz53hgLNSVg-brIU9tLJ4jLC0_Xurl5wEbyZ6D_KQ9-UFqbl2HR6R1V5kpaf6eDFR3c83i1PpCbJ4LTjHAf_njQvL75ByERld23lZtKZyEeE6ujdFXL8ne4fI2qenD1Xeqx9AnXbLf7U_CvZpbX3l1wj7p0Lpn7qixi0AztuLSJMLkMfFpaiwyFZQivi4cqtnI25VIsK6a4KIpl1Sk0AHT-lv9PRadd_JDjWAIzD0SfhpZOskaeA9PljVMp-Y3Xscwg_Qc6u1MIBPg1jKO-ngjhWkgEWBoz5F836P7phT60LVBHhYuk-jRN6HSSNWQ3ineuN-jBkg",
 	}
 

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -223,9 +223,7 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
 	// then Fetch the JWKs from the JWKUrl
 	if metaInfo != nil && metaInfo.JWKUrl != "" {
-		metaInfo.Lock()
 		fetchErr := metaInfo.FetchJWKs()
-		metaInfo.Unlock()
 		if fetchErr != nil {
 			return nil, fetchErr
 		}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -223,9 +223,9 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
 	// then Fetch the JWKs from the JWKUrl
 	if metaInfo != nil && metaInfo.JWKUrl != "" {
-		metaInfo.RLock()
+		metaInfo.Lock()
 		fetchErr := metaInfo.FetchJWKs()
-		metaInfo.RUnlock()
+		metaInfo.Unlock()
 		if fetchErr != nil {
 			return nil, fetchErr
 		}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -220,6 +220,17 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 		return nil, gqlerror.Errorf("No query or mutation found in the generated schema")
 	}
 
+	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
+	// then Fetch the JWKs from the JWKUrl
+	if metaInfo != nil && metaInfo.JWKUrl != "" {
+		metaInfo.RLock()
+		fetchErr := metaInfo.FetchJWKs()
+		metaInfo.RUnlock()
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+	}
+
 	handler := &handler{
 		input:          input,
 		dgraphSchema:   dgSchema,

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1101,7 +1101,7 @@ func TestParseSecrets(t *testing.T) {
 			`,
 			nil,
 			"",
-			errors.New("required field missing in Dgraph.Authorization: `Verification key` `Header` `Namespace` `Algo`"),
+			errors.New("required field missing in Dgraph.Authorization: `Verification key`/`JWKUrl` `Algo` `Header` `Namespace`"),
 		},
 		{
 			"Valid Dgraph.Authorization with audience field",

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -239,7 +239,7 @@ func AppendJWKAndVerificationKey(schema []byte) ([]byte, error) {
 }
 
 func SetAuthMeta(strSchema string) *authorization.AuthMeta {
-	authMeta, err := authorization.ParseAuthMeta(strSchema)
+	authMeta, err := authorization.Parse(strSchema)
 	if err != nil {
 		panic(err)
 	}

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -20,11 +20,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"io/ioutil"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/dgraph/graphql/authorization"
 
 	"github.com/pkg/errors"
 
@@ -225,8 +226,20 @@ func AppendAuthInfo(schema []byte, algo, publicKeyFile string) ([]byte, error) {
 	return append(schema, []byte(authInfo)...), nil
 }
 
+func AppendAuthInfoWithJWKUrl(schema []byte) ([]byte, error) {
+	authInfo := `# Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7"]}`
+	return append(schema, []byte(authInfo)...), nil
+}
+
+// Add JWKUrl and (VerificationKey, Algo) in the same Authorization JSON
+// Adding Dummy values as this should result in validation error
+func AppendJWKAndVerificationKey(schema []byte) ([]byte, error) {
+	authInfo := `# Dgraph.Authorization {"VerificationKey":"some-key","Header":"X-Test-Auth","jwkurl":"some-url", "Namespace":"https://xyz.io/jwt/claims","Algo":"algo","Audience":["fir-project1-259e7"]}`
+	return append(schema, []byte(authInfo)...), nil
+}
+
 func SetAuthMeta(strSchema string) *authorization.AuthMeta {
-	authMeta, err := authorization.Parse(strSchema)
+	authMeta, err := authorization.ParseAuthMeta(strSchema)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes GRAPHQL-693.

This PR extends support for authorization with `jwk_url`. Now users can give `jwkUrl` for their project in the `Dgraph.Authorization` JSON in their schema.
```
#Dgraph.Authorization 
{"VerificationKey":"",
      "Header":"header",
     "Namespace":"your-namespace",
    "jwkurl": "your-jwk-url-",
    "Algo":"",
    "Audience":["your-audience"]
}
```

When `jwkurl` is provided, keep `VerificationKey` and `Algo` empty as they are not needed.


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6564)
<!-- Reviewable:end -->
