### PR TITLE
fix(DQL): ignore ordering of indexes in schema with eq function

### DIFF
--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -53,6 +53,7 @@ func TestQuery(t *testing.T) {
 	t.Run("hash index queries", wrap(QueryHashIndex))
 	t.Run("fuzzy matching", wrap(FuzzyMatch))
 	t.Run("regexp with toggled trigram index", wrap(RegexpToggleTrigramIndex))
+	t.Run("eq with altering order of trigram and term index", wrap(EqWithAlteredIndexOrder))
 	t.Run("groupby uid that works", wrap(GroupByUidWorks))
 	t.Run("cleanup", wrap(SchemaQueryCleanup))
 }
@@ -866,6 +867,41 @@ func RegexpToggleTrigramIndex(t *testing.T, c *dgo.Dgraph) {
 	_, err = c.NewTxn().Query(ctx, `{q(func:regexp(name, /art/)) {name}}`)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Attribute name does not have trigram index for regex matching.")
+}
+
+func EqWithAlteredIndexOrder(t *testing.T, c *dgo.Dgraph) {
+	ctx := context.Background()
+
+	// first, let's set the schema with term before trigram
+	op := &api.Operation{Schema: `name: string @index(term, trigram) .`}
+	require.NoError(t, c.Alter(ctx, op))
+
+	// fill up some data
+	txn := c.NewTxn()
+	_, err := txn.Mutate(ctx, &api.Mutation{
+		SetNquads: []byte(`
+      _:x1 <name> "Alice" .
+      _:x2 <name> "Bob" .
+    `),
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctx))
+
+	// querying with eq should work
+	q := `{q(func: eq(name, "Alice")) {name}}`
+	expectedResult := `{"q":[{"name":"Alice"}]}`
+	resp, err := c.NewReadOnlyTxn().Query(ctx, q)
+	require.NoError(t, err)
+	testutil.CompareJSON(t, expectedResult, string(resp.Json))
+
+	// now, let's set the schema with trigram before term
+	op = &api.Operation{Schema: `name: string @index(trigram, term) .`}
+	require.NoError(t, c.Alter(ctx, op))
+
+	// querying with eq should still work
+	resp, err = c.NewReadOnlyTxn().Query(ctx, q)
+	require.NoError(t, err)
+	testutil.CompareJSON(t, expectedResult, string(resp.Json))
 }
 
 func GroupByUidWorks(t *testing.T, c *dgo.Dgraph) {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -497,7 +497,7 @@ Index Required: An index is required for the `eq(predicate, ...)` forms (see tab
 | `int`      | `int`         |
 | `float`    | `float`       |
 | `bool`     | `bool`        |
-| `string`   | `exact`, `hash` |
+| `string`   | `exact`, `hash`, `term`, `fulltext` |
 | `dateTime` | `dateTime`    |
 
 Test for equality of a predicate or variable to a value or find in a list of values.


### PR DESCRIPTION
Previously, the following schema:

name: string @index(trigram, term) .
with some added data, and the following query:

query {
	q(func: eq(name, "Alice", "Bob")) {
		uid
		name
	}
}
would error out saying it doesn't have a valid tokenizer:

{
  "errors": [
    {
      "message": ": Attribute name does not have a valid tokenizer.",
      "extensions": {
        "code": "ErrorInvalidRequest"
      }
    }
  ],
  "data": null
}
even though term index is present on the predicate.
On the other hand, if you reversed the order of indexes:

name: string @index(term, trigram) .
It would give correct results:

{
  "data": {
    "q": [
      {
        "uid": "0x2",
        "name": "Alice",
        "age": 20
      },
      {
        "uid": "0x3",
        "name": "Bob",
        "age": 25
      }
    ]
  }
}
This PR fixes the above issue.

(cherry picked from commit 0b11439)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7034)
<!-- Reviewable:end -->
