### PR TITLE
Generic alpha log error message for failed ACL login 

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -158,7 +158,7 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 			"invalid username or passowrd")
 	}
 	if !user.PasswordMatch {
-		return nil, errors.Errorf("invalid username or password")
+		return nil, x.ErrorInvalidLogin
 	}
 	return user, nil
 }

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -138,7 +138,7 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 
 		if user == nil {
 			return nil, errors.Errorf("unable to authenticate through refresh token: "+
-				"user not found for id %v", userId)
+				"invalid username or password")
 		}
 
 		glog.Infof("Authenticated user %s through refresh token", userId)
@@ -155,10 +155,10 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 
 	if user == nil {
 		return nil, errors.Errorf("unable to authenticate through password: "+
-			"user not found for id %v", request.Userid)
+			"invalid username or passowrd")
 	}
 	if !user.PasswordMatch {
-		return nil, errors.Errorf("password mismatch for user: %v", request.Userid)
+		return nil, errors.Errorf("invalid username or password")
 	}
 	return user, nil
 }


### PR DESCRIPTION
In case of an invalid login request, we don't reveal info about user. So made the error message more generic in alpha logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6848)
<!-- Reviewable:end -->
