### PR TITLE
docs (feature): Add Union type documentation

### DIFF
--- a/wiki/content/graphql/authorization/authorization-overview.md
+++ b/wiki/content/graphql/authorization/authorization-overview.md
@@ -6,7 +6,7 @@ weight = 1
     identifier = "authorization-overview"
 +++
 
-Dgraph GraphQL comes with inbuilt authorization.  It allows you to annotate your schema with rules that determine who can access or mutate what data.
+Dgraph GraphQL comes with built-in authorization.  It allows you to annotate your schema with rules that determine who can access or mutate what data.
 
 Firstly, let's get some concepts defined.  There are two important concepts in what's often called 'auth'.
 
@@ -37,15 +37,21 @@ type B @auth(...) {
 
 Valid examples look like
 
-`# Dgraph.Authorization {"VerificationKey":"verificationkey","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"HS256","Audience":["aud1","aud5"]}`
+```
+# Dgraph.Authorization {"VerificationKey":"verificationkey","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"HS256","Audience":["aud1","aud5"]}
+```
 
 Without audience field
 
-`# Dgraph.Authorization {"VerificationKey":"secretkey","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"HS256"}`
+```
+# Dgraph.Authorization {"VerificationKey":"secretkey","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"HS256"}
+```
 
 for HMAC-SHA256 JWT with symmetric cryptography (the signing key and verification key are the same), and like
 
-`# Dgraph.Authorization {"VerificationKey":"-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"RS256"}`
+```
+# Dgraph.Authorization {"VerificationKey":"-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----","Header":"X-My-App-Auth","Namespace":"https://my.app.io/jwt/claims","Algo":"RS256"}
+```
 
 for RSA Signature with SHA-256 asymmetric cryptography (the JWT is signed with the private key and Dgraph checks with the public key).
 

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -5,7 +5,11 @@ weight = 2
     parent = "authorization"
 +++
 
-Given an authentication mechanism and signed JWT, it's the `@auth` directive that tells Dgraph how to apply authorization.  The directive can be used on any type (that isn't a `@remote` type) and specifies the authorization for `query` as well as `add`, `update` and `delete` mutations.
+Given an authentication mechanism and signed JWT, it's the `@auth` directive that tells Dgraph how to apply authorization.  The directive can be used on any type except `union` (that isn't a `@remote` type) and specifies the authorization for `query` as well as the `add`, `update` and `delete` mutations.
+
+{{% notice "note" %}}
+The [Union type](/graphql/schema/types#union-type) does not support the `@auth` directive 
+{{% /notice %}}
 
 In each case, `@auth` specifies rules that Dgraph applies during queries and mutations.  Those rules are expressed in exactly the same syntax as GraphQL queries.  Why?  Because the authorization you add to your app is about the graph of your application, so graph rules make sense.  It's also the syntax you already know about, you get syntax help from GraphQL tools in writing such rules, and it turns out to be exactly the kinds of rules Dgraph already knows how to evaluate.
 
@@ -31,7 +35,7 @@ type Todo @auth(
 }
 ```
 
-In addition to it, details of the authentication provider should be given in the last line of the schema, as discussed in section  [authorization-overview](/graphql/authorization/authorization-overview).
+In addition to it, details of the authentication provider should be given in the last line of the schema, as discussed in the [Authorization overview](/graphql/authorization/authorization-overview) section.
 
 Here we define a type `Todo`, that's got an `id`, the `text` of the todo and the username of the `owner` of the todo.  What todos can a user query?  Any `Todo` that the `query` rule would also return.
 

--- a/wiki/content/graphql/mutations/mutations-overview.md
+++ b/wiki/content/graphql/mutations/mutations-overview.md
@@ -151,6 +151,33 @@ Mutations can be used to add a node to a `union` field in a type.
 For the following schema, 
 
 ```graphql
+enum Category {
+  Fish
+  Amphibian
+  Reptile
+  Bird
+  Mammal
+  InVertebrate
+}
+
+interface Animal {
+  id: ID!
+  category: Category @search
+}
+
+type Dog implements Animal {
+  breed: String @search
+}
+
+type Parrot implements Animal {
+  repeatsWords: [String]
+}
+
+type Human {
+  name: String!
+  pets: [Animal!]!
+}
+
 union HomeMember = Dog | Parrot | Human
 
 type Home {
@@ -179,6 +206,12 @@ mutation {
       members {
         ... on Dog {
           breed
+        }
+        ... on Parrot {
+          repeatsWords
+        }
+        ... on Human {
+          name
         }
       }
     }

--- a/wiki/content/graphql/mutations/mutations-overview.md
+++ b/wiki/content/graphql/mutations/mutations-overview.md
@@ -124,7 +124,9 @@ mutation ($post: AddPostInput!, $author: AddAuthorInput!) {
   }
 }
 ```
+
 Variables:
+
 ```json
 {
   "author": {
@@ -138,6 +140,48 @@ Variables:
 	"author": {
 	  "name": "A.N. Author"
 	}
+  }
+}
+```
+
+## Union mutations
+
+Mutations can be used to add a node to a `union` field in a type. 
+
+For the following schema, 
+
+```graphql
+union HomeMember = Dog | Parrot | Human
+
+type Home {
+  id: ID!
+  address: String
+  members: [HomeMember]
+}
+```
+
+This is the mutation for adding `members` to the `Home` type:
+
+```graphql
+mutation {
+  addHome(input: [
+        {
+          "address": "United Street",
+          "members": [
+            { "dogRef": { "category": Mammal, "breed": "German Shephard"} },
+            { "parrotRef": { "category": Bird, "repeatsWords": ["squawk"]} },
+            { "humanRef": { "name": "Han Solo"} }
+          ]
+        }
+      ]) {
+    home {
+      address
+      members {
+        ... on Dog {
+          breed
+        }
+      }
+    }
   }
 }
 ```

--- a/wiki/content/graphql/schema/search.md
+++ b/wiki/content/graphql/schema/search.md
@@ -486,3 +486,102 @@ Only one `polygon` or `multiPolygon` can be given inside the `IntersectsFilter` 
     name
   }
 ```
+
+### Union
+
+Unions can be queried only as a field of a type. Union queries can't be ordered, but you can filter and paginate them.
+
+{{% notice "note" %}}
+Union queries do not support the `order` argument.
+The results will be ordered by the `uid` of each node in ascending order.
+{{% /notice %}}
+
+For example, the following schema will enable to query the `members` union field in the `Home` type with filters and pagination.
+
+```graphql
+union HomeMember = Dog | Parrot | Human
+
+type Home {
+  id: ID!
+  address: String
+  
+  members(filter: HomeMemberFilter, first: Int, offset: Int): [HomeMember]
+}
+
+# Not specifying a field in the filter input will be considered as a null value for that field.
+input HomeMemberFilter {
+	# `homeMemberTypes` is used to specify which types to report back.
+	homeMemberTypes: [HomeMemberType]
+
+	# specifying a null value for this field means query all dogs
+	dogFilter: DogFilter
+
+	# specifying a null value for this field means query all parrots
+	parrotFilter: ParrotFilter
+	# note that there is no HumanFilter because the Human type wasn't filterable
+}
+
+enum HomeMemberType {
+	dog
+	parrot
+	human
+}
+
+input DogFilter {
+	id: [ID!]
+	category: Category_hash
+	breed: StringTermFilter
+	and: DogFilter
+	or: DogFilter
+	not: DogFilter
+}
+
+input ParrotFilter {
+	id: [ID!]
+	category: Category_hash
+	and: ParrotFilter
+	or: ParrotFilter
+	not: ParrotFilter
+}
+```
+
+{{% notice "tip" %}}
+Not specifying any filter at all or specifying any of the `null` values for a filter will query all members.
+{{% /notice %}}
+
+
+
+The same example, but this time with filter and pagination arguments:
+
+```graphql
+query {
+  queryHome {
+    address
+    members (
+      filter: {
+		homeMemberTypes: [dog, parrot] # means we don't want to query humans
+		dogFilter: {
+			# means in Dogs, we only want to query "German Shepherd" breed
+			breed: { allofterms: "German Shepherd"}
+		}
+		# not specifying any filter for parrots means we want to query all parrots
+      }
+      first: 5
+      offset: 10
+    ) {
+      ... on Animal {
+        category
+      }
+      ... on Dog {
+        breed
+      }
+      ... on Parrot {
+        repeatsWords
+      }
+      ... on HomeMember {
+        name
+      }
+    }
+  }
+}
+```

--- a/wiki/content/graphql/schema/types.md
+++ b/wiki/content/graphql/schema/types.md
@@ -149,6 +149,12 @@ type Comment implements Post {
 
 GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types. So no fields may be queried on this type without the use of type refining fragments or inline fragments.
 
+Union types have the potential to be invalid if incorrectly defined:
+
+- A `Union` type must include one or more unique member types.
+- The member types of a `Union` type must all be Object base types; [Scalar](#scalars), [Interface](#interfaces) and `Union` types must not be member types of a Union. Similarly, wrapping types must not be member types of a Union.
+
+
 For example, the following defines the `HomeMember` union type:
 
 ```graphql

--- a/wiki/content/graphql/schema/types.md
+++ b/wiki/content/graphql/schema/types.md
@@ -145,6 +145,106 @@ type Comment implements Post {
 }
 ```
 
+### Union type
+
+GraphQL Unions represent an object that could be one of a list of GraphQL Object types, but provides for no guaranteed fields between those types. So no fields may be queried on this type without the use of type refining fragments or inline fragments.
+
+For example, the following defines the `HomeMember` union type:
+
+```graphql
+enum Category {
+  Fish
+  Amphibian
+  Reptile
+  Bird
+  Mammal
+  InVertebrate
+}
+
+interface Animal {
+  id: ID!
+  category: Category @search
+}
+
+type Dog implements Animal {
+  breed: String @search
+}
+
+type Parrot implements Animal {
+  repeatsWords: [String]
+}
+
+type Cheetah implements Animal {
+  speed: Float
+}
+
+type Human {
+  name: String!
+  pets: [Animal!]!
+}
+
+union HomeMember = Dog | Parrot | Human
+
+type Zoo {
+  id: ID!
+  animals: [Animal]
+  city: String
+}
+
+type Home {
+  id: ID!
+  address: String
+  members: [HomeMember]
+}
+```
+
+So, when you want to query members in a `Home`, you will be able to do a GraphQL query like this:
+
+```graphql
+query {
+  queryHome {
+    address
+    members {
+      ... on Animal {
+        category
+      }
+      ... on Dog {
+        breed
+      }
+      ... on Parrot {
+        repeatsWords
+      }
+      ... on Human {
+        name
+      }
+    }
+  }
+}
+```
+
+And the results of the GraphQL query will look like the following:
+
+```json
+{
+  "data": {
+    "queryHome": {
+      "address": "Earth",
+      "members": [
+        {
+          "category": "Mammal",
+          "breed": "German Shepherd"
+        }, {
+          "category": "Bird",
+          "repeatsWords": ["Good Morning!", "I am a GraphQL parrot"]
+        }, {
+          "name": "Alice"
+        }
+      ]
+    }
+  }
+}
+```
+
 ### Password type
 
 A password for an entity is set with setting the schema for the node type with `@secret` directive. Passwords cannot be queried directly, only checked for a match using the `checkTypePassword` function where `Type` is the node type.


### PR DESCRIPTION
This PR adds documentation for the GraphQL Union type feature (20.11)

Fixes GRAPHQL-725

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6873)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-5ce384719c-107833.surge.sh)
<!-- Dgraph:end -->