### PR TITLE
release/v20.03 - Break out if g.Ctx is done

### DIFF
--- a/worker/groups.go
+++ b/worker/groups.go
@@ -1016,6 +1016,9 @@ func (g *groupi) processOracleDeltaStream() {
 				if err == nil {
 					break
 				}
+				if g.Ctx().Err() != nil {
+					break
+				}
 				glog.Errorf("While proposing delta with MaxAssigned: %d and num txns: %d."+
 					" Error=%v. Retrying...\n", delta.MaxAssigned, len(delta.Txns), err)
 			}


### PR DESCRIPTION
Fixes DGRAPH-2523
(cherry picked from commit a8a47af407ce51c39d15777fb942829e5e80f537)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6676)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b12cea7675-100038.surge.sh)
<!-- Dgraph:end -->