### PR TITLE
test: don't compare counter in successive state calls (GRAPHQL-873)

### DIFF
--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -741,7 +741,6 @@ func adminState(t *testing.T) {
 	queryParams := &GraphQLParams{
 		Query: `query {
 			state {
-				counter
 				groups {
 					id
 					members {
@@ -802,8 +801,7 @@ func adminState(t *testing.T) {
 
 	var result struct {
 		State struct {
-			Counter uint64
-			Groups  []struct {
+			Groups []struct {
 				Id         uint32
 				Members    []*pb.Member
 				Tablets    []*pb.Tablet
@@ -834,7 +832,6 @@ func adminState(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, jsonpb.Unmarshal(bytes.NewReader(stateRes), &state))
 
-	require.Equal(t, state.Counter, result.State.Counter)
 	for _, group := range result.State.Groups {
 		require.Contains(t, state.Groups, group.Id)
 		expectedGroup := state.Groups[group.Id]


### PR DESCRIPTION
This PR fixes the flaky behavior of the test which verifies that the response of `/state` should be the same as the response of GraphQL admin state request. Previously it used to compare the counter returned in the state response, which can change between two consecutive state calls. The counter in state response is set based on the index of the last RAFT entry applied by Zero. If Zero has applied a RAFT entry between the two consecutive state calls, then the counter would have changed. So, let's not compare this in the test.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6967)
<!-- Reviewable:end -->
