### PR TITLE
fix ErrIndexingInProgress if schema update fails (#6583)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -428,6 +428,7 @@ func Load(predicate string) error {
 	if len(predicate) == 0 {
 		return errors.Errorf("Empty predicate")
 	}
+	delete(State().mutSchema, predicate)
 	key := x.SchemaKey(predicate)
 	txn := pstore.NewTransactionAt(1, false)
 	defer txn.Discard()
@@ -448,7 +449,6 @@ func Load(predicate string) error {
 	}
 	State().Set(predicate, &s)
 	State().elog.Printf(logUpdate(&s, predicate))
-	delete(State().mutSchema, predicate)
 	glog.Infoln(logUpdate(&s, predicate))
 	return nil
 }


### PR DESCRIPTION
If index building fails for some reason after starting building indexes, no new schema mutations
can take place. It throws out errIndexingInProgress error. This is because though the schema
update has failed, the predicate remains in the mutSchema. It should be deleted from the map.

(cherry picked from commit 1c7429d75eb79478cd76c8070e594909ba9bac2a)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6912)
<!-- Reviewable:end -->
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-ed2ef08c8f-109602.surge.sh)
<!-- Dgraph:end -->