### PR TITLE
fix(dgraph): fixing race condition in disk storage sync and save

### DIFF
--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -374,6 +374,9 @@ func (w *DiskStorage) NumLogFiles() int {
 
 // Sync calls the Sync method in the underlying badger instance to write all the contents to disk.
 func (w *DiskStorage) Sync() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
 	if err := w.meta.Sync(); err != nil {
 		return errors.Wrapf(err, "while syncing meta")
 	}


### PR DESCRIPTION
This PR fix following race condition
```
Write at 0x00c000306e00 by goroutine 242:
  github.com/dgraph-io/ristretto/z.(*MmapFile).Truncate()
      /home/agent/go/pkg/mod/github.com/dgraph-io/ristretto@v0.0.4-0.20201218073023-6a5070bff779/z/file_linux.go:35 +0x479
  github.com/dgraph-io/ristretto/z.(*MmapFile).AllocateSlice()
      /home/agent/go/pkg/mod/github.com/dgraph-io/ristretto@v0.0.4-0.20201218073023-6a5070bff779/z/file.go:148 +0x279
  github.com/dgraph-io/dgraph/raftwal.(*wal).AddEntries()
      /home/agent/work/4c273890c7f2d4e2/raftwal/wal.go:184 +0x8fa
  github.com/dgraph-io/dgraph/raftwal.(*DiskStorage).Save()
      /home/agent/work/4c273890c7f2d4e2/raftwal/storage.go:332 +0xf8
  github.com/dgraph-io/dgraph/conn.(*Node).SaveToStorage()
      /home/agent/work/4c273890c7f2d4e2/conn/node.go:288 +0xf7
  github.com/dgraph-io/dgraph/worker.(*node).Run()
      /home/agent/work/4c273890c7f2d4e2/worker/draft.go:1195 +0x40c

Previous read at 0x00c000306e00 by goroutine 248:
  github.com/dgraph-io/ristretto/z.(*MmapFile).Sync()
      /home/agent/go/pkg/mod/github.com/dgraph-io/ristretto@v0.0.4-0.20201218073023-6a5070bff779/z/file.go:161 +0x1a4
  github.com/dgraph-io/dgraph/raftwal.(*DiskStorage).Sync()
      /home/agent/work/4c273890c7f2d4e2/raftwal/storage.go:380 +0x96
  github.com/dgraph-io/dgraph/x.StoreSync()
      /home/agent/work/4c273890c7f2d4e2/x/x.go:1065 +0x1e2

Goroutine 242 (running) created at:
  github.com/dgraph-io/dgraph/worker.(*node).InitAndStartNode()
      /home/agent/work/4c273890c7f2d4e2/worker/draft.go:1737 +0x849
  github.com/dgraph-io/dgraph/worker.StartRaftNodes()
      /home/agent/work/4c273890c7f2d4e2/worker/groups.go:147 +0xbd9
  github.com/dgraph-io/dgraph/dgraph/cmd/alpha.run.func4()
      /home/agent/work/4c273890c7f2d4e2/dgraph/cmd/alpha/run.go:760 +0x73

Goroutine 248 (running) created at:
  github.com/dgraph-io/dgraph/worker.(*node).Run()
      /home/agent/work/4c273890c7f2d4e2/worker/draft.go:1076 +0x31ef
==================
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7263)
<!-- Reviewable:end -->
