### PR TITLE
(release/v1.2) Update nextRaftId when starting a node with a raftId > 0.

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -501,6 +501,9 @@ func (s *Server) Connect(ctx context.Context,
 			m.Id = s.nextRaftId
 			s.nextRaftId += 1
 			proposal.MaxRaftId = m.Id
+		} else if m.Id >= s.nextRaftId {
+			s.nextRaftId = m.Id + 1
+			proposal.MaxRaftId = m.Id
 		}
 
 		// We don't have this member. So, let's see if it has preference for a group.


### PR DESCRIPTION
If we don't do that, the next node that starts with an ID of zero
(auto-assign) will be assigned an existing ID.

DGRAPH-2496

(cherry picked from commit a4f21f45b2cc06c6816b09bfcd26e9dcb3a8aa55)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6599)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e1fa48a1b4-97433.surge.sh)
<!-- Dgraph:end -->