### PR TITLE
fix(dgraph): Fix empty string response for zero datetime (#6067)

### DIFF
--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -331,9 +331,8 @@ func (enc *encoder) IsEmpty(fj fastJsonNode) bool {
 }
 
 var (
-	boolTrue    = []byte("true")
-	boolFalse   = []byte("false")
-	emptyString = []byte(`""`)
+	boolTrue  = []byte("true")
+	boolFalse = []byte("false")
 
 	// Below variables are used in stringJsonMarshal function.
 	bufferPool = sync.Pool{
@@ -465,11 +464,7 @@ func valToBytes(v types.Val) ([]byte, error) {
 		}
 		return boolFalse, nil
 	case types.DateTimeID:
-		// Return empty string instead of zero-time value string - issue#3166
 		t := v.Value.(time.Time)
-		if t.IsZero() {
-			return emptyString, nil
-		}
 		return t.MarshalJSON()
 	case types.GeoID:
 		return geojson.Marshal(v.Value.(geom.T))

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -102,6 +102,7 @@ func TestSystem(t *testing.T) {
 	t.Run("overwrite uid predicates across txns", wrap(OverwriteUidPredicatesMultipleTxn))
 	t.Run("overwrite uid predicates reverse index", wrap(OverwriteUidPredicatesReverse))
 	t.Run("delete and query same txn", wrap(DeleteAndQuerySameTxn))
+	t.Run("add and query zero datetime value", wrap(AddAndQueryZeroTimeValue))
 }
 
 func FacetJsonInputSupportsAnyOfTerms(t *testing.T, c *dgo.Dgraph) {
@@ -2422,4 +2423,38 @@ func DeleteAndQuerySameTxn(t *testing.T, c *dgo.Dgraph) {
 	require.NoError(t, err)
 	testutil.CompareJSON(t, `{"me":[{"name":"Alice"}]}`,
 		string(resp.GetJson()))
+}
+
+func AddAndQueryZeroTimeValue(t *testing.T, c *dgo.Dgraph) {
+	ctx := context.Background()
+
+	op := &api.Operation{Schema: `val: datetime .`}
+	require.NoError(t, c.Alter(ctx, op))
+
+	txn := c.NewTxn()
+	_, err := txn.Mutate(ctx, &api.Mutation{
+		SetNquads: []byte(`
+			_:value <val> "0000-01-01T00:00:00Z" .
+		`),
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(ctx))
+
+	const datetimeQuery = `
+	{
+		q(func: has(val)) {
+			val
+		}
+	}`
+
+	txn = c.NewTxn()
+	resp, err := txn.Query(ctx, datetimeQuery)
+	require.NoError(t, err)
+	testutil.CompareJSON(t, `{
+		"q": [
+		  {
+			"val": "0000-01-01T00:00:00Z"
+		  }
+		]
+	  }`, string(resp.Json))
 }


### PR DESCRIPTION
This PR fixes the empty string response for a zero-datetime value. The "0001-01-01T00:00:00Z" datetime is considered to be a zero value. Before we used to allow empty string for datetime mutation and internally stored empty string as zero datetime  so we returned empty string for it but now empty string mutation is not allowed. So, we should return "0001-01-01T00:00:00Z" instead of empty string if the mutation contains "0001-01-01T00:00:00Z".

(cherry picked from commit 386665f95ab538cd6c5aab4516c0cb63e4a1e04c)

Fixes DGRAPH-2859

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7236)
<!-- Reviewable:end -->
