### PR TITLE
Docs (clarification) Note proper use and meaning of --replicas flag

### DIFF
--- a/wiki/content/deploy/cluster-setup.md
+++ b/wiki/content/deploy/cluster-setup.md
@@ -12,13 +12,13 @@ For a single server setup, recommended for new users, please see [Get Started]({
 
 ## Understanding Dgraph cluster
 
-Dgraph is a truly distributed graph database - not a master-slave replication of
-universal dataset. It shards by predicate and replicates predicates across the
-cluster, queries can be run on any node and joins are handled over the
-distributed data.  A query is resolved locally for predicates the node stores,
-and via distributed joins for predicates stored on other nodes.
+Dgraph is a truly distributed graph database. It shards by predicate and
+replicates predicates across the cluster, queries can be run on any node and
+joins are handled over the distributed data. A query is resolved locally for
+predicates the node stores, and using distributed joins for predicates stored on
+other nodes.
 
-For effectively running a Dgraph cluster, it's important to understand how
+To effectively running a Dgraph cluster, it's important to understand how
 sharding, replication and rebalancing works.
 
 ### Sharding
@@ -31,8 +31,8 @@ single group. Dgraph Zero assigns a group to each Alpha node.
 ### Shard rebalancing
 
 Dgraph Zero tries to rebalance the cluster based on the disk usage in each
-group. If Zero detects an imbalance, it would try to move a predicate along with
-its indices to a group that has minimum disk usage. This can make the predicate
+group. If Zero detects an imbalance, it will try to move a predicate along with
+its indices to a group that has lower disk usage. This can make the predicate
 temporarily read-only. Queries for the predicate will still be serviced, but any
 mutations for the predicate will be rejected and should be retried after the
 move is finished.
@@ -44,10 +44,13 @@ groups and move them to the new node.
 
 ### Consistent Replication
 
-If `--replicas` flag is set to something greater than one, Zero would assign the
-same group to multiple nodes. These nodes would then form a Raft group aka
-quorum. Every write would be consistently replicated to the quorum. To achieve
-consensus, its important that the size of quorum be an odd number. Therefore, we
-recommend setting `--replicas` to 1, 3 or 5 (not 2 or 4). This allows 0, 1, or 2
-nodes serving the same group to be down, respectively without affecting the
-overall health of that group.
+When you start the first Zero node, you can pass the `--replicas` flag to assign
+the same group to multiple nodes. The number passed to the `--replicas` flag
+causes that Zero node to assign the same group to the specified number of nodes.
+These nodes will then form a Raft group (or quorum), and every write will be
+consistently replicated to the quorum.
+
+To achieve consensus, it's important that the size of quorum be an odd number.
+Therefore, we recommend setting `--replicas` to 1, 3 or 5 (not 2 or 4). This
+allows 0, 1, or 2 nodes serving the same group to be down, respectively, without
+affecting the overall health of that group.


### PR DESCRIPTION
Updates to: 

https://dgraph.io/docs/deploy/cluster-setup/#consistent-replication specify that the --replicas flag has to be passed to Dgraph Zero, and that it has to be passed only once (for the first Dgraph Zero node launched).

Also includes some rewording.

Fixes SUCCESS-245

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6981)
<!-- Reviewable:end -->
