### PR TITLE
chore(compose): Set --idx for Alphas

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -220,7 +220,6 @@ func getZero(idx int) service {
 		svc.TmpFS = append(svc.TmpFS, fmt.Sprintf("/data/%s/zw", svc.name))
 	}
 
-	svc.Command += fmt.Sprintf(" -o %d --idx=%d", opts.PortOffset+getOffset(idx), idx)
 	svc.Command += fmt.Sprintf(" --my=%s:%d", svc.name, grpcPort)
 	if opts.NumAlphas > 1 {
 		svc.Command += fmt.Sprintf(" --replicas=%d", opts.NumReplicas)

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -205,7 +205,7 @@ func initService(basename string, idx, grpcPort int) service {
 	if opts.LudicrousMode {
 		svc.Command += " --ludicrous_mode=true"
 	}
-
+	svc.Command += fmt.Sprintf(" -o %d --idx=%d", opts.PortOffset+getOffset(idx), idx)
 	return svc
 }
 


### PR DESCRIPTION
If the compose tool doesn't set the idx for alphas, they will be assigned IDs automatically by raft and that leads to confusion. This PR fixes it by explicitly assigning id to all the alphas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6717)
<!-- Reviewable:end -->
