### PR TITLE
Make ACL login error message more generic (#6716)

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -64,9 +64,8 @@ func (s *Server) Login(ctx context.Context,
 
 	user, err := s.authenticateLogin(ctx, request)
 	if err != nil {
-		errMsg := fmt.Sprintf("Authentication from address %s failed: %v", addr, err)
-		glog.Errorf(errMsg)
-		return nil, errors.Errorf(errMsg)
+		glog.Errorf("Authentication from address %s failed: %v", addr, err)
+		return nil, x.ErrorInvalidLogin
 	}
 	glog.Infof("%s logged in successfully", user.UserID)
 

--- a/x/x.go
+++ b/x/x.go
@@ -60,6 +60,8 @@ var (
 	// ErrNotSupported is thrown when an enterprise feature is requested in the open source version.
 	ErrNotSupported = errors.Errorf("Feature available only in Dgraph Enterprise Edition")
 	ErrNoJwt        = errors.New("no accessJwt available")
+	// ErrorInvalidLogin is returned when username or password is incorrect in login
+	ErrorInvalidLogin = errors.New("invalid username or password")
 )
 
 const (


### PR DESCRIPTION
(cherry picked from commit c269de85e0c5351290b9af5e1a1d3a6ede94bfd5)

In case of invalid login request we don't reveal info about user. So make error message more generic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6843)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-0e64f25d60-106622.surge.sh)
<!-- Dgraph:end -->