### PR TITLE
feat(dgraph): enabling TLS config in http zero

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -246,9 +246,18 @@ func (st *state) serveHTTP(l net.Listener) {
 		IdleTimeout:  2 * time.Minute,
 	}
 
+	tlsCfg, err := x.LoadServerTLSConfig(Zero.Conf, "node.crt", "node.key")
+	x.Check(err)
+
 	go func() {
 		defer st.zero.closer.Done()
-		err := srv.Serve(l)
+		switch {
+		case tlsCfg != nil:
+			srv.TLSConfig = tlsCfg
+			err = srv.ServeTLS(l, "", "")
+		default:
+			err = srv.Serve(l)
+		}
 		glog.Errorf("Stopped taking more http(s) requests. Err: %v", err)
 		ctx, cancel := context.WithTimeout(context.Background(), 630*time.Second)
 		defer cancel()

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -264,18 +264,18 @@ func startServers(m cmux.CMux) {
 		if !ok {
 			return false
 		}
-		_, ok = opts.tlsEnabledRoute[path]
-		return !ok
+		enabled, ok := opts.tlsEnabledRoute[path]
+		return ok && !enabled
 	})
 	go startListen(httpRule)
 
 	// if enabled, tls has to be default behaviour because there is no clean way to decrypt request params using cmux.
 	// So when it says tlsEnabledRoute, these route will not be available without TLS.
-	if len(opts.tlsEnabledRoute) > 0 {
+	if Zero.Conf.GetString("tls_dir") != "" {
 		tlsCfg, err := x.LoadServerTLSConfig(Zero.Conf, "node.crt", "node.key")
 		x.Check(err)
 		if tlsCfg == nil {
-			glog.Fatalf("tls_enabled_route is set but tls config is not provided. Please define variable --tls_dir")
+			glog.Fatalf("tls_enabled_route is set but tls config provided is not correct. Please define correct variable --tls_dir")
 		}
 
 		httpsRule := m.Match(cmux.Any())

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -290,7 +290,7 @@ func startServers(m cmux.CMux) {
 		tlsCfg, err := x.LoadServerTLSConfig(Zero.Conf, "node.crt", "node.key")
 		x.Check(err)
 		if tlsCfg == nil {
-			glog.Fatalf("tls_enabled_route is set but tls config provided is not correct. Please define correct variable --tls_dir")
+			glog.Fatalf("tls_dir is set but tls config provided is not correct. Please define correct variable --tls_dir")
 		}
 
 		httpsRule := m.Match(cmux.Any())

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -88,6 +88,7 @@ instances to achieve high-availability.
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
 	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
+	x.RegisterClientTLSFlags(flag)
 }
 
 func setupListener(addr string, port int, kind string) (listener net.Listener, err error) {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -242,7 +242,7 @@ func run() {
 	// Initialize the servers.
 	var st state
 	st.serveGRPC(grpcListener, store)
-	st.serveHTTP(httpListener)
+	st.startListenHttpAndHttps(httpListener)
 
 	http.HandleFunc("/health", st.pingResponse)
 	http.HandleFunc("/state", st.getState)

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -168,6 +168,11 @@ func run() {
 	}
 
 	x.PrintVersion()
+	var tlsDisRoutes []string
+	if Zero.Conf.GetString("tls_disabled_route") != "" {
+		tlsDisRoutes = strings.Split(Zero.Conf.GetString("tls_disabled_route"), ",")
+	}
+
 	opts = options{
 		bindall:           Zero.Conf.GetBool("bindall"),
 		portOffset:        Zero.Conf.GetInt("port_offset"),
@@ -178,7 +183,7 @@ func run() {
 		rebalanceInterval: Zero.Conf.GetDuration("rebalance_interval"),
 		totalCache:        int64(Zero.Conf.GetInt("cache_mb")),
 		tlsDir:            Zero.Conf.GetString("tls_dir"),
-		tlsDisabledRoutes: strings.Split(Zero.Conf.GetString("tls_disabled_route"), ","),
+		tlsDisabledRoutes: tlsDisRoutes,
 	}
 	glog.Infof("Setting Config to: %+v", opts)
 

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -94,7 +94,7 @@ instances to achieve high-availability.
 	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
 	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
 	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
-	flag.String("tls_disabled_route", "", "comma separated zero endpoint which will disabled from TLS encryption."+
+	flag.String("tls_disabled_route", "", "comma separated zero endpoint which will be disabled from TLS encryption."+
 		"Valid values are /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense,/debug.")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/prometheus/common v0.4.1 // indirect
 	github.com/prometheus/procfs v0.0.0-20190517135640-51af30a78b0e // indirect
+	github.com/soheilhy/cmux v0.1.4
 	github.com/spf13/cast v1.3.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -1,0 +1,145 @@
+package all_routes_tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	url        string
+	statusCode int
+	response   string
+}
+
+var testCasesHttp = []testCase{
+	{
+		url:        "http://localhost:6180/health",
+		response:   "Client sent an HTTP request to an HTTPS server.\n",
+		statusCode: 400,
+	},
+	{
+		url:        "http://localhost:6180/state",
+		response:   "Client sent an HTTP request to an HTTPS server.\n",
+		statusCode: 400,
+	},
+	{
+		url:        "http://localhost:6180/removeNode?id=2&group=0",
+		response:   "Client sent an HTTP request to an HTTPS server.\n",
+		statusCode: 400,
+	},
+}
+
+func TestZeroWithAllRoutesTLSWithHTTPClient(t *testing.T) {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+	defer client.CloseIdleConnections()
+	for _, test := range testCasesHttp {
+		request, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		do, err := client.Do(request)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if do != nil && do.StatusCode != test.statusCode {
+			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
+		}
+
+		body := readResponseBody(t, do)
+		if test.response !=  string(body) {
+			t.Fatalf("response is not same. Got: %s Expected: %s", string(body), test.response)
+		}
+	}
+}
+
+var testCasesHttps = []testCase{
+	{
+		url:       "https://localhost:6180/health",
+		response:  "OK",
+		statusCode: 200,
+	},
+	{
+		url:       "https://localhost:6180/state",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		statusCode: 200,
+	},
+}
+
+func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
+	pool, err := generateCertPool("/dgraph-tls/ca.crt", true)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	tlsCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", InsecureSkipVerify: true}
+	tr := &http.Transport{
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
+		TLSClientConfig: tlsCfg,
+	}
+	client := http.Client{
+		Transport: tr,
+	}
+
+	defer client.CloseIdleConnections()
+	for _, test := range testCasesHttps {
+		request, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		do, err := client.Do(request)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if do != nil && do.StatusCode != test.statusCode {
+			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
+		}
+
+		body := readResponseBody(t, do)
+		if !strings.Contains(string(body), test.response)  {
+			t.Fatalf("response is not same. Got: %s Expected: %s", string(body), test.response)
+		}
+	}
+}
+
+func readResponseBody(t *testing.T, do *http.Response) []byte {
+	defer func() { _ = do.Body.Close() }()
+	body, err := ioutil.ReadAll(do.Body)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	return body
+}
+
+func generateCertPool(certPath string, useSystemCA bool) (*x509.CertPool, error) {
+	var pool *x509.CertPool
+	if useSystemCA {
+		var err error
+		if pool, err = x509.SystemCertPool(); err != nil {
+			return nil, err
+		}
+	} else {
+		pool = x509.NewCertPool()
+	}
+
+	if len(certPath) > 0 {
+		caFile, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, err
+		}
+		if !pool.AppendCertsFromPEM(caFile) {
+			return nil, errors.Errorf("error reading CA file %q", certPath)
+		}
+	}
+
+	return pool, nil
+}

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -74,7 +74,7 @@ var testCasesHttps = []testCase{
 }
 
 func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
-	pool, err := generateCertPool("/dgraph-tls/ca.crt", true)
+	pool, err := generateCertPool("../../tls/ca.crt", true)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -68,7 +68,7 @@ var testCasesHttps = []testCase{
 	},
 	{
 		url:       "https://localhost:6180/state",
-		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"zero1:5180\",\"leader\":true,\"amDead\":false",
 		statusCode: 200,
 	},
 }

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -42,13 +43,9 @@ func TestZeroWithAllRoutesTLSWithHTTPClient(t *testing.T) {
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttp {
 		request, err := http.NewRequest("GET", test.url, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		do, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		if do != nil && do.StatusCode != test.statusCode {
 			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
 		}
@@ -75,9 +72,7 @@ var testCasesHttps = []testCase{
 
 func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
 	pool, err := generateCertPool("../../tls/ca.crt", true)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	require.NoError(t, err)
 
 	tlsCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", InsecureSkipVerify: true}
 	tr := &http.Transport{
@@ -92,14 +87,9 @@ func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttps {
 		request, err := http.NewRequest("GET", test.url, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-
+		require.NoError(t, err)
 		do, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		if do != nil && do.StatusCode != test.statusCode {
 			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
 		}
@@ -114,9 +104,7 @@ func TestZeroWithAllRoutesTLSWithTLSClient(t *testing.T) {
 func readResponseBody(t *testing.T, do *http.Response) []byte {
 	defer func() { _ = do.Body.Close() }()
 	body, err := ioutil.ReadAll(do.Body)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	require.NoError(t, err)
 	return body
 }
 

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+      - 5180:5180
+      - 6180:6180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ../tls
+        target: /dgraph-tls
+        read_only: true
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls
+    -v=2 --bindall
+volumes: {}

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -15,9 +15,8 @@ services:
         target: /gobin
         read_only: true
       - type: bind
-        source: ../tls
+        source: ../../tls
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls
-    -v=2 --bindall
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls -v=2 --bindall
 volumes: {}

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "3.5"
 services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+      - 8180:8180
+      - 9180:9180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -33,5 +33,5 @@ services:
         source: ../../tls
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls -v=2 --bindall
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_dir /dgraph-tls -v=2 --bindall
 volumes: {}

--- a/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
+++ b/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
@@ -1,0 +1,139 @@
+package custom_routes_tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	url        string
+	statusCode int
+	response   string
+}
+
+var testCasesHttp = []testCase{
+	{
+		url:        "http://localhost:6180/health",
+		response:   "OK",
+		statusCode: 200,
+	},
+	{
+		url:        "http://localhost:6180/state",
+		response:   "Client sent an HTTP request to an HTTPS server.",
+		statusCode: 400,
+	},
+}
+
+func TestZeroWithCustomTLSWithHTTPClient(t *testing.T) {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+	defer client.CloseIdleConnections()
+	for _, test := range testCasesHttp {
+		request, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		do, err := client.Do(request)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if do != nil && do.StatusCode != test.statusCode {
+			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
+		}
+
+		body := readResponseBody(t, do)
+		if !strings.Contains(string(body), test.response) {
+			t.Fatalf("response is not same. Got: %s Expected: %s", string(body), test.response)
+		}
+	}
+}
+
+var testCasesHttps = []testCase{
+	{
+		url:       "https://localhost:6180/health",
+		response:  "OK",
+		statusCode: 200,
+	},
+	{
+		url:       "https://localhost:6180/state",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		statusCode: 200,
+	},
+}
+
+func TestZeroWithCustomTLSWithTLSClient(t *testing.T) {
+	pool, err := generateCertPool("/dgraph-tls/ca.crt", true)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+
+	tlsCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", InsecureSkipVerify: true}
+	tr := &http.Transport{
+		IdleConnTimeout:    30 * time.Second,
+		DisableCompression: true,
+		TLSClientConfig: tlsCfg,
+	}
+	client := http.Client{
+		Transport: tr,
+	}
+
+	defer client.CloseIdleConnections()
+	for _, test := range testCasesHttps {
+		request, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+
+		do, err := client.Do(request)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if do != nil && do.StatusCode != test.statusCode {
+			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
+		}
+		body := readResponseBody(t, do)
+		if !strings.Contains(string(body), test.response) {
+			t.Fatalf("response is not same. Got: %s Expected: %s", string(body), test.response)
+		}
+	}
+}
+
+func readResponseBody(t *testing.T, do *http.Response) []byte {
+	defer func() { _ = do.Body.Close() }()
+	body, err := ioutil.ReadAll(do.Body)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	return body
+}
+
+func generateCertPool(certPath string, useSystemCA bool) (*x509.CertPool, error) {
+	var pool *x509.CertPool
+	if useSystemCA {
+		var err error
+		if pool, err = x509.SystemCertPool(); err != nil {
+			return nil, err
+		}
+	} else {
+		pool = x509.NewCertPool()
+	}
+
+	if len(certPath) > 0 {
+		caFile, err := ioutil.ReadFile(certPath)
+		if err != nil {
+			return nil, err
+		}
+		if !pool.AppendCertsFromPEM(caFile) {
+			return nil, errors.Errorf("error reading CA file %q", certPath)
+		}
+	}
+
+	return pool, nil
+}

--- a/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
+++ b/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
@@ -69,7 +69,7 @@ var testCasesHttps = []testCase{
 }
 
 func TestZeroWithCustomTLSWithTLSClient(t *testing.T) {
-	pool, err := generateCertPool("/dgraph-tls/ca.crt", true)
+	pool, err := generateCertPool("../../tls/ca.crt", true)
 	if err != nil {
 		t.Fatalf("%+v", err)
 	}

--- a/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
+++ b/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
@@ -63,7 +63,7 @@ var testCasesHttps = []testCase{
 	},
 	{
 		url:       "https://localhost:6180/state",
-		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"zero1:5180\",\"leader\":true,\"amDead\":false",
 		statusCode: 200,
 	},
 }

--- a/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
+++ b/tlstest/zero_https/custom_routes_tls/custom_routes_tls_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -37,13 +38,9 @@ func TestZeroWithCustomTLSWithHTTPClient(t *testing.T) {
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttp {
 		request, err := http.NewRequest("GET", test.url, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		do, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		if do != nil && do.StatusCode != test.statusCode {
 			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
 		}
@@ -70,9 +67,7 @@ var testCasesHttps = []testCase{
 
 func TestZeroWithCustomTLSWithTLSClient(t *testing.T) {
 	pool, err := generateCertPool("../../tls/ca.crt", true)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	require.NoError(t, err)
 
 	tlsCfg := &tls.Config{RootCAs: pool, ServerName: "localhost", InsecureSkipVerify: true}
 	tr := &http.Transport{
@@ -87,14 +82,9 @@ func TestZeroWithCustomTLSWithTLSClient(t *testing.T) {
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttps {
 		request, err := http.NewRequest("GET", test.url, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-
+		require.NoError(t, err)
 		do, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		if do != nil && do.StatusCode != test.statusCode {
 			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
 		}
@@ -108,9 +98,7 @@ func TestZeroWithCustomTLSWithTLSClient(t *testing.T) {
 func readResponseBody(t *testing.T, do *http.Response) []byte {
 	defer func() { _ = do.Body.Close() }()
 	body, err := ioutil.ReadAll(do.Body)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	require.NoError(t, err)
 	return body
 }
 

--- a/tlstest/zero_https/custom_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/custom_routes_tls/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+      - 5180:5180
+      - 6180:6180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ../tls
+        target: /dgraph-tls
+        read_only: true
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls
+    -v=2 --bindall
+volumes: {}

--- a/tlstest/zero_https/custom_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/custom_routes_tls/docker-compose.yml
@@ -15,9 +15,8 @@ services:
         target: /gobin
         read_only: true
       - type: bind
-        source: ../tls
+        source: ../../tls
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls
-    -v=2 --bindall
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls -v=2 --bindall
 volumes: {}

--- a/tlstest/zero_https/custom_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/custom_routes_tls/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "3.5"
 services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+      - 8180:8180
+      - 9180:9180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1

--- a/tlstest/zero_https/custom_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/custom_routes_tls/docker-compose.yml
@@ -33,5 +33,5 @@ services:
         source: ../../tls
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_enabled_route /state,/removeNode,/moveTablet,/assign,/enterpriseLicense --tls_dir /dgraph-tls -v=2 --bindall
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --tls_disabled_route /health --tls_dir /dgraph-tls -v=2 --bindall
 volumes: {}

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    container_name: zero1
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+      - 5180:5180
+      - 6180:6180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 -v=2 --bindall
+volumes: {}

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -1,5 +1,20 @@
 version: "3.5"
 services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    container_name: alpha1
+    working_dir: /data/alpha1
+    labels:
+      cluster: test
+    ports:
+      - 8180:8180
+      - 9180:9180
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
   zero1:
     image: dgraph/dgraph:latest
     container_name: zero1

--- a/tlstest/zero_https/no_tls/no_tls_test.go
+++ b/tlstest/zero_https/no_tls/no_tls_test.go
@@ -1,0 +1,62 @@
+package no_tls
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	url        string
+	statusCode int
+	response   string
+}
+
+var testCasesHttp = []testCase{
+	{
+		url:        "http://localhost:6180/health",
+		response:   "OK",
+		statusCode: 200,
+	},
+	{
+		url:        "http://localhost:6180/state",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		statusCode: 200,
+	},
+}
+
+func TestZeroWithNoTLS(t *testing.T) {
+	client := http.Client{
+		Timeout: time.Second * 10,
+	}
+	defer client.CloseIdleConnections()
+	for _, test := range testCasesHttp {
+		request, err := http.NewRequest("GET", test.url, nil)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		do, err := client.Do(request)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if do != nil && do.StatusCode != test.statusCode {
+			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
+		}
+
+		body := readResponseBody(t, do)
+		if !strings.Contains(string(body), test.response) {
+			t.Fatalf("response is not same. Got: %s Expected: %s", string(body), test.response)
+		}
+	}
+}
+
+func readResponseBody(t *testing.T, do *http.Response) []byte {
+	defer func() { _ = do.Body.Close() }()
+	body, err := ioutil.ReadAll(do.Body)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	return body
+}

--- a/tlstest/zero_https/no_tls/no_tls_test.go
+++ b/tlstest/zero_https/no_tls/no_tls_test.go
@@ -22,7 +22,7 @@ var testCasesHttp = []testCase{
 	},
 	{
 		url:        "http://localhost:6180/state",
-		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"localhost:5080\",\"leader\":true,\"amDead\":false",
+		response:  "\"id\":\"1\",\"groupId\":0,\"addr\":\"zero1:5180\",\"leader\":true,\"amDead\":false",
 		statusCode: 200,
 	},
 }

--- a/tlstest/zero_https/no_tls/no_tls_test.go
+++ b/tlstest/zero_https/no_tls/no_tls_test.go
@@ -1,6 +1,7 @@
 package no_tls
 
 import (
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -34,13 +35,9 @@ func TestZeroWithNoTLS(t *testing.T) {
 	defer client.CloseIdleConnections()
 	for _, test := range testCasesHttp {
 		request, err := http.NewRequest("GET", test.url, nil)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		do, err := client.Do(request)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
+		require.NoError(t, err)
 		if do != nil && do.StatusCode != test.statusCode {
 			t.Fatalf("status code is not same. Got: %d Expected: %d", do.StatusCode, test.statusCode)
 		}
@@ -55,8 +52,6 @@ func TestZeroWithNoTLS(t *testing.T) {
 func readResponseBody(t *testing.T, do *http.Response) []byte {
 	defer func() { _ = do.Body.Close() }()
 	body, err := ioutil.ReadAll(do.Body)
-	if err != nil {
-		t.Fatalf("%+v", err)
-	}
+	require.NoError(t, err)
 	return body
 }


### PR DESCRIPTION
Enabling TLS based encryption in Dgraph zero. 
Fixes https://dgraph.atlassian.net/browse/DGRAPH-1366. Based on discussion here https://discuss.dgraph.io/t/enabling-tls-configuration-for-internal-ports-making-dgraph-more-secure/10860/2
The same variables are used which needs to be defined for alpha tls configuration

Things to consider:
1. With TLS enabled, tls_enabled_route has to be defined.
2. If defined all routes will be accessible with TLS. But ones mentioned in --tls_enabled_route will not be accessible via HTTP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6691)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-93b2fd387f-103012.surge.sh)
<!-- Dgraph:end -->