### PR TITLE
fix(GraphQL): fix exclusion of filters in Query generation in case of just Has Filters.

### DIFF
--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -775,6 +775,20 @@
       }
     }
 
+- name: "Query Has Filter on type which has neither ID field nor any search argument"
+  gqlquery: |
+    query {
+      queryNode(filter: {has: name}){
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryNode(func: type(Node)) @filter(has(Node.name)) {
+        name : Node.name
+        dgraph.uid : uid
+      }
+    }
 -
   name: "Filters in same input object implies AND"
   gqlquery: |

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1163,6 +1163,7 @@ func addFilterArgument(schema *ast.Schema, fld *ast.FieldDefinition) {
 }
 
 func addFilterArgumentForField(schema *ast.Schema, fld *ast.FieldDefinition, fldTypeName string) {
+	// Don't add filters for inbuilt types.
 	if _, ok := inbuiltTypeToDgraph[fldTypeName]; ok {
 		return
 	}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -898,7 +898,7 @@ func cleanupInput(sch *ast.Schema, def *ast.Definition, seen map[string]bool) {
 }
 
 func cleanSchema(sch *ast.Schema) {
-	// Let's go over inputs of the type TRef, TPatch and AddTInput and delete the ones which
+	// Let's go over inputs of the type TRef, TPatch AddTInput, UpdateTInput and delete the ones which
 	// don't have field inside them.
 	for k := range sch.Types {
 		if strings.HasSuffix(k, "Ref") || strings.HasSuffix(k, "Patch") ||
@@ -907,20 +907,20 @@ func cleanSchema(sch *ast.Schema) {
 		}
 	}
 
-	// Let's go over mutations and cleanup those which don't have AddTInput defined in the schema
+	// Let's go over mutations and cleanup those which don't have AddTInput/UpdateTInput defined in the schema
 	// anymore.
 	i := 0 // helps us overwrite the array with valid entries.
 	for _, field := range sch.Mutation.Fields {
 		custom := field.Directives.ForName("custom")
-		// We would only modify add/
+		// We would only modify add/update
 		if custom != nil || !(strings.HasPrefix(field.Name, "add") || strings.HasPrefix(field.Name, "update")) {
 			sch.Mutation.Fields[i] = field
 			i++
 			continue
 		}
 
-		// addT type mutations have an input which is AddTInput so if that doesn't exist anymore,
-		// we can delete the AddTPayload and also skip this mutation.
+		// addT / updateT type mutations have an input which is AddTInput / UpdateTInput so if that doesn't exist anymore,
+		// we can delete the AddTPayload / UpdateTPayload and also skip this mutation.
 
 		var typeName, input string
 		if strings.HasPrefix(field.Name, "add") {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1155,6 +1155,10 @@ func addFilterArgument(schema *ast.Schema, fld *ast.FieldDefinition) {
 }
 
 func addFilterArgumentForField(schema *ast.Schema, fld *ast.FieldDefinition, fldTypeName string) {
+	if _, ok := inbuiltTypeToDgraph[fldTypeName]; ok {
+		return
+	}
+
 	fldType := schema.Types[fldTypeName]
 	if fldType.Kind == ast.Union || hasFilterable(fldType) {
 		fld.Arguments = append(fld.Arguments,

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1335,10 +1335,13 @@ func addFilterType(schema *ast.Schema, defn *ast.Definition) {
 	schema.Types[filterName] = filter
 }
 
+// hasFilterable Returns whether TypeFilter for a defn will be generated or not.
+// It returns true if any field have search arguments or it is an `ID` field or
+// HasFilter for that defn is generated.
 func hasFilterable(defn *ast.Definition) bool {
 	return fieldAny(defn.Fields,
 		func(fld *ast.FieldDefinition) bool {
-			return len(getSearchArgs(fld)) != 0 || isID(fld)
+			return len(getSearchArgs(fld)) != 0 || isID(fld) || !hasCustomOrLambda(fld)
 		})
 }
 

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -297,6 +297,12 @@ type AddTPayload {
 	numUids: Int
 }
 
+type DeleteIPayload {
+	i(filter: IFilter, order: IOrder, first: Int, offset: Int): [I]
+	msg: String
+	numUids: Int
+}
+
 type DeleteTPayload {
 	t(filter: TFilter, order: TOrder, first: Int, offset: Int): [T]
 	msg: String
@@ -309,6 +315,11 @@ type IAggregateResult {
 
 type TAggregateResult {
 	count: Int
+}
+
+type UpdateIPayload {
+	i(filter: IFilter, order: IOrder, first: Int, offset: Int): [I]
+	numUids: Int
 }
 
 type UpdateTPayload {
@@ -374,6 +385,11 @@ input IOrder {
 	then: IOrder
 }
 
+input IPatch {
+	"""Desc"""
+	s: String
+}
+
 input TFilter {
 	id: [ID!]
 	has: THasFilter
@@ -401,6 +417,12 @@ input TRef {
 	i: Int
 }
 
+input UpdateIInput {
+	filter: IFilter!
+	set: IPatch
+	remove: IPatch
+}
+
 input UpdateTInput {
 	filter: TFilter!
 	set: TPatch
@@ -412,8 +434,8 @@ input UpdateTInput {
 #######################
 
 type Query {
-	queryI(order: IOrder, first: Int, offset: Int): [I]
-	aggregateI: IAggregateResult
+	queryI(filter: IFilter, order: IOrder, first: Int, offset: Int): [I]
+	aggregateI(filter: IFilter): IAggregateResult
 	getT(id: ID!): T
 	queryT(filter: TFilter, order: TOrder, first: Int, offset: Int): [T]
 	aggregateT(filter: TFilter): TAggregateResult
@@ -424,6 +446,8 @@ type Query {
 #######################
 
 type Mutation {
+	updateI(input: UpdateIInput!): UpdateIPayload
+	deleteI(filter: IFilter!): DeleteIPayload
 	addT(input: [AddTInput!]!): AddTPayload
 	updateT(input: UpdateTInput!): UpdateTPayload
 	deleteT(filter: TFilter!): DeleteTPayload

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -267,12 +267,23 @@ input StringHashFilter {
 #######################
 
 type AddAtypePayload {
-	atype(order: AtypeOrder, first: Int, offset: Int): [Atype]
+	atype(filter: AtypeFilter, order: AtypeOrder, first: Int, offset: Int): [Atype]
 	numUids: Int
 }
 
 type AtypeAggregateResult {
 	count: Int
+}
+
+type DeleteAtypePayload {
+	atype(filter: AtypeFilter, order: AtypeOrder, first: Int, offset: Int): [Atype]
+	msg: String
+	numUids: Int
+}
+
+type UpdateAtypePayload {
+	atype(filter: AtypeFilter, order: AtypeOrder, first: Int, offset: Int): [Atype]
+	numUids: Int
 }
 
 #######################
@@ -311,9 +322,20 @@ input AtypeOrder {
 	then: AtypeOrder
 }
 
+input AtypePatch {
+	iamDeprecated: String
+	soAmI: String
+}
+
 input AtypeRef {
 	iamDeprecated: String
 	soAmI: String
+}
+
+input UpdateAtypeInput {
+	filter: AtypeFilter!
+	set: AtypePatch
+	remove: AtypePatch
 }
 
 #######################
@@ -321,8 +343,8 @@ input AtypeRef {
 #######################
 
 type Query {
-	queryAtype(order: AtypeOrder, first: Int, offset: Int): [Atype]
-	aggregateAtype: AtypeAggregateResult
+	queryAtype(filter: AtypeFilter, order: AtypeOrder, first: Int, offset: Int): [Atype]
+	aggregateAtype(filter: AtypeFilter): AtypeAggregateResult
 }
 
 #######################
@@ -331,5 +353,7 @@ type Query {
 
 type Mutation {
 	addAtype(input: [AddAtypeInput!]!): AddAtypePayload
+	updateAtype(input: UpdateAtypeInput!): UpdateAtypePayload
+	deleteAtype(filter: AtypeFilter!): DeleteAtypePayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -3,20 +3,20 @@
 #######################
 
 type X {
-	name(first: Int, offset: Int): [Y]
-	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
-	nameAggregate: YAggregateResult
-	f1Aggregate: YAggregateResult
+	name(filter: YFilter, first: Int, offset: Int): [Y]
+	f1(filter: YFilter, first: Int, offset: Int): [Y] @dgraph(pred: "f1")
+	nameAggregate(filter: YFilter): YAggregateResult
+	f1Aggregate(filter: YFilter): YAggregateResult
 }
 
 type Y {
-	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	f1Aggregate: XAggregateResult
+	f1(filter: XFilter, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
+	f1Aggregate(filter: XFilter): XAggregateResult
 }
 
 type Z {
-	add(first: Int, offset: Int): [X]
-	addAggregate: XAggregateResult
+	add(filter: XFilter, first: Int, offset: Int): [X]
+	addAggregate(filter: XFilter): XAggregateResult
 }
 
 #######################
@@ -278,6 +278,44 @@ input StringHashFilter {
 # Generated Types
 #######################
 
+type AddXPayload {
+	x(filter: XFilter, first: Int, offset: Int): [X]
+	numUids: Int
+}
+
+type AddZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	numUids: Int
+}
+
+type DeleteXPayload {
+	x(filter: XFilter, first: Int, offset: Int): [X]
+	msg: String
+	numUids: Int
+}
+
+type DeleteYPayload {
+	y(filter: YFilter, first: Int, offset: Int): [Y]
+	msg: String
+	numUids: Int
+}
+
+type DeleteZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	msg: String
+	numUids: Int
+}
+
+type UpdateXPayload {
+	x(filter: XFilter, first: Int, offset: Int): [X]
+	numUids: Int
+}
+
+type UpdateZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	numUids: Int
+}
+
 type XAggregateResult {
 	count: Int
 }
@@ -334,11 +372,21 @@ input ZFilter {
 #######################
 
 type Query {
-	queryX(first: Int, offset: Int): [X]
-	aggregateX: XAggregateResult
-	queryY(first: Int, offset: Int): [Y]
-	aggregateY: YAggregateResult
-	queryZ(first: Int, offset: Int): [Z]
-	aggregateZ: ZAggregateResult
+	queryX(filter: XFilter, first: Int, offset: Int): [X]
+	aggregateX(filter: XFilter): XAggregateResult
+	queryY(filter: YFilter, first: Int, offset: Int): [Y]
+	aggregateY(filter: YFilter): YAggregateResult
+	queryZ(filter: ZFilter, first: Int, offset: Int): [Z]
+	aggregateZ(filter: ZFilter): ZAggregateResult
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	deleteX(filter: XFilter!): DeleteXPayload
+	deleteY(filter: YFilter!): DeleteYPayload
+	deleteZ(filter: ZFilter!): DeleteZPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -3,24 +3,24 @@
 #######################
 
 type X {
-	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
-	f3(first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
-	f1Aggregate: YAggregateResult
-	f3Aggregate: ZAggregateResult
+	f1(filter: YFilter, first: Int, offset: Int): [Y] @dgraph(pred: "f1")
+	f3(filter: ZFilter, first: Int, offset: Int): [Z] @dgraph(pred: "~f3")
+	f1Aggregate(filter: YFilter): YAggregateResult
+	f3Aggregate(filter: ZFilter): ZAggregateResult
 }
 
 type Y {
-	f1(first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	f2(first: Int, offset: Int): [Z] @dgraph(pred: "f2")
-	f1Aggregate: XAggregateResult
-	f2Aggregate: ZAggregateResult
+	f1(filter: XFilter, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
+	f2(filter: ZFilter, first: Int, offset: Int): [Z] @dgraph(pred: "f2")
+	f1Aggregate(filter: XFilter): XAggregateResult
+	f2Aggregate(filter: ZFilter): ZAggregateResult
 }
 
 type Z {
-	f2(first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
-	f3(first: Int, offset: Int): [X] @dgraph(pred: "f3")
-	f2Aggregate: YAggregateResult
-	f3Aggregate: XAggregateResult
+	f2(filter: YFilter, first: Int, offset: Int): [Y] @dgraph(pred: "~f2")
+	f3(filter: XFilter, first: Int, offset: Int): [X] @dgraph(pred: "f3")
+	f2Aggregate(filter: YFilter): YAggregateResult
+	f3Aggregate(filter: XFilter): XAggregateResult
 }
 
 #######################
@@ -283,17 +283,50 @@ input StringHashFilter {
 #######################
 
 type AddXPayload {
-	x(first: Int, offset: Int): [X]
+	x(filter: XFilter, first: Int, offset: Int): [X]
 	numUids: Int
 }
 
 type AddYPayload {
-	y(first: Int, offset: Int): [Y]
+	y(filter: YFilter, first: Int, offset: Int): [Y]
 	numUids: Int
 }
 
 type AddZPayload {
-	z(first: Int, offset: Int): [Z]
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	numUids: Int
+}
+
+type DeleteXPayload {
+	x(filter: XFilter, first: Int, offset: Int): [X]
+	msg: String
+	numUids: Int
+}
+
+type DeleteYPayload {
+	y(filter: YFilter, first: Int, offset: Int): [Y]
+	msg: String
+	numUids: Int
+}
+
+type DeleteZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	msg: String
+	numUids: Int
+}
+
+type UpdateXPayload {
+	x(filter: XFilter, first: Int, offset: Int): [X]
+	numUids: Int
+}
+
+type UpdateYPayload {
+	y(filter: YFilter, first: Int, offset: Int): [Y]
+	numUids: Int
+}
+
+type UpdateZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
 	numUids: Int
 }
 
@@ -344,11 +377,33 @@ input AddZInput {
 	f3: [XRef]
 }
 
+input UpdateXInput {
+	filter: XFilter!
+	set: XPatch
+	remove: XPatch
+}
+
+input UpdateYInput {
+	filter: YFilter!
+	set: YPatch
+	remove: YPatch
+}
+
+input UpdateZInput {
+	filter: ZFilter!
+	set: ZPatch
+	remove: ZPatch
+}
+
 input XFilter {
 	has: XHasFilter
 	and: [XFilter]
 	or: [XFilter]
 	not: XFilter
+}
+
+input XPatch {
+	f1: [YRef]
 }
 
 input XRef {
@@ -362,6 +417,10 @@ input YFilter {
 	not: YFilter
 }
 
+input YPatch {
+	f2: [ZRef]
+}
+
 input YRef {
 	f2: [ZRef]
 }
@@ -373,6 +432,10 @@ input ZFilter {
 	not: ZFilter
 }
 
+input ZPatch {
+	f3: [XRef]
+}
+
 input ZRef {
 	f3: [XRef]
 }
@@ -382,12 +445,12 @@ input ZRef {
 #######################
 
 type Query {
-	queryX(first: Int, offset: Int): [X]
-	aggregateX: XAggregateResult
-	queryY(first: Int, offset: Int): [Y]
-	aggregateY: YAggregateResult
-	queryZ(first: Int, offset: Int): [Z]
-	aggregateZ: ZAggregateResult
+	queryX(filter: XFilter, first: Int, offset: Int): [X]
+	aggregateX(filter: XFilter): XAggregateResult
+	queryY(filter: YFilter, first: Int, offset: Int): [Y]
+	aggregateY(filter: YFilter): YAggregateResult
+	queryZ(filter: ZFilter, first: Int, offset: Int): [Z]
+	aggregateZ(filter: ZFilter): ZAggregateResult
 }
 
 #######################
@@ -396,7 +459,13 @@ type Query {
 
 type Mutation {
 	addX(input: [AddXInput!]!): AddXPayload
+	updateX(input: UpdateXInput!): UpdateXPayload
+	deleteX(filter: XFilter!): DeleteXPayload
 	addY(input: [AddYInput!]!): AddYPayload
+	updateY(input: UpdateYInput!): UpdateYPayload
+	deleteY(filter: YFilter!): DeleteYPayload
 	addZ(input: [AddZInput!]!): AddZPayload
+	updateZ(input: UpdateZInput!): UpdateZPayload
+	deleteZ(filter: ZFilter!): DeleteZPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -3,22 +3,22 @@
 #######################
 
 type X {
-	f1(first: Int, offset: Int): [Y] @dgraph(pred: "f1")
+	f1(filter: YFilter, first: Int, offset: Int): [Y] @dgraph(pred: "f1")
 	name: String
 	id: ID
-	f1Aggregate: YAggregateResult
+	f1Aggregate(filter: YFilter): YAggregateResult
 }
 
 type Y {
-	f2(first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
+	f2(filter: ZFilter, first: Int, offset: Int): [Z] @dgraph(pred: "~f2")
 	f1(filter: XFilter, order: XOrder, first: Int, offset: Int): [X] @dgraph(pred: "~f1")
-	f2Aggregate: ZAggregateResult
+	f2Aggregate(filter: ZFilter): ZAggregateResult
 	f1Aggregate(filter: XFilter): XAggregateResult
 }
 
 type Z {
-	f2(first: Int, offset: Int): [Y] @dgraph(pred: "f2")
-	f2Aggregate: YAggregateResult
+	f2(filter: YFilter, first: Int, offset: Int): [Y] @dgraph(pred: "f2")
+	f2Aggregate(filter: YFilter): YAggregateResult
 }
 
 #######################
@@ -285,14 +285,36 @@ type AddXPayload {
 	numUids: Int
 }
 
+type AddZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	numUids: Int
+}
+
 type DeleteXPayload {
 	x(filter: XFilter, order: XOrder, first: Int, offset: Int): [X]
 	msg: String
 	numUids: Int
 }
 
+type DeleteYPayload {
+	y(filter: YFilter, first: Int, offset: Int): [Y]
+	msg: String
+	numUids: Int
+}
+
+type DeleteZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
+	msg: String
+	numUids: Int
+}
+
 type UpdateXPayload {
 	x(filter: XFilter, order: XOrder, first: Int, offset: Int): [X]
+	numUids: Int
+}
+
+type UpdateZPayload {
+	z(filter: ZFilter, first: Int, offset: Int): [Z]
 	numUids: Int
 }
 
@@ -386,10 +408,10 @@ type Query {
 	getX(id: ID!): X
 	queryX(filter: XFilter, order: XOrder, first: Int, offset: Int): [X]
 	aggregateX(filter: XFilter): XAggregateResult
-	queryY(first: Int, offset: Int): [Y]
-	aggregateY: YAggregateResult
-	queryZ(first: Int, offset: Int): [Z]
-	aggregateZ: ZAggregateResult
+	queryY(filter: YFilter, first: Int, offset: Int): [Y]
+	aggregateY(filter: YFilter): YAggregateResult
+	queryZ(filter: ZFilter, first: Int, offset: Int): [Z]
+	aggregateZ(filter: ZFilter): ZAggregateResult
 }
 
 #######################
@@ -400,5 +422,7 @@ type Mutation {
 	addX(input: [AddXInput!]!): AddXPayload
 	updateX(input: UpdateXInput!): UpdateXPayload
 	deleteX(filter: XFilter!): DeleteXPayload
+	deleteY(filter: YFilter!): DeleteYPayload
+	deleteZ(filter: ZFilter!): DeleteZPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/hasfilter.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasfilter.graphql
@@ -275,7 +275,7 @@ input StringHashFilter {
 #######################
 
 type AddBPayload {
-	b(order: BOrder, first: Int, offset: Int): [B]
+	b(filter: BFilter, order: BOrder, first: Int, offset: Int): [B]
 	numUids: Int
 }
 
@@ -286,6 +286,12 @@ type AddTPayload {
 
 type BAggregateResult {
 	count: Int
+}
+
+type DeleteBPayload {
+	b(filter: BFilter, order: BOrder, first: Int, offset: Int): [B]
+	msg: String
+	numUids: Int
 }
 
 type DeleteIPayload {
@@ -306,6 +312,11 @@ type IAggregateResult {
 
 type TAggregateResult {
 	count: Int
+}
+
+type UpdateBPayload {
+	b(filter: BFilter, order: BOrder, first: Int, offset: Int): [B]
+	numUids: Int
 }
 
 type UpdateTPayload {
@@ -358,6 +369,10 @@ input BOrder {
 	then: BOrder
 }
 
+input BPatch {
+	name: String
+}
+
 input BRef {
 	name: String
 }
@@ -394,6 +409,12 @@ input TRef {
 	text: String
 }
 
+input UpdateBInput {
+	filter: BFilter!
+	set: BPatch
+	remove: BPatch
+}
+
 input UpdateTInput {
 	filter: TFilter!
 	set: TPatch
@@ -411,8 +432,8 @@ type Query {
 	getT(id: ID!): T
 	queryT(filter: TFilter, order: TOrder, first: Int, offset: Int): [T]
 	aggregateT(filter: TFilter): TAggregateResult
-	queryB(order: BOrder, first: Int, offset: Int): [B]
-	aggregateB: BAggregateResult
+	queryB(filter: BFilter, order: BOrder, first: Int, offset: Int): [B]
+	aggregateB(filter: BFilter): BAggregateResult
 }
 
 #######################
@@ -425,5 +446,7 @@ type Mutation {
 	updateT(input: UpdateTInput!): UpdateTPayload
 	deleteT(filter: TFilter!): DeleteTPayload
 	addB(input: [AddBInput!]!): AddBPayload
+	updateB(input: UpdateBInput!): UpdateBPayload
+	deleteB(filter: BFilter!): DeleteBPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -282,7 +282,7 @@ type AddBookPayload {
 }
 
 type AddLibraryPayload {
-	library(first: Int, offset: Int): [Library]
+	library(filter: LibraryFilter, first: Int, offset: Int): [Library]
 	numUids: Int
 }
 
@@ -302,6 +302,12 @@ type DeleteLibraryItemPayload {
 	numUids: Int
 }
 
+type DeleteLibraryPayload {
+	library(filter: LibraryFilter, first: Int, offset: Int): [Library]
+	msg: String
+	numUids: Int
+}
+
 type LibraryAggregateResult {
 	count: Int
 }
@@ -312,6 +318,11 @@ type LibraryItemAggregateResult {
 
 type UpdateBookPayload {
 	book(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
+	numUids: Int
+}
+
+type UpdateLibraryPayload {
+	library(filter: LibraryFilter, first: Int, offset: Int): [Library]
 	numUids: Int
 }
 
@@ -407,6 +418,10 @@ input LibraryItemRef {
 	refID: String! @id
 }
 
+input LibraryPatch {
+	items: [LibraryItemRef]
+}
+
 input LibraryRef {
 	items: [LibraryItemRef]
 }
@@ -415,6 +430,12 @@ input UpdateBookInput {
 	filter: BookFilter!
 	set: BookPatch
 	remove: BookPatch
+}
+
+input UpdateLibraryInput {
+	filter: LibraryFilter!
+	set: LibraryPatch
+	remove: LibraryPatch
 }
 
 #######################
@@ -428,8 +449,8 @@ type Query {
 	getBook(refID: String!): Book
 	queryBook(filter: BookFilter, order: BookOrder, first: Int, offset: Int): [Book]
 	aggregateBook(filter: BookFilter): BookAggregateResult
-	queryLibrary(first: Int, offset: Int): [Library]
-	aggregateLibrary: LibraryAggregateResult
+	queryLibrary(filter: LibraryFilter, first: Int, offset: Int): [Library]
+	aggregateLibrary(filter: LibraryFilter): LibraryAggregateResult
 }
 
 #######################
@@ -442,5 +463,7 @@ type Mutation {
 	updateBook(input: UpdateBookInput!): UpdateBookPayload
 	deleteBook(filter: BookFilter!): DeleteBookPayload
 	addLibrary(input: [AddLibraryInput!]!): AddLibraryPayload
+	updateLibrary(input: UpdateLibraryInput!): UpdateLibraryPayload
+	deleteLibrary(filter: LibraryFilter!): DeleteLibraryPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -8,13 +8,13 @@ interface Message {
 
 type Question implements Message {
 	text: String
-	askedBy: User
+	askedBy(filter: UserFilter): User
 }
 
 type User {
 	name: String
-	messages(order: MessageOrder, first: Int, offset: Int): [Message]
-	messagesAggregate: MessageAggregateResult
+	messages(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	messagesAggregate(filter: MessageFilter): MessageAggregateResult
 }
 
 #######################
@@ -277,12 +277,30 @@ input StringHashFilter {
 #######################
 
 type AddQuestionPayload {
-	question(order: QuestionOrder, first: Int, offset: Int): [Question]
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
 	numUids: Int
 }
 
 type AddUserPayload {
-	user(order: UserOrder, first: Int, offset: Int): [User]
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
+}
+
+type DeleteMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	msg: String
+	numUids: Int
+}
+
+type DeleteQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+	msg: String
+	numUids: Int
+}
+
+type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	msg: String
 	numUids: Int
 }
 
@@ -292,6 +310,21 @@ type MessageAggregateResult {
 
 type QuestionAggregateResult {
 	count: Int
+}
+
+type UpdateMessagePayload {
+	message(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	numUids: Int
+}
+
+type UpdateQuestionPayload {
+	question(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+	numUids: Int
+}
+
+type UpdateUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
 }
 
 type UserAggregateResult {
@@ -354,6 +387,10 @@ input MessageOrder {
 	then: MessageOrder
 }
 
+input MessagePatch {
+	text: String
+}
+
 input QuestionFilter {
 	has: QuestionHasFilter
 	and: [QuestionFilter]
@@ -367,9 +404,32 @@ input QuestionOrder {
 	then: QuestionOrder
 }
 
+input QuestionPatch {
+	text: String
+	askedBy: UserRef
+}
+
 input QuestionRef {
 	text: String
 	askedBy: UserRef
+}
+
+input UpdateMessageInput {
+	filter: MessageFilter!
+	set: MessagePatch
+	remove: MessagePatch
+}
+
+input UpdateQuestionInput {
+	filter: QuestionFilter!
+	set: QuestionPatch
+	remove: QuestionPatch
+}
+
+input UpdateUserInput {
+	filter: UserFilter!
+	set: UserPatch
+	remove: UserPatch
 }
 
 input UserFilter {
@@ -385,6 +445,10 @@ input UserOrder {
 	then: UserOrder
 }
 
+input UserPatch {
+	name: String
+}
+
 input UserRef {
 	name: String
 }
@@ -394,12 +458,12 @@ input UserRef {
 #######################
 
 type Query {
-	queryMessage(order: MessageOrder, first: Int, offset: Int): [Message]
-	aggregateMessage: MessageAggregateResult
-	queryQuestion(order: QuestionOrder, first: Int, offset: Int): [Question]
-	aggregateQuestion: QuestionAggregateResult
-	queryUser(order: UserOrder, first: Int, offset: Int): [User]
-	aggregateUser: UserAggregateResult
+	queryMessage(filter: MessageFilter, order: MessageOrder, first: Int, offset: Int): [Message]
+	aggregateMessage(filter: MessageFilter): MessageAggregateResult
+	queryQuestion(filter: QuestionFilter, order: QuestionOrder, first: Int, offset: Int): [Question]
+	aggregateQuestion(filter: QuestionFilter): QuestionAggregateResult
+	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	aggregateUser(filter: UserFilter): UserAggregateResult
 }
 
 #######################
@@ -407,7 +471,13 @@ type Query {
 #######################
 
 type Mutation {
+	updateMessage(input: UpdateMessageInput!): UpdateMessagePayload
+	deleteMessage(filter: MessageFilter!): DeleteMessagePayload
 	addQuestion(input: [AddQuestionInput!]!): AddQuestionPayload
+	updateQuestion(input: UpdateQuestionInput!): UpdateQuestionPayload
+	deleteQuestion(filter: QuestionFilter!): DeleteQuestionPayload
 	addUser(input: [AddUserInput!]!): AddUserPayload
+	updateUser(input: UpdateUserInput!): UpdateUserPayload
+	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -5,14 +5,14 @@
 type Post {
 	content: String!
 	author(filter: AuthorFilter): Author!
-	genre: Genre
+	genre(filter: GenreFilter): Genre
 }
 
 type Author {
 	id: ID
 	name: String
-	posts(order: PostOrder, first: Int, offset: Int): [Post]
-	postsAggregate: PostAggregateResult
+	posts(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	postsAggregate(filter: PostFilter): PostAggregateResult
 }
 
 type Genre {
@@ -284,12 +284,12 @@ type AddAuthorPayload {
 }
 
 type AddGenrePayload {
-	genre(order: GenreOrder, first: Int, offset: Int): [Genre]
+	genre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
 	numUids: Int
 }
 
 type AddPostPayload {
-	post(order: PostOrder, first: Int, offset: Int): [Post]
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	numUids: Int
 }
 
@@ -299,6 +299,18 @@ type AuthorAggregateResult {
 
 type DeleteAuthorPayload {
 	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	msg: String
+	numUids: Int
+}
+
+type DeleteGenrePayload {
+	genre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
+	msg: String
+	numUids: Int
+}
+
+type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	msg: String
 	numUids: Int
 }
@@ -313,6 +325,16 @@ type PostAggregateResult {
 
 type UpdateAuthorPayload {
 	author(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
+	numUids: Int
+}
+
+type UpdateGenrePayload {
+	genre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
+	numUids: Int
+}
+
+type UpdatePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
 	numUids: Int
 }
 
@@ -404,6 +426,10 @@ input GenreOrder {
 	then: GenreOrder
 }
 
+input GenrePatch {
+	name: String
+}
+
 input GenreRef {
 	name: String
 }
@@ -421,6 +447,12 @@ input PostOrder {
 	then: PostOrder
 }
 
+input PostPatch {
+	content: String
+	author: AuthorRef
+	genre: GenreRef
+}
+
 input PostRef {
 	content: String
 	author: AuthorRef
@@ -433,18 +465,30 @@ input UpdateAuthorInput {
 	remove: AuthorPatch
 }
 
+input UpdateGenreInput {
+	filter: GenreFilter!
+	set: GenrePatch
+	remove: GenrePatch
+}
+
+input UpdatePostInput {
+	filter: PostFilter!
+	set: PostPatch
+	remove: PostPatch
+}
+
 #######################
 # Generated Query
 #######################
 
 type Query {
-	queryPost(order: PostOrder, first: Int, offset: Int): [Post]
-	aggregatePost: PostAggregateResult
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	aggregatePost(filter: PostFilter): PostAggregateResult
 	getAuthor(id: ID!): Author
 	queryAuthor(filter: AuthorFilter, order: AuthorOrder, first: Int, offset: Int): [Author]
 	aggregateAuthor(filter: AuthorFilter): AuthorAggregateResult
-	queryGenre(order: GenreOrder, first: Int, offset: Int): [Genre]
-	aggregateGenre: GenreAggregateResult
+	queryGenre(filter: GenreFilter, order: GenreOrder, first: Int, offset: Int): [Genre]
+	aggregateGenre(filter: GenreFilter): GenreAggregateResult
 }
 
 #######################
@@ -453,9 +497,13 @@ type Query {
 
 type Mutation {
 	addPost(input: [AddPostInput!]!): AddPostPayload
+	updatePost(input: UpdatePostInput!): UpdatePostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
 	addAuthor(input: [AddAuthorInput!]!): AddAuthorPayload
 	updateAuthor(input: UpdateAuthorInput!): UpdateAuthorPayload
 	deleteAuthor(filter: AuthorFilter!): DeleteAuthorPayload
 	addGenre(input: [AddGenreInput!]!): AddGenrePayload
+	updateGenre(input: UpdateGenreInput!): UpdateGenrePayload
+	deleteGenre(filter: GenreFilter!): DeleteGenrePayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -298,6 +298,12 @@ type DeleteCharacterPayload {
 	numUids: Int
 }
 
+type DeleteEmployeePayload {
+	employee(filter: EmployeeFilter, order: EmployeeOrder, first: Int, offset: Int): [Employee]
+	msg: String
+	numUids: Int
+}
+
 type DeleteHumanPayload {
 	human(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	msg: String
@@ -314,6 +320,11 @@ type HumanAggregateResult {
 
 type UpdateCharacterPayload {
 	character(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
+	numUids: Int
+}
+
+type UpdateEmployeePayload {
+	employee(filter: EmployeeFilter, order: EmployeeOrder, first: Int, offset: Int): [Employee]
 	numUids: Int
 }
 
@@ -409,6 +420,11 @@ input EmployeeOrder {
 	then: EmployeeOrder
 }
 
+input EmployeePatch {
+	employeeId: String
+	title: String
+}
+
 input HumanFilter {
 	id: [ID!]
 	name: StringExactFilter
@@ -447,6 +463,12 @@ input UpdateCharacterInput {
 	remove: CharacterPatch
 }
 
+input UpdateEmployeeInput {
+	filter: EmployeeFilter!
+	set: EmployeePatch
+	remove: EmployeePatch
+}
+
 input UpdateHumanInput {
 	filter: HumanFilter!
 	set: HumanPatch
@@ -461,8 +483,8 @@ type Query {
 	getCharacter(id: ID!): Character
 	queryCharacter(filter: CharacterFilter, order: CharacterOrder, first: Int, offset: Int): [Character]
 	aggregateCharacter(filter: CharacterFilter): CharacterAggregateResult
-	queryEmployee(order: EmployeeOrder, first: Int, offset: Int): [Employee]
-	aggregateEmployee: EmployeeAggregateResult
+	queryEmployee(filter: EmployeeFilter, order: EmployeeOrder, first: Int, offset: Int): [Employee]
+	aggregateEmployee(filter: EmployeeFilter): EmployeeAggregateResult
 	getHuman(id: ID!): Human
 	queryHuman(filter: HumanFilter, order: HumanOrder, first: Int, offset: Int): [Human]
 	aggregateHuman(filter: HumanFilter): HumanAggregateResult
@@ -475,6 +497,8 @@ type Query {
 type Mutation {
 	updateCharacter(input: UpdateCharacterInput!): UpdateCharacterPayload
 	deleteCharacter(filter: CharacterFilter!): DeleteCharacterPayload
+	updateEmployee(input: UpdateEmployeeInput!): UpdateEmployeePayload
+	deleteEmployee(filter: EmployeeFilter!): DeleteEmployeePayload
 	addHuman(input: [AddHumanInput!]!): AddHumanPayload
 	updateHuman(input: UpdateHumanInput!): UpdateHumanPayload
 	deleteHuman(filter: HumanFilter!): DeleteHumanPayload

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -106,6 +106,9 @@ type Starship {
 		"name":      "Character.name",
 		"appearsIn": "Character.appearsIn",
 	}
+	employee := map[string]string{
+		"ename": "Employee.ename",
+	}
 	human := map[string]string{
 		"ename":              "Employee.ename",
 		"name":               "Character.name",
@@ -125,15 +128,13 @@ type Starship {
 	}
 
 	expected := map[string]map[string]string{
-		"Author":              author,
-		"UpdateAuthorPayload": author,
-		"DeleteAuthorPayload": author,
-		"Post":                post,
-		"UpdatePostPayload":   post,
-		"DeletePostPayload":   post,
-		"Employee": map[string]string{
-			"ename": "Employee.ename",
-		},
+		"Author":                   author,
+		"UpdateAuthorPayload":      author,
+		"DeleteAuthorPayload":      author,
+		"Post":                     post,
+		"UpdatePostPayload":        post,
+		"DeletePostPayload":        post,
+		"Employee":                 employee,
 		"Character":                character,
 		"UpdateCharacterPayload":   character,
 		"DeleteCharacterPayload":   character,
@@ -143,8 +144,9 @@ type Starship {
 		"Droid":                    droid,
 		"UpdateDroidPayload":       droid,
 		"DeleteDroidPayload":       droid,
+		"UpdateEmployeePayload":    employee,
+		"DeleteEmployeePayload":    employee,
 		"Starship":                 starship,
-		"UpdateStarshipPayload":    starship,
 		"DeleteStarshipPayload":    starship,
 		"AuthorAggregateResult":    {"count": "AuthorAggregateResult.count"},
 		"CharacterAggregateResult": {"count": "CharacterAggregateResult.count"},
@@ -250,21 +252,24 @@ func TestDgraphMapping_WithDirectives(t *testing.T) {
 		"appearsIn":       "appears_in",
 		"primaryFunction": "roboDroid.primaryFunction",
 	}
+	employee := map[string]string{
+		"ename": "dgraph.employee.en.ename",
+	}
 	starship := map[string]string{
 		"name":   "star.ship.name",
 		"length": "star.ship.length",
 	}
 
 	expected := map[string]map[string]string{
-		"Author":              author,
-		"UpdateAuthorPayload": author,
-		"DeleteAuthorPayload": author,
-		"Post":                post,
-		"UpdatePostPayload":   post,
-		"DeletePostPayload":   post,
-		"Employee": map[string]string{
-			"ename": "dgraph.employee.en.ename",
-		},
+		"Author":                   author,
+		"UpdateAuthorPayload":      author,
+		"DeleteAuthorPayload":      author,
+		"Post":                     post,
+		"UpdatePostPayload":        post,
+		"DeletePostPayload":        post,
+		"Employee":                 employee,
+		"DeleteEmployeePayload":    employee,
+		"UpdateEmployeePayload":    employee,
 		"Character":                character,
 		"UpdateCharacterPayload":   character,
 		"DeleteCharacterPayload":   character,


### PR DESCRIPTION
Fixes GRAPHQL-787.

This PR fixes the Bug in query and mutations generation in case of types that have just `has` filter and not any other kind of filter. For example for the given type: 
```
type Student {
   name: String
   age: Int
}
```
the corresponding query generated was 
```
queryStudent(order: StudentOrder, first: Int, offset: Int): [Student]
```
and only `add` mutation was being generated.
Whereas, the correct query should be: 
```
queryStudent(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
```
and corresponding update and delete mutation should be:
```
updateStudent(input: UpdateStudentInput!): UpdateStudentPayload
deleteStudent(filter: StudentFilter!): DeleteStudentPayload
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6870)
<!-- Reviewable:end -->
