### PR TITLE
docs (Update): Documentation for Parameterized cascade

### DIFF
--- a/wiki/content/graphql/queries/cascade.md
+++ b/wiki/content/graphql/queries/cascade.md
@@ -6,15 +6,14 @@ weight = 5
     name = "Cascade"
 +++
 
-`@cascade` is available as a directive that can be applied to fields. With the @cascade
+The `@cascade` directive can be applied to fields. With the `@cascade`
 directive, nodes that don’t have all fields specified in the query are removed.
 This can be useful in cases where some filter was applied and some nodes might not
 have all the listed fields.
 
-For example, the query below only return the authors which have both reputation
-and posts, where posts have text. Note that `@cascade` trickles down so it would
-automatically be applied at the `posts` level as well if it's applied at the `queryAuthor`
-level.
+For example, the query below only returns the authors which have both `reputation`
+and `posts`, where posts have `text`. Note that `@cascade` trickles down so if it's applied at the `queryAuthor`
+level, it will automatically be applied at the `posts` level too.
 
 ```graphql
 {
@@ -26,6 +25,8 @@ level.
     }
 }
 ```
+
+### Nested `@cascade`
 
 `@cascade` can also be used at nested levels, so the query below would return all authors
 but only those posts which have both `text` and `id`.
@@ -42,12 +43,13 @@ but only those posts which have both `text` and `id`.
 }
 ```
 
-### Parameterized Cascade
+### Parameterized `@cascade`
 
-@cascade can also optionally take a list of fields as an argument. This changes the default behaviour to consider only the supplied fields as mandatory instead of all the fields for a type.
+The `@cascade` directive can optionally take a list of fields as an argument. This changes the default behaviour, considering only the supplied fields as mandatory instead of all the fields for a type.
+Listed fields are automatically cascaded as a required argument to nested selection sets.
 
-In the example below, name is supplied in the fields argument. Listed fields are also automatically cascaded as a required argument to nested selection sets. 
-For example, name is supplied in the fields argument below, so for an author to be in the query response it must have a name and if it has a subfield country, then that must also have name.
+In the example below, `name` is supplied in the `fields` argument. For an author to be in the query response, it must have a `name`, and if it has a `country` subfield, then that subfield must also have `name`.
+
 ```graphql
 {
     queryAuthor  @cascade(fields:["name"]) {
@@ -60,7 +62,9 @@ For example, name is supplied in the fields argument below, so for an author to 
     }
 }
 ```
-The query below only return those posts which have a non-null text field.
+
+The query below only return those `posts` which have a non-null `text` field.
+
 ```graphql
 {
         queryAuthor {
@@ -73,8 +77,12 @@ The query below only return those posts which have a non-null text field.
 	}
 }
 ```
-The cascading nature of field selection is overwritten by a nested @casecade. 
-For example, the query below ensures that an author has fields reputation and name, and, if it has subfield posts, then that must have field text.
+
+#### Nesting
+
+The cascading nature of field selection is overwritten by a nested `@casecade`.
+
+For example, the query below ensures that an author has the `reputation` and `name` fields, and, if it has a `posts` subfield, then that subfield must have a `text` field.
 
 ```graphql
 {


### PR DESCRIPTION
Fixes GRAPHQL-781

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6888)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-952022ad1b-108662.surge.sh)
<!-- Dgraph:end -->