### PR TITLE
Generic alpha log error message for failed ACL login  (#6848)

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -135,7 +135,7 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 
 		if user == nil {
 			return nil, errors.Errorf("unable to authenticate through refresh token: "+
-				"user not found for id %v", userId)
+				"invalid username or password")
 		}
 
 		glog.Infof("Authenticated user %s through refresh token", userId)
@@ -152,10 +152,10 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 
 	if user == nil {
 		return nil, errors.Errorf("unable to authenticate through password: "+
-			"user not found for id %v", request.Userid)
+			"invalid username or passowrd")
 	}
 	if !user.PasswordMatch {
-		return nil, errors.Errorf("password mismatch for user: %v", request.Userid)
+		return nil, x.ErrorInvalidLogin
 	}
 	return user, nil
 }


### PR DESCRIPTION
* In case of an invalid login request, a generic error message will be printed in alpha logs

(cherry picked from commit 7088d59f41f2e176f743a6cc828b21fa8179ba70)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6850)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-a8fefdc999-106867.surge.sh)
<!-- Dgraph:end -->