### PR TITLE
Docs(GraphQL): Correct Deep Mutations Docs (follow-up rewording / typo fix)

### DIFF
--- a/wiki/content/graphql/mutations/deep.md
+++ b/wiki/content/graphql/mutations/deep.md
@@ -6,7 +6,7 @@ weight = 5
     name = "Deep"
 +++
 
-Mutations also allows to perform deep mutation at multiple levels. Deep mutations do not alter linked objects, but they can add deeply-nested new or existing objects. To update an existing nested object, use the update mutation for its type.
+Mutations also let you perform deep mutations at multiple levels. Deep mutations do not alter linked objects, but they can add deeply-nested new objects or link to existing objects. To update an existing nested object, use the update mutation for its type.
 
 We use the following schema to demonstrate some examples.
 
@@ -28,6 +28,7 @@ type Post {
 ```
 
 ### **Example**: Add new nested object
+
 ```graphql
 mutation updateAuthorWithNewPost($author: DeepAuthorInput!) {
   updateAuthor(input: [$author]) {
@@ -42,7 +43,9 @@ mutation updateAuthorWithNewPost($author: DeepAuthorInput!) {
   }
 }
 ```
+
 Variables:
+
 ```json
 { "author":
   { "name": "A.N. Author",
@@ -66,7 +69,7 @@ This syntax does not remove any other existing posts, it just adds the existing 
 {{% /notice %}}
 
 ```graphql
-mutation updateAuthorWithExitingPost($patch: UpdateAuthorInput!) {
+mutation updateAuthorWithExistingPost($patch: UpdateAuthorInput!) {
   updateAuthor(input: $patch) {
     author {
       id
@@ -88,7 +91,7 @@ Variables:
       "posts": [
         {
           "postID": "0x456"
-        } 
+        }
       ]
     }
   }


### PR DESCRIPTION
PR to fix a typo in https://github.com/dgraph-io/dgraph/pull/7144, also some rewording for style

Fixes GRAPHQL-858
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7145)
<!-- Reviewable:end -->
