### PR TITLE
[docs] removed note about order for term and trigram since it has been fixed

### DIFF
--- a/wiki/content/query-language/schema.md
+++ b/wiki/content/query-language/schema.md
@@ -382,19 +382,6 @@ transaction conflict rate. Use only the minimum number of and simplest indexes
 that your application needs.
 {{% /notice %}}
 
-Please note that when specifying at the same time both `term` and `trigram` indexes, in the schema, you will need to specify them in the following exact order:   `<predicate>: string @index(term, trigram) .` not vice-versa.
-Doing otherwise causes queries using the index to return an error about invalid tokenizers.
-
-```
-{
-     "message": ": Attribute streamTitle does not have a valid tokenizer.",
-     "extensions": {
-       "code": "ErrorInvalidRequest"
-     }
-   }
-```   
-
-
 ### DateTime Indices
 
 The indices available for `dateTime` are as follows.


### PR DESCRIPTION
adjusted doc to reflect the fixed behavior by #6996

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7037)
<!-- Reviewable:end -->
