### PR TITLE
fix(GraphQL): fix multiple alias in query

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -345,6 +345,7 @@ func RunAll(t *testing.T) {
 	t.Run("query post with author", queryPostWithAuthor)
 	t.Run("queries have extensions", queriesHaveExtensions)
 	t.Run("alias works for queries", queryWithAlias)
+	t.Run("multiple aliases for same field in query", queryWithMultipleAliasOfSameField)
 	t.Run("cascade directive", queryWithCascade)
 	t.Run("filter in queries with array for AND/OR", filterInQueriesWithArrayForAndOr)
 	t.Run("query geo near filter", queryGeoNearFilter)
@@ -354,6 +355,8 @@ func RunAll(t *testing.T) {
 	t.Run("query count with alias", queryCountWithAlias)
 	t.Run("query count at child level", queryCountAtChildLevel)
 	t.Run("query count at child level with filter", queryCountAtChildLevelWithFilter)
+	t.Run("query count at child level with multiple alias", queryCountAtChildLevelWithMultipleAlias)
+	t.Run("query count at child level with multiple alias on scalar field", queryCountAtChildLevelWithMultipleAliasOnScalarField)
 	t.Run("query count and other fields at child level", queryCountAndOtherFieldsAtChildLevel)
 	t.Run("checkUserPassword query", passwordTest)
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1151,10 +1151,7 @@ func addSelectionSetFrom(
 			auth.varName = parentQryName
 		}
 
-		// skip if we have already added a query for this field in DQL. It helps make sure that if
-		// a field is being asked twice or more, each time with a new alias, then we only add it
-		// once in DQL query.
-		if _, ok := fieldAdded[f.DgraphAlias()]; ok {
+		if f.Type().IsInbuiltOrEnumType() && (fieldSeenCount[f.DgraphAlias()] > 0) {
 			continue
 		}
 		fieldSeenCount[f.DgraphAlias()]++

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -952,8 +952,11 @@ func buildCommonAuthQueries(
 // buildAggregateFields builds DQL queries for aggregate fields like count, avg, max etc.
 // It returns related DQL fields and Auth Queries which are then added to the final DQL query
 // by the caller.
+// fieldAlias is being passed along with the fileld as it depends on the number of times we have
+// encountered that field till now.
 func buildAggregateFields(
 	f schema.Field,
+	fieldAlias string,
 	auth *authRewriter) ([]*gql.GraphQuery, []*gql.GraphQuery) {
 	constructedForType := f.ConstructedFor()
 	constructedForDgraphPredicate := f.ConstructedForDgraphPredicate()
@@ -968,7 +971,7 @@ func buildAggregateFields(
 		}
 		if aggregateField.DgraphAlias() == "count" {
 			aggregateChild := &gql.GraphQuery{
-				Alias: "count_" + f.DgraphAlias(),
+				Alias: "count_" + fieldAlias,
 				Attr:  "count(" + constructedForDgraphPredicate + ")",
 			}
 			filter, _ := f.ArgValue("filter").(map[string]interface{})
@@ -1026,6 +1029,19 @@ func buildAggregateFields(
 	return aggregateChildren, retAuthQueries
 }
 
+// Generate Unique Dgraph Alias for the field based on number of time it has been
+// seen till now in the given query at current level. If it is seen first time then simply returns the field's DgraphAlias,
+// and if  it is seen let's say 3rd time  then return "fieldAlias3" where "fieldAlias"
+// is the  DgraphAlias of the field.
+func generateUniqueDgraphAlias(f schema.Field, fieldSeenCount map[string]int) string {
+	alias := f.DgraphAlias()
+	if fieldSeenCount[alias] == 0 {
+		return alias
+	}
+	return alias + strconv.Itoa(fieldSeenCount[alias])
+}
+
+// TODO(GRAPHQL-874), Optimise Query rewriting in case of multiple alias with same filter.
 // addSelectionSetFrom adds all the selections from field into q, and returns a list
 // of extra queries needed to satisfy auth requirements
 func addSelectionSetFrom(
@@ -1061,8 +1077,11 @@ func addSelectionSetFrom(
 	// are required in the body template for other fields requested within the query. We must
 	// fetch them from Dgraph.
 	requiredFields := make(map[string]schema.FieldDefinition)
-	// fieldAdded is a map from field's dgraph alias to bool
-	fieldAdded := make(map[string]bool)
+	// fieldSeenCount is a map from field's dgraph alias to integer.
+	// It stores the number of times a field was encountered
+	// in the query till now.
+	fieldSeenCount := make(map[string]int)
+
 	for _, f := range field.SelectionSet() {
 		hasCustom, rf := f.HasCustomDirective()
 		if hasCustom {
@@ -1082,12 +1101,8 @@ func addSelectionSetFrom(
 
 		// Handle aggregation queries
 		if f.IsAggregateField() {
-			if _, isAddedField := fieldAdded[f.DgraphAlias()]; isAddedField {
-				continue
-			}
-			fieldAdded[f.DgraphAlias()] = true
-
-			aggregateChildren, aggregateAuthQueries := buildAggregateFields(f, auth)
+			fieldAlias := generateUniqueDgraphAlias(f, fieldSeenCount)
+			aggregateChildren, aggregateAuthQueries := buildAggregateFields(f, fieldAlias, auth)
 
 			authQueries = append(authQueries, aggregateAuthQueries...)
 			q.Children = append(q.Children, aggregateChildren...)
@@ -1096,7 +1111,7 @@ func addSelectionSetFrom(
 		}
 
 		child := &gql.GraphQuery{
-			Alias: f.DgraphAlias(),
+			Alias: generateUniqueDgraphAlias(f, fieldSeenCount),
 		}
 
 		if f.Type().Name() == schema.IDType {
@@ -1142,7 +1157,7 @@ func addSelectionSetFrom(
 		if _, ok := fieldAdded[f.DgraphAlias()]; ok {
 			continue
 		}
-		fieldAdded[f.DgraphAlias()] = true
+		fieldSeenCount[f.DgraphAlias()]++
 
 		if rbac == schema.Positive || rbac == schema.Uncertain {
 			q.Children = append(q.Children, child)
@@ -1218,7 +1233,7 @@ func addSelectionSetFrom(
 	// Add fields required by other custom fields which haven't already been added as a
 	// child to be fetched from Dgraph.
 	for _, dgAlias := range rfset {
-		if _, ok := fieldAdded[dgAlias]; !ok {
+		if fieldSeenCount[dgAlias] == 0 {
 			f := requiredFields[dgAlias]
 			child := &gql.GraphQuery{
 				Alias: f.DgraphAlias(),

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2326,6 +2326,7 @@
       }
     }
 
+
 - name: "Rewrite without custom fields"
   gqlquery: |
     query {
@@ -2445,7 +2446,7 @@
       }
     }
 
-- name: "querying a field multiple times with different aliases adds it only once in rewriting"
+- name: "querying a inbuiltType field multiple times with different aliases adds it only once in rewriting"
   gqlquery: |-
     query {
       queryThingOne {
@@ -2461,6 +2462,144 @@
       queryThingOne(func: type(ThingOne)) {
         id : uid
         name : Thing.name
+      }
+    }
+
+- name: "querying an Enum type field multiple times with different aliases adds it only once in rewrting"
+  gqlquery: |-
+    query {
+      queryPost {
+        title
+        p1: postType
+        p2: postType
+      }
+    }
+  dgquery: |-
+    query {
+      queryPost(func: type(Post)) {
+        title : Post.title
+        postType : Post.postType
+        dgraph.uid : uid
+      }
+    }
+- 
+  name: "querying a non-inbuiltType field multiple times with different aliases should reflect in rewriting"
+  gqlquery: |-
+    query {
+      queryAuthor {
+        name
+        p1: posts(filter: {isPublished: true}){
+          title
+          text
+        }
+        p2: posts(filter: {isPublished: false}){
+          title
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(eq(Post.isPublished, true)) {
+          title : Post.title
+          text : Post.text
+          dgraph.uid : uid
+        }
+        posts1 : Author.posts @filter(eq(Post.isPublished, false)) {
+          title : Post.title
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+- 
+  name: "querying  field multiple times with different aliases and same filters"
+  gqlquery: |-
+    query {
+      queryAuthor {
+        name
+        p1: posts(filter: {isPublished: true}){
+          title
+          text
+        }
+        p2: posts(filter: {isPublished: true}){
+          title
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(eq(Post.isPublished, true)) {
+          title : Post.title
+          text : Post.text
+          dgraph.uid : uid
+        }
+        posts1 : Author.posts @filter(eq(Post.isPublished, true)) {
+          title : Post.title
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+-
+  name: "Query with Same Alias"
+  gqlquery: |-
+    query {
+      queryAuthor {
+        name
+        p1: posts(filter: {isPublished: true}){
+          title
+          text
+        }
+        p1: posts(filter: {isPublished: false}){
+          title
+          text
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        name : Author.name
+        posts : Author.posts @filter(eq(Post.isPublished, true)) {
+          title : Post.title
+          text : Post.text
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+- 
+  name: "Aggregate Query with multiple aliases"
+  gqlquery: |
+    query{
+      queryAuthor{
+        postsAggregate{
+          count
+        }
+        p1: postsAggregate(filter: {tags: {gt: "abc"}}){
+          count
+        }
+        p2: postsAggregate(filter: {tags: {le: "xyz"}}){
+          count
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        count_postsAggregate : count(Author.posts)
+        count_postsAggregate1 : count(Author.posts) @filter(gt(Post.tags, "abc"))
+        count_postsAggregate2 : count(Author.posts) @filter(le(Post.tags, "xyz"))
+        dgraph.uid : uid
       }
     }
 

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -716,7 +716,8 @@ func completeDgraphResult(
 			schema.GQLWrapLocationf(err, field.Location(), "couldn't unmarshal Dgraph result"))
 	}
 
-	switch val := valToComplete[field.DgraphAlias()].(type) {
+	alias := field.DgraphAlias()
+	switch val := valToComplete[alias].(type) {
 	case []interface{}:
 		if field.Type().ListType() == nil {
 			// Turn Dgraph list result to single object
@@ -1325,6 +1326,11 @@ func completeObject(
 
 	x.Check2(buf.WriteRune('{'))
 	dgraphTypes, ok := res["dgraph.type"].([]interface{})
+
+	// fieldSeenCount is to keep track the number of times a specific field
+	// has been seen till now. It is used in generating Unique Dgraph Alias
+	// to extract out the corresponding value of field from the response.
+	fieldSeenCount := make(map[string]int)
 	for _, f := range fields {
 		if f.Skip() || !f.Include() {
 			continue
@@ -1352,7 +1358,15 @@ func completeObject(
 
 		seenField[f.ResponseName()] = true
 
-		val := res[f.DgraphAlias()]
+		var uniqueDgraphAlias string
+		// In case of InbuiltType or Enums, only one alias was passed into the dgraph query.
+		// So just map its value to all of its occurences.
+		if f.Type().IsInbuiltOrEnumType() {
+			uniqueDgraphAlias = f.DgraphAlias()
+		} else {
+			uniqueDgraphAlias = generateUniqueDgraphAlias(f, fieldSeenCount)
+		}
+		val := res[uniqueDgraphAlias]
 		// Handle aggregate queries:
 		// Aggregate Fields in DQL response don't follow the same response as other queries.
 		// Create a map aggregateVal and store response of aggregate fields in a way which
@@ -1362,7 +1376,7 @@ func completeObject(
 			aggregateVal := make(map[string]interface{})
 			for _, aggregateField := range f.SelectionSet() {
 				if aggregateField.DgraphAlias() == "count" {
-					aggregateVal["count"] = res["count_"+f.DgraphAlias()]
+					aggregateVal["count"] = res["count_"+generateUniqueDgraphAlias(f, fieldSeenCount)]
 				}
 			}
 			val = aggregateVal
@@ -1408,6 +1422,7 @@ func completeObject(
 		}
 		x.Check2(buf.Write(completed))
 		comma = ", "
+		fieldSeenCount[f.DgraphAlias()]++
 	}
 	x.Check2(buf.WriteRune('}'))
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -190,6 +190,7 @@ type Type interface {
 	FieldOriginatedFrom(fieldName string) string
 	AuthRules() *TypeAuth
 	IsGeo() bool
+	IsInbuiltOrEnumType() bool
 	fmt.Stringer
 }
 
@@ -1113,6 +1114,11 @@ func (f *field) AbstractType() bool {
 
 func (f *field) GetObjectName() string {
 	return f.field.ObjectDefinition.Name
+}
+
+func (t *astType) IsInbuiltOrEnumType() bool {
+	_, ok := inbuiltTypeToDgraph[t.Name()]
+	return ok || (t.inSchema.schema.Types[t.Name()].Kind == ast.Enum)
 }
 
 func getCustomHTTPConfig(f *field, isQueryOrMutation bool) (FieldHTTPConfig, error) {


### PR DESCRIPTION
Fixes GRAPHQL-806.
Fixes GRAPHQL-793.

This PR extends support for multiple aliases for the same field (except those which are inbuilt) in one query.
For eg:
For the Given Schema:
```
type Author {
        id: ID!
        posts: [Post!] @hasInverse(field: author)
}

type Post {
        postID: ID!
        title: String! @search(by: [term])
        text: String @search(by: [fulltext])
        isPublished: Boolean @search
        author: Author!
}
```
The given query:
```
queryAuthor {
        name
        p1: posts(filter: {isPublished: true}){
          title
          text
        }
        p2: posts(filter: {isPublished: false}){
          title
          text
        }
      }
```
Earlier the results we picked up only for the first alias for `posts` i.e `p1` and the results into `p2` were copied from the `p1`. This PR fixes that. 
Now, `p1` should contain all those posts which have `isPublished: true` and `p2` will contain all those posts which have `isPublished: false`.




<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6940)
<!-- Reviewable:end -->
