### PR TITLE
fix(ludicrous): Fix data race in executor

### DIFF
--- a/worker/executor.go
+++ b/worker/executor.go
@@ -130,9 +130,9 @@ func generateConflictKeys(ctx context.Context, p *subMutation) map[uint64]struct
 }
 
 type mutation struct {
+	inDeg              int64
 	sm                 *subMutation
 	conflictKeys       map[uint64]struct{}
-	inDeg              int
 	dependentMutations map[uint64]*mutation
 	graph              *graph
 }
@@ -185,8 +185,8 @@ func (e *executor) worker(mut *mutation) {
 
 	// Decrease inDeg of dependents. If this mutation unblocks them, queue them.
 	for _, dependent := range mut.dependentMutations {
-		dependent.inDeg -= 1
-		if dependent.inDeg == 0 {
+		atomic.AddInt64(&dependent.inDeg, -1)
+		if atomic.LoadInt64(&dependent.inDeg) == 0 {
 			x.Check(e.throttle.Do())
 			go e.worker(dependent)
 		}
@@ -224,7 +224,6 @@ func (e *executor) processMutationCh(ctx context.Context, ch chan *subMutation) 
 			conflictKeys:       conflicts,
 			dependentMutations: make(map[uint64]*mutation),
 			graph:              g,
-			inDeg:              0,
 		}
 
 		g.Lock()
@@ -238,7 +237,7 @@ func (e *executor) processMutationCh(ctx context.Context, ch chan *subMutation) 
 			for _, dependent := range l {
 				_, ok := dependent.dependentMutations[m.sm.startTs]
 				if !ok {
-					m.inDeg += 1
+					atomic.AddInt64(&m.inDeg, 1)
 					dependent.dependentMutations[m.sm.startTs] = m
 				}
 			}
@@ -248,7 +247,7 @@ func (e *executor) processMutationCh(ctx context.Context, ch chan *subMutation) 
 		}
 		g.Unlock()
 
-		if m.inDeg == 0 {
+		if atomic.LoadInt64(&m.inDeg) == 0 {
 			x.Check(e.throttle.Do())
 			go e.worker(m)
 		}

--- a/worker/executor.go
+++ b/worker/executor.go
@@ -185,8 +185,7 @@ func (e *executor) worker(mut *mutation) {
 
 	// Decrease inDeg of dependents. If this mutation unblocks them, queue them.
 	for _, dependent := range mut.dependentMutations {
-		atomic.AddInt64(&dependent.inDeg, -1)
-		if atomic.LoadInt64(&dependent.inDeg) == 0 {
+		if atomic.AddInt64(&dependent.inDeg, -1) == 0 {
 			x.Check(e.throttle.Do())
 			go e.worker(dependent)
 		}


### PR DESCRIPTION
The operations on `inDeg` field of `mutation` struct should be done atomically because it is being used to check if a mutation in dependent on any other mutation. And the mutations are run concurrently, so this update in `inDeg` should be protected. This change fixes the data race which results in alpha crash due to calling `Done` on watermark which is lesser than `doneUntil` 

Fixes: [DGRAPH-2805](https://dgraph.atlassian.net/browse/DGRAPH-2805)
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7203)
<!-- Reviewable:end -->
