### PR TITLE
fixing race in pick postings + fixing race log in t.go

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -544,12 +544,9 @@ func (l *List) addMutationInternal(ctx context.Context, txn *Txn, t *pb.Directed
 
 // getMutation returns a marshaled version of posting list mutation stored internally.
 func (l *List) getMutation(startTs uint64) []byte {
-	l.Lock()
-	defer l.Unlock()
+	l.RLock()
+	defer l.RUnlock()
 	if pl, ok := l.mutationMap[startTs]; ok {
-		for _, p := range pl.GetPostings() {
-			p.StartTs = 0
-		}
 		data, err := pl.Marshal()
 		x.Check(err)
 		return data
@@ -617,7 +614,6 @@ func (l *List) pickPostings(readTs uint64) (uint64, []*pb.Posting) {
 					deleteBelowTs = effectiveTs
 					continue
 				}
-				mpost.StartTs = startTs
 				posts = append(posts, mpost)
 			}
 		}

--- a/t/t.go
+++ b/t/t.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -200,7 +199,8 @@ func runTestsFor(ctx context.Context, pkg, prefix string) error {
 	oc.Took(tid, pkg, dur)
 	fmt.Printf("Ran tests for package: %s in %s\n", pkg, dur)
 	if detectRace(prefix) {
-		return errors.New("race condition detected. check logs for more details")
+		return fmt.Errorf("race condition detected for test package %s and cluster with prefix" +
+			" %s. check logs for more details", pkg, prefix)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR reverts https://github.com/dgraph-io/dgraph/pull/6206/files. That PR added the race condition. Also, it was not a bug. If needed we will fix this in a different way.

This also fixes one log line with race in t.go.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7149)
<!-- Reviewable:end -->
