### PR TITLE
docs: clarify exact order for trigram and term indexes when specified together 

### DIFF
--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -126,7 +126,7 @@ Background indexing task may fail if an unexpected error occurs while computing
 the indexes. You should retry the Alter operation in order to update the schema,
 or sync the schema across all the alphas.
 
-To learn about how to check background indexing status, see 
+To learn about how to check background indexing status, see
 [Querying Health](https://dgraph.io/docs/master/deploy/dgraph-alpha/#querying-health).
 
 ### HTTP API
@@ -381,6 +381,18 @@ Incorrect index choice can impose performance penalties and an increased
 transaction conflict rate. Use only the minimum number of and simplest indexes
 that your application needs.
 {{% /notice %}}
+
+Please note that when specifying at the same time both `term` and `trigram` indexes, in the schema, you will need to specify them in the following exact order:   `<predicate>: string @index(term, trigram) .` not vice-versa.
+Doing otherwise causes queries using the index to return an error about invalid tokenizers.
+
+```
+{
+     "message": ": Attribute streamTitle does not have a valid tokenizer.",
+     "extensions": {
+       "code": "ErrorInvalidRequest"
+     }
+   }
+```   
 
 
 ### DateTime Indices

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -288,8 +288,6 @@ Here is the table containing data types and the set of indexes that can be appli
 
 Only `string` and `dateTime` data types have an option for more than one index type.
 
-Please note that when specifying at the same time both `trigram` and `term` indexes, in the schema, you will need to specify them in the following **exact** order: `<predicate>: string @index(term, trigram) .` no vice-versa.
-
 Let's create an index on the rating predicate. Ratel UI makes it super simple to add an index.
 
 Here's the sequence of steps:

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -288,6 +288,8 @@ Here is the table containing data types and the set of indexes that can be appli
 
 Only `string` and `dateTime` data types have an option for more than one index type.
 
+Please note that when specifying at the same time both `trigram` and `term` indexes, in the schema, you will need to specify them in the following **exact** order: `<predicate>: string @index(term, trigram) .` no vice-versa.
+
 Let's create an index on the rating predicate. Ratel UI makes it super simple to add an index.
 
 Here's the sequence of steps:


### PR DESCRIPTION
Clarified how it's the exact order for both `trigram` and `term` index when specified together in the schema.

Order has to look like:
```
<predicate>: string @index(term, trigram) . 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6800)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d51c41b35b-104613.surge.sh)
<!-- Dgraph:end -->