### PR TITLE
Docs(DQL)Document the `between` function

### DIFF
--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -1,7 +1,7 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
 title = "Functions"
-weight = 2 
+weight = 2
 [menu.main]
     parent = "query-language"
 +++
@@ -315,7 +315,7 @@ With `IE` replaced by
 * `le` less than or equal to
 * `lt` less than
 * `ge` greater than or equal to
-* `gt` greather than
+* `gt` greater than
 
 Schema Types: `int`, `float`, `string`, `dateTime`
 
@@ -389,6 +389,32 @@ than that of the movie Minority Report.
   me(func: eq(name@en, "Steven Spielberg")) {
     name@en
     director.film @filter(ge(initial_release_date, val(d))) {
+      initial_release_date
+      name@en
+    }
+  }
+}
+{{< /runnable >}}
+
+## between
+
+Syntax Example: `between(predicate, startDateValue, endDateValue)`
+
+Schema Types: `dateTime`
+
+Index Required: `dateTime`
+
+Returns nodes that match a range of `dateTime` values. The `between` function
+performs a range check to improve query efficiency, as a wide-ranging `dateTime`
+query on a large set of data would run slowly.
+
+Query Example: Movies directed by Ridley Scott and released between 1976 and 1983.
+
+{{< runnable >}}
+{
+  me(func: eq(name@en, "Ridley Scott")) {
+    name@en
+    director.film @filter(between(initial_release_date, "1976-01-01", "1983-01-01"))  {
       initial_release_date
       name@en
     }
@@ -638,5 +664,3 @@ Matches all entities where the polygon describing the location given by `predica
   }
 }
 {{< /runnable >}}
-
-

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -400,7 +400,7 @@ than that of the movie Minority Report.
 
 Syntax Example: `between(predicate, startDateValue, endDateValue)`
 
-Schema Types: `dateTime`
+Schema Types: Scalar types, including `dateTime`, `int`, `float` and `string`
 
 Index Required: `dateTime`
 
@@ -408,14 +408,13 @@ Returns nodes that match a range of `dateTime` values. The `between` function
 performs a range check to improve query efficiency, as a wide-ranging `dateTime`
 query on a large set of data would run slowly.
 
-Query Example: Movies directed by Ridley Scott and released between 1976 and 1983.
+Query Example: Movies released between 1976 and 1983, listed by genre.
 
 {{< runnable >}}
 {
-  me(func: eq(name@en, "Ridley Scott")) {
+  me(func: between(initial_release_date, "1976-01-01", "1983-01-01")) {
     name@en
-    director.film @filter(between(initial_release_date, "1976-01-01", "1983-01-01"))  {
-      initial_release_date
+    genre {
       name@en
     }
   }

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -405,8 +405,8 @@ Schema Types: Scalar types, including `dateTime`, `int`, `float` and `string`
 Index Required: `dateTime`
 
 Returns nodes that match a range of `dateTime` values. The `between` function
-performs a range check to improve query efficiency, as a wide-ranging `dateTime`
-query on a large set of data would run slowly without such a check.
+performs a range check to improve query efficiency, helping to prevent a
+wide-ranging `dateTime` query on a large set of data from running slowly.
 
 Query Example: Movies released between 1976 and 1983, listed by genre.
 

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -406,7 +406,7 @@ Index Required: `dateTime`
 
 Returns nodes that match a range of `dateTime` values. The `between` function
 performs a range check to improve query efficiency, as a wide-ranging `dateTime`
-query on a large set of data would run slowly.
+query on a large set of data would run slowly without such a check.
 
 Query Example: Movies released between 1976 and 1983, listed by genre.
 


### PR DESCRIPTION
Updates to functions.md to document the `between` function:

- Noted the usage and types supported
- Provided a syntax example that should be correct (but that causes errors on the site in the "runnable" context because `between` is not yet available in production)

@pawanrawal and @minhaj-shakeel , please let me know if we need to add any caveats or other notes.

fixes DGRAPH-2538

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6711)
<!-- Reviewable:end -->
 
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9ed67ab392-101324.surge.sh)
<!-- Dgraph:end -->