### PR TITLE
fix: Migrate debug tool to new DiskStorage (more efficient)

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -890,7 +890,6 @@ func run() {
 		return
 	}
 
-	// If this is a new format WAL, print and return.
 	if isWal {
 		store, err := raftwal.InitEncrypted(dir, opt.key)
 		x.Check(err)

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -906,22 +906,9 @@ func run() {
 	if isWal && !opt.oldWalFormat {
 		store, err := raftwal.InitEncrypted(dir, opt.key)
 		x.Check(err)
-		fmt.Printf("RaftID: %+v\n", store.Uint(raftwal.RaftId))
-		isZero := store.Uint(raftwal.GroupId) == 0
-
-		// TODO: Fix the pending logic.
-		pending := make(map[uint64]bool)
-
-		start, last := printBasic(store)
-		for start < last-1 {
-			entries, err := store.Entries(start, last+1, 64<<20)
-			x.Check(err)
-			for _, e := range entries {
-				printEntry(e, pending, isZero)
-				start = x.Max(start, e.Index)
-			}
+		if err := handleWal2(store); err != nil {
+			fmt.Printf("\nGot error while handling WAL: %v\n", err)
 		}
-		fmt.Println("Done")
 		return
 	}
 

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -73,7 +73,6 @@ type flagOptions struct {
 	wdir           string
 	wtruncateUntil uint64
 	wsetSnapshot   string
-	oldWalFormat   bool
 }
 
 func init() {
@@ -102,8 +101,6 @@ func init() {
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
-	flag.BoolVar(&opt.oldWalFormat, "old-wal", false,
-		"Denotes that the directory pointed by --wal is a wal directory in old format.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
 		"Remove data from Raft entries until but not including this index.")
 	flag.StringVarP(&opt.wsetSnapshot, "snap", "s", "",
@@ -893,6 +890,16 @@ func run() {
 		return
 	}
 
+	// If this is a new format WAL, print and return.
+	if isWal {
+		store, err := raftwal.InitEncrypted(dir, opt.key)
+		x.Check(err)
+		if err := handleWal(store); err != nil {
+			fmt.Printf("\nGot error while handling WAL: %v\n", err)
+		}
+		return
+	}
+
 	bopts := badger.DefaultOptions(dir).
 		WithReadOnly(opt.readOnly).
 		WithEncryptionKey(opt.key).
@@ -902,31 +909,11 @@ func run() {
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)
 
-	// If this is a new format WAL, print and return.
-	if isWal && !opt.oldWalFormat {
-		store, err := raftwal.InitEncrypted(dir, opt.key)
-		x.Check(err)
-		if err := handleWal2(store); err != nil {
-			fmt.Printf("\nGot error while handling WAL: %v\n", err)
-		}
-		return
-	}
-
 	db, err := badger.OpenManaged(bopts)
 	x.Check(err)
 	// Not using posting list cache
 	posting.Init(db, 0)
 	defer db.Close()
-
-	if isWal {
-		if err := handleWal(db); err != nil {
-			fmt.Printf("\nGot error while handling WAL: %v\n", err)
-		}
-		fmt.Println("Done")
-		// WAL can't execute the getMinMax function, so we need to deal with it
-		// here, instead of in the select case below.
-		return
-	}
 
 	// Commenting the following out because on large Badger DBs, this can take a LONG time.
 	// min, max := getMinMax(db, opt.readTs)

--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -122,7 +122,6 @@ func printBasic(store RaftStore) (uint64, uint64) {
 func printRaft(store *raftwal.DiskStorage) {
 	isZero := store.Uint(raftwal.GroupId) == 0
 
-	// TODO: Fix the pending logic.
 	pending := make(map[uint64]bool)
 	startIdx, lastIdx := printBasic(store)
 

--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -192,26 +192,17 @@ func overwriteSnapshot(store *raftwal.DiskStorage) error {
 }
 
 func handleWal(store *raftwal.DiskStorage) error {
-	_, err := store.HardState()
-	if err != nil {
-		return err
-	}
-
 	rid := store.Uint(raftwal.RaftId)
 	gid := store.Uint(raftwal.GroupId)
 
 	fmt.Printf("Raft Id = %d Groupd Id = %d\n", rid, gid)
 	switch {
 	case len(opt.wsetSnapshot) > 0:
-		err = overwriteSnapshot(store)
-		if err != nil {
-			return err
-		}
+		return overwriteSnapshot(store)
 	case opt.wtruncateUntil != 0:
 		store.TruncateEntriesUntil(opt.wtruncateUntil)
 	default:
 		printRaft(store)
 	}
-
 	return nil
 }

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -75,15 +75,15 @@ func (e entry) Type() uint64       { return binary.BigEndian.Uint64(e[24:]) }
 func (e entry) SetTerm(term uint64)         { binary.BigEndian.PutUint64(e, term) }
 func (e entry) SetIndex(index uint64)       { binary.BigEndian.PutUint64(e[8:], index) }
 func (e entry) SetDataOffset(offset uint64) { binary.BigEndian.PutUint64(e[16:], offset) }
-func (e entry) SetType(type_ uint64)        { binary.BigEndian.PutUint64(e[24:], type_) }
+func (e entry) SetType(typ uint64)          { binary.BigEndian.PutUint64(e[24:], typ) }
 
 func marshalEntry(b []byte, term, index, do, typ uint64) {
 	x.AssertTrue(len(b) == entrySize)
-
-	binary.BigEndian.PutUint64(b, term)
-	binary.BigEndian.PutUint64(b[8:], index)
-	binary.BigEndian.PutUint64(b[16:], do)
-	binary.BigEndian.PutUint64(b[24:], typ)
+	e := entry(b)
+	e.SetTerm(term)
+	e.SetIndex(index)
+	e.SetDataOffset(do)
+	e.SetType(typ)
 }
 
 // logFile represents a single log file.

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -72,18 +72,13 @@ func (e entry) Index() uint64      { return binary.BigEndian.Uint64(e[8:]) }
 func (e entry) DataOffset() uint64 { return binary.BigEndian.Uint64(e[16:]) }
 func (e entry) Type() uint64       { return binary.BigEndian.Uint64(e[24:]) }
 
-func (e entry) SetTerm(term uint64)         { binary.BigEndian.PutUint64(e, term) }
-func (e entry) SetIndex(index uint64)       { binary.BigEndian.PutUint64(e[8:], index) }
-func (e entry) SetDataOffset(offset uint64) { binary.BigEndian.PutUint64(e[16:], offset) }
-func (e entry) SetType(typ uint64)          { binary.BigEndian.PutUint64(e[24:], typ) }
-
 func marshalEntry(b []byte, term, index, do, typ uint64) {
 	x.AssertTrue(len(b) == entrySize)
-	e := entry(b)
-	e.SetTerm(term)
-	e.SetIndex(index)
-	e.SetDataOffset(do)
-	e.SetType(typ)
+
+	binary.BigEndian.PutUint64(b, term)
+	binary.BigEndian.PutUint64(b[8:], index)
+	binary.BigEndian.PutUint64(b[16:], do)
+	binary.BigEndian.PutUint64(b[24:], typ)
 }
 
 // logFile represents a single log file.

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -72,6 +72,11 @@ func (e entry) Index() uint64      { return binary.BigEndian.Uint64(e[8:]) }
 func (e entry) DataOffset() uint64 { return binary.BigEndian.Uint64(e[16:]) }
 func (e entry) Type() uint64       { return binary.BigEndian.Uint64(e[24:]) }
 
+func (e entry) SetTerm(term uint64)         { binary.BigEndian.PutUint64(e, term) }
+func (e entry) SetIndex(index uint64)       { binary.BigEndian.PutUint64(e[8:], index) }
+func (e entry) SetDataOffset(offset uint64) { binary.BigEndian.PutUint64(e[16:], offset) }
+func (e entry) SetType(type_ uint64)        { binary.BigEndian.PutUint64(e[24:], type_) }
+
 func marshalEntry(b []byte, term, index, do, typ uint64) {
 	x.AssertTrue(len(b) == entrySize)
 

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -361,8 +361,8 @@ func (w *DiskStorage) addEntries(entries []raftpb.Entry) error {
 	return nil
 }
 
-// TruncateEntriesUntil deletes the data field of every normal Raft entry
-// with index ∈ [0, lastIdx).
+// truncateEntriesUntil deletes the data field of every raft entry
+// of type EntryNormal and index ∈ [0, lastIdx).
 func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) {
 	w.wal.truncateEntriesUntil(lastIdx)
 }

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -368,6 +368,10 @@ func (w *DiskStorage) addEntries(entries []raftpb.Entry) error {
 	return nil
 }
 
+func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) {
+	w.wal.truncateEntriesUntil(lastIdx)
+}
+
 func (w *DiskStorage) NumLogFiles() int {
 	return len(w.wal.files)
 }

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -70,12 +70,19 @@ const versionKey = 1
 // HardSync is set, msync is called after every write, which flushes those
 // writes to disk.
 type DiskStorage struct {
-	dir  string
-	elog trace.EventLog
+	dir      string
+	commitTs uint64
+	id       uint64
+	gid      uint32
+	elog     trace.EventLog
 
 	meta *metaFile
 	wal  *wal
 	lock sync.Mutex
+}
+
+type indexRange struct {
+	from, until uint64 // index range for deletion, until index is not deleted.
 }
 
 // Init initializes an instance of DiskStorage without encryption.
@@ -363,8 +370,8 @@ func (w *DiskStorage) addEntries(entries []raftpb.Entry) error {
 
 // TruncateEntriesUntil deletes the data field of every normal Raft entry
 // with index ∈ [0, lastIdx).
-func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) error {
-	return w.wal.truncateEntriesUntil(lastIdx)
+func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) {
+	w.wal.truncateEntriesUntil(lastIdx)
 }
 
 func (w *DiskStorage) NumLogFiles() int {

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -70,19 +70,12 @@ const versionKey = 1
 // HardSync is set, msync is called after every write, which flushes those
 // writes to disk.
 type DiskStorage struct {
-	dir      string
-	commitTs uint64
-	id       uint64
-	gid      uint32
-	elog     trace.EventLog
+	dir  string
+	elog trace.EventLog
 
 	meta *metaFile
 	wal  *wal
 	lock sync.Mutex
-}
-
-type indexRange struct {
-	from, until uint64 // index range for deletion, until index is not deleted.
 }
 
 // Init initializes an instance of DiskStorage without encryption.
@@ -370,8 +363,8 @@ func (w *DiskStorage) addEntries(entries []raftpb.Entry) error {
 
 // TruncateEntriesUntil deletes the data field of every normal Raft entry
 // with index ∈ [0, lastIdx).
-func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) {
-	w.wal.truncateEntriesUntil(lastIdx)
+func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) error {
+	return w.wal.truncateEntriesUntil(lastIdx)
 }
 
 func (w *DiskStorage) NumLogFiles() int {

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -368,6 +368,8 @@ func (w *DiskStorage) addEntries(entries []raftpb.Entry) error {
 	return nil
 }
 
+// TruncateEntriesUntil deletes the data field of every normal Raft entry
+// with index ∈ [0, lastIdx).
 func (w *DiskStorage) TruncateEntriesUntil(lastIdx uint64) {
 	w.wal.truncateEntriesUntil(lastIdx)
 }

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -70,19 +70,12 @@ const versionKey = 1
 // HardSync is set, msync is called after every write, which flushes those
 // writes to disk.
 type DiskStorage struct {
-	dir      string
-	commitTs uint64
-	id       uint64
-	gid      uint32
-	elog     trace.EventLog
+	dir  string
+	elog trace.EventLog
 
 	meta *metaFile
 	wal  *wal
 	lock sync.Mutex
-}
-
-type indexRange struct {
-	from, until uint64 // index range for deletion, until index is not deleted.
 }
 
 // Init initializes an instance of DiskStorage without encryption.

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -379,7 +379,7 @@ func TestTruncateStorage(t *testing.T) {
 	}
 
 	// Truncate entries.
-	ds.TruncateEntriesUntil(uint64(numTruncated))
+	ds.TruncateEntriesUntil(numTruncated)
 
 	// Verify all entries.
 	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -360,11 +360,18 @@ func TestTruncateStorage(t *testing.T) {
 
 	// Insert entries.
 	for i := uint64(0); i < numEntries; i++ {
+		var typ raftpb.EntryType
+		if i%3 == 0 {
+			typ = raftpb.EntryConfChange
+		} else {
+			typ = raftpb.EntryNormal
+		}
+
 		idx := i + 1
 		entry := raftpb.Entry{
 			Term:  idx,
 			Index: idx,
-			Type:  raftpb.EntryNormal,
+			Type:  typ,
 			Data:  []byte(fmt.Sprintf("entry %d", idx)),
 		}
 		ds.addEntries([]raftpb.Entry{entry})
@@ -386,7 +393,7 @@ func TestTruncateStorage(t *testing.T) {
 	require.Len(t, entries, int(numEntries))
 	for i := uint64(0); i < numEntries; i++ {
 		idx := i + 1
-		if idx < numTruncated {
+		if idx < numTruncated && i%3 != 0 {
 			require.Empty(t, entries[i].Data)
 		} else {
 			require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))
@@ -411,7 +418,7 @@ func TestTruncateStorage(t *testing.T) {
 	require.Len(t, entries, int(numEntriesNew))
 	for i := uint64(0); i < numEntriesNew; i++ {
 		idx := i + 1
-		if idx < numTruncated {
+		if idx < numTruncated && i%3 != 0 {
 			require.Empty(t, entries[i].Data)
 		} else {
 			require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -379,7 +379,7 @@ func TestTruncateStorage(t *testing.T) {
 	}
 
 	// Truncate entries.
-	ds.TruncateEntriesUntil(numTruncated)
+	ds.TruncateEntriesUntil(uint64(numTruncated))
 
 	// Verify all entries.
 	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -34,6 +34,7 @@ package raftwal
 
 import (
 	"crypto/rand"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
@@ -345,6 +346,77 @@ func TestEntryFile(t *testing.T) {
 	require.Equal(t, uint64(1), entries[0].Index)
 	require.Equal(t, uint64(1), entries[0].Term)
 	require.Equal(t, "abc", string(entries[0].Data))
+}
+
+func TestTruncateStorage(t *testing.T) {
+	dir, err := ioutil.TempDir("", "raftwal")
+	require.NoError(t, err)
+	ds, err := InitEncrypted(dir, nil)
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	const numEntries = uint64(maxNumEntries*3) / 2
+	const numTruncated = numEntries / 2
+
+	// Insert entries.
+	for i := uint64(0); i < numEntries; i++ {
+		idx := i + 1
+		entry := raftpb.Entry{
+			Term:  idx,
+			Index: idx,
+			Type:  raftpb.EntryNormal,
+			Data:  []byte(fmt.Sprintf("entry %d", idx)),
+		}
+		ds.addEntries([]raftpb.Entry{entry})
+	}
+
+	// Verify all entries.
+	entries := ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
+	require.Len(t, entries, int(numEntries))
+	for i := uint64(0); i < numEntries; i++ {
+		idx := i + 1
+		require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))
+	}
+
+	// Truncate entries.
+	ds.TruncateEntriesUntil(uint64(numTruncated))
+
+	// Verify all entries.
+	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
+	require.Len(t, entries, int(numEntries))
+	for i := uint64(0); i < numEntries; i++ {
+		idx := i + 1
+		if idx < numTruncated {
+			require.Empty(t, entries[i].Data)
+		} else {
+			require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))
+		}
+	}
+
+	// Insert more entries.
+	const numEntriesNew = numEntries + maxNumEntries
+	for i := numEntries; i < numEntriesNew; i++ {
+		idx := i + 1
+		entry := raftpb.Entry{
+			Term:  idx,
+			Index: idx,
+			Type:  raftpb.EntryNormal,
+			Data:  []byte(fmt.Sprintf("entry %d", idx)),
+		}
+		ds.addEntries([]raftpb.Entry{entry})
+	}
+
+	// Verify all entries.
+	entries = ds.wal.allEntries(0, math.MaxUint64, math.MaxUint64)
+	require.Len(t, entries, int(numEntriesNew))
+	for i := uint64(0); i < numEntriesNew; i++ {
+		idx := i + 1
+		if idx < numTruncated {
+			require.Empty(t, entries[i].Data)
+		} else {
+			require.Equal(t, entries[i].Data, []byte(fmt.Sprintf("entry %d", idx)))
+		}
+	}
 }
 
 func TestStorageOnlySnap(t *testing.T) {

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -18,7 +18,6 @@ package raftwal
 
 import (
 	"bytes"
-	"math"
 	"sort"
 
 	"github.com/dgraph-io/badger/v2/y"
@@ -105,14 +104,27 @@ func (l *wal) allEntries(lo, hi, maxSize uint64) []raftpb.Entry {
 	return entries
 }
 
-func (l *wal) truncateEntriesUntil(lastIdx uint64) error {
-	entries := l.allEntries(0, math.MaxUint64, math.MaxUint64)
-	for i := range entries {
-		if entries[i].Index < lastIdx && entries[i].Type == raftpb.EntryNormal {
-			entries[i].Data = nil
+func (l *wal) truncateEntriesUntil(lastIdx uint64) {
+	files := append(l.files, l.current)
+	for _, file := range files {
+		if file == nil {
+			continue
+		}
+
+		for idx := 0; idx < maxNumEntries; idx++ {
+			entry := file.getEntry(idx)
+			if entry.Index() >= lastIdx {
+				return
+			}
+
+			// Truncate the data of normal Raft entries.
+			// Setting DataOffset to 0 means that the data field for this entry
+			// will never be accessed.
+			if entry.Type() == uint64(raftpb.EntryNormal) {
+				entry.SetDataOffset(0)
+			}
 		}
 	}
-	return l.AddEntries(entries)
 }
 
 // AddEntries adds the entries to the log. If there are entries in the log with the same index

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -116,6 +116,10 @@ func (l *wal) truncateEntriesUntil(lastIdx uint64) {
 			if entry.Index() >= lastIdx {
 				return
 			}
+
+			// Truncate the data of normal Raft entries.
+			// Setting DataOffset to 0 means that the data field for this entry
+			// will never be accessed.
 			if entry.Type() == uint64(raftpb.EntryNormal) {
 				entry.SetDataOffset(0)
 			}

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -104,8 +104,8 @@ func (l *wal) allEntries(lo, hi, maxSize uint64) []raftpb.Entry {
 	return entries
 }
 
-// truncateEntriesUntil deletes the data field of every normal Raft entry
-// with index ∈ [0, lastIdx).
+// truncateEntriesUntil deletes the data field of every raft entry
+// of type EntryNormal and index ∈ [0, lastIdx).
 func (l *wal) truncateEntriesUntil(lastIdx uint64) {
 	files := append(l.files, l.current)
 	for _, file := range files {
@@ -123,9 +123,17 @@ func (l *wal) truncateEntriesUntil(lastIdx uint64) {
 			// Here, we set the length field of the entry data to zero.
 			// As long as we never directly iterate through the data section,
 			// this operation is safe.
+			// Suppose we truncate indexes [0, 100) and then call AddEntries
+			// with indexes [95, 105]. AddEntries will do the following:
+			// 1. It will zero out all data at index 95 and above
+			// 2. It will find the data offset at index 94 (say 'x')
+			// 3. We start writing new data at x+sliceSize(data, x),
+			//    which will be x+4 if the entry is of type EntryNormal.
+			// Since all entries of index 95 and above have been invalidated,
+			// we can be sure that we don't overwrite any useful data.
 			if entry.Type() == uint64(raftpb.EntryNormal) {
 				offset := int(entry.DataOffset())
-				z.Memclr(file.Data[offset : offset+4])
+				z.ZeroOut(file.Data, offset, offset+4)
 			}
 		}
 	}


### PR DESCRIPTION
This is an alternate implementation of https://github.com/dgraph-io/dgraph/pull/7168. This should be much faster, but leaves us with a fragmented logFile (entry data is not stored contiguously).

This should not break anything, as we never directly iterate through data fields.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7196)
<!-- Reviewable:end -->
