### PR TITLE
fix(bulk): Fix reduce phase crash and memory leak in bulk-loader

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -611,7 +611,7 @@ func (r *reducer) toList(req *encodeRequest) {
 		enc := codec.Encoder{BlockSize: 256}
 		var lastUid uint64
 		slice, next := []byte{}, start
-		for next != -1 && (next < end || end == 0) {
+		for next >= 0 && (next < end || end == 0) {
 			slice, next = cbuf.Slice(next)
 			me := MapEntry(slice)
 
@@ -693,7 +693,7 @@ func (r *reducer) toList(req *encodeRequest) {
 		pl.Reset()
 	}
 
-	for end != -1 {
+	for end >= 0 {
 		slice, next := cbuf.Slice(end)
 		entry := MapEntry(slice)
 		entryKey := entry.Key()

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -381,6 +381,7 @@ func (r *reducer) startWriting(ci *countIndexer, writerCh chan *encodeRequest, c
 
 			})
 			x.Check(err)
+			kvBuf.Release()
 		}
 	}
 
@@ -692,7 +693,7 @@ func (r *reducer) toList(req *encodeRequest) {
 		pl.Reset()
 	}
 
-	for end != 0 {
+	for end != -1 {
 		slice, next := cbuf.Slice(end)
 		entry := MapEntry(slice)
 		entryKey := entry.Key()

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -611,7 +611,7 @@ func (r *reducer) toList(req *encodeRequest) {
 		enc := codec.Encoder{BlockSize: 256}
 		var lastUid uint64
 		slice, next := []byte{}, start
-		for next != 0 && (next < end || end == 0) {
+		for next != -1 && (next < end || end == 0) {
 			slice, next = cbuf.Slice(next)
 			me := MapEntry(slice)
 


### PR DESCRIPTION
The function `( *Buffer) Slice(int)` now returns `-1` for invalid offset. This PR incorporates this change in bulk-loader.
This also fixes a memory leak in bulk-loader, which is caused because we didn't free the `kvBuf`.

**Note: This PR needs some testing**

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/6999)
<!-- Reviewable:end -->
