### PR TITLE
[docs] added example to export to a custom path within the graphql mutation

### DIFF
--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -112,7 +112,7 @@ To fully secure alter operations in the cluster, the auth token must be set for 
 
 ## Exporting Database
 
-An export of all nodes is started by locally executing the following GraphQL mutation on /admin endpoint using any compatible client like Insomnia, GraphQL Playground or GraphiQL.
+An export of all nodes is started by locally executing the following GraphQL mutation on `/admin` endpoint of an Alpha node (e.g. `localhost:8080/admin`) using any compatible client like Insomnia, GraphQL Playground or GraphiQL.
 
 ```graphql
 mutation {
@@ -142,6 +142,19 @@ export.
 Each Alpha leader for a group writes output as a gzipped file to the export
 directory specified via the `--export` flag (defaults to a directory called `"export"`). If any of the groups fail, the
 entire export process is considered failed and an error is returned.
+
+Starting from Dgraph v20.11.0, it is possible to provide an absolute path to the directory where you want to export data in the GraphQL mutation request.
+
+```graphql
+mutation {
+  export(input: {format: "rdf",destination: "<absolute-path-to-your-export-dir>"}) {
+    response {
+      message
+      code
+    }
+  }
+}
+```
 
 The data is exported in RDF format by default. A different output format may be specified with the
 `format` field. For example:

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -112,7 +112,7 @@ To fully secure alter operations in the cluster, the auth token must be set for 
 
 ## Exporting Database
 
-An export of all nodes is started by locally executing the following GraphQL mutation on `/admin` endpoint of an Alpha node (e.g. `localhost:8080/admin`) using any compatible client like Insomnia, GraphQL Playground or GraphiQL.
+An export of all nodes is started by locally executing the following GraphQL mutation on the `/admin` endpoint of an Alpha node (e.g. `localhost:8080/admin`) using any compatible client like Insomnia, GraphQL Playground or GraphiQL.
 
 ```graphql
 mutation {

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -143,7 +143,7 @@ Each Alpha leader for a group writes output as a gzipped file to the export
 directory specified via the `--export` flag (defaults to a directory called `"export"`). If any of the groups fail, the
 entire export process is considered failed and an error is returned.
 
-Starting from Dgraph v20.11.0, it is possible to provide an absolute path to the directory where you want to export data in the GraphQL mutation request.
+Starting from Dgraph v20.11.0 it is possible to provide, in the GraphQL mutation request, an absolute path to the directory where you want to export data.
 
 ```graphql
 mutation {

--- a/wiki/content/deploy/dgraph-administration.md
+++ b/wiki/content/deploy/dgraph-administration.md
@@ -143,7 +143,7 @@ Each Alpha leader for a group writes output as a gzipped file to the export
 directory specified via the `--export` flag (defaults to a directory called `"export"`). If any of the groups fail, the
 entire export process is considered failed and an error is returned.
 
-Starting from Dgraph v20.11.0 it is possible to provide, in the GraphQL mutation request, an absolute path to the directory where you want to export data.
+Starting in Dgraph v20.11.0 you can provide an absolute path to the directory where you want to export data in the GraphQL mutation request, as follows:
 
 ```graphql
 mutation {


### PR DESCRIPTION
Clarified in the docs how to specify a custom path when sending the export request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7000)
<!-- Reviewable:end -->
