### PR TITLE
fix(test): Add sleep before running ludicrous mode tests

### DIFF
--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -74,6 +74,7 @@ func InitData(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
+	// wait for server to be ready
 	time.Sleep(2 * time.Second)
 	InitData(t)
 	ctx := context.Background()
@@ -103,7 +104,9 @@ func TestConcurrentUpdate(t *testing.T) {
 		go mutation(i)
 	}
 	wg.Wait()
-	time.Sleep(time.Second * 1)
+	// eventual consistency
+	time.Sleep(1 * time.Second)
+
 	q := `query all($a: string) {
 			all(func: eq(name, $a)) {
 			  name
@@ -122,6 +125,7 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestSequentialUpdate(t *testing.T) {
+	// wait for server to be ready
 	time.Sleep(2 * time.Second)
 	InitData(t)
 	ctx := context.Background()
@@ -148,6 +152,9 @@ func TestSequentialUpdate(t *testing.T) {
 	for i := 0; i < count; i++ {
 		mutation(i)
 	}
+
+	// eventual consistency
+	time.Sleep(1 * time.Second)
 
 	q := `query all($a: string) {
 			all(func: eq(name, $a)) {

--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dgraph-io/dgo/v200/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
 )
 
 type Person struct {
@@ -73,6 +74,7 @@ func InitData(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
+	time.Sleep(2 * time.Second)
 	InitData(t)
 	ctx := context.Background()
 	dg, err := testutil.DgraphClient(testutil.SockAddr)
@@ -120,6 +122,7 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestSequentialUpdate(t *testing.T) {
+	time.Sleep(2 * time.Second)
 	InitData(t)
 	ctx := context.Background()
 	dg, err := testutil.DgraphClient(testutil.SockAddr)

--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -118,7 +118,7 @@ func TestConcurrentUpdate(t *testing.T) {
 	err = json.Unmarshal(res.Json, &dat)
 	require.NoError(t, err)
 
-	require.Equal(t, len(dat.All[0].Counts), 10)
+	require.Equal(t, 10, len(dat.All[0].Counts))
 }
 
 func TestSequentialUpdate(t *testing.T) {
@@ -163,5 +163,5 @@ func TestSequentialUpdate(t *testing.T) {
 	err = json.Unmarshal(res.Json, &dat)
 	require.NoError(t, err)
 
-	require.Equal(t, len(dat.All[0].Counts), 10)
+	require.Equal(t, 10, len(dat.All[0].Counts))
 }


### PR DESCRIPTION
The tests are currently failing with following  in the CI:
```
Error Trace:	client.go:160
        	            				upsert_test.go:47
        	            				upsert_test.go:76
        	Error:      	Received unexpected error:
        	            	rpc error: code = Unknown desc = Please retry again, server is not ready to accept requests
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6766)
<!-- Reviewable:end -->
