### PR TITLE
release/v20.07 - fix: change default compression on 20.07 to zstd:3

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -102,7 +102,7 @@ func init() {
 		"Ignore UIDs in load files and assign new ones.")
 
 	// Options around how to set up Badger.
-	flag.Int("badger.compression_level", 1,
+	flag.Int("badger.compression_level", 3,
 		"The compression level for Badger. A higher value uses more resources.")
 	flag.Int64("badger.cache_mb", 0, "Total size of cache (in MB) per shard in reducer.")
 	flag.String("badger.cache_percentage", "0,100",

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -64,6 +64,8 @@ func RunRestore(pdir, location, backupId string, key x.SensitiveByteSlice) LoadR
 			// The badger DB should be opened only after creating the backup
 			// file reader and verifying the encryption in the backup file.
 			db, err := badger.OpenManaged(badger.DefaultOptions(dir).
+				WithCompression(options.ZSTD).
+				WithZSTDCompressionLevel(3).
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).
 				WithValueThreshold(1 << 10).


### PR DESCRIPTION
Changes the default compression levels in `bulk` and `store` to `zstd:3` for consistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6995)
<!-- Reviewable:end -->
