### PR TITLE
fix(TestPlugins) Increase sleep timer to prevent connection retries on sleeping cluster

### DIFF
--- a/systest/cluster_setup_test.go
+++ b/systest/cluster_setup_test.go
@@ -82,7 +82,7 @@ func (d *DgraphCluster) StartZeroOnly() error {
 	}
 
 	// Wait for dgraphzero to start listening and become the leader.
-	time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 6)
 	return nil
 }
 
@@ -108,7 +108,7 @@ func (d *DgraphCluster) StartAlphaOnly() error {
 	// programmatically by hitting the query port. This would be quicker than
 	// just waiting 4 seconds (which seems to be the smallest amount of time to
 	// reliably wait).
-	time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 6)
 
 	d.client = dgo.NewDgraphClient(api.NewDgraphClient(dgConn))
 


### PR DESCRIPTION
### Motivation

TestPlugins is flaky in because it sometimes tries to connect to the cluster while the cluster is still not up. 

This PR fixes: DGRAPH-1637



### Components affected by this PR <!-- (Optional) -->

TestPlugins, Systest





### Does this PR break backwards compatibility?

No



### Testing
N/A


### Fixes <!-- (Optional) -->



Fixes DGRAPH-1637

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6652)
<!-- Reviewable:end -->
