### PR TITLE
fix(GraphQL):This PR allows to use fragments on interfaces while querying other interface.  (#6964)

### DIFF
--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -169,6 +169,20 @@ func fragmentInQueryOnInterface(t *testing.T) {
 					n: name
 				}
 			}
+			qc3: queryCharacter {
+				... on Droid{
+					__typename
+					primaryFunction
+				}
+				... on Employee {
+					__typename
+					ename
+				}
+				... on Human {
+					__typename
+					name
+				}
+			}
 			qcRep1: queryCharacter {
 				name
 				... on Human {
@@ -314,6 +328,17 @@ func fragmentInQueryOnInterface(t *testing.T) {
 				"n": "Han"
 			},
 			{
+			}
+		],
+		"qc3":[
+			{
+				"__typename":"Human",
+				"ename":"Han_employee",
+				"name":"Han"
+			},
+			{
+				"__typename":"Droid",
+				"primaryFunction":"Robot"
 			}
 		],
 		"qcRep1": [

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1936,6 +1936,32 @@
     }
 
 -
+  name: "fragment on interface implemented by type which implements multiple interfaces in query on some other interface"
+  gqlquery: |
+    query {
+      queryCharacter {
+        id
+        name
+        ... on Employee {
+            ename
+        }
+        ... on Human {
+            female
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCharacter(func: type(Character)) {
+        dgraph.type
+        id : uid
+        name : Character.name
+        ename : Employee.ename
+        female : Human.female
+      }
+    }
+
+-
   name: "Filter with id uses uid func at root."
   gqlquery: |
     query {

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -275,28 +275,20 @@ func recursivelyExpandFragmentSelections(field *ast.Field, op *operation) {
 	satisfies := []string{typeName, ""}
 	var additionalTypes map[string]bool
 	switch typeKind {
-	case ast.Interface:
-		// expand fragments on types which implement this interface
+	case ast.Interface, ast.Union:
+		// expand fragments on types which implement this interface (for interface case)
+		// expand fragments on member types of this union (for Union case)
 		additionalTypes = getTypeNamesAsMap(op.inSchema.schema.PossibleTypes[typeName])
-		// if there is any fragment in the selection set of this field, need to store a mapping from
-		// fields in that fragment to the fragment's type condition, to be used later in completion.
-		for _, f := range field.SelectionSet {
-			addSelectionToInterfaceImplFragFields(typeName, f, additionalTypes, op)
-		}
-	case ast.Union:
-		// expand fragments on member types of this union
-		additionalTypes = getTypeNamesAsMap(op.inSchema.schema.PossibleTypes[typeName])
-		// also, expand fragments on interfaces which are implemented by the member types of this
-		// union
+		// also, expand fragments on interfaces which are implemented by the member types of this union
+		// And also on additional interfaces which also implement the same type
 		var interfaceFragsToExpand []*ast.Definition
-		for memberType := range additionalTypes {
+		for typ := range additionalTypes {
 			interfaceFragsToExpand = append(interfaceFragsToExpand,
-				op.inSchema.schema.Implements[memberType]...)
+				op.inSchema.schema.Implements[typ]...)
 		}
 		additionalInterfaces := getTypeNamesAsMap(interfaceFragsToExpand)
-		// for fragments in the selection set of this union field, need to store a mapping from
-		// fields in that fragment to the fragment's type condition, for each of the additional
-		// interfaces, to be used later in completion.
+		// if there is any fragment in the selection set of this field, need to store a mapping from
+		// fields in that fragment to the fragment's type condition, to be used later in completion.
 		for interfaceName := range additionalInterfaces {
 			additionalTypes[interfaceName] = true
 			for _, f := range field.SelectionSet {


### PR DESCRIPTION
Fixes GRAPHQL-863
Consider the below schema, Human implements both character and Employee interfaces.

interface Employee { ... }
interface Character { ... }
type Human implements Character & Employee { ... }
type Droid implements Character { ... }

While Querying Character interfaces which can return an object of Droid or Human, we will be able to use fragment on Employee interface if the returned object is of type Human and ignores it if the returned object is of type Droid.

(cherry picked from commit f810e4ec0267bd4d69241e6774c70e8bcc22ea43)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6966)
<!-- Reviewable:end -->
