### PR TITLE
Docs (update to v20.07) - Port encryption and use of mTLS for all internal gRPC communications

### DIFF
--- a/wiki/content/deploy/ports-usage.md
+++ b/wiki/content/deploy/ports-usage.md
@@ -6,72 +6,116 @@ weight = 3
     parent = "deploy"
 +++
 
-Dgraph cluster nodes use different ports to communicate over gRPC and HTTP. Users should pay attention while choosing these ports based on their topology and deployment-mode as each port needs different access security rules or firewall.
+Dgraph cluster nodes use a range of ports to communicate over gRPC and HTTP.
+Choose these ports carefully based on your topology and mode of deployment, as
+this will impact the access security rules or firewall configurations required
+for each port.
 
 ## Types of ports
 
-- **gRPC-internal:** Port that is used between the cluster nodes for internal communication and message exchange.
-- **gRPC-external:** Port that is used by Dgraph clients, Dgraph Live Loader , and Dgraph Bulk loader to access APIs over gRPC.
-- **http-external:** Port that is used by clients to access APIs over HTTP and other monitoring & administrative tasks.
+Dgraph Alpha and Dgraph Zero nodes use a variety of gRPC and HTTP ports, as
+follows:
 
-## Ports used by different nodes
+- **gRPC-internal-private**: Used between the cluster nodes for internal
+ communication and message exchange. Communication using these ports is
+ TLS-encrypted.
+- **gRPC-external-private**: Used by Dgraph Live Loader and Dgraph Bulk loader
+ to access APIs over gRPC.
+- **gRPC-external-public**: Used by Dgraph clients to access APIs in a session
+ that can persist after a query.
+- **HTTP-external-private**: Used for monitoring and administrative tasks.
+- **HTTP-external-public:** Used by clients to access APIs over HTTP.
 
- Dgraph Node Type |     gRPC-internal     | gRPC-external | HTTP-external
-------------------|-----------------------|---------------|---------------
-       zero       |      5080<sup>1</sup> | --Not Used--  |  6080<sup>2</sup>
-       alpha      |      7080             |     9080      |  8080
-       ratel      |  --Not Used--         | --Not Used--  |  8000
+## Default ports used by different nodes
+
+ Dgraph Node Type |  gRPC-internal-private | gRPC-external-private | gRPC-external-public | HTTP-external-private | HTTP-external-public
+------------------|------------------------|-----------------------|----------------------|-----------------------|---------------------
+       zero       |       5080<sup>1</sup> | 5080<sup>1</sup>      |                      | 6080<sup>2</sup>      |
+       alpha      |       7080             |                       |     9080             |                       |    8080
+       ratel      |                        |                       |                      |                       |    8000
 
 
-<sup>1</sup>: Dgraph Zero's gRPC-internal port is used for internal communication within the cluster. It's also needed for the [fast data loading]({{< relref "deploy/fast-data-loading.md" >}}) tools Dgraph Live Loader and Dgraph Bulk Loader.
+<sup>1</sup>: Dgraph Zero uses port 5080 for internal communication within the
+ cluster, and to support the [fast data loading]({{< relref "deploy/fast-data-loading.md" >}})
+ tools: Dgraph Live Loader and Dgraph Bulk Loader.
 
-<sup>2</sup>: Dgraph Zero's HTTP-external port is used for [admin]({{< relref "deploy/dgraph-zero.md" >}}) operations. Access to it is not required by clients.
+<sup>2</sup>: Dgraph Zero uses port 6080 for
+[administrative]({{< relref "deploy/dgraph-zero.md" >}}) operations. Dgraph
+clients cannot access this port.
 
-Users have to modify security rules or open firewall ports depending up on their underlying network to allow communication between cluster nodes and between the Dgraph instances themselves and between Dgraph and a client. A general rule is to make *-external (gRPC/HTTP) ports wide open to clients and gRPC-internal ports open within the cluster nodes.
+Users must modify security rules or open firewall ports depending upon their
+underlying network to allow communication between cluster nodes, between the
+Dgraph instances, and between Dgraph clients. In general, you should configure
+the gRPC and HTTP `external-public` ports for open access by Dgraph clients,
+and configure the gRPC-internal ports for open access by the cluster nodes.
 
-**Ratel UI** accesses Dgraph Alpha on the HTTP-external port (default localhost:8080) and can be configured to talk to remote Dgraph cluster. This way you can run Ratel on your local machine and point to a remote cluster. But if you are deploying Ratel along with Dgraph cluster, then you may have to expose 8000 to the public.
+**Ratel UI** accesses Dgraph Alpha on the `HTTP-external-public port` (which defaults to localhost:8080) and can be configured to talk to a remote Dgraph cluster. This
+way you can run Ratel on your local machine and point to a remote cluster. But,
+if you are deploying Ratel along with Dgraph cluster, then you may have to
+expose port 8000 to the public.
 
-**Port Offset** To make it easier for user to setup the cluster, Dgraph defaults the ports used by Dgraph nodes and let user to provide an offset  (through command option `--port_offset`) to define actual ports used by the node. Offset can also be used when starting multiple zero nodes in a HA setup.
+**Port Offset** To make it easier for users to set up a cluster, Dgraph has
+default values for the ports used by Dgraph nodes. To support multiple nodes
+running on a single machine or VM, you can set a node to use different ports
+using an offset (using the command option `--port_offset`). This command
+increments the actual ports used by the node by the offset value provided. You
+can also use port offsets when starting multiple Dgraph Zero nodes in a
+development environment.
 
-For example, when a user runs a Dgraph Alpha by setting `--port_offset 2`, then the Alpha node binds to 7082 (gRPC-internal), 8082 (HTTP-external) & 9082 (gRPC-external) respectively.
+For example, when a user runs Dgraph Alpha with the `--port_offset 2` setting,
+then the Alpha node binds to port 7082 (`gRPC-internal-private`), 8082
+(`HTTP-external-public`) and 9082 (`gRPC-external-public`), respectively.
 
-**Ratel UI** by default listens on port 8000. You can use the `-port` flag to configure to listen on any other port.
+**Ratel UI** by default listens on port 8000. You can use the `-port` flag to
+configure it to listen on any other port.
 
-## HA Cluster Setup
+## High Availability (HA) cluster configuration
 
-In a high-availability setup, we need to run 3 or 5 replicas for Zero, and similarly, 3 or 5 replicas for Alpha.
-{{% notice "note" %}}
-If number of replicas is 2K + 1, up to **K servers** can be down without any impact on reads or writes.
+In a HA cluster configuration, you should run three or five
+replicas for the Zero node, and three or five replicas for the Alpha node. A
+Dgraph cluster is divided into Raft groups, where Dgraph Zero is group 0 and
+each shard of Dgraph Alpha is a subsequent numbered group (group 1, group 2, etc.).
+The number of replicas in each Raft group must be an odd number for the group
+to have consensus, which will exist when the majority of nodes in a group are
+available.
 
-Avoid keeping replicas to 2K (even number). If K servers go down, this would block reads and writes, due to lack of consensus.
+{{% notice "tip" %}}
+If the number of replicas in a Raft group is **2N + 1**, up to **N** nodes can
+go offline without any impact on reads or writes. So, if there are five
+replicas, three must be online to avoid an impact to reads or writes.
 {{% /notice %}}
 
 ### Dgraph Zero
 
-Run three Zero instances, assigning a unique ID(Integer) to each via `--idx` flag, and
-passing the address of any healthy Zero instance via `--peer` flag.
+Run three Dgraph Zero instances, assigning a unique integer ID to each using the
+`--idx` flag, and passing the address of any healthy Zero instance using the
+`--peer` flag.
 
-To run three replicas for the alphas, set `--replicas=3`. Every time a new
-Dgraph Alpha is added, Zero would check the existing groups and assign them to
-one, which doesn't have three replicas.
+To run three replicas for the Alpha nodes, set `--replicas=3`. Each time a new
+Alpha node is added, the Zero node will check the existing groups and assign
+them as appropriate.
 
 ### Dgraph Alpha
-Run as many Dgraph Alphas as you want. You can manually set `--idx` flag, or you
-can leave that flag empty, and Zero would auto-assign an id to the Alpha. This
-id would get persisted in the write-ahead log, so be careful not to delete it.
+You can run as many Dgraph Alpha nodes as you want. You can manually set the
+`--idx` flag, or you can leave that flag empty, and the Zero node will
+auto-assign an id to the Alpha node. This id persists in the write-ahead log, so
+be careful not to delete it.
 
-The new Alphas will automatically detect each other by communicating with
-Dgraph zero and establish connections to each other. You can provide a list of
-zero addresses to alpha using the `--zero` flag. Alpha will try to connect to
-one of the zeros starting from the first zero address in the list. For example:
-`--zero=zero1,zero2,zero3` where zero1 is the `host:port` of a zero instance.
+The new Alpha nodes will automatically detect each other by communicating with
+Dgraph Zero and establish connections to each other. If you don't have a proxy
+or load balancer for the Zero nodes, you can provide a list of Zero node
+addresses for Alpha nodes to use at startup with the `--zero` flag. The Alpha
+node will try to connect to one of the Zero nodes starting from the first Zero
+node address in the list. For example:
+`--zero=zero1,zero2,zero3` where `zero1` is the `host:port` of a zero instance.
 
-Typically, Zero would first attempt to replicate a group, by assigning a new
-Dgraph alpha to run the same group as assigned to another. Once the group has
-been replicated as per the `--replicas` flag, Zero would create a new group.
+Typically, a Zero node would first attempt to replicate a group, by assigning a
+new Alpha node to run the same group previously assigned to another. After the
+group has been replicated per the `--replicas` flag, Dgraph Zero creates a new
+group.
 
-Over time, the data would be evenly split across all the groups. So, it's
-important to ensure that the number of Dgraph alphas is a multiple of the
-replication setting. For e.g., if you set `--replicas=3` in Zero, then run three
-Dgraph alphas for no sharding, but 3x replication. Run six Dgraph alphas, for
-sharding the data into two groups, with 3x replication.
+Over time, the data will be evenly split across all of the groups. So, it's
+important to ensure that the number of Alpha nodes is a multiple of the
+replication setting. For example, if you set `--replicas=3` in for a Zero node,
+and then run three Alpha nodes for no sharding, but 3x replication. Or, if you
+run six Alpha nodes, sharding the data into two groups, with 3x replication.

--- a/wiki/content/deploy/ports-usage.md
+++ b/wiki/content/deploy/ports-usage.md
@@ -46,13 +46,14 @@ clients cannot access this port.
 Users must modify security rules or open firewall ports depending upon their
 underlying network to allow communication between cluster nodes, between the
 Dgraph instances, and between Dgraph clients. In general, you should configure
-the gRPC and HTTP `external-public` ports for open access by Dgraph clients,
+the gRPC and HTTP external-public ports for open access by Dgraph clients,
 and configure the gRPC-internal ports for open access by the cluster nodes.
 
-**Ratel UI** accesses Dgraph Alpha on the `HTTP-external-public port` (which defaults to localhost:8080) and can be configured to talk to a remote Dgraph cluster. This
-way you can run Ratel on your local machine and point to a remote cluster. But,
-if you are deploying Ratel along with Dgraph cluster, then you may have to
-expose port 8000 to the public.
+**Ratel UI** accesses Dgraph Alpha on the HTTP-external-public port
+(which defaults to **localhost:8080**) and can be configured to talk to a remote
+Dgraph cluster. This way, you can run Ratel on your local machine and point to a
+remote cluster. But, if you are deploying Ratel along with Dgraph cluster, then
+you may have to expose port 8000 to the public.
 
 **Port Offset** To make it easier for users to set up a cluster, Dgraph has
 default values for the ports used by Dgraph nodes. To support multiple nodes
@@ -63,8 +64,8 @@ can also use port offsets when starting multiple Dgraph Zero nodes in a
 development environment.
 
 For example, when a user runs Dgraph Alpha with the `--port_offset 2` setting,
-then the Alpha node binds to port 7082 (`gRPC-internal-private`), 8082
-(`HTTP-external-public`) and 9082 (`gRPC-external-public`), respectively.
+then the Alpha node binds to port 7082 (gRPC-internal-private), 8082
+(HTTP-external-public) and 9082 (gRPC-external-public), respectively.
 
 **Ratel UI** by default listens on port 8000. You can use the `-port` flag to
 configure it to listen on any other port.

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -63,7 +63,7 @@ $ dgraph cert -n localhost -c dgraphuser
 $ dgraph cert ls
 ```
 
-The default location where the _cert_ command stores certificates (and keys) is
+The default location where the `dgraph cert` command stores certificates (and keys) is
 **tls** under the Dgraph working directory. You can override the default path
 using the `--dir` option. For example:
 
@@ -103,8 +103,8 @@ $ dgraph cert -n localhost,104.25.165.23,dgraph.io,2400:cb00:2048:1::6819:a417
 
 ### Certificate inspection
 
-The command **dgraph cert ls** lists all certificates and keys in the **--dir**
-directory (default 'tls'), along with details to inspect and validate cert/key pairs.
+The command `dgraph cert ls` lists all certificates and keys in the `--dir`
+directory (default `"tls"`), along with details to inspect and validate cert/key pairs.
 
 Example of command output:
 
@@ -267,7 +267,7 @@ $ cp /path/to/ca.crt /usr/local/share/ca-certificates/ca.crt
 # Update the CA store
 $ sudo update-ca-certificates`
 ```
-##### macOS X
+##### macOS
 ```sh
 $ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ca.crt
 ```

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -19,9 +19,9 @@ greater RSA or AES encryption are supported.
 
 {{% notice "tip" %}}If you're generating encrypted private keys with the `openssl`
 command, be sure to specify the encryption algorithm explicitly
-(like **-aes256**). This will force `openssl` to include the **DEK-Info** header
+(like `-aes256`). This will force OpenSSL to include the `DEK-Info` header
 in the private key, which Dgraph requires to decrypt the key. When default
-encryption is used, `openssl` doesn't write that header and the key can't be
+encryption is used, OpenSSL doesn't write that header and the key can't be
 decrypted.{{% /notice %}}
 
 ## Dgraph Certificate Management Tool
@@ -288,7 +288,7 @@ $ certutil -addstore -f "ROOT" /path/to/ca.crt
 * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Authorities
 * Click on Import and import the **ca.crt**
 
-### Step 3. Point ratel to the `https://` endpoint of alpha server.
+### Step 3. Point Ratel to the Dgraph Alpha server https:// endpoint
 
 * Change the Dgraph Alpha server address to **https://** instead of **http://**, for example **https://localhost:8080**.
 

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -160,6 +160,8 @@ Zero nodes:
 * `--tls_client_auth string` - TLS client authentication used to validate client
   connections from external ports. To learn more, see
   [Client authentication options](#client-authentication-options).
+* `--tls_internal_port_enabled` - When set to `true`, traffic over internal
+  ports (by default, 5080 and 7080) is TLS-encrypted.
 
 Dgraph Live Loader can be configured with the following options:
 
@@ -203,7 +205,7 @@ The following example shows how to encrypt both internal and external ports:
 # First, create a rootca, node, and client certificates and private keys
 $ dgraph cert -n localhost -c dgraphuser
 # Default use for enabling TLS server with client authentication (after generating certificates and private keys)
-$ dgraph alpha --tls_dir tls --tls_client_auth="REQUIREANDVERIFY"
+$ dgraph alpha --tls_dir tls --tls_client_auth="REQUIREANDVERIFY"  --tls_internal_port_enabled=true
 ```
 
 You can then run Dgraph Live Loader using the following:
@@ -321,19 +323,12 @@ succeed.
 
 ## Using Curl with Client authentication
 
-When TLS is enabled, `curl` requests to Dgraph will need some specific options to work.  For instance (for an export request):
-
-```
-curl --silent https://localhost:8080/admin/export
-```
-
-If you are using `curl` with [Client Authentication](#client-authentication-options) set to `REQUIREANY` or `REQUIREANDVERIFY`, you will need to provide the client certificate and private key.  For instance (for an export request):
+When TLS is enabled, `curl` requests to Dgraph will need some specific options
+to work. For example, see the following export:
 
 ```
 curl --silent --cacert ./tls/ca.crt --cert ./tls/client.dgraphuser.crt --key ./tls/client.dgraphuser.key https://localhost:8080/admin/export
 ```
-
-Refer to the `curl` documentation for further information on its TLS options.
 
 ## Access Data Using a Client
 

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -326,8 +326,8 @@ succeed.
 When TLS is enabled, `curl` requests to Dgraph will need some specific options
 to work. For example, see the following export:
 
-```
-curl --silent --cacert ./tls/ca.crt --cert ./tls/client.dgraphuser.crt --key ./tls/client.dgraphuser.key https://localhost:8080/admin/export
+```sh
+curl --silent --cacert ./tls/ca.crt https://localhost:8080/admin/export
 ```
 
 ## Access Data Using a Client

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -9,7 +9,7 @@ weight = 10
 Connections between Dgraph database and its clients can be secured using TLS. In
 addition, Dgraph can now secure gRPC communications between Dgraph Alpha and
 Dgraph Zero server nodes using mutual TLS (mTLS). Dgraph can now also secure
-communications over the Dgraph Zero `gRPC-external-private` port used by
+communications over the Dgraph Zero **gRPC-external-private** port used by
 Dgraph's Live Loader and Bulk Loader clients. To learn more about the HTTP and
 gRPC ports used by Dgraph Alpha and Dgraph Zero, see [Ports Usage](ports-usage).
 Password-protected private keys are **not supported**.
@@ -17,11 +17,12 @@ Password-protected private keys are **not supported**.
 To further improve TLS security, only TLS v1.2 cypher suites that use 128-bit or
 greater RSA or AES encryption are supported.
 
-{{% notice "tip" %}}If you're generating encrypted private keys with `openssl`,
-be sure to specify the encryption algorithm explicitly (like `-aes256`). This will
-force `openssl` to include `DEK-Info` header in private key, which is required
-to decrypt the key by Dgraph. When default encryption is used, `openssl` doesn't
-write that header and key can't be decrypted.{{% /notice %}}
+{{% notice "tip" %}}If you're generating encrypted private keys with the `openssl`
+command, be sure to specify the encryption algorithm explicitly
+(like **-aes256**). This will force `openssl` to include the **DEK-Info** header
+in the private key, which Dgraph requires to decrypt the key. When default
+encryption is used, `openssl` doesn't write that header and the key can't be
+decrypted.{{% /notice %}}
 
 ## Dgraph Certificate Management Tool
 
@@ -63,7 +64,7 @@ $ dgraph cert ls
 ```
 
 The default location where the _cert_ command stores certificates (and keys) is
-`tls` under the Dgraph working directory. You can override the default dir path
+**tls** under the Dgraph working directory. You can override the default path
 using the `--dir` option. For example:
 
 ```sh
@@ -88,7 +89,7 @@ The Root CA certificate is used for verifying node and client certificates, if c
 For client authentication, each client must have their own certificate and key.
 These are then used to connect to the Dgraph nodes.
 
-The node certificate `node.crt` can support multiple node names using multiple
+The node certificate (**node.crt**) can support multiple node names using multiple
 host names and/or IP address. Just separate the names with commas when
 generating the certificate.
 
@@ -102,7 +103,7 @@ $ dgraph cert -n localhost,104.25.165.23,dgraph.io,2400:cb00:2048:1::6819:a417
 
 ### Certificate inspection
 
-The command `dgraph cert ls` lists all certificates and keys in the `--dir`
+The command **dgraph cert ls** lists all certificates and keys in the **--dir**
 directory (default 'tls'), along with details to inspect and validate cert/key pairs.
 
 Example of command output:
@@ -145,7 +146,7 @@ Important points:
   regenerated. If the Root CA pair differ, all cert/key must be regenerated; the flag `--force`
   can help.
 * All certificates must pass Dgraph CA verification.
-* All key files should have the least access permissions, especially the `ca.key`, but be readable.
+* All key files should have the least access permissions, especially the **ca.key**, but be readable.
 * Key files won't be overwritten if they have limited access, even with `--force`.
 * Node certificates are only valid for the hosts listed.
 * Client certificates are only valid for the named client/user.
@@ -280,22 +281,22 @@ $ certutil -addstore -f "ROOT" /path/to/ca.crt
 ##### Firefox
 
 * Goto Preferences -> Prvacy & Security -> View Certificates -> Authorities
-* Click on Import and import the `ca.crt`
+* Click on Import and import the **ca.crt**
 
 ##### Chrome
 
 * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Authorities
-* Click on Import and import the `ca.crt`
+* Click on Import and import the **ca.crt**
 
 ### Step 3. Point ratel to the `https://` endpoint of alpha server.
 
-* Change the Dgraph Alpha server address to `https://` instead of `http://`, for example `https://localhost:8080`.
+* Change the Dgraph Alpha server address to **https://** instead of **http://**, for example **https://localhost:8080**.
 
-For `REQUIREANY` and `REQUIREANDVERIFY` as `--tls_client_auth` option, you need to follow the steps above and you
+For `REQUIREANY` and `REQUIREANDVERIFY` as the `--tls_client_auth` option, you need to follow the steps above and you
 also need to install client certificate on your browser:
 
 1. Generate a client certificate: `dgraph cert -c laptopuser`.
-2. Convert it to a `.p12` file:
+2. Convert it to a **.p12** file:
    ```sh
    openssl pkcs12 -export \
       -out laptopuser.p12 \
@@ -306,17 +307,17 @@ also need to install client certificate on your browser:
 
 3. Import the client certificate to your browser. It can be done in chrome as follows:
    * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Your Certificates
-   * Click on Import and import the `laptopuser.p12`. For mac OS, this process returns back to KeyChain, and under the area "My Certificates" select `laptopuser.p12`.
+   * Click on Import and import the **laptopuser.p12**. For macOS, this process returns back to KeyChain, and under the area "My Certificates" select **laptopuser.p12**.
 
 {{% notice "note" %}}
-Under macOS you can alternatively import the `.p12` file via command line by `security import ./laptopuser.p12 -P secretPassword`.
+Under macOS you can alternatively import the **.p12** file via command line using **security import ./laptopuser.p12 -P secretPassword**.
 {{% /notice %}}
 {{% notice "note" %}}
 Mutual TLS may not work in Firefox because Firefox is unable to send privately-signed client certificates, this issue is filed [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1662607).
 {{% /notice %}}
 
 
-Next time you use Ratel to connect to an alpha with Client authentication
+Next time you use Ratel to connect to an Alpha node with Client authentication
 enabled the browser will prompt you for a client certificate to use. Select the client's
 certificate you've imported in the step above and queries/mutations will
 succeed.
@@ -324,7 +325,7 @@ succeed.
 ## Using Curl with Client authentication
 
 When TLS is enabled, `curl` requests to Dgraph will need some specific options
-to work. For example, see the following export:
+to work. For example, see the following export command:
 
 ```sh
 curl --silent --cacert ./tls/ca.crt https://localhost:8080/admin/export
@@ -345,13 +346,14 @@ If you are getting errors in Ratel when TLS is enabled, try opening your Dgraph
 Alpha URL as a web page.
 
 Assuming you are running Dgraph on your local machine, opening
-`https://localhost:8080/` in the browser should produce a message `Dgraph browser is available for running separately using the dgraph-ratel binary`.
+**https://localhost:8080** in the browser should produce the following message:
+**Dgraph browser is available for running separately using the dgraph-ratel binary**.
 
 In case you are getting a connection error, try not passing the
-`--tls_client_auth` flag when starting an alpha. If you are still getting an
+`--tls_client_auth` flag when starting an Alpha node. If you are still getting an
 error, check that your hostname is correct and the port is open; then make sure
-that "Dgraph Root CA" certificate is installed and trusted correctly.
+that the Dgraph Root CA certificate is installed and trusted correctly.
 
 After that, if things work without `--tls_client_auth` but stop working when
-`REQUIREANY` and `REQUIREANDVERIFY` is set make sure the `.p12` file is
+`REQUIREANY` and `REQUIREANDVERIFY` is set make sure the **.p12** file is
 installed correctly.

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -267,7 +267,7 @@ $ cp /path/to/ca.crt /usr/local/share/ca-certificates/ca.crt
 # Update the CA store
 $ sudo update-ca-certificates`
 ```
-##### Mac OS X
+##### macOS X
 ```sh
 $ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ca.crt
 ```

--- a/wiki/content/deploy/tls-configuration.md
+++ b/wiki/content/deploy/tls-configuration.md
@@ -6,18 +6,41 @@ weight = 10
     parent = "deploy"
 +++
 
-{{% notice "note" %}}
-This section refers to the `dgraph cert` command which was introduced in v1.0.9. For previous releases, see the previous [TLS configuration documentation](https://dgraph.io/docs/v1.0.7/deploy/#tls-configuration).
-{{% /notice %}}
+Connections between Dgraph database and its clients can be secured using TLS. In
+addition, Dgraph can now secure gRPC communications between Dgraph Alpha and
+Dgraph Zero server nodes using mutual TLS (mTLS). Dgraph can now also secure
+communications over the Dgraph Zero `gRPC-external-private` port used by
+Dgraph's Live Loader and Bulk Loader clients. To learn more about the HTTP and
+gRPC ports used by Dgraph Alpha and Dgraph Zero, see [Ports Usage](ports-usage).
+Password-protected private keys are **not supported**.
 
+To further improve TLS security, only TLS v1.2 cypher suites that use 128-bit or
+greater RSA or AES encryption are supported.
 
-Connections between client and server can be secured with TLS. Password protected private keys are **not supported**.
-
-{{% notice "tip" %}}If you're generating encrypted private keys with `openssl`, be sure to specify encryption algorithm explicitly (like `-aes256`). This will force `openssl` to include `DEK-Info` header in private key, which is required to decrypt the key by Dgraph. When default encryption is used, `openssl` doesn't write that header and key can't be decrypted.{{% /notice %}}
+{{% notice "tip" %}}If you're generating encrypted private keys with `openssl`,
+be sure to specify the encryption algorithm explicitly (like `-aes256`). This will
+force `openssl` to include `DEK-Info` header in private key, which is required
+to decrypt the key by Dgraph. When default encryption is used, `openssl` doesn't
+write that header and key can't be decrypted.{{% /notice %}}
 
 ## Dgraph Certificate Management Tool
 
-The `dgraph cert` program creates and manages CA-signed certificates and private keys using a generated Dgraph Root CA. The `dgraph cert` command simplifies certificate management for you.
+{{% notice "note" %}}
+This section refers to the `dgraph cert` command which was introduced in v1.0.9.
+For previous releases, see the previous [TLS configuration documentation](https://dgraph.io/docs/v1.0.7/deploy/#tls-configuration).
+{{% /notice %}}
+
+The `dgraph cert` program creates and manages CA-signed certificates and private
+keys using a generated Dgraph Root CA. There are three types of certificate/key
+pairs:
+1. Root CA certificate/key pair: This is used to sign and verify node and client
+   certificates. If the root CA certificate is changed then you must regenerate
+   all certificates, and this certificate must be accessible to the Alpha nodes.
+2. Node certificate/key pair: This is shared by the Dgraph Alpha nodes and used
+   for accepting TLS connections.
+3. Client certificate/key pair: This is used by the clients (like live loader
+   and Ratel) to communicate with Dgraph Alpha server nodes where client
+   authentication with mTLS is required.
 
 ```sh
 # To see the available flags.
@@ -39,13 +62,15 @@ $ dgraph cert -n localhost -c dgraphuser
 $ dgraph cert ls
 ```
 
-### File naming conventions
-
-To enable TLS you must specify the directory path to find certificates and keys. The default location where the _cert_ command stores certificates (and keys) is `tls` under the Dgraph working directory; where the data files are found. The default dir path can be overridden using the `--dir` option.
+The default location where the _cert_ command stores certificates (and keys) is
+`tls` under the Dgraph working directory. You can override the default dir path
+using the `--dir` option. For example:
 
 ```sh
 $ dgraph cert --dir ~/mycerts
 ```
+
+### File naming conventions
 
 The following file naming conventions are used by Dgraph for proper TLS setup.
 
@@ -60,9 +85,12 @@ The following file naming conventions are used by Dgraph for proper TLS setup.
 
 The Root CA certificate is used for verifying node and client certificates, if changed you must regenerate all certificates.
 
-For client authentication, each client must have their own certificate and key. These are then used to connect to the Dgraph node(s).
+For client authentication, each client must have their own certificate and key.
+These are then used to connect to the Dgraph nodes.
 
-The node certificate `node.crt` can support multiple node names using multiple host names and/or IP address. Just separate the names with commas when generating the certificate.
+The node certificate `node.crt` can support multiple node names using multiple
+host names and/or IP address. Just separate the names with commas when
+generating the certificate.
 
 ```sh
 $ dgraph cert -n localhost,104.25.165.23,dgraph.io,2400:cb00:2048:1::6819:a417
@@ -74,7 +102,8 @@ $ dgraph cert -n localhost,104.25.165.23,dgraph.io,2400:cb00:2048:1::6819:a417
 
 ### Certificate inspection
 
-The command `dgraph cert ls` lists all certificates and keys in the `--dir` directory (default 'tls'), along with details to inspect and validate cert/key pairs.
+The command `dgraph cert ls` lists all certificates and keys in the `--dir`
+directory (default 'tls'), along with details to inspect and validate cert/key pairs.
 
 Example of command output:
 
@@ -121,13 +150,16 @@ Important points:
 * Node certificates are only valid for the hosts listed.
 * Client certificates are only valid for the named client/user.
 
-## TLS Options
+## TLS options
 
-The following configuration options are available for Alpha:
+The following configuration options are available for Dgraph Alpha and Dgraph
+Zero nodes:
 
 * `--tls_dir string` - TLS dir path; this enables TLS connections (usually 'tls').
 * `--tls_use_system_ca` - Include System CA with Dgraph Root CA.
-* `--tls_client_auth string` - TLS client authentication used to validate client connection. See [Client Authentication Options](#client-authentication-options) for details.
+* `--tls_client_auth string` - TLS client authentication used to validate client
+  connections from external ports. To learn more, see
+  [Client authentication options](#client-authentication-options).
 
 Dgraph Live Loader can be configured with the following options:
 
@@ -137,10 +169,11 @@ Dgraph Live Loader can be configured with the following options:
 * `--tls_key` - User private key file provided by the client to Alpha
 * `--tls_server_name string` - Server name, used for validating the server's TLS host name.
 
+### Using TLS with only external ports encrypted
 
-### Using TLS without Client Authentication
-
-For TLS without client authentication, you can configure certificates and run Alpha server using the following:
+To encrypt communication between Dgraph server nodes and clients over external
+ports, you can configure certificates and run Dgraph Alpha and Dgraph Zero using
+the following commands:
 
 ```sh
 # First, create rootca and node certificates and private keys
@@ -156,9 +189,15 @@ You can then run Dgraph live loader using the following:
 $ dgraph live --tls_cacert ./tls/ca.crt --tls_server_name "localhost" -s 21million.schema -f 21million.rdf.gz
 ```
 
-### Using TLS with Client Authentication
+### Using TLS with internal and external ports encrypted
 
-If you do require Client Authentication (Mutual TLS), you can configure certificates and run Alpha server using the following:
+If you require client authentication (mutual TLS, or mTLS), you can configure
+certificates and run Dgraph Alpha and Dgraph Zero with settings that encrypt
+both internal ports (those used within the cluster) as well as external ports
+(those used by clients that connect to the cluster, including Bulk Loader and
+Live Loader).
+
+The following example shows how to encrypt both internal and external ports:
 
 ```sh
 # First, create a rootca, node, and client certificates and private keys
@@ -167,7 +206,7 @@ $ dgraph cert -n localhost -c dgraphuser
 $ dgraph alpha --tls_dir tls --tls_client_auth="REQUIREANDVERIFY"
 ```
 
-You can then run Dgraph live loader using the following:
+You can then run Dgraph Live Loader using the following:
 
 ```sh
 # Now, connect to server using mTLS (mutual TLS)
@@ -182,7 +221,9 @@ $ dgraph live \
 
 ### Client Authentication Options
 
-The server will always **request** Client Authentication.  There are four different values for the `--tls_client_auth` option that change the security policy of the client certificate.
+The server will always **request** client authentication.  There are four
+different values for the `--tls_client_auth` option that change the security
+policy of the client certificate.
 
 | Value              | Client Cert/Key | Client Certificate Verified |
 |--------------------|-----------------|--------------------|
@@ -191,32 +232,91 @@ The server will always **request** Client Authentication.  There are four differ
 | `VERIFYIFGIVEN`    | optional        | Client certificate is VERIFIED if provided (default) |
 | `REQUIREANDVERIFY` | required        | Client certificate is always VERIFIED (most secure) |
 
-{{% notice "note" %}}REQUIREANDVERIFY is the most secure but also the most difficult to configure for remote clients. When using this value, the value of `--tls_server_name` is matched against the certificate SANs values and the connection host.{{% /notice %}}
+`REQUIREANDVERIFY` is the most secure but also the most difficult to configure
+for clients. When using this value, the value of `--tls_server_name` is matched
+against the certificate SANs values and the connection host.
+
+{{% notice "note" %}}If mTLS is enabled using `--tls_internal_port_enabled=true`,
+internal ports (by default, 5080 and 7080) use the `REQUIREANDVERIFY` setting.
+Unless otherwise configured, external ports (by default, 9080, 8080 and 6080)
+use the `VERIFYIFGIVEN` setting. Changing the `--tls_client_auth` option to
+another setting only affects client authentication on external ports.{{% /notice %}}
 
 ## Using Ratel UI with Client authentication
 
 Ratel UI (and any other JavaScript clients built on top of `dgraph-js-http`)
 connect to Dgraph servers via HTTP, when TLS is enabled servers begin to expect
-HTTPS requests only. Therefore some adjustments need to be made.
+HTTPS requests only.
 
-If the `--tls_client_auth` option is set to `REQUEST`or `VERIFYIFGIVEN` (default):
+If you haven't already created the CA certificate and the node certificate for alpha servers from the earlier instructions (see [Dgraph Certificate Management Tool](#dgraph-certificate-management-tool)), the first step would be to generate these certificates, it can be done by the following command:
+```sh
+# Create rootCA and node certificates/keys
+$ dgraph cert -n localhost
+```
 
-1. Change the connection URL from `http://` to `https://` (e.g. `https://127.0.0.1:8080`).
-2. Install / make trusted the certificate of the Dgraph certificate authority `ca.crt`. Refer to the documentation of your OS / browser for instructions
-(e.g. on Mac OS this means adding `ca.crt` to the KeyChain and making it trusted
-for `Secure Socket Layer`).
+If `--tls_client_auth` option in dgraph alpha is set to `REQUEST` or `VERIFYIFGIVEN` (default), then client certificate is not mandatory. The steps after generating CA/node certificate are as follows:
 
-For `REQUIREANY` and `REQUIREANDVERIFY` you need to follow the steps above and
-also need to install client certificate on your OS / browser:
+### Step 1. Install Dgraph Root CA into System CA
+##### Linux (Debian/Ubuntu)
+```sh
+# Copy the generated CA to the ca-certificates directory
+$ cp /path/to/ca.crt /usr/local/share/ca-certificates/ca.crt
+# Update the CA store
+$ sudo update-ca-certificates`
+```
+##### Mac OS X
+```sh
+$ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /path/to/ca.crt
+```
+##### Windows
+```sh
+$ certutil -addstore -f "ROOT" /path/to/ca.crt
+```
 
-1. Generate a client certificate: `dgraph cert -c MyLaptop`.
+### Step 2. Install Dgraph Root CA into Web Browsers Trusted CA List
+
+##### Firefox
+
+* Goto Preferences -> Prvacy & Security -> View Certificates -> Authorities
+* Click on Import and import the `ca.crt`
+
+##### Chrome
+
+* Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Authorities
+* Click on Import and import the `ca.crt`
+
+### Step 3. Point ratel to the `https://` endpoint of alpha server.
+
+* Change the Dgraph Alpha server address to `https://` instead of `http://`, for example `https://localhost:8080`.
+
+For `REQUIREANY` and `REQUIREANDVERIFY` as `--tls_client_auth` option, you need to follow the steps above and you
+also need to install client certificate on your browser:
+
+1. Generate a client certificate: `dgraph cert -c laptopuser`.
 2. Convert it to a `.p12` file:
-`openssl pkcs12 -export -out MyLaptopCert.p12 -in tls/client.MyLaptop.crt -inkey tls/client.MyLaptop.key`. Use any password you like for export.
-3. Install the generated `MyLaptopCert.p12` file on the client system
-(on Mac OS this means simply double-click the file in Finder).
-4. Next time you use Ratel to connect to an alpha with Client authentication
-enabled the browser will prompt you for a client certificate to use. Select the
-certificate you've just installed in the step above and queries/mutations will
+   ```sh
+   openssl pkcs12 -export \
+      -out laptopuser.p12 \
+      -in tls/client.laptopuser.crt \
+      -inkey tls/client.laptopuser.key
+   ```
+   Use any password you like for export, it is used to encrypt the p12 file.
+
+3. Import the client certificate to your browser. It can be done in chrome as follows:
+   * Goto Settings -> Privacy and Security -> Security -> Manage Certificates -> Your Certificates
+   * Click on Import and import the `laptopuser.p12`. For mac OS, this process returns back to KeyChain, and under the area "My Certificates" select `laptopuser.p12`.
+
+{{% notice "note" %}}
+Under macOS you can alternatively import the `.p12` file via command line by `security import ./laptopuser.p12 -P secretPassword`.
+{{% /notice %}}
+{{% notice "note" %}}
+Mutual TLS may not work in Firefox because Firefox is unable to send privately-signed client certificates, this issue is filed [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1662607).
+{{% /notice %}}
+
+
+Next time you use Ratel to connect to an alpha with Client authentication
+enabled the browser will prompt you for a client certificate to use. Select the client's
+certificate you've imported in the step above and queries/mutations will
 succeed.
 
 ## Using Curl with Client authentication
@@ -224,7 +324,7 @@ succeed.
 When TLS is enabled, `curl` requests to Dgraph will need some specific options to work.  For instance (for an export request):
 
 ```
-curl --silent --cacert ./tls/ca.crt https://localhost:8080/admin/export
+curl --silent https://localhost:8080/admin/export
 ```
 
 If you are using `curl` with [Client Authentication](#client-authentication-options) set to `REQUIREANY` or `REQUIREANDVERIFY`, you will need to provide the client certificate and private key.  For instance (for an export request):
@@ -246,11 +346,11 @@ Some examples of connecting via a [Client](/clients) when TLS is in use can be f
 
 ## Troubleshooting Ratel's Client authentication
 
-If you are getting errors in Ratel when server's TLS is enabled try opening
-your alpha URL as a webpage.
+If you are getting errors in Ratel when TLS is enabled, try opening your Dgraph
+Alpha URL as a web page.
 
 Assuming you are running Dgraph on your local machine, opening
-`https://localhost:8080/` in browser should produce a message `Dgraph browser is available for running separately using the dgraph-ratel binary`.
+`https://localhost:8080/` in the browser should produce a message `Dgraph browser is available for running separately using the dgraph-ratel binary`.
 
 In case you are getting a connection error, try not passing the
 `--tls_client_auth` flag when starting an alpha. If you are still getting an


### PR DESCRIPTION
Updates 20.07 docs to note the addition of mTLS and port encryption. This is not a cherry-pick of https://github.com/dgraph-io/dgraph/pull/6893 because in 20.07 we did not split the `tls_dir` option into  `tls_cacert`, `tls_node_key`, and `tls_node_cert`.

Fixes DGRAPH-2692
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7243)
<!-- Reviewable:end -->
