### PR TITLE
v20.07: fix(GraphQL): don't update cacheMb if not specified by user (GRAPHQL-…

### DIFF
--- a/graphql/admin/config.go
+++ b/graphql/admin/config.go
@@ -28,7 +28,7 @@ import (
 )
 
 type configInput struct {
-	LruMB float64
+	LruMB *float64
 	// LogRequest is used to update WorkerOptions.LogRequest. true value of LogRequest enables
 	// logging of all requests coming to alphas. LogRequest type has been kept as *bool instead of
 	// bool to avoid updating WorkerOptions.LogRequest when it has default value of false.
@@ -43,8 +43,9 @@ func resolveUpdateConfig(ctx context.Context, m schema.Mutation) (*resolve.Resol
 		return resolve.EmptyResult(m, err), false
 	}
 
-	if input.LruMB > 0 {
-		if err = worker.UpdateLruMb(input.LruMB); err != nil {
+	// update LruMB only when it is specified by user
+	if input.LruMB != nil {
+		if err = worker.UpdateLruMb(*input.LruMB); err != nil {
 			return resolve.EmptyResult(m, err), false
 		}
 	}


### PR DESCRIPTION
…888) (#7103)

Fixes GRAPHQL-888.
Previously, if you ran this request:
```
$ curl -H "Content-Type: application/json" http://localhost:8080/admin -d '{"query": "mutation {config(input: {logRequest: false}){response {code message}}}"}'
```
Alpha logs would also print this:
```
I1205 22:22:51.684693 2681396 middlewares.go:178] GraphQL admin mutation. Name =  config
I1205 22:22:51.684724 2681396 config.go:38] Got config update through GraphQL admin API
I1205 22:22:51.684810 2681396 worker.go:138] Updating cacheMb to 0
```
Indicating that cacheMb was also updated, even it wasn't specified in the request.

This PR fixes this issue.

(cherry picked from commit c03c32766f460d20a219e97711bb7ea84e54d965)

\# Conflicts:
\#	graphql/admin/config.go

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7106)
<!-- Reviewable:end -->
