### PR TITLE
Document new concurrency support in Ludicrous mode

### DIFF
--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -8,7 +8,7 @@ weight = 13
 
 Ludicrous mode is available in Dgraph v20.03.1 or later.
 
-Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In Ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
+Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In Ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in query results during data ingestion. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
 
 
 ## How do I enable it?

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -38,3 +38,10 @@ Yes, ludicrous mode works with the cluster set up in a highly-available (HA) con
 ## Can the cluster run with multiple data shards?
 
 Yes, ludicrous mode works with the cluster set up with multiple data shards.
+
+## How does Ludicrous mode handle concurrency?
+
+Ludicrous mode can now run mutations concurrently per predicate. This is enabled
+with a default setting of 2000 concurrent threads, but you can adjust the number
+of concurrent threads allowed using the `--ludicrous_concurrency` configuration
+setting on all of the Alpha and Zero instances in the cluster. 

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -9,7 +9,7 @@ weight = 13
 Ludicrous mode is available in Dgraph v20.03.1 or later.
 
 Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed, but with fewer guarantees. In normal mode, Dgraph provides strong consistency.
-In Ludicrous mode, Dgraph provides eventual consistency (or *optimistic replication*), so any mutation that succeeds should be available eventually. This means changes are applied more slowly during periods of peak data ingestion, and might not be immediately reflected in query results. If Dgraph crashes unexpectedly, there could be unapplied mutations which **will not** be picked up when Dgraph restarts.
+In Ludicrous mode, Dgraph provides eventual consistency, so any mutation that succeeds should be available eventually. This means changes are applied more slowly during periods of peak data ingestion, and might not be immediately reflected in query results. If Dgraph crashes unexpectedly, there could be unapplied mutations which **will not** be picked up when Dgraph restarts.
 
 Because Dgraph with Ludicrous mode enabled is eventually consistent, it is a good fit for any application where maximum performance is more important than strong real-time consistency and transactional guarantees (such as a social media app or game app).
 
@@ -20,9 +20,9 @@ You can enable Ludicrous mode by setting the `--ludicrous_mode` config option on
 
 ## What does it do?
 
-In this mode, Dgraph doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutations. It's equivalent of having `CommitNow` set automatically for all mutations. All the mutations are then sent to background workers which apply them repeatedly.
+In this mode, Dgraph doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutations. It's equivalent of having `CommitNow` set automatically for all mutations. All the mutations are then sent to background workers which apply them continuously.
 
-Also, Dgraph does not sync writes to disk. This increases throughput but may result in loss of un-synced writes in the event of hardware failure.
+Also, Dgraph does not sync writes to disk. If Dgraph crashes unexpectedly, there could be unapplied mutations which **will not** be picked up when Dgraph restarts.
 
 
 ## What is the trade-off?
@@ -43,7 +43,8 @@ Yes, Ludicrous mode works with the cluster set up with multiple data shards.
 
 ## How does Ludicrous mode handle concurrency?
 
-Ludicrous mode now runs mutations concurrently per predicate. This is enabled
-by default with 2000 concurrent threads available, but you can adjust the number
-of concurrent threads available using the `--ludicrous_concurrency`
-configuration setting on the Alpha nodes in a cluster.
+Ludicrous mode now runs mutations concurrently to increase the speed of data
+ingestion. This is enabled by default with 2000 total concurrent threads
+available, but you can adjust the number of concurrent threads available using
+the `--ludicrous_concurrency` configuration setting on the Alpha nodes in a
+cluster.

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -8,40 +8,41 @@ weight = 13
 
 Ludicrous mode is available in Dgraph v20.03.1 or later.
 
-Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In Ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in query results during data ingestion. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
+Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed, but with fewer guarantees. In normal mode, Dgraph provides strong consistency.
+In Ludicrous mode, Dgraph provides eventual consistency (or *optimistic replication*), so any mutation that succeeds should be available eventually. This means changes are applied more slowly during periods of peak data ingestion, and might not be immediately reflected in query results. If Dgraph crashes unexpectedly, there could be unapplied mutations which **will not** be picked up when Dgraph restarts.
 
+Because Dgraph with Ludicrous mode enabled is eventually consistent, it is a good fit for any application where maximum performance is more important than strong real-time consistency and transactional guarantees (such as a social media app or game app).
 
 ## How do I enable it?
 
-You can enable Ludicrous mode by setting the `--ludicrous_mode` config option on all Dgraph Zero and Dgraph Alpha nodes in a cluster.
+You can enable Ludicrous mode by setting the `--Ludicrous_mode` config option on all Dgraph Zero and Dgraph Alpha nodes in a cluster.
 
 
 ## What does it do?
 
-In this mode, Dgraph doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutations. It's equivalent of having `CommitNow` set automatically for all mutations. All the mutations are then sent to background workers which keep applying them.
+In this mode, Dgraph doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutations. It's equivalent of having `CommitNow` set automatically for all mutations. All the mutations are then sent to background workers which apply them repeatedly.
 
-Also, Dgraph does not sync writes to disk. This increases throughput but may result in loss of unsynced writes in the event of hardware failure.
+Also, Dgraph does not sync writes to disk. This increases throughput but may result in loss of un-synced writes in the event of hardware failure.
 
 
 ## What is the trade-off?
 
-As mentioned in the section above, it provides amazing speed at the cost of some guarantees.
+As mentioned above, Ludicrous mode provides amazing speed at the cost of some guarantees.
 
 It can be used to handle write-heavy operations when there is a time gap between queries and mutations, or when you are fine with potentially reading stale data.
 
-There are no transactions in ludicrous mode. That is, you cannot open a transaction, apply a mutation, and then decide to cancel the transaction. Every mutation request is committed to Dgraph.
+There are no transactions in Ludicrous mode. That is, you cannot open a transaction, apply a mutation, and then decide to cancel the transaction. Every mutation request is committed to Dgraph.
 
-## Can the cluster run with HA?
+## Can you use Ludicrous mode in a highly-available (HA) cluster?
 
-Yes, ludicrous mode works with the cluster set up in a highly-available (HA) configuration.
+Yes, Ludicrous mode works with a cluster set up in a highly-available (HA) configuration.
 
-## Can the cluster run with multiple data shards?
+## Can a cluster run with multiple data shards?
 
-Yes, ludicrous mode works with the cluster set up with multiple data shards.
+Yes, Ludicrous mode works with the cluster set up with multiple data shards.
 
 ## How does Ludicrous mode handle concurrency?
 
-Ludicrous mode can now run mutations concurrently per predicate. This is enabled
-with a default setting of 2000 concurrent threads, but you can adjust the number
-of concurrent threads allowed using the `--ludicrous_concurrency` configuration
-setting on all of the Alpha and Zero nodes in the cluster.
+Ludicrous mode now runs mutations concurrently per predicate. This is enabled
+by default with 2000 concurrent threads available, but you can adjust the number
+of concurrent threads available using the `--Ludicrous_concurrency` configuration setting on the Alpha and Zero nodes in a cluster.

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -45,4 +45,5 @@ Yes, Ludicrous mode works with the cluster set up with multiple data shards.
 
 Ludicrous mode now runs mutations concurrently per predicate. This is enabled
 by default with 2000 concurrent threads available, but you can adjust the number
-of concurrent threads available using the `--ludicrous_concurrency` configuration setting on the Alpha and Zero nodes in a cluster.
+of concurrent threads available using the `--ludicrous_concurrency`
+configuration setting on the Alpha nodes in a cluster.

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -15,7 +15,7 @@ Because Dgraph with Ludicrous mode enabled is eventually consistent, it is a goo
 
 ## How do I enable it?
 
-You can enable Ludicrous mode by setting the `--Ludicrous_mode` config option on all Dgraph Zero and Dgraph Alpha nodes in a cluster.
+You can enable Ludicrous mode by setting the `--ludicrous_mode` config option on all Dgraph Zero and Dgraph Alpha nodes in a cluster.
 
 
 ## What does it do?
@@ -45,4 +45,4 @@ Yes, Ludicrous mode works with the cluster set up with multiple data shards.
 
 Ludicrous mode now runs mutations concurrently per predicate. This is enabled
 by default with 2000 concurrent threads available, but you can adjust the number
-of concurrent threads available using the `--Ludicrous_concurrency` configuration setting on the Alpha and Zero nodes in a cluster.
+of concurrent threads available using the `--ludicrous_concurrency` configuration setting on the Alpha and Zero nodes in a cluster.

--- a/wiki/content/deploy/ludicrous-mode.md
+++ b/wiki/content/deploy/ludicrous-mode.md
@@ -8,26 +8,26 @@ weight = 13
 
 Ludicrous mode is available in Dgraph v20.03.1 or later.
 
-Ludicrous mode allows Dgraph to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
+Ludicrous mode allows Dgraph database to ingest data at an incredibly fast speed. It differs from the normal mode as it provides fewer guarantees. In normal mode, Dgraph provides strong consistency. In ludicrous mode, Dgraph provides eventual consistency. In Ludicrous mode, any mutation which succeeds **might be available eventually**. **Eventually** means the changes will be applied later and might not be reflected in queries away. If Dgraph crashes unexpectedly, there **might** be unapplied mutations which **will not** be picked up when Dgraph restarts. Dgraph with ludicrous mode enabled behaves as an eventually consistent system.
 
 
 ## How do I enable it?
 
-Ludicrous mode can be enabled by setting the `--ludicrous_mode` config option to all Zero and Alpha instances in the cluster.
+You can enable Ludicrous mode by setting the `--ludicrous_mode` config option on all Dgraph Zero and Dgraph Alpha nodes in a cluster.
 
 
 ## What does it do?
 
-It doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutation. It's equivalent to having CommitNow set automatically for all mutations. All the mutations are then sent to background workers which keep applying them.
+In this mode, Dgraph doesn't wait for mutations to be applied. When a mutation comes, it proposes the mutation to the cluster and as soon as the proposal reaches the other nodes, it returns the response right away. You don't need to send a commit request for mutations. It's equivalent of having `CommitNow` set automatically for all mutations. All the mutations are then sent to background workers which keep applying them.
 
 Also, Dgraph does not sync writes to disk. This increases throughput but may result in loss of unsynced writes in the event of hardware failure.
 
 
-## What is the trade off?
+## What is the trade-off?
 
 As mentioned in the section above, it provides amazing speed at the cost of some guarantees.
 
-It can be used when we have write-heavy operations and there is a time gap between queries and mutations, or you are fine with potentially reading stale data.
+It can be used to handle write-heavy operations when there is a time gap between queries and mutations, or when you are fine with potentially reading stale data.
 
 There are no transactions in ludicrous mode. That is, you cannot open a transaction, apply a mutation, and then decide to cancel the transaction. Every mutation request is committed to Dgraph.
 
@@ -44,4 +44,4 @@ Yes, ludicrous mode works with the cluster set up with multiple data shards.
 Ludicrous mode can now run mutations concurrently per predicate. This is enabled
 with a default setting of 2000 concurrent threads, but you can adjust the number
 of concurrent threads allowed using the `--ludicrous_concurrency` configuration
-setting on all of the Alpha and Zero instances in the cluster. 
+setting on all of the Alpha and Zero nodes in the cluster.


### PR DESCRIPTION
Documentation for https://github.com/dgraph-io/dgraph/pull/6060

- Noted new `--ludicrous_concurrency` configuration setting.
- Some rewording for usage and style.

Fixes DGRAPH-2758

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6939)
<!-- Reviewable:end -->
