### PR TITLE
test: Fix ToHex test.

### DIFF
--- a/x/x_test.go
+++ b/x/x_test.go
@@ -160,9 +160,9 @@ func TestVersionString(t *testing.T) {
 }
 
 func TestToHex(t *testing.T) {
-	require.Equal(t, []byte(`"0x0"`), ToHex(0))
-	require.Equal(t, []byte(`"0xf"`), ToHex(15))
-	require.Equal(t, []byte(`"0x19"`), ToHex(25))
-	require.Equal(t, []byte(`"0xff"`), ToHex(255))
-	require.Equal(t, []byte(`"0xffffffffffffffff"`), ToHex(math.MaxUint64))
+	require.Equal(t, []byte(`"0x0"`), ToHex(0, false))
+	require.Equal(t, []byte(`"0xf"`), ToHex(15, false))
+	require.Equal(t, []byte(`"0x19"`), ToHex(25, false))
+	require.Equal(t, []byte(`"0xff"`), ToHex(255, false))
+	require.Equal(t, []byte(`"0xffffffffffffffff"`), ToHex(math.MaxUint64, false))
 }


### PR DESCRIPTION
Second argument for ToHex was missing in the test.

    INFO: Running test for github.com/dgraph-io/dgraph/x
    ...
    # github.com/dgraph-io/dgraph/x [github.com/dgraph-io/dgraph/x.test]
    x/x_test.go:163:41: not enough arguments in call to ToHex
    	have (number)
    	want (uint64, bool)
    x/x_test.go:164:41: not enough arguments in call to ToHex
    	have (number)
    	want (uint64, bool)
    x/x_test.go:165:42: not enough arguments in call to ToHex
    	have (number)
    	want (uint64, bool)
    x/x_test.go:166:42: not enough arguments in call to ToHex
    FAIL	github.com/dgraph-io/dgraph/x [build failed]
    	have (number)
    	want (uint64, bool)
    x/x_test.go:167:56: not enough arguments in call to ToHex
    	have (number)
    	want (uint64, bool)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6600)
<!-- Reviewable:end -->
