### PR TITLE
fix(GraphQL): fixes flaky test  for subscriptions.

### DIFF
--- a/graphql/e2e/subscription/subscription_test.go
+++ b/graphql/e2e/subscription/subscription_test.go
@@ -71,8 +71,9 @@ const (
 `
 )
 
-func TestSubscription(t *testing.T) {
+var subExp = 3 * time.Second
 
+func TestSubscription(t *testing.T) {
 	dg, err := testutil.DgraphClient(groupOnegRPC)
 	require.NoError(t, err)
 	testutil.DropAll(t, dg)
@@ -89,6 +90,7 @@ func TestSubscription(t *testing.T) {
 	}
 	addResult := add.ExecuteAsPost(t, adminEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second * 2)
 
 	add = &common.GraphQLParams{
 		Query: `mutation {
@@ -104,16 +106,15 @@ func TestSubscription(t *testing.T) {
 	}
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
-
+	time.Sleep(time.Second)
 	subscriptionClient, err := common.NewGraphQLSubscription(subscriptionEndpoint, &schema.Request{
 		Query: `subscription{
-			getProduct(productID: "0x2"){
+			queryProduct{
 			  name
 			}
 		  }`,
 	}, `{}`)
 	require.Nil(t, err)
-
 	res, err := subscriptionClient.RecvMsg()
 	require.NoError(t, err)
 
@@ -123,12 +124,9 @@ func TestSubscription(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, subscriptionResp.Errors)
 
-	require.JSONEq(t, `{"getProduct":{"name":"sanitizer"}}`, string(subscriptionResp.Data))
+	require.JSONEq(t, `{"queryProduct":[{"name":"sanitizer"}]}`, string(subscriptionResp.Data))
 	require.Contains(t, subscriptionResp.Extensions, touchedUidskey)
 	require.Greater(t, int(subscriptionResp.Extensions[touchedUidskey].(float64)), 0)
-
-	// Background indexing is happening so wait till it get indexed.
-	time.Sleep(time.Second * 2)
 
 	// Update the product to get the latest update.
 	add = &common.GraphQLParams{
@@ -143,6 +141,7 @@ func TestSubscription(t *testing.T) {
 	}
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
@@ -155,11 +154,10 @@ func TestSubscription(t *testing.T) {
 	require.Nil(t, subscriptionResp.Errors)
 
 	// Check the latest update.
-	require.JSONEq(t, `{"getProduct":{"name":"mask"}}`, string(subscriptionResp.Data))
+	require.JSONEq(t, `{"queryProduct":[{"name":"mask"}]}`, string(subscriptionResp.Data))
 	require.Contains(t, subscriptionResp.Extensions, touchedUidskey)
 	require.Greater(t, int(subscriptionResp.Extensions[touchedUidskey].(float64)), 0)
 
-	time.Sleep(2 * time.Second)
 	// Change schema to terminate subscription..
 	add = &common.GraphQLParams{
 		Query: `mutation updateGQLSchema($sch: String!) {
@@ -173,10 +171,9 @@ func TestSubscription(t *testing.T) {
 	}
 	addResult = add.ExecuteAsPost(t, adminEndpoint)
 	require.Nil(t, addResult.Errors)
-
+	time.Sleep(time.Second)
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
-
 	require.Nil(t, res)
 }
 
@@ -227,8 +224,9 @@ func TestSubscriptionAuth(t *testing.T) {
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
-	jwtToken, err := metaInfo.GetSignedToken("secret", 100*time.Second)
+	jwtToken, err := metaInfo.GetSignedToken("secret", subExp)
 	require.NoError(t, err)
 
 	payload := fmt.Sprintf(`{"Authorization": "%s"}`, jwtToken)
@@ -290,6 +288,8 @@ func TestSubscriptionAuth(t *testing.T) {
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
+
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
 
@@ -319,6 +319,7 @@ func TestSubscriptionAuth(t *testing.T) {
 	}
 	addResult = add.ExecuteAsPost(t, adminEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
@@ -372,8 +373,9 @@ func TestSubscriptionWithAuthShouldExpireWithJWT(t *testing.T) {
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
-	jwtToken, err := metaInfo.GetSignedToken("secret", 10*time.Second)
+	jwtToken, err := metaInfo.GetSignedToken("secret", subExp)
 	require.NoError(t, err)
 
 	payload := fmt.Sprintf(`{"Authorization": "%s"}`, jwtToken)
@@ -400,7 +402,7 @@ func TestSubscriptionWithAuthShouldExpireWithJWT(t *testing.T) {
 		string(resp.Data))
 
 	// Wait for JWT to expire.
-	time.Sleep(10 * time.Second)
+	time.Sleep(subExp)
 
 	// Add another TODO for bob but this should not be visible as the subscription should have
 	// ended.
@@ -421,6 +423,7 @@ func TestSubscriptionWithAuthShouldExpireWithJWT(t *testing.T) {
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
@@ -502,7 +505,6 @@ func TestSubscriptionAuthWithoutExpiry(t *testing.T) {
 }
 
 func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndependently(t *testing.T) {
-	t.Skip()
 	dg, err := testutil.DgraphClient(groupOnegRPC)
 	require.NoError(t, err)
 	testutil.DropAll(t, dg)
@@ -549,8 +551,9 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
-	jwtToken, err := metaInfo.GetSignedToken("secret", 10*time.Second)
+	jwtToken, err := metaInfo.GetSignedToken("secret", subExp)
 	require.NoError(t, err)
 
 	// first subscription
@@ -576,7 +579,7 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 		string(resp.Data))
 
 	// 2nd subscription
-	jwtToken, err = metaInfo.GetSignedToken("secret", 20*time.Second)
+	jwtToken, err = metaInfo.GetSignedToken("secret", 2*subExp)
 	require.NoError(t, err)
 	payload = fmt.Sprintf(`{"Authorization": "%s"}`, jwtToken)
 	subscriptionClient1, err := common.NewGraphQLSubscription(subscriptionEndpoint, &schema.Request{
@@ -591,16 +594,14 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 
 	res, err = subscriptionClient1.RecvMsg()
 	require.NoError(t, err)
-
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
-
 	require.Nil(t, resp.Errors)
 	require.JSONEq(t, `{"queryTodo":[{"owner":"jatin","text":"GraphQL is exciting!!"}]}`,
 		string(resp.Data))
 
 	// Wait for JWT to expire for first subscription.
-	time.Sleep(10 * time.Second)
+	time.Sleep(subExp)
 
 	// Add another TODO for jatin for which 1st subscription shouldn't get updates.
 	add = &common.GraphQLParams{
@@ -619,15 +620,18 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 	}
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
 	require.Nil(t, res) // 1st subscription should get the empty response as subscription has expired.
 
+	time.Sleep(time.Second)
 	res, err = subscriptionClient1.RecvMsg()
 	require.NoError(t, err)
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
+	require.Nil(t, resp.Errors)
 	// 2nd one still running and should get the  update
 	require.JSONEq(t, `{"queryTodo": [
 	 {
@@ -640,8 +644,8 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 	}]}`, string(resp.Data))
 
 	// add extra delay for 2nd subscription to timeout
-	time.Sleep(10 * time.Second)
-	// Add another TODO for jatin for which 2nd subscription shouldn't get updates.
+	time.Sleep(subExp)
+	// Add another TODO for jatin for which 2nd subscription shouldn't get update.
 	add = &common.GraphQLParams{
 		Query: `mutation{
 	         addTodo(input: [
@@ -656,14 +660,15 @@ func TestSubscriptionAuth_SameQueryAndClaimsButDifferentExpiry_ShouldExpireIndep
 	      }
 	    }`,
 	}
-
+	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
+	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 	res, err = subscriptionClient1.RecvMsg()
 	require.NoError(t, err)
 	require.Nil(t, res) // 2nd subscription should get the empty response as subscription has expired.
 }
 
 func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndependently(t *testing.T) {
-	t.Skip()
 	dg, err := testutil.DgraphClient(groupOnegRPC)
 	require.NoError(t, err)
 	testutil.DropAll(t, dg)
@@ -710,8 +715,9 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
-	jwtToken, err := metaInfo.GetSignedToken("secret", 10*time.Second)
+	jwtToken, err := metaInfo.GetSignedToken("secret", subExp)
 	require.NoError(t, err)
 
 	// first subscription
@@ -755,10 +761,11 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
 
 	// 2nd subscription
 	metaInfo.AuthVars["USER"] = "pawan"
-	jwtToken, err = metaInfo.GetSignedToken("secret", 20*time.Second)
+	jwtToken, err = metaInfo.GetSignedToken("secret", 2*subExp)
 	require.NoError(t, err)
 	payload = fmt.Sprintf(`{"Authorization": "%s"}`, jwtToken)
 	subscriptionClient1, err := common.NewGraphQLSubscription(subscriptionEndpoint, &schema.Request{
@@ -782,7 +789,7 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 		string(resp.Data))
 
 	// Wait for JWT to expire for 1st subscription.
-	time.Sleep(10 * time.Second)
+	time.Sleep(subExp)
 
 	// Add another TODO for jatin for which 1st subscription shouldn't get updates.
 	add = &common.GraphQLParams{
@@ -801,7 +808,7 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 	}
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
-	require.NoError(t, err)
+	time.Sleep(time.Second)
 	// 1st subscription should get the empty response as subscription has expired
 	res, err = subscriptionClient.RecvMsg()
 	require.NoError(t, err)
@@ -824,11 +831,12 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 	}
 	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
 	require.Nil(t, addResult.Errors)
-
+	time.Sleep(time.Second)
 	res, err = subscriptionClient1.RecvMsg()
 	require.NoError(t, err)
 	err = json.Unmarshal(res, &resp)
 	require.NoError(t, err)
+	require.Nil(t, resp.Errors)
 	// 2nd one still running and should get the  update
 	require.JSONEq(t, `{"queryTodo": [
 	 {
@@ -842,7 +850,7 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 
 	// add delay for 2nd subscription  to timeout
 	// Wait for JWT to expire.
-	time.Sleep(10 * time.Second)
+	time.Sleep(subExp)
 	// Add another TODO for pawan for which 2nd subscription shouldn't get updates.
 	add = &common.GraphQLParams{
 		Query: `mutation{
@@ -859,7 +867,11 @@ func TestSubscriptionAuth_SameQueryDifferentClaimsAndExpiry_ShouldExpireIndepend
 	    }`,
 	}
 
-	// 2nd subscription should get the empty response as subscriptio has expired
+	addResult = add.ExecuteAsPost(t, graphQLEndpoint)
+	require.Nil(t, addResult.Errors)
+	time.Sleep(time.Second)
+
+	// 2nd subscription should get the empty response as subscription has expired
 	res, err = subscriptionClient1.RecvMsg()
 	require.NoError(t, err)
 	require.Nil(t, res)


### PR DESCRIPTION
(cherry picked from commit b4c6a7314fa01fff18f8f190a2cf3078401d54f6)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6724)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-45824387da-101664.surge.sh)
<!-- Dgraph:end -->