### PR TITLE
build(linux): Set --with-malloc-conf when installing jemalloc.

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -96,7 +96,7 @@ jemalloc:
 		curl -s -L ${JEMALLOC_URL} -o jemalloc.tar.bz2 ; \
 		tar xjf ./jemalloc.tar.bz2 ; \
 		cd jemalloc-5.2.1 ; \
-		./configure --with-jemalloc-prefix='je_' ; \
+		./configure --with-jemalloc-prefix='je_' --with-malloc-conf='background_thread:true,metadata_thp:auto'; \
 		make ; \
 		if [ "$(USER_ID)" = "0" ]; then \
 			make install ; \


### PR DESCRIPTION
This sets the flag --with-malloc-conf when installing jemalloc to set the default conf values at runtime. In our case, we're setting:

* background_thread:true
* metadata_thp:auto

Example:

* `sudo rm /usr/local/lib/libjemalloc.a && make install` (install jemalloc)
* `dgraph bulk -f 1million.rdf.gz -s 1million.schema -z localhost:5080`
    ```
    ___ Begin jemalloc statistics ___
    Version: "5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756"
    ...
    Run-time option settings
    ...
        opt.metadata_thp: "auto"
        opt.background_thread: true (background_thread: true)
    ...
    ```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6721)
<!-- Reviewable:end -->
