### PR TITLE
release/v20.03 - fix: change default compression to zstd:3

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -107,7 +107,7 @@ func init() {
 			" The key size indicates the chosen AES encryption (AES-128/192/256 respectively). "+
 			" This key is used to encrypt the output data directories and to decrypt the input "+
 			" schema and data files (if encrytped). Enterprise feature.")
-	flag.Int("badger.compression_level", 1,
+	flag.Int("badger.compression_level", 3,
 		"The compression level for Badger. A higher value uses more resources.")
 	flag.Int64("badger.cache_mb", 0, "Total size of cache (in MB) per shard in reducer.")
 	flag.String("badger.cache_percentage", "0,100",

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -65,6 +65,8 @@ func RunRestore(pdir, location, backupId, keyfile string) LoadResult {
 			// The badger DB should be opened only after creating the backup
 			// file reader and verifying the encryption in the backup file.
 			db, err := badger.OpenManaged(badger.DefaultOptions(dir).
+				WithCompression(options.ZSTD).
+				WithZSTDCompressionLevel(3).
 				WithSyncWrites(false).
 				WithTableLoadingMode(options.MemoryMap).
 				WithValueThreshold(1 << 10).


### PR DESCRIPTION
Changes the default compression levels in bulk and store to `zstd:3` for consistency.