### PR TITLE
chore(logs): add occupancy stats of keycommit to logs

### DIFF
--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -113,8 +113,8 @@ func (o *Oracle) purgeBelow(minTs uint64) {
 	o.keyCommit.DeleteBelow(minTs)
 	o.tmax = minTs
 	stats := o.keyCommit.Stats()
-	glog.Infof("Purged below ts:%d, len(o.commits):%d"+
-		", pages:%d\n", minTs, len(o.commits), stats.NumPages)
+	glog.Infof("Purged below ts:%d, len(o.commits):%d, pages:%d, occupancy:%f\n",
+		minTs, len(o.commits), stats.NumPages, stats.Occupancy)
 }
 
 func (o *Oracle) commit(src *api.TxnContext) error {


### PR DESCRIPTION
This PR adds `occupancy` of keyCommit B+ tree to the logs.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6869)
<!-- Reviewable:end -->
