### PR TITLE
fix(GraphQL Query): Remove extra fields when querying interfaces

### DIFF
--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -125,51 +125,6 @@ func fragmentInQuery(t *testing.T) {
 	cleanupStarwars(t, result.QueryStarship[0].ID, "", "")
 }
 
-/*
-qcRep1: queryCharacter {
-				name
-				... on Human {
-					name
-					totalCredits
-				}
-				... on Droid {
-					name
-					primaryFunction
-				}
-			}
-			qcRep2: queryCharacter {
-				... on Human {
-					totalCredits
-				}
-				name
-				... on Droid {
-					primaryFunction
-				}
-			}
-*/
-
-/*
-"qcRep1": [
-            {
-				"name": "Han"
-                "totalCredits": 10,
-            },
-            {
-                "name": "R2-D2",
-                "primaryFunction": "Robot"
-            }
-		],
-		"qcRep2": [
-            {
-                "totalCredits": 10,
-                "name": "Han"
-            },
-            {
-                "name": "R2-D2",
-                "primaryFunction": "Robot"
-            }
-		],
-*/
 func fragmentInQueryOnInterface(t *testing.T) {
 	newStarship := addStarship(t)
 	humanID := addHuman(t, newStarship.ID)

--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -125,6 +125,51 @@ func fragmentInQuery(t *testing.T) {
 	cleanupStarwars(t, result.QueryStarship[0].ID, "", "")
 }
 
+/*
+qcRep1: queryCharacter {
+				name
+				... on Human {
+					name
+					totalCredits
+				}
+				... on Droid {
+					name
+					primaryFunction
+				}
+			}
+			qcRep2: queryCharacter {
+				... on Human {
+					totalCredits
+				}
+				name
+				... on Droid {
+					primaryFunction
+				}
+			}
+*/
+
+/*
+"qcRep1": [
+            {
+				"name": "Han"
+                "totalCredits": 10,
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
+		],
+		"qcRep2": [
+            {
+                "totalCredits": 10,
+                "name": "Han"
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
+		],
+*/
 func fragmentInQueryOnInterface(t *testing.T) {
 	newStarship := addStarship(t)
 	humanID := addHuman(t, newStarship.ID)
@@ -159,6 +204,27 @@ func fragmentInQueryOnInterface(t *testing.T) {
 				}
 				... on Droid {
 					id
+				}
+			}
+			qcRep1: queryCharacter {
+				name
+				... on Human {
+					name
+					totalCredits
+				}
+				... on Droid {
+					name
+					primaryFunction
+				}
+			}
+			qcRep2: queryCharacter {
+				... on Human {
+					totalCredits
+				}
+				name
+				... on Droid {
+					primaryFunction
+					name
 				}
 			}
 			queryThing {
@@ -268,6 +334,26 @@ func fragmentInQueryOnInterface(t *testing.T) {
 			{
 				"id": "%s"
 			}
+		],
+		"qcRep1": [
+            {
+				"name": "Han",
+                "totalCredits": 10
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
+		],
+		"qcRep2": [
+            {
+                "totalCredits": 10,
+                "name": "Han"
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
 		],
 		"queryThing":[
 			{

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1302,9 +1302,6 @@ func completeObject(
 		x.Check2(buf.WriteString(`": `))
 
 		seenField[f.ResponseName()] = true
-		// if f.GetObjectKind() == ast.Interface || f.GetObjectKind() == ast.Object {
-		// 	seenField[f.ResponseName()] = true
-		// }
 
 		val := res[f.DgraphAlias()]
 		if f.Name() == schema.Typename {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/types"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/api"
@@ -1268,6 +1269,11 @@ func completeObject(
 	var buf bytes.Buffer
 	comma := ""
 
+	// Below map keeps track of fields which have been seen as part of
+	// interface to avoid double entry in the resulting response
+	// var seenField map[string]string
+	seenField := make(map[string]string)
+
 	x.Check2(buf.WriteRune('{'))
 	dgraphTypes, ok := res["dgraph.type"].([]interface{})
 	for _, f := range fields {
@@ -1285,6 +1291,9 @@ func completeObject(
 		if len(dgraphTypes) > 0 {
 			includeField = f.IncludeInterfaceField(dgraphTypes)
 		}
+		if _, ok := seenField[f.Name()]; ok {
+			includeField = false
+		}
 		if !includeField {
 			continue
 		}
@@ -1293,6 +1302,13 @@ func completeObject(
 		x.Check2(buf.WriteRune('"'))
 		x.Check2(buf.WriteString(f.ResponseName()))
 		x.Check2(buf.WriteString(`": `))
+
+		if f.GetObjectKind() == ast.Interface {
+			seenField[f.Name()] = "INTERFACE"
+		}
+		if f.GetObjectKind() == ast.Object {
+			seenField[f.Name()] = "OBJECT"
+		}
 
 		val := res[f.DgraphAlias()]
 		if f.Name() == schema.Typename {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -135,6 +135,7 @@ type Field interface {
 	IncludeInterfaceField(types []interface{}) bool
 	TypeName(dgraphTypes []interface{}) string
 	GetObjectName() string
+	GetObjectKind() ast.DefinitionKind
 	IsAuthQuery() bool
 	CustomHTTPConfig() (FieldHTTPConfig, error)
 	EnumValues() []string
@@ -929,6 +930,9 @@ func (f *field) GetObjectName() string {
 	return f.field.ObjectDefinition.Name
 }
 
+func (f *field) GetObjectKind() ast.DefinitionKind {
+	return f.field.ObjectDefinition.Kind
+}
 func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, error) {
 	custom := f.op.inSchema.customDirectives[f.GetObjectName()][f.Name()]
 	httpArg := custom.Arguments.ForName("http")
@@ -1222,6 +1226,9 @@ func (q *query) GetObjectName() string {
 	return q.field.ObjectDefinition.Name
 }
 
+func (q *query) GetObjectKind() ast.DefinitionKind {
+	return q.field.ObjectDefinition.Kind
+}
 func (q *query) CustomHTTPConfig() (FieldHTTPConfig, error) {
 	return getCustomHTTPConfig((*field)(q), true)
 }
@@ -1402,6 +1409,9 @@ func (m *mutation) GetObjectName() string {
 	return m.field.ObjectDefinition.Name
 }
 
+func (m *mutation) GetObjectKind() ast.DefinitionKind {
+	return m.field.ObjectDefinition.Kind
+}
 func (m *mutation) MutationType() MutationType {
 	return mutationType(m.Name(), m.op.inSchema.customDirectives["Mutation"][m.Name()])
 }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -135,7 +135,6 @@ type Field interface {
 	IncludeInterfaceField(types []interface{}) bool
 	TypeName(dgraphTypes []interface{}) string
 	GetObjectName() string
-	GetObjectKind() ast.DefinitionKind
 	IsAuthQuery() bool
 	CustomHTTPConfig() (FieldHTTPConfig, error)
 	EnumValues() []string
@@ -930,9 +929,6 @@ func (f *field) GetObjectName() string {
 	return f.field.ObjectDefinition.Name
 }
 
-func (f *field) GetObjectKind() ast.DefinitionKind {
-	return f.field.ObjectDefinition.Kind
-}
 func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, error) {
 	custom := f.op.inSchema.customDirectives[f.GetObjectName()][f.Name()]
 	httpArg := custom.Arguments.ForName("http")
@@ -1226,9 +1222,6 @@ func (q *query) GetObjectName() string {
 	return q.field.ObjectDefinition.Name
 }
 
-func (q *query) GetObjectKind() ast.DefinitionKind {
-	return q.field.ObjectDefinition.Kind
-}
 func (q *query) CustomHTTPConfig() (FieldHTTPConfig, error) {
 	return getCustomHTTPConfig((*field)(q), true)
 }
@@ -1409,9 +1402,6 @@ func (m *mutation) GetObjectName() string {
 	return m.field.ObjectDefinition.Name
 }
 
-func (m *mutation) GetObjectKind() ast.DefinitionKind {
-	return m.field.ObjectDefinition.Kind
-}
 func (m *mutation) MutationType() MutationType {
 	return mutationType(m.Name(), m.op.inSchema.customDirectives["Mutation"][m.Name()])
 }


### PR DESCRIPTION
### Motivation
For queries like 
```
 queryCharacter {
	name
	... on Human {
		name
		totalCredits
	}
	... on Droid {
		name
		primaryFunction
	}
}
```
Dgraph response includes the field `name` multiple times. This change fixes that by keeping a `map` of the fields already seen and removing them from the response.


This PR fixes: GRAPHQL-638



### Components affected by this PR <!-- (Optional) -->
Query response for query on fragments in GraphQL





### Does this PR break backwards compatibility?
Yes




### Testing

Added following tests in:

In `fragments.go` tests are added to check that repeated fields are not present in the response and order is preserved.



### Fixes <!-- (Optional) -->
Fixes GRAPHQL-638
https://github.com/99designs/gqlgen/issues/1300


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6596)
<!-- Reviewable:end -->
