### PR TITLE
Fix(GraphQL): Fix bug with password query rewriting

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -427,7 +427,7 @@ func rewriteAsGet(
 		}
 
 		if !implementingTypesHasFailedRules {
-			return &gql.GraphQuery{Attr: query.ResponseName() + "()"}
+			return &gql.GraphQuery{Attr: query.Name() + "()"}
 		}
 	}
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -209,7 +209,7 @@ func passwordQuery(m schema.Query, authRw *authRewriter) (*gql.GraphQuery, error
 	// or dgQuery may be empty and its children may contain check<Type>Password query.
 	// Find the exact dgQuery with the name check<Type>Password query.
 	mainQuery := dgQuery
-	for !strings.HasPrefix(mainQuery.Attr, m.ResponseName()) {
+	for !strings.HasPrefix(mainQuery.Attr, m.Name()) {
 		mainQuery = mainQuery.Children[0]
 	}
 
@@ -412,7 +412,7 @@ func rewriteAsGet(
 	// caught here but in case of interface, we need to check validity on each
 	// implementing type as Rules for the interface are made empty.
 	if rbac == schema.Negative {
-		return &gql.GraphQuery{Attr: query.ResponseName() + "()"}
+		return &gql.GraphQuery{Attr: query.Name() + "()"}
 	}
 
 	// For interface, empty query should be returned if Auth rules are

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2352,6 +2352,24 @@
       }
     }
 
+-
+  name: "Password query with alias"
+  gqlquery: |
+    query {
+      verify : checkUserPassword(name: "user1", pwd: "Password") {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      checkUserPassword(func: eq(User.name, "user1")) @filter((eq(val(pwd), 1) AND type(User))) {
+        name : User.name
+        dgraph.uid : uid
+      }
+      checkPwd(func: eq(User.name, "user1")) @filter(type(User)) {
+        pwd as checkpwd(User.pwd, "Password")
+      }
+    }
 
 - name: "Rewrite without custom fields"
   gqlquery: |


### PR DESCRIPTION
Motivation:
Related Discuss post: https://discuss.dgraph.io/t/panics-on-checkpassword-with-alias/11629
Testing:
Added e2e test and a test to query_test.yaml

Fixes GRAPHQL-884
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7011)
<!-- Reviewable:end -->
