### PR TITLE
Docs (GraphQL): Disk Compression breaking change in 20.11 ( `--badger.compression` replaces `--badger.compression_level`)

### DIFF
--- a/wiki/content/deploy/data-compression.md
+++ b/wiki/content/deploy/data-compression.md
@@ -1,19 +1,43 @@
 +++
 date = "2017-03-20T22:25:17+11:00"
-title = "Data compression on disk"
+title = "Data compression on Disk"
 weight = 17
 [menu.main]
     parent = "deploy"
 +++
 
-Alpha exposes the option `--badger.compression_level` to configure the compression
-level for data on disk using Zstd compression. The option can be set as
+Dgraph Alpha lets you configure the compression of data on disk using the
+`--badger.compression` option. You can choose between the
+[Snappy](https://github.com/golang/snappy) and
+[Zstandard](https://github.com/facebook/zstd) compression algorithms, or choose
+not to compress data on disk.
+
+{{% notice "note" %}}This option replaces the  `--badger.compression_level`
+option used in earlier Dgraph versions. {{% /notice %}}
+
+The following disk compression settings are available:
+
+| Setting | Notes                                                                   |
+|------------|----------------------------------------------------------------------|
+|`none`      | Data on disk will not be compressed.                                 |
+|`zstd:level`| Use Zstandard compression, with a compression level specified (1-3). |
+|`snappy`    | Use Snappy compression (this is the default value)                   |
+
+For example, you could choose to use Zstandard compression with the highest
+compression level using the following command:
 
 ```sh
-dgraph alpha --badger.compression_level=xxx
+dgraph alpha --badger.compression=zstd:3
 ```
 
-A higher compression level is more CPU intensive but offers a better compression
-ratio. The default level is 3.
+This compression setting (Zstandard, level 3) is more CPU-intensive than other
+options, but offers the highest compression ratio. To change back to the default
+compression setting, use the following command:
 
-This option is available in v20.03.1 and later.
+
+```sh
+dgraph alpha --badger.compression=snappy
+```
+
+Using this compression setting (Snappy) provides a good compromise between the
+need for a high compression ratio and efficient use of CPU resources.

--- a/wiki/content/deploy/data-compression.md
+++ b/wiki/content/deploy/data-compression.md
@@ -17,11 +17,11 @@ option used in earlier Dgraph versions. {{% /notice %}}
 
 The following disk compression settings are available:
 
-| Setting | Notes                                                                   |
+| Setting    | Notes                                                                |
 |------------|----------------------------------------------------------------------|
 |`none`      | Data on disk will not be compressed.                                 |
 |`zstd:level`| Use Zstandard compression, with a compression level specified (1-3). |
-|`snappy`    | Use Snappy compression (this is the default value)                   |
+|`snappy`    | Use Snappy compression (this is the default value).                  |
 
 For example, you could choose to use Zstandard compression with the highest
 compression level using the following command:
@@ -40,4 +40,4 @@ dgraph alpha --badger.compression=snappy
 ```
 
 Using this compression setting (Snappy) provides a good compromise between the
-need for a high compression ratio and efficient use of CPU resources.
+need for a high compression ratio and efficient CPU usage.

--- a/wiki/content/deploy/fast-data-loading.md
+++ b/wiki/content/deploy/fast-data-loading.md
@@ -267,7 +267,7 @@ So, with the above two options we have 4 cases:
 
 Error: If the input is encrypted, a key file must be provided.
 
-2. `--encrypted=true` and `encryption_key_file`=`path` to key.
+2. `--encrypted=true` and `encryption_key_file=path-to-key`.
 
 Input is encrypted and output `p` dir is encrypted as well.
 

--- a/wiki/content/deploy/fast-data-loading.md
+++ b/wiki/content/deploy/fast-data-loading.md
@@ -104,8 +104,8 @@ Alpha server.
 
 `-U, --upsertPredicate` (default: disabled): Runs Live Loader in `upsertPredicate` mode. The provided value will be used to store blank nodes as a `xid`.
 
-`--vault_*` flags specifies the Vault server address, role id, secret id and 
-field that contains the encryption key that can be used to decrypt the encrypted export. 
+`--vault_*` flags specifies the Vault server address, role id, secret id and
+field that contains the encryption key that can be used to decrypt the encrypted export.
 
 ## Bulk Loader
 
@@ -252,7 +252,7 @@ Here's an example to run Bulk Loader with a key used to write encrypted data:
 ```bash
 dgraph bulk --encryption_key_file ./enc_key_file -f data.json.gz -s data.schema --map_shards=1 --reduce_shards=1 --http localhost:8000 --zero=localhost:5080
 ```
-Alternatively, starting with v20.07.0, the `vault_*` options can be used to decrypt the encrypted export. 
+Alternatively, starting with v20.07.0, the `vault_*` options can be used to decrypt the encrypted export.
 
 
 ### Encrypting imports via Bulk Loader (Enterprise Feature)
@@ -267,7 +267,7 @@ So, with the above two options we have 4 cases:
 
 Error: If the input is encrypted, a key file must be provided.
 
-2. `--encrypted=true` and `encryption_key_file`=`path to key.
+2. `--encrypted=true` and `encryption_key_file`=`path` to key.
 
 Input is encrypted and output `p` dir is encrypted as well.
 
@@ -279,11 +279,18 @@ Input is not encrypted and the output `p` dir is also not encrypted.
 
 Input is not encrypted but the output is encrypted. (This is the migration use case mentioned above).
 
-Alternatively, starting with v20.07.0, the `vault_*` options can be used instead of the `--encryption_key_file` option above to achieve the same effect except that the keys are sitting in a Vault server. 
+Alternatively, starting with v20.07.0, the `vault_*` options can be used instead of the `--encryption_key_file` option above to achieve the same effect except that the keys are sitting in a Vault server.
 
 ### Other Bulk Loader options
 
-`--new_uids` (default: false): Assign new UIDs instead of using the existing
+You can further configure Bulk Loader using the following options:
+
+`--badger.compression`: Configure the compression of data on disk. By default,
+the Snappy compression format is used, but you can also use Zstandard
+compression. Or, you can choose no compression to minimize CPU usage. To learn
+more, see [Data Compression on Disk](/deploy/data-compression).
+
+`--new_uids`: (default: false): Assign new UIDs instead of using the existing
 UIDs in data files. This is useful to avoid overriding the data in a DB already
 in operation.
 
@@ -299,8 +306,8 @@ use [External IDs]({{< relref "mutations/external-ids.md" >}}).
 
 `--xidmap` (default: disabled. Need a path): Store xid to uid mapping to a directory. Dgraph will save all identifiers used in the load for later use in other data ingest operations. The mapping will be saved in the path you provide and you must indicate that same path in the next load. It is recommended to use this flag if you have full control over your identifiers (Blank-nodes). Because the identifier will be mapped to a specific UID.
 
-`--vault_*` flags specifies the Vault server address, role id, secret id and 
-field that contains the encryption key that can be used to decrypt the encrypted export. 
+`--vault_*` flags specifies the Vault server address, role id, secret id and
+field that contains the encryption key that can be used to decrypt the encrypted export.
 
 ### Tuning & monitoring
 


### PR DESCRIPTION
Fixes GraphQL-876

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6965)
<!-- Reviewable:end -->
