### PR TITLE
fix(GraphQL Query): Remove extra fields when querying interfaces (#6596)

### DIFF
--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -160,6 +160,27 @@ func fragmentInQueryOnInterface(t *testing.T) {
 					id
 				}
 			}
+			qcRep1: queryCharacter {
+				name
+				... on Human {
+					name
+					totalCredits
+				}
+				... on Droid {
+					name
+					primaryFunction
+				}
+			}
+			qcRep2: queryCharacter {
+				... on Human {
+					totalCredits
+				}
+				name
+				... on Droid {
+					primaryFunction
+					name
+				}
+			}
 			queryThing {
 				__typename
 				... on ThingOne {
@@ -267,6 +288,26 @@ func fragmentInQueryOnInterface(t *testing.T) {
 			{
 				"id": "%s"
 			}
+		],
+		"qcRep1": [
+            {
+				"name": "Han",
+                "totalCredits": 10
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
+		],
+		"qcRep2": [
+            {
+                "totalCredits": 10,
+                "name": "Han"
+            },
+            {
+                "name": "R2-D2",
+                "primaryFunction": "Robot"
+            }
 		],
 		"queryThing":[
 			{

--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -179,6 +179,8 @@ func fragmentInQueryOnInterface(t *testing.T) {
 				... on Droid {
 					primaryFunction
 					name
+				}
+			}
 			qc2: queryCharacter {
 				... on Human {
 					name
@@ -312,7 +314,8 @@ func fragmentInQueryOnInterface(t *testing.T) {
             {
                 "name": "R2-D2",
                 "primaryFunction": "Robot"
-            }
+			}
+		],
 		"qc2":[
 			{
 				"name": "Han",

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1265,6 +1265,10 @@ func completeObject(
 	var buf bytes.Buffer
 	comma := ""
 
+	// Below map keeps track of fields which have been seen as part of
+	// interface to avoid double entry in the resulting response
+	seenField := make(map[string]bool)
+
 	x.Check2(buf.WriteRune('{'))
 
 	dgraphTypes, ok := res["dgraph.type"].([]interface{})
@@ -1283,6 +1287,9 @@ func completeObject(
 		if len(dgraphTypes) > 0 {
 			includeField = f.IncludeInterfaceField(dgraphTypes)
 		}
+		if _, ok := seenField[f.ResponseName()]; ok {
+			includeField = false
+		}
 		if !includeField {
 			continue
 		}
@@ -1291,6 +1298,8 @@ func completeObject(
 		x.Check2(buf.WriteRune('"'))
 		x.Check2(buf.WriteString(f.ResponseName()))
 		x.Check2(buf.WriteString(`": `))
+
+		seenField[f.ResponseName()] = true
 
 		val := res[f.DgraphAlias()]
 		if f.Name() == schema.Typename {


### PR DESCRIPTION
(cherry picked from commit cec55674cb343c1c7f3e96dd9c5fe7867a42f5b8)
This PR fixes: GRAPHQL-638

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6647)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-215f7c95aa-99056.surge.sh)
<!-- Dgraph:end -->