### PR TITLE
fix(Ludicrous): Upserts on list type in Dgraph

### DIFF
--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package main
 
 import (

--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -1,0 +1,152 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+type Person struct {
+	Name  string `json:"name,omitempty"`
+	email string
+	count int
+}
+
+type Data struct {
+	Name   string `json:"name,omitempty"`
+	Counts []int  `json:"count,omitempty"`
+}
+type ResponseData struct {
+	All []Data `json:"all,omitempty"`
+}
+
+func InitData(t *testing.T) {
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	testutil.DropAll(t, dg)
+	require.NoError(t, err)
+	schema := `
+		name: string @index(exact) .
+		email: string @index(exact) .
+		count: [int]  .
+	`
+
+	err = dg.Alter(context.Background(), &api.Operation{Schema: schema})
+	require.NoError(t, err)
+
+	p := Person{
+		Name:  "Alice",
+		email: "alice@dgraph.io",
+		count: 1,
+	}
+	pb, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	mu := &api.Mutation{
+		SetJson:   pb,
+		CommitNow: true,
+	}
+	txn := dg.NewTxn()
+	ctx := context.Background()
+	defer txn.Discard(ctx)
+
+	_, err = txn.Mutate(ctx, mu)
+	require.NoError(t, err)
+}
+
+func TestConcurrentUpdate(t *testing.T) {
+	InitData(t)
+	ctx := context.Background()
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+
+	count := 10
+	var wg sync.WaitGroup
+	wg.Add(count)
+	mutation := func(i int) {
+		defer wg.Done()
+		query := fmt.Sprintf(`query {
+			user as var(func: eq(name, "Alice"))
+			}`)
+		mu := &api.Mutation{
+			SetNquads: []byte(fmt.Sprintf(`uid(user) <count> "%d" .`, i)),
+		}
+		req := &api.Request{
+			Query:     query,
+			Mutations: []*api.Mutation{mu},
+			CommitNow: true,
+		}
+		_, err := dg.NewTxn().Do(ctx, req)
+		require.NoError(t, err)
+	}
+	for i := 0; i < count; i++ {
+		go mutation(i)
+	}
+	wg.Wait()
+
+	q := `query all($a: string) {
+			all(func: eq(name, $a)) {
+			  name
+			  count
+			}
+		  }`
+
+	txn := dg.NewTxn()
+	res, err := txn.QueryWithVars(ctx, q, map[string]string{"$a": "Alice"})
+	require.NoError(t, err)
+	var dat ResponseData
+	err = json.Unmarshal(res.Json, &dat)
+	require.NoError(t, err)
+
+	require.Equal(t, len(dat.All[0].Counts), 10)
+}
+
+func TestSequentialUpdate(t *testing.T) {
+	t.Log("TestSequentialUpdate")
+	InitData(t)
+	ctx := context.Background()
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+
+	count := 10
+	mutation := func(i int) {
+		query := fmt.Sprintf(`query {
+			user as var(func: eq(name, "Alice"))
+			}`)
+		mu := &api.Mutation{
+			SetNquads: []byte(fmt.Sprintf(`uid(user) <count> "%d" .`, i)),
+		}
+		req := &api.Request{
+			Query:     query,
+			Mutations: []*api.Mutation{mu},
+			CommitNow: true,
+		}
+		_, err := dg.NewTxn().Do(ctx, req)
+		require.NoError(t, err)
+
+	}
+	for i := 0; i < count; i++ {
+		mutation(i)
+	}
+
+	q := `query all($a: string) {
+			all(func: eq(name, $a)) {
+			  name
+			  count
+			}
+		  }`
+
+	txn := dg.NewTxn()
+	res, err := txn.QueryWithVars(ctx, q, map[string]string{"$a": "Alice"})
+	require.NoError(t, err)
+	var dat ResponseData
+	err = json.Unmarshal(res.Json, &dat)
+	require.NoError(t, err)
+
+	require.Equal(t, len(dat.All[0].Counts), 10)
+}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -679,7 +679,8 @@ func (n *node) processApplyCh() {
 			psz := proposal.Size()
 			totalSize += int64(psz)
 
-			if x.WorkerConfig.LudicrousMode && proposal.Mutations != nil && proposal.Mutations.StartTs == 0 {
+			// In case of upserts the startTs would be > 0, so, no need to check startTs is 0
+			if x.WorkerConfig.LudicrousMode && proposal.Mutations != nil {
 				proposal.Mutations.StartTs = State.GetTimestamp(false)
 			}
 


### PR DESCRIPTION
Fixes DGRAPH-2446

We were not updating startTs for upsert mutations properly in ludicrous mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6754)
<!-- Reviewable:end -->
