### PR TITLE
fix(worker): fix eq filter for non-index predicates.

### DIFF
--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -2936,49 +2936,6 @@ func TestFilterNonIndexedPredicate(t *testing.T) {
 	}
 }
 
-func TestBetweenWithoutIndex(t *testing.T) {
-	tests := []struct {
-		name   string
-		query  string
-		result string
-	}{
-		{
-			`Test Between on Non Indexed Predicate`,
-			`
-			{
-				me(func: type(CarModel)) @filter(between(year,2009,2010)){
-					make
-					model
-					year
-				}
-			}
-			`,
-			`{"data":{"me":[{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
-		},
-		{
-			`Test Between filter at child node`,
-			`
-			{
-				me(func :has(newage)) @filter(between(newage,20,24)) {
-					newage
-					newfriend @filter(between(newage,25,30)){
-					  newage
-					}
-				 }
-			}
-			`,
-			`{"data": {"me": [{"newage": 21},{"newage": 22,"newfriend": [{"newage": 25},{"newage": 26}]},{"newage": 23,"newfriend": [{"newage": 27},{"newage": 28}]},{"newage": 24,"newfriend": [{"newage": 29},{"newage": 30}]}]}}`,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			js := processQueryNoErr(t, tc.query)
-			require.JSONEq(t, js, tc.result)
-		})
-	}
-
-}
-
 func TestEqFilterWithoutIndex(t *testing.T) {
 	test := struct {
 		name   string

--- a/types/compare.go
+++ b/types/compare.go
@@ -45,3 +45,10 @@ func CompareVals(op string, arg1, arg2 Val) bool {
 	}
 	return false
 }
+
+// CompareBetween compares if the dst value lie between
+// two values val1 and val2(both inclusive).
+func CompareBetween(dst, val1, val2 Val) bool {
+	return CompareVals("ge", dst, val1) &&
+		CompareVals("le", dst, val2)
+}

--- a/types/compare.go
+++ b/types/compare.go
@@ -45,10 +45,3 @@ func CompareVals(op string, arg1, arg2 Val) bool {
 	}
 	return false
 }
-
-// CompareBetween compares if the dst value lie between
-// two values val1 and val2(both inclusive).
-func CompareBetween(dst, val1, val2 Val) bool {
-	return CompareVals("ge", dst, val1) &&
-		CompareVals("le", dst, val2)
-}

--- a/worker/task.go
+++ b/worker/task.go
@@ -451,10 +451,20 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 					if val, err = types.Convert(val, srcFn.atype); err != nil {
 						return err
 					}
-					if types.CompareVals(srcFn.fname, val, srcFn.ineqValue) {
-						uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
-						break
+					switch srcFn.fname {
+					case "eq":
+						for _, eqToken := range srcFn.eqTokens {
+							if types.CompareVals(srcFn.fname, val, eqToken) {
+								uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+								break
+							}
+						}
+					default:
+						if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
+							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+						}
 					}
+
 				} else {
 					vl.Values = append(vl.Values, newValue)
 				}


### PR DESCRIPTION
Fixes DGRAPH-1781.

This PR backport the fix of `eq filter on non-indexed predicate`, which was fixed by #6715 earlier.

This PR  fixes the `eq` filter for more than one argument on the non-indexed predicate which earlier used to compare with just the first of the given arguments for the `eq` filter. For eg for the given schema:
```
type CarModel {
	make
	model
	year
}
model                          : string @index(term) @lang .
make                           : string @index(term) .
year                           : int .
```
the below query was not giving proper results earlier.
```
queryCarModel(func: type(CarModel)) @filter(eq(year,2008,2009)){
				make
				model
				year
			}
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6986)
<!-- Reviewable:end -->
