### PR TITLE
test: Enterprise License tests (#5822)

### DIFF
--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -1,0 +1,36 @@
+# Auto-generated with: [compose -a 1 -z 1 -w]
+#
+version: "3.5"
+services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+    - 8180:8180
+    - 9180:9180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+    - 5180:5180
+    - 6180:6180
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --logtostderr -v=2
+      --bindall
+volumes: {}

--- a/systest/license/license_test.go
+++ b/systest/license/license_test.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var expiredKey = []byte(`-----BEGIN PGP MESSAGE-----
+
+owEBwgI9/ZANAwAKAXomeeH3SyppAax7YgxsaWNlbnNlLmpzb25etF5+ewogICJ1
+c2VyIjogIkRncmFwaCBUZXN0IEtleSIsCiAgIm1heF9ub2RlcyI6IDE4NDQ2NzQ0
+MDczNzA5NTUxNjE1LAogICJleHBpcnkiOiAiMTk3MC0wMS0wMVQwMDowMDowMFoi
+Cn0KiQIzBAABCgAdFiEED3lYS97wtaMT1MW+eiZ54fdLKmkFAl60Xn4ACgkQeiZ5
+4fdLKmlVYQ//afX0H7Seb0ukxCMAcM8uqlBEGCEFv3K34avk1g8XRa6y4q/Ys0uU
+DSaaDWdQ8IS5Q9SNlZBbJuqO6Pf1R01dEPTYQizWkDjYIBsY9xJnMZKEaA+F3bkn
+8TXqI588+AvbqxHosz8cvh/nG+Ajk451rI9c2bqKB/FvH/zI6XyfUjqN+PvrqH0E
+POA7nqSrWDemW4cMgNR4PhXehB/n2i3G6cPpwgCUd+N00N1f1mir/LmL6G5T4PrG
+BmVz9fOdEr+U85PbMF9vOke9LkLQYdnF1hEV+7++t2/uoaLDYbxYhUnXpJZxwCBX
+DQTievpyQF47HzuifvqUyxDSEsYiSGhhap1e/tvf1VaZoFUuTYQQpiV7+9K3UrL0
+SnJ5TRWS7cEKBLyZszrakGpqVakvEUlWO4wG0Fp4kUa4YXw8t58oqHRn9aAtoqJd
+UOLnq2semUttaySR4DHhjneO3/RoVm79/aaqMi/QNJzc9Tt9nY0AgcYlA3bVXmAZ
+nM9Rgi6SaO5DxnRdhFzZyYQMb4onFDI0eYMOhPm+NmKWplkFXB+mKPKj5o/pcEb4
+SWHt8fUAWDLsmcooIixDmSay14aBmF08hQ1vtJkY7/jo3hlK36GrLnNdN4IODqk/
+I8mUd/jcj3NZtGWFoxKq4laK/ruoeoHnWMznJyMm75nzcU5QZU9yEEI=
+=2lFm
+-----END PGP MESSAGE-----
+`)
+
+var invalidKey = []byte(`-----BEGIN PGP MESSAGE-----
+
+x7YgxsaWNlbnNlLmpzb25etF5owEBwgI9omeeH3SyppAa/ZANAwAKAX+ewogICJ1
+c2VyIjogIkRncmFwaCBUZXN0IEtleSIsCiAgIm1heF9ub2RlcyI6IDE4NDQ2NzQ0
+MDczNzA5NTUxNjE1LAogICJleHBpcnkiOiAiMTk3MC0wMS0wMVQwMDowMDowMFoi
+Cn0KiQIzBAABCgAdFiEED3lYS97wtaMT1MW+eiZ54fdLKmkFAl60Xn4ACgkQeiZ5
+4fdLKmlVYQ//afX0H7Seb0ukxCMAcM8uqlBEGCEFv3K34avk1g8XRa6y4q/Ys0uU
+DSaaDWdQ8QizWkDjYIBsY9xJnMZKEaAIS5Q9SNlZBbJuqO6Pf1R01dEPTY+F3bkn
+8T1rI9c2bqKB/FvH/zI6XXqI588+AvbqxHosz8cvh/nG+Ajk45yfUjqN+PvrqH0E
+POA7nqSrWDemW4cMgNR4PhXehB/n2i3G6cPpwgCUd+N00N1f1mir/LmL6G5T4PrG
+BmVz9fOdEr+U85PbMF9vOke9LkLQYdnF1hEV+7++t2/uoaLDYbxYhUnXpJZxwCBX
+DQTievpyQxDSEsYiSGhhap1e/tvf1VaZoFUuTYQQpiV7F47HzuifvqUy+9K3UrL0
+SnJ5TRWS7cEKBLyZszrakGpqVakvEUlWO4wG0Fp4kUa4YXw8t58oqHRn9aAtoqJd
+UOLnq2semUttaySR4DHhjneO3/RoVm79/aaqMi/QNJzc9Tt9nY0AgcYlA3bVXmAZ
+nM9Rgi6SaO5DxnRdhFzZyYQMb4onFDI0eYMOhPm+NmKWplkFXB+mKPKj5o/pcEb4
+SWHt8fUAWDLsmcJkY7/jo3hlK36GrLnNdN4IODqkooIixDmSay14aBmF08hQ1vt/
+I8jcj3NZtGWFoxKq4laK/ruoeoHnWMznJyMm7mUd/5nzcU5QZU9yEEI=
+=2lFm
+-----END PGP MESSAGE-----
+`)
+
+type Location struct {
+	Line   int `json:"line,omitempty"`
+	Column int `json:"column,omitempty"`
+}
+
+type GqlError struct {
+	Message    string                 `json:"message"`
+	Locations  []Location             `json:"locations,omitempty"`
+	Path       []interface{}          `json:"path,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+type GqlErrorList []*GqlError
+
+type responseStruct struct {
+	Errors  GqlErrorList           `json:"errors"`
+	Code    string                 `json:"code"`
+	Message string                 `json:"message"`
+	License map[string]interface{} `json:"license"`
+}
+
+func TestEnterpriseLicense(t *testing.T) {
+
+	stateURL := "http://localhost:6180/state"
+	enterpriseLicenseURL := "http://localhost:6180/enterpriseLicense"
+
+	var tests = []struct {
+		name       string
+		licenseKey []byte
+		code       string
+		user       string
+		message    string
+	}{
+		{
+			"Using expired entrerprise license key, should be able to extract user information",
+			expiredKey,
+			`Success`,
+			`Dgraph Test Key`,
+			``,
+		},
+		{
+			"Using invalid entrerprise license key should return an error",
+			invalidKey,
+			``,
+			``,
+			`while extracting enterprise details from the license: while reading PGP message from license file: openpgp: unsupported feature: public key version`,
+		},
+		{
+			"Using empty entrerprise license key should return an error",
+			[]byte(``),
+			``,
+			``,
+			`while extracting enterprise details from the license: while decoding license file: EOF`,
+		},
+	}
+	for _, tt := range tests {
+
+		// Apply the license
+		response, err := http.Post(enterpriseLicenseURL, "application/text", bytes.NewBuffer(tt.licenseKey))
+		require.NoError(t, err)
+
+		var enterpriseResponse responseStruct
+		responseBody, err := ioutil.ReadAll(response.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(responseBody, &enterpriseResponse)
+		require.NoError(t, err)
+
+		// Check if the license is applied
+		require.Equal(t, enterpriseResponse.Code, tt.code)
+
+		if enterpriseResponse.Code == `Success` {
+
+			// check the user information in case the license is applied
+			// Expired license should not be enabled even after it is applied
+
+			response, err := http.Get(stateURL)
+			require.NoError(t, err)
+
+			var stateResponse responseStruct
+			responseBody, err := ioutil.ReadAll(response.Body)
+			require.NoError(t, err)
+			err = json.Unmarshal(responseBody, &stateResponse)
+			require.NoError(t, err)
+
+			require.Equal(t, stateResponse.License["user"], tt.user)
+			require.Equal(t, stateResponse.License["enabled"], false)
+		} else {
+			// check the error message in case the license is not applied
+			require.Equal(t, enterpriseResponse.Errors[0].Message, tt.message)
+		}
+	}
+}

--- a/systest/license/license_test.go
+++ b/systest/license/license_test.go
@@ -153,7 +153,7 @@ func TestEnterpriseLicense(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, stateResponse.License["user"], tt.user)
-			require.Equal(t, stateResponse.License["enabled"], false)
+			require.Equal(t, stateResponse.License["enabled"], nil)
 		} else {
 			// check the error message in case the license is not applied
 			require.Equal(t, enterpriseResponse.Errors[0].Message, tt.message)


### PR DESCRIPTION
Created a file for testing if the license is applied correctly. It contains 3 tests.

1. Applying expired license, this will get applied but it should not be enabled and user information should be extracted
2. Applying invalid license, this won't get applied
3. Applying empty license, this also won't get applied

Co-authored-by: Ibrahim Jarif <ibrahim@dgraph.io>
(cherry picked from commit 61363d1837b929d04fe988af40b888e9f82370ea)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6640)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e3ed01626c-98665.surge.sh)
<!-- Dgraph:end -->