### PR TITLE
fix(DQL): ignore ordering of indexes in schema with eq function (DGRAPH-2601)

### DIFF
--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -15,7 +15,7 @@ Comparison functions (`eq`, `ge`, `gt`, `le`, `lt`) in the query root (aka `func
 be applied on [indexed predicates]({{< relref "query-language/schema.md#indexing" >}}). Since v1.2, comparison functions
 can now be used on [@filter]({{<relref "query-language/graphql-fundamentals.md#applying-filters" >}}) directives even on predicates
 that have not been indexed.
-Filtering on non-indexed predicates can be slow for large datasets, as they require
+Filtering on non-in dexed predicates can be slow for large datasets, as they require
 iterating over all of the possible values at the level where the filter is being used.
 
 All other functions, in the query root or in the filter can only be applied to indexed predicates.
@@ -265,7 +265,7 @@ Index Required: An index is required for the `eq(predicate, ...)` forms (see tab
 | `int`      | `int`         |
 | `float`    | `float`       |
 | `bool`     | `bool`        |
-| `string`   | `exact`, `hash` |
+| `string`   | `exact`, `hash`, `term`, `fulltext` |
 | `dateTime` | `dateTime`    |
 
 Test for equality of a predicate or variable to a value or find in a list of values.

--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -15,7 +15,7 @@ Comparison functions (`eq`, `ge`, `gt`, `le`, `lt`) in the query root (aka `func
 be applied on [indexed predicates]({{< relref "query-language/schema.md#indexing" >}}). Since v1.2, comparison functions
 can now be used on [@filter]({{<relref "query-language/graphql-fundamentals.md#applying-filters" >}}) directives even on predicates
 that have not been indexed.
-Filtering on non-in dexed predicates can be slow for large datasets, as they require
+Filtering on non-indexed predicates can be slow for large datasets, as they require
 iterating over all of the possible values at the level where the filter is being used.
 
 All other functions, in the query root or in the filter can only be applied to indexed predicates.

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -85,7 +85,7 @@ func pickTokenizer(ctx context.Context, attr string, f string) (tok.Tokenizer, e
 
 	tokenizers := schema.State().Tokenizer(ctx, attr)
 	for _, t := range tokenizers {
-		// If function is eq and we found a tokenizer thats !Lossy(), lets return it
+		// If function is eq and we found a tokenizer that's !Lossy(), lets return it
 		switch f {
 		case "eq":
 			// For equality, find a non-lossy tokenizer.
@@ -105,7 +105,15 @@ func pickTokenizer(ctx context.Context, attr string, f string) (tok.Tokenizer, e
 		return nil, errors.Errorf("Attribute:%s does not have proper index for comparison", attr)
 	}
 
-	// We didn't find a sortable or !isLossy() tokenizer, lets return the first one.
+	// If we didn't find a sortable or !isLossy() tokenizer for eq function,
+	// then let's see if we can find a term or fulltext tokenizer
+	for _, t := range tokenizers {
+		if t.Identifier() == tok.IdentTerm || t.Identifier() == tok.IdentFullText {
+			return t, nil
+		}
+	}
+
+	// otherwise, lets return the first one.
 	return tokenizers[0], nil
 }
 

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -105,11 +105,13 @@ func pickTokenizer(ctx context.Context, attr string, f string) (tok.Tokenizer, e
 		return nil, errors.Errorf("Attribute:%s does not have proper index for comparison", attr)
 	}
 
-	// If we didn't find a sortable or !isLossy() tokenizer for eq function,
-	// then let's see if we can find a term or fulltext tokenizer
-	for _, t := range tokenizers {
-		if t.Identifier() == tok.IdentTerm || t.Identifier() == tok.IdentFullText {
-			return t, nil
+	// If we didn't find a !isLossy() tokenizer for eq function on string type predicates,
+	// then let's see if we can find a non-trigram tokenizer
+	if typ, err := schema.State().TypeOf(attr); err == nil && typ == types.StringID {
+		for _, t := range tokenizers {
+			if t.Identifier() != tok.IdentTrigram {
+				return t, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes DGRAPH-2601

Previously, the following schema:
```
name: string @index(trigram, term) .
```
with some added data, and the following query:
```
query {
	q(func: eq(name, "Alice", "Bob")) {
		uid
		name
	}
}
```
would error out saying it doesn't have a valid tokenizer:
```
{
  "errors": [
    {
      "message": ": Attribute name does not have a valid tokenizer.",
      "extensions": {
        "code": "ErrorInvalidRequest"
      }
    }
  ],
  "data": null
}
```
even though `term` index is present on the predicate.
On the other hand, if you reversed the order of indexes:
```
name: string @index(term, trigram) .
```
It would give correct results:
```
{
  "data": {
    "q": [
      {
        "uid": "0x2",
        "name": "Alice",
        "age": 20
      },
      {
        "uid": "0x3",
        "name": "Bob",
        "age": 25
      }
    ]
  }
}
```

This PR fixes the above issue.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6996)
<!-- Reviewable:end -->
