### PR TITLE
perf(xidmap): Use btree with hash of keys for xidmap (#6902)

### DIFF
--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -19,7 +19,6 @@ package xidmap
 import (
 	"context"
 	"encoding/binary"
-	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -28,11 +27,10 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/badger/v2"
-	"github.com/dgraph-io/badger/v2/skl"
-	"github.com/dgraph-io/badger/v2/y"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/dgryski/go-farm"
 	"github.com/golang/glog"
 )
 
@@ -47,17 +45,25 @@ type XidMap struct {
 
 	// Optionally, these can be set to persist the mappings.
 	writer *badger.WriteBatch
+	wg     sync.WaitGroup
+
+	kvBuf  []kv
+	kvChan chan []kv
 }
 
 type shard struct {
 	sync.RWMutex
 	block
 
-	skiplist *skl.Skiplist
+	tree *z.Tree
 }
 
 type block struct {
 	start, end uint64
+}
+
+type kv struct {
+	key, value []byte
 }
 
 // assign assumes the write lock is already acquired.
@@ -80,17 +86,22 @@ func New(zero *grpc.ClientConn, db *badger.DB) *XidMap {
 	xm := &XidMap{
 		newRanges: make(chan *pb.AssignedIds, numShards),
 		shards:    make([]*shard, numShards),
+		kvChan:    make(chan []kv, 64),
 	}
 	for i := range xm.shards {
-		buf, err := z.NewBufferWith(math.MaxUint32, math.MaxUint32, z.UseMmap)
-		x.Check(err)
 		xm.shards[i] = &shard{
-			skiplist: skl.NewSkiplistWithBuffer(buf, false),
+			tree: z.NewTree("", 100<<20),
 		}
 	}
+
 	if db != nil {
 		// If DB is provided, let's load up all the xid -> uid mappings in memory.
 		xm.writer = db.NewWriteBatch()
+
+		for i := 0; i < 16; i++ {
+			xm.wg.Add(1)
+			go xm.dbWriter()
+		}
 
 		err := db.View(func(txn *badger.Txn) error {
 			var count int
@@ -105,7 +116,7 @@ func New(zero *grpc.ClientConn, db *badger.DB) *XidMap {
 				err := item.Value(func(val []byte) error {
 					uid := binary.BigEndian.Uint64(val)
 					// No need to acquire a lock. This is all serial access.
-					sh.skiplist.PutUint64([]byte(key), uid)
+					sh.tree.Set(farm.Fingerprint64([]byte(key)), uid)
 					return nil
 				})
 				if err != nil {
@@ -156,7 +167,7 @@ func (m *XidMap) CheckUid(xid string) bool {
 	sh := m.shardFor(xid)
 	sh.RLock()
 	defer sh.RUnlock()
-	uid, _ := sh.skiplist.GetUint64([]byte(xid))
+	uid := sh.tree.Get(farm.Fingerprint64([]byte(xid)))
 	return uid != 0
 }
 
@@ -164,7 +175,16 @@ func (m *XidMap) SetUid(xid string, uid uint64) {
 	sh := m.shardFor(xid)
 	sh.Lock()
 	defer sh.Unlock()
-	sh.skiplist.PutUint64([]byte(xid), uid)
+	sh.tree.Set(farm.Fingerprint64([]byte(xid)), uid)
+}
+
+func (m *XidMap) dbWriter() {
+	defer m.wg.Done()
+	for buf := range m.kvChan {
+		for _, kv := range buf {
+			x.Panic(m.writer.Set(kv.key, kv.value))
+		}
+	}
 }
 
 // AssignUid creates new or looks up existing XID to UID mappings. It also returns if
@@ -172,7 +192,8 @@ func (m *XidMap) SetUid(xid string, uid uint64) {
 func (m *XidMap) AssignUid(xid string) (uint64, bool) {
 	sh := m.shardFor(xid)
 	sh.RLock()
-	uid, _ := sh.skiplist.GetUint64([]byte(xid))
+
+	uid := sh.tree.Get(farm.Fingerprint64([]byte(xid)))
 	sh.RUnlock()
 	if uid > 0 {
 		return uid, false
@@ -181,13 +202,24 @@ func (m *XidMap) AssignUid(xid string) (uint64, bool) {
 	sh.Lock()
 	defer sh.Unlock()
 
-	uid, _ = sh.skiplist.GetUint64([]byte(xid))
+	uid = sh.tree.Get(farm.Fingerprint64([]byte(xid)))
 	if uid > 0 {
 		return uid, false
 	}
 
 	newUid := sh.assign(m.newRanges)
-	sh.skiplist.PutUint64([]byte(xid), newUid)
+	sh.tree.Set(farm.Fingerprint64([]byte(xid)), newUid)
+
+	if m.writer != nil {
+		var uidBuf [8]byte
+		binary.BigEndian.PutUint64(uidBuf[:], newUid)
+		m.kvBuf = append(m.kvBuf, kv{key: []byte(xid), value: uidBuf[:]})
+
+		if len(m.kvBuf) == 64 {
+			m.kvChan <- m.kvBuf
+			m.kvBuf = make([]kv, 0, 64)
+		}
+	}
 
 	return newUid, true
 }
@@ -248,27 +280,13 @@ func (m *XidMap) Flush() error {
 		glog.Infof("Finished writing xid map to DB")
 	}()
 
+	if m.writer != nil && len(m.kvBuf) > 0 {
+		m.kvChan <- m.kvBuf
+	}
+	close(m.kvChan)
+	m.wg.Wait()
 	for _, shard := range m.shards {
-		var err error
-		if m.writer != nil {
-			shard.Lock()
-			it := shard.skiplist.NewIterator()
-			var uidBuf [8]byte
-			for it.SeekToFirst(); it.Valid(); it.Next() {
-				curKey := it.Key()
-				key := make([]byte, len(curKey))
-				copy(key, curKey)
-				binary.BigEndian.PutUint64(uidBuf[:], it.ValueUint64())
-				err = m.writer.Set(key, uidBuf[:])
-				y.Check(err)
-			}
-			it.Close()
-			shard.Unlock()
-		}
-		shard.skiplist.DecrRef()
-		if err != nil {
-			return err
-		}
+		shard.tree.Release()
 	}
 
 	if m.writer == nil {


### PR DESCRIPTION
Use B+ tree with the hash of xid in xidmap.

(cherry picked from commit 6a18d849909cdf6c93cff3e61e76a6ce20a53ce8)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6926)
<!-- Reviewable:end -->
