### PR TITLE
Docs (GraphQL) Note the addition of Int64 support in 20.11, mention JSON limitations for this type

### DIFF
--- a/wiki/content/graphql/schema/types.md
+++ b/wiki/content/graphql/schema/types.md
@@ -9,15 +9,21 @@ This page describes how you use GraphQL types to set the Dgraph GraphQL schema.
 
 ### Scalars
 
-Dgraph GraphQL comes with the standard GraphQL scalars: `Int`, `Float`, `String`, `Boolean` and `ID`.  There's also a `DateTime` scalar - represented as a string in RFC3339 format.
+Dgraph GraphQL comes with the standard GraphQL scalars: `Int`, `Float`, `String`,
+`Boolean` and `ID`.  There's also an `Int64` scalar, and a `DateTime` scalar
+that is represented as a string in RFC3339 format.
 
-Scalars `Int`, `Float`, `String` and `DateTime` can be used in lists. 
+Scalar types, including `Int`, `Int64`, `Float`, `String` and `DateTime` can be
+used in lists. Lists behave like an unordered set in Dgraph. For example:
+`["e1", "e1", "e2"]` may get stored as `["e2", "e1"]`, so duplicate values will
+not be stored and order may not be preserved. All scalars may be nullable or
+non-nullable.
 
-{{% notice "note" %}}
-Lists behave like an unordered set in Dgraph. For example: `["e1", "e1", "e2"]` may get stored as `["e2", "e1"]`, i.e., duplicate values will not be stored and order may not be preserved.
-{{% /notice %}}
-
-All scalars may be nullable or non-nullable.
+{{% notice "note" %}}The `Int64` type introduced in release 20.11 can represent
+any signed integer ranging between `-(2^53)+1` and `(2^53)-1`; the same range
+supported by [JSON](https://tools.ietf.org/html/rfc8259#section-6). Signed
+`Int64` values that lie outside of this range may trigger a type coercion
+error.{{% /notice %}}
 
 The `ID` type is special.  IDs are auto-generated, immutable, and can be treated as strings.  Fields of type `ID` can be listed as nullable in a schema, but Dgraph will never return null.
 
@@ -224,7 +230,7 @@ type Hotel {
   area: Polygon
 }
 ```
-    
+
 #### Point
 
 ```graphql

--- a/wiki/content/graphql/schema/types.md
+++ b/wiki/content/graphql/schema/types.md
@@ -5,25 +5,28 @@ weight = 2
     parent = "schema"
 +++
 
-This page describes how you use GraphQL types to set the Dgraph GraphQL schema.
+This page describes how to use GraphQL types to set the a GraphQL schema for
+Dgraph database.
 
 ### Scalars
 
-Dgraph GraphQL comes with the standard GraphQL scalars: `Int`, `Float`, `String`,
-`Boolean` and `ID`.  There's also an `Int64` scalar, and a `DateTime` scalar
-that is represented as a string in RFC3339 format.
+Dgraph's GraphQL implementation comes with the standard GraphQL scalar types:
+`Int`, `Float`, `String`, `Boolean` and `ID`.  There's also an `Int64` scalar,
+and a `DateTime` scalar type that is represented as a string in RFC3339 format.
 
-Scalar types, including `Int`, `Int64`, `Float`, `String` and `DateTime` can be
+Scalar types, including `Int`, `Int64`, `Float`, `String` and `DateTime`; can be
 used in lists. Lists behave like an unordered set in Dgraph. For example:
 `["e1", "e1", "e2"]` may get stored as `["e2", "e1"]`, so duplicate values will
-not be stored and order may not be preserved. All scalars may be nullable or
+not be stored and order might not be preserved. All scalars may be nullable or
 non-nullable.
 
-{{% notice "note" %}}The `Int64` type introduced in release 20.11 can represent
-any signed integer ranging between `-(2^53)+1` and `(2^53)-1`; the same range
-supported by [JSON](https://tools.ietf.org/html/rfc8259#section-6). Signed
-`Int64` values that lie outside of this range may trigger a type coercion
-error.{{% /notice %}}
+{{% notice "note" %}}The `Int64` type introduced in release 20.11 represents
+a signed integer ranging between `-(2^63)` and `(2^63 -1)`. Signed `Int64` values
+in this range will be parsed correctly by Dgraph as long as the client can
+serialize the number correctly in JSON. For example, a JavaScript client might
+need to use a serialization library such as
+[`json-bigint`](https://www.npmjs.com/package/json-bigint) to correctly
+write an `Int64` value in JSON.{{% /notice %}}
 
 The `ID` type is special.  IDs are auto-generated, immutable, and can be treated as strings.  Fields of type `ID` can be listed as nullable in a schema, but Dgraph will never return null.
 


### PR DESCRIPTION
The feature requested here will be ready in 20.11: https://discuss.dgraph.io/t/error-coercing-value-to-type-int/9353/10

 Fixes GRAPHQL-782

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6829)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d90b6a5168-106706.surge.sh)
<!-- Dgraph:end -->