### PR TITLE
fix(Dgraph): remove cyclic import

### DIFF
--- a/x/debug.go
+++ b/x/debug.go
@@ -26,7 +26,6 @@ import (
 	"github.com/dgraph-io/badger/v2"
 	bpb "github.com/dgraph-io/badger/v2/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 )
 
 // VerifySnapshot iterates over all the keys in badger. For all data keys it checks
@@ -77,7 +76,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 				}
 				return nil
 			})
-			x.Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
+			Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
 
 			if item.DiscardEarlierVersions() {
 				break


### PR DESCRIPTION
Debug builds are broken due to a file importing its own package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7271)
<!-- Reviewable:end -->
