### PR TITLE
chore: Add flag to test script to avoid building Dgraph

### DIFF
--- a/t/main.go
+++ b/t/main.go
@@ -74,6 +74,8 @@ var (
 		"Clear all the test clusters.")
 	dry = pflag.BoolP("dry", "", false,
 		"Just show how the packages would be executed, without running tests.")
+	noBuild = pflag.BoolP("no-build", "", false,
+		"Run tests without building Dgraph.")
 	useExisting = pflag.String("prefix", "",
 		"Don't bring up a cluster, instead use an existing cluster with this prefix.")
 )
@@ -587,13 +589,15 @@ func run() error {
 	start := time.Now()
 	oc.Took(0, "START", time.Millisecond)
 
-	// cmd := command("make", "BUILD_RACE=y", "install")
-	cmd := command("make", "install")
-	cmd.Dir = *baseDir
-	if err := cmd.Run(); err != nil {
-		return err
+	if !*noBuild {
+		// cmd := command("make", "BUILD_RACE=y", "install")
+		cmd := command("make", "install")
+		cmd.Dir = *baseDir
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+		oc.Took(0, "COMPILE", time.Since(start))
 	}
-	oc.Took(0, "COMPILE", time.Since(start))
 
 	if len(*runPkg) > 0 && len(*runTest) > 0 {
 		log.Fatalf("Both pkg and test can't be set.\n")

--- a/t/main.go
+++ b/t/main.go
@@ -74,8 +74,8 @@ var (
 		"Clear all the test clusters.")
 	dry = pflag.BoolP("dry", "", false,
 		"Just show how the packages would be executed, without running tests.")
-	noBuild = pflag.BoolP("no-build", "", false,
-		"Run tests without building Dgraph.")
+	rebuildBinary = pflag.BoolP("rebuild-binary", "", true,
+		"Build Dgraph before running tests.")
 	useExisting = pflag.String("prefix", "",
 		"Don't bring up a cluster, instead use an existing cluster with this prefix.")
 )
@@ -589,7 +589,7 @@ func run() error {
 	start := time.Now()
 	oc.Took(0, "START", time.Millisecond)
 
-	if !*noBuild {
+	if *rebuildBinary {
 		// cmd := command("make", "BUILD_RACE=y", "install")
 		cmd := command("make", "install")
 		cmd.Dir = *baseDir


### PR DESCRIPTION
Added a `--rebuild-binary` flag to the `t` package that, when disabled, avoids building Dgraph before running tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6962)
<!-- Reviewable:end -->
