### PR TITLE
release/v20.03 - fix(ludicrous mode): Handle deletes correctly (#6773)

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -842,10 +842,14 @@ func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode)
 	// assigned in the processQuery function called below.
 	defer annotateStartTs(qc.span, qc.req.StartTs)
 	// For mutations, we update the startTs if necessary.
-	if isMutation && req.StartTs == 0 && !x.WorkerConfig.LudicrousMode {
-		start := time.Now()
-		req.StartTs = worker.State.GetTimestamp(false)
-		qc.latency.AssignTimestamp = time.Since(start)
+	if isMutation && req.StartTs == 0 {
+		if x.WorkerConfig.LudicrousMode {
+			req.StartTs = posting.Oracle().MaxAssigned()
+		} else {
+			start := time.Now()
+			req.StartTs = worker.State.GetTimestamp(false)
+			qc.latency.AssignTimestamp = time.Since(start)
+		}
 	}
 
 	if resp, rerr = processQuery(ctx, qc); rerr != nil {

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -63,7 +63,6 @@ func expandEdges(ctx context.Context, m *pb.Mutations) ([]*pb.DirectedEdge, erro
 			sg := &SubGraph{}
 			sg.DestUIDs = &pb.List{Uids: []uint64{edge.GetEntity()}}
 			sg.ReadTs = m.StartTs
-
 			types, err := getNodeTypes(ctx, sg)
 			if err != nil {
 				return nil, err

--- a/systest/ludicrous/upsert_test.go
+++ b/systest/ludicrous/upsert_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -28,19 +27,6 @@ import (
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 )
-
-type Person struct {
-	Name  string `json:"name,omitempty"`
-	count int
-}
-
-type Data struct {
-	Name   string `json:"name,omitempty"`
-	Counts []int  `json:"count,omitempty"`
-}
-type ResponseData struct {
-	All []Data `json:"all,omitempty"`
-}
 
 func InitData(t *testing.T) {
 	dg, err := testutil.DgraphClient(testutil.SockAddr)
@@ -54,15 +40,11 @@ func InitData(t *testing.T) {
 	err = dg.Alter(context.Background(), &api.Operation{Schema: schema})
 	require.NoError(t, err)
 
-	p := Person{
-		Name:  "Alice",
-		count: 1,
-	}
-	pb, err := json.Marshal(p)
-	require.NoError(t, err)
-
 	mu := &api.Mutation{
-		SetJson:   pb,
+		SetNquads: []byte(`
+			_:a <name> "Alice" .
+			_:a <count> "1" .
+		`),
 		CommitNow: true,
 	}
 	txn := dg.NewTxn()
@@ -92,7 +74,7 @@ func TestConcurrentUpdate(t *testing.T) {
 		defer wg.Done()
 		query := `query {
 			user as var(func: eq(name, "Alice"))
-			}`
+		}`
 		mu := &api.Mutation{
 			SetNquads: []byte(fmt.Sprintf(`uid(user) <count> "%d" .`, i)),
 		}
@@ -113,7 +95,6 @@ func TestConcurrentUpdate(t *testing.T) {
 
 	q := `query all($a: string) {
 			all(func: eq(name, $a)) {
-			  name
 			  count
 			}
 		  }`
@@ -121,11 +102,7 @@ func TestConcurrentUpdate(t *testing.T) {
 	txn := dg.NewTxn()
 	res, err = txn.QueryWithVars(ctx, q, map[string]string{"$a": "Alice"})
 	require.NoError(t, err)
-	var dat ResponseData
-	err = json.Unmarshal(res.Json, &dat)
-	require.NoError(t, err)
-
-	require.Equal(t, 10, len(dat.All[0].Counts))
+	require.JSONEq(t, `{"all":[{"count":[0,4,5,2,8,1,3,9,6,7]}]}`, string(res.GetJson()))
 }
 
 func TestSequentialUpdate(t *testing.T) {
@@ -166,7 +143,6 @@ func TestSequentialUpdate(t *testing.T) {
 
 	q := `query all($a: string) {
 			all(func: eq(name, $a)) {
-			  name
 			  count
 			}
 		  }`
@@ -174,9 +150,63 @@ func TestSequentialUpdate(t *testing.T) {
 	txn := dg.NewTxn()
 	res, err = txn.QueryWithVars(ctx, q, map[string]string{"$a": "Alice"})
 	require.NoError(t, err)
-	var dat ResponseData
-	err = json.Unmarshal(res.Json, &dat)
+	require.JSONEq(t, `{"all":[{"count":[0,4,5,2,8,1,3,9,6,7]}]}`, string(res.GetJson()))
+}
+
+func TestDelete(t *testing.T) {
+	dg, err := testutil.DgraphClient(testutil.SockAddr)
+	require.NoError(t, err)
+	testutil.DropAll(t, dg)
+	schema := `
+		name: string .
+		xid: string .
+		type MyType {
+		  name
+		  xid
+		}
+	`
+
+	err = dg.Alter(context.Background(), &api.Operation{Schema: schema})
 	require.NoError(t, err)
 
-	require.Equal(t, 10, len(dat.All[0].Counts))
+	mu := &api.Mutation{
+		SetNquads: []byte(`
+			_:n <dgraph.type> "MyType" .
+			_:n <name> "Alice" .
+			_:n <xid> "10" .
+		`),
+
+		CommitNow: true,
+	}
+	txn := dg.NewTxn()
+	ctx := context.Background()
+	defer txn.Discard(ctx)
+
+	res, err := txn.Mutate(ctx, mu)
+	require.NoError(t, err)
+	uid := res.Uids["n"]
+
+	ctx = context.Background()
+	query := func() string {
+		q := `{ q(func: uid(` + uid + `)){ dgraph.type name xid } }`
+		res, err := dg.NewTxn().Query(ctx, q)
+		require.NoError(t, err)
+		return string(res.GetJson())
+	}
+	time.Sleep(time.Second)
+	expected := `{"q":[{"dgraph.type":["MyType"],"name":"Alice","xid":"10"}]}`
+	require.JSONEq(t, expected, query())
+
+	mu = &api.Mutation{
+		DelNquads: []byte(`<` + uid + `> * * .`),
+		CommitNow: true,
+	}
+	txn = dg.NewTxn()
+	ctx = context.Background()
+	defer txn.Discard(ctx)
+
+	_, err = txn.Mutate(ctx, mu)
+	require.NoError(t, err)
+	time.Sleep(time.Second)
+	require.JSONEq(t, `{"q":[]}`, query())
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -622,7 +622,8 @@ func (n *node) processApplyCh() {
 			psz := proposal.Size()
 			totalSize += int64(psz)
 
-			// In case of upserts the startTs would be > 0, so, no need to check startTs is 0
+			// Ignore the start ts in case of ludicrous mode. We get a new ts and use that as the
+			// commit ts.
 			if x.WorkerConfig.LudicrousMode && proposal.Mutations != nil {
 				proposal.Mutations.StartTs = State.GetTimestamp(false)
 			}


### PR DESCRIPTION
In ludicrous mode, we were trying to fetch the list of types (and their
predicates) using a timestamp of 0. This would cause deletes to be
ineffective and the actual data won't be deleted. This PR fixes it.

Co-authored-by: Manish R Jain <manish@dgraph.io>
Fixes - DGRAPH-2593

(cherry picked from commit a0cc3a50d90064919f275d2e30ffc46b58baf7d5)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6831)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-18d952d9ec-106069.surge.sh)
<!-- Dgraph:end -->