### PR TITLE
docs (feature): add documentation for auth on interfaces

### DIFF
--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -138,10 +138,38 @@ type Answer implements Post @auth(
 
 If the `Question` type implemented more interfaces, then the rules for those would also be added in an `AND` condition to the `Question` type's authorization rules.
 
+An example query to get every posted `Question`:
+
+```graphql
+query {
+	queryQuestion {
+		id
+		text
+		author {
+			id
+			name
+		}
+		answered
+	}
+}
+```
+
 ### Interfaces
 
 When it comes to applying `@auth` rules on interfaces themselves, Dgraph will do a `union` query where it queries all the implementing types, and apply the authorization rules on them. 
 The final query will be an `OR` query joining the results from all the implementing types.
+
+For example:
+
+```graphql
+query {
+  queryPost {
+    id
+    text
+    datePublished
+  }
+}
+```
 
 ### Mutations
 

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -138,22 +138,6 @@ type Answer implements Post @auth(
 
 If the `Question` type implemented more interfaces, then the rules for those would also be added in an `AND` condition to the `Question` type's authorization rules.
 
-An example query to get every posted `Question`:
-
-```graphql
-query {
-	queryQuestion {
-		id
-		text
-		author {
-			id
-			name
-		}
-		answered
-	}
-}
-```
-
 ### Interfaces
 
 When it comes to applying `@auth` rules on interfaces themselves, Dgraph will do a `union` query where it queries all the implementing types, and apply the authorization rules on them. 

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -143,18 +143,6 @@ If the `Question` type implemented more interfaces, then the rules for those wou
 When it comes to applying `@auth` rules on interfaces themselves, Dgraph will do a `union` query where it queries all the implementing types, and apply the authorization rules on them. 
 The final query will be an `OR` query joining the results from all the implementing types.
 
-For example:
-
-```graphql
-query {
-  queryPost {
-    id
-    text
-    datePublished
-  }
-}
-```
-
 ### Mutations
 
 Mutations on an interface works in the same manner. For example, in case of a `delete` mutation on an interface, it will be broken down into the implementing type's `delete` mutation. The nodes that satisfy the `@auth` rules of the corresponding implementing types and the interface will get deleted.

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -73,6 +73,66 @@ This means your frontend doesn't need to be sensitive to the auth rules.  Your a
 
 In general, an auth rule should select a field that's expected to exist at the inner most field, often that's the `ID` or `@id` field.  Auth rules are run in a mode that requires all fields in the rule to find a value in order to succeed.  
 
+## `@auth` on Interfaces
+
+The `@auth` directive works just like it works for types which are to provide authorization to perform `query`, `update`, and `delete` on interfaces. 
+The rules provided inside the `@auth` directive on an interface will also be applied as an `AND` rule to those on the implementing types.
+
+{{% notice "tip" %}}
+A type inherits the `@auth` rules of all the implemented interfaces. The final authorization rule is an `AND` of the type's `@auth` rule and of all the implemented interfaces.
+{{% /notice %}}
+
+In the following example, the `Question` and `Answer` types will automatically inherit the auth rules of the `Post` type. 
+This means that a user can only query a subset of questions and answers that are accessible through the `queryPost` query. 
+Dgraph will disallow situations where a user can query more posts through `queryAnswer` or `queryQuestion` than they can through `queryPost`.
+
+```graphql
+type Author {
+  id: ID!
+  name: String! @search(by: [hash])
+  posts: [Post] @hasInverse(field: author)
+}
+
+interface Post @auth(
+    query: { rule: """
+        query ($USER: String!) { 
+            queryPost(filter: { author : { id: { eq: $USER } } } ) { 
+                id 
+            } 
+        }"""
+    }
+){
+  id: ID!
+  text: String @search(by: [fulltext])
+  datePublished: DateTime @search
+  author: Author! 
+}
+
+type Question implements Post @auth(
+    query: { rule: """
+        query ($ANSWERED: Boolean!) { 
+            queryQuestion(filter: { answered: $ANSWERED } ) { 
+                id 
+            } 
+        }"""
+    }
+){
+  answered: Boolean
+}
+
+type Answer implements Post @auth(
+    query: { rule: """
+        query ($USEFUL:Boolean!) { 
+            queryAnswer(filter: { markedUseful: $USEFUL } ) { 
+                id 
+            } 
+        }"""
+    }
+){
+  markedUseful: Boolean
+}
+```
+
 ## Graph traversal in auth rules
 
 Often authorization depends not on the object being queried, but on the connections in the graph that object has or doesn't have.  Because the auth rules are graph queries, they can express very powerful graph search and traversal.

--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -75,7 +75,10 @@ In general, an auth rule should select a field that's expected to exist at the i
 
 ## `@auth` on Interfaces
 
-The `@auth` directive works just like it works for types which are to provide authorization to perform `query`, `update`, and `delete` on interfaces. 
+The `@auth` directive works just like it works for types which are to provide authorization to perform `query`, `update`, and `delete` on interfaces.
+
+### Implementing types
+
 The rules provided inside the `@auth` directive on an interface will also be applied as an `AND` rule to those on the implementing types.
 
 {{% notice "tip" %}}
@@ -132,6 +135,17 @@ type Answer implements Post @auth(
   markedUseful: Boolean
 }
 ```
+
+If the `Question` type implemented more interfaces, then the rules for those would also be added in an `AND` condition to the `Question` type's authorization rules.
+
+### Interfaces
+
+When it comes to applying `@auth` rules on interfaces themselves, Dgraph will do a `union` query where it queries all the implementing types, and apply the authorization rules on them. 
+The final query will be an `OR` query joining the results from all the implementing types.
+
+### Mutations
+
+Mutations on an interface works in the same manner. For example, in case of a `delete` mutation on an interface, it will be broken down into the implementing type's `delete` mutation. The nodes that satisfy the `@auth` rules of the corresponding implementing types and the interface will get deleted.
 
 ## Graph traversal in auth rules
 


### PR DESCRIPTION
This PR adds the documentation for `@auth` on interfaces

Fixes GRAPHQL-750

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6894)
<!-- Reviewable:end -->
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-1358cfe3bc-109507.surge.sh)
<!-- Dgraph:end -->