### PR TITLE
fix ErrIndexingInProgress if schema update fails

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -428,6 +428,7 @@ func Load(predicate string) error {
 	if len(predicate) == 0 {
 		return errors.Errorf("Empty predicate")
 	}
+	delete(State().mutSchema, predicate)
 	key := x.SchemaKey(predicate)
 	txn := pstore.NewTransactionAt(1, false)
 	defer txn.Discard()
@@ -448,7 +449,6 @@ func Load(predicate string) error {
 	}
 	State().Set(predicate, &s)
 	State().elog.Printf(logUpdate(&s, predicate))
-	delete(State().mutSchema, predicate)
 	glog.Infoln(logUpdate(&s, predicate))
 	return nil
 }


### PR DESCRIPTION
Fixes DGRAPH-2370

If index building fails for some reason after starting building indexes, no new schema mutations 
can take place. It throws out `errIndexingInProgress` error. This is because though the schema 
update has failed, the predicate remains in the `mutSchema`. It should be deleted from the map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6583)
<!-- Reviewable:end -->
