### PR TITLE
fix(debug): Use encryption key option for wal.

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -811,6 +811,8 @@ func run() {
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)
 
+	x.WorkerConfig.EncryptionKey = opt.key
+
 	// If this is a new format WAL, print and return.
 	if isWal && !opt.oldWalFormat {
 		store := raftwal.Init(dir)


### PR DESCRIPTION
openLogFile reads the key from WorkerConfig:

https://github.com/dgraph-io/dgraph/blob/efbfce9b04593792bed34b13d814ee6e214945a8/raftwal/log.go#L106

So, the debug tool sets the key in WorkerConfig in order to read an encrypted wal.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7007)
<!-- Reviewable:end -->
