### PR TITLE
fix(graphql): adding support for @id with type other than strings

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -655,6 +655,9 @@ func RunAll(t *testing.T) {
 	t.Run("query aggregate and other fields at child level", queryAggregateAndOtherFieldsAtChildLevel)
 	t.Run("query at child level with multiple alias on scalar field", queryChildLevelWithMultipleAliasOnScalarField)
 	t.Run("checkUserPassword query", passwordTest)
+	t.Run("query id directive with int", idDirectiveWithInt)
+	t.Run("query id directive with int64", idDirectiveWithInt64)
+	t.Run("query id directive with float", idDirectiveWithFloat)
 
 	// mutation tests
 	t.Run("add mutation", addMutation)
@@ -702,6 +705,9 @@ func RunAll(t *testing.T) {
 	t.Run("Geo - MultiPolygon type", mutationMultiPolygonType)
 	t.Run("filter in mutations with array for AND/OR", filterInMutationsWithArrayForAndOr)
 	t.Run("filter in update mutations with array for AND/OR", filterInUpdateMutationsWithFilterAndOr)
+	t.Run("mutation id directive with int", idDirectiveWithIntMutation)
+	t.Run("mutation id directive with int64", idDirectiveWithInt64Mutation)
+	t.Run("mutation id directive with float", idDirectiveWithFloatMutation)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4594,7 +4594,7 @@ func idDirectiveWithInt64Mutation(t *testing.T) {
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	RequireNoGQLErrors(t, response)
-	var expected = `{
+	expected := `{
 		  	"addBook": {
 			  "numUids": 1
 			}

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4605,7 +4605,7 @@ func idDirectiveWithInt64Mutation(t *testing.T) {
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
 
-	DeleteGqlType(t, "Book", map[string]interface{}{}, 1, nil)
+	DeleteGqlType(t, "Book", map[string]interface{}{}, 2, nil)
 }
 
 func idDirectiveWithIntMutation(t *testing.T) {
@@ -4634,7 +4634,7 @@ func idDirectiveWithIntMutation(t *testing.T) {
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
 
-	DeleteGqlType(t, "Chapter", map[string]interface{}{}, 1, nil)
+	DeleteGqlType(t, "Chapter", map[string]interface{}{}, 2, nil)
 }
 
 func idDirectiveWithFloatMutation(t *testing.T) {
@@ -4668,5 +4668,5 @@ func idDirectiveWithFloatMutation(t *testing.T) {
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
 
-	DeleteGqlType(t, "Section", map[string]interface{}{}, 2, nil)
+	DeleteGqlType(t, "Section", map[string]interface{}{}, 4, nil)
 }

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -21,11 +21,9 @@ package common
 // dataset and mutating and leaving unexpected data will result in flaky tests.
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"sort"
 	"testing"
 
@@ -4595,22 +4593,19 @@ func idDirectiveWithInt64Mutation(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
 		  	"addBook": {
 			  "numUids": 1
 			}
 		}`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
+
+	DeleteGqlType(t, "Book", map[string]interface{}{}, 1, nil)
 }
 
 func idDirectiveWithIntMutation(t *testing.T) {
@@ -4627,25 +4622,19 @@ func idDirectiveWithIntMutation(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	if response.Errors != nil {
-		log.Print("error from servce is", response.Errors.Error())
-	}
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
 			"addChapter": {
 			  "numUids": 1
 			}
 		}`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
+
+	DeleteGqlType(t, "Chapter", map[string]interface{}{}, 1, nil)
 }
 
 func idDirectiveWithFloatMutation(t *testing.T) {
@@ -4667,20 +4656,17 @@ func idDirectiveWithFloatMutation(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
 			"addSection": {
 			  "numUids": 2
 			}
 		}`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)
 	require.Contains(t, response.Errors.Error(), "already exists")
+
+	DeleteGqlType(t, "Section", map[string]interface{}{}, 2, nil)
 }

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -21,9 +21,11 @@ package common
 // dataset and mutating and leaving unexpected data will result in flaky tests.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"sort"
 	"testing"
 
@@ -4595,14 +4597,16 @@ func idDirectiveWithInt64Mutation(t *testing.T) {
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
 	var expected = `{
-		  "data": {
-			"addBook": {
+		  	"addBook": {
 			  "numUids": 1
 			}
-		  }
 		}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)
@@ -4623,16 +4627,21 @@ func idDirectiveWithIntMutation(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
+	if response.Errors != nil {
+		log.Print("error from servce is", response.Errors.Error())
+	}
 	require.Nil(t, response.Errors)
 	var expected = `{
-		  "data": {
 			"addChapter": {
 			  "numUids": 1
 			}
-		  }
 		}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)
@@ -4660,14 +4669,16 @@ func idDirectiveWithFloatMutation(t *testing.T) {
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
 	var expected = `{
-		  "data": {
 			"addSection": {
 			  "numUids": 2
 			}
-		  }
 		}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 
 	// adding same mutation again should result in error because of duplicate id
 	response = query.ExecuteAsPost(t, GraphqlURL)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4576,3 +4576,30 @@ func filterInUpdateMutationsWithFilterAndOr(t *testing.T) {
 	DeleteGqlType(t, "post1", filter, 2, nil)
 
 }
+
+func idDirectiveWithIntMutation(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}
+
+func idDirectiveWithInt64Mutation(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}
+
+func idDirectiveWithFloatMutation(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4577,29 +4577,99 @@ func filterInUpdateMutationsWithFilterAndOr(t *testing.T) {
 
 }
 
-func idDirectiveWithIntMutation(t *testing.T) {
-	query := &GraphQLParams{
-		Query: ``,
-	}
-
-	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
-}
-
 func idDirectiveWithInt64Mutation(t *testing.T) {
 	query := &GraphQLParams{
-		Query: ``,
+		Query: `mutation {
+		  addBook(input:[
+			{
+			  bookId: 1234567890123
+			  name: "Graphql"
+			  desc: "Graphql is the next big thing"
+			}
+		  ]) {
+			numUids
+		  }
+		}`,
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
+	var expected = `{
+		  "data": {
+			"addBook": {
+			  "numUids": 1
+			}
+		  }
+		}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
+
+	// adding same mutation again should result in error because of duplicate id
+	response = query.ExecuteAsPost(t, GraphqlURL)
+	require.Contains(t, response.Errors.Error(), "already exists")
+}
+
+func idDirectiveWithIntMutation(t *testing.T) {
+	query := &GraphQLParams{
+		Query: `mutation {
+		  addChapter(input:[{
+			chapterId: 2
+			name: "Graphql and more"
+			bookId: 1234567890123
+		  }]) {
+			numUids
+		  }
+		}`,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+	var expected = `{
+		  "data": {
+			"addChapter": {
+			  "numUids": 1
+			}
+		  }
+		}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
+
+	// adding same mutation again should result in error because of duplicate id
+	response = query.ExecuteAsPost(t, GraphqlURL)
+	require.Contains(t, response.Errors.Error(), "already exists")
 }
 
 func idDirectiveWithFloatMutation(t *testing.T) {
 	query := &GraphQLParams{
-		Query: ``,
+		Query: `mutation {
+		  addSection(input:[{
+			chapterId: 2
+			name: "Graphql: Introduction"
+			sectionId: 2.1
+		  },
+		  {
+			chapterId: 2
+			name: "Graphql Available Data Types"
+			sectionId: 2.2
+		  }]) {
+			numUids
+		  }
+		}`,
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
+	var expected = `{
+		  "data": {
+			"addSection": {
+			  "numUids": 2
+			}
+		  }
+		}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
+
+	// adding same mutation again should result in error because of duplicate id
+	response = query.ExecuteAsPost(t, GraphqlURL)
+	require.Contains(t, response.Errors.Error(), "already exists")
 }

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -68,6 +68,33 @@ func queryCountryByRegExp(t *testing.T, regexp string, expectedCountries []*coun
 	}
 }
 
+func idDirectiveWithInt(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}
+
+func idDirectiveWithInt64(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}
+
+func idDirectiveWithFloat(t *testing.T) {
+	query := &GraphQLParams{
+		Query: ``,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+}
+
 func touchedUidsHeader(t *testing.T) {
 	query := &GraphQLParams{
 		Query: `query {

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -68,33 +68,6 @@ func queryCountryByRegExp(t *testing.T, regexp string, expectedCountries []*coun
 	}
 }
 
-func idDirectiveWithInt(t *testing.T) {
-	query := &GraphQLParams{
-		Query: ``,
-	}
-
-	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
-}
-
-func idDirectiveWithInt64(t *testing.T) {
-	query := &GraphQLParams{
-		Query: ``,
-	}
-
-	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
-}
-
-func idDirectiveWithFloat(t *testing.T) {
-	query := &GraphQLParams{
-		Query: ``,
-	}
-
-	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
-}
-
 func touchedUidsHeader(t *testing.T) {
 	query := &GraphQLParams{
 		Query: `query {
@@ -3309,4 +3282,100 @@ func passwordTest(t *testing.T) {
 	})
 
 	deleteUser(t, *newUser)
+}
+
+func idDirectiveWithInt64(t *testing.T) {
+	query := &GraphQLParams{
+		Query: `query {
+		  queryBook(filter: {
+			bookId: {
+			  eq: 1234567890
+			}
+		  }) {
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+	var expected = `{
+		  "data": {
+			"queryBook": [
+			  {
+				"bookId": 1234567890,
+				"name": "Dgraph and Graphql",
+				"desc": "All love between dgraph and graphql"
+			  }
+			]
+		  }
+		}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
+}
+
+func idDirectiveWithInt(t *testing.T) {
+	query := &GraphQLParams{
+		Query: `query {
+		  queryChapter(filter: {
+			chapterId: {
+			  eq: 1
+			}
+		  }) {
+			bookId
+			chapterId
+			name
+		  }
+		}`,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+	var expected = `{
+	  "data": {
+		"queryChapter": [
+		  {
+			"bookId": 1234567890,
+			"chapterId": 1,
+			"name": "How Dgraph Works"
+		  }
+		]
+	  }
+	}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
+}
+
+func idDirectiveWithFloat(t *testing.T) {
+	query := &GraphQLParams{
+		Query: `query {
+		  querySection(filter: {
+			sectionId: {
+			  eq: 1.1
+			}
+		  }) {
+			chapterId
+			sectionId
+			name
+		  }
+		}`,
+	}
+
+	response := query.ExecuteAsPost(t, GraphqlURL)
+	require.Nil(t, response.Errors)
+	var expected = `{
+	  "data": {
+		"querySection": [
+		  {
+			"chapterId": 1,
+			"sectionId": 1.1,
+			"name": "How to define dgraph schema"
+		  }
+		]
+	  }
+	}`
+	j, _ := response.Data.MarshalJSON()
+	require.Equal(t, string(j), expected)
 }

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -17,6 +17,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -3302,7 +3303,6 @@ func idDirectiveWithInt64(t *testing.T) {
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
 	var expected = `{
-		  "data": {
 			"queryBook": [
 			  {
 				"bookId": 1234567890,
@@ -3310,10 +3310,13 @@ func idDirectiveWithInt64(t *testing.T) {
 				"desc": "All love between dgraph and graphql"
 			  }
 			]
-		  }
-		}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+		 }`
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 }
 
 func idDirectiveWithInt(t *testing.T) {
@@ -3334,18 +3337,20 @@ func idDirectiveWithInt(t *testing.T) {
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
 	var expected = `{
-	  "data": {
-		"queryChapter": [
+	  	"queryChapter": [
 		  {
 			"bookId": 1234567890,
 			"chapterId": 1,
 			"name": "How Dgraph Works"
 		  }
 		]
-	  }
 	}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 }
 
 func idDirectiveWithFloat(t *testing.T) {
@@ -3366,16 +3371,18 @@ func idDirectiveWithFloat(t *testing.T) {
 	response := query.ExecuteAsPost(t, GraphqlURL)
 	require.Nil(t, response.Errors)
 	var expected = `{
-	  "data": {
-		"querySection": [
+	 	"querySection": [
 		  {
 			"chapterId": 1,
 			"sectionId": 1.1,
 			"name": "How to define dgraph schema"
 		  }
 		]
-	  }
 	}`
-	j, _ := response.Data.MarshalJSON()
-	require.Equal(t, string(j), expected)
+	b, _ := response.Data.MarshalJSON()
+	expBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
+	actBuffer := new(bytes.Buffer)
+	require.NoError(t, json.Compact(actBuffer, b))
+	require.Equal(t, expBuffer.String(), actBuffer.String())
 }

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -17,7 +17,6 @@
 package common
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -3288,11 +3287,7 @@ func passwordTest(t *testing.T) {
 func idDirectiveWithInt64(t *testing.T) {
 	query := &GraphQLParams{
 		Query: `query {
-		  queryBook(filter: {
-			bookId: {
-			  eq: 1234567890
-			}
-		  }) {
+		  getBook(bookId: 1234567890) {
 			bookId
 			name
 			desc
@@ -3301,32 +3296,21 @@ func idDirectiveWithInt64(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
-			"queryBook": [
-			  {
+			"getBook": {
 				"bookId": 1234567890,
 				"name": "Dgraph and Graphql",
 				"desc": "All love between dgraph and graphql"
 			  }
-			]
 		 }`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 }
 
 func idDirectiveWithInt(t *testing.T) {
 	query := &GraphQLParams{
 		Query: `query {
-		  queryChapter(filter: {
-			chapterId: {
-			  eq: 1
-			}
-		  }) {
+		  getChapter(chapterId: 1) {
 			bookId
 			chapterId
 			name
@@ -3335,32 +3319,21 @@ func idDirectiveWithInt(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
-	  	"queryChapter": [
-		  {
+	  	"getChapter": {
 			"bookId": 1234567890,
 			"chapterId": 1,
 			"name": "How Dgraph Works"
 		  }
-		]
 	}`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 }
 
 func idDirectiveWithFloat(t *testing.T) {
 	query := &GraphQLParams{
 		Query: `query {
-		  querySection(filter: {
-			sectionId: {
-			  eq: 1.1
-			}
-		  }) {
+		  getSection(sectionId: 1.1) {
 			chapterId
 			sectionId
 			name
@@ -3369,20 +3342,13 @@ func idDirectiveWithFloat(t *testing.T) {
 	}
 
 	response := query.ExecuteAsPost(t, GraphqlURL)
-	require.Nil(t, response.Errors)
+	RequireNoGQLErrors(t, response)
 	var expected = `{
-	 	"querySection": [
-		  {
+	 	"getSection": {
 			"chapterId": 1,
 			"sectionId": 1.1,
 			"name": "How to define dgraph schema"
 		  }
-		]
 	}`
-	b, _ := response.Data.MarshalJSON()
-	expBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(expBuffer, []byte(expected)))
-	actBuffer := new(bytes.Buffer)
-	require.NoError(t, json.Compact(actBuffer, b))
-	require.Equal(t, expBuffer.String(), actBuffer.String())
+	require.JSONEq(t, expected, string(response.Data))
 }

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -283,3 +283,22 @@ type University @generate(
     name: String!
     numStudents: Int
 }
+
+# @id directive with multiple data types
+type Book {
+    bookId: Int64! @id
+    name: String!
+    desc: String
+    chapters: [Chapter!]
+}
+
+type Chapter {
+    chapterId: Int! @id
+    name: String!
+    sections: [Section!]
+}
+
+type Section {
+    sectionId: Float! @id
+    name: String!
+}

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -289,16 +289,16 @@ type Book {
     bookId: Int64! @id
     name: String!
     desc: String
-    chapters: [Chapter!]
 }
 
 type Chapter {
     chapterId: Int! @id
     name: String!
-    sections: [Section!]
+    bookId: Int64! @search
 }
 
 type Section {
     sectionId: Float! @id
     name: String!
+    chapterId: Int! @search
 }

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -500,6 +500,65 @@
         {
             "predicate": "职业",
             "type": "string"
+        },
+        {
+            "predicate": "Book.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Book.desc",
+            "type": "string"
+        },
+        {
+            "predicate": "Section.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Chapter.name",
+            "type": "string"
+        },
+        {
+            "index": true,
+            "predicate": "Section.sectionId",
+            "tokenizer": [
+                "float"
+            ],
+            "type": "float",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Chapter.bookId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int"
+        },
+        {
+            "index": true,
+            "predicate": "Chapter.chapterId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Book.bookId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Section.chapterId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int"
         }
     ],
     "types": [
@@ -968,6 +1027,48 @@
                 }
             ],
             "name": "test.dgraph.employee.en"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Book.name"
+                },
+                {
+                    "name": "Book.desc"
+                },
+                {
+                    "name": "Book.bookId"
+                }
+            ],
+            "name": "Book"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Chapter.name"
+                },
+                {
+                    "name": "Chapter.bookId"
+                },
+                {
+                    "name": "Chapter.chapterId"
+                }
+            ],
+            "name": "Chapter"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Section.sectionId"
+                },
+                {
+                    "name": "Section.chapterId"
+                },
+                {
+                    "name": "Section.name"
+                }
+            ],
+            "name": "Section"
         }
     ]
 }

--- a/graphql/e2e/directives/test_data.json
+++ b/graphql/e2e/directives/test_data.json
@@ -132,28 +132,28 @@
         "hasStates": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
     },
     {
-        "uid": "0x2714",
+        "uid": "_:book1",
         "dgraph.type": "Book",
         "Book.bookId": 1234567890,
         "Book.name": "Dgraph and Graphql",
         "Book.desc": "All love between dgraph and graphql"
     },
     {
-        "uid": "0x2715",
+        "uid": "_:chapter1",
         "dgraph.type": "Chapter",
         "Chapter.bookId": 1234567890,
         "Chapter.chapterId": 1,
         "Chapter.name": "How Dgraph Works"
     },
     {
-        "uid": "0x2716",
+        "uid": "_:section1",
         "dgraph.type": "Section",
         "Section.chapterId": 1,
         "Section.sectionId": 1.1,
         "Section.name": "How to define dgraph schema"
     },
     {
-        "uid": "0x2717",
+        "uid": "_:section2",
         "dgraph.type": "Section",
         "Section.chapterId": 1,
         "Section.sectionId": 1.2,

--- a/graphql/e2e/directives/test_data.json
+++ b/graphql/e2e/directives/test_data.json
@@ -130,5 +130,33 @@
         "dgraph.type": "Country",
         "Country.name": "India",
         "hasStates": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
+    },
+    {
+        "uid": "0x2714",
+        "dgraph.type": "Book",
+        "Book.bookId": 1234567890,
+        "Book.name": "Dgraph and Graphql",
+        "Book.desc": "All love between dgraph and graphql"
+    },
+    {
+        "uid": "0x2715",
+        "dgraph.type": "Chapter",
+        "Chapter.bookId": 1234567890,
+        "Chapter.chapterId": 1,
+        "Chapter.name": "How Dgraph Works"
+    },
+    {
+        "uid": "0x2716",
+        "dgraph.type": "Section",
+        "Section.chapterId": 1,
+        "Section.sectionId": 1.1,
+        "Section.name": "How to define dgraph schema"
+    },
+    {
+        "uid": "0x2717",
+        "dgraph.type": "Section",
+        "Section.chapterId": 1,
+        "Section.sectionId": 1.2,
+        "Section.name": "Dgraph Data Types"
     }
 ]

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -295,10 +295,11 @@ type Book {
 type Chapter {
         chapterId: Int! @id
         name: String!
-        sections: [Section!]
+        bookId: Int64! @search
 }
 
 type Section {
         sectionId: Float! @id
         name: String!
+        chapterId: Int! @search
 }

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -284,3 +284,21 @@ type University @generate(
         name: String!
         numStudents: Int
 }
+
+# @id directive with multiple data types
+type Book {
+        bookId: Int64! @id
+        name: String!
+        desc: String
+}
+
+type Chapter {
+        chapterId: Int! @id
+        name: String!
+        sections: [Section!]
+}
+
+type Section {
+        sectionId: Float! @id
+        name: String!
+}

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -500,6 +500,65 @@
             "predicate": "post1.likesByMonth",
             "list": true,
             "type": "int"
+        },
+        {
+            "predicate": "Book.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Book.desc",
+            "type": "string"
+        },
+        {
+            "predicate": "Section.name",
+            "type": "string"
+        },
+        {
+            "predicate": "Chapter.name",
+            "type": "string"
+        },
+        {
+            "index": true,
+            "predicate": "Section.sectionId",
+            "tokenizer": [
+                "float"
+            ],
+            "type": "float",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Chapter.bookId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int"
+        },
+        {
+            "index": true,
+            "predicate": "Chapter.chapterId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Book.bookId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int",
+            "upsert": true
+        },
+        {
+            "index": true,
+            "predicate": "Section.chapterId",
+            "tokenizer": [
+                "int"
+            ],
+            "type": "int"
         }
     ],
     "types": [
@@ -705,6 +764,48 @@
                 }
             ],
             "name": "Parrot"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Book.name"
+                },
+                {
+                    "name": "Book.desc"
+                },
+                {
+                    "name": "Book.bookId"
+                }
+            ],
+            "name": "Book"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Chapter.name"
+                },
+                {
+                    "name": "Chapter.bookId"
+                },
+                {
+                    "name": "Chapter.chapterId"
+                }
+            ],
+            "name": "Chapter"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Section.sectionId"
+                },
+                {
+                    "name": "Section.chapterId"
+                },
+                {
+                    "name": "Section.name"
+                }
+            ],
+            "name": "Section"
         },
         {
             "fields": [

--- a/graphql/e2e/normal/test_data.json
+++ b/graphql/e2e/normal/test_data.json
@@ -130,5 +130,33 @@
         "dgraph.type": "Country",
         "Country.name": "India",
         "Country.states": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
+    },
+    {
+        "uid": "0x2714",
+        "dgraph.type": "Book",
+        "Book.bookId": 1234567890,
+        "Book.name": "Dgraph and Graphql",
+        "Book.desc": "All love between dgraph and graphql"
+    },
+    {
+        "uid": "0x2715",
+        "dgraph.type": "Chapter",
+        "Chapter.bookId": 1234567890,
+        "Chapter.chapterId": 1,
+        "Chapter.name": "How Dgraph Works"
+    },
+    {
+        "uid": "0x2716",
+        "dgraph.type": "Section",
+        "Section.chapterId": 1,
+        "Section.sectionId": 1.1,
+        "Section.name": "How to define dgraph schema"
+    },
+    {
+        "uid": "0x2717",
+        "dgraph.type": "Section",
+        "Section.chapterId": 1,
+        "Section.sectionId": 1.2,
+        "Section.name": "Dgraph Data Types"
     }
 ]

--- a/graphql/e2e/normal/test_data.json
+++ b/graphql/e2e/normal/test_data.json
@@ -132,28 +132,28 @@
         "Country.states": [{ "uid": "_:mh" }, { "uid": "_:gj" }, { "uid":  "_:ka"}]
     },
     {
-        "uid": "0x2714",
+        "uid": "_:book1",
         "dgraph.type": "Book",
         "Book.bookId": 1234567890,
         "Book.name": "Dgraph and Graphql",
         "Book.desc": "All love between dgraph and graphql"
     },
     {
-        "uid": "0x2715",
+        "uid": "_:chapter1",
         "dgraph.type": "Chapter",
         "Chapter.bookId": 1234567890,
         "Chapter.chapterId": 1,
         "Chapter.name": "How Dgraph Works"
     },
     {
-        "uid": "0x2716",
+        "uid": "_:section1",
         "dgraph.type": "Section",
         "Section.chapterId": 1,
         "Section.sectionId": 1.1,
         "Section.name": "How to define dgraph schema"
     },
     {
-        "uid": "0x2717",
+        "uid": "_:section2",
         "dgraph.type": "Section",
         "Section.chapterId": 1,
         "Section.sectionId": 1.2,

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -992,10 +992,18 @@ func rewriteObject(
 	xidEncounteredFirstTime := false
 	if xid != nil {
 		if xidVal, ok := obj[xid.Name()]; ok && xidVal != nil {
-			xidString, ok = xidVal.(string)
-			if !ok {
+			switch xid.Type().String() {
+			case "Int!":
+				xidString = strconv.FormatInt(xidVal.(int64), 10)
+			case "Int64!":
+				fallthrough
+			case "String!":
+				xidString = xidVal.(string)
+			case "Float!":
+				xidString = strconv.FormatFloat(xidVal.(float64), 'f', -1, 64)
+			default:
 				errFrag := newFragment(nil)
-				errFrag.err = errors.New("encountered an XID that isn't a string")
+				errFrag.err = errors.New("encountered an XID that isn't a String or Int or Int64 or Float")
 				return &mutationRes{secondPass: []*mutationFragment{errFrag}}
 			}
 			// if the object has an xid, the variable name will be formed from the xidValue in order

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -992,7 +992,7 @@ func rewriteObject(
 	xidEncounteredFirstTime := false
 	if xid != nil {
 		if xidVal, ok := obj[xid.Name()]; ok && xidVal != nil {
-			switch xid.Type().String() {
+			switch xid.Type().Name() {
 			case "Int!":
 				xidString = strconv.FormatInt(xidVal.(int64), 10)
 			case "Int64!":

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -995,16 +995,18 @@ func rewriteObject(
 			switch xid.Type().Name() {
 			case "Int!":
 				xidString = strconv.FormatInt(xidVal.(int64), 10)
-			case "Int64!":
-				fallthrough
-			case "String!":
-				xidString = xidVal.(string)
 			case "Float!":
 				xidString = strconv.FormatFloat(xidVal.(float64), 'f', -1, 64)
+			case "Int64!":
+				fallthrough
 			default:
-				errFrag := newFragment(nil)
-				errFrag.err = errors.New("encountered an XID that isn't a String or Int or Int64 or Float")
-				return &mutationRes{secondPass: []*mutationFragment{errFrag}}
+				xidString, ok = xidVal.(string)
+				if !ok {
+					errFrag := newFragment(nil)
+					errFrag.err = errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't " +
+							"a String or Int! or Int64! or Float!", xid.Name(), xid.Type().Name()))
+					return &mutationRes{secondPass: []*mutationFragment{errFrag}}
+				}
 			}
 			// if the object has an xid, the variable name will be formed from the xidValue in order
 			// to handle duplicate object addition/updation

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -994,17 +994,23 @@ func rewriteObject(
 		if xidVal, ok := obj[xid.Name()]; ok && xidVal != nil {
 			switch xid.Type().Name() {
 			case "Int!":
+				fallthrough
+			case "Int":
 				xidString = strconv.FormatInt(xidVal.(int64), 10)
 			case "Float!":
+				fallthrough
+			case "Float":
 				xidString = strconv.FormatFloat(xidVal.(float64), 'f', -1, 64)
 			case "Int64!":
+				fallthrough
+			case "Int64":
 				fallthrough
 			default:
 				xidString, ok = xidVal.(string)
 				if !ok {
 					errFrag := newFragment(nil)
-					errFrag.err = errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't " +
-							"a String or Int! or Int64! or Float!", xid.Name(), xid.Type().Name()))
+					errFrag.err = errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't "+
+						"a String or Int! or Int64! or Float!", xid.Name(), xid.Type().Name()))
 					return &mutationRes{secondPass: []*mutationFragment{errFrag}}
 				}
 			}

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -992,19 +992,34 @@ func rewriteObject(
 	xidEncounteredFirstTime := false
 	if xid != nil {
 		if xidVal, ok := obj[xid.Name()]; ok && xidVal != nil {
+			errResponse := func(err error) *mutationRes {
+				errFrag := newFragment(nil)
+				errFrag.err = err
+				return &mutationRes{secondPass: []*mutationFragment{errFrag}}
+			}
 			switch xid.Type().Name() {
-			case "Int!", "Int":
-				xidString = strconv.FormatInt(xidVal.(int64), 10)
-			case "Float!", "Float":
-				xidString = strconv.FormatFloat(xidVal.(float64), 'f', -1, 64)
-			case "Int64!", "Int64":
+			case "Int":
+				val, ok := xidVal.(int64)
+				if !ok {
+					return errResponse(errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't "+
+						"a Int but data type in schema is Int", xid.Name(), xid.Type().Name())))
+				}
+				xidString = strconv.FormatInt(val, 10)
+			case "Float":
+				val, ok := xidVal.(float64)
+				if !ok {
+					return errResponse(errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't "+
+						"a Float but data type in schema is Float", xid.Name(), xid.Type().Name())))
+				}
+				xidString = strconv.FormatFloat(val, 'f', -1, 64)
+			case "Int64":
 				fallthrough
 			default:
 				xidString, ok = xidVal.(string)
 				if !ok {
 					errFrag := newFragment(nil)
 					errFrag.err = errors.New(fmt.Sprintf("encountered an XID %s with %s that isn't "+
-						"a String or Int! or Int64! or Float!", xid.Name(), xid.Type().Name()))
+						"a String or Int64", xid.Name(), xid.Type().Name()))
 					return &mutationRes{secondPass: []*mutationFragment{errFrag}}
 				}
 			}

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -993,17 +993,11 @@ func rewriteObject(
 	if xid != nil {
 		if xidVal, ok := obj[xid.Name()]; ok && xidVal != nil {
 			switch xid.Type().Name() {
-			case "Int!":
-				fallthrough
-			case "Int":
+			case "Int!", "Int":
 				xidString = strconv.FormatInt(xidVal.(int64), 10)
-			case "Float!":
-				fallthrough
-			case "Float":
+			case "Float!", "Float":
 				xidString = strconv.FormatFloat(xidVal.(float64), 'f', -1, 64)
-			case "Int64!":
-				fallthrough
-			case "Int64":
+			case "Int64!", "Int64":
 				fallthrough
 			default:
 				xidString, ok = xidVal.(string)

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1857,9 +1857,7 @@ func maybeQuoteArg(fn string, arg interface{}) string {
 			return arg
 		}
 		return fmt.Sprintf("%q", arg)
-	case float64:
-		return fmt.Sprintf("\"%v\"", arg)
-	case float32:
+	case float64, float32:
 		return fmt.Sprintf("\"%v\"", arg)
 	default:
 		return fmt.Sprintf("%v", arg)

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1857,6 +1857,10 @@ func maybeQuoteArg(fn string, arg interface{}) string {
 			return arg
 		}
 		return fmt.Sprintf("%q", arg)
+	case float64:
+		return fmt.Sprintf("\"%v\"", arg)
+	case float32:
+		return fmt.Sprintf("\"%v\"", arg)
 	default:
 		return fmt.Sprintf("%v", arg)
 	}

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -868,7 +868,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter((le(Author.dob, "2001-01-01") AND eq(Author.name, "A. N. Author") AND gt(Author.reputation, 2.5))) {
+      queryAuthor(func: type(Author)) @filter((le(Author.dob, "2001-01-01") AND eq(Author.name, "A. N. Author") AND gt(Author.reputation, "2.5"))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -884,7 +884,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(((gt(Author.reputation, 2.5) AND le(Author.dob, "2001-01-01")) AND eq(Author.name, "A. N. Author"))) {
+      queryAuthor(func: type(Author)) @filter(((gt(Author.reputation, "2.5") AND le(Author.dob, "2001-01-01")) AND eq(Author.name, "A. N. Author"))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -965,7 +965,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(((eq(Author.name, "A. N. Author") AND gt(Author.reputation, 2.5)) OR le(Author.dob, "2001-01-01"))) {
+      queryAuthor(func: type(Author)) @filter(((eq(Author.name, "A. N. Author") AND gt(Author.reputation, "2.5")) OR le(Author.dob, "2001-01-01"))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -981,7 +981,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (le(Author.dob, "2001-01-01") AND gt(Author.reputation, 2.5)))) {
+      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (le(Author.dob, "2001-01-01") AND gt(Author.reputation, "2.5")))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -997,7 +997,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (gt(Author.reputation, 2.5) OR le(Author.dob, "2001-01-01")))) {
+      queryAuthor(func: type(Author)) @filter((eq(Author.name, "A. N. Author") OR (gt(Author.reputation, "2.5") OR le(Author.dob, "2001-01-01")))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -1013,7 +1013,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(NOT (gt(Author.reputation, 2.5))) {
+      queryAuthor(func: type(Author)) @filter(NOT (gt(Author.reputation, "2.5"))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -1242,7 +1242,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter((gt(Author.reputation, 1.1) OR (ge(Author.reputation, 1.1) OR (lt(Author.reputation, 1.1) OR (le(Author.reputation, 1.1) OR eq(Author.reputation, 1.1)))))) {
+      queryAuthor(func: type(Author)) @filter((gt(Author.reputation, "1.1") OR (ge(Author.reputation, "1.1") OR (lt(Author.reputation, "1.1") OR (le(Author.reputation, "1.1") OR eq(Author.reputation, "1.1")))))) {
         name : Author.name
         dgraph.uid : uid
       }
@@ -2043,7 +2043,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(between(Author.reputation, 6, 7.2)) {
+      queryAuthor(func: type(Author)) @filter(between(Author.reputation, "6", "7.2")) {
         name : Author.name
         reputation : Author.reputation
         posts : Author.posts @filter(between(Post.numLikes, 10, 100)) {

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1231,6 +1231,21 @@
       }
     }
 
+-
+  name: "Float with large exponentiation"
+  gqlquery: |
+    query {
+      queryAuthor(filter:{ reputation: { gt: 123456789.113 } }) {
+        name
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) @filter(gt(Author.reputation, "1.23456789113e+08")) {
+        name : Author.name
+        dgraph.uid : uid
+      }
+    }
 
 -
   name: "All Float filters work"

--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -712,3 +712,45 @@ schemas:
       Hotel.branches1: geo @index(geo) .
       Hotel.branches2: geo .
       Hotel.branches3: geo @index(geo) .
+
+  - name: "Int field with @id Directive"
+    input: |
+      type TestingSchema {
+        id : Int! @id
+        value: String
+      }
+    output: |
+      type TestingSchema {
+        TestingSchema.id
+        TestingSchema.value
+      }
+      TestingSchema.id: int @index(int) @upsert .
+      TestingSchema.value: string .
+
+  - name: "Int64 field with @id Directive"
+    input: |
+      type TestingSchema {
+        id : Int64! @id
+        value: String
+      }
+    output: |
+      type TestingSchema {
+        TestingSchema.id
+        TestingSchema.value
+      }
+      TestingSchema.id: int @index(int) @upsert .
+      TestingSchema.value: string .
+
+  - name: "Float field with @id Directive"
+    input: |
+      type TestingSchema {
+        id : Float! @id
+        value: String
+      }
+    output: |
+      type TestingSchema {
+        TestingSchema.id
+        TestingSchema.value
+      }
+      TestingSchema.id: float @index(float) @upsert .
+      TestingSchema.value: string .

--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -715,42 +715,42 @@ schemas:
 
   - name: "Int field with @id Directive"
     input: |
-      type TestingSchema {
+      type T {
         id : Int! @id
         value: String
       }
     output: |
-      type TestingSchema {
-        TestingSchema.id
-        TestingSchema.value
+      type T {
+        T.id
+        T.value
       }
-      TestingSchema.id: int @index(int) @upsert .
-      TestingSchema.value: string .
+      T.id: int @index(int) @upsert .
+      T.value: string .
 
   - name: "Int64 field with @id Directive"
     input: |
-      type TestingSchema {
+      type T {
         id : Int64! @id
         value: String
       }
     output: |
-      type TestingSchema {
-        TestingSchema.id
-        TestingSchema.value
+      type T {
+        T.id
+        T.value
       }
-      TestingSchema.id: int @index(int) @upsert .
-      TestingSchema.value: string .
+      T.id: int @index(int) @upsert .
+      T.value: string .
 
   - name: "Float field with @id Directive"
     input: |
-      type TestingSchema {
+      type T {
         id : Float! @id
         value: String
       }
     output: |
-      type TestingSchema {
-        TestingSchema.id
-        TestingSchema.value
+      type T {
+        T.id
+        T.value
       }
-      TestingSchema.id: float @index(float) @upsert .
-      TestingSchema.value: string .
+      T.id: float @index(float) @upsert .
+      T.value: string .

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1506,7 +1506,18 @@ func getSearchArgs(fld *ast.FieldDefinition) []string {
 		}
 		// If search directive wasn't supplied but id was, then hash is the only index
 		// that we apply.
-		return []string{"hash"}
+		switch fld.Type.Name() {
+		case "String":
+			return []string{"hash"}
+		case "Int64":
+			return []string{"int64"}
+		case "Int":
+			return []string{"int"}
+		case "Float":
+			return []string{"float"}
+		default:
+			return nil
+		}
 	}
 	if len(search.Arguments) == 0 ||
 		len(search.Arguments.ForName(searchArgs).Value.Children) == 0 {
@@ -1750,11 +1761,11 @@ func addGetQuery(schema *ast.Schema, defn *ast.Definition, generateSubscription 
 		})
 	}
 	if hasXIDField {
-		name := xidTypeFor(defn)
+		name, dtype := xidTypeFor(defn)
 		qry.Arguments = append(qry.Arguments, &ast.ArgumentDefinition{
 			Name: name,
 			Type: &ast.Type{
-				NamedType: "String",
+				NamedType: dtype,
 				NonNull:   !hasIDField,
 			},
 		})
@@ -2363,13 +2374,13 @@ func idTypeFor(defn *ast.Definition) string {
 	return "ID"
 }
 
-func xidTypeFor(defn *ast.Definition) string {
+func xidTypeFor(defn *ast.Definition) (string, string) {
 	for _, fld := range defn.Fields {
 		if hasIDDirective(fld) {
-			return fld.Name
+			return fld.Name, fld.Type.Name()
 		}
 	}
-	return ""
+	return "", ""
 }
 
 func appendIfNotNull(errs []*gqlerror.Error, err *gqlerror.Error) gqlerror.List {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1500,28 +1500,23 @@ func getDefaultSearchIndex(fldName string) string {
 func getSearchArgs(fld *ast.FieldDefinition) []string {
 	search := fld.Directives.ForName(searchDirective)
 	id := fld.Directives.ForName(idDirective)
+	fldType := fld.Type.Name()
 	if search == nil {
 		if id == nil {
 			return nil
 		}
+		switch fldType {
 		// If search directive wasn't supplied but id was, then hash is the only index
-		// that we apply.
-		switch fld.Type.Name() {
+		// that we apply for string.
 		case "String":
 			return []string{"hash"}
-		case "Int64":
-			return []string{"int64"}
-		case "Int":
-			return []string{"int"}
-		case "Float":
-			return []string{"float"}
 		default:
-			return nil
+			return []string{getDefaultSearchIndex(fldType)}
 		}
 	}
 	if len(search.Arguments) == 0 ||
 		len(search.Arguments.ForName(searchArgs).Value.Children) == 0 {
-		return []string{getDefaultSearchIndex(fld.Type.Name())}
+		return []string{getDefaultSearchIndex(fldType)}
 	}
 	val := search.Arguments.ForName(searchArgs).Value
 	res := make([]string, len(val.Children))

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -239,7 +239,7 @@ invalid_schemas:
     errlist: [
       { "message": "Type Z; Field f: Field f is of type U, but @hasInverse directive only applies to fields with object types.", "locations": [{"line":9, "column":3}]},
       { "message": "Type Z; Field f: has the @search directive but fields of type U can't have the @search directive.", "locations": [{"line":9, "column":34}]},
-      { "message": "Type Z; Field f: with @id directive must be of type String!, not U", "locations": [{"line":9, "column":42}]}
+      { "message": "Type Z; Field f: with @id directive must be of type String!, Int!, Int64! or Float!, not U", "locations": [{"line":9, "column":42}]}
     ]
 
   -
@@ -622,7 +622,7 @@ invalid_schemas:
         f1: [String] @id
       }
     errlist: [
-      {"message": "Type X; Field f1: with @id directive must be of type String!, not [String]",
+      {"message": "Type X; Field f1: with @id directive must be of type String!, Int!, Int64! or Float!, not [String]",
       "locations":[{"line":2, "column":17}]}
       ]
 
@@ -633,7 +633,7 @@ invalid_schemas:
         f1: String @id
       }
     errlist: [
-      {"message": "Type X; Field f1: with @id directive must be of type String!, not String",
+      {"message": "Type X; Field f1: with @id directive must be of type String!, Int!, Int64! or Float!, not String",
       "locations":[{"line":2, "column":15}]}
       ]
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1998,7 +1998,7 @@ func idValidation(sch *ast.Schema,
 	}
 	return []*gqlerror.Error{gqlerror.ErrorPosf(
 		dir.Position,
-		"Type %s; Field %s: with @id directive must be of type String!, not %s",
+		"Type %s; Field %s: with @id directive must be of type String!, Int!, Int64! or Float!, not %s",
 		typ.Name, field.Name, field.Type.String())}
 }
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1990,7 +1990,10 @@ func idValidation(sch *ast.Schema,
 	field *ast.FieldDefinition,
 	dir *ast.Directive,
 	secrets map[string]x.SensitiveByteSlice) gqlerror.List {
-	if field.Type.String() == "String!" {
+	if field.Type.String() == "String!" ||
+		field.Type.String() == "Int!" ||
+		field.Type.String() == "Int64!" ||
+		field.Type.String() == "Float!" {
 		return nil
 	}
 	return []*gqlerror.Error{gqlerror.ErrorPosf(

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -488,7 +488,16 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 					id := f.Directives.ForName(idDirective)
 					if id != nil {
 						upsertStr = "@upsert "
-						indexes = append(indexes, "hash")
+						switch f.Type.Name() {
+						case "Int":
+							fallthrough
+						case "Int64":
+							indexes = append(indexes, "int")
+						case "Float":
+							indexes = append(indexes, "float")
+						case "String":
+							indexes = append(indexes, "hash")
+						}
 					}
 
 					if search != nil {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -489,9 +489,7 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 					if id != nil {
 						upsertStr = "@upsert "
 						switch f.Type.Name() {
-						case "Int":
-							fallthrough
-						case "Int64":
+						case "Int", "Int64":
 							indexes = append(indexes, "int")
 						case "Float":
 							indexes = append(indexes, "float")

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1061,13 +1061,14 @@ func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
 	if xidArgName != "" {
 		var ok bool
 		var xidArgVal string
-		switch f.ArgValue(xidArgName).(type) {
+		switch v := f.ArgValue(xidArgName).(type) {
 		case int64:
-			xidArgVal = strconv.FormatInt(f.ArgValue(xidArgName).(int64), 10)
+			xidArgVal = strconv.FormatInt(v, 10)
 		case float64:
-			xidArgVal = strconv.FormatFloat(f.ArgValue(xidArgName).(float64), 'f', -1, 64)
+			xidArgVal = strconv.FormatFloat(v, 'f', -1, 64)
+		case string:
+			xidArgVal = v
 		default:
-			xidArgVal, ok = f.ArgValue(xidArgName).(string)
 			pos := f.field.GetPosition()
 			if !ok {
 				err = x.GqlErrorf("Argument (%s) of %s was not able to be parsed as a string",

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1059,13 +1059,23 @@ func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
 		}
 	}
 	if xidArgName != "" {
-		xidArgVal, ok := f.ArgValue(xidArgName).(string)
-		pos := f.field.GetPosition()
-		if !ok {
-			err = x.GqlErrorf("Argument (%s) of %s was not able to be parsed as a string",
-				xidArgName, f.Name()).WithLocations(x.Location{Line: pos.Line, Column: pos.Column})
-			return
+		var ok bool
+		var xidArgVal string
+		switch f.ArgValue(xidArgName).(type) {
+		case int64:
+			xidArgVal = strconv.FormatInt(f.ArgValue(xidArgName).(int64), 10)
+		case float64:
+			xidArgVal = strconv.FormatFloat(f.ArgValue(xidArgName).(float64), 'f', -1, 64)
+		default:
+			xidArgVal, ok = f.ArgValue(xidArgName).(string)
+			pos := f.field.GetPosition()
+			if !ok {
+				err = x.GqlErrorf("Argument (%s) of %s was not able to be parsed as a string",
+					xidArgName, f.Name()).WithLocations(x.Location{Line: pos.Line, Column: pos.Column})
+				return
+			}
 		}
+
 		xid = &xidArgVal
 	}
 


### PR DESCRIPTION
This PR fixes GRAPHQL-762. Earlier we only can define String! datatypes with @id directive. This enables user to define @id directive with Int, Int64, Float datatypes too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7019)
<!-- Reviewable:end -->
