### PR TITLE
fix(GraphQL): fix internal Aliases name generation (#7009)

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1170,14 +1170,14 @@ func buildAggregateFields(
 
 // Generate Unique Dgraph Alias for the field based on number of time it has been
 // seen till now in the given query at current level. If it is seen first time then simply returns the field's DgraphAlias,
-// and if  it is seen let's say 3rd time  then return "fieldAlias3" where "fieldAlias"
+// and if  it is seen let's say 3rd time  then return "fieldAlias.3" where "fieldAlias"
 // is the  DgraphAlias of the field.
 func generateUniqueDgraphAlias(f schema.Field, fieldSeenCount map[string]int) string {
 	alias := f.DgraphAlias()
 	if fieldSeenCount[alias] == 0 {
 		return alias
 	}
-	return alias + strconv.Itoa(fieldSeenCount[alias])
+	return alias + "." + strconv.Itoa(fieldSeenCount[alias])
 }
 
 // TODO(GRAPHQL-874), Optimise Query rewriting in case of multiple alias with same filter.

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2982,15 +2982,15 @@
         count_statesAggregate : count(Country.states)
         nameMin_statesAggregate : min(val(statesAggregate_nameVar))
         nameMax_statesAggregate : max(val(statesAggregate_nameVar))
-        statesAggregate1 : Country.states @filter(eq(State.code, "state code")) {
-          statesAggregate1_nameVar as State.name
-          statesAggregate1_capitalVar as State.capital
+        statesAggregate.1 : Country.states @filter(eq(State.code, "state code")) {
+          statesAggregate.1_nameVar as State.name
+          statesAggregate.1_capitalVar as State.capital
           dgraph.uid : uid
         }
-        count_statesAggregate1 : count(Country.states) @filter(eq(State.code, "state code"))
-        nameMin_statesAggregate1 : min(val(statesAggregate1_nameVar))
-        nameMax_statesAggregate1 : max(val(statesAggregate1_nameVar))
-        capitalMin_statesAggregate1 : min(val(statesAggregate1_capitalVar))
+        count_statesAggregate.1 : count(Country.states) @filter(eq(State.code, "state code"))
+        nameMin_statesAggregate.1 : min(val(statesAggregate.1_nameVar))
+        nameMax_statesAggregate.1 : max(val(statesAggregate.1_nameVar))
+        capitalMin_statesAggregate.1 : min(val(statesAggregate.1_capitalVar))
         dgraph.uid : uid
       }
     }
@@ -3023,15 +3023,15 @@
         count_statesAggregate : count(Country.states)
         nameMin_statesAggregate : min(val(statesAggregate_nameVar))
         nameMax_statesAggregate : max(val(statesAggregate_nameVar))
-        statesAggregate1 : Country.states @filter(eq(State.code, "state code")) {
-          statesAggregate1_nameVar as State.name
-          statesAggregate1_capitalVar as State.capital
+        statesAggregate.1 : Country.states @filter(eq(State.code, "state code")) {
+          statesAggregate.1_nameVar as State.name
+          statesAggregate.1_capitalVar as State.capital
           dgraph.uid : uid
         }
-        count_statesAggregate1 : count(Country.states) @filter(eq(State.code, "state code"))
-        nameMin_statesAggregate1 : min(val(statesAggregate1_nameVar))
-        nameMax_statesAggregate1 : max(val(statesAggregate1_nameVar))
-        capitalMin_statesAggregate1 : min(val(statesAggregate1_capitalVar))
+        count_statesAggregate.1 : count(Country.states) @filter(eq(State.code, "state code"))
+        nameMin_statesAggregate.1 : min(val(statesAggregate.1_nameVar))
+        nameMax_statesAggregate.1 : max(val(statesAggregate.1_nameVar))
+        capitalMin_statesAggregate.1 : min(val(statesAggregate.1_capitalVar))
         dgraph.uid : uid
       }
     }

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2584,7 +2584,7 @@
           text : Post.text
           dgraph.uid : uid
         }
-        posts1 : Author.posts @filter(eq(Post.isPublished, false)) {
+        posts.1 : Author.posts @filter(eq(Post.isPublished, false)) {
           title : Post.title
           text : Post.text
           dgraph.uid : uid
@@ -2618,7 +2618,7 @@
           text : Post.text
           dgraph.uid : uid
         }
-        posts1 : Author.posts @filter(eq(Post.isPublished, true)) {
+        posts.1 : Author.posts @filter(eq(Post.isPublished, true)) {
           title : Post.title
           text : Post.text
           dgraph.uid : uid
@@ -2674,8 +2674,8 @@
     query {
       queryAuthor(func: type(Author)) {
         count_postsAggregate : count(Author.posts)
-        count_postsAggregate1 : count(Author.posts) @filter(gt(Post.tags, "abc"))
-        count_postsAggregate2 : count(Author.posts) @filter(le(Post.tags, "xyz"))
+        count_postsAggregate.1 : count(Author.posts) @filter(gt(Post.tags, "abc"))
+        count_postsAggregate.2 : count(Author.posts) @filter(le(Post.tags, "xyz"))
         dgraph.uid : uid
       }
     }


### PR DESCRIPTION
This PR modifies how the internal graph aliases are generated in case of multiple aliases of same field in the query.
For the given graphql query:
```
query {
      queryAuthor {
        name
        p1: posts(filter: {isPublished: true}){
          title
          text
        }
        p2: posts(filter: {isPublished: true}){
          title
          text
        }
      }
    }
```
earlier it was rewritten into:
```
query {
      queryAuthor(func: type(Author)) {
        name : Author.name
        posts : Author.posts @filter(eq(Post.isPublished, true)) {
          title : Post.title
          text : Post.text
          dgraph.uid : uid
        }
        posts1 : Author.posts @filter(eq(Post.isPublished, true)) {
          title : Post.title
          text : Post.text
          dgraph.uid : uid
        }
        dgraph.uid : uid
      }
    }
```
Now it is changed to:
```
query {
      queryAuthor(func: type(Author)) {
        name : Author.name
        posts : Author.posts @filter(eq(Post.isPublished, true)) {
          title : Post.title
          text : Post.text
          dgraph.uid : uid
        }
        posts.1 : Author.posts @filter(eq(Post.isPublished, true)) {
          title : Post.title
          text : Post.text
          dgraph.uid : uid
        }
        dgraph.uid : uid
      }
    }
```

(cherry picked from commit 953f656)


### chore: fix a broken test (#7130)
The test broke after merging #7009 in master.

(cherry picked from commit 09274fb)
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7132)
<!-- Reviewable:end -->
