### PR TITLE
test: Fix integer to string conversion in writer_test

### DIFF
--- a/posting/writer_test.go
+++ b/posting/writer_test.go
@@ -17,6 +17,7 @@
 package posting
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
@@ -35,7 +36,7 @@ func BenchmarkWriter(b *testing.B) {
 	createKVList := func() bpb.KVList {
 		var KVList bpb.KVList
 		for i := 0; i < 5000000; i++ {
-			n := &bpb.KV{Key: []byte(string(i)), Value: val, Version: 5}
+			n := &bpb.KV{Key: []byte(fmt.Sprint(i)), Value: val, Version: 5}
 			KVList.Kv = append(KVList.Kv, n)
 		}
 		return KVList


### PR DESCRIPTION
`i` is of type `int`, but is being converted to a string using `string(i)` - which is incorrect. I've changed this to `fmt.Sprint(i)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6619)
<!-- Reviewable:end -->
