### PR TITLE
Fix(Dgraph): Type names in exported schema are sorrounded by brackets.

### DIFF
--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -83,14 +83,14 @@ var expectedSchema = `<movie>:string .` + " " + `
 <dgraph.graphql.schema>:string .` + " " + `
 <dgraph.graphql.schema_history>:string .` + " " + `
 <dgraph.graphql.schema_created_at>:datetime .` + " " + `
-type Node {
+type <Node> {
 	movie
 }
-type dgraph.graphql {
+type <dgraph.graphql> {
 	dgraph.graphql.schema
 	dgraph.graphql.xid
 }
-type dgraph.graphql.history {
+type <dgraph.graphql.history> {
 	dgraph.graphql.schema_history
 	dgraph.graphql.schema_created_at
 }

--- a/worker/export.go
+++ b/worker/export.go
@@ -321,7 +321,7 @@ func toSchema(attr string, update *pb.SchemaUpdate) (*bpb.KVList, error) {
 
 func toType(attr string, update pb.TypeUpdate) (*bpb.KVList, error) {
 	var buf bytes.Buffer
-	x.Check2(buf.WriteString(fmt.Sprintf("type %s {\n", attr)))
+	x.Check2(buf.WriteString(fmt.Sprintf("type <%s> {\n", attr)))
 	for _, field := range update.Fields {
 		x.Check2(buf.WriteString(fieldToString(field)))
 	}


### PR DESCRIPTION
If they are not surrounded by brackets, type names with special
characters will not be able to be imported to a new DB.

Fixes DGRAPH-2462.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6656)
<!-- Reviewable:end -->
