### PR TITLE
Update docs for count queries

### DIFF
--- a/wiki/content/graphql/queries/count.md
+++ b/wiki/content/graphql/queries/count.md
@@ -6,7 +6,7 @@ weight = 3
     name = "Count Queries"
 +++
 
-Dgraph automatically generates count queries for a given GraphQL schema, enabling you to `count` on predicates, edges and to count nodes satisfying certain criteria specified using a filter. Count Queries are also compatible with `@auth` directive and honor the same authorization rules as `query`.
+Dgraph automatically generates count queries for a given GraphQL schema, enabling you to `count` on predicates, edges, and to count nodes satisfying certain criteria specified using a filter. Count Queries are also compatible with the `@auth` directive and honor the same authorization rules as `query`.
 
 ### Count at root
 

--- a/wiki/content/graphql/queries/count.md
+++ b/wiki/content/graphql/queries/count.md
@@ -6,7 +6,7 @@ weight = 3
     name = "Count Queries"
 +++
 
-Dgraph automatically generates count queries for a given GraphQL schema, enabling you to `count` on predicates, edges and to count nodes satisfying certain criteria specified using a filter.
+Dgraph automatically generates count queries for a given GraphQL schema, enabling you to `count` on predicates, edges and to count nodes satisfying certain criteria specified using a filter. Count Queries are also compatible with `@auth` directive and honor the same authorization rules as `query`.
 
 ### Count at root
 
@@ -41,7 +41,7 @@ Example - Fetch the number of `posts` whose titles contain `GraphQL`.
 
 ### Count for a child
 
-Besides the `aggregate<type name>` query, Dgraph defines `aggregate_<predicate_name>` fields inside `query<type name>` queries, allowing you to do a `count` of predicate edges.
+Besides the `aggregate<type name>` query, Dgraph defines `<predicate_name>Aggregate` fields inside `query<type name>` queries, allowing you to do a `count` of predicate edges.
 
 #### Examples
 
@@ -51,7 +51,7 @@ Example - Fetch the number of `posts` for all authors along with their `name`.
    query {
      queryAuthor {
        name
-       aggregate_posts {
+       postsAggregate {
         count
        }
      }
@@ -64,7 +64,7 @@ Example - Fetch the number of `posts` with a `score` greater than `10` for all a
    query {
      queryAuthor {
        name
-       aggregate_posts(filter: {
+       postsAggregate(filter: {
          score: {
            gt: 10
          }

--- a/wiki/content/graphql/schema/reserved.md
+++ b/wiki/content/graphql/schema/reserved.md
@@ -22,6 +22,7 @@ The following names are reserved and can't be used to define any other identifie
 - `PointList`
 - `Polygon`
 - `MultiPolygon`
+- `Aggregate` (as a suffix of any identifier name)
 
 
 For each type, Dgraph generates a number of GraphQL types needed to operate the GraphQL API, these generated type names also can't be present in the input schema.  For example, for a type `Author`, Dgraph generates:
@@ -36,5 +37,6 @@ For each type, Dgraph generates a number of GraphQL types needed to operate the 
 - `AddAuthorPayload`
 - `DeleteAuthorPayload`
 - `UpdateAuthorPayload`
+- `AuthorAggregateResult`
 
 Thus if `Author` is present in the input schema, all of those become reserved type names.


### PR DESCRIPTION
Motivation:
There were certain changes to how count queries were implemented then what was mentioned in RFC. Specifically the following:
1. Name of Aggregate Fields has been changed to `<name>Aggregate` rather than `aggregate_<name>`
This PR reflects the same. It also adds two types to Reserved Names.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6854)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e852dbbb7a-106963.surge.sh)
<!-- Dgraph:end -->