### PR TITLE
DQL (Docs):GraphQL -> DQL fixes (updating `Content-Type: application/graphql+-` references and noting back-compat, review and fix of add'l `GraphQL+-` references)

### DIFF
--- a/wiki/content/clients/raw-http.md
+++ b/wiki/content/clients/raw-http.md
@@ -108,7 +108,13 @@ new transaction is initiated.**
 ## Run a query
 
 To query the database, the `/query` endpoint is used. Remember to set the `Content-Type` header
-to `application/graphql+-` in order to ensure that the body of the request is correctly parsed.
+to `application/dql` to ensure that the body of the request is parsed correctly.
+
+{{% notice "note" %}}
+GraphQL+- has been renamed to Dgraph Query Language (DQL). While `application/dql`
+is the preferred value for the `Content-Type` header, we will continue to support
+`Content-Type: application/graphql+-` to avoid making breaking changes.
+{{% /notice %}}
 
 To get the balances for both accounts:
 

--- a/wiki/content/get-started/index.md
+++ b/wiki/content/get-started/index.md
@@ -185,11 +185,15 @@ click on **Bulk Edit**, and paste the schema.
 ### Step 4: Run Queries
 
 #### Get all movies
-Run this query to get all the movies.
-The query lists all the movies that have a starring edge.
+Run this query to get all the movies. The query lists all movies that have a
+`starring` edge.
+
+{{% notice "tip" %}}
+You can also run the DQL query from the Query tab in the Ratel UI.
+{{% /notice %}}
 
 ```sh
-curl -H "Content-Type: application/graphql+-" "localhost:8080/query" -XPOST -d $'
+curl -H "Content-Type: application/dql" "localhost:8080/query" -XPOST -d $'
 {
  me(func: has(starring)) {
    name
@@ -198,8 +202,10 @@ curl -H "Content-Type: application/graphql+-" "localhost:8080/query" -XPOST -d $
 ' | python -m json.tool | less
 ```
 
-{{% notice "tip" %}}
-You can also run the DQL query from the Ratel UI's query tab.
+{{% notice "note" %}}
+GraphQL+- has been renamed to Dgraph Query Language (DQL). While `application/dql`
+is the preferred value for the `Content-Type` header, we will continue to support
+`Content-Type: application/graphql+-` to avoid making breaking changes.
 {{% /notice %}}
 
 #### Get all movies released after "1980"
@@ -207,7 +213,7 @@ Run this query to get "Star Wars" movies released after "1980".
 Try it in the user interface to see the result as a graph.
 
 ```sh
-curl -H "Content-Type: application/graphql+-" "localhost:8080/query" -XPOST -d $'
+curl -H "Content-Type: application/dql" "localhost:8080/query" -XPOST -d $'
 {
   me(func:allofterms(name, "Star Wars")) @filter(ge(release_date, "1980")) {
     name

--- a/wiki/content/graphql/custom/graphqlpm.md
+++ b/wiki/content/graphql/custom/graphqlpm.md
@@ -5,10 +5,13 @@ weight = 6
     parent = "custom"
 +++
 
-At present, it is an experimental feature in master. You can specify the DQL (aka GraphQL+-) query you want to execute
-while running a custom GraphQL query, and Dgraph's GraphQL API will execute that for you.
+Dgraph Query Language (DQL - formerly GraphQL+-) is rapidly evolving, and now
+includes support for custom logic. You can specify the DQL (aka GraphQL+-) query
+you want to execute while running a custom GraphQL query, and Dgraph's GraphQL
+API will execute that for you.
 
-It helps to build logic that you can't do with the current GraphQL CRUD API.
+DQL lets you build custom logic that goes beyond whta is possible with the
+current GraphQL CRUD API.
 
 For example, lets say you had following schema:
 ```graphql

--- a/wiki/content/query-language/debug.md
+++ b/wiki/content/query-language/debug.md
@@ -15,7 +15,7 @@ For the purposes of debugging, you can attach a query parameter `debug=true` to 
 
 Query with debug as a query parameter
 ```sh
-curl -H "Content-Type: application/graphql+-" http://localhost:8080/query?debug=true -XPOST -d $'{
+curl -H "Content-Type: application/dql" http://localhost:8080/query?debug=true -XPOST -d $'{
   tbl(func: allofterms(name@en, "The Big Lebowski")) {
     name@en
   }
@@ -57,3 +57,8 @@ Returns `uid` and `server_latency`
   }
 }
 ```
+{{% notice "note" %}}
+GraphQL+- has been renamed to Dgraph Query Language (DQL). While `application/dql`
+is the preferred value for the `Content-Type` header, we will continue to support
+`Content-Type: application/graphql+-` to avoid making breaking changes.
+{{% /notice %}}

--- a/wiki/content/query-language/fragments.md
+++ b/wiki/content/query-language/fragments.md
@@ -6,10 +6,14 @@ weight = 25
     parent = "query-language"
 +++
 
-`fragment` keyword allows you to define new fragments that can be referenced in a query, as per [GraphQL specification](https://facebook.github.io/graphql/#sec-Language.Fragments). The point is that if there are multiple parts which query the same set of fields, you can define a fragment and refer to it multiple times instead. Fragments can be nested inside fragments, but no cycles are allowed. Here is one contrived example.
+The `fragment` keyword lets you to define new fragments that can be referenced
+in a query, per the [GraphQL specification](https://facebook.github.io/graphql/#sec-Language.Fragments).
+Fragments allow for the reuse of common repeated selections of fields, reducing
+duplicated text in the DQL documents. Fragments can be nested inside fragments,
+but no cycles are allowed in such cases. For example:
 
 ```sh
-curl -H "Content-Type: application/graphql+-" localhost:8080/query -XPOST -d $'
+curl -H "Content-Type: application/dql" localhost:8080/query -XPOST -d $'
 query {
   debug(func: uid(1)) {
     name@en
@@ -24,3 +28,9 @@ fragment TestFragB {
   country
 }' | python -m json.tool | less
 ```
+
+{{% notice "note" %}}
+GraphQL+- has been renamed to Dgraph Query Language (DQL). While `application/dql`
+is the preferred value for the `Content-Type` header, we will continue to support
+`Content-Type: application/graphql+-` to avoid making breaking changes.
+{{% /notice %}}

--- a/wiki/content/query-language/graphql-fundamentals.md
+++ b/wiki/content/query-language/graphql-fundamentals.md
@@ -6,7 +6,7 @@ weight = 1
     parent = "query-language"
 +++
 
-Dgraph's DQL is based on Facebook's [GraphQL](https://facebook.github.io/graphql/).  GraphQL wasn't developed for Graph databases, but its graph-like query syntax, schema validation and subgraph shaped response make it a great language choice.  We've modified the language to better support graph operations, adding and removing features to get the best fit for graph databases.  We're calling this simplified, feature rich language, ''GraphQL+-''.
+Dgraph Query Language (DQL) is based on the [GraphQL](https://facebook.github.io/graphql/) specification created by Facebook. GraphQL wasn't developed for Graph databases, but its graph-like query syntax, schema validation and subgraph-shaped response make it a great language choice. We've modified the language to better support graph operations, adding and removing features to get the best fit for graph databases.  We're calling this simplified, feature rich language, ''DQL'' (formerly known as ''GraphQL+-'').
 
 DQL is a work in progress. We're adding more features and we might further simplify existing ones.
 
@@ -222,4 +222,3 @@ Query Example: Some of Bollywood director and actor Farhan Akhtar's movies have 
   }
 }
 {{< /runnable >}}
-


### PR DESCRIPTION
- Updated references to `Content-Type: application/graphql+-` -> `Content-Type: application/dql`
- Added notes about backward-compatibility with `Content-Type: application/graphql+-`
- Scrubbed for additional references to GraphQL +- and updated them as appropriate
- Minor rewording for clarity. Note: The rewording of the lead-in for fragments.md needs a close look from a technical perspective.

Note: I used the following commands from repo root to find and review all files that one would expect to be included in this PR, so I am confident that we got all references that we should update in the `master` branch:

`grep -r -l "application/graphql+-" content/*`
`grep -r -l "GraphQL+-" content/*`

The only item that isn't in-scope is a doc that will be deprecated in a separate PR (content/howto/migrate-dgraph-1-1.md) 

Fixes GRAPHQL-775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6858)
<!-- Reviewable:end -->
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-175a43e91b-106966.surge.sh)
<!-- Dgraph:end -->