### PR TITLE
Docs (Chore) Change example query for between function to run more quickly

### DIFF
--- a/wiki/content/query-language/functions.md
+++ b/wiki/content/query-language/functions.md
@@ -413,12 +413,11 @@ A common use case for the `between` keyword is to search within a
 dataset indexed by `dateTime`. The following example query demonstrates this
 use case.
 
-Query Example: Movies released between the start of 1976 and the end of 1983,
-listed by genre.
+Query Example: Movies initially released in 1977, listed by genre.
 
 {{< runnable >}}
 {
-  me(func: between(initial_release_date, "1976-01-01", "1983-12-31")) {
+  me(func: between(initial_release_date, "1977-01-01", "1977-12-31")) {
     name@en
     genre {
       name@en


### PR DESCRIPTION
Fixes the example query for the `between` function in DQL to return a smaller data set and run in seconds, rather than minutes (the current query functions, but is larger than it should be ).

Staged here: https://deploy-preview-7262--dgraph-docs.netlify.app/query-language/functions/#between

Fixes GRAPHQL-811
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7262)
<!-- Reviewable:end -->
