### PR TITLE
fix(Dgraph): Switch command line options to kebab-case

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -534,6 +534,7 @@ func main() {
 			// dummy to get "Usage:" template in Usage() output.
 		},
 	}
+	cmd.SetGlobalNormalizationFunc(x.NormalizeFlags)
 
 	cmd.PersistentFlags().IntVarP(&opts.NumZeros, "num_zeros", "z", 3,
 		"number of zeros in dgraph cluster")

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -307,7 +307,7 @@ func getAlpha(idx int) service {
 	svc.Command += fmt.Sprintf(" --zero=%s", zerosOpt)
 	svc.Command += fmt.Sprintf(" --logtostderr -v=%d", opts.Verbosity)
 	if opts.LudicrousMode {
-		svc.Command += " --ludicrous_mode=true"
+		svc.Command += " --ludicrous-mode=true"
 	}
 
 	// Don't assign idx, let it auto-assign.
@@ -319,7 +319,7 @@ func getAlpha(idx int) service {
 		svc.Command += " --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 	}
 	if opts.Acl {
-		svc.Command += " --acl_secret_file=/secret/hmac"
+		svc.Command += " --acl-secret-file=/secret/hmac"
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   "./acl-secret",
@@ -328,10 +328,10 @@ func getAlpha(idx int) service {
 		})
 	}
 	if opts.SnapshotAfter != "" {
-		svc.Command += fmt.Sprintf(" --snapshot_after=%s", opts.SnapshotAfter)
+		svc.Command += fmt.Sprintf(" --snapshot-after=%s", opts.SnapshotAfter)
 	}
 	if opts.AclSecret != "" {
-		svc.Command += " --acl_secret_file=/secret/hmac"
+		svc.Command += " --acl-secret-file=/secret/hmac"
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   opts.AclSecret,
@@ -345,7 +345,7 @@ func getAlpha(idx int) service {
 		}
 	}
 	if opts.Encryption {
-		svc.Command += " --encryption_key_file=/secret/enc_key"
+		svc.Command += " --encryption-key-file=/secret/enc_key"
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   "./enc-secret",
@@ -354,7 +354,7 @@ func getAlpha(idx int) service {
 		})
 	}
 	if opts.TlsDir != "" {
-		svc.Command += " --tls_dir=/secret/tls"
+		svc.Command += " --tls-dir=/secret/tls"
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   opts.TlsDir,

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -536,18 +536,18 @@ func main() {
 	}
 	cmd.SetGlobalNormalizationFunc(x.NormalizeFlags)
 
-	cmd.PersistentFlags().IntVarP(&opts.NumZeros, "num_zeros", "z", 3,
+	cmd.PersistentFlags().IntVarP(&opts.NumZeros, "num-zeros", "z", 3,
 		"number of zeros in dgraph cluster")
-	cmd.PersistentFlags().IntVarP(&opts.NumAlphas, "num_alphas", "a", 3,
+	cmd.PersistentFlags().IntVarP(&opts.NumAlphas, "num-alphas", "a", 3,
 		"number of alphas in dgraph cluster")
-	cmd.PersistentFlags().IntVarP(&opts.NumReplicas, "num_replicas", "r", 3,
+	cmd.PersistentFlags().IntVarP(&opts.NumReplicas, "num-replicas", "r", 3,
 		"number of alpha replicas in dgraph cluster")
-	cmd.PersistentFlags().BoolVar(&opts.DataVol, "data_vol", false,
+	cmd.PersistentFlags().BoolVar(&opts.DataVol, "data-vol", false,
 		"mount a docker volume as /data in containers")
-	cmd.PersistentFlags().StringVarP(&opts.DataDir, "data_dir", "d", "",
+	cmd.PersistentFlags().StringVarP(&opts.DataDir, "data-dir", "d", "",
 		"mount a host directory as /data in containers")
 	cmd.PersistentFlags().BoolVar(&opts.Acl, "acl", false, "Create ACL secret file and enable ACLs")
-	cmd.PersistentFlags().StringVar(&opts.AclSecret, "acl_secret", "",
+	cmd.PersistentFlags().StringVar(&opts.AclSecret, "acl-secret", "",
 		"enable ACL feature with specified HMAC secret file")
 	cmd.PersistentFlags().BoolVarP(&opts.UserOwnership, "user", "u", false,
 		"run as the current user rather than root")
@@ -557,7 +557,7 @@ func main() {
 		"include jaeger service")
 	cmd.PersistentFlags().BoolVarP(&opts.Metrics, "metrics", "m", false,
 		"include metrics (prometheus, grafana) services")
-	cmd.PersistentFlags().IntVarP(&opts.PortOffset, "port_offset", "o", 100,
+	cmd.PersistentFlags().IntVarP(&opts.PortOffset, "port-offset", "o", 100,
 		"port offset for alpha and, if not 100, zero as well")
 	cmd.PersistentFlags().IntVarP(&opts.Verbosity, "verbosity", "v", 2,
 		"glog verbosity level")
@@ -573,41 +573,41 @@ func main() {
 		"include a whitelist if true")
 	cmd.PersistentFlags().BoolVar(&opts.Ratel, "ratel", false,
 		"include ratel service")
-	cmd.PersistentFlags().IntVar(&opts.RatelPort, "ratel_port", 8000,
+	cmd.PersistentFlags().IntVar(&opts.RatelPort, "ratel-port", 8000,
 		"Port to expose Ratel service")
 	cmd.PersistentFlags().StringVarP(&opts.MemLimit, "mem", "", "32G",
 		"Limit memory provided to the docker containers, for example 8G.")
-	cmd.PersistentFlags().StringVar(&opts.TlsDir, "tls_dir", "",
+	cmd.PersistentFlags().StringVar(&opts.TlsDir, "tls-dir", "",
 		"TLS Dir.")
-	cmd.PersistentFlags().BoolVar(&opts.ExposePorts, "expose_ports", true,
+	cmd.PersistentFlags().BoolVar(&opts.ExposePorts, "expose-ports", true,
 		"expose host:container ports for each service")
 	cmd.PersistentFlags().StringVar(&opts.Vmodule, "vmodule", "",
 		"comma-separated list of pattern=N settings for file-filtered logging")
 	cmd.PersistentFlags().BoolVar(&opts.Encryption, "encryption", false,
 		"enable encryption-at-rest feature.")
-	cmd.PersistentFlags().BoolVar(&opts.LudicrousMode, "ludicrous_mode", false,
+	cmd.PersistentFlags().BoolVar(&opts.LudicrousMode, "ludicrous-mode", false,
 		"enable zeros and alphas in ludicrous mode.")
-	cmd.PersistentFlags().StringVar(&opts.SnapshotAfter, "snapshot_after", "",
+	cmd.PersistentFlags().StringVar(&opts.SnapshotAfter, "snapshot-after", "",
 		"create a new Raft snapshot after this many number of Raft entries.")
-	cmd.PersistentFlags().StringVar(&opts.AlphaFlags, "extra_alpha_flags", "",
+	cmd.PersistentFlags().StringVar(&opts.AlphaFlags, "extra-alpha-flags", "",
 		"extra flags for alphas.")
-	cmd.PersistentFlags().StringVar(&opts.ZeroFlags, "extra_zero_flags", "",
+	cmd.PersistentFlags().StringVar(&opts.ZeroFlags, "extra-zero-flags", "",
 		"extra flags for zeros.")
 	cmd.PersistentFlags().BoolVar(&opts.ContainerNames, "names", true,
 		"set container names in docker compose.")
-	cmd.PersistentFlags().StringArrayVar(&opts.AlphaVolumes, "alpha_volume", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.AlphaVolumes, "alpha-volume", nil,
 		"alpha volume mounts, following srcdir:dstdir[:ro]")
-	cmd.PersistentFlags().StringArrayVar(&opts.ZeroVolumes, "zero_volume", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.ZeroVolumes, "zero-volume", nil,
 		"zero volume mounts, following srcdir:dstdir[:ro]")
-	cmd.PersistentFlags().StringArrayVar(&opts.AlphaEnvFile, "alpha_env_file", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.AlphaEnvFile, "alpha-env-file", nil,
 		"env_file for alpha")
-	cmd.PersistentFlags().StringArrayVar(&opts.ZeroEnvFile, "zero_env_file", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.ZeroEnvFile, "zero-env-file", nil,
 		"env_file for zero")
 	cmd.PersistentFlags().BoolVar(&opts.Minio, "minio", false,
 		"include minio service")
-	cmd.PersistentFlags().Uint16Var(&opts.MinioPort, "minio_port", 9001,
+	cmd.PersistentFlags().Uint16Var(&opts.MinioPort, "minio-port", 9001,
 		"minio service port")
-	cmd.PersistentFlags().StringArrayVar(&opts.MinioEnvFile, "minio_env_file", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.MinioEnvFile, "minio-env-file", nil,
 		"minio service env_file")
 	err := cmd.ParseFlags(os.Args)
 	if err != nil {
@@ -629,13 +629,13 @@ func main() {
 		fatal(errors.Errorf("number of replicas must be odd"))
 	}
 	if opts.DataVol && opts.DataDir != "" {
-		fatal(errors.Errorf("only one of --data_vol and --data_dir may be used at a time"))
+		fatal(errors.Errorf("only one of --data-vol and --data-dir may be used at a time"))
 	}
 	if opts.UserOwnership && opts.DataDir == "" {
-		fatal(errors.Errorf("--user option requires --data_dir=<path>"))
+		fatal(errors.Errorf("--user option requires --data-dir=<path>"))
 	}
-	if cmd.Flags().Changed("ratel_port") && !opts.Ratel {
-		fatal(errors.Errorf("--ratel_port option requires --ratel"))
+	if cmd.Flags().Changed("ratel-port") && !opts.Ratel {
+		fatal(errors.Errorf("--ratel-port option requires --ratel"))
 	}
 
 	services := make(map[string]service)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -112,11 +112,11 @@ they form a Raft group and provide synchronous replication.
 	enc.RegisterFlags(flag)
 
 	// Snapshot and Transactions.
-	flag.Int("snapshot_after", 10000,
+	flag.Int("snapshot-after", 10000,
 		"Create a new Raft snapshot after this many number of Raft entries. The"+
 			" lower this number, the more frequent snapshot creation would be."+
 			" Also determines how often Rollups would happen.")
-	flag.String("abort_older_than", "5m",
+	flag.String("abort-older-than", "5m",
 		"Abort any pending transactions older than this duration. The liveness of a"+
 			" transaction is determined by its last mutation.")
 
@@ -126,64 +126,64 @@ they form a Raft group and provide synchronous replication.
 			"wish to whitelist for performing admin actions (i.e., --whitelist 144.142.126.254,"+
 			"127.0.0.1:127.0.0.3,192.168.0.0/16,host.docker.internal)")
 	flag.String("export", "export", "Folder in which to store exports.")
-	flag.Int("pending_proposals", 256,
+	flag.Int("pending-proposals", 256,
 		"Number of pending mutation proposals. Useful for rate limiting.")
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
 		"Comma separated list of Dgraph zero addresses of the form IP_ADDRESS:PORT.")
 	flag.Uint64("idx", 0,
 		"Optional Raft ID that this Dgraph Alpha will use to join RAFT groups.")
-	flag.Int("max_retries", -1,
+	flag.Int("max-retries", -1,
 		"Commits to disk will give up after these number of retries to prevent locking the worker"+
 			" in a failed state. Use -1 to retry infinitely.")
-	flag.String("auth_token", "",
+	flag.String("auth-token", "",
 		"If set, all Admin requests to Dgraph would need to have this token."+
 			" The token can be passed as follows: For HTTP requests, in X-Dgraph-AuthToken header."+
 			" For Grpc, in auth-token key in the context.")
 
-	flag.String("acl_secret_file", "", "The file that stores the HMAC secret, "+
+	flag.String("acl-secret-file", "", "The file that stores the HMAC secret, "+
 		"which is used for signing the JWT and should have at least 32 ASCII characters. "+
 		"Enterprise feature.")
-	flag.Duration("acl_access_ttl", 6*time.Hour, "The TTL for the access jwt. "+
+	flag.Duration("acl-access-ttl", 6*time.Hour, "The TTL for the access jwt. "+
 		"Enterprise feature.")
-	flag.Duration("acl_refresh_ttl", 30*24*time.Hour, "The TTL for the refresh jwt. "+
+	flag.Duration("acl-refresh-ttl", 30*24*time.Hour, "The TTL for the refresh jwt. "+
 		"Enterprise feature.")
 	flag.String("mutations", "allow",
 		"Set mutation mode to allow, disallow, or strict.")
 
 	// Useful for running multiple servers on the same machine.
-	flag.IntP("port_offset", "o", 0,
+	flag.IntP("port-offset", "o", 0,
 		"Value added to all listening port numbers. [Internal=7080, HTTP=8080, Grpc=9080]")
 
-	flag.Uint64("query_edge_limit", 1e6,
+	flag.Uint64("query-edge-limit", 1e6,
 		"Limit for the maximum number of edges that can be returned in a query."+
 			" This applies to shortest path and recursive queries.")
-	flag.Uint64("normalize_node_limit", 1e4,
+	flag.Uint64("normalize-node-limit", 1e4,
 		"Limit for the maximum number of nodes that can be returned in a query that uses the "+
 			"normalize directive.")
-	flag.Uint64("mutations_nquad_limit", 1e6,
+	flag.Uint64("mutations-nquad-limit", 1e6,
 		"Limit for the maximum number of nquads that can be inserted in a mutation request")
 
 	//Custom plugins.
-	flag.String("custom_tokenizers", "",
+	flag.String("custom-tokenizers", "",
 		"Comma separated list of tokenizer plugins")
 
 	// By default Go GRPC traces all requests.
 	grpc.EnableTracing = false
 
-	flag.Bool("graphql_introspection", true, "Set to false for no GraphQL schema introspection")
-	flag.Bool("graphql_debug", false, "Enable debug mode in GraphQL. This returns auth errors to clients. We do not recommend turning it on for production.")
+	flag.Bool("graphql-introspection", true, "Set to false for no GraphQL schema introspection")
+	flag.Bool("graphql-debug", false, "Enable debug mode in GraphQL. This returns auth errors to clients. We do not recommend turning it on for production.")
 
 	// Ludicrous mode
-	flag.Bool("ludicrous_mode", false, "Run Dgraph in ludicrous mode.")
-	flag.Int("ludicrous_concurrency", 2000, "Number of concurrent threads in ludicrous mode")
+	flag.Bool("ludicrous-mode", false, "Run Dgraph in ludicrous mode.")
+	flag.Int("ludicrous-concurrency", 2000, "Number of concurrent threads in ludicrous mode")
 
-	flag.Bool("graphql_extensions", true, "Set to false if extensions not required in GraphQL response body")
-	flag.Duration("graphql_poll_interval", time.Second, "polling interval for graphql subscription.")
-	flag.String("graphql_lambda_url", "",
+	flag.Bool("graphql-extensions", true, "Set to false if extensions not required in GraphQL response body")
+	flag.Duration("graphql-poll-interval", time.Second, "polling interval for graphql subscription.")
+	flag.String("graphql-lambda-url", "",
 		"URL of lambda server that implements custom GraphQL JavaScript resolvers")
 
 	// Cache flags
-	flag.String("cache_percentage", "0,65,35,0",
+	flag.String("cache-percentage", "0,65,35,0",
 		`Cache percentages summing up to 100 for various caches (FORMAT:
 		PostingListCache,PstoreBlockCache,PstoreIndexCache,WAL).`)
 
@@ -192,7 +192,7 @@ they form a Raft group and provide synchronous replication.
 }
 
 func setupCustomTokenizers() {
-	customTokenizers := Alpha.Conf.GetString("custom_tokenizers")
+	customTokenizers := Alpha.Conf.GetString("custom-tokenizers")
 	if customTokenizers == "" {
 		return
 	}
@@ -425,7 +425,7 @@ func setupServer(closer *z.Closer) {
 	// TODO: Figure out what this is for?
 	http.HandleFunc("/debug/store", storeStatsHandler)
 
-	introspection := Alpha.Conf.GetBool("graphql_introspection")
+	introspection := Alpha.Conf.GetBool("graphql-introspection")
 
 	// Global Epoch is a lockless synchronization mechanism for graphql service.
 	// It's is just an atomic counter used by the graphql subscription to update its state.
@@ -551,7 +551,7 @@ func setupServer(closer *z.Closer) {
 
 func run() {
 	var err error
-	if Alpha.Conf.GetBool("enable_sentry") {
+	if Alpha.Conf.GetBool("enable-sentry") {
 		x.InitSentry(enc.EeBuild)
 		defer x.FlushSentry()
 		x.ConfigureSentryScope("alpha")
@@ -560,10 +560,10 @@ func run() {
 	}
 	bindall = Alpha.Conf.GetBool("bindall")
 
-	totalCache := int64(Alpha.Conf.GetInt("cache_mb"))
+	totalCache := int64(Alpha.Conf.GetInt("cache-mb"))
 	x.AssertTruef(totalCache >= 0, "ERROR: Cache size must be non-negative")
 
-	cachePercentage := Alpha.Conf.GetString("cache_percentage")
+	cachePercentage := Alpha.Conf.GetString("cache-percentage")
 	cachePercent, err := x.GetCachePercentages(cachePercentage, 4)
 	x.Check(err)
 	postingListCacheSize := (cachePercent[0] * (totalCache << 20)) / 100
@@ -583,10 +583,10 @@ func run() {
 		WalCache:                   walCache,
 
 		MutationsMode: worker.AllowMutations,
-		AuthToken:     Alpha.Conf.GetString("auth_token"),
+		AuthToken:     Alpha.Conf.GetString("auth-token"),
 	}
 
-	secretFile := Alpha.Conf.GetString("acl_secret_file")
+	secretFile := Alpha.Conf.GetString("acl-secret-file")
 	if secretFile != "" {
 		hmacSecret, err := ioutil.ReadFile(secretFile)
 		if err != nil {
@@ -597,8 +597,8 @@ func run() {
 		}
 
 		opts.HmacSecret = hmacSecret
-		opts.AccessJwtTtl = Alpha.Conf.GetDuration("acl_access_ttl")
-		opts.RefreshJwtTtl = Alpha.Conf.GetDuration("acl_refresh_ttl")
+		opts.AccessJwtTtl = Alpha.Conf.GetDuration("acl-access-ttl")
+		opts.RefreshJwtTtl = Alpha.Conf.GetDuration("acl-refresh-ttl")
 
 		glog.Info("HMAC secret loaded successfully.")
 	}
@@ -620,7 +620,7 @@ func run() {
 	ips, err := getIPsFromString(Alpha.Conf.GetString("whitelist"))
 	x.Check(err)
 
-	abortDur, err := time.ParseDuration(Alpha.Conf.GetString("abort_older_than"))
+	abortDur, err := time.ParseDuration(Alpha.Conf.GetString("abort-older-than"))
 	x.Check(err)
 
 	tlsClientConf, err := x.LoadClientTLSConfigForInternalPort(Alpha.Conf)
@@ -630,18 +630,18 @@ func run() {
 
 	x.WorkerConfig = x.WorkerOptions{
 		ExportPath:           Alpha.Conf.GetString("export"),
-		NumPendingProposals:  Alpha.Conf.GetInt("pending_proposals"),
+		NumPendingProposals:  Alpha.Conf.GetInt("pending-proposals"),
 		ZeroAddr:             strings.Split(Alpha.Conf.GetString("zero"), ","),
 		RaftId:               cast.ToUint64(Alpha.Conf.GetString("idx")),
 		WhiteListedIPRanges:  ips,
-		MaxRetries:           Alpha.Conf.GetInt("max_retries"),
+		MaxRetries:           Alpha.Conf.GetInt("max-retries"),
 		StrictMutations:      opts.MutationsMode == worker.StrictMutations,
 		AclEnabled:           secretFile != "",
-		SnapshotAfter:        Alpha.Conf.GetInt("snapshot_after"),
+		SnapshotAfter:        Alpha.Conf.GetInt("snapshot-after"),
 		AbortOlderThan:       abortDur,
 		StartTime:            startTime,
-		LudicrousMode:        Alpha.Conf.GetBool("ludicrous_mode"),
-		LudicrousConcurrency: Alpha.Conf.GetInt("ludicrous_concurrency"),
+		LudicrousMode:        Alpha.Conf.GetBool("ludicrous-mode"),
+		LudicrousConcurrency: Alpha.Conf.GetInt("ludicrous-concurrency"),
 		TLSClientConfig:      tlsClientConf,
 		TLSServerConfig:      tlsServerConf,
 	}
@@ -654,22 +654,22 @@ func run() {
 
 	setupCustomTokenizers()
 	x.Init()
-	x.Config.PortOffset = Alpha.Conf.GetInt("port_offset")
-	x.Config.QueryEdgeLimit = cast.ToUint64(Alpha.Conf.GetString("query_edge_limit"))
-	x.Config.NormalizeNodeLimit = cast.ToInt(Alpha.Conf.GetString("normalize_node_limit"))
-	x.Config.MutationsNQuadLimit = cast.ToInt(Alpha.Conf.GetString("mutations_nquad_limit"))
-	x.Config.PollInterval = Alpha.Conf.GetDuration("graphql_poll_interval")
-	x.Config.GraphqlExtension = Alpha.Conf.GetBool("graphql_extensions")
-	x.Config.GraphqlDebug = Alpha.Conf.GetBool("graphql_debug")
-	x.Config.GraphqlLambdaUrl = Alpha.Conf.GetString("graphql_lambda_url")
+	x.Config.PortOffset = Alpha.Conf.GetInt("port-offset")
+	x.Config.QueryEdgeLimit = cast.ToUint64(Alpha.Conf.GetString("query-edge-limit"))
+	x.Config.NormalizeNodeLimit = cast.ToInt(Alpha.Conf.GetString("normalize-node-limit"))
+	x.Config.MutationsNQuadLimit = cast.ToInt(Alpha.Conf.GetString("mutations-nquad-limit"))
+	x.Config.PollInterval = Alpha.Conf.GetDuration("graphql-poll-interval")
+	x.Config.GraphqlExtension = Alpha.Conf.GetBool("graphql-extensions")
+	x.Config.GraphqlDebug = Alpha.Conf.GetBool("graphql-debug")
+	x.Config.GraphqlLambdaUrl = Alpha.Conf.GetString("graphql-lambda-url")
 	if x.Config.GraphqlLambdaUrl != "" {
 		graphqlLambdaUrl, err := url.Parse(x.Config.GraphqlLambdaUrl)
 		if err != nil {
-			glog.Errorf("unable to parse graphql_lambda_url: %v", err)
+			glog.Errorf("unable to parse graphql-lambda-url: %v", err)
 			return
 		}
 		if !graphqlLambdaUrl.IsAbs() {
-			glog.Errorf("expecting graphql_lambda_url to be an absolute URL, got: %s",
+			glog.Errorf("expecting graphql-lambda-url to be an absolute URL, got: %s",
 				graphqlLambdaUrl.String())
 			return
 		}
@@ -682,7 +682,7 @@ func run() {
 
 	worker.InitServerState()
 
-	if Alpha.Conf.GetBool("expose_trace") {
+	if Alpha.Conf.GetBool("expose-trace") {
 		// TODO: Remove this once we get rid of event logs.
 		trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
 			return true, true

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -56,55 +56,55 @@ func init() {
 		"Location of *.rdf(.gz) or *.json(.gz) file(s) to load.")
 	flag.StringP("schema", "s", "",
 		"Location of schema file.")
-	flag.StringP("graphql_schema", "g", "", "Location of the GraphQL schema file.")
+	flag.StringP("graphql-schema", "g", "", "Location of the GraphQL schema file.")
 	flag.String("format", "",
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
 		"Flag to indicate whether schema and data files are encrypted. "+
-			"Must be specified with --encryption_key_file or vault option(s).")
-	flag.Bool("encrypted_out", false,
+			"Must be specified with --encryption-key-file or vault option(s).")
+	flag.Bool("encrypted-out", false,
 		"Flag to indicate whether to encrypt the output. "+
-			"Must be specified with --encryption_key_file or vault option(s).")
+			"Must be specified with --encryption-key-file or vault option(s).")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
-	flag.Bool("replace_out", false,
+	flag.Bool("replace-out", false,
 		"Replace out directory and its contents if it exists.")
 	flag.String("tmp", "tmp",
 		"Temp directory used to use for on-disk scratch space. Requires free space proportional"+
 			" to the size of the RDF file and the amount of indexing used.")
 
-	flag.IntP("num_go_routines", "j", int(math.Ceil(float64(runtime.NumCPU())/4.0)),
+	flag.IntP("num-go-routines", "j", int(math.Ceil(float64(runtime.NumCPU())/4.0)),
 		"Number of worker threads to use. MORE THREADS LEAD TO HIGHER RAM USAGE.")
-	flag.Int64("mapoutput_mb", 2048,
+	flag.Int64("mapoutput-mb", 2048,
 		"The estimated size of each map file output. Increasing this increases memory usage.")
-	flag.Int64("partition_mb", 4, "Pick a partition key every N megabytes of data.")
-	flag.Bool("skip_map_phase", false,
+	flag.Int64("partition-mb", 4, "Pick a partition key every N megabytes of data.")
+	flag.Bool("skip-map-phase", false,
 		"Skip the map phase (assumes that map output files already exist).")
-	flag.Bool("cleanup_tmp", true,
+	flag.Bool("cleanup-tmp", true,
 		"Clean up the tmp directory after the loader finishes. Setting this to false allows the"+
 			" bulk loader can be re-run while skipping the map phase.")
 	flag.Int("reducers", 1,
 		"Number of reducers to run concurrently. Increasing this can improve performance, and "+
 			"must be less than or equal to the number of reduce shards.")
 	flag.Bool("version", false, "Prints the version of Dgraph Bulk Loader.")
-	flag.Bool("store_xids", false, "Generate an xid edge for each node.")
+	flag.Bool("store-xids", false, "Generate an xid edge for each node.")
 	flag.StringP("zero", "z", "localhost:5080", "gRPC address for Dgraph zero")
 	flag.String("xidmap", "", "Directory to store xid to uid mapping")
 	// TODO: Potentially move http server to main.
 	flag.String("http", "localhost:8080",
 		"Address to serve http (pprof).")
-	flag.Bool("ignore_errors", false, "ignore line parsing errors in rdf files")
-	flag.Int("map_shards", 1,
+	flag.Bool("ignore-errors", false, "ignore line parsing errors in rdf files")
+	flag.Int("map-shards", 1,
 		"Number of map output shards. Must be greater than or equal to the number of reduce "+
 			"shards. Increasing allows more evenly sized reduce shards, at the expense of "+
 			"increased memory usage.")
-	flag.Int("reduce_shards", 1,
+	flag.Int("reduce-shards", 1,
 		"Number of reduce shards. This determines the number of dgraph instances in the final "+
 			"cluster. Increasing this potentially decreases the reduce stage runtime by using "+
 			"more parallelism, but increases memory usage.")
-	flag.String("custom_tokenizers", "",
+	flag.String("custom-tokenizers", "",
 		"Comma separated list of tokenizer plugins")
-	flag.Bool("new_uids", false,
+	flag.Bool("new-uids", false,
 		"Ignore UIDs in load files and assign new ones.")
 
 	// Options around how to set up Badger.
@@ -112,8 +112,8 @@ func init() {
 		"[none, zstd:level, snappy] Specifies the compression algorithm and the compression"+
 			"level (if applicable) for the postings directory. none would disable compression,"+
 			" while zstd:1 would set zstd compression at level 1.")
-	flag.Int64("badger.cache_mb", 64, "Total size of cache (in MB) per shard in reducer.")
-	flag.String("badger.cache_percentage", "70,30",
+	flag.Int64("badger.cache-mb", 64, "Total size of cache (in MB) per shard in reducer.")
+	flag.String("badger.cache-percentage", "70,30",
 		"Cache percentages summing up to 100 for various caches"+
 			" (FORMAT: BlockCacheSize, IndexCacheSize).")
 	x.RegisterClientTLSFlags(flag)
@@ -127,27 +127,27 @@ func run() {
 		DataFiles:        Bulk.Conf.GetString("files"),
 		DataFormat:       Bulk.Conf.GetString("format"),
 		SchemaFile:       Bulk.Conf.GetString("schema"),
-		GqlSchemaFile:    Bulk.Conf.GetString("graphql_schema"),
+		GqlSchemaFile:    Bulk.Conf.GetString("graphql-schema"),
 		Encrypted:        Bulk.Conf.GetBool("encrypted"),
-		EncryptedOut:     Bulk.Conf.GetBool("encrypted_out"),
+		EncryptedOut:     Bulk.Conf.GetBool("encrypted-out"),
 		OutDir:           Bulk.Conf.GetString("out"),
-		ReplaceOutDir:    Bulk.Conf.GetBool("replace_out"),
+		ReplaceOutDir:    Bulk.Conf.GetBool("replace-out"),
 		TmpDir:           Bulk.Conf.GetString("tmp"),
-		NumGoroutines:    Bulk.Conf.GetInt("num_go_routines"),
-		MapBufSize:       uint64(Bulk.Conf.GetInt("mapoutput_mb")),
-		PartitionBufSize: int64(Bulk.Conf.GetInt("partition_mb")),
-		SkipMapPhase:     Bulk.Conf.GetBool("skip_map_phase"),
-		CleanupTmp:       Bulk.Conf.GetBool("cleanup_tmp"),
+		NumGoroutines:    Bulk.Conf.GetInt("num-go-routines"),
+		MapBufSize:       uint64(Bulk.Conf.GetInt("mapoutput-mb")),
+		PartitionBufSize: int64(Bulk.Conf.GetInt("partition-mb")),
+		SkipMapPhase:     Bulk.Conf.GetBool("skip-map-phase"),
+		CleanupTmp:       Bulk.Conf.GetBool("cleanup-tmp"),
 		NumReducers:      Bulk.Conf.GetInt("reducers"),
 		Version:          Bulk.Conf.GetBool("version"),
-		StoreXids:        Bulk.Conf.GetBool("store_xids"),
+		StoreXids:        Bulk.Conf.GetBool("store-xids"),
 		ZeroAddr:         Bulk.Conf.GetString("zero"),
 		HttpAddr:         Bulk.Conf.GetString("http"),
-		IgnoreErrors:     Bulk.Conf.GetBool("ignore_errors"),
-		MapShards:        Bulk.Conf.GetInt("map_shards"),
-		ReduceShards:     Bulk.Conf.GetInt("reduce_shards"),
-		CustomTokenizers: Bulk.Conf.GetString("custom_tokenizers"),
-		NewUids:          Bulk.Conf.GetBool("new_uids"),
+		IgnoreErrors:     Bulk.Conf.GetBool("ignore-errors"),
+		MapShards:        Bulk.Conf.GetInt("map-shards"),
+		ReduceShards:     Bulk.Conf.GetInt("reduce-shards"),
+		CustomTokenizers: Bulk.Conf.GetString("custom-tokenizers"),
+		NewUids:          Bulk.Conf.GetBool("new-uids"),
 		ClientDir:        Bulk.Conf.GetString("xidmap"),
 		// Badger options
 		BadgerCompression:      ctype,
@@ -163,9 +163,9 @@ func run() {
 			opt.BadgerCompressionLevel)
 	}
 
-	totalCache := int64(Bulk.Conf.GetInt("badger.cache_mb"))
+	totalCache := int64(Bulk.Conf.GetInt("badger.cache-mb"))
 	x.AssertTruef(totalCache >= 0, "ERROR: Cache size must be non-negative")
-	cachePercent, err := x.GetCachePercentages(Bulk.Conf.GetString("badger.cache_percentage"), 2)
+	cachePercent, err := x.GetCachePercentages(Bulk.Conf.GetString("badger.cache-percentage"), 2)
 	x.Check(err)
 	totalCache <<= 20 // Convert to MB.
 	opt.BlockCacheSize = (cachePercent[0] * totalCache) / 100
@@ -177,18 +177,18 @@ func run() {
 	}
 	if len(opt.EncryptionKey) == 0 {
 		if opt.Encrypted || opt.EncryptedOut {
-			fmt.Fprint(os.Stderr, "Must use --encryption_key_file or vault option(s).\n")
+			fmt.Fprint(os.Stderr, "Must use --encryption-key-file or vault option(s).\n")
 			os.Exit(1)
 		}
 	} else {
 		requiredFlags := Bulk.Cmd.Flags().Changed("encrypted") &&
-			Bulk.Cmd.Flags().Changed("encrypted_out")
+			Bulk.Cmd.Flags().Changed("encrypted-out")
 		if !requiredFlags {
-			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted_out when providing encryption key.\n")
+			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted-out when providing encryption key.\n")
 			os.Exit(1)
 		}
 		if !opt.Encrypted && !opt.EncryptedOut {
-			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true when providing encryption key.\n")
+			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted-out to true when providing encryption key.\n")
 			os.Exit(1)
 		}
 	}
@@ -215,12 +215,12 @@ func run() {
 	}
 
 	if opt.ReduceShards > opt.MapShards {
-		fmt.Fprintf(os.Stderr, "Invalid flags: reduce_shards(%d) should be <= map_shards(%d)\n",
+		fmt.Fprintf(os.Stderr, "Invalid flags: reduce-shards(%d) should be <= map-shards(%d)\n",
 			opt.ReduceShards, opt.MapShards)
 		os.Exit(1)
 	}
 	if opt.NumReducers > opt.ReduceShards {
-		fmt.Fprintf(os.Stderr, "Invalid flags: shufflers(%d) should be <= reduce_shards(%d)\n",
+		fmt.Fprintf(os.Stderr, "Invalid flags: shufflers(%d) should be <= reduce-shards(%d)\n",
 			opt.NumReducers, opt.ReduceShards)
 		os.Exit(1)
 	}
@@ -230,7 +230,7 @@ func run() {
 		}
 	}
 	if opt.MapBufSize <= 0 || opt.PartitionBufSize <= 0 {
-		fmt.Fprintf(os.Stderr, "mapoutput_mb: %d and partition_mb: %d must be greater than zero\n",
+		fmt.Fprintf(os.Stderr, "mapoutput-mb: %d and partition-mb: %d must be greater than zero\n",
 			opt.MapBufSize, opt.PartitionBufSize)
 		os.Exit(1)
 	}
@@ -254,7 +254,7 @@ func run() {
 		err := x.IsMissingOrEmptyDir(opt.OutDir)
 		if err == nil {
 			fmt.Fprintf(os.Stderr, "Output directory exists and is not empty."+
-				" Use --replace_out to overwrite it.\n")
+				" Use --replace-out to overwrite it.\n")
 			os.Exit(1)
 		} else if err != x.ErrMissingDir {
 			x.CheckfNoTrace(err)

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -212,7 +212,7 @@ func TestLiveLoadJsonUidDiscard(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{testutil.DgraphBinaryPath(), "live", "--new_uids",
+		{testutil.DgraphBinaryPath(), "live", "--new-uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.json",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
@@ -240,7 +240,7 @@ func TestLiveLoadRdfUidDiscard(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	pipeline := [][]string{
-		{testutil.DgraphBinaryPath(), "live", "--new_uids",
+		{testutil.DgraphBinaryPath(), "live", "--new-uids",
 			"--schema", testDataDir + "/family.schema", "--files", testDataDir + "/family.rdf",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -280,7 +280,7 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", localExportPath + "/" + exportId + "/" + groupId + ".schema.gz",
 			"--files", localExportPath + "/" + exportId + "/" + groupId + ".rdf.gz",
-			"--encryption_key_file", testDataDir + "/../../../../ee/enc/test-fixtures/enc-key",
+			"--encryption-key-file", testDataDir + "/../../../../ee/enc/test-fixtures/enc-key",
 			"--alpha", alphaService, "--zero", zeroService, "-u", "groot", "-p", "password"},
 	}
 	_, err := testutil.Pipeline(pipeline)

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -143,23 +143,23 @@ func init() {
 	flag.IntP("batch", "b", 1000,
 		"Number of N-Quads to send as part of a mutation.")
 	flag.StringP("xidmap", "x", "", "Directory to store xid to uid mapping")
-	flag.StringP("auth_token", "t", "",
-		"The auth token passed to the server for Alter operation of the schema file. If used with --slash_grpc_endpoint, then this "+
+	flag.StringP("auth-token", "t", "",
+		"The auth token passed to the server for Alter operation of the schema file. If used with --slash-grpc-endpoint, then this "+
 			"should be set to the API token issued by Slash GraphQL")
-	flag.String("slash_grpc_endpoint", "", "Path to Slash GraphQL GRPC endpoint. If --slash_grpc_endpoint is set, "+
+	flag.String("slash-grpc-endpoint", "", "Path to Slash GraphQL GRPC endpoint. If --slash-grpc-endpoint is set, "+
 		"all other TLS options and connection options will be ignored")
-	flag.BoolP("use_compression", "C", false,
+	flag.BoolP("use-compression", "C", false,
 		"Enable compression on connection to alpha server")
-	flag.Bool("new_uids", false,
+	flag.Bool("new-uids", false,
 		"Ignore UIDs in load files and assign new ones.")
 	flag.String("http", "localhost:6060", "Address to serve http (pprof).")
 	flag.Bool("verbose", false, "Run the live loader in verbose mode")
 	flag.StringP("user", "u", "", "Username if login is required.")
 	flag.StringP("password", "p", "", "Password of the user.")
-	flag.StringP("bufferSize", "m", "100", "Buffer for each thread")
-	flag.Bool("ludicrous_mode", false, "Run live loader in ludicrous mode (Should "+
+	flag.StringP("buffer-size", "m", "100", "Buffer for each thread")
+	flag.Bool("ludicrous-mode", false, "Run live loader in ludicrous mode (Should "+
 		"only be done when alpha is under ludicrous mode)")
-	flag.StringP("upsertPredicate", "U", "", "run in upsertPredicate mode. the value would "+
+	flag.StringP("upsert-predicate", "U", "", "run in upsert-predicate mode. the value would "+
 		"be used to store blank nodes as an xid")
 
 	// Encryption and Vault options
@@ -533,14 +533,14 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 	}
 
 	dialOpts := []grpc.DialOption{}
-	if conf.GetString("slash_grpc_endpoint") != "" && conf.IsSet("auth_token") {
-		dialOpts = append(dialOpts, x.WithAuthorizationCredentials(conf.GetString("auth_token")))
+	if conf.GetString("slash-grpc-endpoint") != "" && conf.IsSet("auth-token") {
+		dialOpts = append(dialOpts, x.WithAuthorizationCredentials(conf.GetString("auth-token")))
 	}
 
 	var tlsConfig *tls.Config = nil
-	if conf.GetString("slash_grpc_endpoint") != "" {
+	if conf.GetString("slash-grpc-endpoint") != "" {
 		var tlsErr error
-		tlsConfig, tlsErr = x.SlashTLSConfig(conf.GetString("slash_grpc_endpoint"))
+		tlsConfig, tlsErr = x.SlashTLSConfig(conf.GetString("slash-grpc-endpoint"))
 		x.Checkf(tlsErr, "Unable to generate TLS Cert Pool")
 	} else {
 		var tlsErr error
@@ -575,8 +575,8 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 
 func run() error {
 	var zero string
-	if Live.Conf.GetString("slash_grpc_endpoint") != "" {
-		zero = Live.Conf.GetString("slash_grpc_endpoint")
+	if Live.Conf.GetString("slash-grpc-endpoint") != "" {
+		zero = Live.Conf.GetString("slash-grpc-endpoint")
 	} else {
 		zero = Live.Conf.GetString("zero")
 	}
@@ -591,14 +591,14 @@ func run() error {
 		concurrent:      Live.Conf.GetInt("conc"),
 		batchSize:       Live.Conf.GetInt("batch"),
 		clientDir:       Live.Conf.GetString("xidmap"),
-		authToken:       Live.Conf.GetString("auth_token"),
-		useCompression:  Live.Conf.GetBool("use_compression"),
-		newUids:         Live.Conf.GetBool("new_uids"),
+		authToken:       Live.Conf.GetString("auth-token"),
+		useCompression:  Live.Conf.GetBool("use-compression"),
+		newUids:         Live.Conf.GetBool("new-uids"),
 		verbose:         Live.Conf.GetBool("verbose"),
 		httpAddr:        Live.Conf.GetString("http"),
-		bufferSize:      Live.Conf.GetInt("bufferSize"),
-		ludicrousMode:   Live.Conf.GetBool("ludicrous_mode"),
-		upsertPredicate: Live.Conf.GetString("upsertPredicate"),
+		bufferSize:      Live.Conf.GetInt("buffer-size"),
+		ludicrousMode:   Live.Conf.GetBool("ludicrous-mode"),
+		upsertPredicate: Live.Conf.GetString("upsert-predicate"),
 	}
 	if opt.key, err = enc.ReadKey(Live.Conf); err != nil {
 		fmt.Printf("unable to read key %v", err)

--- a/dgraph/cmd/migrate/run.go
+++ b/dgraph/cmd/migrate/run.go
@@ -54,8 +54,8 @@ func init() {
 	flag.StringP("db", "", "", "The database to import")
 	flag.StringP("tables", "", "", "The comma separated list of "+
 		"tables to import, an empty string means importing all tables in the database")
-	flag.StringP("output_schema", "s", "schema.txt", "The schema output file")
-	flag.StringP("output_data", "o", "sql.rdf", "The data output file")
+	flag.StringP("output-schema", "s", "schema.txt", "The schema output file")
+	flag.StringP("output-data", "o", "sql.rdf", "The data output file")
 	flag.StringP("separator", "p", ".", "The separator for constructing predicate names")
 	flag.BoolP("quiet", "q", false, "Enable quiet mode to suppress the warning logs")
 	flag.StringP("host", "", "localhost", "The hostname or IP address of the database server.")
@@ -67,8 +67,8 @@ func run(conf *viper.Viper) error {
 	db := conf.GetString("db")
 	password := conf.GetString("password")
 	tables := conf.GetString("tables")
-	schemaOutput := conf.GetString("output_schema")
-	dataOutput := conf.GetString("output_data")
+	schemaOutput := conf.GetString("output-schema")
+	dataOutput := conf.GetString("output-data")
 	host := conf.GetString("host")
 	port := conf.GetString("port")
 	quiet = conf.GetBool("quiet")
@@ -82,10 +82,10 @@ func run(conf *viper.Viper) error {
 	case len(password) == 0:
 		logger.Fatalf("The password property should not be empty.")
 	case len(schemaOutput) == 0:
-		logger.Fatalf("Please use the --output_schema option to " +
+		logger.Fatalf("Please use the --output-schema option to " +
 			"provide the schema output file.")
 	case len(dataOutput) == 0:
-		logger.Fatalf("Please use the --output_data option to provide the data output file.")
+		logger.Fatalf("Please use the --output-data option to provide the data output file.")
 	}
 
 	if err := checkFile(schemaOutput); err != nil {

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -81,6 +81,7 @@ var subcommands = []*x.SubCommand{
 }
 
 func initCmds() {
+	RootCmd.SetGlobalNormalizationFunc(x.NormalizeFlags)
 	RootCmd.PersistentFlags().String("cwd", "",
 		"Change working directory to the path specified. The parent must exist.")
 	RootCmd.PersistentFlags().String("profile_mode", "",

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -155,19 +155,19 @@ func setGlogFlags(conf *viper.Viper) {
 	// https://github.com/golang/glog/blob/master/glog.go#L399
 	// and https://github.com/golang/glog/blob/master/glog_file.go#L41
 	glogFlags := [...]string{
-		"log_dir", "logtostderr", "alsologtostderr", "v",
-		"stderrthreshold", "vmodule", "log_backtrace_at",
+		"log-dir", "logtostderr", "alsologtostderr", "v",
+		"stderrthreshold", "vmodule", "log-backtrace-at",
 	}
 	for _, gflag := range glogFlags {
 		// Set value of flag to the value in config
 		stringValue := conf.GetString(gflag)
-		// Special handling for log_backtrace_at flag because the flag is of
+		// Special handling for log-backtrace-at flag because the flag is of
 		// type tracelocation. The nil value for tracelocation type is
 		// ":0"(See https://github.com/golang/glog/blob/master/glog.go#L322).
 		// But we can't set nil value for the flag because of
 		// https://github.com/golang/glog/blob/master/glog.go#L374
-		// Skip setting value if log_backstrace_at is nil in config.
-		if gflag == "log_backtrace_at" && (stringValue == "0" || stringValue == ":0") {
+		// Skip setting value if log-backstrace-at is nil in config.
+		if gflag == "log-backtrace-at" && (stringValue == "0" || stringValue == ":0") {
 			continue
 		}
 		x.Check(flag.Lookup(gflag).Value.Set(stringValue))

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -84,16 +84,16 @@ func initCmds() {
 	RootCmd.SetGlobalNormalizationFunc(x.NormalizeFlags)
 	RootCmd.PersistentFlags().String("cwd", "",
 		"Change working directory to the path specified. The parent must exist.")
-	RootCmd.PersistentFlags().String("profile_mode", "",
+	RootCmd.PersistentFlags().String("profile-mode", "",
 		"Enable profiling mode, one of [cpu, mem, mutex, block]")
-	RootCmd.PersistentFlags().Int("block_rate", 0,
-		"Block profiling rate. Must be used along with block profile_mode")
+	RootCmd.PersistentFlags().Int("block-rate", 0,
+		"Block profiling rate. Must be used along with block profile-mode")
 	RootCmd.PersistentFlags().String("config", "",
 		"Configuration file. Takes precedence over default values, but is "+
 			"overridden to values set with environment variables and flags.")
 	RootCmd.PersistentFlags().Bool("bindall", true,
 		"Use 0.0.0.0 instead of localhost to bind to all addresses on local machine.")
-	RootCmd.PersistentFlags().Bool("expose_trace", false,
+	RootCmd.PersistentFlags().Bool("expose-trace", false,
 		"Allow trace endpoint to be accessible from remote")
 	x.Check(rootConf.BindPFlags(RootCmd.PersistentFlags()))
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -460,7 +460,7 @@ func (n *node) proposeNewCID() {
 	}
 
 	// Apply trial license only if not already licensed and no enterprise license provided.
-	if n.server.license() == nil && Zero.Conf.GetString("enterprise_license") == "" {
+	if n.server.license() == nil && Zero.Conf.GetString("enterprise-license") == "" {
 		if err := n.proposeTrialLicense(); err != nil {
 			glog.Errorf("while proposing trial license to cluster: %v", err)
 		}
@@ -807,7 +807,7 @@ func (n *node) Run() {
 				// Apply the EE License given on CLI which may over-ride previous
 				// license, if present. That is an intended behavior to allow customers
 				// to apply new/renewed licenses.
-				if license := Zero.Conf.GetString("enterprise_license"); len(license) > 0 {
+				if license := Zero.Conf.GetString("enterprise-license"); len(license) > 0 {
 					go n.server.applyLicenseFile(license)
 				}
 			}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -192,7 +192,7 @@ func run() {
 	x.WorkerConfig.Parse(Zero.Conf)
 
 	if !enc.EeBuild && Zero.Conf.GetString("enterprise-license") != "" {
-		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
+		log.Fatalf("ERROR: enterprise-license option cannot be applied to OSS builds. ")
 	}
 
 	if opts.numReplicas < 0 || opts.numReplicas%2 == 0 {

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -81,15 +81,15 @@ instances to achieve high-availability.
 	flag := Zero.Cmd.Flags()
 	x.FillCommonFlags(flag)
 
-	flag.IntP("port_offset", "o", 0,
+	flag.IntP("port-offset", "o", 0,
 		"Value added to all listening port numbers. [Grpc=5080, HTTP=6080]")
 	flag.Uint64("idx", 1, "Unique node index for this server. idx cannot be 0.")
 	flag.Int("replicas", 1, "How many replicas to run per data shard."+
 		" The count includes the original shard.")
 	flag.String("peer", "", "Address of another dgraphzero server.")
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
-	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
-	flag.String("enterprise_license", "", "Path to the enterprise license file.")
+	flag.Duration("rebalance-interval", 8*time.Minute, "Interval for trying a predicate move.")
+	flag.String("enterprise-license", "", "Path to the enterprise license file.")
 	// TLS configurations
 	x.RegisterServerTLSFlags(flag)
 }
@@ -162,7 +162,7 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 }
 
 func run() {
-	if Zero.Conf.GetBool("enable_sentry") {
+	if Zero.Conf.GetBool("enable-sentry") {
 		x.InitSentry(enc.EeBuild)
 		defer x.FlushSentry()
 		x.ConfigureSentryScope("zero")
@@ -175,13 +175,13 @@ func run() {
 	x.Check(err)
 	opts = options{
 		bindall:           Zero.Conf.GetBool("bindall"),
-		portOffset:        Zero.Conf.GetInt("port_offset"),
+		portOffset:        Zero.Conf.GetInt("port-offset"),
 		nodeId:            uint64(Zero.Conf.GetInt("idx")),
 		numReplicas:       Zero.Conf.GetInt("replicas"),
 		peer:              Zero.Conf.GetString("peer"),
 		w:                 Zero.Conf.GetString("wal"),
-		rebalanceInterval: Zero.Conf.GetDuration("rebalance_interval"),
-		totalCache:        int64(Zero.Conf.GetInt("cache_mb")),
+		rebalanceInterval: Zero.Conf.GetDuration("rebalance-interval"),
+		totalCache:        int64(Zero.Conf.GetInt("cache-mb")),
 		tlsClientConfig:   tlsConf,
 	}
 	glog.Infof("Setting Config to: %+v", opts)
@@ -191,7 +191,7 @@ func run() {
 	}
 	x.WorkerConfig.Parse(Zero.Conf)
 
-	if !enc.EeBuild && Zero.Conf.GetString("enterprise_license") != "" {
+	if !enc.EeBuild && Zero.Conf.GetString("enterprise-license") != "" {
 		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
 	}
 
@@ -200,7 +200,7 @@ func run() {
 			opts.numReplicas)
 	}
 
-	if Zero.Conf.GetBool("expose_trace") {
+	if Zero.Conf.GetBool("expose-trace") {
 		// TODO: Remove this once we get rid of event logs.
 		trace.AuthRequest = func(req *http.Request) (any, sensitive bool) {
 			return true, true

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -42,7 +42,7 @@ func checkForbiddenOpts(conf *viper.Viper, forbiddenOpts []string) error {
 		var isSet bool
 		switch conf.Get(opt).(type) {
 		case string:
-			if opt == "group_list" {
+			if opt == "group-list" {
 				// handle group_list specially since the default value is not an empty string
 				isSet = conf.GetString(opt) != defaultGroupList
 			} else {
@@ -251,12 +251,12 @@ func mod(conf *viper.Viper) error {
 			return err
 		}
 
-		newPassword := conf.GetBool("new_password")
-		groupList := conf.GetString("group_list")
+		newPassword := conf.GetBool("new-password")
+		groupList := conf.GetString("group-list")
 		if (newPassword && groupList != defaultGroupList) ||
 			(!newPassword && groupList == defaultGroupList) {
 			return errors.Errorf(
-				"one of --new_password or --group_list must be provided, but not both")
+				"one of --new-password or --group-list must be provided, but not both")
 		}
 
 		if newPassword {
@@ -267,7 +267,7 @@ func mod(conf *viper.Viper) error {
 	}
 
 	// when modifying the group, some user options are forbidden
-	if err := checkForbiddenOpts(conf, []string{"group_list", "new_password"}); err != nil {
+	if err := checkForbiddenOpts(conf, []string{"group-list", "new-password"}); err != nil {
 		return err
 	}
 	return chMod(conf)

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -43,7 +43,7 @@ func checkForbiddenOpts(conf *viper.Viper, forbiddenOpts []string) error {
 		switch conf.Get(opt).(type) {
 		case string:
 			if opt == "group-list" {
-				// handle group_list specially since the default value is not an empty string
+				// handle group-list specially since the default value is not an empty string
 				isSet = conf.GetString(opt) != defaultGroupList
 			} else {
 				isSet = len(conf.GetString(opt)) > 0

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2679,7 +2679,7 @@ func TestGuardianOnlyAccessForAdminEndpoints(t *testing.T) {
 			queryName:          "config",
 			testGuardianAccess: true,
 			guardianErrs: x.GqlErrorList{{
-				Message:   "resolving config failed because cache_mb must be non-negative",
+				Message:   "resolving config failed because cache-mb must be non-negative",
 				Locations: []x.Location{{Line: 3, Column: 8}},
 			}},
 			guardianData: `{"config": null}`,

--- a/ee/acl/run_ee.go
+++ b/ee/acl/run_ee.go
@@ -27,8 +27,8 @@ var (
 	CmdAcl x.SubCommand
 )
 
-const gName = "guardian_name"
-const gPassword = "guardian_password"
+const gName = "guardian-name"
+const gPassword = "guardian-password"
 const defaultGroupList = "dgraph-unused-group"
 
 func init() {
@@ -108,8 +108,8 @@ func initSubcommands() []*x.SubCommand {
 
 	modFlags := cmdMod.Cmd.Flags()
 	modFlags.StringP("user", "u", "", "The user id to be changed")
-	modFlags.BoolP("new_password", "n", false, "Whether to reset password for the user")
-	modFlags.StringP("group_list", "l", defaultGroupList,
+	modFlags.BoolP("new-password", "n", false, "Whether to reset password for the user")
+	modFlags.StringP("group-list", "l", defaultGroupList,
 		"The list of groups to be set for the user")
 	modFlags.StringP("group", "g", "", "The group whose permission is to be changed")
 	modFlags.StringP("pred", "p", "", "The predicates whose acls are to be changed")

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -116,9 +116,9 @@ $ dgraph restore -p . -l /var/backups/dgraph -z localhost:5080
 	flag.StringVarP(&opt.pdir, "postings", "p", "",
 		"Directory where posting lists are stored (required).")
 	flag.StringVarP(&opt.zero, "zero", "z", "", "gRPC address for Dgraph zero. ex: localhost:5080")
-	flag.StringVarP(&opt.backupId, "backup_id", "", "", "The ID of the backup series to "+
+	flag.StringVarP(&opt.backupId, "backup-id", "", "", "The ID of the backup series to "+
 		"restore. If empty, it will restore the latest series.")
-	flag.BoolVarP(&opt.forceZero, "force_zero", "", true, "If false, no connection to "+
+	flag.BoolVarP(&opt.forceZero, "force-zero", "", true, "If false, no connection to "+
 		"a zero in the cluster will be required. Keep in mind this requires you to manually "+
 		"update the timestamp and max uid when you start the cluster. The correct values are "+
 		"printed near the end of this command's output.")

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -15,9 +15,10 @@ package backup
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/credentials"
 	"os"
 	"time"
+
+	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -266,7 +267,7 @@ func runLsbackupCmd() error {
 
 func initExportBackup() {
 	ExportBackup.Cmd = &cobra.Command{
-		Use:   "export_backup",
+		Use:   "export-backup",
 		Short: "Export data inside single full or incremental backup.",
 		Long:  ``,
 		Args:  cobra.NoArgs,

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -190,7 +190,7 @@ func runRestoreCmd() error {
 	fmt.Println("Writing postings to:", opt.pdir)
 
 	if opt.zero == "" && opt.forceZero {
-		return errors.Errorf("No Dgraph Zero address passed. Use the --force_zero option if you " +
+		return errors.Errorf("No Dgraph Zero address passed. Use the --force-zero option if you " +
 			"meant to do this")
 	}
 

--- a/ee/enc/util_ee.go
+++ b/ee/enc/util_ee.go
@@ -30,7 +30,7 @@ import (
 var EeBuild = true
 
 const (
-	encKeyFile = "encryption_key_file"
+	encKeyFile = "encryption-key-file"
 )
 
 // RegisterFlags registers the required encryption flags.

--- a/ee/enc/vault_ee.go
+++ b/ee/enc/vault_ee.go
@@ -32,12 +32,12 @@ import (
 
 // Configuration options of Vault.
 const (
-	vaultAddr         = "vault_addr"
-	vaultRoleIDFile   = "vault_roleid_file"
-	vaultSecretIDFile = "vault_secretid_file"
-	vaultPath         = "vault_path"
-	vaultField        = "vault_field"
-	vaultFormat       = "vault_format"
+	vaultAddr         = "vault-addr"
+	vaultRoleIDFile   = "vault-roleid-file"
+	vaultSecretIDFile = "vault-secretid-file"
+	vaultPath         = "vault-path"
+	vaultField        = "vault-field"
+	vaultFormat       = "vault-format"
 )
 
 // RegisterVaultFlags registers the required flags to integrate with Vault.

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -260,7 +260,7 @@ const (
 		"""
 		Estimated memory the caches can take. Actual usage by the process would be
 		more than specified here. The caches will be updated according to the
-		cache_percentage flag.
+		cache-percentage flag.
 		"""
 		cacheMb: Float
 
@@ -320,7 +320,7 @@ const (
 		Alter the node's config.
 		"""
 		config(input: ConfigInput!): ConfigPayload
-		
+
 		replaceAllowedCORSOrigins(origins: [String]): Cors
 
 		` + adminMutations + `

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1228,7 +1228,7 @@ func lambdaDirectiveValidation(sch *ast.Schema,
 	if x.Config.GraphqlLambdaUrl == "" {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(dir.Position,
 			"Type %s; Field %s: has the @lambda directive, but the "+
-				"`--graphql_lambda_url` flag wasn't specified during alpha startup.",
+				"`--graphql-lambda-url` flag wasn't specified during alpha startup.",
 			typ.Name, field.Name)}
 	}
 	// reuse @custom directive validation

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -309,7 +309,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	testutil.KeyFile = "../../../ee/enc/test-fixtures/enc-key"
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"--encryption_key_file", testutil.KeyFile, "--force_zero=false"}
+		"--encryption-key-file", testutil.KeyFile, "--force-zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})
@@ -350,7 +350,7 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 
 	// Get key.
 	config := getEncConfig()
-	config.Set("encryption_key_file", "../../../ee/enc/test-fixtures/enc-key")
+	config.Set("encryption-key-file", "../../../ee/enc/test-fixtures/enc-key")
 	k, err := enc.ReadKey(config)
 	require.NotNil(t, k)
 	require.NoError(t, err)

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -334,7 +334,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"--force_zero=false"}
+		"--force-zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/systest/bulk_live_fixture_test.go
+++ b/systest/bulk_live_fixture_test.go
@@ -139,7 +139,7 @@ func (s *suite) setup(schemaFile, rdfFile, gqlSchemaFile string) {
 			"-g", gqlSchemaFile,
 			"--http", "localhost:"+strconv.Itoa(freePort(0)),
 			"-j=1",
-			"--store_xids=true",
+			"--store-xids=true",
 			"-z", "localhost:"+s.bulkCluster.zeroPort,
 		)
 		bulkCmd.Dir = bulkDir

--- a/systest/cluster_setup_test.go
+++ b/systest/cluster_setup_test.go
@@ -90,8 +90,8 @@ func (d *DgraphCluster) StartAlphaOnly() error {
 	d.dgraph = exec.Command(testutil.DgraphBinaryPath(),
 		"alpha",
 		"--zero", ":"+d.zeroPort,
-		"--port_offset", strconv.Itoa(d.alphaPortOffset),
-		"--custom_tokenizers", d.TokenizerPluginsArg,
+		"--port-offset", strconv.Itoa(d.alphaPortOffset),
+		"--custom-tokenizers", d.TokenizerPluginsArg,
 	)
 	d.dgraph.Dir = d.dir
 	if err := d.dgraph.Start(); err != nil {
@@ -132,7 +132,7 @@ func (d *DgraphCluster) AddNode(dir string) (Node, error) {
 	dgraph := exec.Command(testutil.DgraphBinaryPath(),
 		"alpha",
 		"--zero", ":"+d.zeroPort,
-		"--port_offset", o,
+		"--port-offset", o,
 	)
 	dgraph.Dir = dir
 	dgraph.Stdout = os.Stdout

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -43,7 +43,7 @@ func openDgraph(pdir string) (*badger.DB, error) {
 	if err := config.BindPFlags(flags); err != nil {
 		return nil, err
 	}
-	config.Set("encryption_key_file", KeyFile)
+	config.Set("encryption-key-file", KeyFile)
 	k, err := enc.ReadKey(config)
 	if err != nil {
 		return nil, err

--- a/tlstest/acl/acl_over_tls_test.go
+++ b/tlstest/acl/acl_over_tls_test.go
@@ -43,7 +43,7 @@ func generateCertPool(certPath string, useSystemCA bool) (*x509.CertPool, error)
 }
 
 func loadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	// When the --tls_cacert option is pecified, the connection will be set up using TLS instead of
+	// When the --tls-cacert option is pecified, the connection will be set up using TLS instead of
 	// plaintext. However the client cert files are optional, depending on whether the server is
 	// requiring a client certificate.
 	caCert := v.GetString("tls-cacert")

--- a/tlstest/acl/acl_over_tls_test.go
+++ b/tlstest/acl/acl_over_tls_test.go
@@ -46,23 +46,23 @@ func loadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	// When the --tls_cacert option is pecified, the connection will be set up using TLS instead of
 	// plaintext. However the client cert files are optional, depending on whether the server is
 	// requiring a client certificate.
-	caCert := v.GetString("tls_cacert")
+	caCert := v.GetString("tls-cacert")
 	if caCert != "" {
 		tlsCfg := tls.Config{}
 
 		// 1. set up the root CA
-		pool, err := generateCertPool(caCert, v.GetBool("tls_use_system_ca"))
+		pool, err := generateCertPool(caCert, v.GetBool("tls-use-system-ca"))
 		if err != nil {
 			return nil, err
 		}
 		tlsCfg.RootCAs = pool
 
 		// 2. set up the server name for verification
-		tlsCfg.ServerName = v.GetString("tls_server_name")
+		tlsCfg.ServerName = v.GetString("tls-server-name")
 
 		// 3. optionally load the client cert files
-		certFile := v.GetString("tls_cert")
-		keyFile := v.GetString("tls_key")
+		certFile := v.GetString("tls-cert")
+		keyFile := v.GetString("tls-key")
 		if certFile != "" && keyFile != "" {
 			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 			if err != nil {
@@ -99,8 +99,8 @@ func dgraphClientWithCerts(serviceAddr string, conf *viper.Viper) (*dgo.Dgraph, 
 func TestLoginOverTLS(t *testing.T) {
 	t.Skipf("TODO: This test fails for some reason. FIX IT.")
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
 
 	dg, err := dgraphClientWithCerts(testutil.SockAddr, conf)
 	if err != nil {

--- a/tlstest/certrequest/certrequest_test.go
+++ b/tlstest/certrequest/certrequest_test.go
@@ -21,8 +21,8 @@ func TestAccessOverPlaintext(t *testing.T) {
 
 func TestAccessWithCaCert(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)

--- a/tlstest/certrequireandverify/certrequireandverify_test.go
+++ b/tlstest/certrequireandverify/certrequireandverify_test.go
@@ -18,8 +18,8 @@ import (
 
 func TestAccessWithoutClientCert(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)
@@ -29,10 +29,10 @@ func TestAccessWithoutClientCert(t *testing.T) {
 
 func TestAccessWithClientCert(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
-	conf.Set("tls_cert", "../tls/client.acl.crt")
-	conf.Set("tls_key", "../tls/client.acl.key")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
+	conf.Set("tls-cert", "../tls/client.acl.crt")
+	conf.Set("tls-key", "../tls/client.acl.key")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)

--- a/tlstest/certverifyifgiven/certverifyifgiven_test.go
+++ b/tlstest/certverifyifgiven/certverifyifgiven_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestAccessWithoutClientCert(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)
@@ -23,10 +23,10 @@ func TestAccessWithoutClientCert(t *testing.T) {
 
 func TestAccessWithClientCert(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/ca.crt")
-	conf.Set("tls_server_name", "node")
-	conf.Set("tls_cert", "../tls/client.acl.crt")
-	conf.Set("tls_key", "../tls/client.acl.key")
+	conf.Set("tls-cacert", "../tls/ca.crt")
+	conf.Set("tls-server-name", "node")
+	conf.Set("tls-cert", "../tls/client.acl.crt")
+	conf.Set("tls-key", "../tls/client.acl.key")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err, "Unable to get dgraph client: %v", err)

--- a/tlstest/mtls_internal/acl/acl_over_tls_test.go
+++ b/tlstest/mtls_internal/acl/acl_over_tls_test.go
@@ -2,10 +2,11 @@ package acl
 
 import (
 	"context"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/spf13/viper"
@@ -13,8 +14,8 @@ import (
 
 func TestLoginOverTLS(t *testing.T) {
 	conf := viper.New()
-	conf.Set("tls_cacert", "../tls/alpha1/ca.crt")
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../tls/alpha1/ca.crt")
+	conf.Set("tls-server-name", "alpha1")
 
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)

--- a/tlstest/mtls_internal/backup/encryption/backup_test.go
+++ b/tlstest/mtls_internal/backup/encryption/backup_test.go
@@ -76,9 +76,9 @@ func getHttpClient(t *testing.T) *http.Client {
 
 func TestBackupMinioEncrypted(t *testing.T) {
 	conf := viper.GetViper()
-	conf.Set("tls_cacert", "../../tls/live/ca.crt")
-	conf.Set("tls_internal_port_enabled", true)
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../../tls/live/ca.crt")
+	conf.Set("tls-internal-port-enabled", true)
+	conf.Set("tls-server-name", "alpha1")
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)
 
@@ -306,7 +306,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	testutil.KeyFile = "../../../../ee/enc/test-fixtures/enc-key"
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"--encryption_key_file", testutil.KeyFile, "--force_zero=false"}
+		"--encryption-key-file", testutil.KeyFile, "--force_zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})
@@ -347,7 +347,7 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 
 	// Get key.
 	config := getEncConfig()
-	config.Set("encryption_key_file", "../../../../ee/enc/test-fixtures/enc-key")
+	config.Set("encryption-key-file", "../../../../ee/enc/test-fixtures/enc-key")
 	k, err := enc.ReadKey(config)
 	require.NotNil(t, k)
 	require.NoError(t, err)

--- a/tlstest/mtls_internal/backup/encryption/backup_test.go
+++ b/tlstest/mtls_internal/backup/encryption/backup_test.go
@@ -306,7 +306,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	testutil.KeyFile = "../../../../ee/enc/test-fixtures/enc-key"
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"--encryption-key-file", testutil.KeyFile, "--force_zero=false"}
+		"--encryption-key-file", testutil.KeyFile, "--force-zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/tlstest/mtls_internal/backup/filesystem/backup_test.go
+++ b/tlstest/mtls_internal/backup/filesystem/backup_test.go
@@ -77,9 +77,9 @@ func getHttpClient(t *testing.T) *http.Client {
 
 func TestBackupFilesystem(t *testing.T) {
 	conf := viper.GetViper()
-	conf.Set("tls_cacert", "../../tls/live/ca.crt")
-	conf.Set("tls_internal_port_enabled", true)
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../../tls/live/ca.crt")
+	conf.Set("tls-internal-port-enabled", true)
+	conf.Set("tls-server-name", "alpha1")
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)
 

--- a/tlstest/mtls_internal/backup/minio-large/backup_test.go
+++ b/tlstest/mtls_internal/backup/minio-large/backup_test.go
@@ -77,9 +77,9 @@ func getHttpClient(t *testing.T) *http.Client {
 // Test to add a large database and verify backup and restore work as expected.
 func TestBackupMinioLarge(t *testing.T) {
 	conf := viper.GetViper()
-	conf.Set("tls_cacert", "../../tls/live/ca.crt")
-	conf.Set("tls_internal_port_enabled", true)
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../../tls/live/ca.crt")
+	conf.Set("tls-internal-port-enabled", true)
+	conf.Set("tls-server-name", "alpha1")
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/tlstest/mtls_internal/backup/minio/backup_test.go
+++ b/tlstest/mtls_internal/backup/minio/backup_test.go
@@ -75,9 +75,9 @@ func getHttpClient(t *testing.T) *http.Client {
 
 func TestBackupMinioMtls(t *testing.T) {
 	conf := viper.GetViper()
-	conf.Set("tls_cacert", "../../tls/live/ca.crt")
-	conf.Set("tls_internal_port_enabled", true)
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../../tls/live/ca.crt")
+	conf.Set("tls-internal-port-enabled", true)
+	conf.Set("tls-server-name", "alpha1")
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)
 

--- a/tlstest/mtls_internal/backup/minio/backup_test.go
+++ b/tlstest/mtls_internal/backup/minio/backup_test.go
@@ -323,7 +323,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	t.Logf("--- Restoring from: %q", localBackupDst)
 	argv := []string{"dgraph", "restore", "-l", localBackupDst, "-p", "data/restore",
-		"--force_zero=false"}
+		"--force-zero=false"}
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	err = testutil.ExecWithOpts(argv, testutil.CmdOpts{Dir: cwd})

--- a/tlstest/mtls_internal/loader/loader_test.go
+++ b/tlstest/mtls_internal/loader/loader_test.go
@@ -18,12 +18,13 @@ package main
 
 import (
 	"context"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 
 	"github.com/stretchr/testify/require"
 
@@ -35,9 +36,9 @@ import (
 // TestLoaderXidmap checks that live loader re-uses xidmap on loading data from two different files
 func TestLoaderXidmap(t *testing.T) {
 	conf := viper.GetViper()
-	conf.Set("tls_cacert", "../tls/live/ca.crt")
-	conf.Set("tls_internal_port_enabled", true)
-	conf.Set("tls_server_name", "alpha1")
+	conf.Set("tls-cacert", "../tls/live/ca.crt")
+	conf.Set("tls-internal-port-enabled", true)
+	conf.Set("tls-server-name", "alpha1")
 	dg, err := testutil.DgraphClientWithCerts(testutil.SockAddr, conf)
 	require.NoError(t, err)
 	ctx := context.Background()

--- a/tlstest/mtls_internal/loader/loader_test.go
+++ b/tlstest/mtls_internal/loader/loader_test.go
@@ -56,11 +56,11 @@ func TestLoaderXidmap(t *testing.T) {
 		"--files", data,
 		"--alpha", testutil.SockAddr,
 		"--zero", testutil.SockAddrZero,
-		"--tls_cacert", tlsDir + "/ca.crt",
-		"--tls_internal_port_enabled=true",
-		"--tls_cert", tlsDir + "/client.liveclient.crt",
-		"--tls_key", tlsDir + "/client.liveclient.key",
-		"--tls_server_name", "alpha1",
+		"--tls-cacert", tlsDir + "/ca.crt",
+		"--tls-internal-port-enabled=true",
+		"--tls-cert", tlsDir + "/client.liveclient.crt",
+		"--tls-key", tlsDir + "/client.liveclient.key",
+		"--tls-server-name", "alpha1",
 		"-x", "x"}, testutil.CmdOpts{Dir: tmpDir})
 	require.NoError(t, err)
 
@@ -71,11 +71,11 @@ func TestLoaderXidmap(t *testing.T) {
 		"--files", data,
 		"--alpha", testutil.SockAddr,
 		"--zero", testutil.SockAddrZero,
-		"--tls_cacert", tlsDir + "/ca.crt",
-		"--tls_internal_port_enabled=true",
-		"--tls_cert", tlsDir + "/client.liveclient.crt",
-		"--tls_key", tlsDir + "/client.liveclient.key",
-		"--tls_server_name", "alpha1",
+		"--tls-cacert", tlsDir + "/ca.crt",
+		"--tls-internal-port-enabled=true",
+		"--tls-cert", tlsDir + "/client.liveclient.crt",
+		"--tls-key", tlsDir + "/client.liveclient.key",
+		"--tls-server-name", "alpha1",
 		"-x", "x"}, testutil.CmdOpts{Dir: tmpDir})
 	require.NoError(t, err)
 

--- a/upgrade/change_v20.07.0.go
+++ b/upgrade/change_v20.07.0.go
@@ -91,7 +91,7 @@ type updateTypeNameInfo struct {
 }
 
 func upgradeAclTypeNames() error {
-	deleteOld := Upgrade.Conf.GetBool("deleteOld")
+	deleteOld := Upgrade.Conf.GetBool("delete-old")
 	// prepare upgrade info for ACL type names
 	aclTypeNameInfo := []*updateTypeNameInfo{
 		{

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -46,7 +46,7 @@ const (
 	alpha     = "alpha"
 	user      = "user"
 	password  = "password"
-	deleteOld = "deleteOld"
+	deleteOld = "delete-old"
 	from      = "from"
 	to        = "to"
 

--- a/worker/file_handler.go
+++ b/worker/file_handler.go
@@ -42,7 +42,7 @@ type fileHandler struct {
 }
 
 // BackupExporter is an alias of fileHandler so that this struct can be used
-// by the export_backup command.
+// by the export-backup command.
 type BackupExporter struct {
 	fileHandler
 }

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -266,22 +266,22 @@ func getEncConfig(req *pb.RestoreRequest) (*viper.Viper, error) {
 	}
 
 	// Copy from the request.
-	config.Set("encryption_key_file", req.EncryptionKeyFile)
-	config.Set("vault_roleid_file", req.VaultRoleidFile)
-	config.Set("vault_secretid_file", req.VaultSecretidFile)
+	config.Set("encryption-key-file", req.EncryptionKeyFile)
+	config.Set("vault-roleid-file", req.VaultRoleidFile)
+	config.Set("vault-secretid-file", req.VaultSecretidFile)
 
 	// Override only if non-nil
 	if req.VaultAddr != "" {
-		config.Set("vault_addr", req.VaultAddr)
+		config.Set("vault-addr", req.VaultAddr)
 	}
 	if req.VaultPath != "" {
-		config.Set("vault_path", req.VaultPath)
+		config.Set("vault-path", req.VaultPath)
 	}
 	if req.VaultField != "" {
-		config.Set("vault_field", req.VaultField)
+		config.Set("vault-field", req.VaultField)
 	}
 	if req.VaultFormat != "" {
-		config.Set("vault_format", req.VaultField)
+		config.Set("vault-format", req.VaultField)
 	}
 	return config, nil
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -133,11 +133,11 @@ func BlockingStop() {
 	workerServer.Stop()
 }
 
-// UpdateCacheMb updates the value of cache_mb and updates the corresponding cache sizes.
+// UpdateCacheMb updates the value of cache-mb and updates the corresponding cache sizes.
 func UpdateCacheMb(memoryMB int64) error {
 	glog.Infof("Updating cacheMb to %d", memoryMB)
 	if memoryMB < 0 {
-		return errors.Errorf("cache_mb must be non-negative")
+		return errors.Errorf("cache-mb must be non-negative")
 	}
 
 	cachePercent, err := x.GetCachePercentages(Config.CachePercentage, 4)

--- a/x/flags.go
+++ b/x/flags.go
@@ -45,11 +45,11 @@ func FillCommonFlags(flag *pflag.FlagSet) {
 		`)
 
 	// Cache flags.
-	flag.Int64("cache_mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
+	flag.Int64("cache-mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
 
 	// Telemetry.
 	flag.Bool("telemetry", true, "Send anonymous telemetry data to Dgraph devs.")
-	flag.Bool("enable_sentry", true, "Turn on/off sending crash events to Sentry.")
+	flag.Bool("enable-sentry", true, "Turn on/off sending crash events to Sentry.")
 }
 
 // NormalizeFlags normalizes underscores in flags to hyphens.

--- a/x/flags.go
+++ b/x/flags.go
@@ -16,7 +16,11 @@
 
 package x
 
-import "github.com/spf13/pflag"
+import (
+	"strings"
+
+	"github.com/spf13/pflag"
+)
 
 // FillCommonFlags stores flags common to Alpha and Zero.
 func FillCommonFlags(flag *pflag.FlagSet) {
@@ -46,4 +50,9 @@ func FillCommonFlags(flag *pflag.FlagSet) {
 	// Telemetry.
 	flag.Bool("telemetry", true, "Send anonymous telemetry data to Dgraph devs.")
 	flag.Bool("enable_sentry", true, "Turn on/off sending crash events to Sentry.")
+}
+
+// NormalizeFlags normalizes underscores in flags to hyphens.
+func NormalizeFlags(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	return pflag.NormalizedName(strings.ReplaceAll(name, "_", "-"))
 }

--- a/x/profile.go
+++ b/x/profile.go
@@ -32,7 +32,7 @@ type Stopper interface {
 
 // StartProfile starts a new mode for profiling.
 func StartProfile(conf *viper.Viper) Stopper {
-	profileMode := conf.GetString("profile_mode")
+	profileMode := conf.GetString("profile-mode")
 	switch profileMode {
 	case "cpu":
 		return profile.Start(profile.CPUProfile)
@@ -41,7 +41,7 @@ func StartProfile(conf *viper.Viper) Stopper {
 	case "mutex":
 		return profile.Start(profile.MutexProfile)
 	case "block":
-		blockRate := conf.GetInt("block_rate")
+		blockRate := conf.GetInt("block-rate")
 		runtime.SetBlockProfileRate(blockRate)
 		return profile.Start(profile.BlockProfile)
 	case "":

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -47,7 +47,7 @@ const (
 func SentryOptOutNote() {
 	glog.Infof("This instance of Dgraph will send anonymous reports of panics back " +
 		"to Dgraph Labs via Sentry. No confidential information is sent. These reports " +
-		"help improve Dgraph. To opt-out, restart your instance with the --enable_sentry=false " +
+		"help improve Dgraph. To opt-out, restart your instance with the --enable-sentry=false " +
 		"flag. For more info, see https://dgraph.io/docs/howto/#data-handling.")
 }
 

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -143,7 +143,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		return SlashTLSConfig(v.GetString("slash-grpc-endpoint"))
 	}
 
-	// When the --tls_cacert option is pecified, the connection will be set up using TLS instead of
+	// When the --tls-cacert option is pecified, the connection will be set up using TLS instead of
 	// plaintext. However the client cert files are optional, depending on whether the server
 	// requires a client certificate.
 	caCert := v.GetString("tls-cacert")

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -40,68 +40,68 @@ type TLSHelperConfig struct {
 
 // RegisterServerTLSFlags registers the required flags to set up a TLS server.
 func RegisterServerTLSFlags(flag *pflag.FlagSet) {
-	flag.String("tls_cacert", "",
+	flag.String("tls-cacert", "",
 		"The CA Cert file used to initiate server certificates. Required for enabling TLS.")
-	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
-	flag.String("tls_client_auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
-	flag.String("tls_node_cert", "", "The node Cert file which is needed to "+
+	flag.Bool("tls-use-system-ca", true, "Include System CA into CA Certs.")
+	flag.String("tls-client-auth", "VERIFYIFGIVEN", "Enable TLS client authentication")
+	flag.String("tls-node-cert", "", "The node Cert file which is needed to "+
 		"initiate server in the cluster.")
-	flag.String("tls_node_key", "", "The node key file "+
+	flag.String("tls-node-key", "", "The node key file "+
 		"which is needed to initiate server in the cluster.")
-	flag.Bool("tls_internal_port_enabled", false,
+	flag.Bool("tls-internal-port-enabled", false,
 		"(optional) enable inter node TLS encryption between cluster nodes.")
-	flag.String("tls_cert", "", "(optional) The client Cert file which is needed to "+
+	flag.String("tls-cert", "", "(optional) The client Cert file which is needed to "+
 		"connect as a client with the other nodes in the cluster.")
-	flag.String("tls_key", "", "(optional) The private client key file "+
+	flag.String("tls-key", "", "(optional) The private client key file "+
 		"which is needed to connect as a client with the other nodes in the cluster.")
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
 func RegisterClientTLSFlags(flag *pflag.FlagSet) {
-	flag.String("tls_cacert", "",
+	flag.String("tls-cacert", "",
 		"The CA Cert file used to verify server certificates. Required for enabling TLS.")
-	flag.Bool("tls_use_system_ca", true, "Include System CA into CA Certs.")
-	flag.String("tls_server_name", "", "Used to verify the server hostname.")
-	flag.String("tls_cert", "", "(optional) The Cert file provided by the client to the server.")
-	flag.String("tls_key", "", "(optional) The private key file "+
+	flag.Bool("tls-use-system-ca", true, "Include System CA into CA Certs.")
+	flag.String("tls-server-name", "", "Used to verify the server hostname.")
+	flag.String("tls-cert", "", "(optional) The Cert file provided by the client to the server.")
+	flag.String("tls-key", "", "(optional) The private key file "+
 		"provided by the client to the server.")
-	flag.Bool("tls_internal_port_enabled", false, "enable inter node TLS encryption between cluster nodes.")
+	flag.Bool("tls-internal-port-enabled", false, "enable inter node TLS encryption between cluster nodes.")
 }
 
 // LoadClientTLSConfigForInternalPort loads tls config for connecting to internal ports of cluster
 func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	if !v.GetBool("tls_internal_port_enabled") {
+	if !v.GetBool("tls-internal-port-enabled") {
 		return nil, nil
 	}
-	if v.GetString("tls_cert") == "" || v.GetString("tls_key") == "" {
+	if v.GetString("tls-cert") == "" || v.GetString("tls-key") == "" {
 		return nil, errors.Errorf("inter node tls is enabled but client certs are not provided. " +
 			"Intern Node TLS is always client authenticated. Please provide --tls_cert and --tls_key")
 	}
 
 	conf := &TLSHelperConfig{}
-	conf.UseSystemCACerts = v.GetBool("tls_use_system_ca")
-	conf.RootCACert = v.GetString("tls_cacert")
+	conf.UseSystemCACerts = v.GetBool("tls-use-system-ca")
+	conf.RootCACert = v.GetString("tls-cacert")
 	conf.CertRequired = true
-	conf.Cert = v.GetString("tls_cert")
-	conf.Key = v.GetString("tls_key")
+	conf.Cert = v.GetString("tls-cert")
+	conf.Key = v.GetString("tls-key")
 	return GenerateClientTLSConfig(conf)
 }
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
 func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	if !v.GetBool("tls_internal_port_enabled") {
+	if !v.GetBool("tls-internal-port-enabled") {
 		return nil, nil
 	}
-	if v.GetString("tls_node_cert") == "" || v.GetString("tls_node_key") == "" {
+	if v.GetString("tls-node-cert") == "" || v.GetString("tls-node-key") == "" {
 		return nil, errors.Errorf("inter node tls is enabled but server node certs are not provided. " +
 			"Please provide --tls_node_cert and --tls_node_key")
 	}
 	conf := TLSHelperConfig{}
-	conf.UseSystemCACerts = v.GetBool("tls_use_system_ca")
-	conf.RootCACert = v.GetString("tls_cacert")
+	conf.UseSystemCACerts = v.GetBool("tls-use-system-ca")
+	conf.RootCACert = v.GetString("tls-cacert")
 	conf.CertRequired = true
-	conf.Cert = v.GetString("tls_node_cert")
-	conf.Key = v.GetString("tls_node_key")
+	conf.Cert = v.GetString("tls-node-cert")
+	conf.Key = v.GetString("tls-node-key")
 	conf.ClientAuth = "REQUIREANDVERIFY"
 	return GenerateServerTLSConfig(&conf)
 
@@ -109,17 +109,17 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	if v.GetString("tls_node_cert") == "" && v.GetString("tls_node_key") == "" {
+	if v.GetString("tls-node-cert") == "" && v.GetString("tls-node-key") == "" {
 		return nil, nil
 	}
 
 	conf := TLSHelperConfig{}
-	conf.RootCACert = v.GetString("tls_cacert")
+	conf.RootCACert = v.GetString("tls-cacert")
 	conf.CertRequired = true
-	conf.Cert = v.GetString("tls_node_cert")
-	conf.Key = v.GetString("tls_node_key")
-	conf.ClientAuth = v.GetString("tls_client_auth")
-	conf.UseSystemCACerts = v.GetBool("tls_use_system_ca")
+	conf.Cert = v.GetString("tls-node-cert")
+	conf.Key = v.GetString("tls-node-key")
+	conf.ClientAuth = v.GetString("tls-client-auth")
+	conf.UseSystemCACerts = v.GetBool("tls-use-system-ca")
 	return GenerateServerTLSConfig(&conf)
 }
 
@@ -139,30 +139,30 @@ func SlashTLSConfig(endpoint string) (*tls.Config, error) {
 
 // LoadClientTLSConfig loads the TLS config into the client with the given parameters.
 func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	if v.GetString("slash_grpc_endpoint") != "" {
-		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
+	if v.GetString("slash-grpc-endpoint") != "" {
+		return SlashTLSConfig(v.GetString("slash-grpc-endpoint"))
 	}
 
 	// When the --tls_cacert option is pecified, the connection will be set up using TLS instead of
 	// plaintext. However the client cert files are optional, depending on whether the server
 	// requires a client certificate.
-	caCert := v.GetString("tls_cacert")
+	caCert := v.GetString("tls-cacert")
 	if caCert != "" {
 		tlsCfg := tls.Config{}
 
 		// 1. set up the root CA
-		pool, err := generateCertPool(caCert, v.GetBool("tls_use_system_ca"))
+		pool, err := generateCertPool(caCert, v.GetBool("tls-use-system-ca"))
 		if err != nil {
 			return nil, err
 		}
 		tlsCfg.RootCAs = pool
 
 		// 2. set up the server name for verification
-		tlsCfg.ServerName = v.GetString("tls_server_name")
+		tlsCfg.ServerName = v.GetString("tls-server-name")
 
 		// 3. optionally load the client cert files
-		certFile := v.GetString("tls_cert")
-		keyFile := v.GetString("tls_key")
+		certFile := v.GetString("tls-cert")
+		keyFile := v.GetString("tls-key")
 		if certFile != "" && keyFile != "" {
 			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 			if err != nil {
@@ -176,10 +176,10 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	// Attempt to determine if user specified *any* TLS option. Unfortunately and contrary to
 	// Viper's own documentation, there's no way to tell whether an option value came from a
 	// command-line option or a built-it default.
-	if v.GetString("tls_server_name") != "" ||
-		v.GetString("tls_cert") != "" ||
-		v.GetString("tls_key") != "" {
-		return nil, errors.Errorf("--tls_cacert is required for enabling TLS")
+	if v.GetString("tls-server-name") != "" ||
+		v.GetString("tls-cert") != "" ||
+		v.GetString("tls-key") != "" {
+		return nil, errors.Errorf("--tls-cacert is required for enabling TLS")
 	}
 	return nil, nil
 }

--- a/x/x.go
+++ b/x/x.go
@@ -873,15 +873,15 @@ func WithAuthorizationCredentials(authToken string) grpc.DialOption {
 }
 
 // GetDgraphClient creates a Dgraph client based on the following options in the configuration:
-// --slash_grpc_endpoint specifies the grpc endpoint for slash. It takes precedence over --alpha and TLS
+// --slash-grpc-endpoint specifies the grpc endpoint for slash. It takes precedence over --alpha and TLS
 // --alpha specifies a comma separated list of endpoints to connect to
-// --tls_cacert, --tls_cert, --tls_key etc specify the TLS configuration of the connection
+// --tls-cacert, --tls-cert, --tls-key etc specify the TLS configuration of the connection
 // --retries specifies how many times we should retry the connection to each endpoint upon failures
 // --user and --password specify the credentials we should use to login with the server
 func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 	var alphas string
-	if conf.GetString("slash_grpc_endpoint") != "" {
-		alphas = conf.GetString("slash_grpc_endpoint")
+	if conf.GetString("slash-grpc-endpoint") != "" {
+		alphas = conf.GetString("slash-grpc-endpoint")
 	} else {
 		alphas = conf.GetString("alpha")
 	}
@@ -907,8 +907,8 @@ func GetDgraphClient(conf *viper.Viper, login bool) (*dgo.Dgraph, CloseFunc) {
 	}
 
 	dialOpts := []grpc.DialOption{}
-	if conf.GetString("slash_grpc_endpoint") != "" && conf.IsSet("auth_token") {
-		dialOpts = append(dialOpts, WithAuthorizationCredentials(conf.GetString("auth_token")))
+	if conf.GetString("slash-grpc-endpoint") != "" && conf.IsSet("auth-token") {
+		dialOpts = append(dialOpts, WithAuthorizationCredentials(conf.GetString("auth-token")))
 	}
 
 	for _, d := range ds {


### PR DESCRIPTION
This PR changes command line arguments in Dgraph and compose to match POSIX conventions. Long arguments were earlier written as `--snake_case`, but this has now been changed to `--kebab-case`.

Almost everything here is backward compatible - I've added a flag normalization function that converts underscores to hyphens. The only breaking changes are to subcommands that were in `snake_case`, and flags that were in `camelCase`.

Fixes DGRAPH-2703.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6908)
<!-- Reviewable:end -->
