### PR TITLE
fix(metrics): Use LastCount for RaftAppliedIndex and MaxAssignedTs.

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -159,14 +159,14 @@ var (
 			Name:        RaftAppliedIndex.Name(),
 			Measure:     RaftAppliedIndex,
 			Description: RaftAppliedIndex.Description(),
-			Aggregation: view.Count(),
+			Aggregation: view.LastCount(),
 			TagKeys:     allTagKeys,
 		},
 		{
 			Name:        MaxAssignedTs.Name(),
 			Measure:     MaxAssignedTs,
 			Description: MaxAssignedTs.Description(),
-			Aggregation: view.Count(),
+			Aggregation: view.LastCount(),
 			TagKeys:     allTagKeys,
 		},
 		{

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -159,14 +159,14 @@ var (
 			Name:        RaftAppliedIndex.Name(),
 			Measure:     RaftAppliedIndex,
 			Description: RaftAppliedIndex.Description(),
-			Aggregation: view.LastCount(),
+			Aggregation: view.LastValue(),
 			TagKeys:     allTagKeys,
 		},
 		{
 			Name:        MaxAssignedTs.Name(),
 			Measure:     MaxAssignedTs,
 			Description: MaxAssignedTs.Description(),
-			Aggregation: view.LastCount(),
+			Aggregation: view.LastValue(),
 			TagKeys:     allTagKeys,
 		},
 		{


### PR DESCRIPTION
These metrics should be using LastCount to get the measured metric, not just the
number of counted events.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7005)
<!-- Reviewable:end -->
