### PR TITLE
fix(bulk): Fix memory held by tree in reduce phase

### DIFF
--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -276,6 +276,8 @@ func (m *XidMap) AllocateUid() uint64 {
 
 // Flush must be called if DB is provided to XidMap.
 func (m *XidMap) Flush() error {
+	// Make shards nil so that the memory held by the btree can be GCed.
+	m.shards = nil
 	if m.writer == nil {
 		return nil
 	}

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -276,7 +276,11 @@ func (m *XidMap) AllocateUid() uint64 {
 
 // Flush must be called if DB is provided to XidMap.
 func (m *XidMap) Flush() error {
-	// Make shards nil so that the memory held by the btree can be GCed.
+	// While running bulk loader, this method is called at the completion of map phase. After this
+	// method returns xidmap of bulk loader is made nil. But xidmap still show up in memory profiles
+	// even during reduce phase. If bulk loader is running on large dataset, this occupies lot of
+	// memory and causing OOM sometimes. Making shards explicitly nil in this method fixes this.
+	// TODO: find why xidmap is not getting GCed without below line.
 	m.shards = nil
 	if m.writer == nil {
 		return nil


### PR DESCRIPTION
This issue was observed earlier as well and there was a PR fixing it. This PR brings that change back.
https://github.com/dgraph-io/dgraph/pull/4738

We still need to find the exact cause of why the tree is not GCed without explicitly setting it to nil, despite the parent struct set to nil. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7161)
<!-- Reviewable:end -->
