### PR TITLE
fix(Query): Fix incorrect RDF response.

### DIFF
--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -75,6 +75,13 @@ func (b *rdfBuilder) castToRDF(sg *SubGraph) error {
 
 // rdfForSubgraph generates RDF and appends to the output parameter.
 func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
+	// handle the case of recurse queries
+	for _, ch := range sg.Children {
+		if len(ch.uidMatrix) == 0 {
+			return nil
+		}
+	}
+
 	for i, uid := range sg.SrcUIDs.Uids {
 		if sg.Params.IgnoreResult {
 			// Skip ignored values.

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -154,11 +154,8 @@ func (b *rdfBuilder) rdfForUIDList(subject uint64, list *pb.List, sg *SubGraph) 
 }
 
 // rdfForValueList returns rdf for the value list.
+// Ignore RDF's for the attirbute `uid`.
 func (b *rdfBuilder) rdfForValueList(subject uint64, valueList *pb.ValueList, attr string) {
-	if attr == "uid" {
-		b.writeRDF(subject, []byte(attr), x.ToHex(subject, true))
-		return
-	}
 	for _, destValue := range valueList.Values {
 		val, err := convertWithBestEffort(destValue, attr)
 		if err != nil {

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -101,7 +101,7 @@ func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
 		case len(sg.counts) > 0:
 			// Add count rdf.
 			b.rdfForCount(uid, sg.counts[i], sg)
-		case i < len(sg.uidMatrix) && len(sg.uidMatrix[i].Uids) != 0:
+		case i < len(sg.uidMatrix) && len(sg.uidMatrix[i].Uids) != 0 && len(sg.Children) > 0:
 			// Add posting list relation.
 			b.rdfForUIDList(uid, sg.uidMatrix[i], sg)
 		case i < len(sg.valueMatrix):

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -76,10 +76,16 @@ func (b *rdfBuilder) castToRDF(sg *SubGraph) error {
 // rdfForSubgraph generates RDF and appends to the output parameter.
 func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
 	// handle the case of recurse queries
+	// Do not generate RDF if all the children of sg null uidMatrix
+	nonNullChild := false
 	for _, ch := range sg.Children {
-		if len(ch.uidMatrix) == 0 {
-			return nil
+		if len(ch.uidMatrix) != 0 {
+			nonNullChild = true
 		}
+	}
+
+	if nonNullChild {
+		return nil
 	}
 
 	for i, uid := range sg.SrcUIDs.Uids {

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -84,7 +84,7 @@ func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
 		}
 	}
 
-	if nonNullChild {
+	if len(sg.Children) > 0 && !nonNullChild {
 		return nil
 	}
 

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -122,8 +122,8 @@ func TestRDFRecurse(t *testing.T) {
 	rdf, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
 	require.Equal(t, rdf, `<0x1> <name> "Michonne" .
-	<0x17> <name> "Rick Grimes" .
-	<0x19> <name> "Daryl Dixon" .
+<0x17> <name> "Rick Grimes" .
+<0x19> <name> "Daryl Dixon" .
 `)
 }
 func TestRDFCheckPwd(t *testing.T) {

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -111,6 +111,21 @@ func TestRDFIngoreReflex(t *testing.T) {
 		"ignorereflex directive is not supported in the rdf output format")
 }
 
+func TestRDFRecurse(t *testing.T) {
+	query := `
+	{
+		me(func: anyofterms(name, "Michonne Rick Daryl")) @recurse(depth: 1, loop: true) {
+			name
+			friend
+		}
+	}`
+	rdf, err := processQueryRDF(context.Background(), t, query)
+	require.NoError(t, err)
+	require.Equal(t, rdf, `<0x1> <name> "Michonne" .
+	<0x17> <name> "Rick Grimes" .
+	<0x19> <name> "Daryl Dixon" .
+`)
+}
 func TestRDFCheckPwd(t *testing.T) {
 	query := `
     {

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -126,6 +126,23 @@ func TestRDFRecurse(t *testing.T) {
 <0x19> <name> "Daryl Dixon" .
 `)
 }
+
+func TestRDFIgnoreUid(t *testing.T) {
+	query := `
+	{
+		me(func: anyofterms(name, "Michonne Rick Daryl")) {
+			uid
+			name
+		}
+	}`
+	rdf, err := processQueryRDF(context.Background(), t, query)
+	require.NoError(t, err)
+	require.Equal(t, rdf, `<0x1> <name> "Michonne" .
+<0x17> <name> "Rick Grimes" .
+<0x19> <name> "Daryl Dixon" .
+`)
+}
+
 func TestRDFCheckPwd(t *testing.T) {
 	query := `
     {


### PR DESCRIPTION
Fixes DGRAPH-2781.
Fixes DGRAPH-2552.

This PR fixes Some of the bugs in the RDF response.
For the given schema:
```
name: string @index(exact) .
friend: [uid] .
type Person {
	name
	friend
}
```
1) For a query:
```
query(func: type(Person)){
	uid
	name
}
```
The output was:
```
<0x5573a> <uid> <0x5573a> .
<0x5573c> <uid> <0x5573c> .
<0x5573d> <uid> <0x5573d> .
<0x5573a> <name> "Charlie" .
<0x5573c> <name> "Alice" .
<0x5573d> <name> "Bob" .
```
The redundant `<X> <uid> <X>` triplets should be removed from the RDF output. This PR fixes that.

2) For the given query: 
```
query(func: type(Person)){
	name
	friend
}
```
The RDF response is:
```
<0x5573a> <name> "Charlie" .
<0x5573c> <name> "Alice" .
<0x5573d> <name> "Bob" .
<0x5573c> <friend> <0x5573a> .
<0x5573c> <friend> <0x5573d> .
```
The `<X> <friend> <X>` edge should not be there as it is inconsistent with the JSON response.
This issue also lies in the recurse queries. For eg for this query:
```
query(func: type(Person)) @recurse(depth: 1, loop: false){
	name
	friend
}
```
This PR fixes these issues.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7017)
<!-- Reviewable:end -->
