### PR TITLE
perf(GraphQL): Part-2: Remove unnecessary `dgraph.uid : uid` selections for auth queries (GRAPHQL-854)

### DIFF
--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -162,11 +162,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
         uid
@@ -177,20 +174,16 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
+    {
       "Column": [ { "uid": "0x456" } ],
-      "Ticket": [ { "uid": "0x789" } ] 
-    }  
+      "Ticket": [ { "uid": "0x789" } ]
+    }
 
 - name: "Add multiple nodes of different types that fails auth"
   gqlquery: |
@@ -231,11 +224,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
         uid
@@ -246,13 +236,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
@@ -293,9 +279,9 @@
       }
     }
   json: |
-    { 
+    {
       "Project2": [ { "uid": "0x123" } ],
-      "Project5": [ { "uid": "0x123" } ] 
+      "Project5": [ { "uid": "0x123" } ]
     }
   uids: |
     { "Column1": "0x456", "Ticket3": "0x789", "Column4": "0x459", "Ticket6": "0x799" }
@@ -309,11 +295,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
         uid
@@ -324,20 +307,16 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
+    {
       "Column": [ { "uid": "0x456" }, { "uid": "0x459" } ],
-      "Ticket": [ { "uid": "0x789" }, { "uid": "0x799" } ] 
-    }  
+      "Ticket": [ { "uid": "0x789" }, { "uid": "0x799" } ]
+    }
 
 - name: "Add multiples of multiple nodes of different types that fails auth"
   gqlquery: |
@@ -372,9 +351,9 @@
       }
     }
   json: |
-    { 
+    {
       "Project2": [ { "uid": "0x123" } ],
-      "Project5": [ { "uid": "0x123" } ] 
+      "Project5": [ { "uid": "0x123" } ]
     }
   uids: |
     { "Column1": "0x456", "Ticket3": "0x789", "Column4": "0x459", "Ticket6": "0x799" }
@@ -388,11 +367,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
         uid
@@ -403,25 +379,21 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
+    {
       "Column": [ { "uid": "0x456" } ],
-      "Ticket": [ { "uid": "0x789" }, { "uid": "0x799" } ] 
-    }   
+      "Ticket": [ { "uid": "0x789" }, { "uid": "0x799" } ]
+    }
   error:
     { "message": "mutation failed because authorization failed" }
 
 # See comments about additional deletes in add_mutation_test.yaml.
-# Because of those additional deletes, for example, when we add a column and 
+# Because of those additional deletes, for example, when we add a column and
 # link it to an existing ticket, we remove that ticket from the column it was
 # attached to ... so we need authorization to update that column as well
 # as to add the new column.
@@ -464,15 +436,12 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Project2": [ { "uid": "0x123" } ],
       "Ticket3": [ { "uid": "0x789" } ],
       "Column4":  [ { "uid": "0x799" } ],
@@ -490,18 +459,15 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
-      "Column": [ { "uid": "0x456" } ] 
+    {
+      "Column": [ { "uid": "0x456" } ]
     }
-  
+
 - name: "Add with auth on additional delete that fails"
   gqlquery: |
     mutation addColumn($col: AddColumnInput!) {
@@ -541,15 +507,12 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Project2": [ { "uid": "0x123" } ],
       "Ticket3": [ { "uid": "0x789" } ],
       "Column4":  [ { "uid": "0x799" } ]
@@ -566,17 +529,14 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
-      "Column": [ { "uid": "0x456" } ] 
-    }  
+    {
+      "Column": [ { "uid": "0x456" } ]
+    }
   error:
     { "message": "couldn't rewrite query for mutation addColumn because authorization failed" }
 
@@ -592,11 +552,11 @@
   jwtvar:
     USER: "user1"
   variables: |
-    { 
+    {
       "proj": {
         "name": "Project1",
         "pwd": "Password",
-        "columns": [ { 
+        "columns": [ {
           "name": "a column",
           "tickets": [ { "id": "0x789" } ]
         } ]
@@ -620,23 +580,20 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Ticket3": [ { "uid": "0x789" } ],
       "Column4":  [ { "uid": "0x799" } ],
       "Column4.auth": [ { "uid": "0x799" } ]
     }
   uids: |
-    { 
+    {
       "Project1": "0x123",
-      "Column2": "0x456" 
+      "Column2": "0x456"
     }
   authquery: |-
     query {
@@ -648,11 +605,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Project(func: uid(Project3)) @filter(uid(ProjectAuth4)) {
         uid
@@ -661,13 +615,11 @@
       ProjectAuth4 as var(func: uid(Project3)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
+    {
       "Column": [ { "uid": "0x456" } ],
       "Project": [ { "uid": "0x123" } ]
     }
@@ -684,11 +636,11 @@
   jwtvar:
     USER: "user1"
   variables: |
-    { 
+    {
       "proj": {
         "name": "Project1",
         "pwd": "Password",
-        "columns": [ { 
+        "columns": [ {
           "name": "a column",
           "tickets": [ { "id": "0x789" } ]
         } ]
@@ -712,20 +664,17 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Ticket3": [ { "uid": "0x789" } ],
       "Column4":  [ { "uid": "0x799" } ]
     }
   uids: |
-    { 
+    {
       "Project1": "0x123",
       "Column2": "0x456"
     }
@@ -739,11 +688,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Project(func: uid(Project3)) @filter(uid(ProjectAuth4)) {
         uid
@@ -752,16 +698,14 @@
       ProjectAuth4 as var(func: uid(Project3)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
+    {
       "Column": [ { "uid": "0x456" } ],
       "Project": [ { "uid": "0x123" } ]
-    }  
+    }
   error:
     { "message": "couldn't rewrite query for mutation addProject because authorization failed" }
 
@@ -871,9 +815,7 @@
       ProjectAuth2 as var(func: uid(Project1)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
@@ -927,7 +869,6 @@
       Issue1 as var(func: uid(0x789))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
   authjson: |
@@ -979,7 +920,6 @@
       Issue1 as var(func: uid(0x789))
       Issue2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
   error:
@@ -1043,11 +983,11 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     USER: "user1"
     ANS: "true"
   variables: |
-    { "question": 
+    { "question":
       [{
         "text": "A Question",
         "pwd": "password",
@@ -1072,9 +1012,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
@@ -1092,11 +1030,11 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     USER: "user1"
     ANS: "true"
   variables: |
-    { "question": 
+    { "question":
       [{
         "text": "A Question",
         "pwd": "password",
@@ -1121,18 +1059,16 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
     {"Question": [ ], "Author": [ { "uid" : "0x456"} ] }
-  error: 
+  error:
     { "message": "mutation failed because authorization failed"}
 
 - name: "Add type with having RBAC rule on interface successfully"
-  gqlquery: | 
+  gqlquery: |
     mutation addFbPost($post: [AddFbPostInput!]!){
       addFbPost(input: $post){
         fbPost {
@@ -1143,11 +1079,11 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     USER: "user1"
     ROLE: "ADMIN"
   variables: |
-    { "post": 
+    { "post":
       [{
         "text": "A Question",
         "pwd": "password",
@@ -1168,16 +1104,14 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
     {"FbPost": [ {"uid": "0x123"}]}
 
 - name: "Add type with Having RBAC rule on interface failed"
-  gqlquery: | 
+  gqlquery: |
     mutation addFbPost($post: [AddFbPostInput!]!){
       addFbPost(input: $post){
         fbPost{
@@ -1188,7 +1122,7 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     USER: "user1"
     ROLE: "USER"
   variables: |
@@ -1203,6 +1137,6 @@
     }
   uids: |
     {"FbPost1": "0x123", "Author1": "0x456" }
-  error: 
+  error:
     {"message" : "mutation failed because authorization failed"}
   

--- a/graphql/resolve/auth_delete_test.yaml
+++ b/graphql/resolve/auth_delete_test.yaml
@@ -132,13 +132,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -195,13 +191,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       ticket(func: uid(Ticket5)) {
         title : Ticket.title
@@ -228,13 +220,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       var(func: uid(Ticket5)) {
         Column6 as Ticket.onColumn
@@ -255,19 +243,14 @@
       ProjectAuth12 as var(func: uid(Project7)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       ColumnAuth14 as var(func: uid(Column6)) @cascade {
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -530,7 +513,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteIssue(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   variables: |
@@ -554,7 +537,6 @@
       Issue1 as var(func: uid(0x1, 0x2)) @filter(type(Issue))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
@@ -562,11 +544,11 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteIssue(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   variables: |
-    { 
+    {
       "ids": ["0x1", "0x2"]
     }
   jwtvar:
@@ -586,7 +568,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteRole(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   variables: |
@@ -610,7 +592,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteRole(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   variables: |
@@ -636,7 +618,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deletePost(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   variables: |
@@ -672,18 +654,14 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth4 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -691,7 +669,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deletePost(filter: {id: $ids}) {
-    	numUids
+      numUids
       }
     }
   jwtvar:
@@ -715,7 +693,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteA(filter: {id: $ids}) {
-    	numUids
+        numUids
       }
     }
   variables: |
@@ -741,7 +719,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteQuestion(filter: {id: $ids}) {
-    	numUids
+        numUids
       }
     }
   variables: |
@@ -776,9 +754,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -786,7 +762,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteQuestion(filter: {id: $ids}) {
-    	numUids
+        numUids
       }
     }
   variables: |
@@ -809,11 +785,11 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteFbPost(filter: {id: $ids}) {
-    	numUids
+        numUids
       }
     }
   variables: |
-    { 
+    {
       "ids": ["0x1", "0x2"]
     }
   jwtvar:
@@ -833,7 +809,7 @@
   gqlquery: |
     mutation ($ids: [ID!]) {
       deleteFbPost(filter: {id: $ids}) {
-    	numUids
+        numUids
       }
     }
   variables: |
@@ -865,8 +841,6 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -299,9 +299,7 @@
       ProjectAuth5 as var(func: uid(Project4)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       var(func: uid(ProjectRoot)) {
         Column1 as Project.columns
@@ -311,11 +309,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -437,7 +432,6 @@
       Issue3 as var(func: uid(Issue1)) @filter(uid(IssueAuth2))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
@@ -455,14 +449,14 @@
     ROLE: "USER"
     USER: "user1"
   dgquery: |-
-      query {
-        queryUser(func: uid(UserRoot)) {
-          username : User.username
-          dgraph.uid : uid
-        }
-        UserRoot as var(func: uid(User2))
-        User2 as var(func: type(User))
+    query {
+      queryUser(func: uid(UserRoot)) {
+        username : User.username
+        dgraph.uid : uid
       }
+      UserRoot as var(func: uid(User2))
+      User2 as var(func: type(User))
+    }
 
 - name: "Auth with top level AND rbac true"
   gqlquery: |
@@ -484,7 +478,6 @@
       Issue1 as var(func: type(Issue))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
@@ -554,9 +547,9 @@
     ROLE: "USER"
     USER: "user1"
   dgquery: |-
-     query {
-       queryLog()
-     }
+    query {
+      queryLog()
+    }
 
 - name: "Auth with top level AND rbac false"
   gqlquery: |
@@ -569,9 +562,9 @@
     ROLE: "USER"
     USER: "user1"
   dgquery: |-
-     query {
-       queryIssue()
-     }
+    query {
+      queryIssue()
+    }
 
 - name: "Aggregate Query on Auth with top level AND rbac false"
   gqlquery: |
@@ -600,14 +593,14 @@
     ROLE: "ADMIN"
     USER: "user1"
   dgquery: |-
-     query {
-       queryProject(func: uid(ProjectRoot)) {
-         name : Project.name
-         dgraph.uid : uid
-       }
-       ProjectRoot as var(func: uid(Project1))
-       Project1 as var(func: type(Project))
-     }
+    query {
+      queryProject(func: uid(ProjectRoot)) {
+        name : Project.name
+        dgraph.uid : uid
+      }
+      ProjectRoot as var(func: uid(Project1))
+      Project1 as var(func: type(Project))
+    }
 
 - name: "Aggregate on Auth with top level OR rbac true"
   gqlquery: |
@@ -655,17 +648,15 @@
       Group1 as var(func: type(Group))
       GroupAuth2 as var(func: uid(Group1)) @cascade {
         users : Group.users @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
       GroupAuth3 as var(func: uid(Group1)) @cascade {
         createdBy : Group.createdBy @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
 - name: "Auth with top level OR rbac false"
   gqlquery: |
-    query {                                           
+    query {
       queryProject {
         name
       }
@@ -684,9 +675,7 @@
       ProjectAuth2 as var(func: uid(Project1)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -734,13 +723,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -751,7 +736,7 @@
         username
         tickets {
           id
-          title 
+          title
         }
       }
     }
@@ -778,13 +763,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -795,7 +776,7 @@
         username
         tickets(filter: { title: { anyofterms: "graphql" } }) {
           id
-          title 
+          title
         }
       }
     }
@@ -822,13 +803,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -853,13 +830,10 @@
       MovieAuth3 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable {
           users : Region.users @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       MovieAuth4 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
     }
 
@@ -893,13 +867,10 @@
       MovieAuth5 as var(func: uid(Movie3)) @cascade {
         regionsAvailable : Movie.regionsAvailable {
           users : Region.users @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       MovieAuth6 as var(func: uid(Movie3)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
       var(func: uid(MovieRoot)) {
         Region1 as Movie.regionsAvailable
@@ -957,13 +928,10 @@
       MovieAuth10 as var(func: uid(Movie8)) @cascade {
         regionsAvailable : Movie.regionsAvailable {
           users : Region.users @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       MovieAuth11 as var(func: uid(Movie8)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
       var(func: uid(MovieRoot)) {
         Region1 as Movie.regionsAvailable
@@ -1001,13 +969,10 @@
       MovieAuth3 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable {
           users : Region.users @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       MovieAuth4 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
     }
 
@@ -1037,13 +1002,10 @@
       MovieAuth3 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable {
           users : Region.users @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       MovieAuth4 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
     }
 
@@ -1146,7 +1108,6 @@
       MovieAuth2 as var(func: uid(Movie1)) @filter(eq(Movie.hidden, true)) @cascade
       MovieAuth3 as var(func: uid(Movie1)) @cascade {
         regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
-        dgraph.uid : uid
       }
     }
 
@@ -1201,13 +1162,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1261,13 +1218,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       var(func: uid(UserRoot)) {
         IssueAggregateResult4 as User.issues
@@ -1275,7 +1228,6 @@
       Issue6 as var(func: uid(IssueAggregateResult4)) @filter(uid(IssueAuth5))
       IssueAuth5 as var(func: uid(IssueAggregateResult4)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
       var(func: uid(UserRoot)) {
         Ticket7 as User.tickets
@@ -1286,13 +1238,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1328,7 +1276,6 @@
       Issue3 as var(func: uid(IssueAggregateResult1)) @filter(uid(IssueAuth2))
       IssueAuth2 as var(func: uid(IssueAggregateResult1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
@@ -1382,9 +1329,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1410,9 +1355,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1439,9 +1382,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1489,27 +1430,21 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       FbPost1 as var(func: type(FbPost))
       FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth5 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1541,27 +1476,21 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       FbPost1 as var(func: type(FbPost))
       FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth5 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1607,18 +1536,14 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth4 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1649,18 +1574,14 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth4 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "Random")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -1813,9 +1734,7 @@
       ProjectAuth5 as var(func: uid(Project4)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       var(func: uid(ProjectRoot)) {
         Column1 as Project.columns
@@ -1825,11 +1744,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       checkPwd(func: uid(ProjectRoot)) @filter(type(Project)) {
         pwd as checkpwd(Project.pwd, "something")
@@ -1911,9 +1827,7 @@
       FbPostAuth3 as var(func: uid(FbPost1)) @cascade {
         author : Post.author @filter(eq(Author.name, "ADMIN")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       checkPwd(func: uid(PostRoot)) @filter(type(Post)) {

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -447,13 +447,9 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
       inProject : Column.inProject {
         roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
-      dgraph.uid : uid
     }
-    dgraph.uid : uid
   }
   var(func: uid(TicketRoot)) {
     Column1 as Ticket.onColumn
@@ -463,11 +459,8 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
     inProject : Column.inProject {
       roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
         assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
-      dgraph.uid : uid
     }
-    dgraph.uid : uid
   }
 }`,
 		},
@@ -503,13 +496,9 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
       inProject : Column.inProject {
         roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
-      dgraph.uid : uid
     }
-    dgraph.uid : uid
   }
   var(func: uid(TicketRoot)) {
     Column1 as Ticket.onColumn
@@ -519,11 +508,8 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
     inProject : Column.inProject {
       roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
         assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
-      dgraph.uid : uid
     }
-    dgraph.uid : uid
   }
 }`,
 		},

--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -40,10 +40,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "colID": [ "0x123" ] },
-        "set": { 
-          "name": "new name", 
+        "set": {
+          "name": "new name",
           "tickets": [ { "title": "a ticket" } ]
         }
       }
@@ -59,11 +59,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   uids: |
@@ -81,19 +78,15 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { 
-      "Ticket": [ { "uid": "0x789" } ] 
-    }  
+    {
+      "Ticket": [ { "uid": "0x789" } ]
+    }
 
 
 - name: "Update a node that does a deep add and fails auth"
@@ -109,10 +102,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "colID": [ "0x123" ] },
-        "set": { 
-          "name": "new name", 
+        "set": {
+          "name": "new name",
           "tickets": [ { "title": "a ticket" } ]
         }
       }
@@ -128,11 +121,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   uids: |
@@ -150,22 +140,18 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   authjson: |
-    { }  
+    { }
   error:
     { "message": "mutation failed because authorization failed" }
 
 # See comments about additional deletes in update_mutation_test.yaml.
-# Because of those additional deletes, for example, when we update a column and 
+# Because of those additional deletes, for example, when we update a column and
 # link it to an existing ticket, we might remove that ticket from the column it was
 # attached to ... so we need authorization to update that column as well.
 - name: "update with auth on additional delete (updt list edge)"
@@ -181,10 +167,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "colID": [ "0x123" ] },
-        "set": { 
-          "name": "new name", 
+        "set": {
+          "name": "new name",
           "tickets": [ { "id": "0x789" } ]
         }
       }
@@ -200,11 +186,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket4 as Ticket4(func: uid(0x789)) @filter(type(Ticket)) {
         uid
@@ -222,21 +205,18 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Column1": [ { "uid": "0x123" } ],
       "Ticket4": [ { "uid": "0x789" } ],
       "Column5":  [ { "uid": "0x456" } ],
       "Column5.auth": [ { "uid": "0x456" } ]
     }
-  
+
 - name: "update with auth on additional delete that fails (updt list edge)"
   gqlquery: |
     mutation updateColumn($upd: UpdateColumnInput!) {
@@ -250,10 +230,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "colID": [ "0x123" ] },
-        "set": { 
-          "name": "new name", 
+        "set": {
+          "name": "new name",
           "tickets": [ { "id": "0x789" } ]
         }
       }
@@ -269,11 +249,8 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Ticket4 as Ticket4(func: uid(0x789)) @filter(type(Ticket)) {
         uid
@@ -291,15 +268,12 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Column1": [ { "uid": "0x123" } ],
       "Ticket4": [ { "uid": "0x789" } ],
       "Column5":  [ { "uid": "0x456" } ]
@@ -320,10 +294,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "id": [ "0x123" ] },
-        "set": { 
-          "title": "new title", 
+        "set": {
+          "title": "new title",
           "onColumn": { "colID": "0x456" }
         }
       }
@@ -340,13 +314,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Column4 as Column4(func: uid(0x456)) @filter(type(Column)) {
         uid
@@ -364,20 +334,17 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Column4": [ { "uid": "0x456" } ],
       "Column5":  [ { "uid": "0x499" } ],
       "Column5.auth": [ { "uid": "0x499" } ]
     }
-  
+
 - name: "update with auth on additional delete that fails (updt single edge)"
   gqlquery: |
     mutation updateTicket($upd: UpdateTicketInput!) {
@@ -391,10 +358,10 @@
     USER: "user1"
   variables: |
     { "upd":
-      { 
+      {
         "filter": { "id": [ "0x123" ] },
-        "set": { 
-          "title": "new title", 
+        "set": {
+          "title": "new title",
           "onColumn": { "colID": "0x456" }
         }
       }
@@ -411,13 +378,9 @@
           inProject : Column.inProject {
             roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
               assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-              dgraph.uid : uid
             }
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Column4 as Column4(func: uid(0x456)) @filter(type(Column)) {
         uid
@@ -435,15 +398,12 @@
         inProject : Column.inProject {
           roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-            dgraph.uid : uid
           }
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
   json: |
-    { 
+    {
       "Column4": [ { "uid": "0x456" } ],
       "Column5":  [ { "uid": "0x499" } ]
     }
@@ -539,9 +499,7 @@
       ProjectAuth2 as var(func: uid(Project1)) @cascade {
         roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -605,7 +563,6 @@
       Issue1 as var(func: uid(0x123)) @filter(type(Issue))
       IssueAuth2 as var(func: uid(Issue1)) @cascade {
         owner : Issue.owner @filter(eq(User.username, "user1"))
-        dgraph.uid : uid
       }
     }
 
@@ -700,7 +657,7 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     USER: "user1"
     ANS: "true"
   variables: |
@@ -727,9 +684,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -766,7 +721,7 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     ROLE: "ADMIN"
     USER: "user1"
   variables: |
@@ -790,9 +745,7 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -805,7 +758,7 @@
         }
       }
     }
-  jwtvar: 
+  jwtvar:
     ROLE: "USER"
     USER: "user1"
   variables: |
@@ -861,27 +814,21 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       FbPost1 as var(func: type(FbPost))
       FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth5 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 
@@ -919,18 +866,14 @@
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
       Answer1 as var(func: type(Answer))
       AnswerAuth3 as var(func: uid(Answer1)) @cascade {
         dgraph.type
         author : Post.author @filter(eq(Author.name, "user1")) {
           name : Author.name
-          dgraph.uid : uid
         }
-        dgraph.uid : uid
       }
     }
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -559,7 +559,11 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) []*gql.GraphQuery 
 
 	addArgumentsToField(dgQuery[0], field)
 	selectionAuth := addSelectionSetFrom(dgQuery[0], field, authRw)
-	addUID(dgQuery[0])
+	// we don't need to query uid for auth queries, as they always have at least one field in their
+	// selection set.
+	if !authRw.writingAuth() {
+		addUID(dgQuery[0])
+	}
 	addCascadeDirective(dgQuery[0], field)
 
 	dgQuery = authRw.addAuthQueries(field.Type(), dgQuery, rbac)


### PR DESCRIPTION
We don't need to query `uid` for auth queries, as they always have at least one field in their selection set. This optimizes the number of `touched_uids` greatly, while time is not much improved here.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7105)
<!-- Reviewable:end -->
