### PR TITLE
Docs (chore) fix link to password types from GraphQL Directives page

### DIFF
--- a/wiki/content/graphql/directives/index.md
+++ b/wiki/content/graphql/directives/index.md
@@ -46,7 +46,7 @@ Reference: [Subscriptions](/graphql/subscriptions)
 
 `@secret` directive is used to store secret information, it gets encrypted and then stored in Dgraph.
 
-Reference: [Password Type](/graphql/schema/#password-type)
+Reference: [Password Type](/graphql/schema/types/#password-type)
 
 ### @auth
 


### PR DESCRIPTION
The Password Type link from https://dgraph.io/docs/master/graphql/directives/#secret isn't useful. It links to https://dgraph.io/docs/master/graphql/schema/#password-type which provides the sub-menu with no docs for the password type.

This PR fixes this issue, pointing readers to the right location in the docs.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6872)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-e9ccf4d62f-107827.surge.sh)
<!-- Dgraph:end -->