### PR TITLE
acl: fixed a typo + more generic message for failed acl auth

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -137,7 +137,7 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 		}
 
 		if user == nil {
-			return nil, errors.Errorf("unable to authenticate through refresh token: "+
+			return nil, errors.Errorf("unable to authenticate: "+
 				"invalid username or password")
 		}
 
@@ -154,8 +154,8 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 	}
 
 	if user == nil {
-		return nil, errors.Errorf("unable to authenticate through password: "+
-			"invalid username or passowrd")
+		return nil, errors.Errorf("unable to authenticate: "+
+			"invalid username or password")
 	}
 	if !user.PasswordMatch {
 		return nil, x.ErrorInvalidLogin


### PR DESCRIPTION
- made even more generic the alpha log when failing the auth
- fixed typo in `password`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7228)
<!-- Reviewable:end -->
