### PR TITLE
docs(graphql): Fix link to lambda fields.

### DIFF
--- a/wiki/content/graphql/lambda/overview.md
+++ b/wiki/content/graphql/lambda/overview.md
@@ -194,7 +194,7 @@ You should see a response such as
 
 Find out more about the  `@lambda` directive, or check out:
 
-* [lambda fields](/graphql/lambda/directive)
+* [lambda fields](/graphql/lambda/field)
 * [lambda queries](/graphql/lambda/query)
 * [lambda mutations](/graphql/lambda/mutation)
 * [lambda server setup](/graphql/lambda/server)


### PR DESCRIPTION
The /graphql/lambda/directive page doesn't exist. The correct link goes to /graphql/lambda/field.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7163)
<!-- Reviewable:end -->
