### PR TITLE
Opt(query): Respect the first N argument

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -283,6 +283,7 @@ type ListOptions struct {
 	ReadTs    uint64
 	AfterUid  uint64   // Any UIDs returned must be after this value.
 	Intersect *pb.List // Intersect results with this list of UIDs.
+	First     int
 }
 
 // NewPosting takes the given edge and returns its equivalent representation as a posting.
@@ -1118,6 +1119,9 @@ func (l *List) ApproxLen() int {
 // We have to apply the filtering before applying (offset, count).
 // WARNING: Calling this function just to get UIDs is expensive
 func (l *List) Uids(opt ListOptions) (*pb.List, error) {
+	if opt.First == 0 {
+		opt.First = math.MaxInt32
+	}
 	// Pre-assign length to make it faster.
 	l.RLock()
 	// Use approximate length for initial capacity.
@@ -1136,6 +1140,9 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	err := l.iterate(opt.ReadTs, opt.AfterUid, func(p *pb.Posting) error {
 		if p.PostingType == pb.Posting_REF {
 			res = append(res, p.Uid)
+			if len(res) > opt.First {
+				return ErrStopIteration
+			}
 		}
 		return nil
 	})

--- a/posting/list.go
+++ b/posting/list.go
@@ -1140,7 +1140,13 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	err := l.iterate(opt.ReadTs, opt.AfterUid, func(p *pb.Posting) error {
 		if p.PostingType == pb.Posting_REF {
 			res = append(res, p.Uid)
-			if len(res) > opt.First {
+			if opt.First < 0 {
+				// We need the last N.
+				// TODO: This could be optimized by only considering some of the last UidBlocks.
+				if len(res) > -opt.First {
+					res = res[1:]
+				}
+			} else if len(res) > opt.First {
 				return ErrStopIteration
 			}
 		}

--- a/query/query.go
+++ b/query/query.go
@@ -949,7 +949,11 @@ func calculateFirstN(sg *SubGraph) int32 {
 	//     name
 	//   }
 	// }
-	isSupportedFunction := sg.SrcFunc != nil && sg.SrcFunc.Name == "has"
+	// isSupportedFunction := sg.SrcFunc != nil && sg.SrcFunc.Name == "has"
+
+	// Manish: Shouldn't all functions allow this? If we don't have a order and we don't have a
+	// filter, then we can respect the first N, offset Y arguments when retrieving data.
+	isSupportedFunction := true
 	if len(sg.Filters) == 0 && len(sg.Params.Order) == 0 &&
 		isSupportedFunction {
 		// Offset also added because, we need n results to trim the offset.

--- a/worker/match.go
+++ b/worker/match.go
@@ -81,7 +81,10 @@ func matchFuzzy(query, val string, max int) bool {
 // index. matchFuzzy does the actual fuzzy match.
 // Returns the list of uids even if empty, or an error otherwise.
 func uidsForMatch(attr string, arg funcArgs) (*pb.List, error) {
-	opts := posting.ListOptions{ReadTs: arg.q.ReadTs}
+	opts := posting.ListOptions{
+		ReadTs: arg.q.ReadTs,
+		First:  int(arg.q.First),
+	}
 	uidsForNgram := func(ngram string) (*pb.List, error) {
 		key := x.IndexKey(attr, ngram)
 		pl, err := posting.GetNoStore(key, arg.q.ReadTs)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -571,6 +571,7 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 		listOpt := posting.ListOptions{
 			Intersect: ul,
 			ReadTs:    ts.ReadTs,
+			First:     0, // TODO: Should we set the first N here?
 		}
 		result, err := pl.Uids(listOpt) // The actual intersection work is done here.
 		if err != nil {

--- a/worker/task.go
+++ b/worker/task.go
@@ -801,6 +801,7 @@ func (qs *queryState) handleUidPostings(
 					ReadTs:    args.q.ReadTs,
 					AfterUid:  0,
 					Intersect: reqList,
+					First:     int(args.q.First),
 				}
 				plist, err := pl.Uids(topts)
 				if err != nil {
@@ -983,6 +984,7 @@ func (qs *queryState) helpProcessTask(ctx context.Context, q *pb.Query, gid uint
 	opts := posting.ListOptions{
 		ReadTs:   q.ReadTs,
 		AfterUid: q.AfterUid,
+		First:    int(q.First),
 	}
 	// If we have srcFunc and Uids, it means its a filter. So we intersect.
 	if srcFn.fnType != notAFunction && q.UidList != nil && len(q.UidList.Uids) > 0 {

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -36,6 +36,7 @@ func uidsForRegex(attr string, arg funcArgs,
 	var results *pb.List
 	opts := posting.ListOptions{
 		ReadTs: arg.q.ReadTs,
+		First:  int(arg.q.First),
 	}
 	if intersect.Size() > 0 {
 		opts.Intersect = intersect


### PR DESCRIPTION
When retrieving Uids, if we are not doing any filtering or ordering, then we should respect the first: N argument and only retrieve what's being asked for. This really speeds up the query execution.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7072)
<!-- Reviewable:end -->
