### PR TITLE
fix: unmarshal snapshot onto zerosnapshot instead of membershipState

### DIFF
--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -71,11 +71,11 @@ func printBasic(store RaftStore) (uint64, uint64) {
 	} else {
 		fmt.Printf("Snapshot Metadata: %+v\n", snap.Metadata)
 		var ds pb.Snapshot
-		var ms pb.MembershipState
+		var zs pb.ZeroSnapshot
 		if err := ds.Unmarshal(snap.Data); err == nil {
 			fmt.Printf("Snapshot Alpha: %+v\n", ds)
-		} else if err := ms.Unmarshal(snap.Data); err == nil {
-			for gid, group := range ms.GetGroups() {
+		} else if err := zs.Unmarshal(snap.Data); err == nil {
+			for gid, group := range zs.State.GetGroups() {
 				fmt.Printf("\nGROUP: %d\n", gid)
 				for _, member := range group.GetMembers() {
 					fmt.Printf("Member: %+v .\n", member)
@@ -87,8 +87,8 @@ func printBasic(store RaftStore) (uint64, uint64) {
 				group.Tablets = nil
 				fmt.Printf("Group: %d %+v .\n", gid, group)
 			}
-			ms.Groups = nil
-			fmt.Printf("\nSnapshot Zero: %+v\n", ms)
+			zs.State.Groups = nil
+			fmt.Printf("\nSnapshot Zero: %+v\n", zs)
 		} else {
 			fmt.Printf("Unable to unmarshal Dgraph snapshot: %v", err)
 		}

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -546,11 +546,11 @@ func (n *node) initAndStartNode() error {
 			// It is important that we pick up the conf state here.
 			n.SetConfState(&sp.Metadata.ConfState)
 
-			var state pb.MembershipState
-			x.Check(state.Unmarshal(sp.Data))
-			n.server.SetMembershipState(&state)
+			var zs pb.ZeroSnapshot
+			x.Check(zs.Unmarshal(sp.Data))
+			n.server.SetMembershipState(zs.State)
 			for _, id := range sp.Metadata.ConfState.Nodes {
-				n.Connect(id, state.Zeros[id].Addr)
+				n.Connect(id, zs.State.Zeros[id].Addr)
 			}
 		}
 


### PR DESCRIPTION
We were unmarshalling into incorrect type (`MembershipState`) the snapshot which contained data marshalled from `ZeroSnapshot`. This PR fixes that.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7125)
<!-- Reviewable:end -->
