### PR TITLE
Fix(health): Update health only after upserting schema and types

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -774,20 +774,15 @@ func allCountriesAdded() ([]*country, error) {
 
 func CheckGraphQLStarted(url string) error {
 	var err error
-	retries := 6
-	sleep := 10 * time.Second
-
 	// Because of how GraphQL starts (it needs to read the schema from Dgraph),
 	// there's no guarantee that GraphQL is available by now.  So we
 	// need to try and connect and potentially retry a few times.
-	for retries > 0 {
-		retries--
-
+	for i := 0; i < 60; i++ {
 		_, err = hasCurrentGraphQLSchema(url)
 		if err == nil {
 			return nil
 		}
-		time.Sleep(sleep)
+		time.Sleep(time.Second)
 	}
 	return err
 }

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -60,6 +60,7 @@ func requireNoErrors(t *testing.T, resp *common.GraphQLResponse) {
 // in a dgraph alpha for one group, that update should also be propagated to alpha nodes in other
 // groups.
 func TestSchemaSubscribe(t *testing.T) {
+	common.CheckGraphQLStarted(groupOneAdminServer)
 	schema := `
 	type Author {
 		id: ID!

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/types"
-	"github.com/dgraph-io/dgraph/x"
 )
 
 var (
@@ -188,9 +187,8 @@ func GetSchemaOverNetwork(ctx context.Context, schema *pb.SchemaRequest) (
 	ctx, span := otrace.StartSpan(ctx, "worker.GetSchemaOverNetwork")
 	defer span.End()
 
-	if err := x.HealthCheck(); err != nil {
-		return nil, err
-	}
+	// There was a health check here which is not needed. The health check should be done by the
+	// receiver of the request, not the sender.
 
 	if len(schema.Predicates) == 0 && len(schema.Types) > 0 {
 		return nil, nil


### PR DESCRIPTION
Also make the t.go check for health of the cluster before running tests.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7006)
<!-- Reviewable:end -->
