### PR TITLE
fix(x.ValidateAddress): Fix hostname regex check for --my config. (#6…

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -83,8 +83,8 @@ const (
 	// ErrorNoData is an error returned when the requested data cannot be returned.
 	ErrorNoData = "ErrorNoData"
 	// ValidHostnameRegex is a regex that accepts our expected hostname format.
-	ValidHostnameRegex = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]" +
-		"|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+	ValidHostnameRegex = `^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}` +
+		`[a-zA-Z0-9_-]{0,62})*[._]?$`
 	// Star is equivalent to using * in a mutation.
 	// When changing this value also remember to change in in client/client.go:DeleteEdges.
 	Star = "_STAR_ALL"

--- a/x/x_test.go
+++ b/x/x_test.go
@@ -79,7 +79,7 @@ func TestValidateAddress(t *testing.T) {
 		}
 		for _, st := range testData {
 			t.Run(st.name, func(t *testing.T) {
-				if len(st.err) != 0 {
+				if st.err != "" {
 					require.EqualError(t, ValidateAddress(st.address), st.err)
 				} else {
 					require.NoError(t, ValidateAddress(st.address))
@@ -102,13 +102,39 @@ func TestValidateAddress(t *testing.T) {
 		}
 		for _, st := range testData {
 			t.Run(st.name, func(t *testing.T) {
-				if len(st.err) != 0 {
+				if st.err != "" {
 					require.EqualError(t, ValidateAddress(st.address), st.err)
 				} else {
 					require.NoError(t, ValidateAddress(st.address))
 				}
 			})
 		}
+	})
+	t.Run("Hostnames", func(t *testing.T) {
+		testData := []struct {
+			name    string
+			address string
+			err     string
+		}{
+			{"Valid", "dgraph-alpha-0.dgraph-alpha-headless.default.svc.local:9080", ""},
+			{"Valid with underscores", "alpha_1:9080", ""},
+			{"Valid ending in a period", "dgraph-alpha-0.dgraph-alpha-headless.default.svc.:9080", ""},
+			{"Invalid because the name part is longer than 63 characters",
+				"this-is-a-name-that-is-way-too-long-for-a-hostname-that-is-valid:9080",
+				"Invalid hostname: " +
+					"this-is-a-name-that-is-way-too-long-for-a-hostname-that-is-valid"},
+			{"Invalid because it starts with a hyphen", "-alpha1:9080", "Invalid hostname: -alpha1"},
+		}
+		for _, st := range testData {
+			t.Run(st.name, func(t *testing.T) {
+				if st.err != "" {
+					require.EqualError(t, ValidateAddress(st.address), st.err)
+				} else {
+					require.NoError(t, ValidateAddress(st.address))
+				}
+			})
+		}
+
 	})
 }
 


### PR DESCRIPTION
Cherry-pick of #6837.

* fix(x.ValidateAddress): Fix hostname check.

This fixes a panic that happens when the --my flag has a
terminating dot which is still a hostname we can still
technically connect to:

On v20.07.2:

	2020/11/04 23:22:49 dgraph-alpha-0.dgraph-alpha-headless.default.svc.:7080 is not valid address
	github.com/dgraph-io/dgraph/x.AssertTruef
		/ext-go/1/src/github.com/dgraph-io/dgraph/x/error.go:101
	github.com/dgraph-io/dgraph/worker.StartRaftNodes
		/ext-go/1/src/github.com/dgraph-io/dgraph/worker/groups.go:78
	github.com/dgraph-io/dgraph/dgraph/cmd/alpha.run.func4
		/ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:787
	runtime.goexit
		/usr/local/go/src/runtime/asm_amd64.s:1373

On master 59e34068:

	2020/11/04 23:21:51 Invalid hostname: dgraph-alpha-0.dgraph-alpha-headless.default.svc.
	github.com/dgraph-io/dgraph/x.ValidateAddress
		/ext-go/1/src/github.com/dgraph-io/dgraph/x/x.go:674
	github.com/dgraph-io/dgraph/worker.StartRaftNodes
		/ext-go/1/src/github.com/dgraph-io/dgraph/worker/groups.go:76
	github.com/dgraph-io/dgraph/dgraph/cmd/alpha.run.func4
		/ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:735
	runtime.goexit
		/usr/local/go/src/runtime/asm_amd64.s:1373
	
	github.com/dgraph-io/dgraph/x.Check
		/ext-go/1/src/github.com/dgraph-io/dgraph/x/error.go:42
	github.com/dgraph-io/dgraph/worker.StartRaftNodes
		/ext-go/1/src/github.com/dgraph-io/dgraph/worker/groups.go:76
	github.com/dgraph-io/dgraph/dgraph/cmd/alpha.run.func4
		/ext-go/1/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:735
	runtime.goexit
		/usr/local/go/src/runtime/asm_amd64.s:1373

This change updates the ValidHostnameRegex to conform to valid
DNS names as defined in RFC 1035. The exact hostname syntax is
covered in Section 2.3.1. Preferred name syntax and 2.3.4. Size
limits. Our regex adds the following on top of RFC 1035:

1. Allow underscores in hostnames which can happen in Docker Compose
   services (see "Related" below)
2. Allow the hostname to terminate with either a period (.) or
   underscore (_).

Even though RFC 952 says that "The last character must not be a
minus sign or period", systems allow hostnames (as returned by
$(hostname -f)) to have an FQDN that ends with a period which
causes the panic above.

Fixes:

https://discuss.dgraph.io/t/kubernetes-ha-alpha-crashloopbackoff/4232/6

Related:

https://discuss.dgraph.io/t/cluster-setup-using-docker-swarm-not-working-with-dgraph-v1-1-0/5064

* test: Add hostname tests for ValidateAddress.

* chore: Fix issues reported by DeepSource.

Empty string test can be improved (CRT-A0004)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6845)
<!-- Reviewable:end -->
