### PR TITLE
fix(flaky): Fix login error for TLS clusters

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -226,13 +226,12 @@ func (in instance) loginFatal() {
 		if err == nil {
 			return
 		}
-		if strings.Contains(err.Error(), "No Auth Token found") {
+		if strings.Contains(err.Error(), "Invalid X-Dgraph-AuthToken") {
 			// This is caused by Poor Man's auth. Return.
 			return
 		}
 		if strings.Contains(err.Error(), "Client sent an HTTP request to an HTTPS server.") {
 			// This is TLS enabled cluster. We won't be able to login.
-			fmt.Printf("Skipping login becasue TLS is enabled.\n")
 			return
 		}
 		fmt.Printf("Login failed for %s: %v. Retrying...\n", in, err)

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -335,7 +335,10 @@ func HttpLogin(params *LoginParams) (string, string, error) {
 	if err != nil {
 		return "", "", errors.Wrapf(err, "unable to read from response")
 	}
-
+	if resp.StatusCode != http.StatusOK {
+		return "", "", errors.New(fmt.Sprintf("got non 200 response from the server with %s ",
+			string(respBody)))
+	}
 	var outputJson map[string]interface{}
 	if err := json.Unmarshal(respBody, &outputJson); err != nil {
 		var errOutputJson map[string]interface{}


### PR DESCRIPTION
When TLS is enabled, we won't be able to login without the certificates. This PR skips the login if
TLS is enabled. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7010)
<!-- Reviewable:end -->
