### PR TITLE
fix(export): don't return an error if there was no GraphQL schema

### DIFF
--- a/worker/export.go
+++ b/worker/export.go
@@ -677,7 +677,14 @@ func exportInternal(ctx context.Context, in *pb.ExportRequest, db *badger.DB,
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot read value of GraphQL schema")
 			}
-			if len(vals) != 1 {
+			// if the GraphQL schema node was deleted with S * * delete mutation,
+			// then the data key will be overwritten with nil value.
+			// So, just skip exporting it as there will be no value for this data key.
+			if len(vals) == 0 {
+				return nil, nil
+			}
+			// Give an error only if we find more than one value for the schema.
+			if len(vals) > 1 {
 				return nil, errors.Errorf("found multiple values for the GraphQL schema")
 			}
 			val, ok := vals[0].Value.([]byte)


### PR DESCRIPTION
FIxes GRAPHQL-747
Fixes [Discuss Issue](https://discuss.dgraph.io/t/multiple-values-for-the-graphql-schema/10881)
This PR fixes the issue where you would get an error, if you first add a GraphQL schema, then delete the GraphQL schema using `<uid> * *` delete mutation and try to export the DB.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6815)
<!-- Reviewable:end -->
