### PR TITLE
Fix(raftwal): Copy baseIV instead of holding reference

### DIFF
--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -346,6 +346,7 @@ func (lf *logFile) bootstrap() error {
 		return y.Wrapf(err, "Error while creating base IV, while creating logfile")
 	}
 	// Initialize base IV.
-	lf.baseIV = buf[8:]
+	lf.baseIV = make([]byte, 8)
+	y.AssertTrue(8 == copy(lf.baseIV, buf[8:]))
 	return nil
 }


### PR DESCRIPTION
We need to keep a copy of baseIV in raftwal because if we grow, then the underlying buffer will change. Holding reference will cause segmentation fault. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6977)
<!-- Reviewable:end -->
