### PR TITLE
debug(uidpack): add checks for uid pack in debug mode

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -918,6 +918,7 @@ func (out *rollupOutput) marshalPostingListPart(alloc *z.Allocator,
 // MarshalPostingList returns a KV with the marshalled posting list. The caller
 // SHOULD SET the Key and Version for the returned KV.
 func MarshalPostingList(plist *pb.PostingList, alloc *z.Allocator) *bpb.KV {
+	x.VerifyPack(plist)
 	kv := y.NewKV(alloc)
 	if isPlistEmpty(plist) {
 		kv.Value = nil
@@ -1073,6 +1074,7 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		}
 	} else {
 		// We already have a nicely packed posting list. Just use it.
+		x.VerifyPack(l.plist)
 		out.plist = l.plist
 	}
 

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
@@ -1028,6 +1029,64 @@ func TestMultiPartListBasic(t *testing.T) {
 	for i, uid := range l.Uids {
 		require.Equal(t, uint64(i+1), uid)
 	}
+}
+
+// Checks if the binSplit works correctly.
+func TestBinSplit(t *testing.T) {
+	createList := func(t *testing.T, size int) *List {
+		originalListSize := maxListSize
+		maxListSize = math.MaxInt32
+		defer func() {
+			maxListSize = originalListSize
+		}()
+		key := x.DataKey(uuid.New().String(), 1331)
+		ol, err := getNew(key, ps, math.MaxUint64)
+		require.NoError(t, err)
+		for i := 1; i <= size; i++ {
+			edge := &pb.DirectedEdge{
+				ValueId: uint64(i),
+				Label:   strconv.Itoa(i),
+			}
+			txn := Txn{StartTs: uint64(i)}
+			addMutationHelper(t, ol, edge, Set, &txn)
+			require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+		}
+
+		kvs, err := ol.Rollup(nil)
+		for _, kv := range kvs {
+			require.Equal(t, uint64(size+1), kv.Version)
+		}
+		require.NoError(t, err)
+		require.NoError(t, writePostingListToDisk(kvs))
+		ol, err = getNew(key, ps, math.MaxUint64)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(ol.plist.Splits))
+		require.Equal(t, size, len(ol.plist.Postings))
+		return ol
+	}
+	verifyBinSplit := func(t *testing.T, ol *List, startUids []uint64, pls []*pb.PostingList) {
+		require.Equal(t, 2, len(startUids))
+		require.Equal(t, 2, len(pls))
+		uids := codec.Decode(ol.plist.Pack, 0)
+		lowUids := codec.Decode(pls[0].Pack, startUids[0])
+		highUids := codec.Decode(pls[1].Pack, startUids[1])
+		require.Equal(t, uids, append(lowUids, highUids...))
+		require.Equal(t, ol.plist.Postings, append(pls[0].Postings, pls[1].Postings...))
+	}
+	size := int(1e5)
+	ol := createList(t, size)
+	require.Equal(t, size, len(ol.plist.Postings))
+	postings := ol.plist.Postings
+	startUids, pls := binSplit(1, ol.plist)
+	verifyBinSplit(t, ol, startUids, pls)
+
+	// Artifically modify the ol.plist.Posting for purpose of checking binSplit.
+	ol.plist.Postings = postings[:size/3]
+	startUids, pls = binSplit(1, ol.plist)
+	verifyBinSplit(t, ol, startUids, pls)
+	ol.plist.Postings = postings[:0]
+	startUids, pls = binSplit(1, ol.plist)
+	verifyBinSplit(t, ol, startUids, pls)
 }
 
 // Verify that iteration works with an afterUid value greater than zero.

--- a/x/debug.go
+++ b/x/debug.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	bpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/pkg/errors"
 )
 
 // VerifyPack checks that the Pack should not be nil if the postings exist.
@@ -61,6 +60,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 			err := item.Value(func(v []byte) error {
 				plist := &pb.PostingList{}
 				Check(plist.Unmarshal(v))
+				VerifyPack(plist)
 				if len(plist.Splits) == 0 {
 					return nil
 				}
@@ -84,11 +84,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 				}
 				return nil
 			})
-			if err != nil {
-				err = errors.Wrapf(err, "Error getting value of key: %v version: %v", k, item.Version())
-				CaptureSentryException(err)
-				log.Fatalf("%+v", err)
-			}
+			Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
 
 			if item.DiscardEarlierVersions() {
 				break

--- a/x/debug.go
+++ b/x/debug.go
@@ -26,8 +26,15 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	bpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
+	"github.com/pkg/errors"
 )
+
+// VerifyPack checks that the Pack should not be nil if the postings exist.
+func VerifyPack(plist *pb.PostingList) {
+	if plist.Pack == nil && len(plist.Postings) > 0 {
+		log.Panic("UID Pack verification failed: Pack is nil for posting list: %+v", plist)
+	}
+}
 
 // VerifySnapshot iterates over all the keys in badger. For all data keys it checks
 // if key is a split key and it verifies if all part are present in badger as well.
@@ -77,7 +84,11 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 				}
 				return nil
 			})
-			x.Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
+			if err != nil {
+				err = errors.Wrapf(err, "Error getting value of key: %v version: %v", k, item.Version())
+				CaptureSentryException(err)
+				log.Fatalf("%+v", err)
+			}
 
 			if item.DiscardEarlierVersions() {
 				break

--- a/x/nodebug.go
+++ b/x/nodebug.go
@@ -25,6 +25,10 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
+// VerifyPack works in debug mode. Check out the comment in debug_on.go
+func VerifyPack(plist *pb.PostingList) {
+}
+
 // VerifySnapshot works in debug mode. Check out the comment in debug_on.go
 func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 }


### PR DESCRIPTION
Fixes DGRAPH-2840

This PR adds checks for verification of plist's uidpack when dgraph is run in debug mode.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7250)
<!-- Reviewable:end -->
