### PR TITLE
release/v20.07 - fix(ludicrous mode): Handle deletes correctly (#6773)

### DIFF
--- a/query/mutation.go
+++ b/query/mutation.go
@@ -63,7 +63,6 @@ func expandEdges(ctx context.Context, m *pb.Mutations) ([]*pb.DirectedEdge, erro
 			sg := &SubGraph{}
 			sg.DestUIDs = &pb.List{Uids: []uint64{edge.GetEntity()}}
 			sg.ReadTs = m.StartTs
-
 			types, err := getNodeTypes(ctx, sg)
 			if err != nil {
 				return nil, err

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -661,7 +661,8 @@ func (n *node) processApplyCh() {
 			psz := proposal.Size()
 			totalSize += int64(psz)
 
-			// In case of upserts the startTs would be > 0, so, no need to check startTs is 0
+			// Ignore the start ts in case of ludicrous mode. We get a new ts and use that as the
+			// commit ts.
 			if x.WorkerConfig.LudicrousMode && proposal.Mutations != nil {
 				proposal.Mutations.StartTs = State.GetTimestamp(false)
 			}


### PR DESCRIPTION
In ludicrous mode, we were trying to fetch the list of types (and their
predicates) using a timestamp of 0. This would cause deletes to be
ineffective and the actual data won't be deleted. This PR fixes it.

Co-authored-by: Manish R Jain <manish@dgraph.io>
Fixes - DGRAPH-2593

(cherry picked from commit a0cc3a50d90064919f275d2e30ffc46b58baf7d5)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6832)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b3d8514027-106076.surge.sh)
<!-- Dgraph:end -->