### PR TITLE
fix: ExportInput destination doc-string comment (#6990)

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -213,7 +213,7 @@ const (
 		format: String
 
 		"""
-		Destination for the backup: e.g. Minio or S3 bucket or /absolute/path
+		Destination for the export: e.g. Minio or S3 bucket or /absolute/path
 		"""
 		destination: String
 


### PR DESCRIPTION
(cherry picked from commit 80bbf0a576e525b8af2962d10634919e71596f68)

This fixes doc-string for ExportInput { destination } that references backup and not export.  Change to reflect the context of export.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6992)
<!-- Reviewable:end -->
