### PR TITLE
fix(GraphQL): This PR fix panic error when we give null value in filter connectives. (#6707)

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1014,6 +1014,9 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 	// Each key in filter is either "and", "or", "not" or the field name it
 	// applies to such as "title" in: `title: { anyofterms: "GraphQL" }``
 	for _, field := range keys {
+		if filter[field] == nil {
+			continue
+		}
 		switch field {
 
 		// In 'and', 'or' and 'not' cases, filter[field] must be a map[string]interface{}

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1,4 +1,43 @@
 -
+  name: "in filter"
+  gqlquery: |
+    query {
+      queryState(filter: {code: {in: ["abc", "def", "ghi"]}}) {
+        code
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryState(func: type(State)) @filter(eq(State.code, "abc", "def", "ghi")) {
+        code : State.code
+        name : State.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Geo query"
+  gqlquery: |
+    query {
+      queryHotel(filter: { location: { near: { distance: 33.33, coordinate: { latitude: 11.11, longitude: 22.22} } } }) {
+        name
+        location {
+          latitude
+          longitude
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryHotel(func: type(Hotel)) @filter(near(Hotel.location, [22.22,11.11], 33.33)) {
+        name : Hotel.name
+        location : Hotel.location
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "ID query"
   gqlquery: |
     query {
@@ -168,6 +207,70 @@
     }
 
 -
+  name: "Filter connectives with null values gets skipped "
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" },not:null }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+        name : Author.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Query with has Filter"
+  gqlquery: |
+    query {
+      queryTeacher(filter: {has: subject}) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter(has(Teacher.subject)) {
+        name : People.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "has Filter with not"
+  gqlquery: |
+    query {
+      queryTeacher(filter: { not : {has: subject } }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter(NOT (has(Teacher.subject))) {
+        name : People.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "has Filter with and"
+  gqlquery: |
+    query {
+      queryTeacher(filter: {has: subject, and: {has: teaches } }  ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryTeacher(func: type(Teacher)) @filter((has(Teacher.teaches) AND has(Teacher.subject))) {
+        name : People.name
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "Filters in same input object implies AND"
   gqlquery: |
     query {
@@ -194,6 +297,22 @@
   dgquery: |-
     query {
       queryAuthor(func: type(Author)) @filter(((gt(Author.reputation, 2.5) AND le(Author.dob, "2001-01-01")) AND eq(Author.name, "A. N. Author"))) {
+        name : Author.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "has Filter with nested 'and'"
+  gqlquery: |
+    query {
+      queryAuthor(filter: { name: { eq: "A. N. Author" }, and: { dob: { le: "2001-01-01" }, and: { has: country } } } ) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(((has(Author.country) AND le(Author.dob, "2001-01-01")) AND eq(Author.name, "A. N. Author"))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -401,6 +520,51 @@
     }
 
 
+-
+  name: "Deep filter with has filter"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter: { has : tags }) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(has(Post.tags)) {
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Deep filter with has and other filters"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter:{ title : {anyofterms: "GRAPHQL"} , and : { has : tags } } ) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter((has(Post.tags) AND anyofterms(Post.title, "GRAPHQL"))) {
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
 -
   name: "Deep filter with first"
   gqlquery: |
@@ -740,6 +904,203 @@
           dgraph.uid : uid
         }
         dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive on filter query"
+  gqlquery: |
+    query {
+      queryAuthor @cascade(fields:["dob"]) {
+        dob
+        name
+        posts {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade(Author.dob) {
+        dob : Author.dob
+        name : Author.name
+        posts : Author.posts {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive on get query"
+  gqlquery: |
+    query {
+      getAuthor(id: "0x1") @cascade(fields:["dob"]) {
+        dob
+        name
+        posts {
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      getAuthor(func: uid(0x1)) @filter(type(Author)) @cascade(Author.dob) {
+        dob : Author.dob
+        name : Author.name
+        posts : Author.posts {
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive on query field"
+  gqlquery: |
+    query {
+      queryAuthor {
+        dob
+        posts @cascade(fields:["text"]) {
+          text
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        dob : Author.dob
+        posts : Author.posts @cascade(Post.text) {
+          text : Post.text
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive on root and query field"
+  gqlquery: |
+    query {
+      queryAuthor @cascade(fields:["dob"]) {
+        dob
+        reputation
+        posts @cascade(fields:["text","title","postID"]) {
+          text
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade(Author.dob) {
+        dob : Author.dob
+        reputation : Author.reputation
+        posts : Author.posts @cascade(Post.text, Post.title, uid) {
+          text : Post.text
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive with multiple parameters on root and query field"
+  gqlquery: |
+    query {
+      queryAuthor @cascade(fields:["dob","reputation","id"]) {
+        dob
+        reputation
+        posts @cascade(fields:["text","title"]) {
+          text
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade(Author.dob, Author.reputation, uid) {
+        dob : Author.dob
+        reputation : Author.reputation
+        posts : Author.posts @cascade(Post.text, Post.title) {
+          text : Post.text
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Parameterized Cascade directive with argument at outer level which is not present in inner level "
+  gqlquery: |
+    query {
+      queryAuthor @cascade(fields:["dob"]) {
+        dob
+        reputation
+        posts  {
+          text
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @cascade(Author.dob) {
+        dob : Author.dob
+        reputation : Author.reputation
+        posts : Author.posts {
+          text : Post.text
+          title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "parameterized cascade with interface implementation Human"
+  gqlquery: |
+    query {
+      queryHuman @cascade(fields:["id","name","ename","dob"]) {
+        id
+        name
+        ename
+        dob
+        female
+      }
+    }
+  dgquery: |-
+    query {
+      queryHuman(func: type(Human)) @cascade(uid, Character.name, Employee.ename, Human.dob) {
+        id : uid
+        name : Character.name
+        ename : Employee.ename
+        dob : Human.dob
+        female : Human.female
+      }
+    }
+
+-
+  name: "parameterized cascade with interface Character"
+  gqlquery: |
+    query {
+      queryCharacter @cascade(fields:["id","name"]) {
+        id
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryCharacter(func: type(Character)) @cascade(uid, Character.name) {
+        dgraph.type
+        id : uid
+        name : Character.name
       }
     }
 


### PR DESCRIPTION
This PR fix panic error when we give null value in filter connectives. Null values corresponding to connective are skipped now.
For example in the below filter, not connective gets skipped.

```

 filter:{
      id:{eq:"123"},
      not:null
    },

```

(cherry picked from commit 345b6d1e7e04bf660e3c65b9e63a16266d3e9678)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6728)
<!-- Reviewable:end -->
