### PR TITLE
fix(Wiki): Fix typo in add.md in wiki.

### DIFF
--- a/wiki/content/graphql/mutations/add.md
+++ b/wiki/content/graphql/mutations/add.md
@@ -68,7 +68,7 @@ mutation addAuthor($author: [AddAuthorInput!]!) {
 ```
 Variables:
 ```json
-{ "auth":
+{ "author":
   { "name": "A.N. Author",
     "dob": "2000-01-01",
     "posts": []


### PR DESCRIPTION
fix(Wiki): Fix typo in  "Variables" of query: "Example: Add mutation on single type using variables".

In the last section, "Example: Add mutation on single type using variables",
we use "$author" variable in GraphQL.

`mutation addAuthor($author: [AddAuthorInput!]!) {
  addAuthor(input: $author) {
    author {
      id
      name
    }
  }
}`

However, in the query variables, we have "auth" key.

` 
{ "auth":
  { "name": "A.N. Author",
    "dob": "2000-01-01",
    "posts": []
  }
}
`

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6723)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a82188d447-101632.surge.sh)
<!-- Dgraph:end -->