### PR TITLE
docs (fix): fixing incomplete Slash security note

### DIFF
--- a/wiki/content/slash-graphql/security.md
+++ b/wiki/content/slash-graphql/security.md
@@ -17,4 +17,7 @@ Restricting the origins that your Slash GraphQL responds to is a an important st
 
 In order to add origins to the allow list, please see the [settings page](https://slash.dgraph.io/_/settings), under the "CORS" tab. By default, we allow all origins to connect to your endpoint (`Access-Control-Allow-Origin: *`), and adding an origin will prevent this default behavior. On adding your first origin, we automatically add "https://slash.dgraph.io"  as well, so that the API explorer continues to work.
 
-Note: CORS restrictions are not a replacement for writing auth rules, as it is possible for malicious actors to bypass these restrictions. Also note that the CORS restrictions only applies to
+{{% notice "note" %}}
+CORS restrictions are not a replacement for writing auth rules, as it is possible for malicious actors to bypass these restrictions.
+Also, note that CORS restrictions only apply to browsers, and you should never use CORS as a way to secure your system (CORS can only protect user data).
+{{% /notice %}}

--- a/wiki/content/slash-graphql/security.md
+++ b/wiki/content/slash-graphql/security.md
@@ -15,7 +15,7 @@ All GraphQL queries and mutations are unrestricted by default. In order to restr
 
 Restricting the origins that your Slash GraphQL responds to is a an important step in preventing XSS exploits. Your Slash GraphQL backend will prevent any origins that are not in the allowlist from accessing your GraphQL endpoint.
 
-In order to add origins to the allow list, please see the [settings page](https://slash.dgraph.io/_/settings), under the "CORS" tab. By default, we allow all origins to connect to your endpoint (`Access-Control-Allow-Origin: *`), and adding an origin will prevent this default behavior. On adding your first origin, we automatically add "https://slash.dgraph.io"  as well, so that the API explorer continues to work.
+In order to add origins to the allow list, please see the [settings page](https://slash.dgraph.io/_/settings), under the **CORS** tab. By default, we allow all origins to connect to your endpoint (`Access-Control-Allow-Origin: *`), and adding an origin will prevent this default behavior. On adding your first origin, we automatically add `https://slash.dgraph.io`  as well, so that the API explorer continues to work.
 
 {{% notice "note" %}}
 CORS restrictions are not a replacement for writing auth rules, as it is possible for malicious actors to bypass these restrictions.

--- a/wiki/content/slash-graphql/security.md
+++ b/wiki/content/slash-graphql/security.md
@@ -19,5 +19,5 @@ In order to add origins to the allow list, please see the [settings page](https:
 
 {{% notice "note" %}}
 CORS restrictions are not a replacement for writing auth rules, as it is possible for malicious actors to bypass these restrictions.
-Also, note that CORS restrictions only apply to browsers, and you should never use CORS as a way to secure your system (CORS can only protect user data).
+Also, note that CORS restrictions only apply to browsers, so you should never use CORS as a way to secure your system (CORS can only protect user data).
 {{% /notice %}}


### PR DESCRIPTION
Fixes GQLSAAS-794

This PR fixes an incomplete note on https://dgraph.io/docs/master/slash-graphql/security/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6730)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-225efbe0eb-101788.surge.sh)
<!-- Dgraph:end -->