### PR TITLE
fix(worker): fix between filter for non indexed predicates

### DIFF
--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3284,27 +3284,45 @@ func TestBetweenCount(t *testing.T) {
 }
 
 func TestBetweenWithoutIndex(t *testing.T) {
-	test := struct {
+	tests := []struct {
 		name   string
 		query  string
 		result string
 	}{
-		`Test Between on Non Indexed Predicate`,
-		`
 		{
-			me(func: type(CarModel)) @filter(between(year,2009,2010)){
-				make
-				model
-				year
+			`Test Between on Non Indexed Predicate`,
+			`
+			{
+				me(func: type(CarModel)) @filter(between(year,2009,2010)){
+					make
+					model
+					year
+				}
 			}
-		}
-		`,
-		`{"data":{"me":[{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
+			`,
+			`{"data":{"me":[{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
+		},
+		{
+			`Test Between filter at child node`,
+			`
+			{
+				me(func :has(newage)) @filter(between(newage,20,24)) {
+					newage
+					newfriend @filter(between(newage,25,30)){
+					  newage
+					}
+				 }
+			}
+			`,
+			`{"data": {"me": [{"newage": 21},{"newage": 22,"newfriend": [{"newage": 25},{"newage": 26}]},{"newage": 23,"newfriend": [{"newage": 27},{"newage": 28}]},{"newage": 24,"newfriend": [{"newage": 29},{"newage": 30}]}]}`,
+		},
 	}
-	t.Run(test.name, func(t *testing.T) {
-		js := processQueryNoErr(t, test.query)
-		require.JSONEq(t, js, test.result)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			js := processQueryNoErr(t, tc.query)
+			require.JSONEq(t, js, tc.result)
+		})
+	}
 
 }
 
@@ -3326,10 +3344,9 @@ func TestEqFilterWithoutIndex(t *testing.T) {
 		`,
 		`{"data":{"me":[{"make":"Ford","model":"Focus","year":2008},{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
 	}
-	t.Run(test.name, func(t *testing.T) {
-		js := processQueryNoErr(t, test.query)
-		require.JSONEq(t, js, test.result)
-	})
+
+	js := processQueryNoErr(t, test.query)
+	require.JSONEq(t, js, test.result)
 
 }
 

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3314,7 +3314,7 @@ func TestBetweenWithoutIndex(t *testing.T) {
 				 }
 			}
 			`,
-			`{"data": {"me": [{"newage": 21},{"newage": 22,"newfriend": [{"newage": 25},{"newage": 26}]},{"newage": 23,"newfriend": [{"newage": 27},{"newage": 28}]},{"newage": 24,"newfriend": [{"newage": 29},{"newage": 30}]}]}`,
+			`{"data": {"me": [{"newage": 21},{"newage": 22,"newfriend": [{"newage": 25},{"newage": 26}]},{"newage": 23,"newfriend": [{"newage": 27},{"newage": 28}]},{"newage": 24,"newfriend": [{"newage": 29},{"newage": 30}]}]}}`,
 		},
 	}
 	for _, tc := range tests {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3292,23 +3292,23 @@ func TestBetweenWithIndex(t *testing.T) {
 		{
 			`Test Between on Indexed Predicate`,
 			`{
-				me(func :has(newname))  @filter(eq(newname,"P1","P3")){
+				me(func :has(newname))  @filter(between(newname,"P1","P3")){
 					newname
 				  }
 			 }`,
-			`{"data": {"me": [{"newname": "P1"},{"newname": "P3"}]}}`,
+			`{"data": {"me": [{"newname": "P1"},{"newname": "P2"},{"newname": "P3"},{"newname": "P10"},{"newname": "P11"},{"newname": "P12"}]}}`,
 		},
 		{
 			`Test Between on Indexed Predicate at child Node`,
 			`{
-				me(func :has(newname))  @filter(eq(newname,"P1","P3")){
+				me(func :has(newname))  @filter(between(newname,"P12","P2")){
 					newname
-					newfriend @filter(eq(newname, "P3", "P7")){
+					newfriend @filter(between(newname, "P3", "P5")){
 					  newname
 					}
-				}
+				  }
 			 }`,
-			`{"data": {"me": [{"newname": "P1", "newfriend": [{"newname": "P3"}]},{"newname": "P3", "newfriend": [{"newname": "P7"}]}]}}`,
+			`{"data": {"me": [{"newname": "P2", "newfriend": [{"newname": "P5"}]},{"newname": "P12"}]}}`,
 		},
 	}
 

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3308,6 +3308,31 @@ func TestBetweenWithoutIndex(t *testing.T) {
 
 }
 
+func TestEqFilterWithoutIndex(t *testing.T) {
+	test := struct {
+		name   string
+		query  string
+		result string
+	}{
+		`Test eq filter on Non Indexed Predicate`,
+		`
+		{
+			me(func: type(CarModel)) @filter(eq(year,2008,2009)){
+				make
+				model
+				year
+			}
+		}
+		`,
+		`{"data":{"me":[{"make":"Ford","model":"Focus","year":2008},{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
+	}
+	t.Run(test.name, func(t *testing.T) {
+		js := processQueryNoErr(t, test.query)
+		require.JSONEq(t, js, test.result)
+	})
+
+}
+
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3283,6 +3283,31 @@ func TestBetweenCount(t *testing.T) {
 	}
 }
 
+func TestBetweenWithoutIndex(t *testing.T) {
+	test := struct {
+		name   string
+		query  string
+		result string
+	}{
+		`Test Between on Non Indexed Predicate`,
+		`
+		{
+			me(func: type(CarModel)) @filter(between(year,2009,2010)){
+				make
+				model
+				year
+			}
+		}
+		`,
+		`{"data":{"me":[{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
+	}
+	t.Run(test.name, func(t *testing.T) {
+		js := processQueryNoErr(t, test.query)
+		require.JSONEq(t, js, test.result)
+	})
+
+}
+
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3283,6 +3283,42 @@ func TestBetweenCount(t *testing.T) {
 	}
 }
 
+func TestBetweenWithIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		query  string
+		result string
+	}{
+		{
+			`Test Between on Indexed Predicate`,
+			`{
+				me(func :has(newname))  @filter(eq(newname,"P1","P3")){
+					newname
+				  }
+			 }`,
+			`{"data": {"me": [{"newname": "P1"},{"newname": "P3"}]}}`,
+		},
+		{
+			`Test Between on Indexed Predicate at child Node`,
+			`{
+				me(func :has(newname))  @filter(eq(newname,"P1","P3")){
+					newname
+					newfriend @filter(eq(newname, "P3", "P7")){
+					  newname
+					}
+				}
+			 }`,
+			`{"data": {"me": [{"newname": "P1", "newfriend": [{"newname": "P3"}]},{"newname": "P3", "newfriend": [{"newname": "P7"}]}]}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			js := processQueryNoErr(t, tc.query)
+			require.JSONEq(t, js, tc.result)
+		})
+	}
+}
 func TestBetweenWithoutIndex(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/types/compare.go
+++ b/types/compare.go
@@ -50,5 +50,5 @@ func CompareVals(op string, arg1, arg2 Val) bool {
 // two values val1 and val2(both inclusive).
 func CompareBetween(dst, val1, val2 Val) bool {
 	return CompareVals("ge", dst, val1) &&
-		CompareVals("le", dst, val1)
+		CompareVals("le", dst, val2)
 }

--- a/types/compare.go
+++ b/types/compare.go
@@ -45,3 +45,10 @@ func CompareVals(op string, arg1, arg2 Val) bool {
 	}
 	return false
 }
+
+// CompareBetween compares if the dst value lie between
+// two values val1 and val2(both inclusive).
+func CompareBetween(dst, val1, val2 Val) bool {
+	return CompareVals("ge", dst, val1) &&
+		CompareVals("le", dst, val1)
+}

--- a/worker/task.go
+++ b/worker/task.go
@@ -456,18 +456,20 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 						for _, eqToken := range srcFn.eqTokens {
 							if types.CompareVals(srcFn.fname, val, eqToken) {
 								uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+								break
 							}
 						}
 					case "between":
 						if types.CompareVals("ge", val, srcFn.eqTokens[0]) &&
 							types.CompareVals("le", val, srcFn.eqTokens[1]) {
 							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+							break
 						}
 					default:
 						if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
 							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+							break
 						}
-						break
 					}
 
 				} else {

--- a/worker/task.go
+++ b/worker/task.go
@@ -460,15 +460,12 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 							}
 						}
 					case "between":
-						if types.CompareVals("ge", val, srcFn.eqTokens[0]) &&
-							types.CompareVals("le", val, srcFn.eqTokens[1]) {
+						if types.CompareBetween(val, srcFn.eqTokens[0], srcFn.eqTokens[1]) {
 							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
-							break
 						}
 					default:
 						if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
 							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
-							break
 						}
 					}
 
@@ -1345,8 +1342,7 @@ func (qs *queryState) handleCompareFunction(ctx context.Context, arg funcArgs) e
 		}
 	case arg.srcFn.fname == between:
 		compareFunc := func(dst types.Val) bool {
-			return types.CompareVals("ge", dst, arg.srcFn.eqTokens[0]) &&
-				types.CompareVals("le", dst, arg.srcFn.eqTokens[1])
+			return types.CompareBetween(dst, arg.srcFn.eqTokens[0], arg.srcFn.eqTokens[1])
 		}
 		if err := filterRow(0, compareFunc); err != nil {
 			return err

--- a/worker/task.go
+++ b/worker/task.go
@@ -451,10 +451,25 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 					if val, err = types.Convert(val, srcFn.atype); err != nil {
 						return err
 					}
-					if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
-						uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+					switch srcFn.fname {
+					case "eq":
+						for _, eqToken := range srcFn.eqTokens {
+							if types.CompareVals(srcFn.fname, val, eqToken) {
+								uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+							}
+						}
+					case "between":
+						if types.CompareVals("ge", val, srcFn.eqTokens[0]) &&
+							types.CompareVals("le", val, srcFn.eqTokens[1]) {
+							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+						}
+					default:
+						if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
+							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+						}
 						break
 					}
+
 				} else {
 					vl.Values = append(vl.Values, newValue)
 				}


### PR DESCRIPTION
Fixes DGRAPH-2528.
Fixes DGRAPH-2544.

This PR extends the support for `between` filter on non-indexed predicates so that it could be used outside the root also. For example, for the given schema
```
type CarModel {
	make
	model
	year
}
model                          : string @index(term) @lang .
make                           : string @index(term) .
year                           : int .
```
The below query uses between filter on `year` predicate which is non-indexed, should be valid.
```
queryCareModel(func: type(CarModel)) @filter(between(year,2009,2010)){
				make
				model
				year
			}
```
This PR also fixes the `eq` filter for more than one argument on the non-indexed predicate which earlier used to compare with just the first of the given arguments for `eq` filter. For eg the below query was not giving proper results earlier.
```
queryCarModel(func: type(CarModel)) @filter(eq(year,2008,2009)){
				make
				model
				year
			}
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6715)
<!-- Reviewable:end -->
