### PR TITLE
fix(sort): Make sort consistent for indexed and without indexed predicates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20201214114056-bcfae6104545
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6
 	github.com/dgraph-io/gqlgen v0.13.2

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20201214114056-bcfae6104545
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6
 	github.com/dgraph-io/gqlgen v0.13.2

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -324,9 +324,9 @@ noindex_salary                 : float .
 language                       : [string] .
 score                          : [int] @index(int) .
 average                        : [float] @index(float) .
-gender						   : string .
-pred 						   : string @index(exact) .
-predname 					   : string .
+gender                         : string .
+pred                           : string @index(exact) .
+predname                       : string .
 `
 
 func populateCluster() {

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -326,6 +326,7 @@ score                          : [int] @index(int) .
 average                        : [float] @index(float) .
 gender						   : string .
 pred 						   : string @index(exact) .
+predname 					   : string .
 `
 
 func populateCluster() {
@@ -767,16 +768,16 @@ func populateCluster() {
 		<64> <pred> "D" .
 		<65> <pred> "E" .
 
-		<61> <name> "nameA" .
-		<62> <name> "nameB" .
-		<63> <name> "nameC" .
-		<64> <name> "nameD" .
-		<65> <name> "nameE" .
-		<66> <name> "nameF" .
-		<67> <name> "nameG" .
-		<68> <name> "nameH" .
-		<69> <name> "nameI" .
-		<70> <name> "nameJ" .
+		<61> <predname> "nameA" .
+		<62> <predname> "nameB" .
+		<63> <predname> "nameC" .
+		<64> <predname> "nameD" .
+		<65> <predname> "nameE" .
+		<66> <predname> "nameF" .
+		<67> <predname> "nameG" .
+		<68> <predname> "nameH" .
+		<69> <predname> "nameI" .
+		<70> <predname> "nameJ" .
 
 	`)
 	if err != nil {

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -325,8 +325,9 @@ language                       : [string] .
 score                          : [int] @index(int) .
 average                        : [float] @index(float) .
 gender                         : string .
-pred                           : string @index(exact) .
-predname                       : string .
+indexpred                      : string @index(exact) .
+pred                           : string .
+pname                          : string .
 `
 
 func populateCluster() {
@@ -768,16 +769,22 @@ func populateCluster() {
 		<64> <pred> "D" .
 		<65> <pred> "E" .
 
-		<61> <predname> "nameA" .
-		<62> <predname> "nameB" .
-		<63> <predname> "nameC" .
-		<64> <predname> "nameD" .
-		<65> <predname> "nameE" .
-		<66> <predname> "nameF" .
-		<67> <predname> "nameG" .
-		<68> <predname> "nameH" .
-		<69> <predname> "nameI" .
-		<70> <predname> "nameJ" .
+		<61> <indexpred> "A" .
+		<62> <indexpred> "B" .
+		<63> <indexpred> "C" .
+		<64> <indexpred> "D" .
+		<65> <indexpred> "E" .
+
+		<61> <pname> "nameA" .
+		<62> <pname> "nameB" .
+		<63> <pname> "nameC" .
+		<64> <pname> "nameD" .
+		<65> <pname> "nameE" .
+		<66> <pname> "nameF" .
+		<67> <pname> "nameG" .
+		<68> <pname> "nameH" .
+		<69> <pname> "nameI" .
+		<70> <pname> "nameJ" .
 
 	`)
 	if err != nil {

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -325,6 +325,7 @@ language                       : [string] .
 score                          : [int] @index(int) .
 average                        : [float] @index(float) .
 gender						   : string .
+pred 						   : string @index(exact) .
 `
 
 func populateCluster() {
@@ -758,6 +759,25 @@ func populateCluster() {
 		<20001> <average> "49.33" .
 		<20001> <pet_name> "mahi" .
 		<20001> <pet_name> "ms" .
+
+		# data for testing consistency of sort
+		<61> <pred> "A" .
+		<62> <pred> "B" .
+		<63> <pred> "C" .
+		<64> <pred> "D" .
+		<65> <pred> "E" .
+
+		<61> <name> "nameA" .
+		<62> <name> "nameB" .
+		<63> <name> "nameC" .
+		<64> <name> "nameD" .
+		<65> <name> "nameE" .
+		<66> <name> "nameF" .
+		<67> <name> "nameG" .
+		<68> <name> "nameH" .
+		<69> <name> "nameI" .
+		<70> <name> "nameJ" .
+
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1924,99 +1924,106 @@ func TestSortWithNulls(t *testing.T) {
 		desc   bool
 		result string
 	}{
-		{0, -1, -1, false, `{"data": {"me":[{"predname":"nameA","pred":"A"},
-			{"predname":"nameB","pred":"B"},
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameD","pred":"D"},
-			{"predname":"nameE","pred":"E"},
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"},
-			{"predname":"nameJ"}]}}`,
+		{0, -1, -1, false, `{"data": {"me":[
+			{"pname":"nameA","pred":"A"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameE","pred":"E"},
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
+			{"pname":"nameJ"}]}}`,
 		},
 		{1, -1, -1, true, `{"data": {"me":[
-			{"predname":"nameE","pred":"E"},
-			{"predname":"nameD","pred":"D"},
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameB","pred":"B"},
-			{"predname":"nameA","pred":"A"},
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"},
-			{"predname":"nameJ"}]}}`,
+			{"pname":"nameE","pred":"E"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameA","pred":"A"},
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
+			{"pname":"nameJ"}]}}`,
 		},
 		{2, -1, 2, false, `{"data": {"me":[
-			{"predname":"nameA", "pred": "A"},
-			{"predname":"nameB","pred":"B"}]}}`,
+			{"pname":"nameA", "pred": "A"},
+			{"pname":"nameB","pred":"B"}]}}`,
 		},
 		{4, -1, 2, true, `{"data": {"me":[
-			{"predname":"nameE", "pred":"E"},
-			{"predname":"nameD", "pred": "D"}]}}`,
+			{"pname":"nameE", "pred":"E"},
+			{"pname":"nameD", "pred": "D"}]}}`,
 		},
 		{5, -1, 7, false, `{"data": {"me":[
-			{"predname":"nameA","pred":"A"},
-			{"predname":"nameB","pred":"B"},
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameD","pred":"D"},
-			{"predname":"nameE","pred":"E"},
-			{"predname":"nameF"},
-			{"predname":"nameG"}]}}`,
+			{"pname":"nameA","pred":"A"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameE","pred":"E"},
+			{"pname":"nameF"},
+			{"pname":"nameG"}]}}`,
 		},
 		{6, -1, 7, true, `{"data": {"me":[
-			{"predname":"nameE","pred":"E"},
-			{"predname":"nameD","pred":"D"},
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameB","pred":"B"},
-			{"predname":"nameA","pred":"A"},
-			{"predname":"nameF"},
-			{"predname":"nameG"}]}}`,
+			{"pname":"nameE","pred":"E"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameA","pred":"A"},
+			{"pname":"nameF"},
+			{"pname":"nameG"}]}}`,
 		},
 		{7, 2, 7, false, `{"data": {"me":[
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameD","pred":"D"},
-			{"predname":"nameE","pred":"E"},
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"}]}}`,
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameE","pred":"E"},
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"}]}}`,
 		},
 		{8, 2, 7, true, `{"data": {"me":[
-			{"predname":"nameC","pred":"C"},
-			{"predname":"nameB","pred":"B"},
-			{"predname":"nameA","pred":"A"},
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"}]}}`,
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameA","pred":"A"},
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"}]}}`,
 		},
 		{9, 5, 5, false, `{"data": {"me":[
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"},
-			{"predname":"nameJ"}]}}`,
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
+			{"pname":"nameJ"}]}}`,
 		},
 		{10, 5, 5, true, `{"data": {"me":[
-			{"predname":"nameF"},
-			{"predname":"nameG"},
-			{"predname":"nameH"},
-			{"predname":"nameI"},
-			{"predname":"nameJ"}]}}`,
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
+			{"pname":"nameJ"}]}}`,
 		},
 		{11, 9, 5, false, `{"data": {"me":[
-			{"predname":"nameJ"}]}}`,
+			{"pname":"nameJ"}]}}`,
 		},
 		{12, 9, 5, true, `{"data": {"me":[
-			{"predname":"nameJ"}]}}`,
+			{"pname":"nameJ"}]}}`,
 		},
+		{13, 12, 5, false, `{"data": {"me":[]}}`},
+		{14, 12, 5, true, `{"data": {"me":[]}}`},
 	}
 
-	makeQuery := func(offset, first int32, desc bool, expected string) string {
-		order := "orderasc: pred"
+	makeQuery := func(offset, first int32, desc, index bool) string {
+		pred := "pred"
+		if index {
+			pred = "indexpred"
+		}
+		order := "orderasc: " + pred
 		if desc {
-			order = "orderdesc: pred"
+			order = "orderdesc: " + pred
 		}
 		qfunc := "me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), "
 		qfunc += order
@@ -2026,13 +2033,19 @@ func TestSortWithNulls(t *testing.T) {
 		if first != -1 {
 			qfunc += fmt.Sprintf(", first: %d", first)
 		}
-		query := "{" + qfunc + ") { predname pred } }"
+		query := "{" + qfunc + ") { pname " + pred + " } }"
 		return processQueryNoErr(t, query)
 	}
 
 	for _, tc := range tests {
-		actualRes := makeQuery(tc.offset, tc.first, tc.desc, tc.result)
-		require.JSONEqf(t, tc.result, actualRes, "Failed on testcase: %d\n", tc.index)
+		// Case of sort with Index.
+		expected := strings.Replace(tc.result, "pred", "indexpred", -1)
+		actual := makeQuery(tc.offset, tc.first, tc.desc, true)
+		require.JSONEqf(t, expected, actual, "Failed on index-testcase: %d\n", tc.index)
+
+		// Case of sort without index
+		actual = makeQuery(tc.offset, tc.first, tc.desc, false)
+		require.JSONEqf(t, tc.result, actual, "Failed on testcase: %d\n", tc.index)
 	}
 }
 

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1925,7 +1925,16 @@ func TestSortNull1(t *testing.T) {
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA","pred":"A"},{"predname":"nameB","pred":"B"},{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA","pred":"A"},
+	{"predname":"nameB","pred":"B"},
+	{"predname":"nameC","pred":"C"},
+	{"predname":"nameD","pred":"D"},
+	{"predname":"nameE","pred":"E"},
+	{"predname":"nameF"},
+	{"predname":"nameG"},
+	{"predname":"nameH"},
+	{"predname":"nameI"},
+	{"predname":"nameJ"}]}}`, js)
 }
 
 func TestSortNull1Desc(t *testing.T) {
@@ -1938,7 +1947,17 @@ func TestSortNull1Desc(t *testing.T) {
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"},{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"},{"predname":"nameA","pred":"A"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameE","pred":"E"},
+		{"predname":"nameD","pred":"D"},
+		{"predname":"nameC","pred":"C"},
+		{"predname":"nameB","pred":"B"},
+		{"predname":"nameA","pred":"A"},
+		{"predname":"nameF"},
+		{"predname":"nameG"},
+		{"predname":"nameH"},
+		{"predname":"nameI"},
+		{"predname":"nameJ"}]}}`, js)
 }
 
 func TestSortNull2(t *testing.T) {
@@ -1951,7 +1970,14 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7) 
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA","pred":"A"},{"predname":"nameB","pred":"B"},{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameA","pred":"A"},
+		{"predname":"nameB","pred":"B"},
+		{"predname":"nameC","pred":"C"},
+		{"predname":"nameD","pred":"D"},
+		{"predname":"nameE","pred":"E"},
+		{"predname":"nameF"},
+		{"predname":"nameG"}]}}`, js)
 }
 
 func TestSortNull2Desc(t *testing.T) {
@@ -1964,7 +1990,14 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7)
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"},{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameE","pred":"E"},
+		{"predname":"nameD","pred":"D"},
+		{"predname":"nameC","pred":"C"},
+		{"predname":"nameB","pred":"B"},
+		{"predname":"nameA","pred":"A"},
+		{"predname":"nameF"},
+		{"predname":"nameG"}]}}`, js)
 }
 
 func TestSortNull3(t *testing.T) {
@@ -1977,7 +2010,14 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7, 
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameC","pred":"C"},
+		{"predname":"nameD","pred":"D"},
+		{"predname":"nameE","pred":"E"},
+		{"predname":"nameF"},
+		{"predname":"nameG"},
+		{"predname":"nameH"},
+		{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull3Desc(t *testing.T) {
@@ -1990,7 +2030,14 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7,
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameC","pred":"C"},
+		{"predname":"nameB","pred":"B"},
+		{"predname":"nameA","pred":"A"},
+		{"predname":"nameF"},
+		{"predname":"nameG"},
+		{"predname":"nameH"},
+		{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull4(t *testing.T) {
@@ -2003,7 +2050,11 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 4, 
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameF"},
+		{"predname":"nameG"},
+		{"predname":"nameH"},
+		{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull4Desc(t *testing.T) {
@@ -2016,7 +2067,11 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 4,
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameF"},
+		{"predname":"nameG"},
+		{"predname":"nameH"},
+		{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull5(t *testing.T) {
@@ -2029,7 +2084,9 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 2) 
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA", "pred": "A"},{"predname":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameA", "pred": "A"},
+		{"predname":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestSortNull5Desc(t *testing.T) {
@@ -2042,7 +2099,9 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 2)
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[
+		{"predname":"nameE", "pred":"E"},
+		{"predname":"nameD", "pred": "D"}]}}`, js)
 }
 
 func TestMultiSortPaginateWithOffset(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1915,6 +1915,57 @@ func TestMultiSort7Paginate(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25},{"name":"Alice","age":75},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25}]}}`, js)
 }
 
+func TestSortNull1(t *testing.T) {
+
+	query := `{
+		me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"}]}}`, js)
+}
+
+func TestSortNull2(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"}]}}`, js)
+}
+
+func TestSortNull3(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7, offset: 2) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+}
+
+func TestSortNull4(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 4, offset: 5) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+}
 func TestMultiSortPaginateWithOffset(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1964,7 +1964,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7)
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"}, {"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"}]}}`, js)
 }
 
 func TestSortNull3(t *testing.T) {
@@ -1990,7 +1990,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7,
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestSortNull4(t *testing.T) {
@@ -2016,7 +2016,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 4,
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestMultiSortPaginateWithOffset(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1928,6 +1928,19 @@ func TestSortNull1(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"}]}}`, js)
 }
 
+func TestSortNull1Desc(t *testing.T) {
+
+	query := `{
+		me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
+}
+
 func TestSortNull2(t *testing.T) {
 
 	query := `{
@@ -1939,6 +1952,19 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7) 
 
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"}]}}`, js)
+}
+
+func TestSortNull2Desc(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"}, {"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
 }
 
 func TestSortNull3(t *testing.T) {
@@ -1954,6 +1980,19 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7, 
 	require.JSONEq(t, `{"data": {"me":[{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
 }
 
+func TestSortNull3Desc(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7, offset: 2) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
+}
+
 func TestSortNull4(t *testing.T) {
 
 	query := `{
@@ -1966,6 +2005,20 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 4, 
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
 }
+
+func TestSortNull4Desc(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 4, offset: 5) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+}
+
 func TestMultiSortPaginateWithOffset(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1938,7 +1938,7 @@ func TestSortNull1Desc(t *testing.T) {
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"},{"predname":"nameA","pred":"A"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"},{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"},{"predname":"nameA","pred":"A"}]}}`, js)
 }
 
 func TestSortNull2(t *testing.T) {
@@ -1964,7 +1964,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7)
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"},{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"}]}}`, js)
 }
 
 func TestSortNull3(t *testing.T) {
@@ -1990,7 +1990,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7,
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameH"},{"predname":"nameG"},{"predname":"nameF"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestSortNull4(t *testing.T) {
@@ -2042,7 +2042,7 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 2)
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameJ"},{"predname":"nameI"}]}}`, js)
 }
 
 func TestMultiSortPaginateWithOffset(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1919,117 +1919,130 @@ func TestSortNull1(t *testing.T) {
 
 	query := `{
 		me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA","pred":"A"},{"predname":"nameB","pred":"B"},{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"}]}}`, js)
 }
 
 func TestSortNull1Desc(t *testing.T) {
 
 	query := `{
 		me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"},{"name":"nameA","pred":"A"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"},{"predname":"nameA","pred":"A"}]}}`, js)
 }
 
 func TestSortNull2(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameA","pred":"A"},{"name":"nameB","pred":"B"},{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA","pred":"A"},{"predname":"nameB","pred":"B"},{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"}]}}`, js)
 }
 
 func TestSortNull2Desc(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"}]}}`, js)
 }
 
 func TestSortNull3(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 7, offset: 2) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameC","pred":"C"},{"name":"nameD","pred":"D"},{"name":"nameE","pred":"E"},{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameC","pred":"C"},{"predname":"nameD","pred":"D"},{"predname":"nameE","pred":"E"},{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull3Desc(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 7, offset: 2) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameH"},{"name":"nameI"},{"name":"nameJ"},{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameH"},{"predname":"nameI"},{"predname":"nameJ"},{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestSortNull4(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 4, offset: 5) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"},{"name":"nameH"},{"name":"nameI"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"},{"predname":"nameH"},{"predname":"nameI"}]}}`, js)
 }
 
 func TestSortNull4Desc(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 4, offset: 5) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameE","pred":"E"},{"predname":"nameD","pred":"D"},{"predname":"nameC","pred":"C"},{"predname":"nameB","pred":"B"}]}}`, js)
+}
+
+func TestSortNull5(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: pred, first: 2) {
+			predname
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameA", "pred": "A"},{"predname":"nameB","pred":"B"}]}}`, js)
 }
 
 func TestSortNull5Desc(t *testing.T) {
 
 	query := `{
 me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 2) {
-			name
+			predname
 			pred
 		}
 	}`
 
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"predname":"nameF"},{"predname":"nameG"}]}}`, js)
 }
 
 func TestMultiSortPaginateWithOffset(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1992,28 +1992,48 @@ func TestSortWithNulls(t *testing.T) {
 			{"pname":"nameH"},
 			{"pname":"nameI"}]}}`,
 		},
-		{9, 5, 5, false, `{"data": {"me":[
+		{9, 2, 100, false, `{"data": {"me":[
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameD","pred":"D"},
+			{"pname":"nameE","pred":"E"},
 			{"pname":"nameF"},
 			{"pname":"nameG"},
 			{"pname":"nameH"},
 			{"pname":"nameI"},
 			{"pname":"nameJ"}]}}`,
 		},
-		{10, 5, 5, true, `{"data": {"me":[
+		{10, 2, 100, true, `{"data": {"me":[
+			{"pname":"nameC","pred":"C"},
+			{"pname":"nameB","pred":"B"},
+			{"pname":"nameA","pred":"A"},
 			{"pname":"nameF"},
 			{"pname":"nameG"},
 			{"pname":"nameH"},
 			{"pname":"nameI"},
 			{"pname":"nameJ"}]}}`,
 		},
-		{11, 9, 5, false, `{"data": {"me":[
+		{11, 5, 5, false, `{"data": {"me":[
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
 			{"pname":"nameJ"}]}}`,
 		},
-		{12, 9, 5, true, `{"data": {"me":[
+		{12, 5, 5, true, `{"data": {"me":[
+			{"pname":"nameF"},
+			{"pname":"nameG"},
+			{"pname":"nameH"},
+			{"pname":"nameI"},
 			{"pname":"nameJ"}]}}`,
 		},
-		{13, 12, 5, false, `{"data": {"me":[]}}`},
-		{14, 12, 5, true, `{"data": {"me":[]}}`},
+		{13, 9, 5, false, `{"data": {"me":[
+			{"pname":"nameJ"}]}}`,
+		},
+		{14, 9, 5, true, `{"data": {"me":[
+			{"pname":"nameJ"}]}}`,
+		},
+		{15, 12, 5, false, `{"data": {"me":[]}}`},
+		{16, 12, 5, true, `{"data": {"me":[]}}`},
 	}
 
 	makeQuery := func(offset, first int32, desc, index bool) string {
@@ -2033,15 +2053,14 @@ func TestSortWithNulls(t *testing.T) {
 		if first != -1 {
 			qfunc += fmt.Sprintf(", first: %d", first)
 		}
-		query := "{" + qfunc + ") { pname " + pred + " } }"
+		query := "{" + qfunc + ") { pname pred:" + pred + " } }"
 		return processQueryNoErr(t, query)
 	}
 
 	for _, tc := range tests {
 		// Case of sort with Index.
-		expected := strings.Replace(tc.result, "pred", "indexpred", -1)
 		actual := makeQuery(tc.offset, tc.first, tc.desc, true)
-		require.JSONEqf(t, expected, actual, "Failed on index-testcase: %d\n", tc.index)
+		require.JSONEqf(t, tc.result, actual, "Failed on index-testcase: %d\n", tc.index)
 
 		// Case of sort without index
 		actual = makeQuery(tc.offset, tc.first, tc.desc, false)

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -2019,6 +2019,19 @@ me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 4,
 	require.JSONEq(t, `{"data": {"me":[{"name":"nameE","pred":"E"},{"name":"nameD","pred":"D"},{"name":"nameC","pred":"C"},{"name":"nameB","pred":"B"}]}}`, js)
 }
 
+func TestSortNull5Desc(t *testing.T) {
+
+	query := `{
+me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderdesc: pred, first: 2) {
+			name
+			pred
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me":[{"name":"nameF"},{"name":"nameG"}]}}`, js)
+}
+
 func TestMultiSortPaginateWithOffset(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -973,7 +973,13 @@ func TestLanguageOrderIndexed3(t *testing.T) {
 	require.JSONEq(t,
 		`{
 			"data": {
-				"q": []
+				"q": [{
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}, {
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}]
 			}
 		}`,
 		js)
@@ -993,7 +999,13 @@ func TestLanguageOrderIndexed4(t *testing.T) {
 	require.JSONEq(t,
 		`{
 			"data": {
-				"q": []
+				"q": [{
+					"name_lang_index@de": "öffnen",
+					"name_lang_index@sv": "zon"
+				}, {
+					"name_lang_index@de": "zumachen",
+					"name_lang_index@sv": "öppna"
+				}]
 			}
 		}`,
 		js)

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -221,11 +221,11 @@ func TestDateRDF(t *testing.T) {
 	require.NoError(t, err)
 	expected := `<0x1> <name> "Michonne" .
 <0x1> <gender> "female" .
-<0x1> <friend> <0x65> .
 <0x1> <friend> <0x19> .
 <0x1> <friend> <0x18> .
 <0x1> <friend> <0x17> .
 <0x1> <friend> <0x1f> .
+<0x1> <friend> <0x65> .
 <0x17> <name> "Rick Grimes" .
 <0x18> <name> "Glenn Rhee" .
 <0x19> <name> "Daryl Dixon" .

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -219,8 +219,7 @@ func TestDateRDF(t *testing.T) {
 	`
 	rdf, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
-	expected :=
-		`<0x1> <name> "Michonne" .
+	expected := `<0x1> <name> "Michonne" .
 <0x1> <gender> "female" .
 <0x1> <friend> <0x65> .
 <0x1> <friend> <0x19> .

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -219,8 +219,10 @@ func TestDateRDF(t *testing.T) {
 	`
 	rdf, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
-	require.Equal(t, rdf, `<0x1> <name> "Michonne" .
+	expected :=
+		`<0x1> <name> "Michonne" .
 <0x1> <gender> "female" .
+<0x1> <friend> <0x65> .
 <0x1> <friend> <0x19> .
 <0x1> <friend> <0x18> .
 <0x1> <friend> <0x17> .
@@ -233,5 +235,6 @@ func TestDateRDF(t *testing.T) {
 <0x18> <film.film.initial_release_date> "1909-05-05T00:00:00Z" .
 <0x19> <film.film.initial_release_date> "1929-01-10T00:00:00Z" .
 <0x1f> <film.film.initial_release_date> "1801-01-15T00:00:00Z" .
-`)
+`
+	require.Equal(t, expected, rdf)
 }

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -178,6 +178,7 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 	if ctx.Err() != nil {
 		return resultWithError(ctx.Err())
 	}
+
 	span := otrace.FromContext(ctx)
 	span.Annotate(nil, "sortWithIndex")
 
@@ -617,7 +618,6 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 			First:     0, // TODO: Should we set the first N here?
 		}
 		result, err := pl.Uids(listOpt) // The actual intersection work is done here.
-
 		if err != nil {
 			return err
 		}

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -321,7 +321,12 @@ BUCKETS:
 		}
 		nullsRequired := int(ts.Count) - len(r.UidMatrix[i].Uids)
 		canAppend := x.Min(uint64(nullsRequired), uint64(len(toAppend)))
-		r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, toAppend[:canAppend]...)
+		if order.Desc {
+			r.UidMatrix[i].Uids = append(toAppend[:canAppend], r.UidMatrix[i].Uids...)
+		} else {
+
+			r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, toAppend[:canAppend]...)
+		}
 	}
 
 	select {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -19,12 +19,10 @@ package worker
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -305,7 +303,7 @@ BUCKETS:
 			multiSortOffsets = append(multiSortOffsets, il.multiSortOffset)
 		}
 	}
-	spew.Dump(out)
+
 	var toAppend []uint64
 	for i, ul := range ts.UidMatrix {
 		present := make(map[uint64]bool)
@@ -321,9 +319,6 @@ BUCKETS:
 			}
 		}
 		reqCount := int(ts.Count) - len(r.UidMatrix[i].Uids)
-		fmt.Println("result", r.UidMatrix[i].Uids)
-		fmt.Println("skipped", out[i].skippedList.Uids)
-		fmt.Println("toappend", toAppend)
 		if order.Desc {
 			r.UidMatrix[i].Uids = append(out[i].skippedList.Uids, r.UidMatrix[i].Uids...)
 			r.UidMatrix[i].Uids = append(toAppend, r.UidMatrix[i].Uids...)
@@ -337,7 +332,6 @@ BUCKETS:
 			if int(ts.Count) < len(r.UidMatrix[i].Uids) {
 				r.UidMatrix[i].Uids = r.UidMatrix[i].Uids[:ts.Count]
 			}
-			fmt.Println("result", r.UidMatrix[i].Uids)
 		} else {
 			canAppend := x.Min(uint64(reqCount), uint64(len(toAppend)))
 			r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, toAppend[:canAppend]...)

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -585,9 +585,6 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 	out []intersectedList) error {
 	count := int(ts.Count)
 	order := ts.Order[0]
-	if order.Desc {
-		count = 1000
-	}
 	sType, err := schema.State().TypeOf(order.Attr)
 	if err != nil || !sType.IsScalar() {
 		return errors.Errorf("Cannot sort attribute %s of type object.", order.Attr)
@@ -605,6 +602,9 @@ func intersectBucket(ctx context.Context, ts *pb.SortMessage, token string,
 	// For each UID list, we need to intersect with the index bucket.
 	for i, ul := range ts.UidMatrix {
 		il := &out[i]
+		if order.Desc {
+			count = len(ul.Uids)
+		}
 		// We need to reduce multiSortOffset while checking the count as we might have included
 		// some extra uids from the bucket that the offset falls into. We are going to discard
 		// the first multiSortOffset number of uids later after all sorts are applied.

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/dgraph-io/badger/v2"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -304,7 +305,7 @@ BUCKETS:
 			multiSortOffsets = append(multiSortOffsets, il.multiSortOffset)
 		}
 	}
-
+	spew.Dump(out)
 	var toAppend []uint64
 	for i, ul := range ts.UidMatrix {
 		present := make(map[uint64]bool)
@@ -319,12 +320,21 @@ BUCKETS:
 				toAppend = append(toAppend, uid)
 			}
 		}
-		nullsRequired := int(ts.Count) - len(r.UidMatrix[i].Uids)
-		canAppend := x.Min(uint64(nullsRequired), uint64(len(toAppend)))
+		reqCount := int(ts.Count) - len(r.UidMatrix[i].Uids)
 		if order.Desc {
-			r.UidMatrix[i].Uids = append(toAppend[:canAppend], r.UidMatrix[i].Uids...)
+			toAppend = append(toAppend, out[i].skippedList.Uids...)
+			toAppend = append(toAppend, r.UidMatrix[i].Uids...)
+			r.UidMatrix[i].Uids = toAppend
+			if len(r.UidMatrix[i].Uids) > int(ts.Offset) {
+				r.UidMatrix[i].Uids = r.UidMatrix[i].Uids[ts.Offset:]
+			} else {
+				r.UidMatrix[i].Uids = nil
+			}
+			if int(ts.Count) < len(r.UidMatrix[i].Uids) {
+				r.UidMatrix[i].Uids = r.UidMatrix[i].Uids[:ts.Count]
+			}
 		} else {
-
+			canAppend := x.Min(uint64(reqCount), uint64(len(toAppend)))
 			r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, toAppend[:canAppend]...)
 		}
 	}


### PR DESCRIPTION
This PR makes the result of sort consistent for predicate with and without index. There was an issue that for predicate with index, we used to drop the nodes which doesn't contain the predicate used for sorting, while we retained them for that of without index. 

The nulls were dropped in thee case of `sortWithIndex` because in this case to calculate the result, we used to take intersection of the given list for sorting with the index of the predicate used for sorting, hence other predicates were dropped. In this change, we keep track of nodes which have null sort predicates and append them to the result as required.

Some benchmarks:
The dataset contain 1million UIDs, with half of them containing the predicate used for sorting. The time taken are in nano seconds.
```
No Index:
Query                                   Time
orderasc, first:100 ->                  7092526995
orderasc, offset:100000, first:100 ->   6809554104
orderdesc, first:100 ->                 6981851622
orderdesc, offset:100000, first:100 ->  6862242806

Index:
orderasc, first:100 ->                  1421648793
orderasc, offset:100000, first:100 ->   2044206032
orderdesc, first:100 ->                 1577750157
orderdesc, offset:100000, first:100 ->  1956177772
```

The results of the same queries on **Master**:
```
No Index:
orderasc, first:100 ->                  6881212989
orderasc, offset:100000, first:100 ->   7543954929
orderdesc, first:100 ->                 7327315514
orderdesc, offset:100000, first:100 ->  7262242806

Index:
orderasc, first:100 ->                  1410905825
orderasc, offset:100000, first:100 ->   1890659562
orderdesc, first:100 ->                 1404256406
orderdesc, offset:100000, first:100 ->  2106243131
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7241)
<!-- Reviewable:end -->
