### PR TITLE
[UNDO-BREAKING] fix(zero-snapshot): Do not break the raftwal format due to ZeroSnapshot

### DIFF
--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -77,11 +77,11 @@ func printBasic(store RaftStore) (uint64, uint64) {
 	} else {
 		fmt.Printf("Snapshot Metadata: %+v\n", snap.Metadata)
 		var ds pb.Snapshot
-		var ms pb.MembershipState
+		var zs pb.ZeroSnapshot
 		if err := ds.Unmarshal(snap.Data); err == nil {
 			fmt.Printf("Snapshot Alpha: %+v\n", ds)
-		} else if err := ms.Unmarshal(snap.Data); err == nil {
-			for gid, group := range ms.GetGroups() {
+		} else if err := zs.Unmarshal(snap.Data); err == nil {
+			for gid, group := range zs.State.GetGroups() {
 				fmt.Printf("\nGROUP: %d\n", gid)
 				for _, member := range group.GetMembers() {
 					fmt.Printf("Member: %+v .\n", member)
@@ -93,8 +93,8 @@ func printBasic(store RaftStore) (uint64, uint64) {
 				group.Tablets = nil
 				fmt.Printf("Group: %d %+v .\n", gid, group)
 			}
-			ms.Groups = nil
-			fmt.Printf("\nSnapshot Zero: %+v\n", ms)
+			zs.State.Groups = nil
+			fmt.Printf("\nSnapshot Zero: %+v\n", zs)
 		} else {
 			fmt.Printf("Unable to unmarshal Dgraph snapshot: %v", err)
 		}

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -316,9 +316,7 @@ func (n *node) applySnapshot(snap *pb.ZeroSnapshot) error {
 	}
 	n.server.orc.purgeBelow(snap.CheckpointTs)
 
-	// We are storing only the MembershipState in the meta file. The other 2 fields of ZeroSnapshot;
-	// Index and CheckpointTs need not be persisted as they are used only for in-memory operations.
-	data, err := snap.GetState().Marshal()
+	data, err := snap.Marshal()
 	x.Check(err)
 
 	for {
@@ -550,11 +548,11 @@ func (n *node) initAndStartNode() error {
 			// It is important that we pick up the conf state here.
 			n.SetConfState(&sp.Metadata.ConfState)
 
-			var ms pb.MembershipState
-			x.Check(ms.Unmarshal(sp.Data))
-			n.server.SetMembershipState(&ms)
+			var zs pb.ZeroSnapshot
+			x.Check(zs.Unmarshal(sp.Data))
+			n.server.SetMembershipState(zs.State)
 			for _, id := range sp.Metadata.ConfState.Nodes {
-				n.Connect(id, ms.Zeros[id].Addr)
+				n.Connect(id, zs.State.Zeros[id].Addr)
 			}
 		}
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -867,9 +867,9 @@ func (n *node) Run() {
 			}
 
 			if !raft.IsEmptySnap(rd.Snapshot) {
-				var state pb.MembershipState
-				x.Check(state.Unmarshal(rd.Snapshot.Data))
-				n.server.SetMembershipState(&state)
+				var zs pb.ZeroSnapshot
+				x.Check(zs.Unmarshal(rd.Snapshot.Data))
+				n.server.SetMembershipState(zs.State)
 			}
 
 			for _, entry := range rd.CommittedEntries {


### PR DESCRIPTION
We introduced a change in https://github.com/dgraph-io/dgraph/pull/7143 that would have been breaking for the next release v21.03. That change should have been a part of `release/v20.11` but was mistakenly missed. We are doing a revert so that `release/v21.03` is not breaking due to that change. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7249)
<!-- Reviewable:end -->
