### PR TITLE
test: Duplicate fields in queries with fragments

### DIFF
--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -161,6 +161,12 @@ func fragmentInQueryOnInterface(t *testing.T) {
 					id
 				}
 			}
+			qc2: queryCharacter {
+				... on Human {
+					name
+					n: name
+				}
+			}
 			qcRep1: queryCharacter {
 				name
 				... on Human {
@@ -182,11 +188,9 @@ func fragmentInQueryOnInterface(t *testing.T) {
 					name
 				}
 			}
-			qc2: queryCharacter {
-				... on Human {
-					name
-					n: name
-				}
+			qcRep3: queryCharacter {
+				...characterName1
+				...characterName2
 			}
 			queryThing {
 				__typename
@@ -245,6 +249,12 @@ func fragmentInQueryOnInterface(t *testing.T) {
 		fragment droidAppearsIn on Droid {
 			appearsIn
 		}
+		fragment characterName1 on Character {
+			name
+		}
+		fragment characterName2 on Character {
+			name
+		}
 		`,
 	}
 
@@ -296,6 +306,14 @@ func fragmentInQueryOnInterface(t *testing.T) {
 				"id": "%s"
 			}
 		],
+		"qc2":[
+			{
+				"name": "Han",
+				"n": "Han"
+			},
+			{
+			}
+		],
 		"qcRep1": [
             {
 				"name": "Han",
@@ -316,13 +334,13 @@ func fragmentInQueryOnInterface(t *testing.T) {
                 "primaryFunction": "Robot"
             }
 		],
-		"qc2":[
-			{
-				"name": "Han",
-				"n": "Han"
-			},
-			{
-			}
+		"qcRep3": [
+            {
+                "name": "Han"
+            },
+            {
+                "name": "R2-D2"
+            }
 		],
 		"queryThing":[
 			{


### PR DESCRIPTION
GRAPHQL-654 has been fixed in https://github.com/dgraph-io/dgraph/pull/6596, this PR simply adds a test for it. The problem occurring was that using multiple fragments containing the same field would cause that field to appear multiple times in the output. Example:

Query:

```graphql
fragment TaskID on Task {
  remoteId: id
  remoteType: __typename
}

fragment Task on Task {
  title
  remoteId: id
  completed
}

query {
  queryTask {
    ...TaskID
    ...Task
  }
}
```

Schema:

```graphql
type Task {
  id: ID!
  title: String!
  completed: Boolean!
}
```

The resultant JSON listed `remoteId` twice, which was a bug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6623)
<!-- Reviewable:end -->
