### PR TITLE
v20.07: fix(GraphQL): Fix auth-token propagation for HTTP endpoints resolved …

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -616,6 +616,7 @@ func resolveWithAdminServer(gqlReq *schema.Request, r *http.Request,
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 	ctx = x.AttachAccessJwt(ctx, r)
 	ctx = x.AttachRemoteIP(ctx, r)
+	ctx = x.AttachAuthToken(ctx, r)
 
 	return adminServer.Resolve(ctx, gqlReq)
 }


### PR DESCRIPTION
…through GraphQL (GRAPHQL-946) (#7245)

Fixes [Discuss Issue](https://discuss.dgraph.io/t/alpha-problems-with-auth-token/12136).

(cherry picked from commit 146c4f18524f1133fc5f52bffc47a03eaf982a5e)

\# Conflicts:
\#	graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7252)
<!-- Reviewable:end -->
