### PR TITLE
Docs (GraphQL): Document the `in` and `has` keywords for 20.11

### DIFF
--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -223,13 +223,13 @@ You can filter queries to find nodes with one or more specified values using the
 applied.
 
 For example, let's say that your schema defines a `State` type that has the
-`@id` directive applied to the `postal-code` field:
+`@id` directive applied to the `code` field:
 
 ```graphql
 type State {
-        postal-code: String! @id
+        code: String! @id
         name: String!
-	      capital: String
+        capital: String
 }
 ```
 
@@ -238,25 +238,25 @@ code **WA** or **VA** using the following query:
 
 ```graphql
 query {
-      queryState(filter: {postal-code: {in : ["WA", "VA"]}}){
+      queryState(filter: {code: {in : ["WA", "VA"]}}){
         code
         name
       }
     }
 ```
 
-## Filter a query for nodes with specified fields with `has`
+## Filter a query for nodes with specified fields using `has`
 
 You can filter queries to find nodes with a specified field using the `has`
 keyword. The `has` keyword can only check for the presence of a specified field,
-not for specified field values.
+not for specific field values.
 
 For example, your schema might define a `Teacher` type that has basic
 information about each teacher; such as their ID number, name, and age:
 
 ```graphql
 type Teacher {
-  teacher-id: ID!
+  tid: ID!
   age: Int!
   name: String
 }
@@ -265,12 +265,12 @@ type Teacher {
 Specific `Teacher` nodes might have additional fields noting their specific area
 of expertise; for example, a boolean field noting if they have experience with
 teaching mathematics. To query for only those teachers that have a `mathematics`
-field applied, you could use the following query:
+field, you could use the following query:
 
 ```graphql
 query {
   queryTeacher(filter: { has : mathematics } ) {
-    teacher-id
+    tid
     age
     name
   }

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -145,7 +145,8 @@ query {
 
 You can also filter nested objects while querying for a list of objects.
 
-For example, the following query fetches all of the authors whose name contains `Lee` and with their `completed` posts that have a score greater than `10`:
+For example, the following query fetches all of the authors whose name contains
+`Lee` and with their `completed` posts that have a score greater than `10`:
 
 ```graphql
 query {
@@ -173,7 +174,7 @@ query {
 
 ### Filter a query for a range of objects with `between`
 
-You can also filter query results within an inclusive range of indexed and typed
+You can filter query results within an inclusive range of indexed and typed
 scalar values using the `between` keyword.
 
 {{% notice "tip" %}}This keyword is also supported for DQL; to learn more, see
@@ -215,7 +216,63 @@ queryStudent(fitler: {name: between: {min: "ba", max: "hz"}}){
 }
 ```
 
+## Filter queries that match specified values with `in`
+
+You can filter queries to find nodes with one or more specified values using the
+`in` keyword. This keyword can find matches for fields with the `@id` directive
+applied.
+
+For example, let's say that your schema defines a `State` type that has the
+`@id` directive applied to the `postal-code` field:
+
+```graphql
+type State {
+        postal-code: String! @id
+        name: String!
+	      capital: String
+}
+```
+
+Using the `in` keyword, you can query for a list of states that have the postal
+code **WA** or **VA** using the following query:
+
+```graphql
+query {
+      queryState(filter: {postal-code: {in : ["WA", "VA"]}}){
+        code
+        name
+      }
+    }
+```
+
 ## Filter a query with `has`
 
+You can filter queries to find nodes with a specified field using the `has`
+keyword. The `has` keyword can only check for the presence of a specified field,
+not for specified field values.
 
-## Filter a query with `in`
+For example, your schema might define a `Teacher` type that has basic
+information about each teacher; such as their ID number, name, and age:
+
+```graphql
+type Teacher {
+  teacher-id: ID!
+  age: Int!
+  name: String
+}
+```
+
+Specific `Teacher` nodes might have additional fields noting their specific area
+of expertise; for example, a boolean field noting if they have experience with
+teaching mathematics. To query for only those teachers that have a `mathematics`
+field applied, you could use the following query:
+
+```graphql
+query {
+  queryTeacher(filter: { has : mathematics } ) {
+    teacher-id
+    age
+    name
+  }
+}
+```

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -214,3 +214,8 @@ queryStudent(fitler: {name: between: {min: "ba", max: "hz"}}){
     name
 }
 ```
+
+## Filter a query with `has`
+
+
+## Filter a query with `in`

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -222,7 +222,7 @@ queryStudent(fitler: {name: between: {min: "ba", max: "hz"}}){
 You can filter query results to find objects with one or more specified values using the
 `in` keyword. This keyword can find matches for fields with the `@id` directive
 applied. This filter is also supported on `string` and `enum` types with a
-[`Hash` or `Exact` index](https://dgraph.io/docs/master/graphql/schema/search/#string-exact-and-hash-search).
+[`Hash` or `Exact` index](/graphql/schema/search/#string-exact-and-hash-search).
 
 For example, let's say that your schema defines a `State` type that has the
 `@id` directive applied to the `code` field:

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -23,7 +23,8 @@ query {
 }
 ```
 
-Fetching nested linked objects, while using `get` queries is also easy. For example, this is how you would fetch the authors for a post and their friends.
+Fetching nested linked objects, while using `get` queries is also easy. For
+example, this is how you would fetch the authors for a post and their friends.
 
 ```graphql
 query {
@@ -45,7 +46,7 @@ query {
 While fetching nested linked objects, you can also apply a filter on them.
 
 For example, the following query fetches the author with the `id` 0x1 and their
- posts about `GraphQL`.
+posts about `GraphQL`.
 
 ```graphql
 query {
@@ -216,11 +217,12 @@ queryStudent(fitler: {name: between: {min: "ba", max: "hz"}}){
 }
 ```
 
-## Filter queries that match specified values with `in`
+## Filter to match specified field values with `in`
 
-You can filter queries to find nodes with one or more specified values using the
+You can filter query results to find objects with one or more specified values using the
 `in` keyword. This keyword can find matches for fields with the `@id` directive
-applied.
+applied. This filter is also supported on `string` and `enum` types with a
+[`Hash` or `Exact` index](https://dgraph.io/docs/master/graphql/schema/search/#string-exact-and-hash-search).
 
 For example, let's say that your schema defines a `State` type that has the
 `@id` directive applied to the `code` field:
@@ -245,34 +247,29 @@ query {
     }
 ```
 
-## Filter a query for nodes with specified fields using `has`
+## Filter for objects with specified non-null fields using `has`
 
-You can filter queries to find nodes with a specified field using the `has`
-keyword. The `has` keyword can only check for the presence of a specified field,
-not for specific field values.
+You can filter queries to find objects with a non-null value in a specified
+field using the `has` keyword. The `has` keyword can only check whether a field
+returns a non-null value, not for specific field values.
 
-For example, your schema might define a `Teacher` type that has basic
-information about each teacher; such as their ID number, name, and age:
+For example, your schema might define a `Student` type that has basic
+information about each student; such as their ID number, age, and name:
 
 ```graphql
-type Teacher {
-  tid: ID!
-  age: Int!
-  name: String
+type Student {
+   tid: ID!
+   age: Int!
+   name: String
 }
 ```
 
-Specific `Teacher` nodes might have additional fields noting their specific area
-of expertise; for example, a boolean field noting if they have experience with
-teaching mathematics. To query for only those teachers that have a `mathematics`
-field, you could use the following query:
+To find those students who have a non-null `name`, run the following query:
 
 ```graphql
-query {
-  queryTeacher(filter: { has : mathematics } ) {
-    tid
-    age
-    name
-  }
+queryStudent(filter: { has : name } ){
+   tid
+   age
+   name
 }
 ```

--- a/wiki/content/graphql/queries/search-filtering.md
+++ b/wiki/content/graphql/queries/search-filtering.md
@@ -245,7 +245,7 @@ query {
     }
 ```
 
-## Filter a query with `has`
+## Filter a query for nodes with specified fields with `has`
 
 You can filter queries to find nodes with a specified field using the `has`
 keyword. The `has` keyword can only check for the presence of a specified field,


### PR DESCRIPTION
Updating 20.11 documentation to cover the availability of these keywords

Fixes GRAPHQL-778
Fixes GRAPHQL-674

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6898)
<!-- Reviewable:end -->
 
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-f3edd4d1a5-109174.surge.sh)
<!-- Dgraph:end -->