### PR TITLE
fix(test) : http test to be more resilient and fix race

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -78,7 +78,7 @@ func fetchMetric(t *testing.T) int {
 	requiredMetric := "dgraph_txn_aborts_total"
 	req, err := http.NewRequest("GET", addr+"/debug/prometheus_metrics", nil)
 	require.NoError(t, err)
-	_, body, err := runRequest(req)
+	_, body, _, err := runRequest(req)
 	require.NoError(t, err)
 	metricsMap, err := extractMetrics(string(body))
 	require.NoError(t, err)
@@ -93,7 +93,7 @@ func TestMetrics(t *testing.T) {
 	req, err := http.NewRequest("GET", addr+"/debug/prometheus_metrics", nil)
 	require.NoError(t, err)
 
-	_, body, err := runRequest(req)
+	_, body, _, err := runRequest(req)
 	require.NoError(t, err)
 	metricsMap, err := extractMetrics(string(body))
 	require.NoError(t, err, "Unable to get the metrics map: %v", err)

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -1715,7 +1715,7 @@ func CountIndexConcurrentSetDelUIDList(t *testing.T, c *dgo.Dgraph) {
 	err := c.Alter(ctx, op)
 	require.NoError(t, err)
 
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	rand.Seed(time.Now().Unix())
 	maxUID := 100
 	txnTotal := uint64(1000)
 	txnCur := uint64(0)
@@ -1733,7 +1733,7 @@ func CountIndexConcurrentSetDelUIDList(t *testing.T, c *dgo.Dgraph) {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
 					break
 				}
-				id := 2 + int(r.Int31n(int32(maxUID))) // 1 id subject id.
+				id := 2 + int(rand.Int31n(int32(maxUID))) // 1 id subject id.
 				mu := &api.Mutation{
 					CommitNow: true,
 				}
@@ -1784,7 +1784,7 @@ func CountIndexConcurrentSetDelUIDList(t *testing.T, c *dgo.Dgraph) {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
 					break
 				}
-				id := insertedUids[r.Intn(len(insertedUids))]
+				id := insertedUids[rand.Intn(len(insertedUids))]
 				mu := &api.Mutation{
 					CommitNow: true,
 				}
@@ -1836,7 +1836,7 @@ func CountIndexConcurrentSetDelScalarPredicate(t *testing.T, c *dgo.Dgraph) {
 	err := c.Alter(ctx, op)
 	require.NoError(t, err)
 
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	rand.Seed(time.Now().Unix())
 	txnTotal := uint64(100)
 	txnCur := uint64(0)
 
@@ -1850,7 +1850,7 @@ func CountIndexConcurrentSetDelScalarPredicate(t *testing.T, c *dgo.Dgraph) {
 				if atomic.AddUint64(&txnCur, 1) > txnTotal {
 					break
 				}
-				id := int(r.Int31n(int32(10000)))
+				id := int(rand.Int31n(int32(10000)))
 				mu := &api.Mutation{
 					CommitNow: true,
 				}

--- a/worker/proposal_test.go
+++ b/worker/proposal_test.go
@@ -79,12 +79,14 @@ func TestLimiterDeadlock(t *testing.T) {
 	go func() {
 		now := time.Now()
 		for range ticker.C {
+			l.c.L.Lock()
 			fmt.Println("Seconds elapsed :", int64(time.Since(now).Seconds()),
 				"Total proposals: ", atomic.LoadInt64(&currentCount),
 				"Pending proposal: ", atomic.LoadInt64(&pending),
 				"Completed Proposals: ", atomic.LoadInt64(&completed),
 				"Aborted Proposals: ", atomic.LoadInt64(&aborted),
 				"IOU: ", l.iou)
+			l.c.L.Unlock()
 		}
 	}()
 


### PR DESCRIPTION
HTTP tests have race in terms of how they use a token variable. being a global variable it's being rewritten and read by multiple goroutines and thus leading to errors like "Token expired etc.". This PR is to make them more resilient and fix race Also fixes a few in other test cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7167)
<!-- Reviewable:end -->
