### PR TITLE
fix(DQL): ignore ordering of indexes in schema with eq function (DGRA…

### DIFF
--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -54,6 +54,7 @@ func TestQuery(t *testing.T) {
 	t.Run("hash index queries", wrap(QueryHashIndex))
 	t.Run("fuzzy matching", wrap(FuzzyMatch))
 	t.Run("regexp with toggled trigram index", wrap(RegexpToggleTrigramIndex))
+	t.Run("eq with altering order of trigram and term index", wrap(EqWithAlteredIndexOrder))
 	t.Run("groupby uid that works", wrap(GroupByUidWorks))
 	t.Run("cleanup", wrap(SchemaQueryCleanup))
 }
@@ -886,6 +887,41 @@ func RegexpToggleTrigramIndex(t *testing.T, c *dgo.Dgraph) {
 	_, err = c.NewTxn().Query(ctx, `{q(func:regexp(name, /art/)) {name}}`)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Attribute name does not have trigram index for regex matching.")
+}
+
+func EqWithAlteredIndexOrder(t *testing.T, c *dgo.Dgraph) {
+	ctx := context.Background()
+
+	// first, let's set the schema with term before trigram
+	op := &api.Operation{Schema: `name: string @index(term, trigram) .`}
+	require.NoError(t, c.Alter(ctx, op))
+
+	// fill up some data
+	txn := c.NewTxn()
+	_, err := txn.Mutate(ctx, &api.Mutation{
+		SetNquads: []byte(`
+      _:x1 <name> "Alice" .
+      _:x2 <name> "Bob" .
+    `),
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctx))
+
+	// querying with eq should work
+	q := `{q(func: eq(name, "Alice")) {name}}`
+	expectedResult := `{"q":[{"name":"Alice"}]}`
+	resp, err := c.NewReadOnlyTxn().Query(ctx, q)
+	require.NoError(t, err)
+	testutil.CompareJSON(t, expectedResult, string(resp.Json))
+
+	// now, let's set the schema with trigram before term
+	op = &api.Operation{Schema: `name: string @index(trigram, term) .`}
+	require.NoError(t, c.Alter(ctx, op))
+
+	// querying with eq should still work
+	resp, err = c.NewReadOnlyTxn().Query(ctx, q)
+	require.NoError(t, err)
+	testutil.CompareJSON(t, expectedResult, string(resp.Json))
 }
 
 func GroupByUidWorks(t *testing.T, c *dgo.Dgraph) {

--- a/wiki/content/query-language/index.md
+++ b/wiki/content/query-language/index.md
@@ -475,7 +475,7 @@ Index Required: An index is required for the `eq(predicate, ...)` forms (see tab
 | `int`      | `int`         |
 | `float`    | `float`       |
 | `bool`     | `bool`        |
-| `string`   | `exact`, `hash` |
+| `string`   | `exact`, `hash`, `term`, `fulltext` |
 | `dateTime` | `dateTime`    |
 
 Test for equality of a predicate or variable to a value or find in a list of values.
@@ -1806,7 +1806,7 @@ The `_all_` keyword requires that the nodes have types. Dgraph will look for all
 the types that have been assigned to a node, query the types to check which
 attributes they have, and use those to compute the list of predicates to expand.
 
-For example, consider a node that has types `Animal` and `Pet`, which have 
+For example, consider a node that has types `Animal` and `Pet`, which have
 the following definitions:
 
 ```
@@ -1835,7 +1835,7 @@ veterinarian
 ```
 
 For `string` predicates, `expand` only returns values not tagged with a language
-(see [language preference]({{< relref "#language-support" >}})).  So it's often 
+(see [language preference]({{< relref "#language-support" >}})).  So it's often
 required to add `name@fr` or `name@.` as well to an expand query.
 
 ### Filtering during expand.

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -84,7 +84,7 @@ func pickTokenizer(attr string, f string) (tok.Tokenizer, error) {
 
 	tokenizers := schema.State().Tokenizer(attr)
 	for _, t := range tokenizers {
-		// If function is eq and we found a tokenizer thats !Lossy(), lets return it
+		// If function is eq and we found a tokenizer that's !Lossy(), lets return it
 		switch f {
 		case "eq":
 			// For equality, find a non-lossy tokenizer.
@@ -104,7 +104,17 @@ func pickTokenizer(attr string, f string) (tok.Tokenizer, error) {
 		return nil, errors.Errorf("Attribute:%s does not have proper index for comparison", attr)
 	}
 
-	// We didn't find a sortable or !isLossy() tokenizer, lets return the first one.
+	// If we didn't find a !isLossy() tokenizer for eq function on string type predicates,
+	// then let's see if we can find a non-trigram tokenizer
+	if typ, err := schema.State().TypeOf(attr); err == nil && typ == types.StringID {
+		for _, t := range tokenizers {
+			if t.Identifier() != tok.IdentTrigram {
+				return t, nil
+			}
+		}
+	}
+
+	// otherwise, lets return the first one.
 	return tokenizers[0], nil
 }
 


### PR DESCRIPTION
Previously, the following schema:
```
name: string @index(trigram, term) .
```
with some added data, and the following query:
```
query {
	q(func: eq(name, "Alice", "Bob")) {
		uid
		name
	}
}
```
would error out saying it doesn't have a valid tokenizer:
```
{
  "errors": [
    {
      "message": ": Attribute name does not have a valid tokenizer.",
      "extensions": {
        "code": "ErrorInvalidRequest"
      }
    }
  ],
  "data": null
}
```
even though `term` index is present on the predicate.
On the other hand, if you reversed the order of indexes:
```
name: string @index(term, trigram) .
```
It would give correct results:
```
{
  "data": {
    "q": [
      {
        "uid": "0x2",
        "name": "Alice",
        "age": 20
      },
      {
        "uid": "0x3",
        "name": "Bob",
        "age": 25
      }
    ]
  }
}
```

This PR fixes the above issue.

(cherry picked from commit 0b1143966aa04532f851293ba92c2a7d6dc82871)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7035)
<!-- Reviewable:end -->
