### PR TITLE
feat(GraphQL): Add Schema support for federation

### DIFF
--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -759,6 +759,7 @@ schemas:
       extend type Product @key(fields: "id") {
         id: ID! @external
         name: String!
+        price: Int @external
         reviews: [String]
       }
     output: |

--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -754,3 +754,34 @@ schemas:
       }
       T.id: float @index(float) @upsert .
       T.value: string .
+  - name: "type extension having @external field of ID type which is @key"
+    input: |
+      extend type Product @key(fields: "id") {
+        id: ID! @external
+        name: String!
+        reviews: [String]
+      }
+    output: |
+      type Product {
+        Product.id
+        Product.name
+        Product.reviews
+      }
+      Product.id: string @index(hash) @upsert .
+      Product.name: string .
+      Product.reviews: [string] .
+  - name: "type extension having @external field of non ID type which is @key"
+    input: |
+      extend type Product @key(fields: "name") {
+        id: ID! @external
+        name: String! @id @external
+        reviews: [String]
+      }
+    output: |
+      type Product {
+        Product.name
+        Product.reviews
+      }
+      Product.name: string @index(hash) @upsert .
+      Product.reviews: [string] .
+

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -2332,6 +2332,9 @@ func generateObjectString(typ *ast.Definition) string {
 }
 
 func generateUnionString(typ *ast.Definition) string {
+	if typ == nil {
+		return ""
+	}
 	return fmt.Sprintf("%sunion %s%s = %s\n",
 		generateDescription(typ.Description), typ.Name, genDirectivesString(typ.Directives),
 		strings.Join(typ.Types, " | "))

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -2165,6 +2165,7 @@ func getIDField(defn *ast.Definition) ast.FieldList {
 			newFldType := *fld.Type
 			newFld.Type = &newFldType
 			newFld.Directives = nil
+			newFld.Arguments = nil
 			fldList = append(fldList, &newFld)
 			break
 		}
@@ -2196,6 +2197,7 @@ func getXIDField(defn *ast.Definition) ast.FieldList {
 			newFldType := *fld.Type
 			newFld.Type = &newFldType
 			newFld.Directives = nil
+			newFld.Arguments = nil
 			fldList = append(fldList, &newFld)
 			break
 		}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1526,10 +1526,7 @@ func isEnumList(fld *ast.FieldDefinition, sch *ast.Schema) bool {
 
 func hasOrderables(defn *ast.Definition) bool {
 	return fieldAny(defn.Fields, func(fld *ast.FieldDefinition) bool {
-		if !hasExternal(fld) {
-			return orderable[fld.Type.NamedType] && !hasCustomOrLambda(fld)
-		}
-		return isKeyField(fld, defn)
+		return isOrderable(fld, defn)
 	})
 }
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1132,7 +1132,6 @@ func addInputType(schema *ast.Schema, defn *ast.Definition) {
 	}
 }
 
-// Todo: Handle Cases for @external keyword with @key keyword
 func addReferenceType(schema *ast.Schema, defn *ast.Definition) {
 	var flds ast.FieldList
 	if defn.Kind == ast.Interface {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -2051,6 +2051,9 @@ func getNonIDFields(schema *ast.Schema, defn *ast.Definition) ast.FieldList {
 			continue
 		}
 
+		if hasExternal(fld) {
+			continue
+		}
 		// Fields with @custom/@lambda directive should not be part of mutation input,
 		// hence we skip them.
 		if hasCustomOrLambda(fld) {
@@ -2089,6 +2092,10 @@ func getFieldsWithoutIDType(schema *ast.Schema, defn *ast.Definition) ast.FieldL
 	fldList := make([]*ast.FieldDefinition, 0)
 	for _, fld := range defn.Fields {
 		if isIDField(defn, fld) {
+			continue
+		}
+
+		if hasExternal(fld) && fld.Name != defn.Directives.ForName(apolloKeyDirective).Arguments[0].Value.Raw {
 			continue
 		}
 

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -64,6 +64,12 @@ const (
 	cacheControlDirective = "cacheControl"
 	CacheControlHeader    = "Cache-Control"
 
+	// Directives to support Apollo Federation
+	apolloKeyDirective      = "key"
+	apolloKeyArg            = "fields"
+	apolloExternalDirective = "external"
+	apolloExtendsDirective  = "extends"
+
 	// custom directive args and fields
 	dqlArg      = "dql"
 	httpArg     = "http"
@@ -260,6 +266,8 @@ input GenerateMutationParams {
 	delete: Boolean
 }
 
+directive @key(fields: String!) on OBJECT
+
 directive @hasInverse(field: String!) on FIELD_DEFINITION
 directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
 directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
@@ -345,6 +353,18 @@ input StringExactFilter {
 input StringHashFilter {
 	eq: String
 	in: [String]
+}
+`
+
+	apolloFederationExtras = `
+directive @key(fields: String!) on OBJECT | INTERFACE
+directive @extends on OBJECT | INTERFACE
+directive @external on OBJECT | FIELD_DEFINITION
+directive @requires(fields: String!) on FIELD_DEFINITION
+directive @provides(fields: String!) on FIELD_DEFINITION
+scalar _Any
+type _Service {
+  sdl: String
 }
 `
 )

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2673,6 +2673,46 @@ invalid_schemas:
     errlist: [
           { "message": "Field I3.name can only be defined once.", "locations": [ { "line": 2, "column": 5 } ] },
           ]
+  - name: "@external directive can only be used on fields of Type Extension"
+    input: |
+      type Product @key(fields: "id") {
+          id: ID! @external
+          reviews: String
+      }
+    errlist: [
+        { "message": "Type Product: Field id: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", "locations": [ { "line": 2, "column": 14 } ] },
+      ]
+  - name: "@key directive defined more than once"
+    input: |
+      type Product @key(fields: "id") @key(fields: "name") {
+          id: ID!
+          name: String! @id
+          reviews: String
+      }
+    errlist: [
+        { "message": "Type Product; @key directive should not be defined more than once.", "locations": [ { "line": 1, "column": 34 } ] },
+      ]
+  - name: "Argument inside @key directive uses field not defined in the type"
+    input: |
+      type Product @key(fields: "username") {
+          id: ID!
+          name: String! @id
+          reviews: String
+      }
+    errlist: [
+        { "message": "Type Product; @key directive uses a field username which is not defined inside the type.", "locations": [ { "line": 1, "column":19 } ] },
+      ]
+  - name: "Argument inside @key directive must have ID field or field with @id directive"
+    input: |
+      extend type Product @key(fields: "name") {
+          id: ID! @external
+          name: String! @external
+          reviews: String
+      }
+    errlist: [
+        { "message": "Type Product: Field name: used inside @key directive should be of type ID or have @id directive.", "locations": [ { "line": 1, "column": 26 } ] },
+      ]
+    
 
 
 valid_schemas:

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2712,6 +2712,53 @@ invalid_schemas:
     errlist: [
         { "message": "Type Product: Field name: used inside @key directive should be of type ID or have @id directive.", "locations": [ { "line": 1, "column": 26 } ] },
       ]
+  - name: "@extends directive without @key directive"
+    input: |
+      type Product  @extends{
+      id: ID! @external
+      name: String! @id @external
+      reviews: [Reviews]
+      }
+
+      type Reviews @key(fields: "id") {
+          id: ID!
+          review: String!
+      }
+    errlist: [
+      {"message": "Type Product; Type Extension cannot be defined without @key directive", "locations": [ { "line": 11, "column": 12} ] },
+    ]
+  - name: "@remote directive with @key"
+    input: |
+      type Product  @remote @key(fields: "id"){
+      id: ID! 
+      name: String!
+      reviews: [Reviews]
+      }
+
+      type Reviews @key(fields: "id") {
+          id: ID!
+          review: String!
+      }
+    errlist: [
+      {"message": "Type Product; @remote directive cannot be defined with @key directive", "locations": [ { "line": 174, "column": 12} ] },
+    ]
+  - name: "External "
+    input: |
+      extend type Product @key(fields: "name"){
+      id: ID! @external
+      name: String! @id @search @external
+      reviews: [Reviews]
+      }
+
+      type Reviews @key(fields: "id") {
+          id: ID!
+          review: String!
+      }
+    errlist: [
+      {"message": "Type Product: Field name: @search directive can not be defined on field with @external directive.", "locations": [ { "line": 3, "column": 20} ] },
+    ]
+
+
     
 
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2716,7 +2716,7 @@ invalid_schemas:
     input: |
       type Product  @extends{
       id: ID! @external
-      name: String! @id @external
+      name: String! @external
       reviews: [Reviews]
       }
 
@@ -2742,12 +2742,12 @@ invalid_schemas:
     errlist: [
       {"message": "Type Product; @remote directive cannot be defined with @key directive", "locations": [ { "line": 174, "column": 12} ] },
     ]
-  - name: "External "
+  - name: "directives defined on @external fields that are not @key."
     input: |
-      extend type Product @key(fields: "name"){
-      id: ID! @external
-      name: String! @id @search @external
-      reviews: [Reviews]
+      extend type Product @key(fields: "id"){
+        id: ID! @external
+        name: String! @search @external
+        reviews: [Reviews]
       }
 
       type Reviews @key(fields: "id") {
@@ -2755,7 +2755,7 @@ invalid_schemas:
           review: String!
       }
     errlist: [
-      {"message": "Type Product: Field name: @search directive can not be defined on field with @external directive.", "locations": [ { "line": 3, "column": 20} ] },
+      {"message": "Type Product: Field name: @search directive can not be defined on @external fields that are not @key.", "locations": [ { "line": 3, "column": 18} ] },
     ]
 
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -2019,21 +2019,23 @@ func apolloKeyValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.List {
 	if arg == nil || arg.Value.Raw == "" {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s; Argument %s: with @key directive should be defined.", typ.Name, apolloKeyArg)}
-	} else if typ.Fields.ForName(arg.Value.Raw) == nil {
-		return []*gqlerror.Error{gqlerror.ErrorPosf(
-			arg.Position,
-			"Type %s; Field %s: with @key directive is not a valid field.", typ.Name, arg.Value.Raw)}
+			"Type %s; Argument %s inside @key directive must be defined.", typ.Name, apolloKeyArg)}
 	}
 
 	fld := typ.Fields.ForName(arg.Value.Raw)
+	if fld == nil {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			arg.Position,
+			"Type %s; @key directive uses a field %s which is not defined inside the type.", typ.Name, arg.Value.Raw)}
+	}
+
 	if isID(fld) || hasIDDirective(fld) {
 		return nil
 	}
 
 	return []*gqlerror.Error{gqlerror.ErrorPosf(
 		arg.Position,
-		"Type %s: Field %s: with @key directive should be of type ID or have @id directive.", typ.Name, fld.Name)}
+		"Type %s: Field %s: used inside @key directive should be of type ID or have @id directive.", typ.Name, fld.Name)}
 }
 
 func apolloExternalValidation(sch *ast.Schema,
@@ -2049,7 +2051,7 @@ func apolloExternalValidation(sch *ast.Schema,
 
 	return []*gqlerror.Error{gqlerror.ErrorPosf(
 		dir.Position,
-		"Type %s: Field %s: @external directive can only be defined on type extensions .", typ.Name, field.Name)}
+		"Type %s: Field %s: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", typ.Name, field.Name)}
 
 }
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -2083,14 +2083,14 @@ func apolloExternalValidation(sch *ast.Schema,
 			"Type %s: Field %s: @external directive can not be defined on  fields with @custom or @lambda directive.", typ.Name, field.Name)}
 	}
 
-	if isKeyField(field, typ) {
+	if !isKeyField(field, typ) {
 		directiveList := []string{inverseDirective, searchDirective, dgraphDirective, idDirective}
 		for _, directive := range directiveList {
 			dirDefn := field.Directives.ForName(directive)
 			if dirDefn != nil {
 				return []*gqlerror.Error{gqlerror.ErrorPosf(
 					dirDefn.Position,
-					"Type %s: Field %s: @%s directive can not be defined on field with @external directive.", typ.Name, field.Name, directive)}
+					"Type %s: Field %s: @%s directive can not be defined on @external fields that are not @key.", typ.Name, field.Name, directive)}
 			}
 		}
 	}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -173,6 +173,12 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 		return nil, gqlerror.List{gqlErr}
 	}
 
+	for _, ext := range doc.Extensions {
+		ext.Directives = append(ext.Directives, &ast.Directive{Name: "extends"})
+	}
+	doc.Definitions = append(doc.Definitions, doc.Extensions...)
+	doc.Extensions = nil
+
 	gqlErrList := preGQLValidation(doc)
 	if gqlErrList != nil {
 		return nil, gqlErrList

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -173,6 +173,8 @@ func NewHandler(input string, validateOnly bool) (Handler, error) {
 		return nil, gqlerror.List{gqlErr}
 	}
 
+	// Convert All the Type Extensions into the Type Definitions with @external directive
+	// to maintain uniformity in the output schema
 	for _, ext := range doc.Extensions {
 		ext.Directives = append(ext.Directives, &ast.Directive{Name: "extends"})
 	}

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -439,6 +439,11 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 					continue
 				}
 
+				// Ignore @external fields which are not @key
+				if hasExternal(f) && !isKeyField(f, def) {
+					continue
+				}
+
 				// If a field of type ID has @external directive and is a @key field then
 				// it should be translated into a dgraph field with string type having hash index.
 				if f.Type.Name() == "ID" && !(hasExternal(f) && isKeyField(f, def)) {

--- a/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
@@ -1,6 +1,6 @@
 extend type Product @key(fields: "id") {
     id: ID! @external
-    name: String! @id @external
+    name: String! @external
     reviews: [Reviews]
 }
 

--- a/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
@@ -1,0 +1,21 @@
+extend type Product @key(fields: "name") {
+    id: ID! @external
+    name: String! @id @external
+    reviews: [Reviews]
+}
+
+type Reviews @key(fields: "id") {
+    id: ID!
+    review: String!
+}
+
+type Student @key(fields: "id"){
+    id: ID!
+    name: String!
+    age: Int!
+}
+
+type School @key(fields: "id"){
+    id: ID!
+    students: [Student]
+}

--- a/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
@@ -1,4 +1,4 @@
-extend type Product @key(fields: "name") {
+extend type Product @key(fields: "id") {
     id: ID! @external
     name: String! @id @external
     reviews: [Reviews]
@@ -18,4 +18,15 @@ type Student @key(fields: "id"){
 type School @key(fields: "id"){
     id: ID!
     students: [Student]
+}
+
+extend type User @key(fields: "name") {
+    id: ID! @external
+    name: String! @id @external
+    reviews: [Reviews]
+}
+
+type Country {
+    code: String! @id
+    name: String!
 }

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -19,7 +19,19 @@ type School @key(fields: "id") {
 	studentsAggregate(filter: StudentFilter): StudentAggregateResult
 }
 
-type Product @key(fields: "name") @extends {
+type Country {
+	code: String! @id
+	name: String!
+}
+
+type Product @key(fields: "id") @extends {
+	id: ID! @external
+	name: String! @id @external
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	reviewsAggregate(filter: ReviewsFilter): ReviewsAggregateResult
+}
+
+type User @key(fields: "name") @extends {
 	id: ID! @external
 	name: String! @id @external
 	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
@@ -285,7 +297,7 @@ input StringHashFilter {
 #######################
 # Extended Apollo Definitions
 #######################
-union _Entity = Reviews | Student | School | Product
+union _Entity = Reviews | Student | School | Product | User
 
 scalar _Any
 scalar _FieldSet
@@ -301,6 +313,11 @@ directive @extends on OBJECT | INTERFACE
 #######################
 # Generated Types
 #######################
+
+type AddCountryPayload {
+	country(filter: CountryFilter, order: CountryOrder, first: Int, offset: Int): [Country]
+	numUids: Int
+}
 
 type AddProductPayload {
 	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
@@ -319,6 +336,25 @@ type AddSchoolPayload {
 
 type AddStudentPayload {
 	student(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	numUids: Int
+}
+
+type AddUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
+}
+
+type CountryAggregateResult {
+	count: Int
+	codeMin: String
+	codeMax: String
+	nameMin: String
+	nameMax: String
+}
+
+type DeleteCountryPayload {
+	country(filter: CountryFilter, order: CountryOrder, first: Int, offset: Int): [Country]
+	msg: String
 	numUids: Int
 }
 
@@ -342,6 +378,12 @@ type DeleteSchoolPayload {
 
 type DeleteStudentPayload {
 	student(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	msg: String
+	numUids: Int
+}
+
+type DeleteUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	msg: String
 	numUids: Int
 }
@@ -372,6 +414,11 @@ type StudentAggregateResult {
 	ageAvg: Float
 }
 
+type UpdateCountryPayload {
+	country(filter: CountryFilter, order: CountryOrder, first: Int, offset: Int): [Country]
+	numUids: Int
+}
+
 type UpdateProductPayload {
 	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
 	numUids: Int
@@ -392,12 +439,32 @@ type UpdateStudentPayload {
 	numUids: Int
 }
 
+type UpdateUserPayload {
+	user(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	numUids: Int
+}
+
+type UserAggregateResult {
+	count: Int
+	nameMin: String
+	nameMax: String
+}
+
 #######################
 # Generated Enums
 #######################
 
-enum ProductHasFilter {
+enum CountryHasFilter {
+	code
 	name
+}
+
+enum CountryOrderable {
+	code
+	name
+}
+
+enum ProductHasFilter {
 	reviews
 }
 
@@ -427,12 +494,26 @@ enum StudentOrderable {
 	age
 }
 
+enum UserHasFilter {
+	name
+	reviews
+}
+
+enum UserOrderable {
+	name
+}
+
 #######################
 # Generated Inputs
 #######################
 
-input AddProductInput {
+input AddCountryInput {
+	code: String!
 	name: String!
+}
+
+input AddProductInput {
+	id: ID! @external
 	reviews: [ReviewsRef]
 }
 
@@ -449,9 +530,36 @@ input AddStudentInput {
 	age: Int!
 }
 
+input AddUserInput {
+	name: String!
+	reviews: [ReviewsRef]
+}
+
+input CountryFilter {
+	code: StringHashFilter
+	has: CountryHasFilter
+	and: [CountryFilter]
+	or: [CountryFilter]
+	not: CountryFilter
+}
+
+input CountryOrder {
+	asc: CountryOrderable
+	desc: CountryOrderable
+	then: CountryOrder
+}
+
+input CountryPatch {
+	name: String
+}
+
+input CountryRef {
+	code: String
+	name: String
+}
+
 input ProductFilter {
 	id: [ID!]
-	name: StringHashFilter
 	has: ProductHasFilter
 	and: [ProductFilter]
 	or: [ProductFilter]
@@ -470,7 +578,6 @@ input ProductPatch {
 
 input ProductRef {
 	id: ID @external
-	name: String
 	reviews: [ReviewsRef]
 }
 
@@ -539,6 +646,12 @@ input StudentRef {
 	age: Int
 }
 
+input UpdateCountryInput {
+	filter: CountryFilter!
+	set: CountryPatch
+	remove: CountryPatch
+}
+
 input UpdateProductInput {
 	filter: ProductFilter!
 	set: ProductPatch
@@ -563,6 +676,35 @@ input UpdateStudentInput {
 	remove: StudentPatch
 }
 
+input UpdateUserInput {
+	filter: UserFilter!
+	set: UserPatch
+	remove: UserPatch
+}
+
+input UserFilter {
+	name: StringHashFilter
+	has: UserHasFilter
+	and: [UserFilter]
+	or: [UserFilter]
+	not: UserFilter
+}
+
+input UserOrder {
+	asc: UserOrderable
+	desc: UserOrderable
+	then: UserOrder
+}
+
+input UserPatch {
+	reviews: [ReviewsRef]
+}
+
+input UserRef {
+	name: String
+	reviews: [ReviewsRef]
+}
+
 #######################
 # Generated Query
 #######################
@@ -579,9 +721,15 @@ type Query {
 	getSchool(id: ID!): School
 	querySchool(filter: SchoolFilter, first: Int, offset: Int): [School]
 	aggregateSchool(filter: SchoolFilter): SchoolAggregateResult
+	getCountry(code: String!): Country
+	queryCountry(filter: CountryFilter, order: CountryOrder, first: Int, offset: Int): [Country]
+	aggregateCountry(filter: CountryFilter): CountryAggregateResult
 	getProduct(id: ID, name: String): Product
 	queryProduct(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
 	aggregateProduct(filter: ProductFilter): ProductAggregateResult
+	getUser(name: String): User
+	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
+	aggregateUser(filter: UserFilter): UserAggregateResult
 }
 
 #######################
@@ -598,8 +746,14 @@ type Mutation {
 	addSchool(input: [AddSchoolInput!]!): AddSchoolPayload
 	updateSchool(input: UpdateSchoolInput!): UpdateSchoolPayload
 	deleteSchool(filter: SchoolFilter!): DeleteSchoolPayload
+	addCountry(input: [AddCountryInput!]!): AddCountryPayload
+	updateCountry(input: UpdateCountryInput!): UpdateCountryPayload
+	deleteCountry(filter: CountryFilter!): DeleteCountryPayload
 	addProduct(input: [AddProductInput!]!): AddProductPayload
 	updateProduct(input: UpdateProductInput!): UpdateProductPayload
 	deleteProduct(filter: ProductFilter!): DeleteProductPayload
+	addUser(input: [AddUserInput!]!): AddUserPayload
+	updateUser(input: UpdateUserInput!): UpdateUserPayload
+	deleteUser(filter: UserFilter!): DeleteUserPayload
 }
 

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -1,0 +1,605 @@
+#######################
+# Input Schema
+#######################
+
+type Reviews @key(fields: "id") {
+	id: ID!
+	review: String!
+}
+
+type Student @key(fields: "id") {
+	id: ID!
+	name: String!
+	age: Int!
+}
+
+type School @key(fields: "id") {
+	id: ID!
+	students(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	studentsAggregate(filter: StudentFilter): StudentAggregateResult
+}
+
+type Product @key(fields: "name") @extends {
+	id: ID! @external
+	name: String! @id @external
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	reviewsAggregate(filter: ReviewsFilter): ReviewsAggregateResult
+}
+
+#######################
+# Extended Definitions
+#######################
+
+"""
+The Int64 scalar type represents a signed 64‐bit numeric non‐fractional value.
+Int64 can represent values in range [-(2^63),(2^63 - 1)].
+"""
+scalar Int64
+
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+scalar DateTime
+
+input IntRange{
+	min: Int!
+	max: Int!
+}
+
+input FloatRange{
+	min: Float!
+	max: Float!
+}
+
+input Int64Range{
+	min: Int64!
+	max: Int64!
+}
+
+input DateTimeRange{
+	min: DateTime!
+	max: DateTime!
+}
+
+input StringRange{
+	min: String!
+	max: String!
+}
+
+enum DgraphIndex {
+	int
+	int64
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+	geo
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	introspectionHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+type Point {
+	longitude: Float!
+	latitude: Float!
+}
+
+input PointRef {
+	longitude: Float!
+	latitude: Float!
+}
+
+input NearFilter {
+	distance: Float!
+	coordinate: PointRef!
+}
+
+input PointGeoFilter {
+	near: NearFilter
+	within: WithinFilter
+}
+
+type PointList {
+	points: [Point!]!
+}
+
+input PointListRef {
+	points: [PointRef!]!
+}
+
+type Polygon {
+	coordinates: [PointList!]!
+}
+
+input PolygonRef {
+	coordinates: [PointListRef!]!
+}
+
+type MultiPolygon {
+	polygons: [Polygon!]!
+}
+
+input MultiPolygonRef {
+	polygons: [PolygonRef!]!
+}
+
+input WithinFilter {
+	polygon: PolygonRef!
+}
+
+input ContainsFilter {
+	point: PointRef
+	polygon: PolygonRef
+}
+
+input IntersectsFilter {
+	polygon: PolygonRef
+	multiPolygon: MultiPolygonRef
+}
+
+input PolygonGeoFilter {
+	near: NearFilter
+	within: WithinFilter
+	contains: ContainsFilter
+	intersects: IntersectsFilter
+}
+
+input GenerateQueryParams {
+	get: Boolean
+	query: Boolean
+	password: Boolean
+	aggregate: Boolean
+}
+
+input GenerateMutationParams {
+	add: Boolean
+	update: Boolean
+	delete: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	password: AuthRule
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete: AuthRule) on OBJECT | INTERFACE
+directive @custom(http: CustomHTTP, dql: String) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
+directive @cascade(fields: [String]) on FIELD
+directive @lambda on FIELD_DEFINITION
+directive @cacheControl(maxAge: Int!) on QUERY
+directive @generate(
+	query: GenerateQueryParams,
+	mutation: GenerateMutationParams,
+	subscription: Boolean) on OBJECT | INTERFACE
+
+input IntFilter {
+	eq: Int
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+	between: IntRange
+}
+
+input Int64Filter {
+	eq: Int64
+	le: Int64
+	lt: Int64
+	ge: Int64
+	gt: Int64
+	between: Int64Range
+}
+
+input FloatFilter {
+	eq: Float
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+	between: FloatRange
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+	between: DateTimeRange
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	in: [String]
+	le: String
+	lt: String
+	ge: String
+	gt: String
+	between: StringRange
+}
+
+input StringHashFilter {
+	eq: String
+	in: [String]
+}
+
+#######################
+# Extended Apollo Definitions
+#######################
+union _Entity = Reviews | Student | School | Product
+
+scalar _Any
+scalar _FieldSet
+
+type _Service {
+	sdl: String
+}
+
+directive @external on FIELD_DEFINITION
+directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
+directive @extends on OBJECT | INTERFACE
+
+#######################
+# Generated Types
+#######################
+
+type AddProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	numUids: Int
+}
+
+type AddReviewsPayload {
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	numUids: Int
+}
+
+type AddSchoolPayload {
+	school(filter: SchoolFilter, first: Int, offset: Int): [School]
+	numUids: Int
+}
+
+type AddStudentPayload {
+	student(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	numUids: Int
+}
+
+type DeleteProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	msg: String
+	numUids: Int
+}
+
+type DeleteReviewsPayload {
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	msg: String
+	numUids: Int
+}
+
+type DeleteSchoolPayload {
+	school(filter: SchoolFilter, first: Int, offset: Int): [School]
+	msg: String
+	numUids: Int
+}
+
+type DeleteStudentPayload {
+	student(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	msg: String
+	numUids: Int
+}
+
+type ProductAggregateResult {
+	count: Int
+	nameMin: String
+	nameMax: String
+}
+
+type ReviewsAggregateResult {
+	count: Int
+	reviewMin: String
+	reviewMax: String
+}
+
+type SchoolAggregateResult {
+	count: Int
+}
+
+type StudentAggregateResult {
+	count: Int
+	nameMin: String
+	nameMax: String
+	ageMin: Int
+	ageMax: Int
+	ageSum: Int
+	ageAvg: Float
+}
+
+type UpdateProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	numUids: Int
+}
+
+type UpdateReviewsPayload {
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	numUids: Int
+}
+
+type UpdateSchoolPayload {
+	school(filter: SchoolFilter, first: Int, offset: Int): [School]
+	numUids: Int
+}
+
+type UpdateStudentPayload {
+	student(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	numUids: Int
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum ProductHasFilter {
+	name
+	reviews
+}
+
+enum ProductOrderable {
+	name
+}
+
+enum ReviewsHasFilter {
+	review
+}
+
+enum ReviewsOrderable {
+	review
+}
+
+enum SchoolHasFilter {
+	students
+}
+
+enum StudentHasFilter {
+	name
+	age
+}
+
+enum StudentOrderable {
+	name
+	age
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddProductInput {
+	name: String!
+	reviews: [ReviewsRef]
+}
+
+input AddReviewsInput {
+	review: String!
+}
+
+input AddSchoolInput {
+	students: [StudentRef]
+}
+
+input AddStudentInput {
+	name: String!
+	age: Int!
+}
+
+input ProductFilter {
+	id: [ID!]
+	name: StringHashFilter
+	has: ProductHasFilter
+	and: [ProductFilter]
+	or: [ProductFilter]
+	not: ProductFilter
+}
+
+input ProductOrder {
+	asc: ProductOrderable
+	desc: ProductOrderable
+	then: ProductOrder
+}
+
+input ProductPatch {
+	reviews: [ReviewsRef]
+}
+
+input ProductRef {
+	id: ID @external
+	name: String
+	reviews: [ReviewsRef]
+}
+
+input ReviewsFilter {
+	id: [ID!]
+	has: ReviewsHasFilter
+	and: [ReviewsFilter]
+	or: [ReviewsFilter]
+	not: ReviewsFilter
+}
+
+input ReviewsOrder {
+	asc: ReviewsOrderable
+	desc: ReviewsOrderable
+	then: ReviewsOrder
+}
+
+input ReviewsPatch {
+	review: String
+}
+
+input ReviewsRef {
+	id: ID
+	review: String
+}
+
+input SchoolFilter {
+	id: [ID!]
+	has: SchoolHasFilter
+	and: [SchoolFilter]
+	or: [SchoolFilter]
+	not: SchoolFilter
+}
+
+input SchoolPatch {
+	students: [StudentRef]
+}
+
+input SchoolRef {
+	id: ID
+	students: [StudentRef]
+}
+
+input StudentFilter {
+	id: [ID!]
+	has: StudentHasFilter
+	and: [StudentFilter]
+	or: [StudentFilter]
+	not: StudentFilter
+}
+
+input StudentOrder {
+	asc: StudentOrderable
+	desc: StudentOrderable
+	then: StudentOrder
+}
+
+input StudentPatch {
+	name: String
+	age: Int
+}
+
+input StudentRef {
+	id: ID
+	name: String
+	age: Int
+}
+
+input UpdateProductInput {
+	filter: ProductFilter!
+	set: ProductPatch
+	remove: ProductPatch
+}
+
+input UpdateReviewsInput {
+	filter: ReviewsFilter!
+	set: ReviewsPatch
+	remove: ReviewsPatch
+}
+
+input UpdateSchoolInput {
+	filter: SchoolFilter!
+	set: SchoolPatch
+	remove: SchoolPatch
+}
+
+input UpdateStudentInput {
+	filter: StudentFilter!
+	set: StudentPatch
+	remove: StudentPatch
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	_entities(representations: [_Any!]!): [_Entity]!
+	_service: _Service!
+	getReviews(id: ID!): Reviews
+	queryReviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	aggregateReviews(filter: ReviewsFilter): ReviewsAggregateResult
+	getStudent(id: ID!): Student
+	queryStudent(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	aggregateStudent(filter: StudentFilter): StudentAggregateResult
+	getSchool(id: ID!): School
+	querySchool(filter: SchoolFilter, first: Int, offset: Int): [School]
+	aggregateSchool(filter: SchoolFilter): SchoolAggregateResult
+	getProduct(id: ID, name: String): Product
+	queryProduct(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	aggregateProduct(filter: ProductFilter): ProductAggregateResult
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addReviews(input: [AddReviewsInput!]!): AddReviewsPayload
+	updateReviews(input: UpdateReviewsInput!): UpdateReviewsPayload
+	deleteReviews(filter: ReviewsFilter!): DeleteReviewsPayload
+	addStudent(input: [AddStudentInput!]!): AddStudentPayload
+	updateStudent(input: UpdateStudentInput!): UpdateStudentPayload
+	deleteStudent(filter: StudentFilter!): DeleteStudentPayload
+	addSchool(input: [AddSchoolInput!]!): AddSchoolPayload
+	updateSchool(input: UpdateSchoolInput!): UpdateSchoolPayload
+	deleteSchool(filter: SchoolFilter!): DeleteSchoolPayload
+	addProduct(input: [AddProductInput!]!): AddProductPayload
+	updateProduct(input: UpdateProductInput!): UpdateProductPayload
+	deleteProduct(filter: ProductFilter!): DeleteProductPayload
+}
+

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -390,8 +390,8 @@ type DeleteUserPayload {
 
 type ProductAggregateResult {
 	count: Int
-	nameMin: String
-	nameMax: String
+	idMin: ID
+	idMax: ID
 }
 
 type ReviewsAggregateResult {
@@ -469,7 +469,7 @@ enum ProductHasFilter {
 }
 
 enum ProductOrderable {
-	name
+	id
 }
 
 enum ReviewsHasFilter {

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -26,7 +26,7 @@ type Country {
 
 type Product @key(fields: "id") @extends {
 	id: ID! @external
-	name: String! @id @external
+	name: String! @external
 	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
 	reviewsAggregate(filter: ReviewsFilter): ReviewsAggregateResult
 }
@@ -513,7 +513,7 @@ input AddCountryInput {
 }
 
 input AddProductInput {
-	id: ID! @external
+	id: ID!
 	reviews: [ReviewsRef]
 }
 
@@ -577,7 +577,7 @@ input ProductPatch {
 }
 
 input ProductRef {
-	id: ID @external
+	id: ID
 	reviews: [ReviewsRef]
 }
 
@@ -724,10 +724,10 @@ type Query {
 	getCountry(code: String!): Country
 	queryCountry(filter: CountryFilter, order: CountryOrder, first: Int, offset: Int): [Country]
 	aggregateCountry(filter: CountryFilter): CountryAggregateResult
-	getProduct(id: ID, name: String): Product
+	getProduct(id: ID!): Product
 	queryProduct(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
 	aggregateProduct(filter: ProductFilter): ProductAggregateResult
-	getUser(name: String): User
+	getUser(name: String!): User
 	queryUser(filter: UserFilter, order: UserOrder, first: Int, offset: Int): [User]
 	aggregateUser(filter: UserFilter): UserAggregateResult
 }

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -424,7 +424,7 @@ input LibraryItemOrder {
 }
 
 input LibraryItemRef {
-	refID: String! @id
+	refID: String!
 }
 
 input LibraryPatch {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -720,6 +720,14 @@ func hasCustomOrLambda(f *ast.FieldDefinition) bool {
 	return false
 }
 
+func isKeyField(f *ast.FieldDefinition, typ *ast.Definition) bool {
+	keyDirective := typ.Directives.ForName(apolloKeyDirective)
+	if keyDirective == nil {
+		return false
+	}
+	return f.Name == keyDirective.Arguments[0].Value.Raw
+}
+
 // buildCustomDirectiveForLambda returns custom directive for the given field to be used for @lambda
 // The constructed @custom looks like this:
 //	@custom(http: {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -728,6 +728,19 @@ func isKeyField(f *ast.FieldDefinition, typ *ast.Definition) bool {
 	return f.Name == keyDirective.Arguments[0].Value.Raw
 }
 
+// Filter out those fields which have @external directive and are not @key fields
+// in a definition.
+func nonExternalAndKeyFields(defn *ast.Definition) ast.FieldList {
+	fldList := make([]*ast.FieldDefinition, 0)
+	for _, fld := range defn.Fields {
+		if hasExternal(fld) && !isKeyField(fld, defn) {
+			continue
+		}
+		fldList = append(fldList, fld)
+	}
+	return fldList
+}
+
 // buildCustomDirectiveForLambda returns custom directive for the given field to be used for @lambda
 // The constructed @custom looks like this:
 //	@custom(http: {

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -703,6 +703,10 @@ func customAndLambdaMappings(s *ast.Schema) (map[string]map[string]*ast.Directiv
 	return customDirectives, lambdaDirectives
 }
 
+func hasExtends(def *ast.Definition) bool {
+	return def.Directives.ForName(apolloExtendsDirective) != nil
+}
+
 func hasExternal(f *ast.FieldDefinition) bool {
 	return f.Directives.ForName(apolloExternalDirective) != nil
 }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -703,6 +703,10 @@ func customAndLambdaMappings(s *ast.Schema) (map[string]map[string]*ast.Directiv
 	return customDirectives, lambdaDirectives
 }
 
+func hasExternal(f *ast.FieldDefinition) bool {
+	return f.Directives.ForName(apolloExternalDirective) != nil
+}
+
 func hasCustomOrLambda(f *ast.FieldDefinition) bool {
 	for _, dir := range f.Directives {
 		if dir.Name == customDirective || dir.Name == lambdaDirective {


### PR DESCRIPTION
Fix GRAPHQL-905.
This PR implements [Federation Schema Specification](https://www.apollographql.com/docs/federation/federation-spec/#federation-schema-specification) in order to support apollo federation.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7159)
<!-- Reviewable:end -->
