### PR TITLE
feat(metric): Add dgraph_memory_alloc_bytes to track jemalloc memory.

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -96,6 +96,7 @@ func TestMetrics(t *testing.T) {
 
 		// Dgraph Memory Metrics
 		"dgraph_memory_idle_bytes", "dgraph_memory_inuse_bytes", "dgraph_memory_proc_bytes",
+		"dgraph_memory_alloc_bytes",
 		// Dgraph Activity Metrics
 		"dgraph_active_mutations_total", "dgraph_pending_proposals_total",
 		"dgraph_pending_queries_total",

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -461,8 +461,9 @@ func MonitorMemoryMetrics(lc *z.Closer) {
 	defer fastTicker.Stop()
 
 	update := func() {
-		// ReadMemStats stops the world, so don't call it too frequently.
-		// Calling it every minute is OK.
+		// ReadMemStats stops the world which is expensive especially when the
+		// heap is large. So don't call it too frequently. Calling it every
+		// minute is OK.
 		var ms runtime.MemStats
 		runtime.ReadMemStats(&ms)
 

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -482,16 +482,20 @@ func MonitorMemoryMetrics(lc *z.Closer) {
 			MemoryIdle.M(int64(idle)),
 			MemoryProc.M(int64(getMemUsage())))
 	}
+	updateAlloc := func() {
+		ostats.Record(context.Background(), MemoryAlloc.M(z.NumAllocBytes()))
+	}
 	// Call update immediately so that Dgraph reports memory stats without
 	// having to wait for the first tick.
 	update()
+	updateAlloc()
 
 	for {
 		select {
 		case <-lc.HasBeenClosed():
 			return
 		case <-fastTicker.C:
-			ostats.Record(context.Background(), MemoryAlloc.M(z.NumAllocBytes()))
+			updateAlloc()
 		case <-ticker.C:
 			update()
 		}

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -70,7 +70,7 @@ var (
 	// PendingProposals records the current number of pending RAFT proposals.
 	PendingProposals = stats.Int64("pending_proposals_total",
 		"Number of pending proposals", stats.UnitDimensionless)
-	// MemoryInUse records the amount of memory allocated via jemalloc/Go
+	// MemoryAlloc records the amount of memory allocated via jemalloc
 	MemoryAlloc = stats.Int64("memory_alloc_bytes",
 		"Amount of memory allocated", stats.UnitBytes)
 	// MemoryInUse records the current amount of used memory by Dgraph.


### PR DESCRIPTION
This adds a new metric called `dgraph_memory_alloc_bytes` that tracks the jemalloc memory reported by `z.NumAllocBytes()`. 

Changes
* Add `dgraph_memory_alloc_bytes` Prometheus metric.
* Add comment about runtime.ReadMemStats stopping the world.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG
Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7051)
<!-- Reviewable:end -->
