### PR TITLE
topic(Docs): Remove link to github issues for issues related to dgraph 

### DIFF
--- a/wiki/content/tutorial-1/index.md
+++ b/wiki/content/tutorial-1/index.md
@@ -232,5 +232,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-1/index.md
+++ b/wiki/content/tutorial-1/index.md
@@ -232,4 +232,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorial-2/index.md
+++ b/wiki/content/tutorial-2/index.md
@@ -375,5 +375,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-2/index.md
+++ b/wiki/content/tutorial-2/index.md
@@ -375,4 +375,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -568,4 +568,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorial-3/index.md
+++ b/wiki/content/tutorial-3/index.md
@@ -568,5 +568,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -396,8 +396,7 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-4/index.md
+++ b/wiki/content/tutorial-4/index.md
@@ -396,7 +396,7 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-5/index.md
+++ b/wiki/content/tutorial-5/index.md
@@ -579,7 +579,7 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-5/index.md
+++ b/wiki/content/tutorial-5/index.md
@@ -579,8 +579,7 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
 
 <style>
   /* blockquote styling */

--- a/wiki/content/tutorial-6/index.md
+++ b/wiki/content/tutorial-6/index.md
@@ -382,5 +382,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-6/index.md
+++ b/wiki/content/tutorial-6/index.md
@@ -382,4 +382,4 @@ Check out our next tutorial of the getting started series [here]({{< relref "tut
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorial-7/index.md
+++ b/wiki/content/tutorial-7/index.md
@@ -299,4 +299,4 @@ to get the latest tutorial right to your inbox.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorial-7/index.md
+++ b/wiki/content/tutorial-7/index.md
@@ -299,5 +299,4 @@ to get the latest tutorial right to your inbox.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-8/index.md
+++ b/wiki/content/tutorial-8/index.md
@@ -1676,5 +1676,4 @@ with Dgraph from your application.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorial-8/index.md
+++ b/wiki/content/tutorial-8/index.md
@@ -1676,4 +1676,4 @@ with Dgraph from your application.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.

--- a/wiki/content/tutorials/index.md
+++ b/wiki/content/tutorials/index.md
@@ -128,5 +128,4 @@ with Dgraph from your application.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests and discussions.
-* Please use [Github Issues](https://github.com/dgraph-io/dgraph/issues) if you encounter bugs or have feature requests.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.

--- a/wiki/content/tutorials/index.md
+++ b/wiki/content/tutorials/index.md
@@ -128,4 +128,4 @@ with Dgraph from your application.
 
 ## Need Help
 
-* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs and discussions.
+* Please use [discuss.dgraph.io](https://discuss.dgraph.io) for questions, feature requests, bugs, and discussions.


### PR DESCRIPTION
This PR removes the links to https://github.com/dgraph-io/dgraph/issues since it's usage is deprecated, see https://github.com/dgraph-io/dgraph/issues/5947. Instead [discuss.dgraph.io](https://discuss.dgraph.io/c/issues/dgraph/38) should be used.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7160)
<!-- Reviewable:end -->
