### PR TITLE
feat(Query): Allow filters in expand(_all_) queries on predicates pointing to nodes

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -212,6 +212,9 @@ const testSchema = `
 type Person {
 	name
 	pet
+	friend
+	gender
+	alive
 }
 
 type Animal {
@@ -243,6 +246,9 @@ type SchoolInfo {
 type User {
 	name
 	password
+	gender
+	friend
+	alive
 }
 
 type Node {
@@ -318,6 +324,7 @@ noindex_salary                 : float .
 language                       : [string] .
 score                          : [int] @index(int) .
 average                        : [float] @index(float) .
+gender						   : string .
 `
 
 func populateCluster() {
@@ -615,6 +622,10 @@ func populateCluster() {
 		<5> <dgraph.type> "Pet" .
 		<6> <dgraph.type> "Animal" .
 		<6> <dgraph.type> "Pet" .
+		<23> <dgraph.type> "Person" .
+		<24> <dgraph.type> "Person" .
+		<25> <dgraph.type> "Person" .
+		<31> <dgraph.type> "Person" .
 		<32> <dgraph.type> "SchoolInfo" .
 		<33> <dgraph.type> "SchoolInfo" .
 		<34> <dgraph.type> "SchoolInfo" .

--- a/query/query.go
+++ b/query/query.go
@@ -397,7 +397,8 @@ func (sg *SubGraph) isSimilar(ssg *SubGraph) bool {
 		}
 		return false
 	}
-	// TODO(Anurag): Below check can be expanded to check deeper equivalence
+	// Below check doesn't differentiate between different filters.
+	// It is added to differential between `hasFriend` and `hasFriend @filter()`
 	if sg.Filters != nil {
 		if ssg.Filters != nil && len(sg.Filters) == len(ssg.Filters) {
 			return true

--- a/query/query.go
+++ b/query/query.go
@@ -397,6 +397,13 @@ func (sg *SubGraph) isSimilar(ssg *SubGraph) bool {
 		}
 		return false
 	}
+	// TODO(Anurag): Below check can be expanded to check deeper equivalence
+	if sg.Filters != nil {
+		if ssg.Filters != nil && len(sg.Filters) == len(ssg.Filters) {
+			return true
+		}
+		return false
+	}
 	return true
 }
 

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -2341,7 +2341,7 @@ func TestPasswordExpandAll1(t *testing.T) {
     }
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Michonne"}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"alive":true, "gender":"female","name":"Michonne"}]}}`, js)
 }
 
 func TestPasswordExpandAll2(t *testing.T) {
@@ -2354,7 +2354,8 @@ func TestPasswordExpandAll2(t *testing.T) {
     }
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Michonne", "checkpwd(password)":false}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"alive":true, "checkpwd(password)":false,
+	"gender":"female", "name":"Michonne"}]}}`, js)
 }
 
 func TestPasswordExpandError(t *testing.T) {
@@ -3069,7 +3070,8 @@ func TestTypeFunction(t *testing.T) {
 	`
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t,
-		`{"data": {"me":[{"uid":"0x2"}, {"uid":"0x3"}, {"uid":"0x4"}, {"uid":"0xcb"}]}}`,
+		`{"data": {"me":[{"uid":"0x2"}, {"uid":"0x3"}, {"uid":"0x4"},{"uid":"0x17"},
+		{"uid":"0x18"},{"uid":"0x19"}, {"uid":"0x1f"}, {"uid":"0xcb"}]}}`,
 		js)
 }
 
@@ -3143,17 +3145,17 @@ func TestQueryUnknownType(t *testing.T) {
 func TestQuerySingleType(t *testing.T) {
 	query := `schema(type: Person) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[{"name":"Person",
-		"fields":[{"name":"name"}, {"name":"pet"}]}]}}`,
+	require.JSONEq(t, `{"data":{"types":[{"fields":[{"name":"name"},{"name":"pet"},
+	{"name":"friend"},{"name":"gender"},{"name":"alive"}],"name":"Person"}]}}`,
 		js)
 }
 
 func TestQueryMultipleTypes(t *testing.T) {
 	query := `schema(type: [Person, Animal]) {}`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"types":[{"name":"Animal",
-		"fields":[{"name":"name"}]},
-	{"name":"Person", "fields":[{"name":"name"}, {"name":"pet"}]}]}}`, js)
+	require.JSONEq(t, `{"data":{"types":[{"fields":[{"name":"name"}],"name":"Animal"},
+	{"fields":[{"name":"name"},{"name":"pet"},{"name":"friend"},{"name":"gender"},
+	{"name":"alive"}],"name":"Person"}]}}`, js)
 }
 
 func TestRegexInFilterNoDataOnRoot(t *testing.T) {
@@ -3193,7 +3195,8 @@ func TestMultiRegexInFilter(t *testing.T) {
 		}
 	`
 	res := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"q": [{"name": "Michonne"}]}}`, res)
+	require.JSONEq(t, `{"data": {"q": [{"alive":true, "gender":"female",
+	"name":"Michonne"}]}}`, res)
 }
 
 func TestMultiRegexInFilter2(t *testing.T) {

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -633,8 +633,6 @@ func TestFilterAtSameLevelOnUIDWithExpand(t *testing.T) {
 		}
 	}`
 	js := processQueryNoErr(t, query)
-	// res, _ := json.MarshalIndent(js, " ", "\t")
-	fmt.Println("JS: ", string(js))
 	require.JSONEq(t, `{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
 	"friend":[{"gender":"male","alive":true,"name":"Rick Grimes"}]}]}}`, js)
 }

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -623,6 +623,22 @@ func TestTypeFilterAtExpandEmptyResults(t *testing.T) {
 	require.JSONEq(t, `{"data": {"q":[]}}`, js)
 }
 
+func TestFilterAtSameLevelOnUIDWithExpand(t *testing.T) {
+	query := `{
+		q(func: eq(name, "Michonne")) {
+			expand(_all_)
+			friend @filter(eq(alive, true)){
+				expand(_all_)
+			}
+		}
+	}`
+	js := processQueryNoErr(t, query)
+	// res, _ := json.MarshalIndent(js, " ", "\t")
+	fmt.Println("JS: ", string(js))
+	require.JSONEq(t, `{"data":{"q":[{"name":"Michonne","gender":"female","alive":true,
+	"friend":[{"gender":"male","alive":true,"name":"Rick Grimes"}]}]}}`, js)
+}
+
 // Test Related to worker based pagination.
 
 func TestHasOrderDesc(t *testing.T) {


### PR DESCRIPTION

### Motivation
Enable queries that can declare filters on predicates while using `expand(_all_)` directive. 
Example: 
```
q(func: eq(name, "Michonne")) {
	expand(_all_)
	friend @filter(eq(alive, true)){
		expand(_all_)
	}
}
```
Note: Queries that explicitly ask for scalar predicates while using `expand(_all_)` will continue to throw. 

This PR fixes: DGRAPH-2524

Further discussion: https://discuss.dgraph.io/t/expand-with-predicate-filters/10611

### Components affected by this PR <!-- (Optional) -->

Query Package particularly queries involving `expand(_all_)` directive.





### Does this PR break backwards compatibility?

No



### Testing

Added following tests in:

1. TestFilterAtSameLevelOnUIDWithExpand



### Fixes <!-- (Optional) -->
Fixes DGRAPH-2524





<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6752)
<!-- Reviewable:end -->
