### PR TITLE
chore(raft-migrate): make raft-migrate a no-op if already migrated

### DIFF
--- a/dgraph/cmd/raft-migrate/run.go
+++ b/dgraph/cmd/raft-migrate/run.go
@@ -82,6 +82,51 @@ func parseAndConvertSnapshot(snap *raftpb.Snapshot) {
 	x.Check(err)
 }
 
+func shouldMigrate(oldWal *raftwal.DiskStorage, oldEntries []raftpb.Entry) bool {
+	isOldFormat := func(entry raftpb.Entry) bool {
+		if entry.Data[0] == 0 {
+			return false
+		}
+		return true
+	}
+
+	groupID := oldWal.Uint(raftwal.GroupId)
+	if groupID == 0 {
+		// For zero we need to verify both the Snapshot as well as raft-entries.
+		snapshot, err := oldWal.Snapshot()
+		x.Checkf(err, "failed to read snaphot %s", err)
+		var ms pb.MembershipState
+		if err := ms.Unmarshal(snapshot.Data); err != nil {
+			// We are unmarshalling the ZeroSnapshot into MembershipState. If this fails, this means
+			// we are on newer version.
+			fmt.Println("Zero snapshot unmarshalling failed => New format")
+			return false
+		}
+		for _, entry := range oldEntries {
+			// Raft commits an empty entry on becoming leader.
+			if entry.Type == raftpb.EntryConfChange || len(entry.Data) == 0 {
+				continue
+			}
+			// In new format, we prepend key to entry.Data in first 8 bytes. First 4 bytes out of
+			// those contain a node ID. If we assume node ID to be not bigger than 1<<7 (128). Then,
+			// if entry.Data[0] = 0, we can conclude that we are on new format.
+			return isOldFormat(entry)
+		}
+	} else {
+		// For alpha we need to only verify the raft-entries, as the format of alpha Snapshot has
+		// not changed across RC2 and RC5.
+		for _, entry := range oldEntries {
+			// Raft commits an empty entry on becoming leader.
+			if entry.Type == raftpb.EntryConfChange || len(entry.Data) == 0 {
+				continue
+			}
+			return isOldFormat(entry)
+		}
+	}
+	// We can safely opt for not migrating the data here.
+	return false
+}
+
 func run(conf *viper.Viper) error {
 	oldDir := conf.GetString("old-dir")
 	newDir := conf.GetString("new-dir")
@@ -106,6 +151,12 @@ func run(conf *viper.Viper) error {
 	fmt.Printf("Fetching entries from low: %d to high: %d\n", firstIndex, lastIndex)
 	// Should we batch this up?
 	oldEntries, err := oldWal.Entries(firstIndex, lastIndex+1, math.MaxUint64)
+	x.Check(err)
+
+	if !shouldMigrate(oldWal, oldEntries) {
+		fmt.Println("No need to do raft migration!!")
+		return nil
+	}
 
 	newEntries := make([]raftpb.Entry, len(oldEntries))
 	for i, entry := range oldEntries {

--- a/dgraph/cmd/raft-migrate/run.go
+++ b/dgraph/cmd/raft-migrate/run.go
@@ -108,8 +108,8 @@ func shouldMigrate(oldWal *raftwal.DiskStorage, oldEntries []raftpb.Entry) bool 
 				continue
 			}
 			// In new format, we prepend key to entry.Data in first 8 bytes. First 4 bytes out of
-			// those contain a node ID. If we assume node ID to be not bigger than 1<<7 (128). Then,
-			// if entry.Data[0] = 0, we can conclude that we are on new format.
+			// those contain a node ID. If we assume node ID to be less than 1<<24. Then, if
+			// entry.Data[0] = 0, we can conclude that we are on new format.
 			return isOldFormat(entry)
 		}
 	} else {


### PR DESCRIPTION
Slash wants the raft-migrate to be a no-op if it is already on the newer version. We currently don't store any version (like we store `magic number` in badger). So, we need to check the encoding of protobuf data.
 
This PR makes raft-migrate a No-op if the raftwal is already at new format.
Reference: [Protobuf encoding format](https://developers.google.com/protocol-buffers/docs/encoding#structure)
In the new format, we prepend Key in the first 8 bytes of the Marshalled proposal. 
https://github.com/dgraph-io/dgraph/blob/6884b151c355669d1387f30696566f458d0a905f/dgraph/cmd/zero/raft.go#L77-L79
So, the first byte will be 0 if the node ID is less than 1<<24, which is a valid assumption for a reasonable cluster.

If we were on older cluster, then the entry.Data[0] would be storing the `wireType` and `fieldNum` which has to be a non-zero number. 
Quoting from above, the first byte of stream is key (which further consist of wireType and fieldNum). So if its zero, then we can infer that we are on new format.
`You now know that the first number in the stream is always a varint key, and here it's 08, or (dropping the msb):`
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7204)
<!-- Reviewable:end -->
