### PR TITLE
fix(log): Fix noisy log if cors isn't initialized yet.

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -747,6 +747,7 @@ func run() {
 			origins, err := edgraph.GetCorsOrigins(updaters.Ctx())
 			if err != nil {
 				glog.Errorf("Error while retrieving cors origins: %s", err.Error())
+				time.Sleep(10 * time.Second)
 				continue
 			}
 			x.UpdateCorsOrigins(origins)


### PR DESCRIPTION
Fixes a noisy log that can appear thousands of times per second:

```
    E1118 23:20:02.201625       1 run.go:747] Error while retrieving cors origins: Please retry again, server is not ready to accept requests
```

```
    E1121 03:10:35.365249  614164 run.go:749] Error while retrieving cors origins: : dispatchTaskOverNetwork: while retrieving connection.: Unhealthy connection
```

This log can happen when Alpha group 1 (or whatever Alpha group is responsible for dgraph.cors) is unavailable.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6938)
<!-- Reviewable:end -->
