### PR TITLE
fix: Undo normalization of glog files

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -170,6 +170,11 @@ func setGlogFlags(conf *viper.Viper) {
 		if gflag == "log-backtrace-at" && (stringValue == "0" || stringValue == ":0") {
 			continue
 		}
+
+		// glog uses snake_case flags. Although we use a normalization function,
+		// the actual lookup value for the flags would not change here.
+		// So, we undo any normalization before setting the flags.
+		gflag = strings.ReplaceAll(gflag, "-", "_")
 		x.Check(flag.Lookup(gflag).Value.Set(stringValue))
 	}
 }

--- a/dgraph/cmd/version/version_test.go
+++ b/dgraph/cmd/version/version_test.go
@@ -1,0 +1,26 @@
+package version
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// Test `dgraph version` with an empty config file.
+func TestDgraphVersion(t *testing.T) {
+	tmpPath, err := ioutil.TempDir("", "test.tmp-")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpPath)
+
+	configPath := filepath.Join(tmpPath, "config.yml")
+	configFile, err := os.Create(configPath)
+	require.NoError(t, err)
+	defer configFile.Close()
+
+	err = testutil.Exec(testutil.DgraphBinaryPath(), "version", "--config", configPath)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
The recent `--kebab-case` PR included a normalization function that messed with `glog` flags. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6998)
<!-- Reviewable:end -->
