### PR TITLE
feat(graphql):  adding auth token support for regexp, in and arrays

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/dgrijalva/jwt-go/v4"
 	"os"
 	"strings"
 	"testing"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 )
@@ -1889,4 +1889,227 @@ func TestAuthWithSecretDirective(t *testing.T) {
 	gqlResponse = checkLogPassword(t, logID, newLog.Pwd, "USER")
 	require.JSONEq(t, `{"checkLogPassword": null}`, string(gqlResponse.Data))
 	deleteLog(t, logID)
+}
+
+var bookResponse = `{"queryBook":[{"bookId":"book1","name":"Introduction","desc":"Intro book"}]}`
+
+func TestAuthEqFilterWithObjectAsTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, map[string]interface{}{"a":"b"}, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthEqFilterWithFloatTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 123.12, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthEqFilterWithInt64TokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 1237890123456, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthEqFilterWithIntTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 1234, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthEqFilterWithBoolTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, true, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthInFilterWithObjectAsTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, map[string]interface{}{"e":"f"}, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthInFilterWithFloatTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 312.124, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthInFilterWithInt64TokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 1246879976444232435, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthInFilterWithIntTokenVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, 6872, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthEqFilterFromTokenWithArrayVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, []int{456,1234}, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthInFilterFromTokenWithArrayVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, []int{124324, 6872}, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthRegexFilter(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, "xyz@dgraph.io", nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+}
+
+func TestAuthRegexFilterFromTokenWithArrayVal(t *testing.T) {
+	getUserParams := &common.GraphQLParams{
+		Headers: common.GetJWT(t, []string{"abc@def.com", "xyz@dgraph.io"}, nil, metaInfo),
+		Query: `query {
+		  queryBook{
+			bookId
+			name
+			desc
+		  }
+		}`,
+	}
+
+	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
+	require.Nil(t, gqlResponse.Errors)
+	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
 }

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -1893,7 +1893,7 @@ func TestAuthWithSecretDirective(t *testing.T) {
 	deleteLog(t, logID)
 }
 
-func TestAuth(t *testing.T) {
+func TestAuthRBACEvaluation(t *testing.T) {
 	tcs := []struct {
 		name   string
 		header http.Header

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/dgrijalva/jwt-go/v4"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/dgrijalva/jwt-go/v4"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -1891,225 +1893,168 @@ func TestAuthWithSecretDirective(t *testing.T) {
 	deleteLog(t, logID)
 }
 
-var bookResponse = `{"queryBook":[{"bookId":"book1","name":"Introduction","desc":"Intro book"}]}`
-
-func TestAuthEqFilterWithObjectAsTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, map[string]interface{}{"a":"b"}, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
+func TestAuth(t *testing.T) {
+	tcs := []struct {
+		name   string
+		header http.Header
+		query  string
+	}{
+		{
+			name: "Test Auth Eq Filter With Object As Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, map[string]interface{}{"a": "b"}, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Eq Filter With Float Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 123.12, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Eq Filter With Int64 Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 1237890123456, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Eq Filter With Int Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 1234, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Eq Filter With Bool Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, true, nil, metaInfo),
+		},
+		{
+			name: "Test Auth In Filter With Object As Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, map[string]interface{}{"e": "f"}, nil, metaInfo),
+		},
+		{
+			name: "Test Auth In Filter With Float Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 312.124, nil, metaInfo),
+		},
+		{
+			name: "Test Auth In Filter With Int64 Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 1246879976444232435, nil, metaInfo),
+		},
+		{
+			name: "Test Auth In Filter With Int Token Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, 6872, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Eq Filter From Token With Array Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, []int{456, 1234}, nil, metaInfo),
+		},
+		{
+			name: "Test Auth In Filter From Token With Array Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, []int{124324, 6872}, nil, metaInfo),
+		},
+		{
+			name: "Test Auth Regex Filter",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, "xyz@dgraph.io", nil, metaInfo),
+		},
+		{
+			name: "Test Auth Regex Filter From Token With Array Val",
+			query: `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`,
+			header: common.GetJWT(t, []string{"abc@def.com", "xyz@dgraph.io"}, nil, metaInfo),
+		},
 	}
+	bookResponse := `{"queryBook":[{"bookId":"book1","name":"Introduction","desc":"Intro book"}]}`
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			queryParams := &common.GraphQLParams{
+				Headers: tc.header,
+				Query:   tc.query,
+			}
 
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
+			gqlResponse := queryParams.ExecuteAsPost(t, common.GraphqlURL)
+			common.RequireNoGQLErrors(t, gqlResponse)
+			require.JSONEq(t, string(gqlResponse.Data), bookResponse)
+		})
 
-func TestAuthEqFilterWithFloatTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 123.12, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
 	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthEqFilterWithInt64TokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 1237890123456, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthEqFilterWithIntTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 1234, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthEqFilterWithBoolTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, true, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthInFilterWithObjectAsTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, map[string]interface{}{"e":"f"}, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthInFilterWithFloatTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 312.124, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthInFilterWithInt64TokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 1246879976444232435, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthInFilterWithIntTokenVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, 6872, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthEqFilterFromTokenWithArrayVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, []int{456,1234}, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthInFilterFromTokenWithArrayVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, []int{124324, 6872}, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthRegexFilter(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, "xyz@dgraph.io", nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
-}
-
-func TestAuthRegexFilterFromTokenWithArrayVal(t *testing.T) {
-	getUserParams := &common.GraphQLParams{
-		Headers: common.GetJWT(t, []string{"abc@def.com", "xyz@dgraph.io"}, nil, metaInfo),
-		Query: `query {
-		  queryBook{
-			bookId
-			name
-			desc
-		  }
-		}`,
-	}
-
-	gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)
-	require.Nil(t, gqlResponse.Errors)
-	require.JSONEq(t, string(gqlResponse.Data), bookResponse)
 }

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -1894,152 +1894,67 @@ func TestAuthWithSecretDirective(t *testing.T) {
 }
 
 func TestAuthRBACEvaluation(t *testing.T) {
+	query := `query {
+			  queryBook{
+				bookId
+				name
+				desc
+			  }
+			}`
 	tcs := []struct {
 		name   string
 		header http.Header
-		query  string
 	}{
 		{
-			name: "Test Auth Eq Filter With Object As Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter With Object As Token Val",
 			header: common.GetJWT(t, map[string]interface{}{"a": "b"}, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Eq Filter With Float Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter With Float Token Val",
 			header: common.GetJWT(t, 123.12, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Eq Filter With Int64 Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter With Int64 Token Val",
 			header: common.GetJWT(t, 1237890123456, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Eq Filter With Int Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter With Int Token Val",
 			header: common.GetJWT(t, 1234, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Eq Filter With Bool Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter With Bool Token Val",
 			header: common.GetJWT(t, true, nil, metaInfo),
 		},
 		{
-			name: "Test Auth In Filter With Object As Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth In Filter With Object As Token Val",
 			header: common.GetJWT(t, map[string]interface{}{"e": "f"}, nil, metaInfo),
 		},
 		{
-			name: "Test Auth In Filter With Float Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth In Filter With Float Token Val",
 			header: common.GetJWT(t, 312.124, nil, metaInfo),
 		},
 		{
-			name: "Test Auth In Filter With Int64 Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth In Filter With Int64 Token Val",
 			header: common.GetJWT(t, 1246879976444232435, nil, metaInfo),
 		},
 		{
-			name: "Test Auth In Filter With Int Token Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth In Filter With Int Token Val",
 			header: common.GetJWT(t, 6872, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Eq Filter From Token With Array Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Eq Filter From Token With Array Val",
 			header: common.GetJWT(t, []int{456, 1234}, nil, metaInfo),
 		},
 		{
-			name: "Test Auth In Filter From Token With Array Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth In Filter From Token With Array Val",
 			header: common.GetJWT(t, []int{124324, 6872}, nil, metaInfo),
 		},
 		{
-			name: "Test Auth Regex Filter",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Regex Filter",
 			header: common.GetJWT(t, "xyz@dgraph.io", nil, metaInfo),
 		},
 		{
-			name: "Test Auth Regex Filter From Token With Array Val",
-			query: `query {
-			  queryBook{
-				bookId
-				name
-				desc
-			  }
-			}`,
+			name:   "Test Auth Regex Filter From Token With Array Val",
 			header: common.GetJWT(t, []string{"abc@def.com", "xyz@dgraph.io"}, nil, metaInfo),
 		},
 	}
@@ -2048,7 +1963,7 @@ func TestAuthRBACEvaluation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			queryParams := &common.GraphQLParams{
 				Headers: tc.header,
-				Query:   tc.query,
+				Query:   query,
 			}
 
 			gqlResponse := queryParams.ExecuteAsPost(t, common.GraphqlURL)

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -754,3 +754,24 @@ type Todo {
     owner: String
     text: String
 }
+
+type Book @auth(
+    query: { or: [
+        {rule: "{$USER: { eq: {\"a\": \"b\"} } }"}, # this will be used to test eq with object
+        {rule: "{$USER: { eq: 123.12 } }"}, # this will be used to test eq with float
+        {rule: "{$USER: { eq: 1237890123456 } }"}, # this will be used to test eq with int64
+        {rule: "{$USER: { eq: 1234 } }"}, # this will be used to test eq with int and array too
+        {rule: "{$USER: { eq: true } }"}, # this will be used to test eq with boolean
+
+        {rule: "{$USER: { in: [{\"c\": \"d\"}, {\"e\":\"f\"}] } }"}, # this will be used to test in with object
+        {rule: "{$USER: { in: [456.23, 312.124] } }"}, # this will be used to test in with float
+        {rule: "{$USER: { in: [9876543219876543, 1246879976444232435] } }"}, # this will be used to test in with int64
+        {rule: "{$USER: { in: [5678, 6872] } }"}, # this will be used to test in with int and array too
+
+        {rule: "{$USER: { regexp: \"^(.*)@dgraph.io$\" } }"}
+    ]}
+){
+    bookId: String!
+    name: String!
+    desc: String!
+}

--- a/graphql/e2e/auth/test_data.json
+++ b/graphql/e2e/auth/test_data.json
@@ -242,6 +242,13 @@
 		"UserSecret.aSecret": "Sensitive information",
 		"UserSecret.ownedBy": "user1"
 	},
+	{
+		"uid": "_:book1",
+		"dgraph.type": "Book",
+		"Book.bookId": "book1",
+		"Book.name": "Introduction",
+		"Book.desc": "Intro book"
+	},
 	{"uid":"_:Question1","Post.text":"A Question"},
 	{"uid":"_:Question2","Post.text":"B Question"},
 	{"uid":"_:Question3","Post.text":"C Question"},

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/common/log"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -509,7 +509,7 @@ func addSchemaAndData(schema, data []byte, client *dgo.Dgraph) {
 		}
 
 		if containsRetryableUpdateGQLSchemaError(err.Error()) {
-			log.Infof("Got error while addSchemaAndData: %v. Retrying...\n", err)
+			glog.Infof("Got error while addSchemaAndData: %v. Retrying...\n", err)
 			time.Sleep(time.Second)
 			continue
 		}
@@ -1158,13 +1158,13 @@ func addSchema(url, schema string) error {
 	return nil
 }
 
-func GetJWT(t *testing.T, user, role string, metaInfo *testutil.AuthMeta) http.Header {
+func GetJWT(t *testing.T, user, role interface{}, metaInfo *testutil.AuthMeta) http.Header {
 	metaInfo.AuthVars = map[string]interface{}{}
-	if user != "" {
+	if user != nil {
 		metaInfo.AuthVars["USER"] = user
 	}
 
-	if role != "" {
+	if role != nil {
 		metaInfo.AuthVars["ROLE"] = role
 	}
 

--- a/graphql/schema/auth.go
+++ b/graphql/schema/auth.go
@@ -140,7 +140,7 @@ func (rq *RBACQuery) EvaluateRBACRule(av map[string]interface{}) RuleResult {
 		// check has to consider that
 		if tokenCastErr != nil {
 			// this means value for variable in token in not an array
-			return rq.checkIfMatch(tokenValues)
+			return rq.checkIfMatch(av[rq.Variable])
 		}
 
 		return rq.checkIfMatchInArray(tokenValues)

--- a/graphql/schema/auth.go
+++ b/graphql/schema/auth.go
@@ -18,7 +18,7 @@ package schema
 
 import (
 	"encoding/json"
-	"log"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -71,7 +71,7 @@ const (
 
 func checkIfExistInArray(arr []interface{}, val interface{}) RuleResult {
 	for _, v := range arr {
-		if v == val {
+		if reflect.DeepEqual(v, val) {
 			return Positive
 		}
 	}
@@ -79,7 +79,7 @@ func checkIfExistInArray(arr []interface{}, val interface{}) RuleResult {
 }
 
 func checkIfEqual(val1 interface{}, val2 interface{}) RuleResult {
-	if val1 == val2 {
+	if reflect.DeepEqual(val1, val2) {
 		return Positive
 	}
 	return Negative
@@ -470,7 +470,6 @@ func rbacValidateRule(typ *ast.Definition, rule string) (*RBACQuery, error) {
 		Operand:  op,
 	}
 
-	log.Print("operand is", op)
 	if !strings.HasPrefix(query.Variable, "$") {
 		return nil, gqlerror.Errorf("Type %s: @auth: `%s` is not a valid GraphQL variable.",
 			typ.Name, query.Variable)

--- a/graphql/schema/auth.go
+++ b/graphql/schema/auth.go
@@ -518,7 +518,7 @@ func validateRBACOperators(typ *ast.Definition, query *RBACQuery) (bool, string)
 				" Value should be an array.", typ.Name, query.Operator, query.Operand)
 		}
 	default:
-		return false, fmt.Sprintf("Type %s: @auth: `%s` operator is not supported ",
+		return false, fmt.Sprintf("Type %s: @auth: `%s` operator is not supported.",
 			typ.Name, query.Operator)
 	}
 

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -30,13 +30,14 @@ invalid_schemas:
   - name: "Invalid RBAC rule: in filter not array variable 1"
     input: |
       type X @auth(
-          query: { rule:  "{$USER: { in: \"amanbansal@dgraph.io\" } }"}
+          query: { rule:  "{$USER: { in: \"xyz@dgraph.io\" } }"}
       ) {
         username: String! @id
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in` operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `in` operator has invalid value `xyz@dgraph.io` in this rule.
+      Reason: Value should be an array." }
     ]
 
   - name: "Invalid RBAC rule: in filter not array variable 2"
@@ -48,9 +49,11 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in` operator has invalid value in this rule."}
+      { "message": "Type X: @auth: `in` operator has invalid value `true` in this rule.
+      Reason: Value should be an array."}
     ]
-  - name: "Invalid RBAC rule: null as the value"
+
+  - name: "Invalid RBAC rule: nil as the value"
     input: |
       type X @auth(
         query: { rule:  "{$USER: { eq: nil } }"}
@@ -71,7 +74,7 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `$USER` is not a valid GraphQL variable. object with nil values aren't supported" }
+      { "message": "Type X: @auth: `eq` operator has invalid value. null values aren't supported." }
     ]
 
   - name: "Invalid RBAC rule: regexp filter not string variable"
@@ -83,7 +86,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `regexp` operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `regexp` operator has invalid value `12345` in this rule.
+      Reason: Value should be of type String." }
     ]
 
   - name: "RBAC rule invalid variable"

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -59,7 +59,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `eq` operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `$USER` is not a valid GraphQL variable." }
+    ]
 
   - name: "Invalid RBAC rule: null as the value"
     input: |
@@ -70,7 +71,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `eq` operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `$USER` is not a valid GraphQL variable. object with nil values aren't supported" }
+    ]
 
   - name: "Invalid RBAC rule: regexp filter not string variable"
     input: |

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -110,7 +110,7 @@ invalid_schemas:
         username: String! @id
         userRole: String @search(by: [hash])
       }
-    errlist: [{"message": "Type X: @auth: `xyz` operator is not supported in this rule."}]
+    errlist: [{"message": "Type X: @auth: `xyz` operator is not supported."}]
 
   - name: "Invalid RBAC rule"
     input: |

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -36,8 +36,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in` operator has invalid value `xyz@dgraph.io` in this rule.
-      Reason: Value should be an array." }
+      { "message": "Type X: @auth: `in` operator has invalid value `xyz@dgraph.io`.
+      Value should be an array." }
     ]
 
   - name: "Invalid RBAC rule: in filter not array variable 2"
@@ -49,8 +49,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in` operator has invalid value `true` in this rule.
-      Reason: Value should be an array."}
+      { "message": "Type X: @auth: `in` operator has invalid value `true`.
+      Value should be an array."}
     ]
 
   - name: "Invalid RBAC rule: nil as the value"
@@ -86,8 +86,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `regexp` operator has invalid value `12345` in this rule.
-      Reason: Value should be of type String." }
+      { "message": "Type X: @auth: `regexp` operator has invalid value `12345`.
+      Value should be of type String." }
     ]
 
   - name: "RBAC rule invalid variable"

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -36,8 +36,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "resolving updateGQLSchema failed because Type X: @auth: `in`
-      operator has invalid value amanbansal@dgraph.io in this rule." }
+      { "message": "Type X: @auth: `in`
+      operator has invalid value in this rule." }
     ]
 
   - name: "Invalid RBAC rule: in filter not array variable 2"
@@ -49,8 +49,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "resolving updateGQLSchema failed because Type X: @auth: `in`
-      operator has invalid value amanbansal@dgraph.io in this rule."}
+      { "message": "Type X: @auth: `in`
+      operator has invalid value in this rule."}
     ]
 
   - name: "Invalid RBAC rule: regexp filter not string variable"
@@ -62,8 +62,8 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "resolving updateGQLSchema failed because Type X: @auth: `regexp`
-          operator has invalid value amanbansal@dgraph.io in this rule." }
+      { "message": "Type X: @auth: `regexp`
+          operator has invalid value in this rule." }
     ]
 
   - name: "RBAC rule invalid variable"

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -36,8 +36,7 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in`
-      operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `in` operator has invalid value in this rule." }
     ]
 
   - name: "Invalid RBAC rule: in filter not array variable 2"
@@ -49,9 +48,29 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `in`
-      operator has invalid value in this rule."}
+      { "message": "Type X: @auth: `in` operator has invalid value in this rule."}
     ]
+  - name: "Invalid RBAC rule: null as the value"
+    input: |
+      type X @auth(
+        query: { rule:  "{$USER: { eq: nil } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      { "message": "Type X: @auth: `eq` operator has invalid value in this rule." }
+
+  - name: "Invalid RBAC rule: null as the value"
+    input: |
+      type X @auth(
+        query: { rule:  "{$USER: { eq: null } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      { "message": "Type X: @auth: `eq` operator has invalid value in this rule." }
 
   - name: "Invalid RBAC rule: regexp filter not string variable"
     input: |
@@ -62,8 +81,7 @@ invalid_schemas:
         userRole: String @search(by: [hash])
       }
     errlist: [
-      { "message": "Type X: @auth: `regexp`
-          operator has invalid value in this rule." }
+      { "message": "Type X: @auth: `regexp` operator has invalid value in this rule." }
     ]
 
   - name: "RBAC rule invalid variable"

--- a/graphql/schema/auth_schemas_test.yaml
+++ b/graphql/schema/auth_schemas_test.yaml
@@ -27,6 +27,45 @@ invalid_schemas:
       Did you mean userRole or username?]"}
     ]
 
+  - name: "Invalid RBAC rule: in filter not array variable 1"
+    input: |
+      type X @auth(
+          query: { rule:  "{$USER: { in: \"amanbansal@dgraph.io\" } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      { "message": "resolving updateGQLSchema failed because Type X: @auth: `in`
+      operator has invalid value amanbansal@dgraph.io in this rule." }
+    ]
+
+  - name: "Invalid RBAC rule: in filter not array variable 2"
+    input: |
+      type X @auth(
+        query: { rule:  "{$USER: { in: true } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      { "message": "resolving updateGQLSchema failed because Type X: @auth: `in`
+      operator has invalid value amanbansal@dgraph.io in this rule."}
+    ]
+
+  - name: "Invalid RBAC rule: regexp filter not string variable"
+    input: |
+      type X @auth(
+        query: { rule:  "{$USER: { regexp: 12345 } }"}
+      ) {
+        username: String! @id
+        userRole: String @search(by: [hash])
+      }
+    errlist: [
+      { "message": "resolving updateGQLSchema failed because Type X: @auth: `regexp`
+          operator has invalid value amanbansal@dgraph.io in this rule." }
+    ]
+
   - name: "RBAC rule invalid variable"
     input: |
       type X @auth(


### PR DESCRIPTION
This PR aims to fix GRAPHQL-808. This enables multiple things.
1. support for regex matching in custom claims.
2. support for array in custom claims.
3. Claims match based on float, int64, int, structs, bool, string
4. in based custom claim match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7039)
<!-- Reviewable:end -->
