### PR TITLE
bug(GraphQL): fix IN filter for `enum` types. (#6865)

### DIFF
--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1,5 +1,5 @@
 -
-  name: "in filter"
+  name: "in filter on string type"
   gqlquery: |
     query {
       queryState(filter: {code: {in: ["abc", "def", "ghi"]}}) {
@@ -16,6 +16,23 @@
       }
     }
 
+-
+  name: "in filter on enum type"
+  gqlquery: |
+    query{
+      queryVerification(filter: {status: {in: [ACTIVE, DEACTIVATED]}}){
+        name
+        status
+      }
+    }
+  dgquery: |-
+    query {
+      queryVerification(func: type(Verification)) @filter(eq(Verification.status, "ACTIVE", "DEACTIVATED")) {
+        name : Verification.name
+        status : Verification.status
+        dgraph.uid : uid
+      }
+    }
 -
   name: "Point query near filter"
   gqlquery: |

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -86,6 +86,18 @@ type Human implements Character & Employee {
         female: Boolean
 }
 
+# just for testing IN filter on enum types
+
+type Verification {
+  name: String @search(by: [exact])
+  status: Status @search
+}
+
+enum Status {
+  ACTIVE
+  DEACTIVATED
+}
+
 # just for testing singluar (non-list) edges in both directions
 
 type House {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1225,9 +1225,16 @@ func getFilterTypes(schema *ast.Schema, fld *ast.FieldDefinition, filterName str
 			var l ast.FieldList
 
 			for _, i := range schema.Types[stringFilterName].Fields {
+				typ := fld.Type
+
+				// In case of IN filter we need to construct List of enums as Input Type.
+				if i.Type.Elem != nil && fld.Type.Elem == nil {
+					typ = &ast.Type{Elem: &ast.Type{NamedType: fld.Type.NamedType, NonNull: fld.Type.NonNull}}
+				}
+
 				l = append(l, &ast.FieldDefinition{
 					Name:         i.Name,
-					Type:         fld.Type,
+					Type:         typ,
 					Description:  i.Description,
 					DefaultValue: i.DefaultValue,
 				})

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -480,7 +480,7 @@ input PostRef {
 
 input PostType_exact {
 	eq: PostType
-	in: PostType
+	in: [PostType]
 	le: PostType
 	lt: PostType
 	ge: PostType
@@ -490,7 +490,7 @@ input PostType_exact {
 
 input PostType_exact_StringRegExpFilter {
 	eq: PostType
-	in: PostType
+	in: [PostType]
 	le: PostType
 	lt: PostType
 	ge: PostType
@@ -501,12 +501,12 @@ input PostType_exact_StringRegExpFilter {
 
 input PostType_hash {
 	eq: PostType
-	in: PostType
+	in: [PostType]
 }
 
 input PostType_hash_StringRegExpFilter {
 	eq: PostType
-	in: PostType
+	in: [PostType]
 	regexp: String
 }
 


### PR DESCRIPTION
Fixes GRAPHQL-785.

This PR fixes incorrect Schema being generated for the `IN` filter on `enum` types.
for eg: For the given schema:-
```
type Verification {
  status: Status! @search
}

enum Status {
  ACTIVE
  DEACTIVATED
}
```
The filter generated was:-
```
type Status_hash {
   eq: Status!
   in: Status!
}
```
whereas It should be
```
{
   eq: Status!
   in: [Status!]
}
```
This PR fixes that.

(cherry picked from commit ecace57b1d2eddd004cd9c2d7b4ed3907cae627a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6906)
<!-- Reviewable:end -->
