### PR TITLE
Fix(Tests): Fixes failing tests TestBasicRestore and TestMoveTablets

### DIFF
--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -92,7 +92,7 @@ func waitForRestore(t *testing.T, restoreId int, dg *dgo.Dgraph) {
 			restoreDone = true
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(4 * time.Second)
 	}
 	require.True(t, restoreDone)
 


### PR DESCRIPTION
Motivation:
Recently, it was observed that the tests TestBasicRestore and TestMoveTablets were failing in TeamCity. This is a temporary fix to unblock users by increasing duration between statusRestore requests.

Fixes DGRAPH-2576, DGRAPH-1740

(cherry picked from commit 7a75b15ad615291d367a15633cd74b54415c44a7)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6747)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d3f466bb77-102306.surge.sh)
<!-- Dgraph:end -->