### PR TITLE
feat: Liveloader can use Alpha for assigning uids

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -383,6 +383,8 @@ func serveGRPC(l net.Listener, tlsCfg *tls.Config, closer *z.Closer) {
 	s := grpc.NewServer(opt...)
 	api.RegisterDgraphServer(s, &edgraph.Server{})
 	hapi.RegisterHealthServer(s, health.NewServer())
+	worker.RegisterZeroProxyServer(s)
+
 	err := s.Serve(l)
 	glog.Errorf("GRPC listener canceled: %v\n", err)
 	s.Stop()

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -122,6 +122,20 @@ func TestLiveLoadJSONFile(t *testing.T) {
 	checkLoadedData(t)
 }
 
+func TestLiveLoadCanUseAlphaForAssigningUids(t *testing.T) {
+	testutil.DropAll(t, dg)
+
+	pipeline := [][]string{
+		{testutil.DgraphBinaryPath(), "live",
+			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
+			"--alpha", alphaService, "--zero", alphaService, "-u", "groot", "-p", "password"},
+	}
+	_, err := testutil.Pipeline(pipeline)
+	require.NoError(t, err, "live loading JSON file exited with error")
+
+	checkLoadedData(t)
+}
+
 func TestLiveLoadJSONCompressedStream(t *testing.T) {
 	testutil.DropAll(t, dg)
 

--- a/worker/zero_proxy.go
+++ b/worker/zero_proxy.go
@@ -1,0 +1,38 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/dgraph-io/dgraph/conn"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"google.golang.org/grpc"
+)
+
+func forwardAssignUidsToZero(ctx context.Context, in *pb.Num) (*pb.AssignedIds, error) {
+	pl := groups().Leader(0)
+	if pl == nil {
+		return nil, conn.ErrNoConnection
+	}
+	zc := pb.NewZeroClient(pl.Get())
+	return zc.AssignUids(ctx, in)
+}
+
+// RegisterZeroProxyServer forwards select GRPC calls over to Zero
+func RegisterZeroProxyServer(s *grpc.Server) {
+	s.RegisterService(&grpc.ServiceDesc{
+		ServiceName: "pb.Zero",
+		HandlerType: (*interface{})(nil), // Don't really need complex type checking here
+		Methods: []grpc.MethodDesc{
+			{
+				MethodName: "AssignUids",
+				Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, _ grpc.UnaryServerInterceptor) (interface{}, error) {
+					in := new(pb.Num)
+					if err := dec(in); err != nil {
+						return nil, err
+					}
+					return forwardAssignUidsToZero(ctx, in)
+				},
+			},
+		},
+	}, &struct{}{})
+}


### PR DESCRIPTION
Alpha now forwards /pb.Zero/AssignUids to the zero leader. This allows
live loader to only talk to alpha (with alpha internally dispatching
this API call to zero).

This is useful to Slash GraphQL as we no longer need to look at
FullMethodName in order to forward GRPC requests to alpha or zero

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6878)
<!-- Reviewable:end -->
