### PR TITLE
fix(GraphQL): fix e2e test for in filter

### DIFF
--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -405,6 +405,9 @@ func inFilter(t *testing.T) {
 	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result.QueryState))
+	queriedResult := map[string]*state{}
+	queriedResult[result.QueryState[0].Name] = result.QueryState[0]
+	queriedResult[result.QueryState[1].Name] = result.QueryState[1]
 
 	state1 := &state{
 		Name:    "A State",
@@ -417,9 +420,11 @@ func inFilter(t *testing.T) {
 		Capital: "Common Capital",
 	}
 
-	expected := []*state{state1, state2}
+	if diff := cmp.Diff(state1, queriedResult[state1.Name]); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
 
-	if diff := cmp.Diff(expected, result.QueryState); diff != "" {
+	if diff := cmp.Diff(state2, queriedResult[state2.Name]); diff != "" {
 		t.Errorf("result mismatch (-want +got):\n%s", diff)
 	}
 


### PR DESCRIPTION
This PR slightly modifies `e2e` test for in filter.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6702)
<!-- Reviewable:end -->
