### PR TITLE
Fix(GraphQL): Fix failing auth tests

### DIFF
--- a/graphql/e2e/auth/add_mutation_test.go
+++ b/graphql/e2e/auth/add_mutation_test.go
@@ -159,6 +159,7 @@ func TestAuth_AddOnTypeWithRBACRuleOnInterface(t *testing.T) {
 		role: "ADMIN",
 		variables: map[string]interface{}{"fbpost": &FbPost{
 			Text: "New FbPost",
+			Pwd:  "password",
 			Author: &Author{
 				Name: "user1@dgraph.io",
 			},
@@ -177,6 +178,7 @@ func TestAuth_AddOnTypeWithRBACRuleOnInterface(t *testing.T) {
 		role: "USER",
 		variables: map[string]interface{}{"fbpost": &FbPost{
 			Text: "New FbPost",
+			Pwd:  "password",
 			Author: &Author{
 				Name: "user1@dgraph.io",
 			},
@@ -264,6 +266,7 @@ func TestAuth_AddOnTypeWithGraphTraversalRuleOnInterface(t *testing.T) {
 		ans:  true,
 		variables: map[string]interface{}{"question": &Question{
 			Text: "A Question",
+			Pwd:  "password",
 			Author: &Author{
 				Name: "user1@dgraph.io",
 			},
@@ -275,6 +278,7 @@ func TestAuth_AddOnTypeWithGraphTraversalRuleOnInterface(t *testing.T) {
 		ans:  false,
 		variables: map[string]interface{}{"question": &Question{
 			Text: "A Question",
+			Pwd:  "password",
 			Author: &Author{
 				Name: "user1",
 			},
@@ -287,6 +291,7 @@ func TestAuth_AddOnTypeWithGraphTraversalRuleOnInterface(t *testing.T) {
 			ans:  true,
 			variables: map[string]interface{}{"question": &Question{
 				Text: "A Question",
+				Pwd:  "password",
 				Author: &Author{
 					Name: "user1",
 				},
@@ -361,6 +366,7 @@ func TestAddDeepFilter(t *testing.T) {
 			Name: "column_add_1",
 			InProject: &Project{
 				Name: "project_add_1",
+				Pwd:  "password1",
 			},
 		}},
 	}, {
@@ -372,10 +378,12 @@ func TestAddDeepFilter(t *testing.T) {
 			Name: "column_add_2",
 			InProject: &Project{
 				Name: "project_add_2",
+				Pwd:  "password2",
 				Roles: []*Role{{
 					Permission: "ADMIN",
 					AssignedTo: []*common.User{{
 						Username: "user2",
+						Password: "password",
 					}},
 				}},
 			},
@@ -388,15 +396,18 @@ func TestAddDeepFilter(t *testing.T) {
 			Name: "column_add_3",
 			InProject: &Project{
 				Name: "project_add_4",
+				Pwd:  "password4",
 				Roles: []*Role{{
 					Permission: "ADMIN",
 					AssignedTo: []*common.User{{
 						Username: "user6",
+						Password: "password",
 					}},
 				}, {
 					Permission: "VIEW",
 					AssignedTo: []*common.User{{
 						Username: "user6",
+						Password: "password",
 					}},
 				}},
 			},
@@ -468,6 +479,7 @@ func TestAddOrRBACFilter(t *testing.T) {
 		result: `{"addProject": {"project":[{"name":"project_add_1"}]}}`,
 		variables: map[string]interface{}{"project": &Project{
 			Name: "project_add_1",
+			Pwd:  "password1",
 		}},
 	}, {
 		// Test case fails as the role isn't assigned to the correct user
@@ -476,10 +488,12 @@ func TestAddOrRBACFilter(t *testing.T) {
 		result: ``,
 		variables: map[string]interface{}{"project": &Project{
 			Name: "project_add_2",
+			Pwd:  "password2",
 			Roles: []*Role{{
 				Permission: "ADMIN",
 				AssignedTo: []*common.User{{
 					Username: "user2",
+					Password: "password",
 				}},
 			}},
 		}},
@@ -489,15 +503,18 @@ func TestAddOrRBACFilter(t *testing.T) {
 		result: `{"addProject": {"project":[{"name":"project_add_3"}]}}`,
 		variables: map[string]interface{}{"project": &Project{
 			Name: "project_add_3",
+			Pwd:  "password3",
 			Roles: []*Role{{
 				Permission: "ADMIN",
 				AssignedTo: []*common.User{{
 					Username: "user7",
+					Password: "password",
 				}},
 			}, {
 				Permission: "VIEW",
 				AssignedTo: []*common.User{{
 					Username: "user7",
+					Password: "password",
 				}},
 			}},
 		}},
@@ -817,6 +834,7 @@ func TestAddRBACFilter(t *testing.T) {
 		result: `{"addLog": {"log":[{"logs":"log_add_1"}]}}`,
 		variables: map[string]interface{}{"issue": &Log{
 			Logs: "log_add_1",
+			Pwd:  "password1",
 		}},
 	}, {
 		user:   "user1",
@@ -824,6 +842,7 @@ func TestAddRBACFilter(t *testing.T) {
 		result: ``,
 		variables: map[string]interface{}{"issue": &Log{
 			Logs: "log_add_2",
+			Pwd:  "password2",
 		}},
 	}}
 

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -78,6 +78,7 @@ type Question struct {
 	Text     string  `json:"text,omitempty"`
 	Answered bool    `json:"answered,omitempty"`
 	Author   *Author `json:"author,omitempty"`
+	Pwd      string  `json:"pwd,omitempty"`
 }
 
 type Answer struct {
@@ -93,6 +94,7 @@ type FbPost struct {
 	Sender    *Author `json:"sender,omitempty"`
 	Receiver  *Author `json:"receiver,omitempty"`
 	PostCount int     `json:"postCount,omitempty"`
+	Pwd       string  `json:"pwd,omitempty"`
 }
 
 type Log struct {
@@ -133,6 +135,7 @@ type Project struct {
 	Name    string    `json:"name,omitempty"`
 	Roles   []*Role   `json:"roles,omitempty"`
 	Columns []*Column `json:"columns,omitempty"`
+	Pwd     string    `json:"pwd,omitempty"`
 }
 
 type Student struct {

--- a/graphql/e2e/auth/delete_mutation_test.go
+++ b/graphql/e2e/auth/delete_mutation_test.go
@@ -29,13 +29,13 @@ func (l *Log) add(t *testing.T, user, role string) {
 	getParams := &common.GraphQLParams{
 		Headers: common.GetJWT(t, user, role, metaInfo),
 		Query: `
-		mutation addLog($log: AddLogInput!) {
-		  addLog(input: [$log]) {
+		mutation addLog($pwd: String!, $logs: String, $random: String) {
+		  addLog(input: [{pwd: $pwd, logs: $logs, random: $random}]) {
 			numUids
 		  }
 		}
 		`,
-		Variables: map[string]interface{}{"log": l},
+		Variables: map[string]interface{}{"pwd": "password", "logs": l.Logs, "random": l.Random},
 	}
 	gqlResponse := getParams.ExecuteAsPost(t, graphqlURL)
 	require.Nil(t, gqlResponse.Errors)
@@ -93,13 +93,13 @@ func (q *Question) add(t *testing.T, user string, ans bool) {
 	getParams := &common.GraphQLParams{
 		Headers: common.GetJWTForInterfaceAuth(t, user, "", ans, metaInfo),
 		Query: `
-		mutation addQuestion($text: String!,$id: ID!, $ans: Boolean ){
-			addQuestion(input: [{text: $text, author: {id: $id}, answered: $ans }]){
+		mutation addQuestion($text: String!,$id: ID!, $ans: Boolean, $pwd: String! ){
+			addQuestion(input: [{text: $text, author: {id: $id}, answered: $ans, pwd: $pwd }]){
 			  numUids
 			}
 		  }
 		`,
-		Variables: map[string]interface{}{"text": q.Text, "ans": q.Answered, "id": q.Author.Id},
+		Variables: map[string]interface{}{"text": q.Text, "ans": q.Answered, "id": q.Author.Id, "pwd": "password"},
 	}
 	gqlResponse := getParams.ExecuteAsPost(t, graphqlURL)
 	require.Nil(t, gqlResponse.Errors)
@@ -109,13 +109,13 @@ func (a *Answer) add(t *testing.T, user string) {
 	getParams := &common.GraphQLParams{
 		Headers: common.GetJWT(t, user, "", metaInfo),
 		Query: `
-		mutation addAnswer($text: String!,$id: ID!){
-			addAnswer(input: [{text: $text, author: {id: $id}}]){
+		mutation addAnswer($text: String!,$id: ID!, $pwd: String!){
+			addAnswer(input: [{text: $text, pwd: $pwd, author: {id: $id}}]){
 			  numUids
 			}
 		  }
 		`,
-		Variables: map[string]interface{}{"text": a.Text, "id": a.Author.Id},
+		Variables: map[string]interface{}{"text": a.Text, "id": a.Author.Id, "pwd": "password"},
 	}
 	gqlResponse := getParams.ExecuteAsPost(t, graphqlURL)
 	require.Nil(t, gqlResponse.Errors)
@@ -125,13 +125,13 @@ func (f *FbPost) add(t *testing.T, user, role string) {
 	getParams := &common.GraphQLParams{
 		Headers: common.GetJWT(t, user, role, metaInfo),
 		Query: `
-		mutation addFbPost($text: String!,$id1: ID!,$id2:ID!, $id3: ID!, $postCount: Int! ){
-			addFbPost(input: [{text: $text, author: {id: $id1},sender: {id: $id2}, receiver: {id: $id3}, postCount: $postCount }]){
+		mutation addFbPost($text: String!,$id1: ID!,$id2:ID!, $id3: ID!, $postCount: Int!, $pwd: String! ){
+			addFbPost(input: [{text: $text, author: {id: $id1},sender: {id: $id2}, receiver: {id: $id3}, postCount: $postCount, pwd: $pwd }]){
 			  numUids
 			}
 		  }
 		`,
-		Variables: map[string]interface{}{"text": f.Text, "id1": f.Author.Id, "id2": f.Sender.Id, "id3": f.Receiver.Id, "postCount": f.PostCount},
+		Variables: map[string]interface{}{"text": f.Text, "id1": f.Author.Id, "id2": f.Sender.Id, "id3": f.Receiver.Id, "postCount": f.PostCount, "pwd": "password"},
 	}
 	gqlResponse := getParams.ExecuteAsPost(t, graphqlURL)
 	require.Nil(t, gqlResponse.Errors)


### PR DESCRIPTION
Motivation:
Recently, the PR, https://github.com/dgraph-io/dgraph/pull/6907 was pushed to master which resulted in failure of auth tests. This PR fixes those failing tests.
Testing:
Tested Manually.
rajas@rajas-ThinkPad-T490:~/Github/dgraph/graphql/e2e/auth|master⚡ ⇒  go test
[Decoder]: Using assembly version of decoder
testutil: "" localhost:9080 localhost:5080
PASS
PASS
ok  	github.com/dgraph-io/dgraph/graphql/e2e/auth	43.578s


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6923)
<!-- Reviewable:end -->
