### PR TITLE
fix(worker): fix eq filter for non-index predicates. (#6986)

### DIFF
--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -2908,6 +2908,30 @@ func TestFilterNonIndexedPredicate(t *testing.T) {
 	}
 }
 
+func TestEqFilterWithoutIndex(t *testing.T) {
+	test := struct {
+		name   string
+		query  string
+		result string
+	}{
+		`Test eq filter on Non Indexed Predicate`,
+		`
+		{
+			me(func: type(CarModel)) @filter(eq(year,2008,2009)){
+				make
+				model
+				year
+			}
+		}
+		`,
+		`{"data":{"me":[{"make":"Ford","model":"Focus","year":2008},{"make":"Ford","model":"Focus","year":2009},{"make":"Toyota","model":"Prius","year":2009}]}}`,
+	}
+
+	js := processQueryNoErr(t, test.query)
+	require.JSONEq(t, js, test.result)
+
+}
+
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -442,10 +442,20 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 					if val, err = types.Convert(val, srcFn.atype); err != nil {
 						return err
 					}
-					if types.CompareVals(srcFn.fname, val, srcFn.ineqValue) {
-						uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
-						break
+					switch srcFn.fname {
+					case "eq":
+						for _, eqToken := range srcFn.eqTokens {
+							if types.CompareVals(srcFn.fname, val, eqToken) {
+								uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+								break
+							}
+						}
+					default:
+						if types.CompareVals(srcFn.fname, val, srcFn.eqTokens[0]) {
+							uidList.Uids = append(uidList.Uids, q.UidList.Uids[i])
+						}
 					}
+
 				} else {
 					vl.Values = append(vl.Values, newValue)
 				}


### PR DESCRIPTION
* fix eq function with non indexed predicate

* remove tests for between function

(cherry picked from commit 54ef639ae160bc2bdd313853bc1c37efed98bed2)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6988)
<!-- Reviewable:end -->
