### PR TITLE
fix(config): Set glog -v flag correctly from config files.

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -157,18 +157,17 @@ func setGlogFlags(conf *viper.Viper) {
 	}
 	for _, gflag := range glogFlags {
 		// Set value of flag to the value in config
-		if stringValue, ok := conf.Get(gflag).(string); ok {
-			// Special handling for log_backtrace_at flag because the flag is of
-			// type tracelocation. The nil value for tracelocation type is
-			// ":0"(See https://github.com/golang/glog/blob/master/glog.go#L322).
-			// But we can't set nil value for the flag because of
-			// https://github.com/golang/glog/blob/master/glog.go#L374
-			// Skip setting value if log_backstrace_at is nil in config.
-			if gflag == "log_backtrace_at" && stringValue == ":0" {
-				continue
-			}
-			x.Check(flag.Lookup(gflag).Value.Set(stringValue))
+		stringValue := conf.GetString(gflag)
+		// Special handling for log_backtrace_at flag because the flag is of
+		// type tracelocation. The nil value for tracelocation type is
+		// ":0"(See https://github.com/golang/glog/blob/master/glog.go#L322).
+		// But we can't set nil value for the flag because of
+		// https://github.com/golang/glog/blob/master/glog.go#L374
+		// Skip setting value if log_backstrace_at is nil in config.
+		if gflag == "log_backtrace_at" && (stringValue == "0" || stringValue == ":0") {
+			continue
 		}
+		x.Check(flag.Lookup(gflag).Value.Set(stringValue))
 	}
 }
 


### PR DESCRIPTION
This fixes setting glog's `v` config option when set via a [config file](https://dgraph.io/docs/deploy/config) (e.g., YAML).

This change reads all glog config values as strings and then sets them accordingly. Before, we were only setting values that could correctly be cast as a string (`conf.Get(gflag).(string)`). Any non-string values were _ignored_.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6678)
<!-- Reviewable:end -->
