### PR TITLE
fix(compose): Don't add ludicrous_mode flag to zero

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -202,10 +202,6 @@ func initService(basename string, idx, grpcPort int) service {
 	if opts.Jaeger {
 		svc.Command += " --jaeger.collector=http://jaeger:14268"
 	}
-	if opts.LudicrousMode {
-		svc.Command += " --ludicrous_mode=true"
-	}
-
 	return svc
 }
 
@@ -281,6 +277,9 @@ func getAlpha(idx int) service {
 	svc.Command += fmt.Sprintf(" --my=%s:%d", svc.name, internalPort)
 	svc.Command += fmt.Sprintf(" --zero=%s", zerosOpt)
 	svc.Command += fmt.Sprintf(" --logtostderr -v=%d", opts.Verbosity)
+	if opts.LudicrousMode {
+		svc.Command += " --ludicrous_mode=true"
+	}
 
 	// Don't assign idx, let it auto-assign.
 	// svc.Command += fmt.Sprintf(" --idx=%d", idx)


### PR DESCRIPTION
Zero no longer has the `--ludicrous_mode` flag but the compose tool was generating it with this flag. This PR fixes the compose tool so that it doesn't generate `--ludicrous_mode` for zeros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6772)
<!-- Reviewable:end -->
