### PR TITLE
release/v20.03 - fix(gqlParser): Handle strings with only whitespace in parseID (#6615)

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -368,9 +368,6 @@ func substituteVariables(gq *GraphQuery, vmap varMap) error {
 
 	idVal, ok := gq.Args["id"]
 	if ok && len(gq.UID) == 0 {
-		if idVal == "" {
-			return errors.Errorf("Id can't be empty")
-		}
 		uids, err := parseID(idVal)
 		if err != nil {
 			return err
@@ -482,9 +479,6 @@ func substituteVariablesFilter(f *FilterTree, vmap varMap) error {
 				idVal, ok := vmap[v.Value]
 				if !ok {
 					return errors.Errorf("Couldn't find value for GraphQL variable: [%s]", v.Value)
-				}
-				if idVal.Value == "" {
-					return errors.Errorf("Id can't be empty")
 				}
 				uids, err := parseID(idVal.Value)
 				if err != nil {
@@ -2261,8 +2255,11 @@ loop:
 // Parses ID list. Only used for GraphQL variables.
 // TODO - Maybe get rid of this by lexing individual IDs.
 func parseID(val string) ([]uint64, error) {
-	var uids []uint64
 	val = x.WhiteSpace.Replace(val)
+	if val == "" {
+		return nil, errors.Errorf("ID can't be empty")
+	}
+	var uids []uint64
 	if val[0] != '[' {
 		uid, err := strconv.ParseUint(val, 0, 64)
 		if err != nil {

--- a/gql/parser_test.go
+++ b/gql/parser_test.go
@@ -5238,3 +5238,13 @@ func TestFilterWithEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, gq.Query[0].Filter.Func.Args[0].Value, "")
 }
+
+func TestEmptyId(t *testing.T) {
+	q := "query me($a: string) { q(func: uid($a)) { name }}"
+	r := Request{
+		Str:       q,
+		Variables: map[string]string{"$a": "   "},
+	}
+	_, err := Parse(r)
+	require.Error(t, err, "ID cannot be empty")
+}


### PR DESCRIPTION
ParseID function would panic if the input consists of only whitespace characters. This PR fixes it.
Fixes GRAPHQL-720

(cherry picked from commit d994cb3d638ba521b0299a8f4ed66155c5ab3ff0)

Conflicts:
	gql/parser_test.go

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6673)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-21da995e7c-100016.surge.sh)
<!-- Dgraph:end -->