### PR TITLE
[Stale]Make ACL login error message more generic

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -149,13 +149,16 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 	// authorize the user using password
 	user, err := authorizeUser(ctx, request.Userid, request.Password)
 	if err != nil {
+		glog.Error(err)
 		return nil, invalidLogin
 	}
 
 	if user == nil {
+		glog.Errorf("user not found for id %s", request.Userid)
 		return nil, invalidLogin
 	}
 	if !user.PasswordMatch {
+		glog.Errorf("password mismatch for user %s", request.Userid)
 		return nil, invalidLogin
 	}
 	return user, nil

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -121,6 +121,7 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 		return nil, errors.Wrapf(err, "invalid login request")
 	}
 
+	invalidLogin := errors.New("Invalid username or password")
 	var user *acl.User
 	if len(request.RefreshToken) > 0 {
 		userData, err := validateToken(request.RefreshToken)
@@ -132,7 +133,8 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 		userId := userData[0]
 		user, err = authorizeUser(ctx, userId, "")
 		if err != nil {
-			return nil, errors.Wrapf(err, "while querying user with id %v", userId)
+			glog.Errorf("%s while querying user with id %s", err.Error(), userId)
+			return nil, invalidLogin
 		}
 
 		if user == nil {
@@ -145,7 +147,6 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 	}
 
 	// authorize the user using password
-	invalidLogin := errors.New("Invalid username or password")
 	user, err := authorizeUser(ctx, request.Userid, request.Password)
 	if err != nil {
 		return nil, invalidLogin

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -145,19 +145,17 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 	}
 
 	// authorize the user using password
-	var err error
-	user, err = authorizeUser(ctx, request.Userid, request.Password)
+	invalidLogin := errors.New("Invalid username or password")
+	user, err := authorizeUser(ctx, request.Userid, request.Password)
 	if err != nil {
-		return nil, errors.Wrapf(err, "while querying user with id %v",
-			request.Userid)
+		return nil, invalidLogin
 	}
 
 	if user == nil {
-		return nil, errors.Errorf("unable to authenticate through password: "+
-			"user not found for id %v", request.Userid)
+		return nil, invalidLogin
 	}
 	if !user.PasswordMatch {
-		return nil, errors.Errorf("password mismatch for user: %v", request.Userid)
+		return nil, invalidLogin
 	}
 	return user, nil
 }


### PR DESCRIPTION
In case of invalid login request we don't reveal info about user. So make error message more generic
Fixes DGRAPH-2468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6704)
<!-- Reviewable:end -->
