### PR TITLE
fix: ExportInput destination doc-string comment

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -213,7 +213,7 @@ const (
 		format: String
 
 		"""
-		Destination for the backup: e.g. Minio or S3 bucket or /absolute/path
+		Destination for the export: e.g. Minio or S3 bucket or /absolute/path
 		"""
 		destination: String
 


### PR DESCRIPTION
Small fix to change comment from backups to export, as this is in the context of exports.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6990)
<!-- Reviewable:end -->
