### PR TITLE
release(v20.11): [cherry-pick]  Update Raft migrate tool to handle new proposal format

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -907,6 +907,7 @@ func run() {
 		store, err := raftwal.InitEncrypted(dir, opt.key)
 		x.Check(err)
 		fmt.Printf("RaftID: %+v\n", store.Uint(raftwal.RaftId))
+		isZero := store.Uint(raftwal.GroupId) == 0
 
 		// TODO: Fix the pending logic.
 		pending := make(map[uint64]bool)
@@ -916,7 +917,7 @@ func run() {
 			entries, err := store.Entries(start, last+1, 64<<20)
 			x.Check(err)
 			for _, e := range entries {
-				printEntry(e, pending)
+				printEntry(e, pending, isZero)
 				start = x.Max(start, e.Index)
 			}
 		}

--- a/dgraph/cmd/raft-migrate/run.go
+++ b/dgraph/cmd/raft-migrate/run.go
@@ -121,17 +121,17 @@ func run(conf *viper.Viper) error {
 	newWal, err := raftwal.InitEncrypted(newDir, encKey)
 	x.Check(err)
 
-	// Set the raft ID
+	// Set the raft ID.
 	raftID := oldWal.Uint(raftwal.RaftId)
 	fmt.Printf("Setting raftID to: %+v\n", raftID)
 	newWal.SetUint(raftwal.RaftId, raftID)
 
-	// Set the Group ID
+	// Set the Group ID.
 	groupID := oldWal.Uint(raftwal.GroupId)
 	fmt.Printf("Setting GroupID to: %+v\n", groupID)
 	newWal.SetUint(raftwal.GroupId, groupID)
 
-	// Set the checkpoint index
+	// Set the checkpoint index.
 	checkPoint, err := oldWal.Checkpoint()
 	x.Checkf(err, "failed to read checkpoint %s", err)
 	newWal.SetUint(raftwal.CheckpointIndex, checkPoint)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -333,9 +333,6 @@ func (n *node) applyProposal(e raftpb.Entry) (uint64, error) {
 	if err := p.Unmarshal(e.Data[8:]); err != nil {
 		return key, err
 	}
-	if key == 0 {
-		return key, errInvalidProposal
-	}
 	span := otrace.FromContext(n.Proposals.Ctx(key))
 
 	n.server.Lock()


### PR DESCRIPTION
Cherry picked from https://github.com/dgraph-io/dgraph/commit/ab0f3ea898f02221c1726ab4ad21f4ecf4492f11

This PR updates the raftmigrate tool. We recently updated raft proposal format for alpha and zero, see #7059 .
The tool now can migrate raftwal from old proposal format to new proposal format wherein we are encoding the proposal.Key within the entry.Data.
This change will help to migrate raftwal from [RC-2,RC-3] to RC-4 onwards.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7157)
<!-- Reviewable:end -->
