### PR TITLE
fix(dgraph): giving users the option to control tls versions

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -706,6 +706,7 @@ func run() {
 		TLSClientConfig:     tlsConf,
 		TLSDir:              Alpha.Conf.GetString("tls_dir"),
 		TLSInterNodeEnabled: Alpha.Conf.GetBool("tls_internal_port_enabled"),
+		TLSMinVersion:       Alpha.Conf.GetString("tls_min_version"),
 	}
 	if x.WorkerConfig.EncryptionKey, err = enc.ReadKey(Alpha.Conf); err != nil {
 		glog.Infof("unable to read key %v", err)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -197,7 +197,8 @@ they form a Raft group and provide synchronous replication.
 		"connect as a client with the other nodes in the cluster.")
 	flag.String("tls_key", "", "(optional) The private key file name "+
 		"in tls_dir needed to connect as a client with the other nodes in the cluster.")
-
+	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
+	flag.String("tls_max_version", "TLS12", "max version of tls supported. Valid values are TLS11, TLS12")
 	//Custom plugins.
 	flag.String("custom_tokenizers", "",
 		"Comma separated list of tokenizer plugins")

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -198,7 +198,6 @@ they form a Raft group and provide synchronous replication.
 	flag.String("tls_key", "", "(optional) The private key file name "+
 		"in tls_dir needed to connect as a client with the other nodes in the cluster.")
 	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
-	flag.String("tls_max_version", "TLS12", "max version of tls supported. Valid values are TLS11, TLS12")
 	//Custom plugins.
 	flag.String("custom_tokenizers", "",
 		"Comma separated list of tokenizer plugins")

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -187,17 +187,6 @@ they form a Raft group and provide synchronous replication.
 	flag.Uint64("normalize_node_limit", 1e4,
 		"Limit for the maximum number of nodes that can be returned in a query that uses the "+
 			"normalize directive.")
-
-	// TLS configurations
-	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
-	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
-	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
-	flag.Bool("tls_internal_port_enabled", false, "(optional) enable inter node TLS encryption between cluster nodes.")
-	flag.String("tls_cert", "", "(optional) The Cert file name in tls_dir which is needed to "+
-		"connect as a client with the other nodes in the cluster.")
-	flag.String("tls_key", "", "(optional) The private key file name "+
-		"in tls_dir needed to connect as a client with the other nodes in the cluster.")
-	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
 	//Custom plugins.
 	flag.String("custom_tokenizers", "",
 		"Comma separated list of tokenizer plugins")
@@ -221,6 +210,8 @@ they form a Raft group and provide synchronous replication.
 		PostingListCache,PstoreBlockCache,PstoreIndexCache,WstoreBlockCache,WstoreIndexCache).
 		PostingListCache should be 0 and is a no-op.
 		`)
+	// TLS configurations
+	x.RegisterServerTLSFlags(flag)
 }
 
 func setupCustomTokenizers() {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -107,15 +107,6 @@ instances to achieve high-availability.
 		" exporter does not support annotation logs and would discard them.")
 	flag.Bool("ludicrous_mode", false, "Run zero in ludicrous mode")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
-	// TLS configurations
-	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
-	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
-	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
-	flag.Bool("tls_internal_port_enabled", false, "(optional) enable inter node TLS encryption between cluster nodes.")
-	flag.String("tls_cert", "", "(optional) The Cert file name in tls_dir which is needed to "+
-		"connect as a client with the other nodes in the cluster.")
-	flag.String("tls_key", "", "(optional) The private key file name "+
-		"in tls_dir which is needed to connect as a client with the other nodes in the cluster.")
 	// Cache flags
 	flag.Int64("cache_mb", 0, "Total size of cache (in MB) to be used in zero.")
 	flag.String("cache_percentage", "100,0",
@@ -131,6 +122,8 @@ instances to achieve high-availability.
 			"log directory. mmap consumes more RAM, but provides better performance.")
 	flag.Int("badger.compression_level", 3,
 		"The compression level for Badger. A higher value uses more resources.")
+	// TLS configurations
+	x.RegisterServerTLSFlags(flag)
 }
 
 func setupListener(addr string, port int, kind string) (listener net.Listener, err error) {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -147,7 +147,10 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
 	}
 
-	tlsConf, err := x.LoadServerTLSConfigForInternalPort(Zero.Conf.GetBool("tls_internal_port_enabled"), Zero.Conf.GetString("tls_dir"))
+	tlsConf, err := x.LoadServerTLSConfigForInternalPort(
+		Zero.Conf.GetBool("tls_internal_port_enabled"),
+		Zero.Conf.GetString("tls_dir"),
+		Zero.Conf.GetString("tls_min_version"))
 	x.Check(err)
 	if tlsConf != nil {
 		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(tlsConf)))

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -71,7 +71,10 @@ func Init(ps *badger.DB) {
 		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
 	}
 
-	tlsConf, err := x.LoadServerTLSConfigForInternalPort(x.WorkerConfig.TLSInterNodeEnabled, x.WorkerConfig.TLSDir)
+	tlsConf, err := x.LoadServerTLSConfigForInternalPort(
+		x.WorkerConfig.TLSInterNodeEnabled,
+		x.WorkerConfig.TLSDir,
+		x.WorkerConfig.TLSMinVersion)
 	x.Check(err)
 	if tlsConf != nil {
 		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(tlsConf)))

--- a/x/config.go
+++ b/x/config.go
@@ -70,6 +70,8 @@ type WorkerOptions struct {
 	TLSDir string
 	// Set to true if inter node tls is enabled for the cluster
 	TLSInterNodeEnabled bool
+	// min TLS version supported
+	TLSMinVersion string
 	// RaftId represents the id of this alpha instance for participating in the RAFT
 	// consensus protocol.
 	RaftId uint64

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -51,7 +51,7 @@ type TLSHelperConfig struct {
 	MinVersion       string
 }
 
-// RegisterClientTLSFlags registers the required flags to set up a TLS client.
+// RegisterServerTLSFlags registers the required flags to set up a TLS client.
 func RegisterServerTLSFlags(flag *pflag.FlagSet) {
 	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
 	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
@@ -114,7 +114,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 }
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
-func LoadServerTLSConfigForInternalPort(tlsEnabled bool, tlsDir string) (*tls.Config, error) {
+func LoadServerTLSConfigForInternalPort(tlsEnabled bool, tlsDir, tlsMinVersion string) (*tls.Config, error) {
 	if !tlsEnabled {
 		return nil, nil
 	}
@@ -127,6 +127,7 @@ func LoadServerTLSConfigForInternalPort(tlsEnabled bool, tlsDir string) (*tls.Co
 		conf.Cert = path.Join(conf.CertDir, TLSNodeCert)
 		conf.Key = path.Join(conf.CertDir, TLSNodeKey)
 		conf.ClientAuth = "REQUIREANDVERIFY"
+		conf.MinVersion = tlsMinVersion
 		return GenerateServerTLSConfig(&conf)
 	}
 

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -269,13 +269,21 @@ func setupVersion(cfg *tls.Config, minVersion string, maxVersion string) error {
 		return fmt.Errorf("invalid min_version '%s'. Valid values [TLS11, TLS12]", minVersion)
 	}
 
-	if val, has := tlsVersion[strings.ToUpper(maxVersion)]; has && val >= cfg.MinVersion {
-		cfg.MaxVersion = val
-	} else {
-		if has {
-			return fmt.Errorf("cannot use '%s' as max_version, it's lower than '%s'", maxVersion, minVersion)
-		}
-		return fmt.Errorf("invalid max_version '%s'. Valid values [TLS11, TLS12]", maxVersion)
+	cfg.MaxVersion = tls.VersionTLS12
+	cfg.CipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	}
 
 	return nil

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -52,6 +52,19 @@ type TLSHelperConfig struct {
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
+func RegisterServerTLSFlags(flag *pflag.FlagSet) {
+	flag.String("tls_dir", "", "Path to directory that has TLS certificates and keys.")
+	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
+	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
+	flag.Bool("tls_internal_port_enabled", false, "(optional) enable inter node TLS encryption between cluster nodes.")
+	flag.String("tls_cert", "", "(optional) The Cert file name in tls_dir which is needed to "+
+		"connect as a client with the other nodes in the cluster.")
+	flag.String("tls_key", "", "(optional) The private key file name "+
+		"in tls_dir needed to connect as a client with the other nodes in the cluster.")
+	flag.String("tls_min_version", "TLS11", "min version of tls supported. Valid values are TLS11, TLS12")
+}
+
+// RegisterClientTLSFlags registers the required flags to set up a TLS client.
 func RegisterClientTLSFlags(flag *pflag.FlagSet) {
 	flag.String("tls_cacert", "",
 		"The CA Cert file used to verify server certificates. Required for enabling TLS.")

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -49,7 +49,6 @@ type TLSHelperConfig struct {
 	ClientAuth       string
 	UseSystemCACerts bool
 	MinVersion       string
-	MaxVersion       string
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
@@ -132,7 +131,6 @@ func LoadServerTLSConfig(v *viper.Viper, tlsCertFile string, tlsKeyFile string) 
 		conf.Key = path.Join(conf.CertDir, tlsKeyFile)
 		conf.ClientAuth = v.GetString("tls_client_auth")
 		conf.MinVersion = v.GetString("tls_min_version")
-		conf.MaxVersion = v.GetString("tls_max_version")
 	}
 	conf.UseSystemCACerts = v.GetBool("tls_use_system_ca")
 
@@ -248,7 +246,7 @@ func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err e
 		}
 		tlsCfg.ClientAuth = auth
 
-		err = setupVersion(tlsCfg, config.MinVersion, config.MaxVersion)
+		err = setupVersion(tlsCfg, config.MinVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -257,7 +255,7 @@ func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err e
 	return nil, nil
 }
 
-func setupVersion(cfg *tls.Config, minVersion string, maxVersion string) error {
+func setupVersion(cfg *tls.Config, minVersion string) error {
 	tlsVersion := map[string]uint16{
 		"TLS11": tls.VersionTLS11,
 		"TLS12": tls.VersionTLS12,


### PR DESCRIPTION
Fixes DGRAPH-2469 for patch release 20.07.
Currently Dgraph supports both tls v1.1 and tls v1.2 which introduces security concerns. This PR limits the min version to v1.2 and also enables only selected cipher suites which are more secure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6820)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-98b2fbbe99-108815.surge.sh)
<!-- Dgraph:end -->