### PR TITLE
test: Fix raftwal tests.

### DIFF
--- a/worker/draft_test.go
+++ b/worker/draft_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/v2"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
@@ -29,11 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft/raftpb"
 )
-
-func openBadger(dir string) (*badger.DB, error) {
-	opt := badger.DefaultOptions(dir)
-	return badger.Open(opt)
-}
 
 func getEntryForMutation(index, startTs uint64) raftpb.Entry {
 	proposal := pb.Proposal{Mutations: &pb.Mutations{StartTs: startTs}}
@@ -52,14 +46,12 @@ func getEntryForCommit(index, startTs, commitTs uint64) raftpb.Entry {
 }
 
 func TestCalculateSnapshot(t *testing.T) {
-	dir, err := ioutil.TempDir("", "badger")
+	dir, err := ioutil.TempDir("", "raftwal")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
-	db, err := badger.OpenManaged(badger.DefaultOptions(dir))
-	require.NoError(t, err)
-	ds := raftwal.Init(db, 0, 0)
-	defer ds.Closer.SignalAndWait()
+	ds := raftwal.Init(dir)
+	defer ds.Close()
 
 	n := newNode(ds, 1, 1, "")
 	var entries []raftpb.Entry


### PR DESCRIPTION
These tests weren't compiling.

    $ go test -c
    # github.com/dgraph-io/dgraph/worker [github.com/dgraph-io/dgraph/worker.test]
    ./draft_test.go:61:20: too many arguments in call to raftwal.Init
        have (*badger.DB, number, number)
        want (string)

    # github.com/dgraph-io/dgraph/worker [github.com/dgraph-io/dgraph/worker.test]
    ./draft_test.go:61:20: cannot use db (type *badger.DB) as type string in argument to raftwal.Init
    ./draft_test.go:62:10: ds.Closer undefined (type *raftwal.DiskStorage has no field or method Closer)

`TestCalculateSnapshot` now runs and passes:

```
$ go test -v . -run=TestCalculateSnapshot
Using z.Allocator with starting ref: e502000000000000
[Decoder]: Using assembly version of decoder
badger 2020/10/01 02:41:53 INFO: All 0 tables opened in 0s
badger 2020/10/01 02:41:53 INFO: No head keys found
=== RUN   TestCalculateSnapshot
--- PASS: TestCalculateSnapshot (0.03s)
PASS
ok  	github.com/dgraph-io/dgraph/worker	0.107s
```

Not really sure why it still prints out some `badger` logs. Do you know why, @jarifibrahim?
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6617)
<!-- Reviewable:end -->
