### PR TITLE
(release/v20.03) build: Makefile to build Dgraph inside docker container

### DIFF
--- a/contrib/docker-build/Makefile
+++ b/contrib/docker-build/Makefile
@@ -1,0 +1,4 @@
+install:
+	@docker-compose up
+	@sudo chown $(USER) ../../dgraph/dgraph
+	@mv ../../dgraph/dgraph $(GOPATH)/bin

--- a/contrib/docker-build/README.md
+++ b/contrib/docker-build/README.md
@@ -1,0 +1,13 @@
+# Docker build script
+
+This directory contains a Makefile that can be used to build Dgraph inside the
+official Dgraph Docker container. This is useful for situations when the host
+system cannot be used to build a binary that will work with the container (for
+example, if the host system has a different version of glibc).
+
+## Usage
+
+Run `make install` in this directory. The script will ask you for your password
+in order to change ownership of the compiled binary. By default, files written
+by Docker will be owned by root. This script also takes care of moving the
+binary to $GOPATH/bin.

--- a/contrib/docker-build/build.sh
+++ b/contrib/docker-build/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y build-essential git golang
+cd /dgraph/dgraph
+make

--- a/contrib/docker-build/docker-compose.yml
+++ b/contrib/docker-build/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.5"
+services:
+  build:
+    image: dgraph/dgraph:latest
+    container_name: build
+    working_dir: /data/build
+    labels:
+      cluster: test
+      service: build
+    volumes:
+      - type: bind
+        source: ../../
+        target: /dgraph
+    command: /dgraph/contrib/docker-build/build.sh


### PR DESCRIPTION
The script is useful for situations in which the host system creates a
binary that's incompatible with the docker container (e.g different
versions of glibc).

(cherry picked from commit c7897381637dc898ce694aa2060116e6bfedb3ee)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6602)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-49800ba573-97530.surge.sh)
<!-- Dgraph:end -->