### PR TITLE
Increase sleep timer to prevent connection retries before the cluster…

### DIFF
--- a/systest/cluster_setup_test.go
+++ b/systest/cluster_setup_test.go
@@ -82,7 +82,7 @@ func (d *DgraphCluster) StartZeroOnly() error {
 	}
 
 	// Wait for dgraphzero to start listening and become the leader.
-	time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 6)
 	return nil
 }
 
@@ -108,7 +108,7 @@ func (d *DgraphCluster) StartAlphaOnly() error {
 	// programmatically by hitting the query port. This would be quicker than
 	// just waiting 4 seconds (which seems to be the smallest amount of time to
 	// reliably wait).
-	time.Sleep(time.Second * 4)
+	time.Sleep(time.Second * 6)
 
 	d.client = dgo.NewDgraphClient(api.NewDgraphClient(dgConn))
 


### PR DESCRIPTION
… is up (#6652)

(cherry picked from commit f868c88c088f249e85df840a1c82e984d5dce9eb)
Fixes DGRAPH-1637
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6738)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-9966fb8f2f-101966.surge.sh)
<!-- Dgraph:end -->