### PR TITLE
Feat(GraphQL): Add Aggregation Queries at Child Level

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -1594,16 +1594,42 @@ func TestMain(m *testing.M) {
 	os.Exit(0)
 }
 
-func TestChildCountQueryWithDeepRBAC(t *testing.T) {
+func TestChildAggregateQueryWithDeepRBAC(t *testing.T) {
 	testCases := []TestCase{
 		{
-			user:   "user1",
-			role:   "USER",
-			result: `{"queryUser": [{"username": "user1", "issuesAggregate":{"count": null}}]}`},
+			user: "user1",
+			role: "USER",
+			result: `{
+						"queryUser":
+							[
+								{
+									"username": "user1",
+									"issuesAggregate":
+										{
+											"count": null,
+											"msgMax": null,
+											"msgMin": null
+										}
+								}
+							]
+					}`},
 		{
-			user:   "user1",
-			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","issuesAggregate":{"count":1}}]}`},
+			user: "user1",
+			role: "ADMIN",
+			result: `{
+						"queryUser":
+							[
+								{
+									"username":"user1",
+									"issuesAggregate":
+										{
+											"count":1,
+											"msgMax": "Issue1",
+											"msgMin": "Issue1"
+										}
+								}
+							]
+					}`},
 	}
 
 	query := `
@@ -1612,6 +1638,8 @@ func TestChildCountQueryWithDeepRBAC(t *testing.T) {
 		username
 		issuesAggregate {
 		  count
+		  msgMax
+		  msgMin
 		}
 	  }
 	}
@@ -1632,16 +1660,49 @@ func TestChildCountQueryWithDeepRBAC(t *testing.T) {
 	}
 }
 
-func TestChildCountQueryWithOtherFields(t *testing.T) {
+func TestChildAggregateQueryWithOtherFields(t *testing.T) {
 	testCases := []TestCase{
 		{
-			user:   "user1",
-			role:   "USER",
-			result: `{"queryUser": [{"username": "user1","issues":[],"issuesAggregate":{"count": null}}]}`},
+			user: "user1",
+			role: "USER",
+			result: `{
+						"queryUser":
+							[
+								{
+									"username": "user1",
+									"issues":[],
+									"issuesAggregate":
+										{
+											"count": null,
+											"msgMin": null,
+											"msgMax": null
+										}
+								}
+							]
+					}`},
 		{
-			user:   "user1",
-			role:   "ADMIN",
-			result: `{"queryUser":[{"username":"user1","issues":[{"msg":"Issue1"}],"issuesAggregate":{"count":1}}]}`},
+			user: "user1",
+			role: "ADMIN",
+			result: `{
+						"queryUser":
+							[
+								{
+									"username":"user1",
+									"issues":
+										[
+											{
+												"msg":"Issue1"
+											}
+										],
+									"issuesAggregate":
+										{
+											"count": 1,
+											"msgMin": "Issue1",
+											"msgMax": "Issue1"
+										}
+								}
+							]
+					}`},
 	}
 
 	query := `
@@ -1650,6 +1711,8 @@ func TestChildCountQueryWithOtherFields(t *testing.T) {
 		username
 		issuesAggregate {
 		  count
+		  msgMin
+		  msgMax
 		}
 		issues {
 		  msg

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -365,11 +365,11 @@ func RunAll(t *testing.T) {
 	t.Run("query aggregate without filter", queryAggregateWithoutFilter)
 	t.Run("query aggregate with filter", queryAggregateWithFilter)
 	t.Run("query aggregate with alias", queryAggregateWithAlias)
-	t.Run("query count at child level", queryCountAtChildLevel)
-	t.Run("query count at child level with filter", queryCountAtChildLevelWithFilter)
-	t.Run("query count at child level with multiple alias", queryCountAtChildLevelWithMultipleAlias)
+	t.Run("query aggregate at child level", queryAggregateAtChildLevel)
+	t.Run("query aggregate at child level with filter", queryAggregateAtChildLevelWithFilter)
+	t.Run("query aggregate at child level with multiple alias", queryAggregateAtChildLevelWithMultipleAlias)
+	t.Run("query aggregate and other fields at child level", queryAggregateAndOtherFieldsAtChildLevel)
 	t.Run("query at child level with multiple alias on scalar field", queryChildLevelWithMultipleAliasOnScalarField)
-	t.Run("query count and other fields at child level", queryCountAndOtherFieldsAtChildLevel)
 	t.Run("checkUserPassword query", passwordTest)
 
 	// mutation tests

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1165,12 +1165,14 @@
       }
     }
 
-- name: "Count at child with Auth deep filter and field filter"
+- name: "Aggregate Fields at child with Auth deep filter and field filter"
   gqlquery: |
     query {
       queryUser {
         ticketsAggregate(filter: { title: { anyofterms: "graphql" } }) {
           count
+          titleMin
+          titleMax
         }
       }
     }
@@ -1179,7 +1181,13 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
+        ticketsAggregate : User.tickets @filter(uid(Ticket3)) {
+          ticketsAggregate_titleVar as Ticket.title
+          dgraph.uid : uid
+        }
         count_ticketsAggregate : count(User.tickets) @filter(uid(Ticket3))
+        titleMin_ticketsAggregate : min(val(ticketsAggregate_titleVar))
+        titleMax_ticketsAggregate : max(val(ticketsAggregate_titleVar))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1203,15 +1211,16 @@
       }
     }
 
-- name: "Multiple Count queries at child level and other queries with Auth deep filter"
+- name: "Multiple Aggregate queries at child level and other queries with Auth deep filter"
   gqlquery: |
     query {
       queryUser {
         ticketsAggregate(filter: { title: { anyofterms: "graphql" } }) {
-          count
+          titleMin
         }
         issuesAggregate {
           count
+          msgMax
         }
         tickets(filter: { title: { anyofterms: "graphql2" } }) {
           title
@@ -1224,8 +1233,17 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        count_ticketsAggregate : count(User.tickets) @filter(uid(Ticket3))
+        ticketsAggregate : User.tickets @filter(uid(Ticket3)) {
+          ticketsAggregate_titleVar as Ticket.title
+          dgraph.uid : uid
+        }
+        titleMin_ticketsAggregate : min(val(ticketsAggregate_titleVar))
+        issuesAggregate : User.issues @filter(uid(Issue6)) {
+          issuesAggregate_msgVar as Issue.msg
+          dgraph.uid : uid
+        }
         count_issuesAggregate : count(User.issues) @filter(uid(Issue6))
+        msgMax_issuesAggregate : max(val(issuesAggregate_msgVar))
         tickets : User.tickets @filter(uid(Ticket9)) {
           title : Ticket.title
           dgraph.uid : uid
@@ -1278,12 +1296,13 @@
       }
     }
 
-- name: "count at child with RBAC rules true"
+- name: "Aggregate at child with RBAC rules true"
   gqlquery: |
     query {
       queryUser {
         issuesAggregate {
           count
+          msgMin
         }
       }
     }
@@ -1293,7 +1312,12 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
+        issuesAggregate : User.issues @filter(uid(Issue3)) {
+          issuesAggregate_msgVar as Issue.msg
+          dgraph.uid : uid
+        }
         count_issuesAggregate : count(User.issues) @filter(uid(Issue3))
+        msgMin_issuesAggregate : min(val(issuesAggregate_msgVar))
         dgraph.uid : uid
       }
       UserRoot as var(func: uid(User4))
@@ -1308,13 +1332,14 @@
       }
     }
 
-- name: "count with Deep RBAC rules false"
+- name: "Aggregate Fields with Deep RBAC rules false"
   gqlquery: |
     query {
       queryUser {
         username
         issuesAggregate {
           count
+          msgMin
         }
       }
     }

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1116,7 +1116,7 @@ func buildAggregateFields(
 		}
 	}
 	// mainField is only added as an aggregate child if it has any children fields inside it.
-	// This ensures that if only count aggregation field is there, the mainField is added.
+	// This ensures that if only count aggregation field is there, the mainField is not added.
 	// As mainField contains only var fields. It is not needed in case of count.
 	if len(mainField.Children) > 0 {
 		aggregateChildren = append([]*gql.GraphQuery{mainField}, aggregateChildren...)

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1015,7 +1015,7 @@ func buildCommonAuthQueries(
 // buildAggregateFields builds DQL queries for aggregate fields like count, avg, max etc.
 // It returns related DQL fields and Auth Queries which are then added to the final DQL query
 // by the caller.
-// fieldAlias is being passed along with the fileld as it depends on the number of times we have
+// fieldAlias is being passed along with the field as it depends on the number of times we have
 // encountered that field till now.
 func buildAggregateFields(
 	f schema.Field,
@@ -1023,25 +1023,103 @@ func buildAggregateFields(
 	auth *authRewriter) ([]*gql.GraphQuery, []*gql.GraphQuery) {
 	constructedForType := f.ConstructedFor()
 	constructedForDgraphPredicate := f.ConstructedForDgraphPredicate()
-	// Iterate over fields queried inside aggregate.
+
+	// aggregateChildren contains the count query field and mainField (described below).
+	// otherAggregateChildren contains other min,max,sum,avg fields.
+	// These fields are considered separately as filters (auth and other filters) need to
+	// be added to count fields and mainFields but not for other aggregate fields.
 	var aggregateChildren []*gql.GraphQuery
+	var otherAggregateChildren []*gql.GraphQuery
+	// mainField contains the queried Aggregate Field and has all var fields inside it.
+	// Eg. the mainQuery for
+	// postsAggregate {
+	//   titleMin
+	// }
+	// is
+	// postsAggregate : Author.posts {
+	//   postsAggregate_titleVar as Post.title
+	//   ... other queried aggregate fields
+	// }
+	mainField := &gql.GraphQuery{
+		Alias: fieldAlias,
+		Attr:  constructedForDgraphPredicate,
+	}
+
+	// Filter for aggregate Fields. This is added to all count aggregate fields
+	// and mainField
+	fieldFilter, _ := f.ArgValue("filter").(map[string]interface{})
+	_ = addFilter(mainField, constructedForType, fieldFilter)
+
 	// addedAggregateFields is a map from aggregate field name to boolean
 	addedAggregateField := make(map[string]bool)
+	// isAggregateFieldVisited is a map from field name to boolean. It is used to
+	// ensure that a field is added to Var query at maximum once.
+	// Eg. Even if scoreMax and scoreMin are queried, the corresponding field will
+	// contain "scoreVar as Tweets.score" only once.
+	isAggregateFieldVisited := make(map[string]bool)
+
+	// Iterate over fields queried inside aggregate.
 	for _, aggregateField := range f.SelectionSet() {
 		// Don't add the same field twice
 		if _, isAddedAggregateField := addedAggregateField[aggregateField.DgraphAlias()]; isAddedAggregateField {
 			continue
 		}
+		addedAggregateField[aggregateField.DgraphAlias()] = true
+
+		// Handle count fields inside aggregate fields.
 		if aggregateField.DgraphAlias() == "count" {
 			aggregateChild := &gql.GraphQuery{
 				Alias: "count_" + fieldAlias,
 				Attr:  "count(" + constructedForDgraphPredicate + ")",
 			}
-			filter, _ := f.ArgValue("filter").(map[string]interface{})
-			_ = addFilter(aggregateChild, constructedForType, filter)
+			// Add filter to count aggregation field.
+			_ = addFilter(aggregateChild, constructedForType, fieldFilter)
 			aggregateChildren = append(aggregateChildren, aggregateChild)
-			addedAggregateField[aggregateField.DgraphAlias()] = true
+			continue
 		}
+		// Handle other aggregate functions than count
+		aggregateFunctions := []string{"Max", "Min", "Sum", "Avg"}
+		for _, function := range aggregateFunctions {
+			aggregateFldName := aggregateField.Name()
+			// A field can have at maximum one aggregation function as suffix.
+			if strings.HasSuffix(aggregateFldName, function) {
+				// constructedForField contains the field name for which aggregate function
+				// has been queried. Eg. name for nameMax. Removing last 3 characters as all
+				// aggregation functions have length 3
+				constructedForField := aggregateFldName[:len(aggregateFldName)-3]
+				// constructedForDgraphPredicate stores the Dgraph predicate for which aggregate function
+				// has been queried. Eg. Post.name for nameMin
+				constructedForDgraphPredicateField := aggregateField.DgraphPredicateForAggregateField()
+				// Adding the corresponding var field if it has not been added before. isAggregateFieldVisited
+				// ensures that a var queried is added at maximum once.
+				if !isAggregateFieldVisited[constructedForField] {
+					child := &gql.GraphQuery{
+						Var:  fieldAlias + "_" + constructedForField + "Var",
+						Attr: constructedForDgraphPredicateField,
+					}
+					// The var field is added to mainQuery. This adds the following DQL query.
+					// postsAggregate : Author.posts {
+					//   postsAggregate_nameVar as Post.name
+					// }
+					mainField.Children = append(mainField.Children, child)
+					isAggregateFieldVisited[constructedForField] = true
+				}
+				aggregateChild := &gql.GraphQuery{
+					Alias: aggregateFldName + "_" + fieldAlias,
+					Attr:  strings.ToLower(function) + "(val(" + fieldAlias + "_" + constructedForField + "Var))",
+				}
+				// This adds the following DQL query
+				// nameMin_postsAggregate : min(val(postsAggregate_nameVar))
+				otherAggregateChildren = append(otherAggregateChildren, aggregateChild)
+				break
+			}
+		}
+	}
+	// mainField is only added as an aggregate child if it has any children fields inside it.
+	// This ensures that if only count aggregation field is there, the mainField is added.
+	// As mainField contains only var fields. It is not needed in case of count.
+	if len(mainField.Children) > 0 {
+		aggregateChildren = append([]*gql.GraphQuery{mainField}, aggregateChildren...)
 	}
 	rbac := auth.evaluateStaticRules(constructedForType)
 	if rbac == schema.Negative {
@@ -1059,6 +1137,10 @@ func buildAggregateFields(
 	if rbac == schema.Uncertain {
 		fieldAuth, authFilter = auth.rewriteAuthQueries(constructedForType)
 	}
+	// At this stage aggregateChildren only contains the count aggregate fields and
+	// possibly mainField. Auth filters are added to count aggregation fields and
+	// mainField. Adding filters only for mainField is sufficient for other aggregate
+	// functions as the aggregation functions use var from mainField.
 	for _, aggregateChild := range aggregateChildren {
 		if authFilter != nil {
 			if aggregateChild.Filter == nil {
@@ -1071,6 +1153,9 @@ func buildAggregateFields(
 			}
 		}
 	}
+	// Adds auth queries. The variable authQueriesAppended ensures that auth queries are
+	// appended only once. This also merges auth filters and any other filters of count
+	// aggregation fields / mainField.
 	if len(f.SelectionSet()) > 0 && !auth.isWritingAuth && auth.hasAuthRules {
 		commonAuthQueryVars := buildCommonAuthQueries(f, auth, parentQryName)
 		var authQueriesAppended = false
@@ -1088,6 +1173,10 @@ func buildAggregateFields(
 			}
 		}
 	}
+	// otherAggregation Children are appended to aggregationChildren to return them.
+	// This step is performed at the end to ensure that auth and other filters are
+	// not added to them.
+	aggregateChildren = append(aggregateChildren, otherAggregateChildren...)
 	retAuthQueries = append(retAuthQueries, fieldAuth...)
 	return aggregateChildren, retAuthQueries
 }

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2927,6 +2927,47 @@
     }
 
 -
+  name: "Aggregate query at child level with filter and multiple aggregate fields"
+  gqlquery: |
+    query {
+      queryCountry {
+        nm : name
+        ag : statesAggregate {
+          nMin : nameMin
+          nMax : nameMax
+        }
+        statesAggregate(filter: { code: { eq: "state code" } }) {
+          cnt : count
+          nMin : nameMin
+          nMax : nameMax
+          cMin : capitalMin
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryCountry(func: type(Country)) {
+        name : Country.name
+        statesAggregate : Country.states {
+          statesAggregate_nameVar as State.name
+          dgraph.uid : uid
+        }
+        nameMin_statesAggregate : min(val(statesAggregate_nameVar))
+        nameMax_statesAggregate : max(val(statesAggregate_nameVar))
+        statesAggregate1 : Country.states @filter(eq(State.code, "state code")) {
+          statesAggregate1_nameVar as State.name
+          statesAggregate1_capitalVar as State.capital
+          dgraph.uid : uid
+        }
+        count_statesAggregate1 : count(Country.states) @filter(eq(State.code, "state code"))
+        nameMin_statesAggregate1 : min(val(statesAggregate1_nameVar))
+        nameMax_statesAggregate1 : max(val(statesAggregate1_nameVar))
+        capitalMin_statesAggregate1 : min(val(statesAggregate1_capitalVar))
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "Count query at child level with filter"
   gqlquery: |
     query {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1393,9 +1393,8 @@ func completeObject(
 		if f.IsAggregateField() {
 			aggregateVal := make(map[string]interface{})
 			for _, aggregateField := range f.SelectionSet() {
-				fieldAlias := generateUniqueDgraphAlias(f, fieldSeenCount)
 				aggregateFieldName := aggregateField.Name()
-				aggregateVal[aggregateFieldName] = res[aggregateFieldName+"_"+fieldAlias]
+				aggregateVal[aggregateFieldName] = res[aggregateFieldName+"_"+uniqueDgraphAlias]
 			}
 			val = aggregateVal
 		}

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1393,9 +1393,9 @@ func completeObject(
 		if f.IsAggregateField() {
 			aggregateVal := make(map[string]interface{})
 			for _, aggregateField := range f.SelectionSet() {
-				if aggregateField.DgraphAlias() == "count" {
-					aggregateVal["count"] = res["count_"+generateUniqueDgraphAlias(f, fieldSeenCount)]
-				}
+				fieldAlias := generateUniqueDgraphAlias(f, fieldSeenCount)
+				aggregateFieldName := aggregateField.Name()
+				aggregateVal[aggregateFieldName] = res[aggregateFieldName+"_"+fieldAlias]
 			}
 			val = aggregateVal
 		}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1659,8 +1659,7 @@ func addAggregationResultType(schema *ast.Schema, defn *ast.Definition) {
 				Name: fld.Name + "Max",
 				Type: aggregateFieldType,
 			}
-			aggregateFields = append(aggregateFields, minField)
-			aggregateFields = append(aggregateFields, maxField)
+			aggregateFields = append(aggregateFields, minField, maxField)
 		}
 
 		// Adds scoreSum and scoreAvg field for a field of name score.
@@ -1678,8 +1677,7 @@ func addAggregationResultType(schema *ast.Schema, defn *ast.Definition) {
 					NonNull:   false,
 				},
 			}
-			aggregateFields = append(aggregateFields, sumField)
-			aggregateFields = append(aggregateFields, avgField)
+			aggregateFields = append(aggregateFields, sumField, avgField)
 		}
 	}
 


### PR DESCRIPTION
Motivation:
This PR adds Aggregation Queries at child level. Aggregation Queries handle Avg,Max,Min,Sum functions for scalar fields.
Related RFC: https://discuss.dgraph.io/t/count-queries-in-graphql/10714/9
This PR contains the following changes:
1. Support for aggregation queries at child levels in query_rewriter.go
2. Changes to resolver.go to handle response of aggregation queries at child level.
3. Tests to query_test.yaml and auth_query_test.yaml
4. e2e tests for aggregation queries at child level.
Fixes GRAPHQL-773
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7022)
<!-- Reviewable:end -->
