### PR TITLE
opt(bulk): Close the stream after done

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -356,7 +356,16 @@ func (r *reducer) startWriting(ci *countIndexer, writerCh chan *encodeRequest, c
 		req.wg.Add(1) // One for finishing the writes.
 		go func() {
 			defer req.wg.Done()
+			var attr string
 			for kvlist := range req.listCh {
+				for _, kv := range kvlist.GetKv() {
+					pk, err := x.Parse(kv.Key)
+					x.Check(err)
+					if pk.Attr != attr {
+						fmt.Printf("---> WRITING attr: %s\n", pk.Attr)
+						attr = pk.Attr
+					}
+				}
 				x.Check(ci.writer.Write(kvlist))
 			}
 		}()

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -352,24 +352,33 @@ func (r *reducer) startWriting(ci *countIndexer, writerCh chan *encodeRequest, c
 		}
 	}
 
-	for req := range writerCh {
-		req.wg.Add(1) // One for finishing the writes.
-		go func() {
-			defer req.wg.Done()
-			var attr string
-			for kvlist := range req.listCh {
-				for _, kv := range kvlist.GetKv() {
-					pk, err := x.Parse(kv.Key)
-					x.Check(err)
-					if pk.Attr != attr {
-						fmt.Printf("---> WRITING attr: %s\n", pk.Attr)
-						attr = pk.Attr
-					}
+	var lastStreamId uint32
+	write := func(req *encodeRequest) {
+		for kvlist := range req.listCh {
+			x.Check(ci.writer.Write(kvlist))
+
+			for _, kv := range kvlist.GetKv() {
+				if lastStreamId == kv.StreamId {
+					continue
 				}
-				x.Check(ci.writer.Write(kvlist))
+				if lastStreamId > 0 {
+					fmt.Printf("Finishing stream id: %d\n", lastStreamId)
+					list := &bpb.KVList{}
+					list.Kv = append(list.Kv, &bpb.KV{
+						StreamId:   lastStreamId,
+						StreamDone: true,
+					})
+					ci.writer.Write(list)
+				}
+				lastStreamId = kv.StreamId
 			}
-		}()
+		}
+	}
+
+	for req := range writerCh {
+		write(req)
 		req.wg.Wait()
+
 		count(req)
 	}
 


### PR DESCRIPTION
We should close the stream after we're done in the bulk loader, so we're not holding onto those tables. Otherwise, these tables are kept around and use up a lot of memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6710)
<!-- Reviewable:end -->
