### PR TITLE
(release/v1.2) test: Fix flakiness in group_delete_test.go

### DIFF
--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -40,7 +40,16 @@ import (
 func NodesSetup(t *testing.T, c *dgo.Dgraph) {
 	ctx := context.Background()
 
-	require.NoError(t, c.Alter(ctx, &api.Operation{DropAll: true}))
+	// Retry DropAll to make sure the nodes is up and running.
+	var err error
+	for i := 0; i < 3; i ++ {
+		if err =c.Alter(ctx, &api.Operation{DropAll: true}); err != nil {
+			time.Sleep(5*time.Second)
+			continue
+		}
+		break
+	}
+	require.NoError(t, err, "error while dropping all the data")
 
 	schema, err := ioutil.ReadFile(`../data/goldendata.schema`)
 	require.NoError(t, err)
@@ -149,7 +158,10 @@ func TestNodes(t *testing.T) {
 		t.Errorf("moving tablets failed")
 	}
 
-	resp, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=3&id=3")
+	groupNodes, err := testutil.GetNodesInGroup("3")
+	require.NoError(t, err)
+	resp, err := http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=3&id=" +
+		groupNodes[0])
 	require.NoError(t, err)
 	require.NoError(t, getError(resp.Body))
 
@@ -183,7 +195,10 @@ func TestNodes(t *testing.T) {
 		t.Errorf("moving tablets failed")
 	}
 
-	resp, err = http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=2&id=2")
+	groupNodes, err = testutil.GetNodesInGroup("2")
+	require.NoError(t, err)
+	resp, err = http.Get("http://" + testutil.SockAddrZeroHttp + "/removeNode?group=2&id=" +
+		groupNodes[0])
 	require.NoError(t, err)
 	require.NoError(t, getError(resp.Body))
 


### PR DESCRIPTION
The test and utility were assuming that node 1 was in group 1, node 2 in
group 2, and so on. This is not true all the time, hence the flakiness.

Fixing the code to not make this assumptions as well as retrying the
DropAll in NodesSetup to ensure all the nodes are up before proceeding
with the test.

(cherry picked from commit 36638a79143c1c318be47d3fd1dcfabd797a941b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6627)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e5c9113e84-98434.surge.sh)
<!-- Dgraph:end -->