### PR TITLE
docs(metrics): Document dgraph_txn_aborts_total metric

### DIFF
--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -33,7 +33,7 @@ not interact directly with the filesystem. Instead it relies on
 Memory metrics let you track the memory usage of the Dgraph process. The idle
 and `inuse` metrics give you a better sense of the active memory usage of the
 Dgraph process. The process memory metric shows the memory usage as measured by
-the operating system.
+the operating system. 
 
 By looking at all three metrics you can see how much memory a Dgraph process is
 holding from the operating system and how much is actively in use.

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -15,7 +15,7 @@ Dgraph metrics follow the
 ## Disk metrics
 
 Disk metrics let you track the disk activity of the Dgraph process. Dgraph does
-not interact directly with the filesystem. Instead it relies on
+not interact directly with the filesystem. Instead, it relies on
 [Badger](https://github.com/dgraph-io/badger) to read from and write to disk.
 
  Metrics                          	 | Description
@@ -33,7 +33,7 @@ not interact directly with the filesystem. Instead it relies on
 Memory metrics let you track the memory usage of the Dgraph process. The idle
 and `inuse` metrics give you a better sense of the active memory usage of the
 Dgraph process. The process memory metric shows the memory usage as measured by
-the operating system. 
+the operating system.
 
 By looking at all three metrics you can see how much memory a Dgraph process is
 holding from the operating system and how much is actively in use.

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -14,9 +14,9 @@ Dgraph metrics follow the
 
 ## Disk metrics
 
-Disk metrics let you track the disk activity of the Dgraph process. Dgraph does not interact
-directly with the filesystem. Instead it relies on [Badger](https://github.com/dgraph-io/badger) to
-read from and write to disk.
+Disk metrics let you track the disk activity of the Dgraph process. Dgraph does
+not interact directly with the filesystem. Instead it relies on
+[Badger](https://github.com/dgraph-io/badger) to read from and write to disk.
 
  Metrics                          	 | Description
  -------                          	 | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -10,7 +10,8 @@ weight = 15
 Dgraph database provides metrics on disk activity, memory usage, Dgraph instance
 activity and server node health; along with built-in metrics provided by Go.
 Dgraph metrics follow the
-[metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
+[metric and label conventions for the Prometheus](https://prometheus.io/docs/practices/naming/)
+monitoring and alerting toolkit.
 
 ## Disk metrics
 

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -56,14 +56,8 @@ The activity metrics let you track the mutations, queries, and proposals of an D
 
 ## Health Metrics
 
-The health metrics let you track to check the health of a Dgraph Alpha server
-node, or transaction aborts across a Dgraph cluster.
-
- Metrics                          | Description
- -------                          | -----------
- `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha is ready to accept requests; otherwise 0.
- `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This will show the latest max assigned timestamp. All alphas (within the same alpha group) should show the same timestamp if they are in sync.
- `dgraph_txn_aborts_total`        | Shows the total number of transaction aborts that have occurred on the cluster.
+Health metrics let you check the health of a Dgraph Alpha server node, or track
+transaction aborts across a Dgraph cluster.
 
 ## Go Metrics
 

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -56,12 +56,14 @@ The activity metrics let you track the mutations, queries, and proposals of an D
 
 ## Health Metrics
 
-The health metrics let you track to check the availability of an Dgraph Alpha instance.
+The health metrics let you track to check the health of a Dgraph Alpha server
+node, or transaction aborts across a Dgraph cluster.
 
  Metrics                          | Description
  -------                          | -----------
  `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha is ready to accept requests; otherwise 0.
  `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This will show the latest max assigned timestamp. All alphas (within the same alpha group) should show the same timestamp if they are in sync.
+ `dgraph_txn_aborts_total`        | Shows the total number of transaction aborts that have occurred on the cluster.
 
 ## Go Metrics
 

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -8,7 +8,7 @@ weight = 15
 
 
 Dgraph database provides metrics on disk activity, memory usage, Dgraph instance activity
-and server node health - along with built-in metrics provided by Go. Dgraph metrics follow
+and server node health; along with built-in metrics provided by Go. Dgraph metrics follow
 the [metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
 
 ## Disk metrics

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -30,12 +30,13 @@ not interact directly with the filesystem. Instead it relies on
 
 ## Memory metrics
 
-Memory metrics let you track the memory usage of the Dgraph process. The idle and `inuse` metrics
-give you a better sense of the active memory usage of the Dgraph process. The process memory metric
-shows the memory usage as measured by the operating system.
+Memory metrics let you track the memory usage of the Dgraph process. The idle
+and `inuse` metrics give you a better sense of the active memory usage of the
+Dgraph process. The process memory metric shows the memory usage as measured by
+the operating system.
 
-By looking at all three metrics you can see how much memory a Dgraph process is holding from the
-operating system and how much is actively in use.
+By looking at all three metrics you can see how much memory a Dgraph process is
+holding from the operating system and how much is actively in use.
 
  Metrics                          | Description
  -------                          | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -33,10 +33,10 @@ not interact directly with the filesystem. Instead it relies on
 Memory metrics let you track the memory usage of the Dgraph process. The idle
 and `inuse` metrics give you a better sense of the active memory usage of the
 Dgraph process. The process memory metric shows the memory usage as measured by
-the operating system.
+the operating system. 
 
 By looking at all three metrics you can see how much memory a Dgraph process is
-holding from the operating system and how much is actively in use. 
+holding from the operating system and how much is actively in use.
 
  Metrics                          | Description
  -------                          | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -70,8 +70,7 @@ Health metrics let you check the health of a Dgraph Alpha server node.
 
 ## Go Metrics
 
-Go's built-in metrics may also be useful to measure memory usage and garbage
-collection time.
+Go's built-in metrics may also be useful to measure memory usage and garbage collection time.
 
  Metrics                        | Description
  -------                        | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -7,12 +7,13 @@ weight = 15
 +++
 
 
-Dgraph metrics follow the [metric and label conventions for
-Prometheus](https://prometheus.io/docs/practices/naming/).
+Dgraph database provides metrics on disk activity, memory usage, Dgraph instance activity
+and server node health - along with built-in metrics provided by Go. Dgraph metrics follow
+the [metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
 
-## Disk Metrics
+## Disk metrics
 
-The disk metrics let you track the disk activity of the Dgraph process. Dgraph does not interact
+Disk metrics let you track the disk activity of the Dgraph process. Dgraph does not interact
 directly with the filesystem. Instead it relies on [Badger](https://github.com/dgraph-io/badger) to
 read from and write to disk.
 
@@ -26,10 +27,10 @@ read from and write to disk.
  `badger_v2_read_bytes`              | Total bytes read from Badger.
  `badger_v2_written_bytes`           | Total bytes written to Badger.
 
-## Memory Metrics
+## Memory metrics
 
-The memory metrics let you track the memory usage of the Dgraph process. The idle and inuse metrics
-gives you a better sense of the active memory usage of the Dgraph process. The process memory metric
+Memory metrics let you track the memory usage of the Dgraph process. The idle and `inuse` metrics
+give you a better sense of the active memory usage of the Dgraph process. The process memory metric
 shows the memory usage as measured by the operating system.
 
 By looking at all three metrics you can see how much memory a Dgraph process is holding from the
@@ -43,7 +44,7 @@ operating system and how much is actively in use.
 
 ## Activity Metrics
 
-The activity metrics let you track the mutations, queries, and proposals of an Dgraph instance.
+Activity metrics let you track the mutations, queries, and proposals of a Dgraph instance.
 
  Metrics                                            | Description
  -------                                            | -----------
@@ -56,18 +57,17 @@ The activity metrics let you track the mutations, queries, and proposals of an D
 
 ## Health Metrics
 
-Health metrics let you check the health of a Dgraph Alpha server node, or track
-transaction aborts across a Dgraph cluster.
+Health metrics let you check the health of a Dgraph Alpha server node.
 
  Metrics                          | Description
  -------                          | -----------
- `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha is ready to accept requests; otherwise 0.
- `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This will show the latest max assigned timestamp. All alphas (within the same alpha group) should show the same timestamp if they are in sync.
- `dgraph_txn_aborts_total`        | Shows the total number of transaction aborts that have occurred on the cluster.
+ `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha node is ready to accept requests; otherwise 0.
+ `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This shows the latest max assigned timestamp. All Alpha nodes within the same Alpha group should show the same timestamp if they are in sync.
+ `dgraph_txn_aborts_total`        | **Only applicable to Dgraph Alpha**. Shows the total number of transaction aborts that have occurred on the Alpha node.
 
 ## Go Metrics
 
-Go's built-in metrics may also be useful to measure for memory usage and garbage collection time.
+Go's built-in metrics may also be useful to measure memory usage and garbage collection time.
 
  Metrics                        | Description
  -------                        | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -59,6 +59,12 @@ The activity metrics let you track the mutations, queries, and proposals of an D
 Health metrics let you check the health of a Dgraph Alpha server node, or track
 transaction aborts across a Dgraph cluster.
 
+ Metrics                          | Description
+ -------                          | -----------
+ `dgraph_alpha_health_status`     | **Only applicable to Dgraph Alpha**. Value is 1 when the Alpha is ready to accept requests; otherwise 0.
+ `dgraph_max_assigned_ts`         | **Only applicable to Dgraph Alpha**. This will show the latest max assigned timestamp. All alphas (within the same alpha group) should show the same timestamp if they are in sync.
+ `dgraph_txn_aborts_total`        | Shows the total number of transaction aborts that have occurred on the cluster.
+
 ## Go Metrics
 
 Go's built-in metrics may also be useful to measure for memory usage and garbage collection time.

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -33,10 +33,10 @@ not interact directly with the filesystem. Instead it relies on
 Memory metrics let you track the memory usage of the Dgraph process. The idle
 and `inuse` metrics give you a better sense of the active memory usage of the
 Dgraph process. The process memory metric shows the memory usage as measured by
-the operating system. 
+the operating system.
 
 By looking at all three metrics you can see how much memory a Dgraph process is
-holding from the operating system and how much is actively in use.
+holding from the operating system and how much is actively in use. 
 
  Metrics                          | Description
  -------                          | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -8,7 +8,7 @@ weight = 15
 
 
 Dgraph database provides metrics on disk activity, memory usage, Dgraph instance activity
-and server node health; along with built-in metrics provided by Go. Dgraph metrics follow
+and server node health - along with built-in metrics provided by Go. Dgraph metrics follow
 the [metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
 
 ## Disk metrics

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -70,7 +70,8 @@ Health metrics let you check the health of a Dgraph Alpha server node.
 
 ## Go Metrics
 
-Go's built-in metrics may also be useful to measure memory usage and garbage collection time.
+Go's built-in metrics may also be useful to measure memory usage and garbage
+collection time.
 
  Metrics                        | Description
  -------                        | -----------

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -7,9 +7,10 @@ weight = 15
 +++
 
 
-Dgraph database provides metrics on disk activity, memory usage, Dgraph instance activity
-and server node health; along with built-in metrics provided by Go. Dgraph metrics follow
-the [metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
+Dgraph database provides metrics on disk activity, memory usage, Dgraph instance
+activity and server node health; along with built-in metrics provided by Go.
+Dgraph metrics follow the
+[metric and label conventions for Prometheus](https://prometheus.io/docs/practices/naming/).
 
 ## Disk metrics
 

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -15,7 +15,7 @@ Dgraph metrics follow the
 ## Disk metrics
 
 Disk metrics let you track the disk activity of the Dgraph process. Dgraph does
-not interact directly with the filesystem. Instead, it relies on
+not interact directly with the filesystem. Instead it relies on
 [Badger](https://github.com/dgraph-io/badger) to read from and write to disk.
 
  Metrics                          	 | Description

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -30,7 +30,7 @@ not interact directly with the filesystem. Instead it relies on
 
 ## Memory metrics
 
-Memory metrics let you track the memory usage of the Dgraph process. The idle
+Memory metrics let you track the memory usage of the Dgraph process. The `idle`
 and `inuse` metrics give you a better sense of the active memory usage of the
 Dgraph process. The process memory metric shows the memory usage as measured by
 the operating system.

--- a/wiki/content/deploy/metrics.md
+++ b/wiki/content/deploy/metrics.md
@@ -46,7 +46,8 @@ holding from the operating system and how much is actively in use.
 
 ## Activity Metrics
 
-Activity metrics let you track the mutations, queries, and proposals of a Dgraph instance.
+Activity metrics let you track the mutations, queries, and proposals of a Dgraph
+instance.
 
  Metrics                                            | Description
  -------                                            | -----------


### PR DESCRIPTION
**Still blocked by CLA Assistant, no matter what I change on my client or how many times I try to sign the CLA**

Document the new dgraph_txn_aborts_total metric that counts transaction aborts for a Dgraph server cluster.

Also:
* Added an introduction sentence
* Shifted headers to sentence-case,
* Minor rewording for usage and style 

Fixes DGRAPH-2606

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6927)
<!-- Reviewable:end -->
 
 
 
 
 
 
<!-- Dgraph:start -->
Docs Preview: [<img src="https://bl.ocks.org/prashant-shahi/raw/3a9f99bec84231cfe3c0e82cf883f159/0e588d908ad8c8b10958b87ebdd2ba68779ccf4f/dgraph.svg" height="34" align="absmiddle" alt="Dgraph Preview"/>](https://dgraph-298412bd30-110406.surge.sh)
<!-- Dgraph:end -->