### PR TITLE
fix(GraphQL): fix dangling containers in Custom Cluster tests related to GraphQL

### DIFF
--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -37,6 +37,8 @@ services:
   mock:
     build:
       context: ./cmd
+    labels:
+      cluster: test
     ports:
     - 8888:8888
 


### PR DESCRIPTION
Running `./test.sh -C graphql` in the `dgraph` repository leaves `dgraph_mock_1` container dangling. This PR fixes that.
Related to GRAPHQL-560.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6595)
<!-- Reviewable:end -->
