### PR TITLE
Fix(GraphQL): Refactor output of query/mutation rewriting

### DIFF
--- a/graphql/admin/add_group.go
+++ b/graphql/admin/add_group.go
@@ -42,7 +42,7 @@ func (mrw *addGroupRewriter) FromMutationResult(
 	ctx context.Context,
 	mutation schema.Mutation,
 	assigned map[string]string,
-	result map[string]interface{}) (*gql.GraphQuery, error) {
+	result map[string]interface{}) ([]*gql.GraphQuery, error) {
 
 	return ((*resolve.AddRewriter)(mrw)).FromMutationResult(ctx, mutation, assigned, result)
 }

--- a/graphql/admin/current_user.go
+++ b/graphql/admin/current_user.go
@@ -66,7 +66,7 @@ func extractName(ctx context.Context) (string, error) {
 }
 
 func (gsr *currentUserResolver) Rewrite(ctx context.Context,
-	gqlQuery schema.Query) (*gql.GraphQuery, error) {
+	gqlQuery schema.Query) ([]*gql.GraphQuery, error) {
 
 	name, err := extractName(ctx)
 	if err != nil {

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+
 	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
 
 	"github.com/dgraph-io/dgraph/edgraph"
@@ -94,7 +95,7 @@ func (usr *updateSchemaResolver) Resolve(ctx context.Context, m schema.Mutation)
 }
 
 func (gsr *getSchemaResolver) Rewrite(ctx context.Context,
-	gqlQuery schema.Query) (*gql.GraphQuery, error) {
+	gqlQuery schema.Query) ([]*gql.GraphQuery, error) {
 	gsr.gqlQuery = gqlQuery
 	return nil, nil
 }

--- a/graphql/admin/update_group.go
+++ b/graphql/admin/update_group.go
@@ -127,7 +127,7 @@ func (urw *updateGroupRewriter) Rewrite(
 	}
 
 	return []*resolve.UpsertMutation{{
-		Query:     &gql.GraphQuery{Children: []*gql.GraphQuery{upsertQuery}},
+		Query:     upsertQuery,
 		Mutations: append(mutSet, mutDel...),
 	}}, schema.GQLWrapf(schema.AppendGQLErrs(errSet, errDel), "failed to rewrite mutation payload")
 }
@@ -137,15 +137,15 @@ func (urw *updateGroupRewriter) FromMutationResult(
 	ctx context.Context,
 	mutation schema.Mutation,
 	assigned map[string]string,
-	result map[string]interface{}) (*gql.GraphQuery, error) {
+	result map[string]interface{}) ([]*gql.GraphQuery, error) {
 
 	return ((*resolve.UpdateRewriter)(urw)).FromMutationResult(ctx, mutation, assigned, result)
 }
 
 // addAclRuleQuery adds a *gql.GraphQuery to upsertQuery.Children to query a rule inside a group
 // based on its predicate value.
-func addAclRuleQuery(upsertQuery *gql.GraphQuery, predicate, variable string) {
-	upsertQuery.Children = append(upsertQuery.Children, &gql.GraphQuery{
+func addAclRuleQuery(upsertQuery []*gql.GraphQuery, predicate, variable string) {
+	upsertQuery[0].Children = append(upsertQuery[0].Children, &gql.GraphQuery{
 		Attr:  "dgraph.acl.rule",
 		Alias: variable,
 		Var:   variable,

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -27,14 +27,22 @@ import (
 // AsString writes query as an indented dql query string.  AsString doesn't
 // validate query, and so doesn't return an error if query is 'malformed' - it might
 // just write something that wouldn't parse as a Dgraph query.
-func AsString(query *gql.GraphQuery) string {
+func AsString(query []*gql.GraphQuery) string {
 	if query == nil {
 		return ""
 	}
 
 	var b strings.Builder
 	x.Check2(b.WriteString("query {\n"))
-	writeQuery(&b, query, "  ")
+	for _, q := range query {
+		if q == nil {
+			// In a well formed case this should not happen.
+			// This condition is satisfied in case of mutation is rewritten
+			// and the query is completely empty
+			return ""
+		}
+		writeQuery(&b, q, "  ")
+	}
 	x.Check2(b.WriteString("}"))
 
 	return b.String()

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -27,24 +27,30 @@ import (
 // AsString writes query as an indented dql query string.  AsString doesn't
 // validate query, and so doesn't return an error if query is 'malformed' - it might
 // just write something that wouldn't parse as a Dgraph query.
-func AsString(query []*gql.GraphQuery) string {
-	if query == nil {
+func AsString(queries []*gql.GraphQuery) string {
+	if queries == nil {
 		return ""
 	}
 
 	var b strings.Builder
 	x.Check2(b.WriteString("query {\n"))
-	for _, q := range query {
+	numRewrittenQueries := 0
+	for _, q := range queries {
 		if q == nil {
-			// In a well formed case this should not happen.
-			// This condition is satisfied in case of mutation is rewritten
-			// and the query is completely empty
-			return ""
+			// Don't call writeQuery on a nil query
+			continue
 		}
 		writeQuery(&b, q, "  ")
+		numRewrittenQueries++
 	}
 	x.Check2(b.WriteString("}"))
 
+	if numRewrittenQueries == 0 {
+		// In case writeQuery has not been called on any query or all queries
+		// are nil. Then, return empty string. This case needs to be considered as
+		// we don't want to return query{} in this case.
+		return ""
+	}
 	return b.String()
 }
 

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -98,7 +98,7 @@ type MutationRewriter interface {
 		ctx context.Context,
 		m schema.Mutation,
 		assigned map[string]string,
-		result map[string]interface{}) (*gql.GraphQuery, error)
+		result map[string]interface{}) ([]*gql.GraphQuery, error)
 }
 
 // A DgraphExecutor can execute a mutation and returns the request response and any errors.
@@ -114,7 +114,7 @@ type DgraphExecutor interface {
 // The node types is a blank node name -> Type mapping of nodes that could
 // be created by the upsert.
 type UpsertMutation struct {
-	Query     *gql.GraphQuery
+	Query     []*gql.GraphQuery
 	Mutations []*dgoapi.Mutation
 	NewNodes  map[string]schema.Type
 }
@@ -495,7 +495,7 @@ func authorizeNewNodes(
 
 	resp, errs := queryExecutor.Execute(ctx,
 		&dgoapi.Request{
-			Query:   dgraph.AsString(&gql.GraphQuery{Children: qs}),
+			Query:   dgraph.AsString(qs),
 			StartTs: txn.GetStartTs(),
 		})
 	if errs != nil || len(resp.Json) == 0 {

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -41,7 +41,7 @@ type QueryResolver interface {
 
 // A QueryRewriter can build a Dgraph gql.GraphQuery from a GraphQL query,
 type QueryRewriter interface {
-	Rewrite(ctx context.Context, q schema.Query) (*gql.GraphQuery, error)
+	Rewrite(ctx context.Context, q schema.Query) ([]*gql.GraphQuery, error)
 }
 
 // QueryResolverFunc is an adapter that allows to build a QueryResolver from

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -421,28 +421,7 @@ func addFilterToField(dgQuery *gql.GraphQuery, field schema.Field) {
 }
 
 func addTopLevelTypeFilter(query *gql.GraphQuery, field schema.Field) {
-	if query.Attr != "" {
-		addTypeFilter(query, field.Type())
-		return
-	}
-
-	var rootQuery *gql.GraphQuery
-	for _, q := range query.Children {
-		if q.Attr == field.Name() {
-			rootQuery = q
-			break
-		}
-		for _, cq := range q.Children {
-			if cq.Attr == field.Name() {
-				rootQuery = cq
-				break
-			}
-		}
-	}
-
-	if rootQuery != nil {
-		addTypeFilter(rootQuery, field.Type())
-	}
+	addTypeFilter(query, field.Type())
 }
 
 func rewriteAsGet(

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -110,7 +110,7 @@ func getAuthSelector(queryType schema.QueryType) func(t schema.Type) *schema.Rul
 // Rewrite rewrites a GraphQL query into a Dgraph GraphQuery.
 func (qr *queryRewriter) Rewrite(
 	ctx context.Context,
-	gqlQuery schema.Query) (*gql.GraphQuery, error) {
+	gqlQuery schema.Query) ([]*gql.GraphQuery, error) {
 
 	authVariables, _ := ctx.Value(authorization.AuthVariables).(map[string]interface{})
 
@@ -162,7 +162,7 @@ func (qr *queryRewriter) Rewrite(
 	}
 }
 
-func aggregateQuery(query schema.Query, authRw *authRewriter) *gql.GraphQuery {
+func aggregateQuery(query schema.Query, authRw *authRewriter) []*gql.GraphQuery {
 
 	// Get the type which the count query is written for
 	mainType := query.ConstructedFor()
@@ -174,17 +174,13 @@ func aggregateQuery(query schema.Query, authRw *authRewriter) *gql.GraphQuery {
 
 	// Add filter
 	filter, _ := query.ArgValue("filter").(map[string]interface{})
-	_ = addFilter(dgQuery, mainType, filter)
+	_ = addFilter(dgQuery[0], mainType, filter)
 
 	dgQuery = authRw.addAuthQueries(mainType, dgQuery, rbac)
 
-	// dgQuery may contain the query with aggregate<Type> name
-	// or dgQuery may be empty and its children may contain aggregate<Type> query.
-	// Find the exact query with the name aggregate<Type>.
-	mainQuery := dgQuery
-	for !strings.HasPrefix(mainQuery.Attr, query.Name()) {
-		mainQuery = mainQuery.Children[0]
-	}
+	// mainQuery is the query with Attr: query.Name()
+	// It is the first query in dgQuery list.
+	mainQuery := dgQuery[0]
 
 	// Changing mainQuery Attr name to var. This is used in the final aggregate<Type> query.
 	mainQuery.Attr = "var"
@@ -252,10 +248,10 @@ func aggregateQuery(query schema.Query, authRw *authRewriter) *gql.GraphQuery {
 		}
 	}
 
-	return &gql.GraphQuery{Children: []*gql.GraphQuery{finalMainQuery, dgQuery}}
+	return append([]*gql.GraphQuery{finalMainQuery}, dgQuery...)
 }
 
-func passwordQuery(m schema.Query, authRw *authRewriter) (*gql.GraphQuery, error) {
+func passwordQuery(m schema.Query, authRw *authRewriter) ([]*gql.GraphQuery, error) {
 	xid, uid, err := m.IDArgValue()
 	if err != nil {
 		return nil, err
@@ -264,17 +260,13 @@ func passwordQuery(m schema.Query, authRw *authRewriter) (*gql.GraphQuery, error
 	dgQuery := rewriteAsGet(m, uid, xid, authRw)
 
 	// Handle empty dgQuery
-	if strings.HasSuffix(dgQuery.Attr, "()") {
+	if strings.HasSuffix(dgQuery[0].Attr, "()") {
 		return dgQuery, nil
 	}
 
-	// dgQuery may contain the query with check<Type>Password name
-	// or dgQuery may be empty and its children may contain check<Type>Password query.
-	// Find the exact dgQuery with the name check<Type>Password query.
-	mainQuery := dgQuery
-	for !strings.HasPrefix(mainQuery.Attr, m.Name()) {
-		mainQuery = mainQuery.Children[0]
-	}
+	// mainQuery is the query with check<Type>Password as Attr.
+	// It is the first in the list of dgQuery.
+	mainQuery := dgQuery[0]
 
 	queriedType := m.Type()
 	name := queriedType.PasswordField().Name()
@@ -316,16 +308,7 @@ func passwordQuery(m schema.Query, authRw *authRewriter) (*gql.GraphQuery, error
 
 	mainQuery.Filter = ft
 
-	// The additional checkPwd query should be added as child if dgQuery is empty.
-	// This is to ensure proper formation of the query.
-	if dgQuery.Attr == "" {
-		dgQuery.Children = append(dgQuery.Children, op)
-		return dgQuery, nil
-	}
-	qry := &gql.GraphQuery{
-		Children: []*gql.GraphQuery{dgQuery, op},
-	}
-	return qry, nil
+	return append(dgQuery, op), nil
 }
 
 func intersection(a, b []uint64) []uint64 {
@@ -379,27 +362,27 @@ func addUID(dgQuery *gql.GraphQuery) {
 func rewriteAsQueryByIds(
 	field schema.Field,
 	uids []uint64,
-	authRw *authRewriter) *gql.GraphQuery {
+	authRw *authRewriter) []*gql.GraphQuery {
 	rbac := authRw.evaluateStaticRules(field.Type())
-	dgQuery := &gql.GraphQuery{
+	dgQuery := []*gql.GraphQuery{{
 		Attr: field.Name(),
-	}
+	}}
 
 	if rbac == schema.Negative {
-		dgQuery.Attr = dgQuery.Attr + "()"
+		dgQuery[0].Attr = dgQuery[0].Attr + "()"
 		return dgQuery
 	}
 
-	dgQuery.Func = &gql.Function{
+	dgQuery[0].Func = &gql.Function{
 		Name: "uid",
 		UID:  uids,
 	}
 
 	if ids := idFilter(extractQueryFilter(field), field.Type().IDField()); ids != nil {
-		addUIDFunc(dgQuery, intersection(ids, uids))
+		addUIDFunc(dgQuery[0], intersection(ids, uids))
 	}
 
-	addArgumentsToField(dgQuery, field)
+	addArgumentsToField(dgQuery[0], field)
 
 	// The function getQueryByIds is called for passwordQuery or fetching query result types
 	// after making a mutation. In both cases, we want the selectionSet to use the `query` auth
@@ -408,16 +391,16 @@ func rewriteAsQueryByIds(
 	// from addSelectionSetFrom function.
 	oldAuthSelector := authRw.selector
 	authRw.selector = queryAuthSelector
-	selectionAuth := addSelectionSetFrom(dgQuery, field, authRw)
+	selectionAuth := addSelectionSetFrom(dgQuery[0], field, authRw)
 	authRw.selector = oldAuthSelector
 
-	addUID(dgQuery)
-	addCascadeDirective(dgQuery, field)
+	addUID(dgQuery[0])
+	addCascadeDirective(dgQuery[0], field)
 
 	dgQuery = authRw.addAuthQueries(field.Type(), dgQuery, rbac)
 
 	if len(selectionAuth) > 0 {
-		dgQuery = &gql.GraphQuery{Children: append([]*gql.GraphQuery{dgQuery}, selectionAuth...)}
+		dgQuery = append(dgQuery, selectionAuth...)
 	}
 
 	return dgQuery
@@ -466,16 +449,16 @@ func rewriteAsGet(
 	query schema.Query,
 	uid uint64,
 	xid *string,
-	auth *authRewriter) *gql.GraphQuery {
+	auth *authRewriter) []*gql.GraphQuery {
 
-	var dgQuery *gql.GraphQuery
+	var dgQuery []*gql.GraphQuery
 	rbac := auth.evaluateStaticRules(query.Type())
 
 	// If Get query is for Type and none of the authrules are satisfied, then it is
 	// caught here but in case of interface, we need to check validity on each
 	// implementing type as Rules for the interface are made empty.
 	if rbac == schema.Negative {
-		return &gql.GraphQuery{Attr: query.Name() + "()"}
+		return []*gql.GraphQuery{{Attr: query.Name() + "()"}}
 	}
 
 	// For interface, empty query should be returned if Auth rules are
@@ -490,7 +473,7 @@ func rewriteAsGet(
 		}
 
 		if !implementingTypesHasFailedRules {
-			return &gql.GraphQuery{Attr: query.Name() + "()"}
+			return []*gql.GraphQuery{{Attr: query.Name() + "()"}}
 		}
 	}
 
@@ -499,7 +482,7 @@ func rewriteAsGet(
 
 		// Add the type filter to the top level get query. When the auth has been written into the
 		// query the top level get query may be present in query's children.
-		addTopLevelTypeFilter(dgQuery, query)
+		addTopLevelTypeFilter(dgQuery[0], query)
 
 		return dgQuery
 	}
@@ -514,38 +497,38 @@ func rewriteAsGet(
 	}
 
 	if uid > 0 {
-		dgQuery = &gql.GraphQuery{
+		dgQuery = []*gql.GraphQuery{{
 			Attr: query.Name(),
 			Func: &gql.Function{
 				Name: "uid",
 				UID:  []uint64{uid},
 			},
-		}
-		dgQuery.Filter = &gql.FilterTree{
+		}}
+		dgQuery[0].Filter = &gql.FilterTree{
 			Func: eqXidFunc,
 		}
 
 	} else {
-		dgQuery = &gql.GraphQuery{
+		dgQuery = []*gql.GraphQuery{{
 			Attr: query.Name(),
 			Func: eqXidFunc,
-		}
+		}}
 	}
 
 	// Apply query auth rules even for password query
 	oldAuthSelector := auth.selector
 	auth.selector = queryAuthSelector
-	selectionAuth := addSelectionSetFrom(dgQuery, query, auth)
+	selectionAuth := addSelectionSetFrom(dgQuery[0], query, auth)
 	auth.selector = oldAuthSelector
 
-	addUID(dgQuery)
-	addTypeFilter(dgQuery, query.Type())
-	addCascadeDirective(dgQuery, query)
+	addUID(dgQuery[0])
+	addTypeFilter(dgQuery[0], query.Type())
+	addCascadeDirective(dgQuery[0], query)
 
 	dgQuery = auth.addAuthQueries(query.Type(), dgQuery, rbac)
 
 	if len(selectionAuth) > 0 {
-		dgQuery = &gql.GraphQuery{Children: append([]*gql.GraphQuery{dgQuery}, selectionAuth...)}
+		dgQuery = append(dgQuery, selectionAuth...)
 	}
 
 	return dgQuery
@@ -553,7 +536,10 @@ func rewriteAsGet(
 
 // Adds common RBAC and UID, Type rules to DQL query.
 // This function is used by rewriteAsQuery and aggregateQuery functions
-func addCommonRules(field schema.Field, fieldType schema.Type, authRw *authRewriter) (*gql.GraphQuery, schema.RuleResult) {
+func addCommonRules(
+	field schema.Field,
+	fieldType schema.Type,
+	authRw *authRewriter) ([]*gql.GraphQuery, schema.RuleResult) {
 	rbac := authRw.evaluateStaticRules(fieldType)
 	dgQuery := &gql.GraphQuery{
 		Attr: field.Name(),
@@ -561,7 +547,7 @@ func addCommonRules(field schema.Field, fieldType schema.Type, authRw *authRewri
 
 	if rbac == schema.Negative {
 		dgQuery.Attr = dgQuery.Attr + "()"
-		return dgQuery, rbac
+		return []*gql.GraphQuery{dgQuery}, rbac
 	}
 
 	if authRw != nil && (authRw.isWritingAuth || authRw.filterByUid) && (authRw.varName != "" || authRw.parentVarName != "") {
@@ -583,24 +569,24 @@ func addCommonRules(field schema.Field, fieldType schema.Type, authRw *authRewri
 	} else {
 		addTypeFunc(dgQuery, fieldType.DgraphName())
 	}
-	return dgQuery, rbac
+	return []*gql.GraphQuery{dgQuery}, rbac
 }
 
-func rewriteAsQuery(field schema.Field, authRw *authRewriter) *gql.GraphQuery {
+func rewriteAsQuery(field schema.Field, authRw *authRewriter) []*gql.GraphQuery {
 	dgQuery, rbac := addCommonRules(field, field.Type(), authRw)
 	if rbac == schema.Negative {
 		return dgQuery
 	}
 
-	addArgumentsToField(dgQuery, field)
-	selectionAuth := addSelectionSetFrom(dgQuery, field, authRw)
-	addUID(dgQuery)
-	addCascadeDirective(dgQuery, field)
+	addArgumentsToField(dgQuery[0], field)
+	selectionAuth := addSelectionSetFrom(dgQuery[0], field, authRw)
+	addUID(dgQuery[0])
+	addCascadeDirective(dgQuery[0], field)
 
 	dgQuery = authRw.addAuthQueries(field.Type(), dgQuery, rbac)
 
 	if len(selectionAuth) > 0 {
-		dgQuery = &gql.GraphQuery{Children: append([]*gql.GraphQuery{dgQuery}, selectionAuth...)}
+		return append(dgQuery, selectionAuth...)
 	}
 
 	return dgQuery
@@ -617,8 +603,8 @@ func (authRw *authRewriter) writingAuth() bool {
 // original query and the auth.
 func (authRw *authRewriter) addAuthQueries(
 	typ schema.Type,
-	dgQuery *gql.GraphQuery,
-	rbacEval schema.RuleResult) *gql.GraphQuery {
+	dgQuery []*gql.GraphQuery,
+	rbacEval schema.RuleResult) []*gql.GraphQuery {
 
 	// There's no need to recursively inject auth queries into other auth queries, so if
 	// we are already generating an auth query, there's nothing to add.
@@ -692,7 +678,7 @@ func (authRw *authRewriter) addAuthQueries(
 				objfilter = &gql.FilterTree{
 					Func: &gql.Function{
 						Name: "uid",
-						Args: []gql.Arg{gql.Arg{Value: queryVar, IsValueVar: false, IsGraphQLVar: false}},
+						Args: []gql.Arg{{Value: queryVar, IsValueVar: false, IsGraphQLVar: false}},
 					},
 				}
 				filts = append(filts, objfilter)
@@ -705,9 +691,9 @@ func (authRw *authRewriter) addAuthQueries(
 		// For an interface having Auth rules in some of the implementing types, len(qrys) = 0
 		// indicates that None of the type satisfied the Auth rules, We must return Empty Query here.
 		if implementingTypesHasAuthRules == true && len(qrys) == 0 {
-			return &gql.GraphQuery{
-				Attr: dgQuery.Attr + "()",
-			}
+			return []*gql.GraphQuery{{
+				Attr: dgQuery[0].Attr + "()",
+			}}
 		}
 
 		// Join all the queries in qrys using OR filter and
@@ -753,8 +739,8 @@ func (authRw *authRewriter) addAuthQueries(
 	varQry := &gql.GraphQuery{
 		Var:    authRw.varName,
 		Attr:   "var",
-		Func:   dgQuery.Func,
-		Filter: dgQuery.Filter,
+		Func:   dgQuery[0].Func,
+		Filter: dgQuery[0].Filter,
 	}
 
 	rootQry := &gql.GraphQuery{
@@ -767,12 +753,12 @@ func (authRw *authRewriter) addAuthQueries(
 		Filter: filter,
 	}
 
-	dgQuery.Filter = nil
+	dgQuery[0].Filter = nil
 
 	// The user query starts from the var query generated above and is filtered
 	// by the the filter generated from auth processing, so now we build
 	//   queryTodo(func: uid(Todo1)) @filter(...auth-queries...) { ... }
-	dgQuery.Func = &gql.Function{
+	dgQuery[0].Func = &gql.Function{
 		Name: "uid",
 		Args: []gql.Arg{{Value: authRw.parentVarName}},
 	}
@@ -783,7 +769,9 @@ func (authRw *authRewriter) addAuthQueries(
 	// Todo1 as var(func: ... ) @filter(...)
 	// Todo2 as var(func: uid(Todo1)) @cascade { ...auth query 1... }
 	// Todo3 as var(func: uid(Todo1)) @cascade { ...auth query 2... }
-	return &gql.GraphQuery{Children: append([]*gql.GraphQuery{dgQuery, rootQry, varQry}, fldAuthQueries...)}
+	ret := append(dgQuery, rootQry, varQry)
+	ret = append(ret, fldAuthQueries...)
+	return ret
 }
 
 func (authRw *authRewriter) addVariableUIDFunc(q *gql.GraphQuery) {
@@ -912,11 +900,11 @@ func (authRw *authRewriter) rewriteRuleNode(
 		// Todo2 as var(func: uid(Todo1)) @cascade { ...auth query 1... }
 		varName := authRw.varGen.Next(typ, "", "", authRw.isWritingAuth)
 		r1 := rewriteAsQuery(qry, authRw)
-		r1.Var = varName
-		r1.Attr = "var"
-		r1.Cascade = append(r1.Cascade, "__all__")
+		r1[0].Var = varName
+		r1[0].Attr = "var"
+		r1[0].Cascade = append(r1[0].Cascade, "__all__")
 
-		return []*gql.GraphQuery{r1}, &gql.FilterTree{
+		return []*gql.GraphQuery{r1[0]}, &gql.FilterTree{
 			Func: &gql.Function{
 				Name: "uid",
 				Args: []gql.Arg{{Value: varName}},


### PR DESCRIPTION
Motivation:
Currently, a GraphQL query/mutation is rewritten to DQL query. This is done in query_rewriter.go and mutation_rewriter.go . The GraphQL query/mutation is first converted into *gql.GraphQuery and then finally rewritten to DQL query. 
As the DQL query is not a single query, but a list of queries (involving a query and multiple functions), currently to store such multiple queries, *gql.GraphQuery is kept empty and its children (*gql.GraphQuery.Children[]) are used to store them. This is problematic as at many places one needs to iterate over Children and also to have different cases to handle case in which the top level *gql.GraphQuery is empty.
This PR fixes this and replaces *gql.GraphQuery as output of query rewriting with []*gql.GraphQuery .

Testing:
Tested locally all tests in graphql/resolve and graphql/e2e . No new tests added.
Fixes GRAPHQL-861
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7080)
<!-- Reviewable:end -->
