### PR TITLE
fix(test): removing ludicrous mode from the zero init

### DIFF
--- a/systest/ludicrous/docker-compose.yml
+++ b/systest/ludicrous/docker-compose.yml
@@ -73,6 +73,6 @@ services:
       read_only: true
     - data:/data
     command: /gobin/dgraph zero -o 100 --idx=1 --my=zero1:5180 --replicas=1 --logtostderr
-      -v=2 --bindall --ludicrous_mode
+      -v=2 --bindall
 volumes:
   data:

--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sync"
-	"testing"
-
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
 )
 
 type Person struct {
@@ -101,7 +101,7 @@ func TestConcurrentUpdate(t *testing.T) {
 		go mutation(i)
 	}
 	wg.Wait()
-
+	time.Sleep(time.Second * 1)
 	q := `query all($a: string) {
 			all(func: eq(name, $a)) {
 			  name


### PR DESCRIPTION
ludicrous test have been failing in master because --ludicrous_mode option has been removed from the zero initialization

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6767)
<!-- Reviewable:end -->
