### PR TITLE
Make ACL login error message more generic

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -74,8 +74,7 @@ func (s *Server) Login(ctx context.Context,
 
 	user, err := s.authenticateLogin(ctx, request)
 	if err != nil {
-		errMsg := fmt.Sprintf("Authentication from address %s failed: %v", addr, err)
-		glog.Errorf(errMsg)
+		glog.Errorf("Authentication from address %s failed: %v", addr, err)
 		return nil, x.ErrorInvalidLogin
 	}
 	glog.Infof("%s logged in successfully", user.UserID)

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -76,7 +76,7 @@ func (s *Server) Login(ctx context.Context,
 	if err != nil {
 		errMsg := fmt.Sprintf("Authentication from address %s failed: %v", addr, err)
 		glog.Errorf(errMsg)
-		return nil, errors.Errorf(errMsg)
+		return nil, x.ErrorInvalidLogin
 	}
 	glog.Infof("%s logged in successfully", user.UserID)
 

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -3117,6 +3117,7 @@ func TestFailedLogin(t *testing.T) {
 	if err := grootClient.Alter(ctx, &op); err != nil {
 		t.Fatalf("Unable to cleanup db:%v", err)
 	}
+	require.NoError(t, err)
 
 	client, err := testutil.DgraphClient(testutil.SockAddr)
 	require.NoError(t, err)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -3107,3 +3107,29 @@ func TestMutationWithValueVar(t *testing.T) {
 
 	testutil.CompareJSON(t, `{"me": [{"name":"r1","nickname":"r1"}]}`, string(resp.GetJson()))
 }
+
+func TestFailedLogin(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 1*time.Second)
+
+	grootClient, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
+	require.NoError(t, err)
+	op := api.Operation{DropAll: true}
+	if err := grootClient.Alter(ctx, &op); err != nil {
+		t.Fatalf("Unable to cleanup db:%v", err)
+	}
+
+	client, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+
+	// User is not present
+	err = client.Login(ctx, userid, "simplepassword")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), x.ErrorInvalidLogin.Error())
+
+	resetUser(t)
+	// User is present
+	err = client.Login(ctx, userid, "randomstring")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), x.ErrorInvalidLogin.Error())
+
+}

--- a/x/x.go
+++ b/x/x.go
@@ -66,7 +66,7 @@ var (
 	// ErrNotSupported is thrown when an enterprise feature is requested in the open source version.
 	ErrNotSupported = errors.Errorf("Feature available only in Dgraph Enterprise Edition")
 	ErrNoJwt        = errors.New("no accessJwt available")
-	// ErrorInvalidLogin is error when username or password is incorrect in login
+	// ErrorInvalidLogin is returned when username or password is incorrect in login
 	ErrorInvalidLogin = errors.New("invalid username or password")
 )
 

--- a/x/x.go
+++ b/x/x.go
@@ -66,6 +66,8 @@ var (
 	// ErrNotSupported is thrown when an enterprise feature is requested in the open source version.
 	ErrNotSupported = errors.Errorf("Feature available only in Dgraph Enterprise Edition")
 	ErrNoJwt        = errors.New("no accessJwt available")
+	// ErrorInvalidLogin is error when username or password is incorrect in login
+	ErrorInvalidLogin = errors.New("invalid username or password")
 )
 
 const (


### PR DESCRIPTION
In case of invalid login request we don't reveal info about user. So make error message more generic
Fixes DGRAPH-2468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6716)
<!-- Reviewable:end -->
