### PR TITLE
Docs (clarification): Clarify switch from semantic to calendar versioning

### DIFF
--- a/wiki/content/releases/index.md
+++ b/wiki/content/releases/index.md
@@ -6,8 +6,13 @@ title = "Dgraph Releases"
   weight = 14
 +++
 
-Dgraph releases starting with v20.03 follow [calendar versioning](https://calver.org).
-You can watch the [Announce][] Discuss category to know about the latest releases and other important announcements.
+Dgraph releases starting with v20.03 follow
+[calendar versioning](https://calver.org). To learn more about our switch from
+semantic to calendar versioning, and why v2-v19 don't exist as a result of this
+switch, see our [Blog post on the switch to calendar versioning]().
+
+To learn about the latest releases and other important announcements, watch the
+[Announce][] category on Discuss .
 
 [Announce]: https://discuss.dgraph.io/c/announce
 

--- a/wiki/content/releases/index.md
+++ b/wiki/content/releases/index.md
@@ -9,10 +9,11 @@ title = "Dgraph Releases"
 Dgraph releases starting with v20.03 follow
 [calendar versioning](https://calver.org). To learn more about our switch from
 semantic to calendar versioning, and why v2-v19 don't exist as a result of this
-switch, see our [Blog post on the switch to calendar versioning]().
+switch, see our Blog post on the 
+[switch to calendar versioning](https://dgraph.io/blog/post/dgraph-calendar-versioning/).
 
 To learn about the latest releases and other important announcements, watch the
-[Announce][] category on Discuss .
+[Announce][] category on Discuss.
 
 [Announce]: https://discuss.dgraph.io/c/announce
 


### PR DESCRIPTION
Customers are sometimes confused about why we don't have versions 2-19. This PR aims to clarify this by linking from our versioning page to our blog post on this topic

Fixes Success-171

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6973)
<!-- Reviewable:end -->
