### PR TITLE
fix(Query): Fix wrong path response for k-shortest paths (#6437)

### DIFF
--- a/query/shortest.go
+++ b/query/shortest.go
@@ -340,8 +340,13 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 				continue
 			}
 
-			// Add path to list.
+			// Add path to list after making a copy of the path in itemRoute. A copy of
+			// *item.path.route is required because it has to be put back in the sync pool and a
+			// future reuse can alter the item already present in kroute because it is a pointer.
+			itemRoute := make([]pathInfo, len(*item.path.route))
+			copy(itemRoute, *item.path.route)
 			newRoute := item.path
+			newRoute.route = &itemRoute
 			newRoute.totalWeight = item.cost
 			kroutes = append(kroutes, newRoute)
 			if len(kroutes) == numPaths {


### PR DESCRIPTION
The k-shortest path query sometimes returns a wrong response. The cause
of this issue is inappropriate use of sync.pools. Whenever a valid path
is found a new variable is assigned with this route and that variable is
appended in the kroutes (which is then parsed to produce response).
But the route is also put in the sync.pool. Since the route is a
structure containing a pointer to slice along with other fields, when
it is fetched back from the pool in future then any mutation on this fetched
route causes modification in the kroutes, resulting in garbage response.

This issue is fixed by making a copy of the route struct rather
than just assigning it to a variable, which causes a shallow copy.

(cherry picked from commit 4792d8b1c4391a08ce2627f9615ed12699f2885f)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6654)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-531aaa9bd7-99438.surge.sh)
<!-- Dgraph:end -->