### PR TITLE
Pagination param "after" does not work when using func: uid(v) (#6365)

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1982,6 +1982,11 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 				return sg.DestUIDs.Uids[i] < sg.DestUIDs.Uids[j]
 			})
 		}
+		if sg.Params.AfterUID > 0 {
+			i := sort.Search(len(sg.DestUIDs.Uids), func(i int) bool { return sg.DestUIDs.Uids[i] > sg.Params.AfterUID })
+			sg.DestUIDs.Uids = sg.DestUIDs.Uids[i:]
+		}
+
 	case sg.Attr == "":
 		// This is when we have uid function in children.
 		if sg.SrcFunc != nil && sg.SrcFunc.Name == "uid" {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -668,6 +668,43 @@ func TestHasFuncAtRootWithAfter(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"friend":[{"count":1}],"name":"Rick Grimes","uid":"0x17"},{"friend":[{"count":1}],"name":"Andrea","uid":"0x1f"}]}}`, js)
 }
 
+func TestHasFuncAtRootWithAfterOnUIDs(t *testing.T) {
+
+	query := `
+	{
+			var(func: has(name)) {
+					uids as uid
+			}
+			me(func: uid(uids), first: 2, after: 0x5) {
+					uid
+			}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"uid":"0x6"},{"uid":"0x7"}]}}`, js)
+}
+
+func TestHasFuncAtRootWithAfterOnUIDsOtherThanRoot(t *testing.T) {
+
+	query := `
+	{
+		var(func: has(name)) {
+			uids as uid
+		}
+		me(func: uid(0x1, 0x1f)) {
+				uid
+				friend(first:2, after:0x5) @filter(uid(uids)) {
+					uid
+			}
+		}
+	}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"uid":"0x1","friend":[{"uid": "0x17"},{"uid": "0x18"}]},{"uid": "0x1f","friend": [{"uid": "0x18"}]}]}}`, js)
+}
+
 func TestHasFuncAtRootFilter(t *testing.T) {
 
 	query := `


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
Pagination param "after" does not work when using func: uid(v)

for query
```
{
  var(func: has(name@en), first: 50) {
    test as uid
  }

  ss(func: uid(test), first: 2, after: 0x6) {
    uid
  }
}
```

the response was

```
{
  "data": {
    "ss": [
      {
        "uid": "0x4"
      },
      {
        "uid": "0x6"
      }
    ]
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6631)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-70fd76f0af-98614.surge.sh)
<!-- Dgraph:end -->