### PR TITLE
Feat(Docs): Add documentation for auth with secret directive (#6972)

### DIFF
--- a/wiki/content/graphql/authorization/directive.md
+++ b/wiki/content/graphql/authorization/directive.md
@@ -5,7 +5,7 @@ weight = 2
     parent = "authorization"
 +++
 
-Given an authentication mechanism and signed JWT, it's the `@auth` directive that tells Dgraph how to apply authorization.  The directive can be used on any type except `union` (that isn't a `@remote` type) and specifies the authorization for `query` as well as the `add`, `update` and `delete` mutations.
+Given an authentication mechanism and a signed JSON Web Token (JWT), it's the `@auth` directive that tells Dgraph how to apply authorization.  The directive can be used on any type except `union` (that isn't a `@remote` type) and specifies the authorization for `query` as well as the `add`, `update`, and `delete` mutations. Additionally, this directive can also be used with the [`@secret`](/graphql/schema/types.md#password-type) directive. If you specify a `password` auth rule, Dgraph will use it to authorize the `check<Type>Password` query.
 
 {{% notice "note" %}}
 The [Union type](/graphql/schema/types#union-type) does not support the `@auth` directive 


### PR DESCRIPTION
* Add documentation for auth with secret directive

* Update wiki/content/graphql/authorization/directive.md

Co-authored-by: Damián Parrino <bucanero@users.noreply.github.com>

Co-authored-by: Damián Parrino <bucanero@users.noreply.github.com>
(cherry picked from commit 32e48a400b0030676edd23b0612d487b4cfc788d)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7001)
<!-- Reviewable:end -->
