### PR TITLE
chore: Fix gql fuzz tests

### DIFF
--- a/gql/fuzzit.sh
+++ b/gql/fuzzit.sh
@@ -8,8 +8,8 @@ export GO111MODULE="on"
 go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
 
 ## Build a fuzz target which is later used for fuzzitdev for Continuous Fuzzing.
-go-fuzz-build -libfuzzer -o parser-fuzz-target.a $GOPATH/src/github.com/dgraph-io/dgraph/gql/
-docker run --rm -v $(pwd):/tmp rsmmr/clang clang -fsanitize=fuzzer /tmp/parser-fuzz-target.a -o /tmp/parser-fuzz-target
+go-fuzz-build -o parser-fuzz-target.a -libfuzzer .
+docker run --rm -v "$(pwd):/tmp" teeks99/clang-ubuntu:10 clang-10 -fsanitize=fuzzer /tmp/parser-fuzz-target.a -o /tmp/parser-fuzz-target
 
 ## Step 2: Perform Fuzzing and local regression on the fuzz target using fuzzit CLI
 
@@ -19,7 +19,7 @@ chmod a+x fuzzit
 
 ## Create a target on fuzzit servers
 ./fuzzit create target --skip-if-exists --seed ./gql/fuzz-data/corpus.tar.gz parser-fuzz-target
-## Start a job (${1} = [fuzzing][local-regression]). 
-./fuzzit create job --type ${1} dgraph-io-gh/parser-fuzz-target parser-fuzz-target
+## Start a job (${1} = [fuzzing][local-regression]).
+./fuzzit create job --type "${1}" dgraph-io-gh/parser-fuzz-target parser-fuzz-target
 
 rm -f parser-fuzz-target parser-fuzz-target.a fuzzit


### PR DESCRIPTION
Fixes some issues with the fuzz test script:
- Assuming the Dgraph folder is present in `$GOPATH`. This is not necessarily true, I've changed this to only run tests in the current (`gql`) directory.
- The Docker image being used for clang doesn't seem to be updated any more, and was causing problems with the latest builds. I've replaced it with the most popular clang image on Docker Hub. Note that I had to use `clang-10`, because the `clang-11` image is based on Ubuntu Bionic (glibc 2.39), which causes issues in our CI. This can be changed once we upgrade.
- Bash quoting/whitespace nits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7015)
<!-- Reviewable:end -->
