### PR TITLE
fix(logs): Fix logs in xidmap flush

### DIFF
--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -276,19 +276,19 @@ func (m *XidMap) AllocateUid() uint64 {
 
 // Flush must be called if DB is provided to XidMap.
 func (m *XidMap) Flush() error {
+	if m.writer == nil {
+		return nil
+	}
 	glog.Infof("Writing xid map to DB")
 	defer func() {
 		glog.Infof("Finished writing xid map to DB")
 	}()
 
-	if m.writer != nil && len(m.kvBuf) > 0 {
+	if len(m.kvBuf) > 0 {
 		m.kvChan <- m.kvBuf
 	}
 	close(m.kvChan)
 	m.wg.Wait()
 
-	if m.writer == nil {
-		return nil
-	}
 	return m.writer.Flush()
 }


### PR DESCRIPTION
We should only log "Writing to DB" when it is actually being written.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7082)
<!-- Reviewable:end -->
