### PR TITLE
Docs (Authentication):Fix for DGRAPH-2235 to restore missing admin authentication docs deleted by split-pages Docs PR

### DIFF
--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -6,7 +6,41 @@ weight = 18
     parent = "deploy"
 +++
 
-Each Dgraph Alpha exposes administrative operations over HTTP to export data and to perform a clean shutdown.
+Each Dgraph Alpha exposes various administrative (admin) endpoints both over
+HTTP and GraphQL, for example endpoints to export data and to perform a clean
+shutdown. All such admin endpoints are protected by three layers of authentication:
+
+1. IP White-listing (use `--whitelist` flag in alpha to whitelist IPs other than
+   localhost).
+2. Poor-man's auth, if alpha is started with the `--auth_token` flag (means you
+   will need to pass the `auth_token` as `X-Dgraph-AuthToken` header while
+   making the HTTP request).
+3. Guardian-only access, if ACL is enabled (means you need to pass the ACL-JWT
+   of a Guardian user using the `X-Dgraph-AccessToken` header while making the
+  HTTP request).
+
+An admin endpoint is any HTTP endpoint which provides admin functionality.
+Admin endpoints nornally start with the `/admin` path. The current list of admin
+endpoints includes:
+
+* /admin
+* /admin/backup
+* /admin/config/lru_mb
+* /admin/draining
+* /admin/export
+* /admin/shutdown
+* /admin/schema
+* /alter
+* /login
+
+There are a few exceptions to the general rule described above:
+
+* `/login`: This endpoint logs-in an ACL user, and provides them with a JWT.
+  Only IP Whitelisting and Poor-man's auth checks are performed for this endpoint.
+* `/admin`: This endpoint provides GraphQL queries/mutations corresponding to
+  the HTTP admin endpoints. All the queries/mutations on `/admin` have all three
+  layers of authentication, except for `login (mutation)`, whcih has the has the
+  same behavior as the above HTTP `/login` endpoint.
 
 ## Whitelisting Admin Operations
 
@@ -215,7 +249,7 @@ dgraph upgrade --acl -a localhost:9080 -u groot -p password
     They have now been renamed as `dgraph.type.User`, `dgraph.type.Group` and `dgraph.type.Rule`, to
     keep them in dgraph's internal namespace. This upgrade just changes the type-names for the ACL
     nodes to the new type-names.
-    
+
     You can use `--dry-run` option in `dgraph upgrade` command to see a dry run of what the upgrade
     command will do.
 8. If you have types or predicates in your schema whose names start with `dgraph.`, then

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -23,15 +23,15 @@ An admin endpoint is any HTTP endpoint which provides admin functionality.
 Admin endpoints usually start with the `/admin` path. The current list of admin
 endpoints includes the following:
 
-* /admin
-* /admin/backup
-* /admin/config/lru_mb
-* /admin/draining
-* /admin/export
-* /admin/shutdown
-* /admin/schema
-* /alter
-* /login
+* `/admin`
+* `/admin/backup`
+* `/admin/config/lru_mb`
+* `/admin/draining`
+* `/admin/export`
+* `/admin/shutdown`
+* `/admin/schema`
+* `/alter`
+* `/login`
 
 There are a few exceptions to the general rule described above:
 

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -20,8 +20,8 @@ shutdown. All such admin endpoints are protected by three layers of authenticati
   HTTP request).
 
 An admin endpoint is any HTTP endpoint which provides admin functionality.
-Admin endpoints nornally start with the `/admin` path. The current list of admin
-endpoints includes:
+Admin endpoints usually start with the `/admin` path. The current list of admin
+endpoints includes the following:
 
 * /admin
 * /admin/backup
@@ -38,8 +38,8 @@ There are a few exceptions to the general rule described above:
 * `/login`: This endpoint logs-in an ACL user, and provides them with a JWT.
   Only IP Whitelisting and Poor-man's auth checks are performed for this endpoint.
 * `/admin`: This endpoint provides GraphQL queries/mutations corresponding to
-  the HTTP admin endpoints. All the queries/mutations on `/admin` have all three
-  layers of authentication, except for `login (mutation)`, whcih has the has the
+  the HTTP admin endpoints. All of the queries/mutations on `/admin` have all
+  three layers of authentication, except for `login (mutation)`, which has the
   same behavior as the above HTTP `/login` endpoint.
 
 ## Whitelisting Admin Operations

--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -509,6 +509,9 @@ schema(pred: [name, friend]) {
 }
 ```
 
+{{% notice "note" %}} If ACL is enabled, then the schema query returns only the
+predicates for which the logged-in ACL user has read access. {{% /notice %}}
+
 Types can also be queried. Below are some example queries.
 
 ```


### PR DESCRIPTION
* https://dgraph.io/docs/deploy/dgraph-administration/ now has missing content from PR 5842 (wiki/content/deploy/index.md) 
* https://dgraph.io/docs/query-language/schema/ now has missing content from PR 5842 (wiki/content/query-language/index.md)

Fixes DGRAPH-2235

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6709)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d90fe5bc19-101047.surge.sh)
<!-- Dgraph:end -->