### PR TITLE
fix(dgraph): correcting crash log level

### DIFF
--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -115,7 +115,7 @@ func setBadgerOptions(opt badger.Options, wal bool) badger.Options {
 	case "disk":
 		opt.TableLoadingMode = options.FileIO
 	default:
-		x.Fatalf("Invalid Badger Tables options")
+		glog.Fatalf("Invalid Badger Tables options")
 	}
 
 	glog.Infof("Setting Badger value log load option: %s", Config.BadgerVlog)


### PR DESCRIPTION
This is related to DGRAPH-2225. While exploring one issue, a crash was reported and it's been logged without log level. To have better clarity this has been fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6585)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c301ac7858-97395.surge.sh)
<!-- Dgraph:end -->