### PR TITLE
test: Fix flakiness in group_delete_test.go

### DIFF
--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -40,7 +40,16 @@ import (
 func NodesSetup(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 
-	require.NoError(t, c.Alter(ctx, &api.Operation{DropAll: true}))
+	// Retry DropAll to make sure the nodes is up and running.
+	var err error
+	for i := 0; i < 3; i ++ {
+		if err =c.Alter(ctx, &api.Operation{DropAll: true}); err != nil {
+			time.Sleep(5*time.Second)
+			continue
+		}
+		break
+	}
+	require.NoError(t, err, "error while dropping all the data")
 
 	schema, err := ioutil.ReadFile(`../data/goldendata.schema`)
 	require.NoError(t, err)
@@ -157,7 +166,10 @@ func TestNodes(t *testing.T) {
 		t.Errorf("moving tablets failed")
 	}
 
-	resp, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=3&id=3")
+	groupNodes, err := testutil.GetNodesInGroup("3")
+	require.NoError(t, err)
+	resp, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=3&id=" +
+		groupNodes[0])
 	require.NoError(t, err)
 	require.NoError(t, getError(resp.Body))
 
@@ -191,7 +203,10 @@ func TestNodes(t *testing.T) {
 		t.Errorf("moving tablets failed")
 	}
 
-	resp, err = http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=2&id=2")
+	groupNodes, err = testutil.GetNodesInGroup("2")
+	require.NoError(t, err)
+	resp, err = http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=2&id=" +
+		groupNodes[0])
 	require.NoError(t, err)
 	require.NoError(t, getError(resp.Body))
 

--- a/testutil/zero.go
+++ b/testutil/zero.go
@@ -138,7 +138,7 @@ func GetNodesInGroup(gid string) ([]string, error) {
 	}
 
 	nodes := make([]string, 0)
-	for id, _ := range group.Members {
+	for id := range group.Members {
 		nodes = append(nodes, id)
 	}
 	return nodes, nil

--- a/testutil/zero.go
+++ b/testutil/zero.go
@@ -31,17 +31,19 @@ import (
 	"google.golang.org/grpc"
 )
 
+type Member struct {
+	Addr       string `json:"addr"`
+	GroupID    int    `json:"groupId"`
+	ID         string `json:"id"`
+	LastUpdate string `json:"lastUpdate"`
+	Leader     bool   `json:"leader"`
+}
+
 // StateResponse represents the structure of the JSON object returned by calling
 // the /state endpoint in zero.
 type StateResponse struct {
 	Groups map[string]struct {
-		Members map[string]struct {
-			Addr       string `json:"addr"`
-			GroupID    int    `json:"groupId"`
-			ID         string `json:"id"`
-			LastUpdate string `json:"lastUpdate"`
-			Leader     bool   `json:"leader"`
-		} `json:"members"`
+		Members map[string]Member `json:"members"`
 		Tablets map[string]struct {
 			GroupID   int    `json:"groupId"`
 			Predicate string `json:"predicate"`
@@ -79,22 +81,27 @@ func GetState() (*StateResponse, error) {
 }
 
 // GetClientToGroup returns a dgraph client connected to an alpha in the given group.
-func GetClientToGroup(groupID string) (*dgo.Dgraph, error) {
+func GetClientToGroup(gid string) (*dgo.Dgraph, error) {
 	state, err := GetState()
 	if err != nil {
 		return nil, err
 	}
 
-	group, ok := state.Groups[groupID]
+	group, ok := state.Groups[gid]
 	if !ok {
-		return nil, errors.Errorf("group %s does not exist", groupID)
+		return nil, errors.Errorf("group %s does not exist", gid)
 	}
 
 	if len(group.Members) == 0 {
-		return nil, errors.Errorf("the group %s has no members", groupID)
+		return nil, errors.Errorf("the group %s has no members", gid)
 	}
 
-	member := group.Members["1"]
+	// Select the first member found in the iteration.
+	var member Member
+	for _, m := range group.Members {
+		member = m
+		break
+	}
 	parts := strings.Split(member.Addr, ":")
 	if len(parts) != 2 {
 		return nil, errors.Errorf("the member has an invalid address: %v", member.Addr)
@@ -113,4 +120,26 @@ func GetClientToGroup(groupID string) (*dgo.Dgraph, error) {
 		return nil, err
 	}
 	return dgo.NewDgraphClient(api.NewDgraphClient(conn)), nil
+}
+
+func GetNodesInGroup(gid string) ([]string, error) {
+	state, err := GetState()
+	if err != nil {
+		return nil, err
+	}
+
+	group, ok := state.Groups[gid]
+	if !ok {
+		return nil, errors.Errorf("group %s does not exist", gid)
+	}
+
+	if len(group.Members) == 0 {
+		return nil, errors.Errorf("the group %s has no members", gid)
+	}
+
+	nodes := make([]string, 0)
+	for id, _ := range group.Members {
+		nodes = append(nodes, id)
+	}
+	return nodes, nil
 }


### PR DESCRIPTION
The test and utility were assuming that node 1 was in group 1, node 2 in
group 2, and so on. This is not true all the time, hence the flakiness.

Fixing the code to not make this assumptions as well as retrying the
DropAll in NodesSetup to ensure all the nodes are up before proceeding
with the test.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6624)
<!-- Reviewable:end -->
