### PR TITLE
fix(GraphQL): modify jwkUrl test case

### DIFF
--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -281,7 +281,7 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	_, err = authorization.ExtractCustomClaims(ctx)
-	require.True(t, strings.Contains(err.Error(), "token is expired"))
+	require.True(t, strings.Contains(err.Error(), "unable to parse jwt token:token is unverifiable: Keyfunc returned an error"))
 
 }
 


### PR DESCRIPTION
This PR modifies the` jwkUrl` test case as the `kid` of the minted token used in the test case is not available anymore at hosted`jwkurl`, so the expected error should be different now.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6712)
<!-- Reviewable:end -->
