### PR TITLE
fix(rollup): Periodically rollup keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20201214114056-bcfae6104545
+	github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20210104145141-d041618df3fe
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.1.2

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20201214114056-bcfae6104545 h1:s3361r5bydGBIq/TQruKAxPonvPPAe+6tKuvtNx6pY4=
-github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20201214114056-bcfae6104545/go.mod h1:5RUGROQEPbBw8Ba5Q4Tff8/dgwoJM6EeJCsCOLgSeek=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20210104145141-d041618df3fe h1:bwx4wmxmE/+OcsY0ZrKgZwu0UpwndgWlkC3yMkLM0nE=
+github.com/dgraph-io/badger/v2 v2.0.1-rc1.0.20210104145141-d041618df3fe/go.mod h1:5RUGROQEPbBw8Ba5Q4Tff8/dgwoJM6EeJCsCOLgSeek=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6 h1:toHzMCdCUgYsjM0cW9+wafnKFXfp1HizIJUyzihN+vk=
 github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6/go.mod h1:rHa+h3kI4M8ASOirxyIyNeXBfHFgeskVUum2OrDMN3U=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/ee/enc"
+	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/schema"
@@ -146,10 +147,11 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	raftServer.UpdateNode(gr.Node.Node)
 	gr.Node.InitAndStartNode()
 
-	gr.closer = z.NewCloser(3) // Match CLOSER:1 in this file.
+	gr.closer = z.NewCloser(4) // Match CLOSER:1 in this file.
 	go gr.sendMembershipUpdates()
 	go gr.receiveMembershipUpdates()
 	go gr.processOracleDeltaStream()
+	go posting.IncrRollup.Start(gr.closer)
 
 	gr.informZeroAboutTablets()
 	gr.proposeInitialSchema()


### PR DESCRIPTION
This PR adds support for periodic rollups since the existing implementation
is ineffective in rollups. We scan the entire DB and try to rollup 1000 deltas in each scan.

This PR depends upon https://github.com/dgraph-io/badger/pull/1633
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7242)
<!-- Reviewable:end -->
