### PR TITLE
Fix a bunch of flaky tests

### DIFF
--- a/dgraph/cmd/alpha/reindex_test.go
+++ b/dgraph/cmd/alpha/reindex_test.go
@@ -189,15 +189,16 @@ func TestReindexReverseCount(t *testing.T) {
 }
 
 func checkSchema(t *testing.T, query, key string) {
-	for i := 0; i < 10; i++ {
+	N := 10
+	for i := 0; i < N; i++ {
 		res, _, err := queryWithTs(query, "application/dql", "", 0)
 		require.NoError(t, err)
 		if strings.Contains(res, key) {
 			return
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Second)
 
-		if i == 9 {
+		if i == N-1 {
 			t.Fatalf("expected %v, got schema: %v", key, res)
 		}
 	}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -249,6 +249,9 @@ func parseSchemaFromAlterOperation(op *api.Operation) (*schema.ParsedSchema, err
 	for _, update := range result.Preds {
 		// Pre-defined predicates cannot be altered but let the update go through
 		// if the update is equal to the existing one.
+		//
+		// TODO: Should we allow Guardians to make this change? To fix up a broken index, for
+		// example?
 		if schema.IsPreDefPredChanged(update) {
 			return nil, errors.Errorf("predicate %s is pre-defined and is not allowed to be"+
 				" modified", update.Predicate)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -241,10 +242,14 @@ func addSchemaAndData(schema, data []byte, client *dgo.Dgraph) {
 		err := addSchema(GraphqlAdminURL, string(schema))
 		if err == nil {
 			break
-		} else if strings.Contains(err.Error(), "errIndexingInProgress") {
+		}
+		if strings.Contains(err.Error(), "errIndexingInProgress") ||
+			strings.Contains(err.Error(), "is already running") {
+			glog.V(2).Infof("Got error while addSchemaAndData: %v. Retrying...\n", err)
 			time.Sleep(time.Second)
 			continue
-		} else if err != nil {
+		}
+		if err != nil {
 			x.Panic(err)
 		}
 	}

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -237,12 +237,19 @@ func (us *UserSecret) Delete(t *testing.T, user, role string, metaInfo *testutil
 }
 
 func addSchemaAndData(schema, data []byte, client *dgo.Dgraph) {
-	err := addSchema(GraphqlAdminURL, string(schema))
-	if err != nil {
-		x.Panic(err)
+	for {
+		err := addSchema(GraphqlAdminURL, string(schema))
+		if err == nil {
+			break
+		} else if strings.Contains(err.Error(), "errIndexingInProgress") {
+			time.Sleep(time.Second)
+			continue
+		} else if err != nil {
+			x.Panic(err)
+		}
 	}
 
-	err = maybePopulateData(client, data)
+	err := maybePopulateData(client, data)
 	if err != nil {
 		x.Panic(err)
 	}

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
+      read_only: true
     - type: volume
       source: backup
       target: /data/backup
@@ -38,6 +42,10 @@ services:
     - type: bind
       source: $GOPATH/bin
       target: /gobin
+      read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
       read_only: true
     - type: bind
       source: ./keys
@@ -69,6 +77,10 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
+      read_only: true
     - type: volume
       source: backup
       target: /data/backup
@@ -94,6 +106,10 @@ services:
     - type: bind
       source: ./keys
       target: /data/keys
+      read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
       read_only: true
     - type: volume
       source: backup
@@ -121,6 +137,10 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
+      read_only: true
     - type: volume
       source: backup
       target: /data/backup
@@ -146,6 +166,10 @@ services:
     - type: bind
       source: ./keys
       target: /data/keys
+      read_only: true
+    - type: bind
+      source: ./backup
+      target: /data/backup2
       read_only: true
     - type: volume
       source: backup

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
@@ -43,8 +43,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
@@ -69,8 +69,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
@@ -95,8 +95,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha4:7080 --zero=zero1:5080
@@ -121,8 +121,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha5:7080 --zero=zero1:5080
@@ -147,8 +147,8 @@ services:
       source: ./keys
       target: /data/keys
       read_only: true
-    - type: bind
-      source: ./backup
+    - type: volume
+      source: backup
       target: /data/backup
       read_only: false
     command: /gobin/dgraph alpha --my=alpha6:7080 --zero=zero1:5080
@@ -174,4 +174,5 @@ services:
       read_only: true
     command: /gobin/dgraph zero --idx=1 --my=zero1:5080 --replicas=3 --logtostderr
       -v=2 --bindall
-volumes: {}
+volumes:
+  backup: {}

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -40,7 +40,7 @@ import (
 
 func sendRestoreRequest(t *testing.T, location, backupId string, backupNum int) int {
 	if location == "" {
-		location = "/data/backup"
+		location = "/data/backup2"
 	}
 	params := testutil.GraphQLParams{
 		Query: `mutation restore($location: String!, $backupId: String, $backupNum: Int) {
@@ -269,7 +269,7 @@ func TestRestoreBackupNumInvalid(t *testing.T) {
 
 	// Send a request with a backupNum greater than the number of manifests.
 	restoreRequest := fmt.Sprintf(`mutation restore() {
-		 restore(input: {location: "/data/backup", backupId: "%s", backupNum: %d,
+		 restore(input: {location: "/data/backup2", backupId: "%s", backupNum: %d,
 		 	encryptionKeyFile: "/data/keys/enc_key"}) {
 			code
 			message
@@ -292,7 +292,7 @@ func TestRestoreBackupNumInvalid(t *testing.T) {
 
 	// Send a request with a negative backupNum value.
 	restoreRequest = fmt.Sprintf(`mutation restore() {
-		 restore(input: {location: "/data/backup", backupId: "%s", backupNum: %d,
+		 restore(input: {location: "/data/backup2", backupId: "%s", backupNum: %d,
 		 	encryptionKeyFile: "/data/keys/enc_key"}) {
 			code
 			message
@@ -379,7 +379,7 @@ func TestInvalidBackupId(t *testing.T) {
 
 func TestListBackups(t *testing.T) {
 	query := `query backup() {
-		listBackups(input: {location: "/data/backup"}) {
+		listBackups(input: {location: "/data/backup2"}) {
 			backupId
 			backupNum
 			encrypted

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -435,9 +435,16 @@ func TestRestoreWithDropOperations(t *testing.T) {
 	require.NoError(t, err)
 
 	// setup backup directories
-	backupDir := "/data/backup/tmp"
-	localFsDirs := []string{"./backup/tmp"}
+	backupDir := "/data/backup"
+	tmpdir, err := ioutil.TempDir("./backup/", "tmp")
+	require.NoError(t, err)
+	backupDir = path.Join(backupDir, path.Base(tmpdir))
+	t.Logf("Creating tmp dir at: %s using docker dir: %s\n", tmpdir, backupDir)
+
+	localFsDirs := []string{tmpdir}
 	setupDirs(t, localFsDirs)
+	// remove backup directories to make sure this test doesn't leave anything behind.
+	defer cleanupDirs(t, localFsDirs)
 
 	// create a full backup in backupDir
 	backup(t, backupDir)
@@ -576,10 +583,6 @@ func TestRestoreWithDropOperations(t *testing.T) {
 				"name": "Flower"
 			}`,
 		})
-
-	// remove backup directories to make sure this test doesn't leave anything behind
-	// TODO: This is having some problem on TeamCity
-	//cleanupDirs(t, localFsDirs)
 }
 
 func setupDirs(t *testing.T, dirs []string) {
@@ -594,7 +597,7 @@ func setupDirs(t *testing.T, dirs []string) {
 
 func cleanupDirs(t *testing.T, dirs []string) {
 	for _, dir := range dirs {
-		require.NoError(t, os.RemoveAll(dir))
+		os.RemoveAll(dir)
 	}
 }
 

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -434,18 +434,7 @@ func TestRestoreWithDropOperations(t *testing.T) {
 		CommitNow: true})
 	require.NoError(t, err)
 
-	// setup backup directories
 	backupDir := "/data/backup"
-	tmpdir, err := ioutil.TempDir("./backup/", "tmp")
-	require.NoError(t, err)
-	backupDir = path.Join(backupDir, path.Base(tmpdir))
-	t.Logf("Creating tmp dir at: %s using docker dir: %s\n", tmpdir, backupDir)
-
-	localFsDirs := []string{tmpdir}
-	setupDirs(t, localFsDirs)
-	// remove backup directories to make sure this test doesn't leave anything behind.
-	defer cleanupDirs(t, localFsDirs)
-
 	// create a full backup in backupDir
 	backup(t, backupDir)
 
@@ -597,7 +586,9 @@ func setupDirs(t *testing.T, dirs []string) {
 
 func cleanupDirs(t *testing.T, dirs []string) {
 	for _, dir := range dirs {
-		os.RemoveAll(dir)
+		if err := os.RemoveAll(dir); err != nil {
+			t.Logf("Got error while removing: %s: %v\n", dir, err)
+		}
 	}
 }
 

--- a/t/main.go
+++ b/t/main.go
@@ -563,6 +563,7 @@ func run() error {
 		removeAllTestContainers()
 		return nil
 	}
+	fmt.Printf("Proc ID is %d\n", procId)
 
 	start := time.Now()
 	oc.Took(0, "START", time.Millisecond)

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -219,7 +219,7 @@ func ProcessListBackups(ctx context.Context, location string, creds *Credentials
 
 	manifests, err := ListBackupManifests(location, creds)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cannot read manfiests at location %s", location)
+		return nil, errors.Wrapf(err, "cannot read manifests at location %s", location)
 	}
 
 	res := make([]*Manifest, 0)


### PR DESCRIPTION
- Make error checking in TestGuardianOnlyAccessForAdminEndpoints to be more robust.
- Make addSchemaAndData handle temporary server errors better.
- Make online-restore not leave behind directories created by root in Docker by using docker volume for backup tests.
- Remove docker volumes left behind by tests.
- Create backup path if it doesn't exist during backup (not needed to fix any tests, but useful in general).

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6958)
<!-- Reviewable:end -->
