### PR TITLE
fix(restore): reset acl accounts once restore is done if necessary

### DIFF
--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -20,13 +20,14 @@ package worker
 
 import (
 	"context"
+	"sync"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 )
 
-func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) error {
+func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync.WaitGroup) error {
 	glog.Warningf("Restore failed: %v", x.ErrNotSupported)
 	return x.ErrNotSupported
 }

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -20,13 +20,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgraph-io/ristretto/z"
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 
-	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -38,7 +40,8 @@ const (
 )
 
 // ProcessRestoreRequest verifies the backup data and sends a restore proposal to each group.
-func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) error {
+func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest,
+	restoreCloser *z.Closer) error {
 	if req == nil {
 		return errors.Errorf("restore request cannot be nil")
 	}
@@ -106,6 +109,7 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) error {
 			if err := <-errCh; err != nil {
 				glog.Errorf("Error while restoring %v", err)
 			}
+			restoreCloser.Signal()
 		}
 	}()
 

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -93,11 +93,11 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync
 
 	// TODO: prevent partial restores when proposeRestoreOrSend only sends the restore
 	// request to a subset of groups.
-	wg.Add(1)
 	errCh := make(chan error, len(currentGroups))
 	for _, gid := range currentGroups {
 		reqCopy := proto.Clone(req).(*pb.RestoreRequest)
 		reqCopy.GroupId = gid
+		wg.Add(1)
 		go func() {
 			errCh <- tryRestoreProposal(ctx, reqCopy)
 		}()
@@ -108,8 +108,8 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync
 			if err := <-errCh; err != nil {
 				glog.Errorf("Error while restoring %v", err)
 			}
+			wg.Done()
 		}
-		wg.Done()
 	}()
 
 	return nil


### PR DESCRIPTION
This PR reset the ACL accounts once the restore is complete. When we start the restore, it apply DROP_ALL mutation and thus deleting ACL accounts. It's a common across all the alter operation, where we reset ACL accounts once we have the DROP_ALL operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7202)
<!-- Reviewable:end -->
