### PR TITLE
docs: add notes regarding restricted JSON values

### DIFF
--- a/wiki/content/mutations/json-mutation-format.md
+++ b/wiki/content/mutations/json-mutation-format.md
@@ -61,6 +61,22 @@ to the key `blank-0`. You could specify your own key like
 In this case, the assigned uids map would have a key called `diggy` with the value being the uid
 assigned to it.
 
+### Forbidden values
+ 
+{{% notice "note" %}}
+When using JSON mutations, the following string values are not accepted: `uid( )`, `val( )` 
+{{% /notice %}}
+
+For example, the following JSON can't be processed by Dgraph:
+
+```json
+{
+  "uid": "uid(t)",
+  "user_name": "uid(s ia)",
+  "name": "val (s kl)",
+}
+```
+
 ## Language support
 
 An important difference between RDF and JSON mutations is in regards to specifying a string value's
@@ -319,7 +335,7 @@ upsert {
 }' | jq
 ```
 
-## Creating a list with JSON and interacting with
+## Creating a list with JSON and interacting with it
 
 Schema:
 


### PR DESCRIPTION
Fixes DGRAPH-2868

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7234)
<!-- Reviewable:end -->
