### PR TITLE
docs: fixed localhost typo

### DIFF
--- a/wiki/content/howto/migrate-dgraph-1-1.md
+++ b/wiki/content/howto/migrate-dgraph-1-1.md
@@ -214,7 +214,7 @@ For JSON mutations, set the `Content-Type` header to `application/json`.
 Before (in Dgraph v1.0):
 
 ```sh
-curl -H 'X-Dgraph-MutationType: json' -H "X-Dgraph-CommitNow: true" locahost:8080/mutate -d '{
+curl -H 'X-Dgraph-MutationType: json' -H "X-Dgraph-CommitNow: true" localhost:8080/mutate -d '{
   "set": [
     {
       "name": "Alice"
@@ -226,7 +226,7 @@ curl -H 'X-Dgraph-MutationType: json' -H "X-Dgraph-CommitNow: true" locahost:808
 Now (in Dgraph v1.1):
 
 ```sh
-curl -H 'Content-Type: application/json' locahost:8080/mutate?commitNow=true -d '{
+curl -H 'Content-Type: application/json' localhost:8080/mutate?commitNow=true -d '{
   "set": [
     {
       "name": "Alice"


### PR DESCRIPTION
Fixed typo: `locahost` --> `localhost`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6855)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c6668afe73-106944.surge.sh)
<!-- Dgraph:end -->