### PR TITLE
fix(GraphQL): This PR adds support for "application/dql" in content header. 

### DIFF
--- a/contrib/scripts/goldendata-queries.sh
+++ b/contrib/scripts/goldendata-queries.sh
@@ -18,7 +18,7 @@ function run_index_test {
   do
     set +e
     accessToken=`loginWithGroot`
-    N=`curl -s -H 'Content-Type: application/graphql+-' localhost:8180/query -XPOST -d @${X}.in -H "X-Dgraph-AccessToken: $accessToken"`
+    N=`curl -s -H 'Content-Type: application/dql' localhost:8180/query -XPOST -d @${X}.in -H "X-Dgraph-AccessToken: $accessToken"`
     exitCode=$?
 
     set -e

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -197,11 +197,11 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 			x.SetStatus(w, x.ErrorInvalidRequest, jsonErr.Error())
 			return
 		}
-	case "application/graphql+-":
+	case "application/graphql+-", "application/dql":
 		params.Query = string(body)
 	default:
 		x.SetStatus(w, x.ErrorInvalidRequest, "Unsupported Content-Type. "+
-			"Supported content types are application/json, application/graphql+-")
+			"Supported content types are application/json, application/graphql+-,application/dql")
 		return
 	}
 

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -970,7 +970,7 @@ func TestContentTypeCharset(t *testing.T) {
 	require.True(t, err != nil && strings.Contains(err.Error(), "Unsupported charset"))
 }
 
-func TestQueryBackwardCompatibleWithgraphqlPlusMinusHeader(t *testing.T) {
+func TestQueryBackwardCompatibleWithGraphqlPlusMinusHeader(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`name: string @index(term) .`))
 

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -454,7 +454,7 @@ func TestTransactionBasic(t *testing.T) {
 	  }
 	}
 	`
-	_, ts, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	_, ts, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	m1 := `
@@ -480,18 +480,18 @@ func TestTransactionBasic(t *testing.T) {
 	require.Equal(t, "balance", parsedPreds[0])
 	require.Equal(t, "name", parsedPreds[1])
 
-	data, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[]}}`, data)
 
 	// Query with same timestamp.
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", ts)
+	data, _, err = queryWithTs(q1, "application/dql", "", ts)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 
 	// Commit and query.
 	require.NoError(t, commitWithTs(mr.keys, mr.preds, ts))
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 }
@@ -508,7 +508,7 @@ func TestTransactionBasicNoPreds(t *testing.T) {
 	  }
 	}
 	`
-	_, ts, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	_, ts, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	m1 := `
@@ -526,18 +526,18 @@ func TestTransactionBasicNoPreds(t *testing.T) {
 	require.Equal(t, mr.startTs, ts)
 	require.Equal(t, 4, len(mr.keys))
 
-	data, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[]}}`, data)
 
 	// Query with same timestamp.
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", ts)
+	data, _, err = queryWithTs(q1, "application/dql", "", ts)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 
 	// Commit and query.
 	require.NoError(t, commitWithTs(mr.keys, nil, ts))
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 }
@@ -553,7 +553,7 @@ func TestTransactionForCost(t *testing.T) {
 	  }
 	}
 	`
-	_, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	_, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	m1 := `
@@ -570,7 +570,7 @@ func TestTransactionForCost(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "5", mr.cost)
 
-	_, _, resp, err := queryWithTsForResp(q1, "application/graphql+-", "", 0)
+	_, _, resp, err := queryWithTsForResp(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, "2", resp.Header.Get(x.DgraphCostHeader))
 }
@@ -587,7 +587,7 @@ func TestTransactionBasicOldCommitFormat(t *testing.T) {
 	  }
 	}
 	`
-	_, ts, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	_, ts, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	m1 := `
@@ -605,12 +605,12 @@ func TestTransactionBasicOldCommitFormat(t *testing.T) {
 	require.Equal(t, mr.startTs, ts)
 	require.Equal(t, 4, len(mr.keys))
 
-	data, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[]}}`, data)
 
 	// Query with same timestamp.
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", ts)
+	data, _, err = queryWithTs(q1, "application/dql", "", ts)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 
@@ -623,7 +623,7 @@ func TestTransactionBasicOldCommitFormat(t *testing.T) {
 
 	// Commit (using a list of keys instead of a map) and query.
 	require.NoError(t, commitWithTsKeysOnly(mr.keys, ts))
-	data, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	data, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Equal(t, `{"data":{"balances":[{"name":"Bob","balance":"110"}]}}`, data)
 
@@ -697,32 +697,32 @@ func TestHttpCompressionSupport(t *testing.T) {
 	err := runMutation(m1)
 	require.NoError(t, err)
 
-	data, resp, err := queryWithGz(q1, "application/graphql+-", "false", "", false, false)
+	data, resp, err := queryWithGz(q1, "application/dql", "false", "", false, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", false, true)
+	data, resp, err = queryWithGz(q1, "application/dql", "", "", false, true)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", true, false)
+	data, resp, err = queryWithGz(q1, "application/dql", "", "", true, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "", true, true)
+	data, resp, err = queryWithGz(q1, "application/dql", "", "", true, true)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
 	// query with timeout
-	data, _, err = queryWithGz(q1, "application/graphql+-", "", "1ms", false, false)
+	data, _, err = queryWithGz(q1, "application/dql", "", "1ms", false, false)
 	require.EqualError(t, err, ": context deadline exceeded")
 	require.Equal(t, "", data)
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "", "1s", false, false)
+	data, resp, err = queryWithGz(q1, "application/dql", "", "1s", false, false)
 	require.NoError(t, err)
 	require.Equal(t, r1, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
@@ -798,32 +798,32 @@ func TestDebugSupport(t *testing.T) {
 		require.Equal(t, exp, actual)
 	}
 
-	data, resp, err := queryWithGz(q1, "application/graphql+-", "true", "", false, false)
+	data, resp, err := queryWithGz(q1, "application/dql", "true", "", false, false)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", false, true)
+	data, resp, err = queryWithGz(q1, "application/dql", "true", "", false, true)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", true, false)
+	data, resp, err = queryWithGz(q1, "application/dql", "true", "", true, false)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "", true, true)
+	data, resp, err = queryWithGz(q1, "application/dql", "true", "", true, true)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Equal(t, "gzip", resp.Header.Get("Content-Encoding"))
 
 	// query with timeout
-	data, _, err = queryWithGz(q1, "application/graphql+-", "true", "1ms", false, false)
+	data, _, err = queryWithGz(q1, "application/dql", "true", "1ms", false, false)
 	require.EqualError(t, err, ": context deadline exceeded")
 	require.Equal(t, "", data)
 
-	data, resp, err = queryWithGz(q1, "application/graphql+-", "true", "1s", false, false)
+	data, resp, err = queryWithGz(q1, "application/dql", "true", "1s", false, false)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
@@ -836,7 +836,7 @@ func TestDebugSupport(t *testing.T) {
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
 
 	// This test passes access token along with debug flag
-	data, _, err = queryWithTs(q1, "application/graphql+-", "true", 0)
+	data, _, err = queryWithTs(q1, "application/dql", "true", 0)
 	require.NoError(t, err)
 	requireEqual(t, data)
 	require.Empty(t, resp.Header.Get("Content-Encoding"))
@@ -883,7 +883,7 @@ func TestDrainingMode(t *testing.T) {
 	  }
 	}
 	`
-		_, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+		_, _, err := queryWithTs(q1, "application/dql", "", 0)
 		if expectErr {
 			require.True(t, err != nil && strings.Contains(err.Error(), "the server is in draining mode"))
 		} else {
@@ -968,4 +968,38 @@ func TestContentTypeCharset(t *testing.T) {
 
 	_, err = mutationWithTs(`{}`, "application/rdf; charset=latin1", false, true, 0)
 	require.True(t, err != nil && strings.Contains(err.Error(), "Unsupported charset"))
+}
+
+func TestQueryBackwardCompatibleWithgraphqlPlusMinus(t *testing.T) {
+	require.NoError(t, dropAll())
+	require.NoError(t, alterSchema(`name: string @index(term) .`))
+
+	q1 := `
+	{
+	  balances(func: anyofterms(name, "Alice Bob")) {
+	    name
+	    balance
+	  }
+	}
+	`
+	_, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+
+	m1 := `
+    {
+	  set {
+		_:alice <name> "Bob" .
+		_:alice <balance> "110" .
+		_:bob <balance> "60" .
+	  }
+	}
+	`
+
+	mr, err := mutationWithTs(m1, "application/rdf", false, true, 0)
+	require.NoError(t, err)
+	require.Equal(t, "5", mr.cost)
+
+	_, _, resp, err := queryWithTsForResp(q1, "application/graphql+-", "", 0)
+	require.NoError(t, err)
+	require.Equal(t, "2", resp.Header.Get(x.DgraphCostHeader))
 }

--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -970,7 +970,7 @@ func TestContentTypeCharset(t *testing.T) {
 	require.True(t, err != nil && strings.Contains(err.Error(), "Unsupported charset"))
 }
 
-func TestQueryBackwardCompatibleWithgraphqlPlusMinus(t *testing.T) {
+func TestQueryBackwardCompatibleWithgraphqlPlusMinusHeader(t *testing.T) {
 	require.NoError(t, dropAll())
 	require.NoError(t, alterSchema(`name: string @index(term) .`))
 

--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -46,7 +46,7 @@ func TestReindexTerm(t *testing.T) {
         name
       }
     }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, `{"name":"Ab Bc"}`)
 	require.Contains(t, res, `{"name":"Bc Cd"}`)
@@ -76,7 +76,7 @@ func TestReindexLang(t *testing.T) {
       name@en
     }
   }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
     "data": {
@@ -98,7 +98,7 @@ func TestReindexLang(t *testing.T) {
 	_, err = mutationWithTs(m2, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
     "data": {
@@ -149,7 +149,7 @@ func TestReindexReverseCount(t *testing.T) {
       uid
     }
   }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
     "data": {
@@ -169,7 +169,7 @@ func TestReindexReverseCount(t *testing.T) {
 	_, err = mutationWithTs(m2, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.JSONEq(t, `{
     "data": {
@@ -190,7 +190,7 @@ func TestReindexReverseCount(t *testing.T) {
 
 func checkSchema(t *testing.T, query, key string) {
 	for i := 0; i < 10; i++ {
-		res, _, err := queryWithTs(query, "application/graphql+-", "", 0)
+		res, _, err := queryWithTs(query, "application/dql", "", 0)
 		require.NoError(t, err)
 		if strings.Contains(res, key) {
 			return

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -87,7 +87,7 @@ func processToFastJSON(q string) string {
 }
 
 func runGraphqlQuery(q string) (string, error) {
-	output, _, err := queryWithTs(q, "application/graphql+-", "", 0)
+	output, _, err := queryWithTs(q, "application/dql", "", 0)
 	return string(output), err
 }
 

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -81,7 +81,7 @@ upsert {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -109,7 +109,7 @@ upsert {
 	require.Equal(t, 1, len(result.Queries["q"]))
 
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -183,7 +183,7 @@ func TestUpsertExampleJSON(t *testing.T) {
     amount
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -235,7 +235,7 @@ func TestUpsertExample0JSON(t *testing.T) {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -256,7 +256,7 @@ func TestUpsertExample0JSON(t *testing.T) {
 	require.Equal(t, []string{"name"}, splitPreds(mr.preds))
 
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -473,7 +473,7 @@ upsert {
     oldest
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user3")
 	require.Contains(t, res, "56")
@@ -506,7 +506,7 @@ upsert {
     age
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user1")
 }
@@ -565,7 +565,7 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user2")
 
@@ -602,7 +602,7 @@ upsert {
     }
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user2")
 }
@@ -649,7 +649,7 @@ friend: uid @reverse .`))
     oldest
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user3")
 	require.Contains(t, res, "56")
@@ -675,7 +675,7 @@ friend: uid @reverse .`))
     age
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user1")
 }
@@ -726,7 +726,7 @@ friend: uid @reverse .`))
     }
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user2")
 
@@ -751,7 +751,7 @@ friend: uid @reverse .`))
     }
   }
 }`
-	res, _, err = queryWithTs(q3, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q3, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "user2")
 }
@@ -788,7 +788,7 @@ upsert {
     name
   }
 }`
-	res, _, err := queryWithTs(q, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "user1")
 	require.Contains(t, res, "user2")
@@ -864,7 +864,7 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(q, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q, "application/dql", "", 0)
 	require.NoError(t, err)
 	expected := `
 {
@@ -959,7 +959,7 @@ upsert {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -987,7 +987,7 @@ upsert {
 	require.Equal(t, 1, len(result.Queries["q"]))
 
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -1028,7 +1028,7 @@ func TestConditionalUpsertExample0JSON(t *testing.T) {
     email
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Wrong")
 
@@ -1052,7 +1052,7 @@ func TestConditionalUpsertExample0JSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(mr.data, &result))
 	require.Equal(t, 1, len(result.Queries["q"]))
 	// query should return correct name
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "Ashish")
 }
@@ -1122,7 +1122,7 @@ upsert {
     works_with
   }
 }`
-	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user1","works_for":"company1","color":"red"},`+
 		`{"name":"user2","works_for":"company1","color":"red"}]}}`, res)
@@ -1177,12 +1177,12 @@ upsert {
 	mr, err = mutationWithTs(m4, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err = queryWithTs(fmt.Sprintf(q2, "company1"), "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(fmt.Sprintf(q2, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user1","works_for":"company1"},`+
 		`{"name":"user2","works_for":"company1"}]}}`, res)
 
-	res, _, err = queryWithTs(fmt.Sprintf(q2, "company2"), "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(fmt.Sprintf(q2, "company2"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user3","works_for":"company2","color":"blue"},`+
 		`{"name":"user4","works_for":"company2","color":"blue"}]}}`, res)
@@ -1219,12 +1219,12 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(fmt.Sprintf(q1, "company1"), "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(fmt.Sprintf(q1, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user2","works_with":[{"name":"user3"},{"name":"user4"}]},`+
 		`{"name":"user1","works_with":[{"name":"user3"},{"name":"user4"}]}]}}`, res)
 
-	res, _, err = queryWithTs(fmt.Sprintf(q1, "company2"), "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(fmt.Sprintf(q1, "company2"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user3","works_with":[{"name":"user1"},{"name":"user2"}]},`+
 		`{"name":"user4","works_with":[{"name":"user1"},{"name":"user2"}]}]}}`, res)
@@ -1255,12 +1255,12 @@ upsert {
 	require.Equal(t, 1, len(result.Queries["user1"]))
 	require.Equal(t, 1, len(result.Queries["user2"]))
 
-	res, _, err = queryWithTs(fmt.Sprintf(q1, "company1"), "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(fmt.Sprintf(q1, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user1","works_with":[{"name":"user4"}]},`+
 		`{"name":"user2","works_with":[{"name":"user4"},{"name":"user3"}]}]}}`, res)
 
-	res, _, err = queryWithTs(fmt.Sprintf(q1, "company2"), "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(fmt.Sprintf(q1, "company2"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user3","works_with":[{"name":"user2"}]},`+
 		`{"name":"user4","works_with":[{"name":"user1"},{"name":"user2"}]}]}}`, res)
@@ -1301,7 +1301,7 @@ upsert {
     }
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user5","email":"user5@company1.io",`+
 		`"works_for":"company1","works_with":[{"name":"user3"},{"name":"user4"}]}]}}`, res)
@@ -1467,7 +1467,7 @@ upsert {
     content
   }
 }`
-	res, _, err := queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.Contains(t, res, "post4")
 
@@ -1496,7 +1496,7 @@ upsert {
 	require.NoError(t, err)
 
 	// post4 shouldn't exist anymore
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "post4")
 }
@@ -1560,7 +1560,7 @@ amount: float .`))
     loc
   }
 }`
-	expectedRes, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	expectedRes, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	m2 := `
@@ -1603,7 +1603,7 @@ upsert {
 	require.NoError(t, json.Unmarshal(mr.data, &result))
 	require.Equal(t, 3, len(result.Queries["q"]))
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, res, expectedRes)
 }
@@ -1643,7 +1643,7 @@ upsert {
 		_, err = mutationWithTs(m, "application/rdf", false, true, 0)
 		require.NoError(t, err)
 
-		got, _, err := queryWithTs(q, "application/graphql+-", "", 0)
+		got, _, err := queryWithTs(q, "application/dql", "", 0)
 		require.NoError(t, err)
 
 		require.JSONEq(t, fmt.Sprintf(`{"data":{"q":[{"amount":%d}]}}`, count), got)
@@ -1736,7 +1736,7 @@ amount: float .`))
     amount
   }
 }`
-	expectedRes, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	expectedRes, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	return expectedRes
@@ -1772,7 +1772,7 @@ upsert {
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, res, expectedRes)
 }
@@ -1807,7 +1807,7 @@ upsert {
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	// There should be no change
 	testutil.CompareJSON(t, res, expectedRes)
@@ -1842,7 +1842,7 @@ upsert {
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "amount")
 }
@@ -1879,7 +1879,7 @@ upsert {
 	_, err := mutationWithTs(m1, "application/rdf", false, true, 0)
 	require.NoError(t, err)
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -1935,7 +1935,7 @@ upsert {
 	require.NoError(t, json.Unmarshal(mr.data, &result))
 	require.Equal(t, 3, len(result.Queries["q"]))
 
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -2040,7 +2040,7 @@ upsert {
     amount
   }
 }`
-	res, _, err := queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "San Francisco")
 	require.Contains(t, res, "user1")
@@ -2068,7 +2068,7 @@ upsert {
 	require.NoError(t, json.Unmarshal(mr.data, &result))
 	require.Equal(t, 3, len(result.Queries["q"]))
 
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "San Francisco")
 	require.NotContains(t, res, "Fuller Street, SF")
@@ -2118,7 +2118,7 @@ upsert {
       count(~game_answer)
     }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NotContains(t, res, "count(~game_answer)")
 }
@@ -2258,7 +2258,7 @@ upsert {
     name
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -2280,7 +2280,7 @@ upsert {
     name
   }
 }`
-	res, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 
 	expectedRes = `
@@ -2344,7 +2344,7 @@ upsert {
     name
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -2401,7 +2401,7 @@ upsert {
     count
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -2445,7 +2445,7 @@ upsert {
 	require.True(t, len(mr.keys) == 0)
 	require.Equal(t, []string{"count"}, splitPreds(mr.preds))
 
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	expectedRes = `
 {
   "data": {
@@ -2484,7 +2484,7 @@ email: [string] @index(exact) @upsert .`))
     uid
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	var result struct {
 		Data struct {
@@ -2557,7 +2557,7 @@ upsert {
 	require.True(t, len(mr.keys) == 0)
 	require.Equal(t, []string{"email", "name"}, splitPreds(mr.preds))
 
-	res, _, err = queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err = queryWithTs(q1, "application/dql", "", 0)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal([]byte(res), &result))
 	require.Equal(t, 1, len(result.Data.Q))
@@ -2615,7 +2615,7 @@ func TestJsonOldAndNewAPI(t *testing.T) {
       }
     }
   }`
-	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `
   {
@@ -2694,7 +2694,7 @@ func TestJsonNewAPI(t *testing.T) {
       }
     }
   }`
-	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `
   {
@@ -2762,7 +2762,7 @@ func TestUpsertMultiValueJson(t *testing.T) {
     works_with
   }
 }`
-	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(fmt.Sprintf(q2, "company1"), "application/dql", "", 0)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"data":{"q":[{"name":"user1","works_for":"company1","color":"red"},`+
 		`{"name":"user2","works_for":"company1","color":"red"}]}}`, res)
@@ -2847,7 +2847,7 @@ upsert {
     version
   }
 }`
-	res, _, err := queryWithTs(q1, "application/graphql+-", "", 0)
+	res, _, err := queryWithTs(q1, "application/dql", "", 0)
 	expectedRes := `
 {
   "data": {
@@ -2904,6 +2904,6 @@ upsert {
     number
   }
 }`
-	_, _, err = queryWithTs(q2, "application/graphql+-", "", 0)
+	_, _, err = queryWithTs(q2, "application/dql", "", 0)
 	require.NoError(t, err)
 }

--- a/dgraph/cmd/bulk/systest/run.sh
+++ b/dgraph/cmd/bulk/systest/run.sh
@@ -37,7 +37,7 @@ for suite in $script_dir/suite*; do
 	sleep 2
 
 	popd >/dev/null # out of tmp
-	result=$(curl --silent -H "Content-Type: application/graphql+-" localhost:8080/query -XPOST -d @$suite/query.json)
+	result=$(curl --silent -H "Content-Type: application/dql" localhost:8080/query -XPOST -d @$suite/query.json)
 	if ! $(jq --argfile a <(echo $result) --argfile b $suite/result.json -n 'def post_recurse(f): def r: (f | select(. != null) | r), .; r; def post_recurse: post_recurse(.[]?); ($a | (post_recurse | arrays) |= sort) as $a | ($b | (post_recurse | arrays) |= sort) as $b | $a == $b')
 	then
 		echo "Actual result doesn't match expected result:"

--- a/dgraph/cmd/bulk/systest/test-bulk-schema.sh
+++ b/dgraph/cmd/bulk/systest/test-bulk-schema.sh
@@ -119,7 +119,7 @@ function QuerySchema
 {
   INFO "running schema query"
   local out_file="schema.out"
-  curl -sS -H "Content-Type: application/graphql+-" localhost:$HTTP_PORT/query -XPOST -d'schema(pred:[genre,language,name,revenue,predicate_with_default_type,predicate_with_index_no_uid_count,predicate_with_no_uid_count]) {}' | python3 -c "import json,sys; d=json.load(sys.stdin); json.dump(d['data'],sys.stdout,sort_keys=True,indent=2)"  > $out_file
+  curl -sS -H "Content-Type: application/dql" localhost:$HTTP_PORT/query -XPOST -d'schema(pred:[genre,language,name,revenue,predicate_with_default_type,predicate_with_index_no_uid_count,predicate_with_no_uid_count]) {}' | python3 -c "import json,sys; d=json.load(sys.stdin); json.dump(d['data'],sys.stdout,sort_keys=True,indent=2)"  > $out_file
   echo >> $out_file
 }
 

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -48,7 +48,7 @@ func TestCurlAuthorization(t *testing.T) {
 	// alter and mutate should fail.
 	queryArgs := func(jwt string) []string {
 		return []string{"-H", fmt.Sprintf("X-Dgraph-AccessToken:%s", jwt),
-			"-H", "Content-Type: application/graphql+-",
+			"-H", "Content-Type: application/dql",
 			"-d", query, curlQueryEndpoint}
 	}
 	testutil.VerifyCurlCmd(t, queryArgs(accessJwt), &testutil.CurlFailureConfig{

--- a/graphql/admin/add_group.go
+++ b/graphql/admin/add_group.go
@@ -16,7 +16,7 @@ func NewAddGroupRewriter() resolve.MutationRewriter {
 	return &addGroupRewriter{}
 }
 
-// Rewrite rewrites schema.Mutation into GraphQL+- upsert mutations only for Group type.
+// Rewrite rewrites schema.Mutation into dql upsert mutations only for Group type.
 // It ensures that only the last rule out of all duplicate rules in input is preserved.
 // A rule is duplicate if it has same predicate name as another rule.
 func (mrw *addGroupRewriter) Rewrite(

--- a/graphql/admin/update_group.go
+++ b/graphql/admin/update_group.go
@@ -17,7 +17,7 @@ func NewUpdateGroupRewriter() resolve.MutationRewriter {
 	return &updateGroupRewriter{}
 }
 
-// Rewrite rewrites set and remove update patches into GraphQL+- upsert mutations
+// Rewrite rewrites set and remove update patches into dql upsert mutations
 // only for Group type. It ensures that if a rule already exists in db, it is updated;
 // otherwise, it is created. It also ensures that only the last rule out of all
 // duplicate rules in input is preserved. A rule is duplicate if it has same predicate

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -24,7 +24,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-// AsString writes query as an indented GraphQL+- query string.  AsString doesn't
+// AsString writes query as an indented dql query string.  AsString doesn't
 // validate query, and so doesn't return an error if query is 'malformed' - it might
 // just write something that wouldn't parse as a Dgraph query.
 func AsString(query *gql.GraphQuery) string {

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -407,7 +407,7 @@ func (mrw *AddRewriter) FromMutationResult(
 	return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), errs
 }
 
-// Rewrite rewrites set and remove update patches into GraphQL+- upsert mutations.
+// Rewrite rewrites set and remove update patches into dql upsert mutations.
 // The GraphQL updates look like:
 //
 // input UpdateAuthorInput {

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -549,7 +549,7 @@ func SchemaQueryTestHTTP(t *testing.T, c *dgo.Dgraph) {
 	client := http.Client{}
 	req, err := http.NewRequest("POST", "http://localhost:8180/query", &bb)
 	require.NoError(t, err)
-	req.Header.Add("Content-Type", "application/graphql+-")
+	req.Header.Add("Content-Type", "application/dql")
 	req.Header.Add("X-Dgraph-AccessToken", accessJwt)
 	res, err := client.Do(req)
 	require.NoError(t, err)

--- a/wiki/content/clients/raw-http.md
+++ b/wiki/content/clients/raw-http.md
@@ -108,12 +108,12 @@ new transaction is initiated.**
 ## Run a query
 
 To query the database, the `/query` endpoint is used. Remember to set the `Content-Type` header
-to `application/dql` in order to ensure that the body of the request is correctly parsed.
+to `application/graphql+-` in order to ensure that the body of the request is correctly parsed.
 
 To get the balances for both accounts:
 
 ```sh
-$ curl -H "Content-Type: application/dql" -X POST localhost:8080/query -d $'
+$ curl -H "Content-Type: application/graphql+-" -X POST localhost:8080/query -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -320,7 +320,7 @@ You can set the query parameter `ro=true` to `/query` to set it as a
 
 
 ```sh
-$ curl -H "Content-Type: application/dql" -X POST "localhost:8080/query?ro=true" -d $'
+$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?ro=true" -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -337,7 +337,7 @@ You can set the query parameter `be=true` to `/query` to set it as a
 
 
 ```sh
-$ curl -H "Content-Type: application/dql" -X POST "localhost:8080/query?be=true" -d $'
+$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?be=true" -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -371,7 +371,7 @@ Example of a compressed request via curl:
 ```sh
 $ curl -X POST \
   -H 'Accept-Encoding: gzip' \
-  -H "Content-Type: application/dql" \
+  -H "Content-Type: application/graphql+-" \
   localhost:8080/query -d $'schema {}' | gzip --decompress
 ```
 
@@ -391,7 +391,7 @@ $ zcat query.gz # query.gz is gzipped compressed
 $ curl -X POST \
   -H 'Content-Encoding: gzip' \
   -H 'Accept-Encoding: gzip' \
-  -H "Content-Type: application/dql" \
+  -H "Content-Type: application/graphql+-" \
   localhost:8080/query --data-binary @query.gz | gzip --decompress
 ```
 
@@ -399,7 +399,7 @@ $ curl -X POST \
 Curl has a `--compressed` option that automatically requests for a compressed response (`Accept-Encoding` header) and decompresses the compressed response.
 
 ```sh
-$ curl -X POST --compressed -H "Content-Type: application/dql" localhost:8080/query -d $'schema {}'
+$ curl -X POST --compressed -H "Content-Type: application/graphql+-" localhost:8080/query -d $'schema {}'
 ```
 {{% /notice %}}
 

--- a/wiki/content/clients/raw-http.md
+++ b/wiki/content/clients/raw-http.md
@@ -108,12 +108,12 @@ new transaction is initiated.**
 ## Run a query
 
 To query the database, the `/query` endpoint is used. Remember to set the `Content-Type` header
-to `application/graphql+-` in order to ensure that the body of the request is correctly parsed.
+to `application/dql` in order to ensure that the body of the request is correctly parsed.
 
 To get the balances for both accounts:
 
 ```sh
-$ curl -H "Content-Type: application/graphql+-" -X POST localhost:8080/query -d $'
+$ curl -H "Content-Type: application/dql" -X POST localhost:8080/query -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -320,7 +320,7 @@ You can set the query parameter `ro=true` to `/query` to set it as a
 
 
 ```sh
-$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?ro=true" -d $'
+$ curl -H "Content-Type: application/dql" -X POST "localhost:8080/query?ro=true" -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -337,7 +337,7 @@ You can set the query parameter `be=true` to `/query` to set it as a
 
 
 ```sh
-$ curl -H "Content-Type: application/graphql+-" -X POST "localhost:8080/query?be=true" -d $'
+$ curl -H "Content-Type: application/dql" -X POST "localhost:8080/query?be=true" -d $'
 {
   balances(func: anyofterms(name, "Alice Bob")) {
     uid
@@ -371,7 +371,7 @@ Example of a compressed request via curl:
 ```sh
 $ curl -X POST \
   -H 'Accept-Encoding: gzip' \
-  -H "Content-Type: application/graphql+-" \
+  -H "Content-Type: application/dql" \
   localhost:8080/query -d $'schema {}' | gzip --decompress
 ```
 
@@ -391,7 +391,7 @@ $ zcat query.gz # query.gz is gzipped compressed
 $ curl -X POST \
   -H 'Content-Encoding: gzip' \
   -H 'Accept-Encoding: gzip' \
-  -H "Content-Type: application/graphql+-" \
+  -H "Content-Type: application/dql" \
   localhost:8080/query --data-binary @query.gz | gzip --decompress
 ```
 
@@ -399,7 +399,7 @@ $ curl -X POST \
 Curl has a `--compressed` option that automatically requests for a compressed response (`Accept-Encoding` header) and decompresses the compressed response.
 
 ```sh
-$ curl -X POST --compressed -H "Content-Type: application/graphql+-" localhost:8080/query -d $'schema {}'
+$ curl -X POST --compressed -H "Content-Type: application/dql" localhost:8080/query -d $'schema {}'
 ```
 {{% /notice %}}
 


### PR DESCRIPTION

Fixes GRAPHQL-706

This PR Add support for below header in query endpoint

`curl -H "Content-Type: application/dql" "localhost:8080/query"`

We are also keeping support for the old header.

`curl -H "Content-Type: application/graphql+-" "localhost:8080/query"`
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6849)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-d4b996c791-106781.surge.sh)
<!-- Dgraph:end -->