### PR TITLE
docs (20.11): add documentation for Cached Results

### DIFF
--- a/wiki/content/graphql/queries/cached-results.md
+++ b/wiki/content/graphql/queries/cached-results.md
@@ -1,0 +1,42 @@
++++
+title = "Cached Results"
+weight = 4
+[menu.main]
+    parent = "graphql-queries"
++++
+
+Cached results can be used to serve read-heavy workloads with complex queries to improve performance. When cached results are enabled for a query, the stored results are served if queried within the defined time-to-live (TTL) of the cached query.
+
+When using cached results, Dgraph will add the appropriate HTTP headers so the caching can be done at the browser or content delivery network (CDN) level.
+
+
+{{% notice "note" %}}
+Caching refers to external caching at the browser/CDN level. Internal caching at the database layer is not currently supported.
+{{% /notice %}}
+
+### Enabling cached results
+
+To enable the external result cache you need to add the `@cacheControl(maxAge: int)` directive at the top of your query. This directive adds the appropriate `Cache-Control` HTTP headers to the response, so that browsers and CDNs can cache the results.
+
+For example, the following query defines a cache with TTL of 15 seconds.
+
+```graphql
+query @cacheControl(maxAge: 15){
+  queryReview(filter: { comment: {alloftext: "Fantastic"}}) {
+    comment
+    by {
+      username
+    }
+    about {
+      name
+    }
+  }
+}
+```
+
+Dgraph's returned HTTP headers:
+
+```
+Cache-Control: public,max-age=15
+Vary: Accept-Encoding
+```


### PR DESCRIPTION
This PR adds the "Cached results" feature documentation  (https://github.com/dgraph-io/dgraph/pull/6799)

Fixes GRAPHQL-703

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6890)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-b006a1d3d4-108762.surge.sh)
<!-- Dgraph:end -->