### PR TITLE
feat(Query): Enable persistent queries in dgraph

### DIFF
--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -247,7 +247,7 @@ func TestDeletePredicate(t *testing.T) {
 	testutil.CompareJSON(t, `{"data":{"schema":[`+
 		`{"predicate":"age","type":"default"},`+
 		`{"predicate":"name","type":"string","index":true, "tokenizer":["term"]},`+
-		x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+
+		x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+x.PersistedQueryPredicate+","+
 		`{"predicate":"dgraph.type","type":"string","index":true, "tokenizer":["exact"],
 			"list":true}],`+x.InitialTypes+`}}`, output)
 
@@ -1077,7 +1077,7 @@ func TestListTypeSchemaChange(t *testing.T) {
 	res, err = runGraphqlQuery(q)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"schema":[`+
-		x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+
+		x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+x.PersistedQueryPredicate+","+
 		`{"predicate":"occupations","type":"string"},`+
 		`{"predicate":"dgraph.type", "type":"string", "index":true, "tokenizer": ["exact"],
 			"list":true}],`+x.InitialTypes+`}}`, res)
@@ -1325,7 +1325,7 @@ func TestDropAll(t *testing.T) {
 	require.NoError(t, err)
 	testutil.CompareJSON(t,
 		`{"data":{"schema":[`+
-			x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+
+			x.AclPredicates+","+x.GraphqlPredicates+","+x.CorsPredicate+","+x.PersistedQueryPredicate+","+
 			`{"predicate":"dgraph.type", "type":"string", "index":true, "tokenizer":["exact"],
 				"list":true}],`+x.InitialTypes+`}}`, output)
 

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -201,11 +201,11 @@ EOF
   diff <(LC_ALL=C sort all_dbs.out | uniq -c) - <<EOF
       1 dgraph.acl.rule
       1 dgraph.cors
+      1 dgraph.graphql.p_query
+      1 dgraph.graphql.p_sha256hash
       1 dgraph.graphql.schema
       1 dgraph.graphql.schema_created_at
       1 dgraph.graphql.schema_history
-      1 dgraph.graphql.p_query
-      1 dgraph.graphql.p_sha256hash
       1 dgraph.graphql.xid
       1 dgraph.password
       1 dgraph.rule.permission

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -204,6 +204,8 @@ EOF
       1 dgraph.graphql.schema
       1 dgraph.graphql.schema_created_at
       1 dgraph.graphql.schema_history
+      1 dgraph.graphql.p_query
+      1 dgraph.graphql.p_sha256hash
       1 dgraph.graphql.xid
       1 dgraph.password
       1 dgraph.rule.permission

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -299,7 +299,7 @@ func getGrootAndGuardiansUid(t *testing.T, dg *dgo.Dgraph) (string, string) {
 		GrootUser []userNode `json:"grootUser"`
 	}
 
-	resp,err := txn.Query(ctx, grootUserQuery)
+	resp, err := txn.Query(ctx, grootUserQuery)
 	require.NoError(t, err, "groot user query failed")
 
 	var userResp userQryResp
@@ -939,7 +939,7 @@ func TestUnauthorizedDeletion(t *testing.T) {
 	err = userClient.Login(ctx, userid, userpassword)
 	require.NoError(t, err)
 
-	_, err = deleteUsingNQuad(userClient, "<" + nodeUID + ">", "<" + unAuthPred + ">", "*")
+	_, err = deleteUsingNQuad(userClient, "<"+nodeUID+">", "<"+unAuthPred+">", "*")
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "PermissionDenied")
@@ -1395,7 +1395,7 @@ func TestDeleteQueryWithACLPermissions(t *testing.T) {
 	require.NoError(t, err)
 
 	// delete S * * (user now has permission to name and age)
-	_, err = deleteUsingNQuad(userClient, "<" + nodeUID + ">", "*", "*")
+	_, err = deleteUsingNQuad(userClient, "<"+nodeUID+">", "*", "*")
 	require.NoError(t, err)
 
 	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
@@ -1416,7 +1416,7 @@ func TestDeleteQueryWithACLPermissions(t *testing.T) {
 	time.Sleep(5 * time.Second)
 
 	// delete S * * (user now has permission to name, age and dgraph.type)
-	_, err = deleteUsingNQuad(userClient, "<" + nodeUID + ">", "*", "*")
+	_, err = deleteUsingNQuad(userClient, "<"+nodeUID+">", "*", "*")
 	require.NoError(t, err)
 
 	accessJwt, _, err = testutil.HttpLogin(&testutil.LoginParams{
@@ -2146,6 +2146,16 @@ func TestSchemaQueryWithACL(t *testing.T) {
       	],
       	"upsert": true
 	},
+	{
+		"predicate":"dgraph.graphql.p_query",
+		"type":"string"
+	},
+	{
+		"predicate":"dgraph.graphql.p_sha256hash",
+		"type":"string",
+		"index":true,
+		"tokenizer":["exact"]
+	},
     {
       "predicate": "dgraph.graphql.schema",
       "type": "string"
@@ -2231,6 +2241,17 @@ func TestSchemaQueryWithACL(t *testing.T) {
 		],
 		"name": "dgraph.graphql.history"
 	},
+	{
+		"fields": [
+			{
+				"name": "dgraph.graphql.p_query"
+			},
+			{
+				"name": "dgraph.graphql.p_sha256hash"
+			}
+		],
+		"name": "dgraph.graphql.persisted_query"
+	},
     {
       "fields": [
         {
@@ -2288,6 +2309,10 @@ func TestSchemaQueryWithACL(t *testing.T) {
 	{
 		"fields": [],
 		"name": "dgraph.graphql.history"
+	},
+	{
+		"fields":[],
+		"name":"dgraph.graphql.persisted_query"
 	},
     {
       "fields": [],
@@ -3221,7 +3246,6 @@ func TestDeleteGrootUserShouldFail(t *testing.T) {
 	})
 	require.NoError(t, err, "login failed")
 
-
 	resp := deleteUser(t, accessJwt, "groot", false)
 	require.Contains(t, resp.Errors.Error(),
 		"guardians group and groot user cannot be deleted.")
@@ -3252,12 +3276,12 @@ func TestDeleteGrootAndGuardiansUsingDelNQuadShouldFail(t *testing.T) {
 	grootUid, guardiansUid := getGrootAndGuardiansUid(t, dg)
 
 	// Try deleting groot user
-	_, err = deleteUsingNQuad(dg, "<" + grootUid + ">", "*", "*")
+	_, err = deleteUsingNQuad(dg, "<"+grootUid+">", "*", "*")
 	require.Error(t, err, "Deleting groot user should have returned an error")
 	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
 
 	// Try deleting guardians group
-	_, err = deleteUsingNQuad(dg, "<" + guardiansUid + ">", "*", "*")
+	_, err = deleteUsingNQuad(dg, "<"+guardiansUid+">", "*", "*")
 	require.Error(t, err, "Deleting guardians group should have returned an error")
 	require.Contains(t, err.Error(), "Properties of guardians group and groot user cannot be deleted")
 }
@@ -3291,7 +3315,7 @@ func TestDropAllShouldResetGuardiansAndGroot(t *testing.T) {
 	// Try Drop All
 	op := api.Operation{
 		DropAll: true,
-		DropOp: api.Operation_ALL,
+		DropOp:  api.Operation_ALL,
 	}
 	if err := dg.Alter(ctx, &op); err != nil {
 		t.Fatalf("Unable to drop all. Error:%v", err)
@@ -3302,7 +3326,7 @@ func TestDropAllShouldResetGuardiansAndGroot(t *testing.T) {
 
 	// Try Drop Data
 	op = api.Operation{
-		DropOp:  api.Operation_DATA,
+		DropOp: api.Operation_DATA,
 	}
 	if err := dg.Alter(ctx, &op); err != nil {
 		t.Fatalf("Unable to drop data. Error:%v", err)

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -288,7 +288,6 @@ const (
 		config: Config
 		getAllowedCORSOrigins: Cors
 		querySchemaHistory(first: Int, offset: Int): [SchemaHistory]
-		queryPersistedQuery: PersistedQuery
 		` + adminQueries + `
 	}
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -80,6 +80,14 @@ const (
 	}
 
 	"""
+	PersistedQuery contains the query and sha256hash of the query.
+	"""
+	type PersistedQuery @dgraph(type: "dgraph.graphql.persisted_query") {
+		query: String! @dgraph(pred: "dgraph.graphql.p_query")
+		sha256Hash: String! @id @dgraph(pred: "dgraph.graphql.p_sha256hash")
+	}
+
+	"""
 	A NodeState is the state of an individual node in the Dgraph cluster.
 	"""
 	type NodeState {
@@ -280,6 +288,7 @@ const (
 		config: Config
 		getAllowedCORSOrigins: Cors
 		querySchemaHistory(first: Int, offset: Int): [SchemaHistory]
+		queryPersistedQuery: PersistedQuery
 		` + adminQueries + `
 	}
 

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -125,7 +125,7 @@ const (
                 }
             ],
             "name": "dgraph.graphql.persisted_query"
-        },
+        }
     ]
 }`
 
@@ -148,6 +148,16 @@ const (
              "exact"
             ],
             "upsert": true
+        },
+        {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
         },
         {
             "predicate": "dgraph.graphql.schema",
@@ -208,6 +218,17 @@ const (
                 }
             ],
             "name": "dgraph.graphql.history"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
         }
     ]
 }`
@@ -246,6 +267,16 @@ const (
              "exact"
             ],
             "upsert": true
+        },
+        {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
         },
         {
             "predicate": "dgraph.graphql.schema",
@@ -309,6 +340,17 @@ const (
                 }
             ],
             "name": "dgraph.graphql.history"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
         }
     ]
 }`
@@ -355,6 +397,16 @@ const (
              "exact"
             ],
             "upsert": true
+        },
+        {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
         },
         {
             "predicate": "dgraph.graphql.schema",
@@ -421,6 +473,17 @@ const (
                 }
             ],
             "name": "dgraph.graphql.history"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
         }
     ]
 }`

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -54,6 +54,16 @@ const (
             "upsert": true
         },
         {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
+        },
+        {
             "predicate": "dgraph.graphql.schema",
             "type": "string"
         },
@@ -104,7 +114,18 @@ const (
                 }
             ],
             "name": "dgraph.graphql.history"
-        }
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
+        },
     ]
 }`
 

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/graphql/schema"
+
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
@@ -82,9 +84,10 @@ const (
 // header to the same.
 
 type GraphQLParams struct {
-	Query         string                 `json:"query"`
-	OperationName string                 `json:"operationName"`
-	Variables     map[string]interface{} `json:"variables"`
+	Query         string                    `json:"query"`
+	OperationName string                    `json:"operationName"`
+	Variables     map[string]interface{}    `json:"variables"`
+	Extensions    *schema.RequestExtensions `json:"extensions,omitempty"`
 	acceptGzip    bool
 	gzipEncoding  bool
 	Headers       http.Header
@@ -341,6 +344,7 @@ func RunAll(t *testing.T) {
 	t.Run("alias works for queries", queryWithAlias)
 	t.Run("cascade directive", queryWithCascade)
 	t.Run("query geo near filter", queryGeoNearFilter)
+	t.Run("persisted query", persistedQuery)
 
 	// mutation tests
 	t.Run("add mutation", addMutation)

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/graphql/schema"
+
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
@@ -2309,4 +2311,43 @@ func queryGeoNearFilter(t *testing.T) {
 	testutil.CompareJSON(t, queryHotelExpected, string(gqlResponse.Data))
 	// Cleanup
 	deleteGqlType(t, "Hotel", map[string]interface{}{}, 3, nil)
+}
+
+func persistedQuery(t *testing.T) {
+	queryCountryParams := &GraphQLParams{
+		Extensions: &schema.RequestExtensions{PersistedQuery: schema.PersistedQuery{
+			Sha256Hash: "shaWithoutAnyPersistedQuery",
+		}},
+	}
+	gqlResponse := queryCountryParams.ExecuteAsPost(t, GraphqlURL)
+	require.Len(t, gqlResponse.Errors, 1)
+	require.Contains(t, gqlResponse.Errors[0].Message, "PersistedQueryNotFound")
+
+	queryCountryParams = &GraphQLParams{
+		Query: `query ($countryName: String){
+			queryCountry(filter: {name: {eq: $countryName}}) {
+				name
+			}
+		}`,
+		Variables: map[string]interface{}{"countryName": "Bangladesh"},
+		Extensions: &schema.RequestExtensions{PersistedQuery: schema.PersistedQuery{
+			Sha256Hash: "incorrectSha",
+		}},
+	}
+	gqlResponse = queryCountryParams.ExecuteAsPost(t, GraphqlURL)
+	require.Len(t, gqlResponse.Errors, 1)
+	require.Contains(t, gqlResponse.Errors[0].Message, "provided sha does not match query")
+
+	queryCountryParams.Extensions.PersistedQuery.Sha256Hash = "bbc0af44f82ce5c38e775f7f14c71e5eba1936b12b3e66c452ee262ef147f1ed"
+	gqlResponse = queryCountryParams.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+
+	queryCountryParams.Query = ""
+	gqlResponse = queryCountryParams.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+
+	// test get method as well
+	queryCountryParams.Extensions = nil
+	gqlResponse = queryCountryParams.ExecuteAsGet(t, GraphqlURL+`?extensions={"persistedQuery":{"sha256Hash":"bbc0af44f82ce5c38e775f7f14c71e5eba1936b12b3e66c452ee262ef147f1ed"}}`)
+	RequireNoGQLErrors(t, gqlResponse)
 }

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -166,6 +166,16 @@
             "upsert": true
         },
         {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
+        },
+        {
             "predicate": "dgraph.graphql.schema",
             "type": "string"
         },
@@ -688,6 +698,17 @@
                 }
             ],
             "name": "dgraph.graphql.history"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
         },
         {
             "fields": [

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -423,6 +423,16 @@
             "type": "string"
         },
         {
+            "predicate":"dgraph.graphql.p_query",
+            "type":"string"
+        },
+        {
+            "predicate":"dgraph.graphql.p_sha256hash",
+            "type":"string",
+            "index":true,
+            "tokenizer":["exact"]
+        },
+        {
             "predicate": "dgraph.graphql.xid",
             "type": "string",
             "index": true,
@@ -870,6 +880,17 @@
                 }
             ],
             "name": "dgraph.graphql.history"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.graphql.p_query"
+                },
+                {
+                    "name": "dgraph.graphql.p_sha256hash"
+                }
+            ],
+            "name": "dgraph.graphql.persisted_query"
         },
         {
             "fields": [

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -299,7 +299,7 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
 				}
 			],
 			"name": "dgraph.graphql.persisted_query"
-		},
+		}
     ]
 }`, tcases[lastSuccessTcaseIdx].dgraphSchema)
 	finalGraphQLSchema := tcases[lastSuccessTcaseIdx].graphQLSchema

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -220,6 +220,16 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
       		"upsert": true
 		},
 		{
+			"predicate":"dgraph.graphql.p_query",
+			"type":"string"
+		},
+		{
+			"predicate":"dgraph.graphql.p_sha256hash",
+			"type":"string",
+			"index":true,
+			"tokenizer":["exact"]
+		},
+		{
             "predicate": "dgraph.graphql.schema",
             "type": "string"
 		},
@@ -230,16 +240,6 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
         {
             "predicate": "dgraph.graphql.schema_history",
             "type": "string"
-		},
-		{
-			"predicate":"dgraph.graphql.p_query",
-			"type":"string"
-		},
-		{
-			"predicate":"dgraph.graphql.p_sha256hash",
-			"type":"string",
-			"index":true,
-			"tokenizer":["exact"]
 		},
         {
             "predicate": "dgraph.graphql.xid",

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -231,6 +231,16 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
             "predicate": "dgraph.graphql.schema_history",
             "type": "string"
 		},
+		{
+			"predicate":"dgraph.graphql.p_query",
+			"type":"string"
+		},
+		{
+			"predicate":"dgraph.graphql.p_sha256hash",
+			"type":"string",
+			"index":true,
+			"tokenizer":["exact"]
+		},
         {
             "predicate": "dgraph.graphql.xid",
             "type": "string",
@@ -278,7 +288,18 @@ func TestConcurrentSchemaUpdates(t *testing.T) {
                 }
             ],
             "name": "dgraph.graphql.history"
-        }
+		},
+		{
+			"fields": [
+				{
+					"name": "dgraph.graphql.p_query"
+				},
+				{
+					"name": "dgraph.graphql.p_sha256hash"
+				}
+			],
+			"name": "dgraph.graphql.persisted_query"
+		},
     ]
 }`, tcases[lastSuccessTcaseIdx].dgraphSchema)
 	finalGraphQLSchema := tcases[lastSuccessTcaseIdx].graphQLSchema

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -32,8 +32,16 @@ type Request struct {
 	Query         string                 `json:"query"`
 	OperationName string                 `json:"operationName"`
 	Variables     map[string]interface{} `json:"variables"`
+	Extensions    struct {
+		PersistedQuery PersistedQuery
+	}
 
 	Header http.Header
+}
+
+// PersistedQuery represents the query struct received from clients like Apollo
+type PersistedQuery struct {
+	Sha256Hash string
 }
 
 // Operation finds the operation in req, if it is a valid request for GraphQL

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -32,11 +32,13 @@ type Request struct {
 	Query         string                 `json:"query"`
 	OperationName string                 `json:"operationName"`
 	Variables     map[string]interface{} `json:"variables"`
-	Extensions    struct {
-		PersistedQuery PersistedQuery
-	}
+	Extensions    RequestExtensions
+	Header        http.Header
+}
 
-	Header http.Header
+// RequestExtensions represents extensions recieved in requests
+type RequestExtensions struct {
+	PersistedQuery PersistedQuery
 }
 
 // PersistedQuery represents the query struct received from clients like Apollo

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -223,7 +223,6 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	res = gh.resolver.Resolve(ctx, gqlReq)
 	write(w, res, strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
-	return
 }
 
 func (gh *graphqlHandler) isValid() bool {

--- a/graphql/web/http.go
+++ b/graphql/web/http.go
@@ -222,8 +222,8 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	res = gh.resolver.Resolve(ctx, gqlReq)
-
 	write(w, res, strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
+	return
 }
 
 func (gh *graphqlHandler) isValid() bool {
@@ -260,10 +260,12 @@ func getRequest(ctx context.Context, r *http.Request) (*schema.Request, error) {
 		gqlReq.Query = query.Get("query")
 		gqlReq.OperationName = query.Get("operationName")
 		if extensions, ok := query["extensions"]; ok {
-			d := json.NewDecoder(strings.NewReader(extensions[0]))
-			d.UseNumber()
-			if err := d.Decode(&gqlReq.Extensions); err != nil {
-				return nil, errors.Wrap(err, "Not a valid GraphQL request body")
+			if len(extensions) > 0 {
+				d := json.NewDecoder(strings.NewReader(extensions[0]))
+				d.UseNumber()
+				if err := d.Decode(&gqlReq.Extensions); err != nil {
+					return nil, errors.Wrap(err, "Not a valid GraphQL request body")
+				}
 			}
 		}
 		variables, ok := query["variables"]

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -692,8 +692,6 @@ func initialSchemaInternal(all bool) []*pb.SchemaUpdate {
 		}, &pb.SchemaUpdate{
 			Predicate: "dgraph.graphql.p_query",
 			ValueType: pb.Posting_STRING,
-			Directive: pb.SchemaUpdate_INDEX,
-			Tokenizer: []string{"exact"},
 		}, &pb.SchemaUpdate{
 			Predicate: "dgraph.graphql.p_sha256hash",
 			ValueType: pb.Posting_STRING,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -577,6 +577,17 @@ func initialTypesInternal(all bool) []*pb.TypeUpdate {
 					ValueType: pb.Posting_DATETIME,
 				},
 			},
+		}, &pb.TypeUpdate{
+			TypeName: "dgraph.graphql.persisted_query",
+			Fields: []*pb.SchemaUpdate{
+				{
+					Predicate: "dgraph.graphql.p_query",
+					ValueType: pb.Posting_STRING,
+				}, {
+					Predicate: "dgraph.graphql.p_sha256hash",
+					ValueType: pb.Posting_STRING,
+				},
+			},
 		})
 
 	if all || x.WorkerConfig.AclEnabled {
@@ -678,6 +689,16 @@ func initialSchemaInternal(all bool) []*pb.SchemaUpdate {
 		}, &pb.SchemaUpdate{
 			Predicate: "dgraph.graphql.schema_created_at",
 			ValueType: pb.Posting_DATETIME,
+		}, &pb.SchemaUpdate{
+			Predicate: "dgraph.graphql.p_query",
+			ValueType: pb.Posting_STRING,
+			Directive: pb.SchemaUpdate_INDEX,
+			Tokenizer: []string{"exact"},
+		}, &pb.SchemaUpdate{
+			Predicate: "dgraph.graphql.p_sha256hash",
+			ValueType: pb.Posting_STRING,
+			Directive: pb.SchemaUpdate_INDEX,
+			Tokenizer: []string{"exact"},
 		})
 
 	if all || x.WorkerConfig.AclEnabled {

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -301,7 +301,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	restoredTypes, err := testutil.GetTypeNames(pdir)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node", "dgraph.graphql", "dgraph.graphql.history"}, restoredTypes)
+	require.ElementsMatch(t, []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}, restoredTypes)
 
 	require.NoError(t, err)
 	t.Logf("--- Restored values: %+v\n", restored)

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -295,7 +295,8 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	restoredPreds, err := testutil.GetPredicateNames(pdir)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"dgraph.graphql.schema", "dgraph.cors", "dgraph.graphql.xid",
-		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at"},
+		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at",
+		"dgraph.graphql.p_query", "dgraph.graphql.p_sha256hash"},
 		restoredPreds)
 
 	restoredTypes, err := testutil.GetTypeNames(pdir)

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -123,7 +123,7 @@ func TestBackupFilesystem(t *testing.T) {
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "name", "dgraph.graphql.xid",
 		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at",
 		"dgraph.graphql.p_query", "dgraph.graphql.p_sha256hash"}
-	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history"}
+	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}
 	testutil.CheckSchema(t, preds, types)
 
 	verifyUids := func() {

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -121,7 +121,8 @@ func TestBackupFilesystem(t *testing.T) {
 	// Check the predicates and types in the schema are as expected.
 	// TODO: refactor tests so that minio and filesystem tests share most of their logic.
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "name", "dgraph.graphql.xid",
-		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at"}
+		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at",
+		"dgraph.graphql.p_query", "dgraph.graphql.p_sha256hash"}
 	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history"}
 	testutil.CheckSchema(t, preds, types)
 

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -117,7 +117,7 @@ func TestBackupMinio(t *testing.T) {
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "dgraph.graphql.xid", "dgraph.type", "movie",
 		"dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at", "dgraph.graphql.p_query",
 		"dgraph.graphql.p_sha256hash"}
-	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history"}
+	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}
 	testutil.CheckSchema(t, preds, types)
 
 	checks := []struct {

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -115,7 +115,8 @@ func TestBackupMinio(t *testing.T) {
 	// Check the predicates and types in the schema are as expected.
 	// TODO: refactor tests so that minio and filesystem tests share most of their logic.
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "dgraph.graphql.xid", "dgraph.type", "movie",
-		"dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at"}
+		"dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at", "dgraph.graphql.p_query",
+		"dgraph.graphql.p_sha256hash"}
 	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history"}
 	testutil.CheckSchema(t, preds, types)
 

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -81,6 +81,8 @@ var expectedSchema = `<movie>:string .` + " " + `
 <dgraph.type>:[string] @index(exact) .` + " " + `
 <dgraph.graphql.xid>:string @index(exact) @upsert .` + " " + `
 <dgraph.graphql.schema>:string .` + " " + `
+<dgraph.graphql.p_query>:string .` + " " + `
+<dgraph.graphql.p_sha256hash>:string @index(exact) .` + " " + `
 <dgraph.graphql.schema_history>:string .` + " " + `
 <dgraph.graphql.schema_created_at>:datetime .` + " " + `
 type <Node> {
@@ -93,6 +95,10 @@ type <dgraph.graphql> {
 type <dgraph.graphql.history> {
 	dgraph.graphql.schema_history
 	dgraph.graphql.schema_created_at
+}
+type <dgraph.graphql.persisted_query> {
+	dgraph.graphql.p_query
+	dgraph.graphql.p_sha256hash
 }
 `
 

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -636,7 +636,7 @@ func SchemaAfterDeleteNode(t *testing.T, c *dgo.Dgraph) {
 
 	resp, err := c.NewTxn().Query(ctx, `schema{}`)
 	require.NoError(t, err)
-	testutil.CompareJSON(t, asJson(`[`+x.CorsPredicate+","+
+	testutil.CompareJSON(t, asJson(`[`+x.CorsPredicate+","+x.PersistedQueryPredicate+","+
 		x.AclPredicates+","+x.GraphqlPredicates+","+
 		`{"predicate":"friend","type":"uid","list":true},`+
 		`{"predicate":"married","type":"bool"},`+
@@ -659,7 +659,7 @@ func SchemaAfterDeleteNode(t *testing.T, c *dgo.Dgraph) {
 	resp, err = c.NewTxn().Query(ctx, `schema{}`)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, asJson(`[`+
-		x.AclPredicates+","+x.CorsPredicate+","+
+		x.AclPredicates+","+x.CorsPredicate+","+x.PersistedQueryPredicate+","+
 		x.GraphqlPredicates+","+
 		`{"predicate":"friend","type":"uid","list":true},`+
 		`{"predicate":"name","type":"default"},`+

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -336,7 +336,7 @@ func SchemaQueryTest(t *testing.T, c *dgo.Dgraph) {
 	require.NoError(t, err)
 	js := `
   {
-    "schema": [` + x.CorsPredicate + "," + x.AclPredicates + `,` + x.GraphqlPredicates + `,
+    "schema": [` + x.CorsPredicate + "," + x.PersistedQueryPredicate + "," + x.AclPredicates + `,` + x.GraphqlPredicates + `,
       {
         "predicate": "dgraph.type",
         "type": "string",
@@ -393,6 +393,12 @@ func SchemaQueryTestPredicate1(t *testing.T, c *dgo.Dgraph) {
 		"predicate": "dgraph.cors"
 	  },
 	  {
+		"predicate": "dgraph.graphql.p_query"
+	  },
+	  {
+		"predicate": "dgraph.graphql.p_sha256hash"
+	  },
+	  {
 	    "predicate": "dgraph.graphql.schema_history"
 	  },
 	  {
@@ -400,7 +406,7 @@ func SchemaQueryTestPredicate1(t *testing.T, c *dgo.Dgraph) {
 	  },
       {
         "predicate": "dgraph.xid"
-      },
+	  },
       {
         "predicate": "dgraph.password"
       },
@@ -560,7 +566,7 @@ func SchemaQueryTestHTTP(t *testing.T, c *dgo.Dgraph) {
 
 	js := `
   {
-    "schema": [` + x.CorsPredicate + `,` + x.AclPredicates + `,` + x.GraphqlPredicates + `,
+    "schema": [` + x.CorsPredicate + `,` + x.PersistedQueryPredicate + `,` + x.AclPredicates + `,` + x.GraphqlPredicates + `,
       {
         "index": true,
         "predicate": "dgraph.type",

--- a/worker/export.go
+++ b/worker/export.go
@@ -663,6 +663,10 @@ func exportInternal(ctx context.Context, in *pb.ExportRequest, db *badger.DB,
 			// Ignore this predicate.
 		case pk.Attr == "dgraph.graphql.schema_history":
 			// Ignore this predicate.
+		case pk.Attr == "dgraph.graphql.p_query":
+			// Ignore this predicate.
+		case pk.Attr == "dgraph.graphql.p_sha256hash":
+			// Ignore this predicate.
 		case pk.IsData() && pk.Attr == "dgraph.graphql.schema":
 			// Export the graphql schema.
 			pl, err := posting.ReadPostingList(key, itr)

--- a/x/keys.go
+++ b/x/keys.go
@@ -546,6 +546,8 @@ var graphqlReservedPredicate = map[string]struct{}{
 	"dgraph.cors":                      {},
 	"dgraph.graphql.schema_history":    {},
 	"dgraph.graphql.schema_created_at": {},
+	"dgraph.graphql.p_query":           {},
+	"dgraph.graphql.p_sha256hash":      {},
 }
 
 // internalPredicateMap stores a set of Dgraph's internal predicate. An internal

--- a/x/keys.go
+++ b/x/keys.go
@@ -556,11 +556,12 @@ var internalPredicateMap = map[string]struct{}{
 }
 
 var preDefinedTypeMap = map[string]struct{}{
-	"dgraph.graphql":         {},
-	"dgraph.type.User":       {},
-	"dgraph.type.Group":      {},
-	"dgraph.type.Rule":       {},
-	"dgraph.graphql.history": {},
+	"dgraph.graphql":                 {},
+	"dgraph.type.User":               {},
+	"dgraph.type.Group":              {},
+	"dgraph.type.Rule":               {},
+	"dgraph.graphql.history":         {},
+	"dgraph.graphql.persisted_query": {},
 }
 
 // IsGraphqlReservedPredicate returns true if it is the predicate is reserved by graphql.

--- a/x/x.go
+++ b/x/x.go
@@ -128,8 +128,13 @@ const (
 {"predicate":"dgraph.rule.permission","type":"int"}
 `
 	// CorsPredicate is the json representation of the predicate reserved by dgraph for the use
-	//of cors
+	// of cors
 	CorsPredicate = `{"predicate":"dgraph.cors","type":"string","list":true,"type":"string","index":true,"tokenizer":["exact"],"upsert":true}`
+
+	// PersistedQueryPredicate is the json representation of the predicate reserved by dgraph for the use of persisted queries
+	PersistedQueryPredicate = `
+	{"predicate":"dgraph.graphql.p_query","type":"string"},
+	{"predicate":"dgraph.graphql.p_sha256hash","type":"string","index":true,"tokenizer":["exact"]}`
 
 	InitialTypes = `
 "types": [{
@@ -147,6 +152,9 @@ const (
 }, {
 	"fields": [{"name": "dgraph.graphql.schema_history"},{"name": "dgraph.graphql.schema_created_at"}],
 	"name": "dgraph.graphql.history"
+}, {
+	"fields": [{"name": "dgraph.graphql.p_query"},{"name": "dgraph.graphql.p_sha256hash"}],
+	"name": "dgraph.graphql.persisted_query"
 }]`
 
 	// GroupIdFileName is the name of the file storing the ID of the group to which


### PR DESCRIPTION
### Motivation
Enable persistent queries as discussed in [RFC on discuss.](https://discuss.dgraph.io/t/rfc-persistent-queries-and-cached-results/10636)

This PR fixes: GRAPHQL-721

This feature works out-of-the-box with Apollo client for GraphQL

### Components affected by this PR <!-- (Optional) -->
Query package






### Does this PR break backwards compatibility?

No



### Testing

Added following tests in:

-  `persistedQuery` in `common.go`. It is an end-to-end test which checks following cases:

     1. If incorrect sha is given throw with `provided sha doesn't match the query`
     2. If only sha is given and it is not present in dgraph throw with `PersistedQueryNotFound`
     3. If both query and sha are given and they match, then execute query and persis the query-sha pair. Check for no error.
     4. Use sha provided in `step iii` to execute the query and check that it throws no error.
     5. Do `step iv` via a `GET` request



### Fixes <!-- (Optional) -->
Fixes GRAPHQL-721
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6788)
<!-- Reviewable:end -->
