### PR TITLE
feat(tool/decrypt): Add dgraph decrypt tool (#7248)

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/migrate"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/version"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/zero"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/tool"
 	"github.com/dgraph-io/dgraph/upgrade"
 	"github.com/dgraph-io/dgraph/x"
 
@@ -75,7 +76,7 @@ var rootConf = viper.New()
 // subcommands initially contains all default sub-commands.
 var subcommands = []*x.SubCommand{
 	&bulk.Bulk, &cert.Cert, &conv.Conv, &live.Live, &alpha.Alpha, &zero.Zero, &version.Version,
-	&debug.Debug, &increment.Increment, &migrate.Migrate, &debuginfo.DebugInfo, &upgrade.Upgrade,
+	&debug.Debug, &increment.Increment, &migrate.Migrate, &debuginfo.DebugInfo, &upgrade.Upgrade, tool.Tool
 }
 
 func initCmds() {

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -30,9 +30,9 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/increment"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/live"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/migrate"
+	"github.com/dgraph-io/dgraph/dgraph/cmd/tool"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/version"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/zero"
-	"github.com/dgraph-io/dgraph/dgraph/cmd/tool"
 	"github.com/dgraph-io/dgraph/upgrade"
 	"github.com/dgraph-io/dgraph/x"
 
@@ -76,7 +76,7 @@ var rootConf = viper.New()
 // subcommands initially contains all default sub-commands.
 var subcommands = []*x.SubCommand{
 	&bulk.Bulk, &cert.Cert, &conv.Conv, &live.Live, &alpha.Alpha, &zero.Zero, &version.Version,
-	&debug.Debug, &increment.Increment, &migrate.Migrate, &debuginfo.DebugInfo, &upgrade.Upgrade, tool.Tool
+	&debug.Debug, &increment.Increment, &migrate.Migrate, &debuginfo.DebugInfo, &upgrade.Upgrade, &tool.Tool,
 }
 
 func initCmds() {

--- a/dgraph/cmd/tool/decrypt/decrypt.go
+++ b/dgraph/cmd/tool/decrypt/decrypt.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/dgraph-io/dgraph/ee/enc"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/spf13/cobra"
+)
+
+type options struct {
+	// keyfile comes from the encryption_key_file or Vault flags
+	keyfile x.SensitiveByteSlice
+	file    string
+	output  string
+}
+
+var Decrypt x.SubCommand
+
+func init() {
+	Decrypt.Cmd = &cobra.Command{
+		Use:   "decrypt",
+		Short: "Run Decrypt tool",
+		Long:  "A tool to decrypt an export file created by an encrypted Dgraph cluster",
+		Run: func(cmd *cobra.Command, args []string) {
+			run()
+		},
+	}
+	Decrypt.EnvPrefix = "DGRAPH_TOOL_DECRYPT"
+	flag := Decrypt.Cmd.Flags()
+	flag.StringP("file", "f", "", "Path to file to decrypt.")
+	flag.StringP("out", "o", "", "Path to the decrypted file.")
+	enc.RegisterFlags(flag)
+}
+func run() {
+	opts := options{
+		file:   Decrypt.Conf.GetString("file"),
+		output: Decrypt.Conf.GetString("out"),
+	}
+	sensitiveKey, err := enc.ReadKey(Decrypt.Conf)
+	x.Checkf(err, "could not read encryption key file")
+	opts.keyfile = sensitiveKey
+	if len(opts.keyfile) == 0 {
+		log.Fatal("Error while reading encryption key: Key is empty")
+	}
+	f, err := os.Open(opts.file)
+	if err != nil {
+		log.Fatalf("Error opening file: %v\n", err)
+	}
+	defer f.Close()
+	reader, err := enc.GetReader(opts.keyfile, f)
+	x.Checkf(err, "could not open key reader")
+	if strings.HasSuffix(strings.ToLower(opts.file), ".gz") {
+		reader, err = gzip.NewReader(reader)
+		x.Check(err)
+	}
+	outf, err := os.OpenFile(opts.output, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		log.Fatalf("Error while opening output file: %v\n", err)
+	}
+	w := gzip.NewWriter(outf)
+	fmt.Printf("Decrypting %s\n", opts.file)
+	fmt.Printf("Writing to %v\n", opts.output)
+	_, err = io.Copy(w, reader)
+	if err != nil {
+		log.Fatalf("Error while writing: %v\n", err)
+	}
+	err = w.Flush()
+	x.Check(err)
+	err = w.Close()
+	x.Check(err)
+	err = outf.Close()
+	x.Check(err)
+	fmt.Println("Done.")
+}

--- a/dgraph/cmd/tool/run.go
+++ b/dgraph/cmd/tool/run.go
@@ -1,0 +1,51 @@
+/*Copyright 2017-2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tool
+
+import (
+	"strings"
+
+	tool "github.com/dgraph-io/dgraph/dgraph/cmd/tool/decrypt"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Tool x.SubCommand
+
+var subcommands = []*x.SubCommand{
+	&tool.Decrypt,
+}
+
+func init() {
+	Tool.Cmd = &cobra.Command{
+		Use:   "tool",
+		Short: "Run a Dgraph tool",
+		Long:  "A suite of Dgraph tools",
+	}
+	Tool.EnvPrefix = "DGRAPH_TOOL"
+	for _, sc := range subcommands {
+		Tool.Cmd.AddCommand(sc.Cmd)
+		sc.Conf = viper.New()
+		x.Check(sc.Conf.BindPFlags(sc.Cmd.Flags()))
+		x.Check(sc.Conf.BindPFlags(Tool.Cmd.PersistentFlags()))
+		sc.Conf.AutomaticEnv()
+		sc.Conf.SetEnvPrefix(sc.EnvPrefix)
+		// Options that contain a "." should use "_" in its place when provided as an
+		// environment variable.
+		sc.Conf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	}
+}

--- a/ee/enc/util_ee.go
+++ b/ee/enc/util_ee.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/dgraph-io/badger/v2/y"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -123,7 +122,6 @@ func newKeyReader(cfg *viper.Viper) (keyReader, error) {
 		return nil, errors.Errorf("cannot have local and vault key readers. " +
 			"re-check the configuration")
 	}
-	glog.Infof("KeyReader instantiated of type %T", keyReader)
 	return keyReader, nil
 }
 


### PR DESCRIPTION
Create a tool `dgraph tool decrypt` to decrypt encrypted export data.

e.g.
```
$ dgraph tool -h
[Decoder]: Using assembly version of decoder
A suite of Dgraph tools

Usage:
  dgraph tool [command]

Available Commands:
  decrypt     Run Decrypt tool
```

```
$ dgraph tool decrypt -h
[Decoder]: Using assembly version of decoder
A tool to decrypt an export file created by an encrypted Dgraph cluster

Usage:
  dgraph tool decrypt [flags]

Flags:
      --encryption_key_file string   The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively). Enterprise feature.
  -f, --file string                  Path to file to decrypt.
  -h, --help                         help for decrypt
  -o, --out string                   Path to the decrypted file.
      --vault_addr string            Vault server's address in the form http://ip:port. (default "http://localhost:8200")
      --vault_field string           Vault kv store field whose value is the Base64 encoded encryption key. (default "enc_key")
      --vault_format string          Vault field format. raw or base64 (default "base64")
      --vault_path string            Vault kv store path. e.g. secret/data/dgraph for kv-v2, kv/dgraph for kv-v1. (default "secret/data/dgraph")
      --vault_roleid_file string     File containing Vault role-id used for approle auth.
      --vault_secretid_file string   File containing Vault secret-id used for approle auth.
```

Changes:
* feat: Add `dgraph tool decrypt` command
* chore(ee): Remove glog when reading encryption key file.

(cherry picked from commit f53e6c0af9f53b78dafc80bdef76532191f71d2f)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7273)
<!-- Reviewable:end -->
