### PR TITLE
fix(GraphQL): make `audience` necessary if `JWKUrl` is provided

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -83,6 +83,11 @@ func (a *AuthMeta) validate() error {
 		if a.VerificationKey != "" || a.Algo != "" {
 			return fmt.Errorf("expecting either JWKUrl or (VerificationKey, Algo), both were given")
 		}
+
+		// Audience should be a required field if JWKUrl is provided.
+		if len(a.Audience) == 0 {
+			fields = " `Audience` "
+		}
 	} else {
 		if a.VerificationKey == "" {
 			fields = " `Verification key`/`JWKUrl`"

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -258,6 +258,15 @@ func TestInvalidAuthInfo(t *testing.T) {
 	require.Error(t, err, fmt.Errorf("Expecting either JWKUrl or (VerificationKey, Algo), both were given"))
 }
 
+func TestMissingAudienceWithJWKUrl(t *testing.T) {
+	sch, err := ioutil.ReadFile("../e2e/auth/schema.graphql")
+	require.NoError(t, err, "Unable to read schema file")
+	authSchema, err := testutil.AppendAuthInfoWithJWKUrlAndWithoutAudience(sch)
+	require.NoError(t, err)
+	_, err = schema.NewHandler(string(authSchema), false)
+	require.Error(t, err, fmt.Errorf("required field missing in Dgraph.Authorization: `Audience`"))
+}
+
 //Todo(Minhaj): Add a testcase for token without Expiry
 func TestVerificationWithJWKUrl(t *testing.T) {
 	sch, err := ioutil.ReadFile("../e2e/auth/schema.graphql")

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -241,6 +241,11 @@ func AppendAuthInfoWithJWKUrl(schema []byte) ([]byte, error) {
 	return append(schema, []byte(authInfo)...), nil
 }
 
+func AppendAuthInfoWithJWKUrlAndWithoutAudience(schema []byte) ([]byte, error) {
+	authInfo := `# Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":[]}`
+	return append(schema, []byte(authInfo)...), nil
+}
+
 // Add JWKUrl and (VerificationKey, Algo) in the same Authorization JSON
 // Adding Dummy values as this should result in validation error
 func AppendJWKAndVerificationKey(schema []byte) ([]byte, error) {


### PR DESCRIPTION
Fixes GRAPHQL-795.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6866)
<!-- Reviewable:end -->
