### PR TITLE
fix(GraphQL): This PR fix panic error when we give null value in filter connectives. (#6707)

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1014,6 +1014,9 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 	// Each key in filter is either "and", "or", "not" or the field name it
 	// applies to such as "title" in: `title: { anyofterms: "GraphQL" }``
 	for _, field := range keys {
+		if filter[field] == nil {
+			continue
+		}
 		switch field {
 
 		// In 'and', 'or' and 'not' cases, filter[field] must be a map[string]interface{}

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1,4 +1,43 @@
 -
+  name: "in filter"
+  gqlquery: |
+    query {
+      queryState(filter: {code: {in: ["abc", "def", "ghi"]}}) {
+        code
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryState(func: type(State)) @filter(eq(State.code, "abc", "def", "ghi")) {
+        code : State.code
+        name : State.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Geo query"
+  gqlquery: |
+    query {
+      queryHotel(filter: { location: { near: { distance: 33.33, coordinate: { latitude: 11.11, longitude: 22.22} } } }) {
+        name
+        location {
+          latitude
+          longitude
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryHotel(func: type(Hotel)) @filter(near(Hotel.location, [22.22,11.11], 33.33)) {
+        name : Hotel.name
+        location : Hotel.location
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "ID query"
   gqlquery: |
     query {
@@ -163,6 +202,70 @@
     query {
       queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
         name : Author.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Filter connectives with null values gets skipped "
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" },not:null }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Query with has Filter"
+  gqlquery: |
+    query {
+      queryTeacher(filter: {has: subject}) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter(has(Teacher.subject)) {
+        name : People.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "has Filter with not"
+  gqlquery: |
+    query {
+      queryTeacher(filter: { not : {has: subject } }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter(NOT (has(Teacher.subject))) {
+        name : People.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "has Filter with and"
+  gqlquery: |
+    query {
+      queryTeacher(filter: {has: subject, and: {has: teaches } }  ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter((has(Teacher.teaches) AND has(Teacher.subject))) {
+        name : People.name
         dgraph.uid : uid
       }
     }


### PR DESCRIPTION
This PR fix panic error when we give null value in filter connectives. Null values corresponding to connective are skipped now.
For example in the below filter, not connective gets skipped.

```

 filter:{
      id:{eq:"123"},
      not:null
    },

```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6727)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-510929c87f-101685.surge.sh)
<!-- Dgraph:end -->