### PR TITLE
docs(How-To-Guide): update and correct "Simple Login System"

### DIFF
--- a/wiki/content/howto/login-system.md
+++ b/wiki/content/howto/login-system.md
@@ -40,9 +40,7 @@ resp, err := txn.Query(ctx, q)
 // be found. Otherwise it will contain a bool to indicate if the password matched.
 var login struct {
     Account []struct {
-        Pass []struct {
-            CheckPwd bool `json:"checkpwd"`
-        } `json:"pass"`
+            CheckPwd bool `json:"checkpwd(pass)"`
     } `json:"login_attempt"`
 }
 err = json.Unmarshal(resp.GetJson(), &login); err != nil {
@@ -56,7 +54,7 @@ if len(login.Account) == 0 {
     _, err = txn.Mutate(ctx, mu)
     // Commit the mutation, making it visible outside of the transaction.
     err = txn.Commit(ctx)
-} else if login.Account[0].Pass[0].CheckPwd {
+} else if login.Account[0].CheckPwd {
     fmt.Println("Login successful!")
 } else {
     fmt.Println("Wrong email or password.")


### PR DESCRIPTION
Using v20.11.0 the how-to guide seems outdated as the returned json does not match with the defined struct and leads to index out of range panics when accessing the not existing "Pass" field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7246)
<!-- Reviewable:end -->
