### PR TITLE
fix(GraphQL): Fix panic caused when trying to delete a nested object which doesn't have id/xid

### DIFF
--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1054,8 +1054,9 @@ func rewriteObject(
 		} else if !withAdditionalDeletes {
 			// In case of delete, id/xid is required
 			if xid == nil && id == nil {
-				f := newFragment(map[string]interface{}{})
-				return &mutationRes{secondPass: []*mutationFragment{{fragment: f}}}
+				err := errors.Errorf("object of type: %s doesn't have a field of type ID! "+
+					"or @id and can't be referenced for deletion", typ.Name())
+				return &mutationRes{secondPass: []*mutationFragment{{err: err}}}
 			}
 			var name string
 			if xid != nil {

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1053,6 +1053,10 @@ func rewriteObject(
 			}
 		} else if !withAdditionalDeletes {
 			// In case of delete, id/xid is required
+			if xid == nil && id == nil {
+				f := newFragment(map[string]interface{}{})
+				return &mutationRes{secondPass: []*mutationFragment{{fragment: f}}}
+			}
 			var name string
 			if xid != nil {
 				name = xid.Name()

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -206,7 +206,6 @@ func mutationRewriting(t *testing.T, file string, rewriterFactory func() Mutatio
 
 			// -- Act --
 			upsert, err := rewriterToTest.Rewrite(context.Background(), mut)
-
 			// -- Assert --
 			if tcase.Error != nil || err != nil {
 				require.NotNil(t, err)

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -352,3 +352,12 @@ type Home {
     favouriteMember: HomeMember
 }
 # union testing - end
+
+type Workflow {
+    id: ID!
+    nodes: [Node!]
+}
+
+type Node {
+    name: String!
+}

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -676,7 +676,7 @@
     }
   dgmutations:
     - deletejson: |
-        { 
+        {
                 "Author.posts": [{
                         "uid" : "0x124",
                         "Post.author": {
@@ -734,6 +734,48 @@
         uid
       }
       Post3 as Post3(func: uid(0x456)) @filter(type(Post)) {
+        uid
+      }
+    }
+
+-
+  name: "Update remove reference without id or xid"
+  gqlmutation: |
+    mutation updateWorkflow($patch: UpdateWorkflowInput!) {
+      updateWorkflow(input: $patch) {
+        workflow {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    { "patch":
+      { "filter": {
+          "id": ["0x123"]
+        },
+        "remove": {
+          "nodes": [ { "name": "node" } ]
+        },
+        "set": {
+          "nodes": [ { "name": "node" } ]
+        }
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "Workflow.nodes": [{"Node.name":"node","dgraph.type":["Node"],"uid":"_:Node3"}],
+          "uid":"uid(x)"
+        }
+      cond: "@if(gt(len(x), 0))"
+    - deletejson: |
+        { "uid" : "uid(x)",
+          "Workflow.nodes": [{}]
+        }
+      cond: "@if(gt(len(x), 0))"
+  dgquery: |-
+    query {
+      x as updateWorkflow(func: uid(0x123)) @filter(type(Workflow)) {
         uid
       }
     }
@@ -1376,16 +1418,16 @@
 # Additional Deletes
 #
 # If we have
-# 
+#
 # type Post { ... author: Author @hasInverse(field: posts) ... }
 # type Author { ... posts: [Post] ... }
 #
 # and existing edge
-# 
+#
 # Post1 --- author --> Author1
-# 
+#
 # there must also exist edge
-# 
+#
 # Author1 --- posts --> Post1
 #
 # So if we did an update that changes the author of Post1 to Author2, we need to
@@ -1402,7 +1444,7 @@
 # author we are updating.
 #
 # Updates can only happen at the top level of a mutation, so there's no deep cases.
-# There's four cases to consider: 
+# There's four cases to consider:
 #  * updating a node by adding a reference by ID (e.g. attaching a post to an author
 #    causes a delete on the author the post was attached to - if it's not the post
 #    being updated)
@@ -1422,8 +1464,8 @@
       }
     }
   gqlvariables: |
-    { 
-      "patch": { 
+    {
+      "patch": {
         "filter": {
           "id": ["0x123"]
         },
@@ -1434,7 +1476,7 @@
     }
   dgmutations:
     - setjson: |
-        { 
+        {
           "uid" : "uid(x)",
           "Author.posts": [
             {
@@ -1488,7 +1530,7 @@
     - setjson: |
         { "uid" : "uid(x)",
           "Post.text": "updated text",
-          "Post.author": { 
+          "Post.author": {
             "uid": "0x456",
             "Author.posts": [ { "uid": "uid(x)" } ]
           }
@@ -1524,8 +1566,8 @@
       }
     }
   gqlvariables: |
-    { 
-      "patch": { 
+    {
+      "patch": {
         "filter": {
           "id": ["0x123"]
         },
@@ -1545,7 +1587,7 @@
       cond: "@if(eq(len(State4), 0) AND gt(len(x), 0))"
   dgmutationssec:
     - setjson: |
-        { 
+        {
           "uid" : "uid(x)",
           "Country.states": [
             {
@@ -1618,16 +1660,16 @@
       }
     }
   gqlvariables: |
-    { 
+    {
       "patch":
-      { 
+      {
         "filter": { "name": { "eq": "A.N. Owner" } },
         "set": { "computers": { "name": "Comp" } }
       }
     }
   dgmutations:
     - setjson: |
-        { 
+        {
           "uid": "_:Computer4",
           "dgraph.type": ["Computer"],
           "Computer.name": "Comp"
@@ -1636,7 +1678,7 @@
   dgmutationssec:
     - setjson: |
         { "uid" : "uid(x)",
-          "ComputerOwner.computers": { 
+          "ComputerOwner.computers": {
             "uid": "uid(Computer4)",
             "Computer.owners": [ { "uid": "uid(x)" } ]
           }

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -761,24 +761,9 @@
         }
       }
     }
-  dgmutations:
-    - setjson: |
-        {
-          "Workflow.nodes": [{"Node.name":"node","dgraph.type":["Node"],"uid":"_:Node3"}],
-          "uid":"uid(x)"
-        }
-      cond: "@if(gt(len(x), 0))"
-    - deletejson: |
-        { "uid" : "uid(x)",
-          "Workflow.nodes": [{}]
-        }
-      cond: "@if(gt(len(x), 0))"
-  dgquery: |-
-    query {
-      x as updateWorkflow(func: uid(0x123)) @filter(type(Workflow)) {
-        uid
-      }
-    }
+  error:
+    message: |-
+      failed to rewrite mutation payload because object of type: Node doesn't have a field of type ID! or @id and can't be referenced for deletion
 
 -
   name: "Update add and remove together"


### PR DESCRIPTION
Fixes GRAPHQL-745.

While doing an updateMutation, when the linked object didn't have an `id` or `xid` our code was panicking. This change fixes that behavior by returning an error instead.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6810)
<!-- Reviewable:end -->
