### PR TITLE
docs:v20.03 docs trigram term order

### DIFF
--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -2433,6 +2433,17 @@ transaction conflict rate. Use only the minimum number of and simplest indexes
 that your application needs.
 {{% /notice %}}
 
+Please note that when specifying at the same time both `term` and `trigram` indexes, in the schema, you will need to specify them in the following exact order:   `<predicate>: string @index(term, trigram) .` not vice-versa.
+Doing otherwise causes queries using the index to return an error about invalid tokenizers.
+
+```
+{
+     "message": ": Attribute streamTitle does not have a valid tokenizer.",
+     "extensions": {
+       "code": "ErrorInvalidRequest"
+     }
+   }
+```  
 
 #### DateTime Indices
 


### PR DESCRIPTION
Clarified how it's the exact order for both trigram and term index when specified together in the schema.

Order has to look like:

```
<predicate>: string @index(term, trigram) . 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6809)
<!-- Reviewable:end -->
