### PR TITLE
Feat(GraphQL): Add count queries feature at non-root levels

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -1519,18 +1519,18 @@ func TestChildCountQueryWithDeepRBAC(t *testing.T) {
 		{
 			user:   "user1",
 			role:   "USER",
-			result: `{"queryUser": [{"username": "user1", "aggregate_issues":{"count": null}}]}`},
+			result: `{"queryUser": [{"username": "user1", "aggregateissues":{"count": null}}]}`},
 		{
 			user:   "user1",
 			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","aggregate_issues":{"count":1}}]}`},
+			result: `{"queryUser":[{"username":"user1","aggregateissues":{"count":1}}]}`},
 	}
 
 	query := `
 	query {
 	  queryUser (filter:{username:{eq:"user1"}}) {
 		username
-		aggregate_issues {
+		aggregateissues {
 		  count
 		}
 	  }
@@ -1557,18 +1557,18 @@ func TestChildCountQueryWithOtherFields(t *testing.T) {
 		{
 			user:   "user1",
 			role:   "USER",
-			result: `{"queryUser": [{"username": "user1","issues":[],"aggregate_issues":{"count": null}}]}`},
+			result: `{"queryUser": [{"username": "user1","issues":[],"aggregateissues":{"count": null}}]}`},
 		{
 			user:   "user1",
 			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","issues":[{"msg":"Issue1"}],"aggregate_issues":{"count":1}}]}`},
+			result: `{"queryUser":[{"username":"user1","issues":[{"msg":"Issue1"}],"aggregateissues":{"count":1}}]}`},
 	}
 
 	query := `
 	query {
 	  queryUser (filter:{username:{eq:"user1"}}) {
 		username
-		aggregate_issues {
+		aggregateissues {
 		  count
 		}
 		issues {

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -1519,18 +1519,18 @@ func TestChildCountQueryWithDeepRBAC(t *testing.T) {
 		{
 			user:   "user1",
 			role:   "USER",
-			result: `{"queryUser": [{"username": "user1", "aggregateissues":{"count": null}}]}`},
+			result: `{"queryUser": [{"username": "user1", "issuesAggregate":{"count": null}}]}`},
 		{
 			user:   "user1",
 			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","aggregateissues":{"count":1}}]}`},
+			result: `{"queryUser":[{"username":"user1","issuesAggregate":{"count":1}}]}`},
 	}
 
 	query := `
 	query {
 	  queryUser (filter:{username:{eq:"user1"}}) {
 		username
-		aggregateissues {
+		issuesAggregate {
 		  count
 		}
 	  }
@@ -1557,18 +1557,18 @@ func TestChildCountQueryWithOtherFields(t *testing.T) {
 		{
 			user:   "user1",
 			role:   "USER",
-			result: `{"queryUser": [{"username": "user1","issues":[],"aggregateissues":{"count": null}}]}`},
+			result: `{"queryUser": [{"username": "user1","issues":[],"issuesAggregate":{"count": null}}]}`},
 		{
 			user:   "user1",
 			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","issues":[{"msg":"Issue1"}],"aggregateissues":{"count":1}}]}`},
+			result: `{"queryUser":[{"username":"user1","issues":[{"msg":"Issue1"}],"issuesAggregate":{"count":1}}]}`},
 	}
 
 	query := `
 	query {
 	  queryUser (filter:{username:{eq:"user1"}}) {
 		username
-		aggregateissues {
+		issuesAggregate {
 		  count
 		}
 		issues {

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -355,6 +355,9 @@ func RunAll(t *testing.T) {
 	t.Run("query count without filter", queryCountWithoutFilter)
 	t.Run("query count with filter", queryCountWithFilter)
 	t.Run("query count with alias", queryCountWithAlias)
+	t.Run("query count at child level", queryCountAtChildLevel)
+	t.Run("query count at child level with filter", queryCountAtChildLevelWithFilter)
+	t.Run("query count and other fields at child level", queryCountAndOtherFieldsAtChildLevel)
 
 	// mutation tests
 	t.Run("add mutation", addMutation)

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -92,10 +92,11 @@ func graphQLCompletionOn(t *testing.T) {
 			}
 			err := json.Unmarshal([]byte(gqlResponse.Data), &result)
 			require.NoError(t, err)
-			require.Equal(t, 4, len(result.QueryCountry))
+			require.Equal(t, 5, len(result.QueryCountry))
 			expected.QueryCountry = []*country{
 				&country{Name: "Angola"},
 				&country{Name: "Bangladesh"},
+				&country{Name: "India"},
 				&country{Name: "Mozambique"},
 				nil,
 			}
@@ -107,11 +108,11 @@ func graphQLCompletionOn(t *testing.T) {
 				return result.QueryCountry[i].Name < result.QueryCountry[j].Name
 			})
 
-			for i := 0; i < 3; i++ {
+			for i := 0; i < 4; i++ {
 				require.NotNil(t, result.QueryCountry[i])
 				require.Equal(t, result.QueryCountry[i].Name, expected.QueryCountry[i].Name)
 			}
-			require.Nil(t, result.QueryCountry[3])
+			require.Nil(t, result.QueryCountry[4])
 		})
 	}
 

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -153,6 +153,7 @@ func queryByTypeWithEncoding(t *testing.T, acceptGzip, gzipEncoding bool) {
 	expected.QueryCountry = []*country{
 		&country{Name: "Angola"},
 		&country{Name: "Bangladesh"},
+		&country{Name: "India"},
 		&country{Name: "Mozambique"},
 	}
 	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
@@ -188,6 +189,7 @@ func uidAlias(t *testing.T) {
 	expected.QueryCountry = []*countryUID{
 		&countryUID{UID: "Angola"},
 		&countryUID{UID: "Bangladesh"},
+		&countryUID{UID: "India"},
 		&countryUID{UID: "Mozambique"},
 	}
 	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
@@ -216,6 +218,7 @@ func orderAtRoot(t *testing.T) {
 	expected.QueryCountry = []*country{
 		&country{Name: "Angola"},
 		&country{Name: "Bangladesh"},
+		&country{Name: "India"},
 		&country{Name: "Mozambique"},
 	}
 	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
@@ -242,8 +245,8 @@ func pageAtRoot(t *testing.T) {
 		QueryCountry []*country
 	}
 	expected.QueryCountry = []*country{
+		&country{Name: "India"},
 		&country{Name: "Bangladesh"},
-		&country{Name: "Angola"},
 	}
 	err := json.Unmarshal([]byte(gqlResponse.Data), &result)
 	require.NoError(t, err)
@@ -1356,6 +1359,7 @@ func queryApplicationGraphQl(t *testing.T) {
 	"queryCountry": [
           { "name": "Angola"},
           { "name": "Bangladesh"},
+		  { "name": "India"},
           { "name": "Mozambique"}
         ]
 }`
@@ -1384,6 +1388,10 @@ func queryTypename(t *testing.T) {
           },
           {
                 "name": "Bangladesh",
+                "__typename": "Country"
+          },
+		  {
+                "name": "India",
                 "__typename": "Country"
           },
           {
@@ -2431,5 +2439,99 @@ func queryCountWithAlias(t *testing.T) {
 	RequireNoGQLErrors(t, gqlResponse)
 	testutil.CompareJSON(t,
 		`{"aggregatePost":{"cnt":4}}`,
+		string(gqlResponse.Data))
+}
+
+func queryCountAtChildLevel(t *testing.T) {
+	queryNumberOfStates := &GraphQLParams{
+		Query: `query 
+		{
+			queryCountry(filter: { name: { eq: "India" } }) {
+				name
+				ag : aggregate_states {
+                	count   
+                }
+			}
+		}`,
+	}
+	gqlResponse := queryNumberOfStates.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t,
+		`
+		{
+			"queryCountry": [{
+				"name": "India",
+				"ag": { 
+					"count" : 3
+				}
+			}]
+		}`,
+		string(gqlResponse.Data))
+}
+
+func queryCountAtChildLevelWithFilter(t *testing.T) {
+	queryNumberOfIndianStates := &GraphQLParams{
+		Query: `query 
+		{
+			queryCountry(filter: { name: { eq: "India" } }) {
+				name
+				ag : aggregate_states(filter: {xcode: {in: ["ka", "mh"]}}) {
+                	count   
+                }
+			}
+		}`,
+	}
+	gqlResponse := queryNumberOfIndianStates.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t,
+		`
+		{
+			"queryCountry": [{
+				"name": "India",
+				"ag": { 
+					"count" : 2
+				}
+			}]
+		}`,
+		string(gqlResponse.Data))
+}
+
+func queryCountAndOtherFieldsAtChildLevel(t *testing.T) {
+	queryNumberOfIndianStates := &GraphQLParams{
+		Query: `query 
+		{
+			queryCountry(filter: { name: { eq: "India" } }) {
+				name
+				ag : aggregate_states {
+                	count   
+                },
+				states {
+					name
+				}
+			}
+		}`,
+	}
+	gqlResponse := queryNumberOfIndianStates.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+	testutil.CompareJSON(t,
+		`
+		{
+			"queryCountry": [{
+				"name": "India",
+				"ag": { 
+					"count" : 3
+				},
+				"states": [
+				{
+					"name": "Maharashtra"
+				}, 
+				{
+					"name": "Gujarat"
+				},
+				{
+					"name": "Karnataka"
+				}]
+			}]
+		}`,
 		string(gqlResponse.Data))
 }

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -2444,13 +2444,13 @@ func queryCountWithAlias(t *testing.T) {
 
 func queryCountAtChildLevel(t *testing.T) {
 	queryNumberOfStates := &GraphQLParams{
-		Query: `query 
+		Query: `query
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregate_states {
-                	count   
-                }
+				ag : aggregatestates {
+					count
+				}
 			}
 		}`,
 	}
@@ -2475,7 +2475,7 @@ func queryCountAtChildLevelWithFilter(t *testing.T) {
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregate_states(filter: {xcode: {in: ["ka", "mh"]}}) {
+				ag : aggregatestates(filter: {xcode: {in: ["ka", "mh"]}}) {
                 	count   
                 }
 			}
@@ -2502,7 +2502,7 @@ func queryCountAndOtherFieldsAtChildLevel(t *testing.T) {
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregate_states {
+				ag : aggregatestates {
                 	count   
                 },
 				states {

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -2448,7 +2448,7 @@ func queryCountAtChildLevel(t *testing.T) {
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregatestates {
+				ag : statesAggregate {
 					count
 				}
 			}
@@ -2475,7 +2475,7 @@ func queryCountAtChildLevelWithFilter(t *testing.T) {
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregatestates(filter: {xcode: {in: ["ka", "mh"]}}) {
+				ag : statesAggregate(filter: {xcode: {in: ["ka", "mh"]}}) {
                 	count   
                 }
 			}
@@ -2502,7 +2502,7 @@ func queryCountAndOtherFieldsAtChildLevel(t *testing.T) {
 		{
 			queryCountry(filter: { name: { eq: "India" } }) {
 				name
-				ag : aggregatestates {
+				ag : statesAggregate {
                 	count   
                 },
 				states {

--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -84,7 +84,7 @@ const (
 				"description": ""
             },
 			{
-				"name": "aggregateposts",
+				"name": "postsAggregate",
 				"description": ""
 			}
 		],

--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -84,7 +84,7 @@ const (
 				"description": ""
             },
 			{
-				"name": "aggregate_posts",
+				"name": "aggregateposts",
 				"description": ""
 			}
 		],

--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -82,7 +82,11 @@ const (
             {
                 "name": "rank",
 				"description": ""
-            }
+            },
+			{
+				"name": "aggregate_posts",
+				"description": ""
+			}
 		],
 		"enumValues":[]
 	}, "__typename" : "Query" }`

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -20,8 +20,8 @@ type State {
         id: ID!
         xcode: String! @id @search(by: [regexp])
         name: String!
-	capital: String
-	country: Country @dgraph(pred: "inCountry")
+        capital: String
+	    country: Country @dgraph(pred: "inCountry")
 }
 
 # **Don't delete** Comments in the middle of schemas should work

--- a/graphql/e2e/directives/test_data.json
+++ b/graphql/e2e/directives/test_data.json
@@ -103,5 +103,32 @@
         "dgraph.type": "State",
         "State.name": "Nusa",
         "State.xcode": "nusa"
+    },
+    {
+        "uid": "_:mh",
+        "dgraph.type": "State",
+        "State.name": "Maharashtra",
+        "State.xcode": "mh",
+        "inCountry": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:gj",
+        "dgraph.type": "State",
+        "State.name": "Gujarat",
+        "State.xcode": "gj",
+        "inCountry": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:ka",
+        "dgraph.type": "State",
+        "State.name": "Karnataka",
+        "State.xcode": "ka",
+        "inCountry": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:india",
+        "dgraph.type": "Country",
+        "Country.name": "India",
+        "hasStates": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
     }
 ]

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -20,8 +20,8 @@ type State {
         id: ID!
         xcode: String! @id @search(by: [regexp])
         name: String!
-	capital: String
-	country: Country
+        capital: String
+        country: Country
 }
 
 # **Don't delete** Comments in the middle of schemas should work

--- a/graphql/e2e/normal/test_data.json
+++ b/graphql/e2e/normal/test_data.json
@@ -103,5 +103,32 @@
         "dgraph.type": "State",
         "State.name": "Nusa",
         "State.xcode": "nusa"
+    },
+    {
+        "uid": "_:mh",
+        "dgraph.type": "State",
+        "State.name": "Maharashtra",
+        "State.xcode": "mh",
+        "State.country": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:gj",
+        "dgraph.type": "State",
+        "State.name": "Gujarat",
+        "State.xcode": "gj",
+        "State.country": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:ka",
+        "dgraph.type": "State",
+        "State.name": "Karnataka",
+        "State.xcode": "ka",
+        "State.country": {"uid":  "_:india"}
+    },
+    {
+        "uid": "_:india",
+        "dgraph.type": "Country",
+        "Country.name": "India",
+        "Country.states": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
     }
 ]

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -70,7 +70,20 @@ func TestSchemaSubscribe(t *testing.T) {
 		Query: introspectionQuery,
 	}
 
-	expectedResult := `{"__type":{"name":"Author","fields":[{"name":"id"},{"name":"name"}]}}`
+	expectedResult :=
+		`{
+			"__type": {
+				"name":"Author",
+				"fields": [
+					{
+						"name": "id"
+					},
+					{
+						"name": "name"
+					}
+				]
+			}
+		}`
 	introspectionResult := introspect.ExecuteAsPost(t, groupOneServer)
 	require.Nil(t, introspectionResult.Errors)
 	testutil.CompareJSON(t, expectedResult, string(introspectionResult.Data))
@@ -96,7 +109,26 @@ func TestSchemaSubscribe(t *testing.T) {
 	}`
 	updateGQLSchemaRequireNoErrors(t, schema, groupThreeAdminServer)
 
-	expectedResult = `{"__type":{"name":"Author","fields":[{"name":"id"},{"name":"name"},{"name":"posts"}]}}`
+	expectedResult =
+		`{
+			"__type": {
+				"name": "Author",
+				"fields": [
+					{
+						"name": "id"
+					},
+					{
+						"name": "name"
+					},
+					{
+						"name": "posts"
+					},
+					{
+						"name": "postsAggregate"
+					}
+				]
+			}
+		}`
 	introspectionResult = introspect.ExecuteAsPost(t, groupOneServer)
 	require.Nil(t, introspectionResult.Errors)
 	testutil.CompareJSON(t, expectedResult, string(introspectionResult.Data))

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -456,7 +456,6 @@
         User2 as var(func: type(User))
       }
 
-
 - name: "Auth with top level AND rbac true"
   gqlquery: |
     query {
@@ -580,7 +579,6 @@
     query {
       aggregateIssue()
     }
-
 
 - name: "Auth with top level OR rbac true"
   gqlquery: |
@@ -1143,6 +1141,212 @@
       }
     }
 
+- name: "Count at child with Auth deep filter and field filter"
+  gqlquery: |
+    query {
+      queryUser {
+        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
+          count
+        }
+      }
+    }
+  jwtvar:
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUser(func: uid(UserRoot)) {
+        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
+        dgraph.uid : uid
+      }
+      UserRoot as var(func: uid(User4))
+      User4 as var(func: type(User))
+      var(func: uid(UserRoot)) {
+        TicketAggregateResult1 as User.tickets
+      }
+      Ticket3 as var(func: uid(TicketAggregateResult1)) @filter((anyofterms(Ticket.title, "graphql") AND uid(TicketAuth2)))
+      TicketAuth2 as var(func: uid(TicketAggregateResult1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+- name: "Multiple Count queries at child level with Auth deep filter"
+  gqlquery: |
+    query {
+      queryUser {
+        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
+          count
+        }
+        aggregate_issues {
+          count
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "ADMIN"
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUser(func: uid(UserRoot)) {
+        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
+        count_aggregate_issues : count(User.issues) @filter(uid(Issue6))
+        dgraph.uid : uid
+      }
+      UserRoot as var(func: uid(User7))
+      User7 as var(func: type(User))
+      var(func: uid(UserRoot)) {
+        TicketAggregateResult1 as User.tickets
+      }
+      Ticket3 as var(func: uid(TicketAggregateResult1)) @filter((anyofterms(Ticket.title, "graphql") AND uid(TicketAuth2)))
+      TicketAuth2 as var(func: uid(TicketAggregateResult1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      var(func: uid(UserRoot)) {
+        IssueAggregateResult4 as User.issues
+      }
+      Issue6 as var(func: uid(IssueAggregateResult4)) @filter(uid(IssueAuth5))
+      IssueAuth5 as var(func: uid(IssueAggregateResult4)) @cascade {
+        owner : Issue.owner @filter(eq(User.username, "user1"))
+        dgraph.uid : uid
+      }
+    }
+
+- name: "count at child with RBAC rules true"
+  gqlquery: |
+    query {
+      queryUser {
+        aggregate_issues {
+          count
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "ADMIN"
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUser(func: uid(UserRoot)) {
+        count_aggregate_issues : count(User.issues) @filter(uid(Issue3))
+        dgraph.uid : uid
+      }
+      UserRoot as var(func: uid(User4))
+      User4 as var(func: type(User))
+      var(func: uid(UserRoot)) {
+        IssueAggregateResult1 as User.issues
+      }
+      Issue3 as var(func: uid(IssueAggregateResult1)) @filter(uid(IssueAuth2))
+      IssueAuth2 as var(func: uid(IssueAggregateResult1)) @cascade {
+        owner : Issue.owner @filter(eq(User.username, "user1"))
+        dgraph.uid : uid
+      }
+    }
+
+- name: "count with Deep RBAC rules false"
+  gqlquery: |
+    query {
+      queryUser {
+        username
+        aggregate_issues {
+          count
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "USER"
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUser(func: uid(UserRoot)) {
+        username : User.username
+        dgraph.uid : uid
+      }
+      UserRoot as var(func: uid(User1))
+      User1 as var(func: type(User))
+    }
+
+- name: "Count at child and other child level fields with Auth deep filter and field filter"
+  gqlquery: |
+    query {
+      queryUser {
+        username
+        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
+          count
+        }
+        tickets(filter: { title: { anyofterms: "graphql2" } }) {
+          title
+        }
+      }
+    }
+  jwtvar:
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUser(func: uid(UserRoot)) {
+        username : User.username
+        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
+        tickets : User.tickets @filter(uid(Ticket6)) {
+          title : Ticket.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      UserRoot as var(func: uid(User7))
+      User7 as var(func: type(User))
+      var(func: uid(UserRoot)) {
+        TicketAggregateResult1 as User.tickets
+      }
+      Ticket3 as var(func: uid(TicketAggregateResult1)) @filter((anyofterms(Ticket.title, "graphql") AND uid(TicketAuth2)))
+      TicketAuth2 as var(func: uid(TicketAggregateResult1)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      var(func: uid(UserRoot)) {
+        Ticket4 as User.tickets
+      }
+      Ticket6 as var(func: uid(Ticket4)) @filter((anyofterms(Ticket.title, "graphql2") AND uid(TicketAuth5)))
+      TicketAuth5 as var(func: uid(Ticket4)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
 - name: "Type should apply Interface's query rules and along with its own auth rules"
   gqlquery: |
     query {
@@ -1299,6 +1503,7 @@
         dgraph.uid : uid
       }
     }
+
 - name: "Filters on query Interface should work correctly"
   gqlquery: |
     query {
@@ -1350,6 +1555,7 @@
         dgraph.uid : uid
       }
     }
+
 - name: "Query interface should return empty if the auth rule of interface is not satisfied"
   gqlquery: |
     query {
@@ -1364,6 +1570,7 @@
     query {
       queryPost()
     }
+
 - name: "Query interface should return partial types if the auth rule of interface is not satisfied"
   gqlquery: |
     query {
@@ -1405,6 +1612,7 @@
         dgraph.uid : uid
       }
     }
+
 - name: "Get Query interface having Auth Rules apply Auth filters of types also"
   gqlquery: |
     query {
@@ -1446,6 +1654,7 @@
         dgraph.uid : uid
       }
     }
+
 - name: "Get Query interface having Auth Rules should return empty if the Auth rules are not satisfied"
   gqlquery: |
     query {
@@ -1458,6 +1667,7 @@
     query {
       getPost()
     }
+
 - name: "Query interface having no Auth Rules should apply auth rules on implementing types that are satisfied"
   gqlquery: |
     query {
@@ -1482,6 +1692,7 @@
         id : uid
       }
     }
+
 - name: "Query interface having no Auth Rules but some type have Auth rules and those are not satified are excluded (for eg: type C )"
   gqlquery: |
     query {

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1145,7 +1145,7 @@
   gqlquery: |
     query {
       queryUser {
-        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
+        aggregatetickets(filter: { title: { anyofterms: "graphql" } }) {
           count
         }
       }
@@ -1155,7 +1155,7 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
+        count_aggregatetickets : count(User.tickets) @filter(uid(Ticket3))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1179,15 +1179,18 @@
       }
     }
 
-- name: "Multiple Count queries at child level with Auth deep filter"
+- name: "Multiple Count queries at child level and other queries with Auth deep filter"
   gqlquery: |
     query {
       queryUser {
-        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
+        aggregatetickets(filter: { title: { anyofterms: "graphql" } }) {
           count
         }
-        aggregate_issues {
+        aggregateissues {
           count
+        }
+        tickets(filter: { title: { anyofterms: "graphql2" } }) {
+          title
         }
       }
     }
@@ -1197,12 +1200,16 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
-        count_aggregate_issues : count(User.issues) @filter(uid(Issue6))
+        count_aggregatetickets : count(User.tickets) @filter(uid(Ticket3))
+        count_aggregateissues : count(User.issues) @filter(uid(Issue6))
+        tickets : User.tickets @filter(uid(Ticket9)) {
+          title : Ticket.title
+          dgraph.uid : uid
+        }
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User7))
-      User7 as var(func: type(User))
+      UserRoot as var(func: uid(User10))
+      User10 as var(func: type(User))
       var(func: uid(UserRoot)) {
         TicketAggregateResult1 as User.tickets
       }
@@ -1228,13 +1235,30 @@
         owner : Issue.owner @filter(eq(User.username, "user1"))
         dgraph.uid : uid
       }
+      var(func: uid(UserRoot)) {
+        Ticket7 as User.tickets
+      }
+      Ticket9 as var(func: uid(Ticket7)) @filter((anyofterms(Ticket.title, "graphql2") AND uid(TicketAuth8)))
+      TicketAuth8 as var(func: uid(Ticket7)) @cascade {
+        onColumn : Ticket.onColumn {
+          inProject : Column.inProject {
+            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+              dgraph.uid : uid
+            }
+            dgraph.uid : uid
+          }
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
     }
 
 - name: "count at child with RBAC rules true"
   gqlquery: |
     query {
       queryUser {
-        aggregate_issues {
+        aggregateissues {
           count
         }
       }
@@ -1245,7 +1269,7 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregate_issues : count(User.issues) @filter(uid(Issue3))
+        count_aggregateissues : count(User.issues) @filter(uid(Issue3))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1265,7 +1289,7 @@
     query {
       queryUser {
         username
-        aggregate_issues {
+        aggregateissues {
           count
         }
       }
@@ -1281,70 +1305,6 @@
       }
       UserRoot as var(func: uid(User1))
       User1 as var(func: type(User))
-    }
-
-- name: "Count at child and other child level fields with Auth deep filter and field filter"
-  gqlquery: |
-    query {
-      queryUser {
-        username
-        aggregate_tickets(filter: { title: { anyofterms: "graphql" } }) {
-          count
-        }
-        tickets(filter: { title: { anyofterms: "graphql2" } }) {
-          title
-        }
-      }
-    }
-  jwtvar:
-    USER: "user1"
-  dgquery: |-
-    query {
-      queryUser(func: uid(UserRoot)) {
-        username : User.username
-        count_aggregate_tickets : count(User.tickets) @filter(uid(Ticket3))
-        tickets : User.tickets @filter(uid(Ticket6)) {
-          title : Ticket.title
-          dgraph.uid : uid
-        }
-        dgraph.uid : uid
-      }
-      UserRoot as var(func: uid(User7))
-      User7 as var(func: type(User))
-      var(func: uid(UserRoot)) {
-        TicketAggregateResult1 as User.tickets
-      }
-      Ticket3 as var(func: uid(TicketAggregateResult1)) @filter((anyofterms(Ticket.title, "graphql") AND uid(TicketAuth2)))
-      TicketAuth2 as var(func: uid(TicketAggregateResult1)) @cascade {
-        onColumn : Ticket.onColumn {
-          inProject : Column.inProject {
-            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
-              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
-            }
-            dgraph.uid : uid
-          }
-          dgraph.uid : uid
-        }
-        dgraph.uid : uid
-      }
-      var(func: uid(UserRoot)) {
-        Ticket4 as User.tickets
-      }
-      Ticket6 as var(func: uid(Ticket4)) @filter((anyofterms(Ticket.title, "graphql2") AND uid(TicketAuth5)))
-      TicketAuth5 as var(func: uid(Ticket4)) @cascade {
-        onColumn : Ticket.onColumn {
-          inProject : Column.inProject {
-            roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
-              assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
-            }
-            dgraph.uid : uid
-          }
-          dgraph.uid : uid
-        }
-        dgraph.uid : uid
-      }
     }
 
 - name: "Type should apply Interface's query rules and along with its own auth rules"

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1145,7 +1145,7 @@
   gqlquery: |
     query {
       queryUser {
-        aggregatetickets(filter: { title: { anyofterms: "graphql" } }) {
+        ticketsAggregate(filter: { title: { anyofterms: "graphql" } }) {
           count
         }
       }
@@ -1155,7 +1155,7 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregatetickets : count(User.tickets) @filter(uid(Ticket3))
+        count_ticketsAggregate : count(User.tickets) @filter(uid(Ticket3))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1183,10 +1183,10 @@
   gqlquery: |
     query {
       queryUser {
-        aggregatetickets(filter: { title: { anyofterms: "graphql" } }) {
+        ticketsAggregate(filter: { title: { anyofterms: "graphql" } }) {
           count
         }
-        aggregateissues {
+        issuesAggregate {
           count
         }
         tickets(filter: { title: { anyofterms: "graphql2" } }) {
@@ -1200,8 +1200,8 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregatetickets : count(User.tickets) @filter(uid(Ticket3))
-        count_aggregateissues : count(User.issues) @filter(uid(Issue6))
+        count_ticketsAggregate : count(User.tickets) @filter(uid(Ticket3))
+        count_issuesAggregate : count(User.issues) @filter(uid(Issue6))
         tickets : User.tickets @filter(uid(Ticket9)) {
           title : Ticket.title
           dgraph.uid : uid
@@ -1258,7 +1258,7 @@
   gqlquery: |
     query {
       queryUser {
-        aggregateissues {
+        issuesAggregate {
           count
         }
       }
@@ -1269,7 +1269,7 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_aggregateissues : count(User.issues) @filter(uid(Issue3))
+        count_issuesAggregate : count(User.issues) @filter(uid(Issue3))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1289,7 +1289,7 @@
     query {
       queryUser {
         username
-        aggregateissues {
+        issuesAggregate {
           count
         }
       }

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dgrijalva/jwt-go/v4"
 	"io/ioutil"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/dgrijalva/jwt-go/v4"
 
 	"google.golang.org/grpc/metadata"
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/graphql/authorization"
@@ -58,7 +59,7 @@ func NewQueryRewriter() QueryRewriter {
 }
 
 func hasAuthRules(field schema.Field, authRw *authRewriter) bool {
-	rn := authRw.selector(field.Type())
+	rn := authRw.selector(field.ConstructedFor())
 	if rn != nil {
 		return true
 	}
@@ -858,7 +859,7 @@ func addSelectionSetFrom(
 			len(selSet) == 1 &&
 			selSet[0].Name() == schema.Typename {
 			q.Children = append(q.Children, &gql.GraphQuery{
-				//we don't need this for auth queries because they are added by us used for internal purposes.
+				// we don't need this for auth queries because they are added by us used for internal purposes.
 				// Querying it for them would just add an overhead which we can avoid.
 				Attr:  "uid",
 				Alias: "dgraph.uid",
@@ -888,6 +889,117 @@ func addSelectionSetFrom(
 		// dgraph.type depending upon if the type is interface or not. For interface type
 		// we always query dgraph.type and can pick up the value from there.
 		if f.Skip() || !f.Include() || f.Name() == schema.Typename {
+			continue
+		}
+
+		// Handle aggregation queries
+		if strings.HasPrefix(f.Name(), "aggregate_") {
+			// Don't add field if it has already been added
+			if _, isAddedField := fieldAdded[f.Name()]; isAddedField {
+				continue
+			}
+			fieldAdded[f.Name()] = true
+			constructedForType := f.ConstructedFor()
+			constructedForDgraphPredicate := f.ConstructedForDgraphPredicate()
+			// Iterate over fields queried inside aggregate. Currently this will only have count
+			var aggregateChildren []*gql.GraphQuery
+			// addedAggregateFields is a map from aggregate field name to boolean
+			addedAggregateField := make(map[string]bool)
+			for _, aggregateField := range f.SelectionSet() {
+				// Don't add the same field twice
+				if _, isAddedAggregateField := addedAggregateField[aggregateField.Name()]; isAddedAggregateField {
+					continue
+				}
+				if aggregateField.Name() == "count" {
+					aggregateChild := &gql.GraphQuery{
+						Alias: "count_" + f.Name(),
+						Attr:  "count(" + constructedForDgraphPredicate + ")",
+					}
+					filter, _ := f.ArgValue("filter").(map[string]interface{})
+					_ = addFilter(aggregateChild, constructedForType, filter)
+					aggregateChildren = append(aggregateChildren, aggregateChild)
+					addedAggregateField[aggregateField.Name()] = true
+				}
+			}
+			rbac := auth.evaluateStaticRules(f.ConstructedFor())
+			if rbac == schema.Negative {
+				continue
+			}
+			var parentVarName, parentQryName string
+			if len(f.SelectionSet()) > 0 && !auth.isWritingAuth && auth.hasAuthRules {
+				parentVarName = auth.parentVarName
+				parentQryName = auth.varGen.Next(f.Type(), "", "", auth.isWritingAuth)
+				auth.parentVarName = parentQryName
+				auth.varName = parentQryName
+			}
+			auth.parentVarName = parentVarName
+			auth.varName = parentQryName
+			var fieldAuth []*gql.GraphQuery
+			var authFilter *gql.FilterTree
+			if rbac == schema.Uncertain {
+				fieldAuth, authFilter = auth.rewriteAuthQueries(f.ConstructedFor())
+			}
+			for _, aggregateChild := range aggregateChildren {
+				if authFilter != nil {
+					if aggregateChild.Filter == nil {
+						aggregateChild.Filter = authFilter
+					} else {
+						aggregateChild.Filter = &gql.FilterTree{
+							Op:    "and",
+							Child: []*gql.FilterTree{aggregateChild.Filter, authFilter},
+						}
+					}
+				}
+			}
+			if len(f.SelectionSet()) > 0 && !auth.isWritingAuth && auth.hasAuthRules {
+				// This adds the following query.
+				//	var(func: uid(Ticket)) {
+				//		User as Ticket.assignedTo
+				//	}
+				// where `Ticket` is the nodes selected at parent level and `User` is the nodes we
+				// need on the current level.
+				parentQry := &gql.GraphQuery{
+					Func: &gql.Function{
+						Name: "uid",
+						Args: []gql.Arg{{Value: auth.parentVarName}},
+					},
+					Attr:     "var",
+					Children: []*gql.GraphQuery{{Attr: f.ConstructedForDgraphPredicate(), Var: parentQryName}},
+				}
+
+				// This query aggregates all filters and auth rules and is used by root query to filter
+				// the final nodes for the current level.
+				// User6 as var(func: uid(User2), orderasc: ...) @filter((eq(User.username, "User1") AND (...Auth Filter))))
+				filtervarName := auth.varGen.Next(f.ConstructedFor(), "", "", auth.isWritingAuth)
+				selectionQry := &gql.GraphQuery{
+					Var:  filtervarName,
+					Attr: "var",
+					Func: &gql.Function{
+						Name: "uid",
+						Args: []gql.Arg{{Value: parentQryName}},
+					},
+				}
+
+				addFilterToField(selectionQry, f)
+				var authQueriesAppended bool = false
+				for _, aggregateChild := range aggregateChildren {
+					selectionQry.Filter = aggregateChild.Filter
+					if !authQueriesAppended {
+						authQueries = append(authQueries, parentQry, selectionQry)
+						authQueriesAppended = true
+					}
+					aggregateChild.Filter = &gql.FilterTree{
+						Func: &gql.Function{
+							Name: "uid",
+							Args: []gql.Arg{{Value: filtervarName}},
+						},
+					}
+				}
+			}
+			authQueries = append(authQueries, fieldAuth...)
+
+			q.Children = append(q.Children, aggregateChildren...)
+			// As all child fields inside aggregate have been looked at. We can continue
 			continue
 		}
 

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2558,7 +2558,7 @@
     query {
       queryCountry {
         nm : name
-        ag : aggregate_states{
+        ag : aggregatestates {
           cnt : count
         }
       }
@@ -2567,7 +2567,7 @@
     query {
       queryCountry(func: type(Country)) {
         name : Country.name
-        count_aggregate_states : count(Country.states)
+        count_aggregatestates : count(Country.states)
         dgraph.uid : uid
       }
     }
@@ -2578,7 +2578,7 @@
     query {
       queryCountry {
         nm : name
-        ag : aggregate_states(filter: { code: { eq: "state code" } }) {
+        ag : aggregatestates(filter: { code: { eq: "state code" } }) {
           cnt : count
         }
         st : states {
@@ -2590,7 +2590,7 @@
     query {
       queryCountry(func: type(Country)) {
         name : Country.name
-        count_aggregate_states : count(Country.states) @filter(eq(State.code, "state code"))
+        count_aggregatestates : count(Country.states) @filter(eq(State.code, "state code"))
         states : Country.states {
           capital : State.capital
           dgraph.uid : uid
@@ -2606,7 +2606,7 @@
       getAuthor(id: "0x1") {
         nm : name
         country {
-          ag : aggregate_states(filter: { code: { eq: "state code" } }) {
+          ag : aggregatestates(filter: { code: { eq: "state code" } }) {
             count
           }
         }
@@ -2617,7 +2617,7 @@
       getAuthor(func: uid(0x1)) @filter(type(Author)) {
         name : Author.name
         country : Author.country {
-          count_aggregate_states : count(Country.states) @filter(eq(State.code, "state code"))
+          count_aggregatestates : count(Country.states) @filter(eq(State.code, "state code"))
           dgraph.uid : uid
         }
         dgraph.uid : uid

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2558,7 +2558,7 @@
     query {
       queryCountry {
         nm : name
-        ag : aggregatestates {
+        ag : statesAggregate {
           cnt : count
         }
       }
@@ -2567,7 +2567,7 @@
     query {
       queryCountry(func: type(Country)) {
         name : Country.name
-        count_aggregatestates : count(Country.states)
+        count_statesAggregate : count(Country.states)
         dgraph.uid : uid
       }
     }
@@ -2578,7 +2578,7 @@
     query {
       queryCountry {
         nm : name
-        ag : aggregatestates(filter: { code: { eq: "state code" } }) {
+        ag : statesAggregate(filter: { code: { eq: "state code" } }) {
           cnt : count
         }
         st : states {
@@ -2590,7 +2590,7 @@
     query {
       queryCountry(func: type(Country)) {
         name : Country.name
-        count_aggregatestates : count(Country.states) @filter(eq(State.code, "state code"))
+        count_statesAggregate : count(Country.states) @filter(eq(State.code, "state code"))
         states : Country.states {
           capital : State.capital
           dgraph.uid : uid
@@ -2606,7 +2606,7 @@
       getAuthor(id: "0x1") {
         nm : name
         country {
-          ag : aggregatestates(filter: { code: { eq: "state code" } }) {
+          ag : statesAggregate(filter: { code: { eq: "state code" } }) {
             count
           }
         }
@@ -2617,7 +2617,7 @@
       getAuthor(func: uid(0x1)) @filter(type(Author)) {
         name : Author.name
         country : Author.country {
-          count_aggregatestates : count(Country.states) @filter(eq(State.code, "state code"))
+          count_statesAggregate : count(Country.states) @filter(eq(State.code, "state code"))
           dgraph.uid : uid
         }
         dgraph.uid : uid

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2614,7 +2614,7 @@
     }
   dgquery: |-
     query {
-      getAuthor(func: type(Country)) @filter(type(Author)) {
+      getAuthor(func: uid(0x1)) @filter(type(Author)) {
         name : Author.name
         country : Author.country {
           count_aggregate_states : count(Country.states) @filter(eq(State.code, "state code"))

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2551,3 +2551,75 @@
         dgraph.uid : uid
       }
     }
+
+-
+  name: "Count query at child level"
+  gqlquery: |
+    query {
+      queryCountry {
+        nm : name
+        ag : aggregate_states{
+          cnt : count
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCountry(func: type(Country)) {
+        name : Country.name
+        count_aggregate_states : count(Country.states)
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Count query at child level with filter"
+  gqlquery: |
+    query {
+      queryCountry {
+        nm : name
+        ag : aggregate_states(filter: { code: { eq: "state code" } }) {
+          cnt : count
+        }
+        st : states {
+          capital
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCountry(func: type(Country)) {
+        name : Country.name
+        count_aggregate_states : count(Country.states) @filter(eq(State.code, "state code"))
+        states : Country.states {
+          capital : State.capital
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Deep child level get query with count"
+  gqlquery: |
+    query {
+      getAuthor(id: "0x1") {
+        nm : name
+        country {
+          ag : aggregate_states(filter: { code: { eq: "state code" } }) {
+            count
+          }
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      getAuthor(func: type(Country)) @filter(type(Author)) {
+        name : Author.name
+        country : Author.country {
+          count_aggregate_states : count(Country.states) @filter(eq(State.code, "state code"))
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1355,7 +1355,7 @@ func completeObject(
 		val := res[f.DgraphAlias()]
 		// Handle aggregate queries:
 		// Aggregate Fields in DQL response don't follow the same response as other queries.
-		// Create a map aggregate_val and store response of aggregate fields in a way which
+		// Create a map aggregateVal and store response of aggregate fields in a way which
 		// GraphQL aggregate fields expect it to be. completeValue function called later on
 		// will convert then fill up the GraphQL response.
 		if f.IsAggregateField() {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1353,6 +1353,20 @@ func completeObject(
 		seenField[f.ResponseName()] = true
 
 		val := res[f.DgraphAlias()]
+		// Handle aggregate queries:
+		// Aggregate Fields in DQL response don't follow the same response as other queries.
+		// Create a map aggregate_val and store response of aggregate fields in a way which
+		// GraphQL aggregate fields expect it to be. completeValue function called later on
+		// will convert then fill up the GraphQL response.
+		if f.IsAggregateField() {
+			aggregateVal := make(map[string]interface{})
+			for _, aggregateField := range f.SelectionSet() {
+				if aggregateField.DgraphAlias() == "count" {
+					aggregateVal["count"] = res["count_"+f.DgraphAlias()]
+				}
+			}
+			val = aggregateVal
+		}
 		if f.Name() == schema.Typename {
 			// From GraphQL spec:
 			// https://graphql.github.io/graphql-spec/June2018/#sec-Type-Name-Introspection

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -19,7 +19,7 @@ type State {
         code: String! @id
         country: Country
         name: String!
-	capital: String
+        capital: String
 }
 
 type Author {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1128,7 +1128,7 @@ func addFieldFilters(schema *ast.Schema, defn *ast.Definition) {
 // type list of object. eg. If defn is like
 // type T {fiedldA : [A]}
 // The following aggregate field is added to type T
-// aggregatefieldA(filter : AFilter) : AAggregateResult
+// fieldAAggregate(filter : AFilter) : AAggregateResult
 // These fields are added to support aggregate queries like count, avg, min
 func addAggregateFields(schema *ast.Schema, defn *ast.Definition) {
 	for _, fld := range defn.Fields {
@@ -1139,7 +1139,7 @@ func addAggregateFields(schema *ast.Schema, defn *ast.Definition) {
 			(schema.Types[fld.Type.Name()].Kind == ast.Object ||
 				schema.Types[fld.Type.Name()].Kind == ast.Interface) {
 			aggregateField := &ast.FieldDefinition{
-				Name: "aggregate" + fld.Name,
+				Name: fld.Name + "Aggregate",
 				Type: &ast.Type{
 					NamedType: fld.Type.Name() + "AggregateResult",
 				},

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -852,11 +852,12 @@ func completeSchema(sch *ast.Schema, definitions []string) {
 		addFilterType(sch, defn)
 		addTypeOrderable(sch, defn)
 		addFieldFilters(sch, defn)
-		if params.generateAggregateQuery {
-			addAggregationResultType(sch, defn)
-		}
+		addAggregationResultType(sch, defn)
 		addQueries(sch, defn, params)
 		addTypeHasFilter(sch, defn)
+		// We need to call this at last as aggregateFields
+		// should not be part of hasfilter of updatepayloadtype etc.
+		addAggregateFields(sch, defn)
 	}
 }
 
@@ -1113,7 +1114,7 @@ func addFieldFilters(schema *ast.Schema, defn *ast.Definition) {
 
 		// Ordering and pagination, however, only makes sense for fields of
 		// list types (not scalar lists).
-		if _, scalar := inbuiltTypeToDgraph[fld.Type.Name()]; !scalar && fld.Type.Elem != nil {
+		if isTypeList(fld) {
 			addOrderArgument(schema, fld)
 
 			// Pagination even makes sense when there's no orderables because
@@ -1121,6 +1122,37 @@ func addFieldFilters(schema *ast.Schema, defn *ast.Definition) {
 			addPaginationArguments(fld)
 		}
 	}
+}
+
+// addAggregateFields adds aggregate fields for fields which are of
+// type list of object. eg. If defn is like
+// type T {fiedldA : [A]}
+// The following aggregate field is added to type T
+// aggregate_fieldA(filter : AFilter) : AAggregateResult
+// These fields are added to support aggregate queries like count, avg, min
+func addAggregateFields(schema *ast.Schema, defn *ast.Definition) {
+	var aggregateFields []*ast.FieldDefinition
+	for _, fld := range defn.Fields {
+		// Aggregate Fields only makes sense for fields of
+		// list types of kind Object or Interface
+		// (not scalar lists or not singleton types or lists of other kinds).
+		// TODO: Add aggregateField generation for fields of type list[Union]
+		if isTypeList(fld) && !hasCustomOrLambda(fld) &&
+			(schema.Types[fld.Type.Name()].Kind == ast.Object ||
+				schema.Types[fld.Type.Name()].Kind == ast.Interface) {
+			aggregateField := &ast.FieldDefinition{
+				Name: "aggregate_" + fld.Name,
+				Type: &ast.Type{
+					Elem: &ast.Type{
+						NamedType: fld.Type.Name() + "AggregateResult",
+					},
+				},
+			}
+			addFilterArgumentForField(schema, aggregateField, fld.Type.Name())
+			aggregateFields = append(aggregateFields, aggregateField)
+		}
+	}
+	defn.Fields = append(defn.Fields, aggregateFields...)
 }
 
 func addFilterArgument(schema *ast.Schema, fld *ast.FieldDefinition) {
@@ -1313,6 +1345,13 @@ func hasFilterable(defn *ast.Definition) bool {
 		func(fld *ast.FieldDefinition) bool {
 			return len(getSearchArgs(fld)) != 0 || isID(fld)
 		})
+}
+
+// Returns if given field is a list of type
+// This returns true for list of all non scalar types
+func isTypeList(fld *ast.FieldDefinition) bool {
+	_, scalar := inbuiltTypeToDgraph[fld.Type.Name()]
+	return !scalar && fld.Type.Elem != nil
 }
 
 func hasOrderables(defn *ast.Definition) bool {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -856,7 +856,7 @@ func completeSchema(sch *ast.Schema, definitions []string) {
 		addQueries(sch, defn, params)
 		addTypeHasFilter(sch, defn)
 		// We need to call this at last as aggregateFields
-		// should not be part of hasfilter of updatepayloadtype etc.
+		// should not be part of HasFilter or UpdatePayloadType etc.
 		addAggregateFields(sch, defn)
 	}
 }
@@ -1128,29 +1128,26 @@ func addFieldFilters(schema *ast.Schema, defn *ast.Definition) {
 // type list of object. eg. If defn is like
 // type T {fiedldA : [A]}
 // The following aggregate field is added to type T
-// aggregate_fieldA(filter : AFilter) : AAggregateResult
+// aggregatefieldA(filter : AFilter) : AAggregateResult
 // These fields are added to support aggregate queries like count, avg, min
 func addAggregateFields(schema *ast.Schema, defn *ast.Definition) {
-	var aggregateFields []*ast.FieldDefinition
 	for _, fld := range defn.Fields {
 		// Aggregate Fields only makes sense for fields of
 		// list types of kind Object or Interface
 		// (not scalar lists or not singleton types or lists of other kinds).
-		// TODO: Add aggregateField generation for fields of type list[Union]
 		if isTypeList(fld) && !hasCustomOrLambda(fld) &&
 			(schema.Types[fld.Type.Name()].Kind == ast.Object ||
 				schema.Types[fld.Type.Name()].Kind == ast.Interface) {
 			aggregateField := &ast.FieldDefinition{
-				Name: "aggregate_" + fld.Name,
+				Name: "aggregate" + fld.Name,
 				Type: &ast.Type{
 					NamedType: fld.Type.Name() + "AggregateResult",
 				},
 			}
 			addFilterArgumentForField(schema, aggregateField, fld.Type.Name())
-			aggregateFields = append(aggregateFields, aggregateField)
+			defn.Fields = append(defn.Fields, aggregateField)
 		}
 	}
-	defn.Fields = append(defn.Fields, aggregateFields...)
 }
 
 func addFilterArgument(schema *ast.Schema, fld *ast.FieldDefinition) {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1143,9 +1143,7 @@ func addAggregateFields(schema *ast.Schema, defn *ast.Definition) {
 			aggregateField := &ast.FieldDefinition{
 				Name: "aggregate_" + fld.Name,
 				Type: &ast.Type{
-					Elem: &ast.Type{
-						NamedType: fld.Type.Name() + "AggregateResult",
-					},
+					NamedType: fld.Type.Name() + "AggregateResult",
 				},
 			}
 			addFilterArgumentForField(schema, aggregateField, fld.Type.Name())

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -784,11 +784,11 @@ func fieldNameCheck(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.Li
 				"you cannot declare a field with this name.",
 			typ.Name, field.Name, field.Name)}
 	}
-	// ensure that there are not fields with "aggregate" as prefix
-	if strings.HasPrefix(field.Name, "aggregate") {
+	// ensure that there are not fields with "Aggregate" as suffix
+	if strings.HasSuffix(field.Name, "Aggregate") {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
-			field.Position, "Type %s; Field %s: aggregate is a reserved keyword and "+
-				"you cannot declare a field with aggregate as prefix.",
+			field.Position, "Type %s; Field %s: Aggregate is a reserved keyword and "+
+				"you cannot declare a field with Aggregate as suffix.",
 			typ.Name, field.Name)}
 	}
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -306,6 +306,7 @@ func typeNameValidation(schema *ast.SchemaDocument) gqlerror.List {
 			forbiddenTypeNames["Update"+defName+"Input"] = true
 			forbiddenTypeNames["Update"+defName+"Payload"] = true
 			forbiddenTypeNames["Delete"+defName+"Input"] = true
+			forbiddenTypeNames[defName+"AggregateResult"] = true
 
 			if defn.Kind == ast.Object {
 				forbiddenTypeNames["Add"+defName+"Input"] = true
@@ -782,6 +783,13 @@ func fieldNameCheck(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.Li
 			field.Position, "Type %s; Field %s: %s is a reserved keyword and "+
 				"you cannot declare a field with this name.",
 			typ.Name, field.Name, field.Name)}
+	}
+	// ensure that there are not fields with "aggregate" as prefix
+	if strings.HasPrefix(field.Name, "aggregate") {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			field.Position, "Type %s; Field %s: aggregate is a reserved keyword and "+
+				"you cannot declare a field with aggregate as prefix.",
+			typ.Name, field.Name)}
 	}
 
 	return nil

--- a/graphql/schema/testdata/schemagen/output/auth-on-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/auth-on-interfaces.graphql
@@ -6,6 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 interface Post @auth(query: {rule:"query($TEXT: String!) { \n  queryPost(filter: { text : {eq: $TEXT } } ) { \n    id \n  } \n}"}) {

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -11,13 +11,13 @@ type Todo @auth(query: {or:[{rule:"query($X_MyApp_User: String!) { \n    queryTo
 	sharedWith(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	owner(filter: UserFilter): User @hasInverse(field: "todos")
 	somethingPrivate: String
-	aggregate_sharedWith(filter: UserFilter): UserAggregateResult
+	aggregatesharedWith(filter: UserFilter): UserAggregateResult
 }
 
 type User @auth(update: {rule:"query($X_MyApp_User: String!) { \n    queryUser(filter: { username: { eq: $X_MyApp_User }}) {\n        username\n    }\n}"}) {
 	username: String! @id
 	todos(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo] @hasInverse(field: owner)
-	aggregate_todos(filter: TodoFilter): TodoAggregateResult
+	aggregatetodos(filter: TodoFilter): TodoAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -11,13 +11,13 @@ type Todo @auth(query: {or:[{rule:"query($X_MyApp_User: String!) { \n    queryTo
 	sharedWith(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	owner(filter: UserFilter): User @hasInverse(field: "todos")
 	somethingPrivate: String
-	aggregatesharedWith(filter: UserFilter): UserAggregateResult
+	sharedWithAggregate(filter: UserFilter): UserAggregateResult
 }
 
 type User @auth(update: {rule:"query($X_MyApp_User: String!) { \n    queryUser(filter: { username: { eq: $X_MyApp_User }}) {\n        username\n    }\n}"}) {
 	username: String! @id
 	todos(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo] @hasInverse(field: owner)
-	aggregatetodos(filter: TodoFilter): TodoAggregateResult
+	todosAggregate(filter: TodoFilter): TodoAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -11,11 +11,13 @@ type Todo @auth(query: {or:[{rule:"query($X_MyApp_User: String!) { \n    queryTo
 	sharedWith(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	owner(filter: UserFilter): User @hasInverse(field: "todos")
 	somethingPrivate: String
+	aggregate_sharedWith(filter: UserFilter): [UserAggregateResult]
 }
 
 type User @auth(update: {rule:"query($X_MyApp_User: String!) { \n    queryUser(filter: { username: { eq: $X_MyApp_User }}) {\n        username\n    }\n}"}) {
 	username: String! @id
 	todos(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo] @hasInverse(field: owner)
+	aggregate_todos(filter: TodoFilter): [TodoAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -11,13 +11,13 @@ type Todo @auth(query: {or:[{rule:"query($X_MyApp_User: String!) { \n    queryTo
 	sharedWith(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	owner(filter: UserFilter): User @hasInverse(field: "todos")
 	somethingPrivate: String
-	aggregate_sharedWith(filter: UserFilter): [UserAggregateResult]
+	aggregate_sharedWith(filter: UserFilter): UserAggregateResult
 }
 
 type User @auth(update: {rule:"query($X_MyApp_User: String!) { \n    queryUser(filter: { username: { eq: $X_MyApp_User }}) {\n        username\n    }\n}"}) {
 	username: String! @id
 	todos(filter: TodoFilter, order: TodoOrder, first: Int, offset: Int): [Todo] @hasInverse(field: owner)
-	aggregate_todos(filter: TodoFilter): [TodoAggregateResult]
+	aggregate_todos(filter: TodoFilter): TodoAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
-	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
+	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
 	year: Int!
-	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
+	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "~directed.movies")
-	aggregate_directed(filter: OscarMovieFilter): OscarMovieAggregateResult
+	aggregatedirected(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -6,6 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
+	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
 }
 
 type OscarMovie implements Movie {
@@ -13,12 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
 	year: Int!
+	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "~directed.movies")
+	aggregate_directed(filter: OscarMovieFilter): [OscarMovieAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
-	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
+	directorAggregate(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
 	year: Int!
-	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
+	directorAggregate(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "~directed.movies")
-	aggregatedirected(filter: OscarMovieFilter): OscarMovieAggregateResult
+	directedAggregate(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
-	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
+	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "directed.movies")
 	year: Int!
-	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
+	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "~directed.movies")
-	aggregate_directed(filter: OscarMovieFilter): [OscarMovieAggregateResult]
+	aggregate_directed(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
-	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
+	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
 	year: Int!
-	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
+	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "directed.movies")
-	aggregate_directed(filter: OscarMovieFilter): OscarMovieAggregateResult
+	aggregatedirected(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
-	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
+	directorAggregate(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
 	year: Int!
-	aggregatedirector(filter: DirectorFilter): DirectorAggregateResult
+	directorAggregate(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "directed.movies")
-	aggregatedirected(filter: OscarMovieFilter): OscarMovieAggregateResult
+	directedAggregate(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -6,6 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
+	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
 }
 
 type OscarMovie implements Movie {
@@ -13,12 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
 	year: Int!
+	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "directed.movies")
+	aggregate_directed(filter: OscarMovieFilter): [OscarMovieAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -6,7 +6,7 @@ interface Movie {
 	id: ID!
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
-	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
+	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type OscarMovie implements Movie {
@@ -14,14 +14,14 @@ type OscarMovie implements Movie {
 	name: String!
 	director(filter: DirectorFilter, order: DirectorOrder, first: Int, offset: Int): [Director] @dgraph(pred: "~directed.movies")
 	year: Int!
-	aggregate_director(filter: DirectorFilter): [DirectorAggregateResult]
+	aggregate_director(filter: DirectorFilter): DirectorAggregateResult
 }
 
 type Director {
 	id: ID!
 	name: String!
 	directed(filter: OscarMovieFilter, order: OscarMovieOrder, first: Int, offset: Int): [OscarMovie] @dgraph(pred: "directed.movies")
-	aggregate_directed(filter: OscarMovieFilter): [OscarMovieAggregateResult]
+	aggregate_directed(filter: OscarMovieFilter): OscarMovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Author {
 	name: String! @id @search(by: [regexp])
 	pen_name: String
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Author {
 	name: String! @id @search(by: [regexp])
 	pen_name: String
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -14,6 +14,7 @@ type Author {
 	name: String! @id @search(by: [regexp])
 	pen_name: String
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Author {
 	name: String! @id @search(by: [regexp])
 	pen_name: String
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -6,14 +6,14 @@ type Movie {
 	id: ID!
 	name: String!
 	director(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector] @dgraph(pred: "~directed.movies")
-	aggregate_director(filter: MovieDirectorFilter): [MovieDirectorAggregateResult]
+	aggregate_director(filter: MovieDirectorFilter): MovieDirectorAggregateResult
 }
 
 type MovieDirector {
 	id: ID!
 	name: String!
 	directed(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie] @dgraph(pred: "directed.movies")
-	aggregate_directed(filter: MovieFilter): [MovieAggregateResult]
+	aggregate_directed(filter: MovieFilter): MovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -6,14 +6,14 @@ type Movie {
 	id: ID!
 	name: String!
 	director(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector] @dgraph(pred: "~directed.movies")
-	aggregatedirector(filter: MovieDirectorFilter): MovieDirectorAggregateResult
+	directorAggregate(filter: MovieDirectorFilter): MovieDirectorAggregateResult
 }
 
 type MovieDirector {
 	id: ID!
 	name: String!
 	directed(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie] @dgraph(pred: "directed.movies")
-	aggregatedirected(filter: MovieFilter): MovieAggregateResult
+	directedAggregate(filter: MovieFilter): MovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -6,12 +6,14 @@ type Movie {
 	id: ID!
 	name: String!
 	director(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector] @dgraph(pred: "~directed.movies")
+	aggregate_director(filter: MovieDirectorFilter): [MovieDirectorAggregateResult]
 }
 
 type MovieDirector {
 	id: ID!
 	name: String!
 	directed(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie] @dgraph(pred: "directed.movies")
+	aggregate_directed(filter: MovieFilter): [MovieAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -6,14 +6,14 @@ type Movie {
 	id: ID!
 	name: String!
 	director(filter: MovieDirectorFilter, order: MovieDirectorOrder, first: Int, offset: Int): [MovieDirector] @dgraph(pred: "~directed.movies")
-	aggregate_director(filter: MovieDirectorFilter): MovieDirectorAggregateResult
+	aggregatedirector(filter: MovieDirectorFilter): MovieDirectorAggregateResult
 }
 
 type MovieDirector {
 	id: ID!
 	name: String!
 	directed(filter: MovieFilter, order: MovieOrder, first: Int, offset: Int): [Movie] @dgraph(pred: "directed.movies")
-	aggregate_directed(filter: MovieFilter): MovieAggregateResult
+	aggregatedirected(filter: MovieFilter): MovieAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -5,18 +5,18 @@
 type X {
 	name(first: Int, offset: Int): [Y]
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
-	aggregate_name: YAggregateResult
-	aggregate_f1: YAggregateResult
+	aggregatename: YAggregateResult
+	aggregatef1: YAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregate_f1: XAggregateResult
+	aggregatef1: XAggregateResult
 }
 
 type Z {
 	add(first: Int, offset: Int): [X]
-	aggregate_add: XAggregateResult
+	aggregateadd: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -5,18 +5,18 @@
 type X {
 	name(first: Int, offset: Int): [Y]
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
-	aggregatename: YAggregateResult
-	aggregatef1: YAggregateResult
+	nameAggregate: YAggregateResult
+	f1Aggregate: YAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregatef1: XAggregateResult
+	f1Aggregate: XAggregateResult
 }
 
 type Z {
 	add(first: Int, offset: Int): [X]
-	aggregateadd: XAggregateResult
+	addAggregate: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -5,14 +5,18 @@
 type X {
 	name(first: Int, offset: Int): [Y]
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
+	aggregate_name: [YAggregateResult]
+	aggregate_f1: [YAggregateResult]
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
+	aggregate_f1: [XAggregateResult]
 }
 
 type Z {
 	add(first: Int, offset: Int): [X]
+	aggregate_add: [XAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -5,18 +5,18 @@
 type X {
 	name(first: Int, offset: Int): [Y]
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
-	aggregate_name: [YAggregateResult]
-	aggregate_f1: [YAggregateResult]
+	aggregate_name: YAggregateResult
+	aggregate_f1: YAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregate_f1: [XAggregateResult]
+	aggregate_f1: XAggregateResult
 }
 
 type Z {
 	add(first: Int, offset: Int): [X]
-	aggregate_add: [XAggregateResult]
+	aggregate_add: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -5,16 +5,22 @@
 type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	f3(first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
+	aggregate_f1: [YAggregateResult]
+	aggregate_f3: [ZAggregateResult]
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "f2")
+	aggregate_f1: [XAggregateResult]
+	aggregate_f2: [ZAggregateResult]
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
 	f3(first: Int, offset: Int): [X] @dgraph(pred: "f3")
+	aggregate_f2: [YAggregateResult]
+	aggregate_f3: [XAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -5,22 +5,22 @@
 type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	f3(first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
-	aggregate_f1: [YAggregateResult]
-	aggregate_f3: [ZAggregateResult]
+	aggregate_f1: YAggregateResult
+	aggregate_f3: ZAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "f2")
-	aggregate_f1: [XAggregateResult]
-	aggregate_f2: [ZAggregateResult]
+	aggregate_f1: XAggregateResult
+	aggregate_f2: ZAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
 	f3(first: Int, offset: Int): [X] @dgraph(pred: "f3")
-	aggregate_f2: [YAggregateResult]
-	aggregate_f3: [XAggregateResult]
+	aggregate_f2: YAggregateResult
+	aggregate_f3: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -5,22 +5,22 @@
 type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	f3(first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
-	aggregatef1: YAggregateResult
-	aggregatef3: ZAggregateResult
+	f1Aggregate: YAggregateResult
+	f3Aggregate: ZAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "f2")
-	aggregatef1: XAggregateResult
-	aggregatef2: ZAggregateResult
+	f1Aggregate: XAggregateResult
+	f2Aggregate: ZAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
 	f3(first: Int, offset: Int): [X] @dgraph(pred: "f3")
-	aggregatef2: YAggregateResult
-	aggregatef3: XAggregateResult
+	f2Aggregate: YAggregateResult
+	f3Aggregate: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -5,22 +5,22 @@
 type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	f3(first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
-	aggregate_f1: YAggregateResult
-	aggregate_f3: ZAggregateResult
+	aggregatef1: YAggregateResult
+	aggregatef3: ZAggregateResult
 }
 
 type Y {
 	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "f2")
-	aggregate_f1: XAggregateResult
-	aggregate_f2: ZAggregateResult
+	aggregatef1: XAggregateResult
+	aggregatef2: ZAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
 	f3(first: Int, offset: Int): [X] @dgraph(pred: "f3")
-	aggregate_f2: YAggregateResult
-	aggregate_f3: XAggregateResult
+	aggregatef2: YAggregateResult
+	aggregatef3: XAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -6,19 +6,19 @@ type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	name: String
 	id: ID
-	aggregatef1: YAggregateResult
+	f1Aggregate: YAggregateResult
 }
 
 type Y {
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
 	f1(filter: XFilter, order: XOrder, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregatef2: ZAggregateResult
-	aggregatef1(filter: XFilter): XAggregateResult
+	f2Aggregate: ZAggregateResult
+	f1Aggregate(filter: XFilter): XAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "f2")
-	aggregatef2: YAggregateResult
+	f2Aggregate: YAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -6,19 +6,19 @@ type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	name: String
 	id: ID
-	aggregate_f1: [YAggregateResult]
+	aggregate_f1: YAggregateResult
 }
 
 type Y {
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
 	f1(filter: XFilter, order: XOrder, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregate_f2: [ZAggregateResult]
-	aggregate_f1(filter: XFilter): [XAggregateResult]
+	aggregate_f2: ZAggregateResult
+	aggregate_f1(filter: XFilter): XAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "f2")
-	aggregate_f2: [YAggregateResult]
+	aggregate_f2: YAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -6,19 +6,19 @@ type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	name: String
 	id: ID
-	aggregate_f1: YAggregateResult
+	aggregatef1: YAggregateResult
 }
 
 type Y {
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
 	f1(filter: XFilter, order: XOrder, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	aggregate_f2: ZAggregateResult
-	aggregate_f1(filter: XFilter): XAggregateResult
+	aggregatef2: ZAggregateResult
+	aggregatef1(filter: XFilter): XAggregateResult
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "f2")
-	aggregate_f2: YAggregateResult
+	aggregatef2: YAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -6,15 +6,19 @@ type X {
 	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	name: String
 	id: ID
+	aggregate_f1: [YAggregateResult]
 }
 
 type Y {
 	f2(first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
 	f1(filter: XFilter, order: XOrder, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
+	aggregate_f2: [ZAggregateResult]
+	aggregate_f1(filter: XFilter): [XAggregateResult]
 }
 
 type Z {
 	f2(first: Int, offset: Int): [Y] @dgraph(pred: "f2")
+	aggregate_f2: [YAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/generate-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/generate-directive.graphql
@@ -6,7 +6,7 @@ interface Character @secret(field: "password") @generate(query: {get:false,passw
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @generate(query: {aggregate:true}, subscription: true) @secret(field: "password") {
@@ -14,7 +14,7 @@ type Human implements Character @generate(query: {aggregate:true}, subscription:
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Person @withSubscription @generate(query: {get:false,query:true,password:true,aggregate:false}, mutation: {add:false,delete:false}, subscription: false) {

--- a/graphql/schema/testdata/schemagen/output/generate-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/generate-directive.graphql
@@ -6,6 +6,7 @@ interface Character @secret(field: "password") @generate(query: {get:false,passw
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 type Human implements Character @generate(query: {aggregate:true}, subscription: true) @secret(field: "password") {
@@ -13,6 +14,7 @@ type Human implements Character @generate(query: {aggregate:true}, subscription:
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 type Person @withSubscription @generate(query: {get:false,query:true,password:true,aggregate:false}, mutation: {add:false,delete:false}, subscription: false) {
@@ -301,6 +303,10 @@ type DeleteHumanPayload {
 }
 
 type HumanAggregateResult {
+	count: Int
+}
+
+type PersonAggregateResult {
 	count: Int
 }
 

--- a/graphql/schema/testdata/schemagen/output/generate-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/generate-directive.graphql
@@ -6,7 +6,7 @@ interface Character @secret(field: "password") @generate(query: {get:false,passw
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @generate(query: {aggregate:true}, subscription: true) @secret(field: "password") {
@@ -14,7 +14,7 @@ type Human implements Character @generate(query: {aggregate:true}, subscription:
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Person @withSubscription @generate(query: {get:false,query:true,password:true,aggregate:false}, mutation: {add:false,delete:false}, subscription: false) {

--- a/graphql/schema/testdata/schemagen/output/generate-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/generate-directive.graphql
@@ -6,7 +6,7 @@ interface Character @secret(field: "password") @generate(query: {get:false,passw
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @generate(query: {aggregate:true}, subscription: true) @secret(field: "password") {
@@ -14,7 +14,7 @@ type Human implements Character @generate(query: {aggregate:true}, subscription:
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Person @withSubscription @generate(query: {get:false,query:true,password:true,aggregate:false}, mutation: {add:false,delete:false}, subscription: false) {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -6,6 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -7,8 +7,8 @@ type Author {
 	name: String! @search(by: [hash])
 	questions(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question] @hasInverse(field: author)
 	answers(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer] @hasInverse(field: author)
-	aggregate_questions(filter: QuestionFilter): [QuestionAggregateResult]
-	aggregate_answers(filter: AnswerFilter): [AnswerAggregateResult]
+	aggregate_questions(filter: QuestionFilter): QuestionAggregateResult
+	aggregate_answers(filter: AnswerFilter): AnswerAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -7,8 +7,8 @@ type Author {
 	name: String! @search(by: [hash])
 	questions(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question] @hasInverse(field: author)
 	answers(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer] @hasInverse(field: author)
-	aggregatequestions(filter: QuestionFilter): QuestionAggregateResult
-	aggregateanswers(filter: AnswerFilter): AnswerAggregateResult
+	questionsAggregate(filter: QuestionFilter): QuestionAggregateResult
+	answersAggregate(filter: AnswerFilter): AnswerAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -7,6 +7,8 @@ type Author {
 	name: String! @search(by: [hash])
 	questions(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question] @hasInverse(field: author)
 	answers(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer] @hasInverse(field: author)
+	aggregate_questions(filter: QuestionFilter): [QuestionAggregateResult]
+	aggregate_answers(filter: AnswerFilter): [AnswerAggregateResult]
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -7,8 +7,8 @@ type Author {
 	name: String! @search(by: [hash])
 	questions(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question] @hasInverse(field: author)
 	answers(filter: AnswerFilter, order: AnswerOrder, first: Int, offset: Int): [Answer] @hasInverse(field: author)
-	aggregate_questions(filter: QuestionFilter): QuestionAggregateResult
-	aggregate_answers(filter: AnswerFilter): AnswerAggregateResult
+	aggregatequestions(filter: QuestionFilter): QuestionAggregateResult
+	aggregateanswers(filter: AnswerFilter): AnswerAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -6,6 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -6,7 +6,7 @@ type Author {
 	id: ID!
 	name: String! @search(by: [hash])
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post] @hasInverse(field: author)
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 interface Post {

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -10,6 +10,7 @@ type Post {
 type Author {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -10,6 +10,7 @@ type Post {
 type Author @withSubscription {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author @withSubscription {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author @withSubscription {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -10,7 +10,7 @@ type Post {
 type Author @withSubscription {
 	id: ID!
 	posts(filter: PostFilter, first: Int, offset: Int): [Post!]! @hasInverse(field: "author")
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -13,12 +13,14 @@ type BusinessMan implements Person {
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
 	companyName: String
+	aggregate_owns(filter: ObjectFilter): [ObjectAggregateResult]
 }
 
 interface Person {
 	id: ID!
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
+	aggregate_owns(filter: ObjectFilter): [ObjectAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -13,14 +13,14 @@ type BusinessMan implements Person {
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
 	companyName: String
-	aggregate_owns(filter: ObjectFilter): ObjectAggregateResult
+	aggregateowns(filter: ObjectFilter): ObjectAggregateResult
 }
 
 interface Person {
 	id: ID!
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
-	aggregate_owns(filter: ObjectFilter): ObjectAggregateResult
+	aggregateowns(filter: ObjectFilter): ObjectAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -13,14 +13,14 @@ type BusinessMan implements Person {
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
 	companyName: String
-	aggregate_owns(filter: ObjectFilter): [ObjectAggregateResult]
+	aggregate_owns(filter: ObjectFilter): ObjectAggregateResult
 }
 
 interface Person {
 	id: ID!
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
-	aggregate_owns(filter: ObjectFilter): [ObjectAggregateResult]
+	aggregate_owns(filter: ObjectFilter): ObjectAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -13,14 +13,14 @@ type BusinessMan implements Person {
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
 	companyName: String
-	aggregateowns(filter: ObjectFilter): ObjectAggregateResult
+	ownsAggregate(filter: ObjectFilter): ObjectAggregateResult
 }
 
 interface Person {
 	id: ID!
 	name: String
 	owns(filter: ObjectFilter, order: ObjectOrder, first: Int, offset: Int): [Object] @dgraph(pred: "~Object.owner")
-	aggregateowns(filter: ObjectFilter): ObjectAggregateResult
+	ownsAggregate(filter: ObjectFilter): ObjectAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -14,6 +14,7 @@ type Book implements LibraryItem {
 
 type Library {
 	items(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
+	aggregate_items(filter: LibraryItemFilter): [LibraryItemAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Book implements LibraryItem {
 
 type Library {
 	items(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
-	aggregateitems(filter: LibraryItemFilter): LibraryItemAggregateResult
+	itemsAggregate(filter: LibraryItemFilter): LibraryItemAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Book implements LibraryItem {
 
 type Library {
 	items(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
-	aggregate_items(filter: LibraryItemFilter): [LibraryItemAggregateResult]
+	aggregate_items(filter: LibraryItemFilter): LibraryItemAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -14,7 +14,7 @@ type Book implements LibraryItem {
 
 type Library {
 	items(filter: LibraryItemFilter, order: LibraryItemOrder, first: Int, offset: Int): [LibraryItem]
-	aggregate_items(filter: LibraryItemFilter): LibraryItemAggregateResult
+	aggregateitems(filter: LibraryItemFilter): LibraryItemAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -14,6 +14,7 @@ type Question implements Message {
 type User {
 	name: String
 	messages(order: MessageOrder, first: Int, offset: Int): [Message]
+	aggregate_messages: [MessageAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -14,7 +14,7 @@ type Question implements Message {
 type User {
 	name: String
 	messages(order: MessageOrder, first: Int, offset: Int): [Message]
-	aggregate_messages: [MessageAggregateResult]
+	aggregate_messages: MessageAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -14,7 +14,7 @@ type Question implements Message {
 type User {
 	name: String
 	messages(order: MessageOrder, first: Int, offset: Int): [Message]
-	aggregatemessages: MessageAggregateResult
+	messagesAggregate: MessageAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -14,7 +14,7 @@ type Question implements Message {
 type User {
 	name: String
 	messages(order: MessageOrder, first: Int, offset: Int): [Message]
-	aggregate_messages: MessageAggregateResult
+	aggregatemessages: MessageAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -7,7 +7,7 @@ interface Character @secret(field: "password") {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @secret(field: "password") {
@@ -17,8 +17,8 @@ type Human implements Character @secret(field: "password") {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
-	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character @secret(field: "password") {
@@ -27,7 +27,7 @@ type Droid implements Character @secret(field: "password") {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -7,7 +7,7 @@ interface Character @secret(field: "password") {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @secret(field: "password") {
@@ -17,8 +17,8 @@ type Human implements Character @secret(field: "password") {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
-	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character @secret(field: "password") {
@@ -27,7 +27,7 @@ type Droid implements Character @secret(field: "password") {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -7,6 +7,7 @@ interface Character @secret(field: "password") {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 type Human implements Character @secret(field: "password") {
@@ -16,6 +17,8 @@ type Human implements Character @secret(field: "password") {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
 }
 
 type Droid implements Character @secret(field: "password") {
@@ -24,6 +27,7 @@ type Droid implements Character @secret(field: "password") {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -7,7 +7,7 @@ interface Character @secret(field: "password") {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character @secret(field: "password") {
@@ -17,8 +17,8 @@ type Human implements Character @secret(field: "password") {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
-	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
+	starshipsAggregate(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character @secret(field: "password") {
@@ -27,7 +27,7 @@ type Droid implements Character @secret(field: "password") {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -7,6 +7,7 @@ interface Character {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 type Human implements Character {
@@ -16,6 +17,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
 }
 
 type Droid implements Character {
@@ -24,6 +27,7 @@ type Droid implements Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -7,7 +7,7 @@ interface Character {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -17,8 +17,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
-	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
+	starshipsAggregate(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -27,7 +27,7 @@ type Droid implements Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -7,7 +7,7 @@ interface Character {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -17,8 +17,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
-	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -27,7 +27,7 @@ type Droid implements Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -7,7 +7,7 @@ interface Character {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -17,8 +17,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
-	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -27,7 +27,7 @@ type Droid implements Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -12,7 +12,7 @@ type Author {
 	id: ID
 	name: String
 	posts(order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts: PostAggregateResult
+	aggregateposts: PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -12,6 +12,7 @@ type Author {
 	id: ID
 	name: String
 	posts(order: PostOrder, first: Int, offset: Int): [Post]
+	aggregate_posts: [PostAggregateResult]
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -12,7 +12,7 @@ type Author {
 	id: ID
 	name: String
 	posts(order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts: [PostAggregateResult]
+	aggregate_posts: PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -12,7 +12,7 @@ type Author {
 	id: ID
 	name: String
 	posts(order: PostOrder, first: Int, offset: Int): [Post]
-	aggregateposts: PostAggregateResult
+	postsAggregate: PostAggregateResult
 }
 
 type Genre {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -7,7 +7,7 @@ type Author {
 	name: String! @search(by: [hash])
 	dob: DateTime
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts(filter: PostFilter): PostAggregateResult
+	aggregateposts(filter: PostFilter): PostAggregateResult
 }
 
 type Post {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -7,7 +7,7 @@ type Author {
 	name: String! @search(by: [hash])
 	dob: DateTime
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregateposts(filter: PostFilter): PostAggregateResult
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 type Post {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -7,6 +7,7 @@ type Author {
 	name: String! @search(by: [hash])
 	dob: DateTime
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	aggregate_posts(filter: PostFilter): [PostAggregateResult]
 }
 
 type Post {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -7,7 +7,7 @@ type Author {
 	name: String! @search(by: [hash])
 	dob: DateTime
 	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
-	aggregate_posts(filter: PostFilter): [PostAggregateResult]
+	aggregate_posts(filter: PostFilter): PostAggregateResult
 }
 
 type Post {

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -6,7 +6,7 @@ interface Character {
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 interface Employee {
@@ -21,7 +21,7 @@ type Human implements Character & Employee {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -6,7 +6,7 @@ interface Character {
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 interface Employee {
@@ -21,7 +21,7 @@ type Human implements Character & Employee {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -6,7 +6,7 @@ interface Character {
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 interface Employee {
@@ -21,7 +21,7 @@ type Human implements Character & Employee {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -6,6 +6,7 @@ interface Character {
 	id: ID!
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 interface Employee {
@@ -20,6 +21,7 @@ type Human implements Character & Employee {
 	name: String! @search(by: [exact])
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	totalCredits: Int
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 #######################

--- a/graphql/schema/testdata/schemagen/output/union.graphql
+++ b/graphql/schema/testdata/schemagen/output/union.graphql
@@ -8,7 +8,7 @@ interface Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -19,8 +19,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
-	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -30,7 +30,7 @@ type Droid implements Character {
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/union.graphql
+++ b/graphql/schema/testdata/schemagen/output/union.graphql
@@ -8,7 +8,7 @@ interface Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -19,8 +19,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
-	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
+	starshipsAggregate(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -30,7 +30,7 @@ type Droid implements Character {
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	friendsAggregate(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/union.graphql
+++ b/graphql/schema/testdata/schemagen/output/union.graphql
@@ -8,7 +8,7 @@ interface Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 type Human implements Character {
@@ -19,8 +19,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
-	aggregate_starships(filter: StarshipFilter): StarshipAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatestarships(filter: StarshipFilter): StarshipAggregateResult
 }
 
 type Droid implements Character {
@@ -30,7 +30,7 @@ type Droid implements Character {
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
-	aggregate_friends(filter: CharacterFilter): CharacterAggregateResult
+	aggregatefriends(filter: CharacterFilter): CharacterAggregateResult
 }
 
 enum Episode {

--- a/graphql/schema/testdata/schemagen/output/union.graphql
+++ b/graphql/schema/testdata/schemagen/output/union.graphql
@@ -8,6 +8,7 @@ interface Character {
 	friends(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 type Human implements Character {
@@ -18,6 +19,8 @@ type Human implements Character {
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	starships(filter: StarshipFilter, order: StarshipOrder, first: Int, offset: Int): [Starship]
 	totalCredits: Int
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
+	aggregate_starships(filter: StarshipFilter): [StarshipAggregateResult]
 }
 
 type Droid implements Character {
@@ -27,6 +30,7 @@ type Droid implements Character {
 	enemyOf(filter: ResidentFilter): Resident
 	appearsIn(first: Int, offset: Int): [Episode!]! @search
 	primaryFunction: String
+	aggregate_friends(filter: CharacterFilter): [CharacterAggregateResult]
 }
 
 enum Episode {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -873,7 +873,7 @@ func (f *field) IsAuthQuery() bool {
 }
 
 func (f *field) IsAggregateField() bool {
-	return strings.HasPrefix(f.DgraphAlias(), "aggregate_") &&
+	return strings.HasPrefix(f.DgraphAlias(), "aggregate") &&
 		strings.HasSuffix(f.Type().Name(), "AggregateResult")
 }
 
@@ -1420,6 +1420,8 @@ func (m *mutation) ConstructedFor() Type {
 	return (*field)(m).ConstructedFor()
 }
 
+// In case the field f is of type aggregate<Type>, the Type is retunred.
+// In all other case the function returns the type of field f.
 func (f *field) ConstructedFor() Type {
 	if !f.IsAggregateField() {
 		return f.Type()
@@ -1461,11 +1463,15 @@ func (q *query) ConstructedForDgraphPredicate() string {
 	return (*field)(q).ConstructedForDgraphPredicate()
 }
 
+// In case, the field f is of type aggregate<Type> it returns dgraph predicate of the Type.
+// In all other cases it returns dgraph predicate of the field.
 func (f *field) ConstructedForDgraphPredicate() string {
 	if !f.IsAggregateField() {
 		return f.DgraphPredicate()
 	}
-	return f.op.inSchema.dgraphPredicate[f.field.ObjectDefinition.Name][f.Name()[10:]]
+	// Remove first 9 characters of the field name they will be "aggregate"
+	// Eg. to get "FieldName" from "aggregateFieldName"
+	return f.op.inSchema.dgraphPredicate[f.field.ObjectDefinition.Name][f.Name()[9:]]
 }
 
 func (q *query) QueryType() QueryType {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -141,6 +141,8 @@ type Field interface {
 	IsAuthQuery() bool
 	CustomHTTPConfig() (FieldHTTPConfig, error)
 	EnumValues() []string
+	ConstructedFor() Type
+	ConstructedForDgraphPredicate() string
 }
 
 // A Mutation is a field (from the schema's Mutation type) from an Operation
@@ -155,7 +157,6 @@ type Mutation interface {
 // A Query is a field (from the schema's Query type) from an Operation
 type Query interface {
 	Field
-	ConstructedFor() Type
 	QueryType() QueryType
 	DQLQuery() string
 	Rename(newName string)
@@ -1405,21 +1406,46 @@ func (q *query) EnumValues() []string {
 	return nil
 }
 
-func (q *query) ConstructedFor() Type {
-	if q.QueryType() != AggregateQuery {
-		return q.Type()
+func (m *mutation) ConstructedFor() Type {
+	return (*field)(m).ConstructedFor()
+}
+
+func (f *field) ConstructedFor() Type {
+	fieldName := f.Type().Name()
+	if !strings.HasSuffix(fieldName, "AggregateResult") {
+		return f.Type()
 	}
 
-	// Its of type AggregateQuery
-	queryName := q.Type().Name()
-	typeName := queryName[:len(queryName)-15]
+	// f has type of the form <SomeTypeName>AggregateResult
+	typeName := fieldName[:len(fieldName)-15]
 	return &astType{
 		typ: &ast.Type{
 			NamedType: typeName,
 		},
-		inSchema:        q.op.inSchema,
-		dgraphPredicate: q.op.inSchema.dgraphPredicate,
+		inSchema:        f.op.inSchema,
+		dgraphPredicate: f.op.inSchema.dgraphPredicate,
 	}
+
+}
+
+func (q *query) ConstructedFor() Type {
+	if q.QueryType() != AggregateQuery {
+		return q.Type()
+	}
+	// Its of type AggregateQuery
+	return (*field)(q).ConstructedFor()
+}
+
+func (m *mutation) ConstructedForDgraphPredicate() string {
+	return (*field)(m).ConstructedForDgraphPredicate()
+}
+
+func (q *query) ConstructedForDgraphPredicate() string {
+	return (*field)(q).ConstructedForDgraphPredicate()
+}
+
+func (f *field) ConstructedForDgraphPredicate() string {
+	return f.op.inSchema.dgraphPredicate[f.field.ObjectDefinition.Name][f.Name()[10:]]
 }
 
 func (q *query) QueryType() QueryType {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -873,7 +873,7 @@ func (f *field) IsAuthQuery() bool {
 }
 
 func (f *field) IsAggregateField() bool {
-	return strings.HasPrefix(f.DgraphAlias(), "aggregate") &&
+	return strings.HasSuffix(f.DgraphAlias(), "Aggregate") &&
 		strings.HasSuffix(f.Type().Name(), "AggregateResult")
 }
 
@@ -1420,7 +1420,7 @@ func (m *mutation) ConstructedFor() Type {
 	return (*field)(m).ConstructedFor()
 }
 
-// In case the field f is of type aggregate<Type>, the Type is retunred.
+// In case the field f is of type <Type>Aggregate, the Type is retunred.
 // In all other case the function returns the type of field f.
 func (f *field) ConstructedFor() Type {
 	if !f.IsAggregateField() {
@@ -1463,15 +1463,16 @@ func (q *query) ConstructedForDgraphPredicate() string {
 	return (*field)(q).ConstructedForDgraphPredicate()
 }
 
-// In case, the field f is of type aggregate<Type> it returns dgraph predicate of the Type.
+// In case, the field f is of type <Type>Aggregate it returns dgraph predicate of the Type.
 // In all other cases it returns dgraph predicate of the field.
 func (f *field) ConstructedForDgraphPredicate() string {
 	if !f.IsAggregateField() {
 		return f.DgraphPredicate()
 	}
-	// Remove first 9 characters of the field name they will be "aggregate"
-	// Eg. to get "FieldName" from "aggregateFieldName"
-	return f.op.inSchema.dgraphPredicate[f.field.ObjectDefinition.Name][f.Name()[9:]]
+	// Remove last 9 characters of the field name.
+	// Eg. to get "FieldName" from "FieldNameAggregate"
+	fldName := f.Name()
+	return f.op.inSchema.dgraphPredicate[f.field.ObjectDefinition.Name][fldName[:len(fldName)-9]]
 }
 
 func (q *query) QueryType() QueryType {

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -96,7 +96,7 @@ type Starship {
 		"dob":            "Author.dob",
 		"reputation":     "Author.reputation",
 		"posts":          "Author.posts",
-		"postsAggregate": "dgraph.author.postsAggregate",
+		"postsAggregate": "Author.postsAggregate",
 	}
 	post := map[string]string{
 		"postType": "Post.postType",

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -92,10 +92,11 @@ type Starship {
 	require.True(t, ok, "expected to be able to convert sch to internal schema type")
 
 	author := map[string]string{
-		"name":       "Author.name",
-		"dob":        "Author.dob",
-		"reputation": "Author.reputation",
-		"posts":      "Author.posts",
+		"name":           "Author.name",
+		"dob":            "Author.dob",
+		"reputation":     "Author.reputation",
+		"posts":          "Author.posts",
+		"postsAggregate": "dgraph.author.postsAggregate",
 	}
 	post := map[string]string{
 		"postType": "Post.postType",
@@ -106,11 +107,12 @@ type Starship {
 		"appearsIn": "Character.appearsIn",
 	}
 	human := map[string]string{
-		"ename":        "Employee.ename",
-		"name":         "Character.name",
-		"appearsIn":    "Character.appearsIn",
-		"starships":    "Human.starships",
-		"totalCredits": "Human.totalCredits",
+		"ename":              "Employee.ename",
+		"name":               "Character.name",
+		"appearsIn":          "Character.appearsIn",
+		"starships":          "Human.starships",
+		"totalCredits":       "Human.totalCredits",
+		"starshipsAggregate": "Human.starshipsAggregate",
 	}
 	droid := map[string]string{
 		"name":            "Character.name",
@@ -221,10 +223,11 @@ func TestDgraphMapping_WithDirectives(t *testing.T) {
 	require.True(t, ok, "expected to be able to convert sch to internal schema type")
 
 	author := map[string]string{
-		"name":       "dgraph.author.name",
-		"dob":        "dgraph.author.dob",
-		"reputation": "dgraph.author.reputation",
-		"posts":      "dgraph.author.posts",
+		"name":           "dgraph.author.name",
+		"dob":            "dgraph.author.dob",
+		"reputation":     "dgraph.author.reputation",
+		"posts":          "dgraph.author.posts",
+		"postsAggregate": "dgraph.author.postsAggregate",
 	}
 	post := map[string]string{
 		"postType": "dgraph.post_type",
@@ -235,11 +238,12 @@ func TestDgraphMapping_WithDirectives(t *testing.T) {
 		"appearsIn": "appears_in",
 	}
 	human := map[string]string{
-		"ename":        "dgraph.employee.en.ename",
-		"name":         "performance.character.name",
-		"appearsIn":    "appears_in",
-		"starships":    "Human.starships",
-		"totalCredits": "credits",
+		"ename":              "dgraph.employee.en.ename",
+		"name":               "performance.character.name",
+		"appearsIn":          "appears_in",
+		"starships":          "Human.starships",
+		"totalCredits":       "credits",
+		"starshipsAggregate": "Human.starshipsAggregate",
 	}
 	droid := map[string]string{
 		"name":            "performance.character.name",


### PR DESCRIPTION
Fixes GRAPHQL-746
Motivation:
Relate RFC: https://discuss.dgraph.io/t/count-queries-in-graphql/10714/9
The PR adds the following things:
1. Adds aggregate_<fieldName> fields to graphql output schema.
2. Adds functionality to do count queries at non-root levels in GraphQL
3. Adds tests in graphql/resolve/auth_query_test.yaml and graphql/resolve/query_test.yaml
4. Adds e2e tests in graphql/e2e/common/


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6834)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ad964cd069-106491.surge.sh)
<!-- Dgraph:end -->