### PR TITLE
fix(GraphQL): This PR allows repetition of fields inside implementing type which are present in interface and also allow to inherit field of same name of type ID  from multiple interfaces.

### DIFF
--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -105,11 +105,20 @@ interface Character @dgraph(type: "performance.character") {
 }
 
 type Human implements Character & Employee {
+        id: ID!
+        name: String! @search(by: [exact])
+        appearsIn: [Episode!] @search
+        bio: String @lambda
+        ename: String!
         starships: [Starship]
         totalCredits: Float @dgraph(pred: "credits")
 }
 
 type Droid implements Character @dgraph(type: "roboDroid") {
+        id: ID!
+        name: String! @search(by: [exact])
+        appearsIn: [Episode!] @search
+        bio: String @lambda
         primaryFunction: String
 }
 

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -105,11 +105,20 @@ interface Character {
 }
 
 type Human implements Character & Employee {
+        id: ID!
+        name: String! @search(by: [exact])
+        appearsIn: [Episode!] @search
+        bio: String @lambda
+        ename: String!
         starships: [Starship]
         totalCredits: Float
 }
 
 type Droid implements Character {
+        id: ID!
+        name: String! @search(by: [exact])
+        appearsIn: [Episode!] @search
+        bio: String @lambda
         primaryFunction: String
 }
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -684,12 +684,10 @@ func expandSchema(doc *ast.SchemaDocument) *gqlerror.Error {
 						if fieldSeen[field.Name] == "" {
 							// Overwrite the existing field definition in type with the field definition of interface
 							assignAstFieldDef(field, defn.Fields.ForName(field.Name))
-						} else {
+						} else if field.Type.NamedType != IDType {
 							// If field definition is already written,just add interface definition in type
 							// It will later results in validation error because of repeated fields
-							if field.Type.NamedType != IDType {
-								fields = append(fields, copyAstFieldDef(field))
-							}
+							fields = append(fields, copyAstFieldDef(field))
 						}
 					} else if field.Type.NamedType == IDType && fieldSeen[field.Name] != "" {
 						// If ID type is already seen in any other interface then we don't copy it again

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -657,7 +657,7 @@ func expandSchema(doc *ast.SchemaDocument) *gqlerror.Error {
 				defFields[d.Name]++
 			}
 			initialDefFields := defn.Fields
-			// initialDefFields store initial definitions of the type.
+			// initialDefFields store initial field definitions of the type.
 			for _, implements := range defn.Interfaces {
 				i, ok := interfaces[implements]
 				if !ok {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -612,18 +612,6 @@ var schemaValidations []func(schema *ast.Schema, definitions []string) gqlerror.
 var defnValidations, typeValidations []func(schema *ast.Schema, defn *ast.Definition) gqlerror.List
 var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.List
 
-func assignAstFieldDef(src, dst *ast.FieldDefinition) {
-	var dirs ast.DirectiveList
-	dirs = append(dirs, src.Directives...)
-
-	dst.Name = src.Name
-	dst.DefaultValue = src.DefaultValue
-	dst.Type = src.Type
-	dst.Directives = dirs
-	dst.Arguments = src.Arguments
-	dst.Position = src.Position
-}
-
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	var dirs ast.DirectiveList
 	dirs = append(dirs, src.Directives...)

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -612,7 +612,7 @@ var schemaValidations []func(schema *ast.Schema, definitions []string) gqlerror.
 var defnValidations, typeValidations []func(schema *ast.Schema, defn *ast.Definition) gqlerror.List
 var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.List
 
-func assignAstFieldDef(src *ast.FieldDefinition, dst *ast.FieldDefinition) {
+func assignAstFieldDef(src, dst *ast.FieldDefinition) {
 	var dirs ast.DirectiveList
 	dirs = append(dirs, src.Directives...)
 
@@ -681,7 +681,7 @@ func expandSchema(doc *ast.SchemaDocument) *gqlerror.Error {
 							return gqlerror.ErrorPosf(defn.Position, "For type \"%s\" to implement interface"+
 								" \"%s\" the field \"%s\" must have type \"%s\"", defn.Name, i.Name, field.Name, field.Type.String())
 						}
-						if fieldSeen[field.Name] == false {
+						if !fieldSeen[field.Name] {
 							// Overwrite the existing field definition in type with the field definition of interface
 							assignAstFieldDef(field, defn.Fields.ForName(field.Name))
 						} else {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -612,6 +612,18 @@ var schemaValidations []func(schema *ast.Schema, definitions []string) gqlerror.
 var defnValidations, typeValidations []func(schema *ast.Schema, defn *ast.Definition) gqlerror.List
 var fieldValidations []func(typ *ast.Definition, field *ast.FieldDefinition) gqlerror.List
 
+func assignAstFieldDef(src *ast.FieldDefinition, dst *ast.FieldDefinition) {
+	var dirs ast.DirectiveList
+	dirs = append(dirs, src.Directives...)
+
+	dst.Name = src.Name
+	dst.DefaultValue = src.DefaultValue
+	dst.Type = src.Type
+	dst.Directives = dirs
+	dst.Arguments = src.Arguments
+	dst.Position = src.Position
+}
+
 func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 	var dirs ast.DirectiveList
 	dirs = append(dirs, src.Directives...)
@@ -630,7 +642,7 @@ func copyAstFieldDef(src *ast.FieldDefinition) *ast.FieldDefinition {
 
 // expandSchema adds schemaExtras to the doc and adds any fields inherited from interfaces into
 // implementing types
-func expandSchema(doc *ast.SchemaDocument) {
+func expandSchema(doc *ast.SchemaDocument) *gqlerror.Error {
 	docExtras, gqlErr := parser.ParseSchema(&ast.Source{Input: schemaExtras})
 	if gqlErr != nil {
 		x.Panic(gqlErr)
@@ -649,6 +661,12 @@ func expandSchema(doc *ast.SchemaDocument) {
 	// interface.
 	for _, defn := range doc.Definitions {
 		if defn.Kind == ast.Object && len(defn.Interfaces) > 0 {
+			fieldSeen := make(map[string]bool)
+			defFields := make(map[string]int64)
+			for _, d := range defn.Fields {
+				defFields[d.Name]++
+			}
+			initialDefFields := defn.Fields
 			for _, implements := range defn.Interfaces {
 				i, ok := interfaces[implements]
 				if !ok {
@@ -657,9 +675,26 @@ func expandSchema(doc *ast.SchemaDocument) {
 				}
 				fields := make([]*ast.FieldDefinition, 0, len(i.Fields))
 				for _, field := range i.Fields {
-					// Creating a copy here is important, otherwise arguments like filter, order
-					// etc. are added multiple times if the pointer is shared.
-					fields = append(fields, copyAstFieldDef(field))
+					// If field name is repeated multiple times in type then it will result in validation error later.
+					if defFields[field.Name] == 1 {
+						if field.Type.String() != initialDefFields.ForName(field.Name).Type.String() {
+							return gqlerror.ErrorPosf(defn.Position, "For type \"%s\" to implement interface"+
+								" \"%s\" the field \"%s\" must have type \"%s\"", defn.Name, i.Name, field.Name, field.Type.String())
+						}
+						if fieldSeen[field.Name] == false {
+							// Overwrite the existing field definition in type with the field definition of interface
+							assignAstFieldDef(field, defn.Fields.ForName(field.Name))
+						} else {
+							// if field definition is already written,just add interface definition in type
+							// it will later results in validation error because of repeated fields
+							fields = append(fields, copyAstFieldDef(field))
+						}
+						fieldSeen[field.Name] = true
+					} else {
+						// Creating a copy here is important, otherwise arguments like filter, order
+						// etc. are added multiple times if the pointer is shared.
+						fields = append(fields, copyAstFieldDef(field))
+					}
 				}
 				defn.Fields = append(fields, defn.Fields...)
 				passwordDirective := i.Directives.ForName("secret")
@@ -672,6 +707,7 @@ func expandSchema(doc *ast.SchemaDocument) {
 
 	doc.Definitions = append(doc.Definitions, docExtras.Definitions...)
 	doc.Directives = append(doc.Directives, docExtras.Directives...)
+	return nil
 }
 
 // preGQLValidation validates schema before GraphQL validation.  Validation

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -691,20 +691,18 @@ func expandSchema(doc *ast.SchemaDocument) *gqlerror.Error {
 								fields = append(fields, copyAstFieldDef(field))
 							}
 						}
-					} else {
+					} else if field.Type.NamedType == IDType && fieldSeen[field.Name] != "" {
 						// If ID type is already seen in any other interface then we don't copy it again
 						// And validator won't through error for id types later
-						if field.Type.NamedType == IDType && fieldSeen[field.Name] != "" {
-							if field.Type.String() != defn.Fields.ForName(field.Name).Type.String() {
-								return gqlerror.ErrorPosf(defn.Position, "field %s is of type %s in interface %s"+
-									"and is of type %s in interface %s",
-									field.Name, field.Type.String(), i.Name, defn.Fields.ForName(field.Name).Type.String(), fieldSeen[field.Name])
-							}
-						} else {
-							// Creating a copy here is important, otherwise arguments like filter, order
-							// etc. are added multiple times if the pointer is shared.
-							fields = append(fields, copyAstFieldDef(field))
+						if field.Type.String() != defn.Fields.ForName(field.Name).Type.String() {
+							return gqlerror.ErrorPosf(defn.Position, "field %s is of type %s in interface %s"+
+								" and is of type %s in interface %s",
+								field.Name, field.Type.String(), i.Name, defn.Fields.ForName(field.Name).Type.String(), fieldSeen[field.Name])
 						}
+					} else {
+						// Creating a copy here is important, otherwise arguments like filter, order
+						// etc. are added multiple times if the pointer is shared.
+						fields = append(fields, copyAstFieldDef(field))
 					}
 					fieldSeen[field.Name] = i.Name
 				}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2692,9 +2692,11 @@ valid_schemas:
     input: |
       interface Y {
         id: ID
+        name:String
       }
       type X implements Y {
         id: ID
+        name:String
         y: String
       }
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -547,21 +547,6 @@ invalid_schemas:
       ]
 
   -
-    name: "Type implements an interface with the field definition repeated"
-    input: |
-      interface Y {
-        id: ID
-      }
-      type X implements Y {
-        id: ID
-        y: String
-      }
-    errlist: [
-      {"message": "Field X.id can only be defined once.",
-      "locations":[{"line":5, "column":3}]}
-      ]
-
-  -
     name: "Type implements an interface with the field name repeated but different type"
     input: |
       interface Y {
@@ -572,8 +557,8 @@ invalid_schemas:
         y: String
       }
     errlist: [
-      {"message": "Field X.id can only be defined once.",
-      "locations":[{"line":5, "column":3}]}
+      {"message": "For type \"X\" to implement interface \"Y\" the field \"id\" must have type \"ID\"",
+      "locations":[{"line":4, "column":6}]}
       ]
 
   -
@@ -2662,8 +2647,45 @@ invalid_schemas:
       { "message": "Type X; Field name: pred argument 'as' for @dgraph directive is a reserved keyword.", "locations": [ { "line": 3, "column": 17 } ] },
     ]
 
+  - name: "field type mismatched between implementation and interface"
+    input: |
+      interface I1 {
+          name: String!
+        }
+      type I3 implements I1 {
+          name:String
+        }
+    errlist: [
+        { "message": "For type \"I3\" to implement interface \"I1\" the field \"name\" must have type \"String!\"", "locations": [ { "line": 4, "column": 6 } ] },
+      ]
+
+  - name: "Type implements multiple interfaces with same field name"
+    input: |
+      interface I1 {
+          name: String!
+        }
+      interface I2 {
+          name: String!
+        }
+      type I3 implements I1 & I2 {
+          name:String!
+        }
+    errlist: [
+          { "message": "Field I3.name can only be defined once.", "locations": [ { "line": 2, "column": 5 } ] },
+          ]
+
 
 valid_schemas:
+  - name: "Type implements an interface with the field definition repeated"
+    input: |
+      interface Y {
+        id: ID
+      }
+      type X implements Y {
+        id: ID
+        y: String
+      }
+
   - name: "schema with union"
     input: |
       interface W {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -557,7 +557,7 @@ invalid_schemas:
         y: String
       }
     errlist: [
-      {"message": "For type \"X\" to implement interface \"Y\" the field \"id\" must have type \"ID\"",
+      {"message": "For type X to implement interface Y the field id must have type ID",
       "locations":[{"line":4, "column":6}]}
       ]
 
@@ -575,10 +575,10 @@ invalid_schemas:
       ]
 
   -
-    name: "Type implements from two interfaces where both have ID"
+    name: "Type implements from two interfaces where both have ID with different type"
     input: |
       interface X {
-        id: ID
+        id: ID!
       }
       interface Y {
         id: ID
@@ -587,8 +587,8 @@ invalid_schemas:
         name: String
       }
     errlist: [
-      {"message": "Field Z.id can only be defined once.",
-      "locations":[{"line":2, "column":3}]}
+      {"message": "field id is of type ID in interface Y and is of type ID! in interface X",
+      "locations":[{"line":7, "column":6}]}
       ]
 
   -
@@ -2656,7 +2656,7 @@ invalid_schemas:
           name:String
         }
     errlist: [
-        { "message": "For type \"I3\" to implement interface \"I1\" the field \"name\" must have type \"String!\"", "locations": [ { "line": 4, "column": 6 } ] },
+        { "message": "For type I3 to implement interface I1 the field name must have type String!", "locations": [ { "line": 4, "column": 6 } ] },
       ]
 
   - name: "Type implements multiple interfaces with same field name"
@@ -2676,6 +2676,18 @@ invalid_schemas:
 
 
 valid_schemas:
+  - name: "Type implements from two interfaces where both have ID"
+    input: |
+      interface X {
+          id: ID
+        }
+      interface Y {
+          id: ID
+        }
+      type Z implements X & Y {
+          name: String
+        }
+
   - name: "Type implements an interface with the field definition repeated"
     input: |
       interface Y {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -194,7 +194,10 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 		typesToComplete = append(typesToComplete, defn.Name)
 	}
 
-	expandSchema(doc)
+	gqlErr = expandSchema(doc)
+	if gqlErr != nil {
+		return nil, gqlerror.List{gqlErr}
+	}
 
 	sch, gqlErr := validator.ValidateSchemaDocument(doc)
 	if gqlErr != nil {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -194,8 +194,7 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 		typesToComplete = append(typesToComplete, defn.Name)
 	}
 
-	gqlErr = expandSchema(doc)
-	if gqlErr != nil {
+	if gqlErr = expandSchema(doc); gqlErr != nil {
 		return nil, gqlerror.List{gqlErr}
 	}
 


### PR DESCRIPTION
Fixes GRAPHQL-672
Currently, we don't allow the repetition of fields in implementing types that are in the interface. But according to GraphQl specs, we should allow them. Not allowing them can also result in unexpected behavior in some scenarios.
For example, in the below example `Banana` type doesn't have any fields apart from that are in the Fruit interface. And we don't allow empty types. So allowing repetitive fields solve this problem.

```
interface Fruit {
    id: ID!
    price: Int!
}

type Apple implements Fruit {
    id: ID!
    price: Int!
    color: String!
}

type Banana implements Fruit {
    id: ID!
    price: Int!
}

```
Also, currently, if we have two interfaces and a type that implements both then we don't allow a field of the same name in both of them. We are allowing it for `ID` type fields because it's required in some use cases and there is no problem with it as `ID` type field is not actually a predicate.

```
interface I1 {
  f1: ID!
}
interface I2 {
 f1: ID!
}
type T implements I1 & I2 {
 f2: Int!
}

```
 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7053)
<!-- Reviewable:end -->
