### PR TITLE
docs (fix): Fix Geolocation feature example 

### DIFF
--- a/wiki/content/graphql/schema/search.md
+++ b/wiki/content/graphql/schema/search.md
@@ -387,14 +387,35 @@ The `contains` filter matches all entities where the `Polygon` or `MultiPolygon`
 Only one `point` or `polygon` can be taken inside the `ContainsFilter` at a time.
 {{% /notice %}}
 
+A `cointains` example using `point`:
+
 ```graphql
 queryHotel(filter: {
     area: { 
         contains: {
             point: {
+              latitude: 0.5,
+              longitude: 2.5
+            }
+        }
+    }
+}) {
+  name
+}
+```
+
+A `cointains` example using `polygon`:
+
+```graphql
+ queryHotel(filter: {
+    area: { 
+        contains: {
+            polygon: {
                 coordinates: [{
-                    latitute: 37.771935, 
+                  points:[{
+                    latitude: 37.771935, 
                     longitude: -122.469829
+                  }]
                 }],
             }
         }
@@ -402,7 +423,6 @@ queryHotel(filter: {
 }) {
   name
 }
-
 ```
 
 #### intersects 


### PR DESCRIPTION
Fix an error in the Geolocation`contains` example

Fixes GRAPHQL-837

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6892)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-c26b70254b-108886.surge.sh)
<!-- Dgraph:end -->