### PR TITLE
Fix(ACL) : Disallow deleting of groot user and guardians group

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -523,7 +523,7 @@ func ResetAcl(closer *z.Closer) {
 		}
 		atomic.StoreUint64(&x.GrootUserUid, grootUserUidUint)
 		glog.Infof("groot user uid: %d", grootUserUidUint)
-		glog.Infof("Successfully upserted groot user account")
+		glog.Infof("Successfully upserted groot account")
 		return nil
 	}
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -439,7 +439,7 @@ func ResetAcl(closer *z.Closer) {
 		var groupResp groupQryResp
 		var guardiansGroupUid string
 		if err := json.Unmarshal(resp.GetJson(), &groupResp); err != nil {
-			return errors.Wrap(err, "Couldn't unmarshal response from Guardians group query")
+			return errors.Wrap(err, "Couldn't unmarshal response from guardians group query")
 		}
 		if len(groupResp.GuardiansGroup) == 0 {
 			// no guardians group found
@@ -450,7 +450,7 @@ func ResetAcl(closer *z.Closer) {
 			// we found a guardians group
 			guardiansGroupUid = groupResp.GuardiansGroup[0].Uid
 		} else {
-			return errors.Wrap(err, "Multiple Guardians group found")
+			return errors.Wrap(err, "Multiple guardians group found")
 		}
 
 		guardiansGroupUidUint, err := strconv.ParseUint(guardiansGroupUid, 0, 64)
@@ -459,8 +459,8 @@ func ResetAcl(closer *z.Closer) {
 		}
 		x.GuardiansGroupUid.Store(guardiansGroupUidUint)
 
-		glog.Infof("Guardians group uid: %d", guardiansGroupUidUint)
-		glog.Infof("Successfully upserted the guardian group")
+		glog.Infof("guardians group uid: %d", guardiansGroupUidUint)
+		glog.Infof("Successfully upserted the guardians group")
 		return nil
 	}
 
@@ -500,7 +500,7 @@ func ResetAcl(closer *z.Closer) {
 		var grootUserUid string
 		var userResp userQryResp
 		if err := json.Unmarshal(resp.GetJson(), &userResp); err != nil {
-			return errors.Wrap(err, "Couldn't unmarshal response from Groot user group query")
+			return errors.Wrap(err, "Couldn't unmarshal response from groot user query")
 		}
 		if len(userResp.GrootUser) == 0 {
 			// no groot user found from query
@@ -516,11 +516,11 @@ func ResetAcl(closer *z.Closer) {
 
 		grootUserUidUint, err := strconv.ParseUint(grootUserUid, 0, 64)
 		if err != nil {
-			return errors.Wrapf(err, "Error while parsing Uid: %s of groot User", grootUserUid)
+			return errors.Wrapf(err, "Error while parsing Uid: %s of groot user", grootUserUid)
 		}
 		x.GrootUserUid.Store(grootUserUidUint)
 		glog.Infof("groot user uid: %d", grootUserUidUint)
-		glog.Infof("Successfully upserted groot account")
+		glog.Infof("Successfully upserted groot user account")
 		return nil
 	}
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -453,7 +453,6 @@ func ResetAcl(closer *z.Closer) {
 		}
 		atomic.StoreUint64(&x.GuardiansGroupUid, guardiansGroupUidUint)
 
-		glog.Infof("guardians group uid: %d", guardiansGroupUidUint)
 		glog.Infof("Successfully upserted the guardians group")
 		return nil
 	}
@@ -522,7 +521,7 @@ func ResetAcl(closer *z.Closer) {
 			return errors.Wrapf(err, "Error while parsing Uid: %s of groot user", grootUserUid)
 		}
 		atomic.StoreUint64(&x.GrootUserUid, grootUserUidUint)
-		glog.Infof("groot user uid: %d", grootUserUidUint)
+
 		glog.Infof("Successfully upserted groot account")
 		return nil
 	}

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -131,7 +131,7 @@ func deleteGroup(t *testing.T, accessToken, name string, confirmDeletion bool) *
 	return resp
 }
 
-func deleteUsingNQuad(userClient *dgo.Dgraph, sub string, pred string, val string) (*api.Response, error) {
+func deleteUsingNQuad(userClient *dgo.Dgraph, sub, pred, val string) (*api.Response, error) {
 	ctx := context.Background()
 	txn := userClient.NewTxn()
 	mutString := fmt.Sprintf("%s %s %s .", sub, pred, val)
@@ -3219,6 +3219,8 @@ func TestDeleteGrootUserShouldFail(t *testing.T) {
 		UserID:   x.GrootId,
 		Passwd:   "password",
 	})
+	require.NoError(t, err, "login failed")
+
 
 	resp := deleteUser(t, accessJwt, "groot", false)
 	require.Contains(t, resp.Errors.Error(),

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -83,7 +83,7 @@ func checkUserCount(t *testing.T, resp []byte, expected int) {
 	require.Equal(t, expected, len(r.AddUser.User))
 }
 
-func deleteUser(t *testing.T, accessToken, username string, confirmDeletion bool) {
+func deleteUser(t *testing.T, accessToken, username string, confirmDeletion bool) *testutil.GraphQLResponse {
 	delUser := `
 	mutation deleteUser($name: String!) {
 		deleteUser(filter: {name: {eq: $name}}) {
@@ -99,16 +99,17 @@ func deleteUser(t *testing.T, accessToken, username string, confirmDeletion bool
 		},
 	}
 	resp := makeRequest(t, accessToken, params)
-	resp.RequireNoGraphQLErrors(t)
 
 	if confirmDeletion {
+		resp.RequireNoGraphQLErrors(t)
 		require.JSONEq(t, `{"deleteUser":{"msg":"Deleted","numUids":1}}`, string(resp.Data))
 	}
+	return resp
 }
 
-func deleteGroup(t *testing.T, accessToken, name string) {
+func deleteGroup(t *testing.T, accessToken, name string, confirmDeletion bool) *testutil.GraphQLResponse {
 	delGroup := `
-	mutation deleteUser($name: String!) {
+	mutation deleteGroup($name: String!) {
 		deleteGroup(filter: {name: {eq: $name}}) {
 			msg
 			numUids
@@ -122,9 +123,12 @@ func deleteGroup(t *testing.T, accessToken, name string) {
 		},
 	}
 	resp := makeRequest(t, accessToken, params)
-	resp.RequireNoGraphQLErrors(t)
 
-	require.JSONEq(t, `{"deleteGroup":{"msg":"Deleted","numUids":1}}`, string(resp.Data))
+	if confirmDeletion {
+		resp.RequireNoGraphQLErrors(t)
+		require.JSONEq(t, `{"deleteGroup":{"msg":"Deleted","numUids":1}}`, string(resp.Data))
+	}
+	return resp
 }
 
 func TestInvalidGetUser(t *testing.T) {
@@ -170,7 +174,8 @@ func TestGetCurrentUser(t *testing.T) {
 
 	// clean up the user to allow repeated running of this test
 	userid := "hamilton"
-	deleteUser(t, accessJwt, userid, false)
+	deleteUserResp := deleteUser(t, accessJwt, userid, false)
+	deleteUserResp.RequireNoGraphQLErrors(t)
 	glog.Infof("cleaned up db user state")
 
 	resp := createUser(t, accessJwt, userid, userpassword)
@@ -202,7 +207,7 @@ func TestCreateAndDeleteUsers(t *testing.T) {
 	checkUserCount(t, resp.Data, 0)
 
 	// delete the user
-	deleteUser(t, accessJwt, userid, true)
+	_ = deleteUser(t, accessJwt, userid, true)
 
 	resp = createUser(t, accessJwt, userid, userpassword)
 	resp.RequireNoGraphQLErrors(t)
@@ -214,7 +219,8 @@ func resetUser(t *testing.T) {
 	accessJwt, _ := testutil.GrootHttpLogin(adminEndpoint)
 
 	// clean up the user to allow repeated running of this test
-	deleteUser(t, accessJwt, userid, false)
+	deleteUserResp := deleteUser(t, accessJwt, userid, false)
+	deleteUserResp.RequireNoGraphQLErrors(t)
 	glog.Infof("deleted user")
 
 	resp := createUser(t, accessJwt, userid, userpassword)
@@ -2286,7 +2292,7 @@ func TestDeleteUserShouldDeleteUserFromGroup(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-	deleteUser(t, accessJwt, userid, true)
+	_ = deleteUser(t, accessJwt, userid, true)
 
 	gqlQuery := `
 	query {
@@ -2361,7 +2367,7 @@ func TestGroupDeleteShouldDeleteGroupFromUser(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-	deleteGroup(t, accessJwt, "dev-a")
+	_ = deleteGroup(t, accessJwt, "dev-a", true)
 
 	gqlQuery := `
 	query {
@@ -2799,7 +2805,7 @@ func TestAddUpdateGroupWithDuplicateRules(t *testing.T) {
 	require.ElementsMatch(t, []rule{updatedRules[0], updatedRules[2]}, updatedGroup1.Rules)
 
 	// cleanup
-	deleteGroup(t, grootJwt, groupName)
+	_ = deleteGroup(t, grootJwt, groupName, true)
 }
 
 func TestAllowUIDAccess(t *testing.T) {
@@ -3132,5 +3138,53 @@ func TestFailedLogin(t *testing.T) {
 	err = client.Login(ctx, userid, "randomstring")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), x.ErrorInvalidLogin.Error())
+}
 
+func TestDeleteGuardiansGroupShouldFail(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	require.NoError(t, err)
+	addDataAndRules(ctx, t, dg)
+
+	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint: adminEndpoint,
+		UserID:   x.GrootId,
+		Passwd:   "password",
+	})
+	require.NoError(t, err, "login failed")
+
+	resp := deleteGroup(t, accessJwt, "guardians", false)
+	require.Contains(t, resp.Errors.Error(),
+		"guardians group and groot user cannot be deleted.")
+}
+
+func TestDeleteGrootUserShouldFail(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	require.NoError(t, err)
+	addDataAndRules(ctx, t, dg)
+
+	accessJwt, _, err := testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint: adminEndpoint,
+		UserID:   x.GrootId,
+		Passwd:   "password",
+	})
+
+	resp := deleteUser(t, accessJwt, "groot", false)
+	require.Contains(t, resp.Errors.Error(),
+		"guardians group and groot user cannot be deleted.")
+}
+
+func TestDeleteGrootUserFromGuardiansGroupShouldFail(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 100*time.Second)
+	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	require.NoError(t, err)
+	addDataAndRules(ctx, t, dg)
+
+	require.NoError(t, err, "login failed")
+
+	gqlresp := removeUserFromGroup(t, "groot", "guardians")
+
+	require.Contains(t, gqlresp.Errors.Error(),
+		"guardians group and groot user cannot be deleted.")
 }

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -256,19 +256,17 @@ func checkIfDeletingAclOperation(edges []*pb.DirectedEdge) error {
 	for _, edge := range edges {
 		// Disallow deleting of guardians group
 		if edge.Entity == guardianGroupUid && edge.Op == pb.DirectedEdge_DEL {
-			glog.Info("Trying to delete guardians group. Operation not allowed.")
 			isDeleteAclOperation = true
 			break
 		}
 		// Disallow deleting of groot user
 		if edge.Entity == grootUserUid && edge.Op == pb.DirectedEdge_DEL {
-			glog.Info("Trying to delete groot user. Operation not allowed.")
 			isDeleteAclOperation = true
 			break
 		}
 	}
 	if isDeleteAclOperation {
-		return errors.Errorf("guardians group and groot user cannot be deleted.")
+		return errors.Errorf("Properties of guardians group and groot user cannot be deleted.")
 	}
 	return nil
 }

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -27,6 +27,7 @@ import (
 	"math/rand"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -117,10 +118,11 @@ func TestCountIndex(t *testing.T) {
 			if _, err := dg.NewTxn().Mutate(context.Background(), &api.Mutation{
 				CommitNow: true,
 				DelNquads: []byte(fmt.Sprintf(`<%v> <value> "%v" .`, uid, ec-1)),
-			}); err != nil && !errors.Is(err, dgo.ErrAborted) {
-				t.Fatalf("error in deletion :: %v\n", err)
-			} else if errors.Is(err, dgo.ErrAborted) {
+			}); err != nil && (errors.Is(err, dgo.ErrAborted) ||
+				strings.Contains(err.Error(), "Properties of guardians group and groot user cannot be deleted")) {
 				return
+			} else if err != nil {
+				t.Fatalf("error in deletion :: %v\n", err)
 			}
 			ec--
 		case 2:

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -92,7 +92,7 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 			restoreDone = true
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(4 * time.Second)
 	}
 	require.True(t, restoreDone)
 

--- a/x/x.go
+++ b/x/x.go
@@ -177,15 +177,15 @@ var (
 	// AcceptedOrigins is allowed list of origins to make request to the graphql endpoint.
 	AcceptedOrigins = atomic.Value{}
 	// GuardiansGroupUid is Uid of guardians group node.
-	GuardiansGroupUid = atomic.Value{}
+	GuardiansGroupUid uint64
 	// GrootUser Uid is Uid of groot user node.
-	GrootUserUid = atomic.Value{}
+	GrootUserUid uint64
 )
 
 func init() {
 	AcceptedOrigins.Store(map[string]struct{}{})
-	GuardiansGroupUid.Store(uint64(0))
-	GrootUserUid.Store(uint64(0))
+	atomic.StoreUint64(&GuardiansGroupUid, 0)
+	atomic.StoreUint64(&GrootUserUid, 0)
 }
 
 // UpdateCorsOrigins updates the cors allowlist with the given origins.

--- a/x/x.go
+++ b/x/x.go
@@ -176,10 +176,16 @@ var (
 	Nilbyte []byte
 	// AcceptedOrigins is allowed list of origins to make request to the graphql endpoint.
 	AcceptedOrigins = atomic.Value{}
+	// GuardiansGroupUid is Uid of guardians group node.
+	GuardiansGroupUid = atomic.Value{}
+	// GrootUser Uid is Uid of groot user node.
+	GrootUserUid = atomic.Value{}
 )
 
 func init() {
 	AcceptedOrigins.Store(map[string]struct{}{})
+	GuardiansGroupUid.Store(uint64(0))
+	GrootUserUid.Store(uint64(0))
 }
 
 // UpdateCorsOrigins updates the cors allowlist with the given origins.


### PR DESCRIPTION
Motivation
Currently, it is possible to delete guardians user group and groot user using a simple graphql query. 
This behaviour causes bad user experience as guardians is the admin group and groot user is the primary admin user. 
Once, the group has been deleted, to get back access to groot user, the user has to restart dgraph alpha again. 
This PR adds fixes this. This PR makes it impossible to delete groot user and guardians group.
Related discuss issue: https://discuss.dgraph.io/t/customers-can-delete-guardians-group-and-lose-access/9614

Components affected by this PR:
Dgraph ACL

Does this PR break backwards compatibility?:
No

Fixes DGRAPH-2454
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6580)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-77245812ec-100763.surge.sh)
<!-- Dgraph:end -->