### PR TITLE
fix(dgraph): giving users the option to control tls versions

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -172,7 +172,8 @@ they form a Raft group and provide synchronous replication.
 	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
 	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
 	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
-
+	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
+	flag.String("tls_max_version", "TLS12", "max version of tls supported. Valid values are TLS11, TLS12")
 	//Custom plugins.
 	flag.String("custom_tokenizers", "",
 		"Comma separated list of tokenizer plugins")

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -96,6 +96,9 @@ instances to achieve high-availability.
 	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
 	flag.String("tls_disabled_route", "", "comma separated zero endpoint which will be disabled from TLS encryption."+
 		"Valid values are /health,/state,/removeNode,/moveTablet,/assign,/enterpriseLicense,/debug.")
+
+	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
+	flag.String("tls_max_version", "TLS12", "max version of tls supported. Valid values are TLS11, TLS12")
 }
 
 func setupListener(addr string, port int, kind string) (listener net.Listener, err error) {

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -19,6 +19,7 @@ package x
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"path"
 	"strings"
@@ -42,6 +43,8 @@ type TLSHelperConfig struct {
 	RootCACert       string
 	ClientAuth       string
 	UseSystemCACerts bool
+	MinVersion       string
+	MaxVersion       string
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
@@ -66,6 +69,8 @@ func LoadServerTLSConfig(v *viper.Viper, tlsCertFile string, tlsKeyFile string) 
 		conf.Cert = path.Join(conf.CertDir, tlsCertFile)
 		conf.Key = path.Join(conf.CertDir, tlsKeyFile)
 		conf.ClientAuth = v.GetString("tls_client_auth")
+		conf.MinVersion = v.GetString("tls_min_version")
+		conf.MaxVersion = v.GetString("tls_max_version")
 	}
 	conf.UseSystemCACerts = v.GetBool("tls_use_system_ca")
 
@@ -199,12 +204,37 @@ func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err e
 		}
 		tlsCfg.ClientAuth = auth
 
-		tlsCfg.MinVersion = tls.VersionTLS11
-		tlsCfg.MaxVersion = tls.VersionTLS12
-
+		err = setupVersion(tlsCfg, config.MinVersion, config.MaxVersion)
+		if err != nil {
+			return nil, err
+		}
 		return tlsCfg, nil
 	}
 	return nil, nil
+}
+
+func setupVersion(cfg *tls.Config, minVersion string, maxVersion string) error {
+	tlsVersion := map[string]uint16{
+		"TLS11": tls.VersionTLS11,
+		"TLS12": tls.VersionTLS12,
+	}
+
+	if val, has := tlsVersion[strings.ToUpper(minVersion)]; has {
+		cfg.MinVersion = val
+	} else {
+		return fmt.Errorf("invalid min_version '%s'. Valid values [TLS11, TLS12]", minVersion)
+	}
+
+	if val, has := tlsVersion[strings.ToUpper(maxVersion)]; has && val >= cfg.MinVersion {
+		cfg.MaxVersion = val
+	} else {
+		if has {
+			return fmt.Errorf("cannot use '%s' as max_version, it's lower than '%s'", maxVersion, minVersion)
+		}
+		return fmt.Errorf("invalid max_version '%s'. Valid values [TLS11, TLS12]", maxVersion)
+	}
+
+	return nil
 }
 
 // GenerateClientTLSConfig creates and returns a new client side *tls.Config with the


### PR DESCRIPTION
This fixes DGRAPH-2469. Now users will have the option to control tls version of their cluster. This provides them the option to make their cluster more secure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6794)
<!-- Reviewable:end -->
