### PR TITLE
fix(GraphQL): Fix auth-token propagation for HTTP endpoints resolved through GraphQL (GRAPHQL-946)

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -642,6 +642,7 @@ func resolveWithAdminServer(gqlReq *schema.Request, r *http.Request,
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	ctx = x.AttachAccessJwt(ctx, r)
 	ctx = x.AttachRemoteIP(ctx, r)
+	ctx = x.AttachAuthToken(ctx, r)
 
 	return adminServer.Resolve(ctx, gqlReq)
 }

--- a/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
+++ b/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
@@ -17,7 +17,9 @@
 package admin_auth
 
 import (
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/x"
@@ -51,6 +53,20 @@ func TestAdminOnlyPoorManAuth(t *testing.T) {
 	common.SafelyUpdateGQLSchema(t, common.Alpha1HTTP, schema, headers)
 }
 
+func TestPoorManAuthOnAdminSchemaHttpEndpoint(t *testing.T) {
+	// without X-Dgraph-AuthToken should give error
+	require.Contains(t, makeAdminSchemaRequest(t, ""), "Invalid X-Dgraph-AuthToken")
+
+	// setting a wrong value for the token should still give error
+	require.Contains(t, makeAdminSchemaRequest(t, wrongAuthToken), "Invalid X-Dgraph-AuthToken")
+
+	// setting correct value for the token should successfully update the schema
+	oldCounter := common.RetryProbeGraphQL(t, common.Alpha1HTTP).SchemaUpdateCounter
+	require.JSONEq(t, `{"data":{"code":"Success","message":"Done"}}`, makeAdminSchemaRequest(t,
+		authToken))
+	common.AssertSchemaUpdateCounterIncrement(t, common.Alpha1HTTP, oldCounter)
+}
+
 func assertAuthTokenError(t *testing.T, schema string, headers http.Header) {
 	resp := common.RetryUpdateGQLSchema(t, common.Alpha1HTTP, schema, headers)
 	require.Equal(t, x.GqlErrorList{{
@@ -58,4 +74,24 @@ func assertAuthTokenError(t *testing.T, schema string, headers http.Header) {
 		Extensions: map[string]interface{}{"code": "ErrorUnauthorized"},
 	}}, resp.Errors)
 	require.Nil(t, resp.Data)
+}
+
+func makeAdminSchemaRequest(t *testing.T, authTokenValue string) string {
+	schema := `type Person {
+		id: ID!
+		name: String! @id
+	}`
+	req, err := http.NewRequest(http.MethodPost, common.GraphqlAdminURL+"/schema",
+		strings.NewReader(schema))
+	require.NoError(t, err)
+	if authTokenValue != "" {
+		req.Header.Set(authTokenHeader, authTokenValue)
+	}
+
+	resp, err := (&http.Client{}).Do(req)
+	require.NoError(t, err)
+	b, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	return string(b)
 }

--- a/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
+++ b/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
@@ -90,6 +90,7 @@ func makeAdminSchemaRequest(t *testing.T, authTokenValue string) string {
 
 	resp, err := (&http.Client{}).Do(req)
 	require.NoError(t, err)
+	defer resp.Body.Close()
 	b, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Fixes [Discuss Issue](https://discuss.dgraph.io/t/alpha-problems-with-auth-token/12136).
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7245)
<!-- Reviewable:end -->
