### PR TITLE
Fix(metric): rename txn_aborts to txn_aborts_total

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -35,7 +35,7 @@ func TestMetricTxnAborts(t *testing.T) {
 	}
 	`
 
-	// Create initial 'dgraph_txn_aborts' metric
+	// Create initial 'dgraph_txn_aborts_total' metric
 	mr1, err := mutationWithTs(mt, "application/rdf", false, false, 0)
 	require.NoError(t, err)
 	mr2, err := mutationWithTs(mt, "application/rdf", false, false, 0)
@@ -49,12 +49,12 @@ func TestMetricTxnAborts(t *testing.T) {
 	_, body, err := runRequest(req)
 	require.NoError(t, err)
 	metricsMap, err := extractMetrics(string(body))
-	requiredMetric := "dgraph_txn_aborts"
+	requiredMetric := "dgraph_txn_aborts_total"
 	txnAbort, ok := metricsMap[requiredMetric]
 	require.True(t, ok, "the required metric '%s' is not found", requiredMetric)
 	txnAbort1, _ := strconv.Atoi(txnAbort.(string))
 
-	// Create second 'dgraph_txn_aborts' metric
+	// Create second 'dgraph_txn_aborts_total' metric
 	mr1, err = mutationWithTs(mt, "application/rdf", false, false, 0)
 	require.NoError(t, err)
 	mr2, err = mutationWithTs(mt, "application/rdf", false, false, 0)
@@ -68,8 +68,8 @@ func TestMetricTxnAborts(t *testing.T) {
 	_, body, err = runRequest(req)
 	require.NoError(t, err)
 	metricsMap, err = extractMetrics(string(body))
-	requiredMetric = "dgraph_txn_aborts"
-	txnAbort, ok = metricsMap["dgraph_txn_aborts"]
+	requiredMetric = "dgraph_txn_aborts_total"
+	txnAbort, ok = metricsMap["dgraph_txn_aborts_total"]
 	txnAbort2, _ := strconv.Atoi(txnAbort.(string))
 
 	require.Equal(t, txnAbort1+1, txnAbort2, "txnAbort was not incremented")

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -82,7 +82,7 @@ var (
 	MaxAssignedTs = stats.Int64("max_assigned_ts",
 		"Latest max assigned timestamp", stats.UnitDimensionless)
 	// TxnAborts records count of aborted transactions.
-	TxnAborts = stats.Int64("txn_aborts",
+	TxnAborts = stats.Int64("txn_aborts_total",
 		"Number of transaction aborts", stats.UnitDimensionless)
 	// PBlockHitRatio records the hit ratio of posting store block cache.
 	PBlockHitRatio = stats.Float64("hit_ratio_postings_block",


### PR DESCRIPTION
This PR renames the metric `txn_aborts` to `txn_aborts_total` to be compliant with naming guidelines from Prometheus (ref. https://prometheus.io/docs/practices/naming/).

## Testing

```bash
SRC_PATH=${GOPATH}/src/github.com/dgraph-io/dgraph/
cd $SRC_PATH
git checkout joaquin/txn-abort-metric-rename
make 
cd dgraph/
docker-compose up --detach
cd cmd/alpha
go test -v -run TestMetricTxnAborts
```

### Test Results

```
Using z.Allocator with starting ref: a3f5000000000000
[Decoder]: Using assembly version of decoder
=== RUN   TestMetricTxnAborts
--- PASS: TestMetricTxnAborts (0.07s)
PASS
ok  	github.com/dgraph-io/dgraph/dgraph/cmd/alpha	0.181s
```



<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6606)
<!-- Reviewable:end -->
