### PR TITLE
Docs(GraphQL)Document the `between` function 

### DIFF
--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -11,7 +11,7 @@ objects for a type.
 
 ### Get a single object
 
-Fetch the title, text and `datePublished` for a post with id `0x1`.
+Fetch the `title`, `text` and `datePublished` for a post with id `0x1`.
 
 ```graphql
 query {
@@ -44,7 +44,8 @@ query {
 
 While fetching nested linked objects, you can also apply a filter on them.
 
-For example, the following query fetches the author with the `id` 0x1 and their posts about GraphQL.
+For example, the following query fetches the author with the `id` 0x1 and their
+ posts about `GraphQL`.
 
 ```graphql
 query {
@@ -65,7 +66,7 @@ query {
 
 If your type has a field with the `@id` directive applied to it, you can also fetch objects using that.
 
-For example, given the following schema, the query below fetches a user's name and age by `userID` (which has the `@id` directive):
+For example, given the following schema, the query below fetches a user's `name` and `age` by `userID` (which has the `@id` directive):
 
 **Schema**:
 
@@ -90,7 +91,7 @@ query {
 
 ### Query a list of objects
 
-You can query a list of objects using GraphQL. For example, the following query fetches the title, text and and `datePublished` for all posts:
+You can query a list of objects using GraphQL. For example, the following query fetches the `title`, `text` and and `datePublished` for all posts:
 
 ```graphql
 query {
@@ -144,7 +145,7 @@ query {
 
 You can also filter nested objects while querying for a list of objects.
 
-For example, the following query fetches all of the authors whose name contains `Lee` and with their `completed` posts that have a score greater than 10:
+For example, the following query fetches all of the authors whose name contains `Lee` and with their `completed` posts that have a score greater than `10`:
 
 ```graphql
 query {
@@ -173,8 +174,11 @@ query {
 ### Filter a query for a range of objects with `between`
 
 You can also filter query results within an inclusive range of indexed and typed
-scalar values using the `between` keyword. This keyword is also supported for
-DQL; to learn more, see [DQL Functions: `between`](/query-language/functions/#between).
+scalar values using the `between` keyword.
+
+{{% notice "tip" %}}This keyword is also supported for DQL; to learn more, see
+[DQL Functions: `between`](/query-language/functions/#between).{{% /notice %}}
+
 
 For example, you might start with the following example schema used to track students at a school:
 

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -170,11 +170,11 @@ query {
 }
 ```
 
-### Filter
+### Filter a query for a range of objects with `between`
 
-You can also filter within a wide range of scalar values when indexed in a type using the `between` filter.
+You can also filter query results within a wide range of indexed and typed scalar values using the `between` keyword. This keyword is also supported for DQL; to learn more, see [DQL Functions: `between`](/query-language/functions/#between).
 
-For example, you could start with the following example schema used to track students at a school:
+For example, you might start with the following example schema used to track students at a school:
 
 **Schema**:
 
@@ -184,7 +184,8 @@ type Student{
    name: String @search(by: [exact])
 }
 ```
-Using the `between` filter, you could fetch records for students who are between 10 and 20 years of age:
+Using the `between` filter, you could fetch records for students who are between
+10 and 20 years of age:
 
 **Query**:
 
@@ -195,12 +196,13 @@ queryStudent(fitler: {age: between: {min: 10, max: 20}}){
 }
 ```
 
-You could also use this filter to fetch records for students where their names falls alphabetically between `Aa` and `Ba`:
+You could also use this filter to fetch records for students whose names fall
+alphabetically between `ba` and `hz`:
 
 **Query**:
 
 ```graphql
-queryStudent(fitler: {name: between: {min: "abc", max: "def"}}){
+queryStudent(fitler: {name: between: {min: "ba", max: "hz"}}){
     age
     name
 }

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -172,7 +172,9 @@ query {
 
 ### Filter a query for a range of objects with `between`
 
-You can also filter query results within a wide range of indexed and typed scalar values using the `between` keyword. This keyword is also supported for DQL; to learn more, see [DQL Functions: `between`](/query-language/functions/#between).
+You can also filter query results within an inclusive range of indexed and typed
+scalar values using the `between` keyword. This keyword is also supported for
+DQL; to learn more, see [DQL Functions: `between`](/query-language/functions/#between).
 
 For example, you might start with the following example schema used to track students at a school:
 

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -11,7 +11,7 @@ objects for a type.
 
 ### Get a single object
 
-Fetch the title, text and datePublished for a post with id `0x1`.
+Fetch the title, text and `datePublished` for a post with id `0x1`.
 
 ```graphql
 query {
@@ -23,8 +23,7 @@ query {
 }
 ```
 
-Fetching nested linked objects, while using get queries is also easy. This is how
-you would fetch the authors for a post and their friends.
+Fetching nested linked objects, while using `get` queries is also easy. For example, this is how you would fetch the authors for a post and their friends.
 
 ```graphql
 query {
@@ -45,7 +44,7 @@ query {
 
 While fetching nested linked objects, you can also apply a filter on them.
 
-Example - Fetching author with id 0x1 and their posts about GraphQL.
+For example, the following query fetches the author with the `id` 0x1 and their posts about GraphQL.
 
 ```graphql
 query {
@@ -64,11 +63,11 @@ query {
 }
 ```
 
-If your type has a field with `@id` directive on it, you can also fetch objects using that.
+If your type has a field with the `@id` directive applied to it, you can also fetch objects using that.
 
-Example: To fetch a user's name and age by userID which has @id directive.
+For example, given the following schema, the query below fetches a user's name and age by `userID` (which has the `@id` directive):
 
-Schema
+**Schema**:
 
 ```graphql
 type User {
@@ -78,7 +77,7 @@ type User {
 }
 ```
 
-Query
+**Query**:
 
 ```graphql
 query {
@@ -89,9 +88,9 @@ query {
 }
 ```
 
-### Query list of objects
+### Query a list of objects
 
-Fetch the title, text and and datePublished for all the posts.
+You can query a list of objects using GraphQL. For example, the following query fetches the title, text and and `datePublished` for all posts:
 
 ```graphql
 query {
@@ -104,7 +103,7 @@ query {
 }
 ```
 
-Fetching a list of posts by their ids.
+The following example query fetches a list of posts by their post `id`:
 
 ```graphql
 query {
@@ -119,9 +118,7 @@ query {
 }
 ```
 
-You also filter the posts by different fields in the Post type which have a
-`@search` directive on them. To only fetch posts which `GraphQL` in their title
-and have a `score > 100`, you can run the following query.
+You also filter posts by different fields in the `Post` type that have a `@search` directive applied. To only fetch posts which have `GraphQL` in their title and have a `score > 100`, you can run the following query:
 
 ```graphql
 query {
@@ -143,10 +140,11 @@ query {
 }
 ```
 
+### Filter a query for a list of objects
+
 You can also filter nested objects while querying for a list of objects.
 
-Example - To fetch all the authors whose name have `Lee` in them and their`completed` posts
-with score greater than 10.
+For example, the following query fetches all of the authors whose name contains `Lee` and with their `completed` posts that have a score greater than 10:
 
 ```graphql
 query {
@@ -169,5 +167,41 @@ query {
       datePublished
     }
   }
+}
+```
+
+### Filter
+
+You can also filter within a wide range of scalar values when indexed in a type using the `between` filter.
+
+For example, you could start with the following example schema used to track students at a school:
+
+**Schema**:
+
+```graphql
+type Student{
+   age: Int @search
+   name: String @search(by: [exact])
+}
+```
+Using the `between` filter, you could fetch records for students who are between 10 and 20 years of age:
+
+**Query**:
+
+```graphql
+queryStudent(fitler: {age: between: {min: 10, max: 20}}){
+    age
+    name
+}
+```
+
+You could also use this filter to fetch records for students where their names falls alphabetically between `Aa` and `Ba`:
+
+**Query**:
+
+```graphql
+queryStudent(fitler: {name: between: {min: "abc", max: "def"}}){
+    age
+    name
 }
 ```

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -180,7 +180,8 @@ scalar values using the `between` keyword.
 [DQL Functions: `between`](/query-language/functions/#between).{{% /notice %}}
 
 
-For example, you might start with the following example schema used to track students at a school:
+For example, you might start with the following example schema used to track
+students at a school:
 
 **Schema**:
 

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -404,15 +404,16 @@ Schema Types: Scalar types, including `dateTime`, `int`, `float` and `string`
 
 Index Required: `dateTime`
 
-Returns nodes that match a range of `dateTime` values. The `between` function
+Returns nodes that match an inclusive range of `dateTime` values. The `between` function
 performs a range check to improve query efficiency, helping to prevent a
 wide-ranging `dateTime` query on a large set of data from running slowly.
 
-Query Example: Movies released between 1976 and 1983, listed by genre.
+Query Example: Movies released between the start of 1976 and the end of 1983,
+listed by genre.
 
 {{< runnable >}}
 {
-  me(func: between(initial_release_date, "1976-01-01", "1983-01-01")) {
+  me(func: between(initial_release_date, "1976-01-01", "1983-12-31")) {
     name@en
     genre {
       name@en

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -402,11 +402,16 @@ Syntax Example: `between(predicate, startDateValue, endDateValue)`
 
 Schema Types: Scalar types, including `dateTime`, `int`, `float` and `string`
 
-Index Required: `dateTime`
+Index Required: `dateTime`, `int`, `float`, and `exact` on strings
 
-Returns nodes that match an inclusive range of `dateTime` values. The `between` function
-performs a range check to improve query efficiency, helping to prevent a
-wide-ranging `dateTime` query on a large set of data from running slowly.
+Returns nodes that match an inclusive range of indexed values. The `between`
+keyword performs a range check on the index to improve query efficiency,
+helping to prevent a wide-ranging query on a large set of data from running
+slowly.
+
+A common use case for the `between` keyword is to search within a
+dataset indexed by `dateTime`. The following example query demonstrates this
+use case.
 
 Query Example: Movies released between the start of 1976 and the end of 1983,
 listed by genre.


### PR DESCRIPTION
Adding documentation for the `between` filter for GraphQL, also minor wording changes to the rest of this page.

Updates to search-filtering.md to document the `between` function in GraphQL:

- Added coverage of the `between` keyword in GraphQL, along with syntax examples from the related code PR (https://github.com/dgraph-io/dgraph/pull/6651)
- Minor rewording throughout

Minor updates to functions.md (DQL) to note that `between` searches in an inclusive range.

@minhaj-shakeel , please let me know if we need to add any caveats or other notes.

Fixes DGRAPH-2607

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6813)
<!-- Reviewable:end -->
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-2ad448189b-105832.surge.sh)
<!-- Dgraph:end -->