### PR TITLE
fix(raftwal): Change the raftwal file size to 64MB (#6919)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -216,7 +216,6 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
@@ -418,7 +417,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -459,7 +457,6 @@ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20190228193606-a943ad0ee4c9 h1:3QcOf2A2G8CYue5DY60PR20dsJlfTT/vdnXEdU3ba7c=
 go.etcd.io/etcd v0.0.0-20190228193606-a943ad0ee4c9/go.mod h1:KSGwdbiFchh5KIC9My2+ZVl5/3ANcwohw50dpPwa2cw=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
-go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.5 h1:dntmOdLpSpHlVqbW5Eay97DelsZHe+55D+xC6i0dDS0=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
@@ -562,7 +559,6 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/genproto v0.0.0-20180608181217-32ee49c4dd80/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
-google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107 h1:xtNn7qFlagY2mQNFHMSRPjT2RkOV4OXM7P5TVy9xATo=
 google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb h1:i1Ppqkc3WQXikh8bXiwHqAN5Rv3/qDCcRk0/Otx73BY=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/raftwal/encryption_test.go
+++ b/raftwal/encryption_test.go
@@ -18,6 +18,8 @@ package raftwal
 
 import (
 	"io/ioutil"
+	"log"
+	"math"
 	"math/rand"
 	"os"
 	"testing"
@@ -64,4 +66,91 @@ func TestEntryReadWrite(t *testing.T) {
 	x.WorkerConfig.EncryptionKey = nil
 	_, err = openWal(dir)
 	require.EqualError(t, err, "Logfile is encrypted but encryption key is nil")
+}
+
+// TestLogRotate writes enough log file entries to cause 1 file rotation.
+func TestLogRotate(t *testing.T) {
+	dir, err := ioutil.TempDir("", "raftwal")
+	require.NoError(t, err)
+	el, err := openWal(dir)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	// Generate deterministic entries using a seed.
+	const SEED = 1
+	rand.Seed(SEED)
+	makeEntry := func(i int) raftpb.Entry {
+		// Be careful when changing this value, as it could easily end up filling up
+		// the entire tmpfs. Currently, this writes ~1.5GB.
+		data := make([]byte, rand.Intn(1<<16))
+		rand.Read(data)
+		return raftpb.Entry{Index: uint64(i + 1), Term: 1, Data: data}
+	}
+
+	// Write enough entries to fill ~1.5x logfiles, causing a rotation.
+	const totalEntries = (maxNumEntries * 3) / 2
+	totalBytes := 0
+	for i := 0; i < totalEntries; i++ {
+		entry := makeEntry(i)
+		err = el.AddEntries([]raftpb.Entry{entry})
+		require.NoError(t, err)
+		totalBytes += len(entry.Data)
+	}
+	log.Printf("Wrote %d bytes", totalBytes)
+
+	// Reopen the file and retrieve all entries.
+	el, err = openWal(dir)
+	require.NoError(t, err)
+	entries := el.allEntries(0, math.MaxInt64, math.MaxInt64)
+	require.Equal(t, totalEntries, len(entries))
+
+	// Use the previous seed to verify the written entries.
+	rand.Seed(SEED)
+	for i, gotEntry := range entries {
+		expEntry := makeEntry(i)
+		require.Equal(t, len(expEntry.Data), len(gotEntry.Data))
+		if len(expEntry.Data) > 0 {
+			require.Equal(t, expEntry.Data, gotEntry.Data)
+		}
+		require.Equal(t, expEntry.Index, gotEntry.Index)
+		require.Equal(t, expEntry.Term, gotEntry.Term)
+		require.Equal(t, expEntry.Type, gotEntry.Type)
+	}
+}
+
+// TestLogGrow writes data of sufficient size to grow the log file.
+func TestLogGrow(t *testing.T) {
+	dir, err := ioutil.TempDir("", "raftwal")
+	require.NoError(t, err)
+	el, err := openWal(dir)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	var entries []raftpb.Entry
+
+	const numEntries = (maxNumEntries * 3) / 2
+
+	// 5KB * 30000 is ~ 150MB, this will cause the log file to grow.
+	for i := 0; i < numEntries; i++ {
+		data := make([]byte, 5<<10)
+		rand.Read(data)
+		entry := raftpb.Entry{Index: uint64(i + 1), Term: 1, Data: data}
+		entries = append(entries, entry)
+	}
+	err = el.AddEntries(entries)
+	require.NoError(t, err)
+
+	// Reopen the file and retrieve all entries.
+	el, err = openWal(dir)
+	require.NoError(t, err)
+	readEntries := el.allEntries(0, math.MaxInt64, math.MaxInt64)
+	require.Equal(t, numEntries, len(readEntries))
+
+	for i, gotEntry := range readEntries {
+		expEntry := entries[i]
+		require.Equal(t, expEntry.Data, gotEntry.Data)
+		require.Equal(t, expEntry.Index, gotEntry.Index)
+		require.Equal(t, expEntry.Term, gotEntry.Term)
+		require.Equal(t, expEntry.Type, gotEntry.Type)
+	}
 }

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -53,7 +53,7 @@ const (
 	// and baseIV (remaining 8 bytes) are stored.
 	encOffset = logFileOffset - 16 // 1MB - 16B
 	// logFileSize is the initial size of the log file.
-	logFileSize = 16 << 30
+	logFileSize = 64 << 20 // 64MB
 	// entrySize is the size in bytes of a single entry.
 	entrySize = 32
 	// logSuffix is the suffix for log files.
@@ -171,7 +171,8 @@ func (lf *logFile) GetRaftEntry(idx int) raftpb.Entry {
 		Index: entry.Index(),
 		Type:  raftpb.EntryType(int32(entry.Type())),
 	}
-	if entry.DataOffset() > 0 && entry.DataOffset() < logFileSize {
+	if entry.DataOffset() > 0 {
+		x.AssertTrue(entry.DataOffset() < uint64(len(lf.Data)))
 		data := lf.Slice(int(entry.DataOffset()))
 		if len(data) > 0 {
 			// Copy the data over to allow the mmaped file to be deleted later.


### PR DESCRIPTION
Change the initial size of raftwal log file to 64MB. Add a test to check the file grows correctly.

(cherry picked from commit ab0805550f220649e3be6568c781d2a6a837faa6)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6943)
<!-- Reviewable:end -->
