### PR TITLE
release/v20.11:  fix(restore): multiple restore requests should be rejected and propos…

### DIFF
--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -62,10 +62,38 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) (int, er
 	if err := VerifyBackup(req, &creds, currentGroups); err != nil {
 		return 0, errors.Wrapf(err, "failed to verify backup")
 	}
-
 	if err := FillRestoreCredentials(req.Location, req); err != nil {
 		return 0, errors.Wrapf(err, "cannot fill restore proposal with the right credentials")
 	}
+	// Restore Tracker keeps tracks of ongoing restore operation initiated on the node.
+	// Restore Tracker are node specific. They manage restore operation initiated on the node.
+	// If already initiated on this node, rt.Add() will return already running operation error.
+	restoreId, err := rt.Add()
+	if err != nil {
+		return 0, errors.Wrapf(err, "cannot assign ID to restore operation")
+	}
+
+	// This check if any restore operation running on the node.
+	// Operation initiated on other nodes doesn't have record in the record tracker.
+	// This keeps track if there is an already running restore operation return the error.
+	// IMP: This introduces few corner cases.
+	// Like two concurrent restore operation on different nodes.
+	// Considering Restore as admin operation, solving all those complexities has low gains
+	// than to sacrifice the simplicity.
+	isRestoreRunning := func() bool {
+		tasks := GetOngoingTasks()
+		for _, t := range tasks {
+			if t == opRestore.String() {
+				return true
+			}
+		}
+		return false
+	}
+	if isRestoreRunning() {
+		return 0, errors.Errorf("another restore operation is already running. " +
+			"Please retry later.")
+	}
+
 	req.RestoreTs = State.GetTimestamp(false)
 
 	// TODO: prevent partial restores when proposeRestoreOrSend only sends the restore
@@ -80,10 +108,6 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest) (int, er
 		}()
 	}
 
-	restoreId, err := rt.Add()
-	if err != nil {
-		return 0, errors.Wrapf(err, "cannot assign ID to restore operation")
-	}
 	go func(restoreId int) {
 		errs := make([]error, 0)
 		for range currentGroups {


### PR DESCRIPTION
…als should not be submitted (#7118)

* fix(restore): multiple restore requests should be rejected and proposals should not be submitted

* adding doc defining restore behaviour

* changing message to be more concrete

* making restore return error if operation already running

* making use of GetOngoingTasks

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7276)
<!-- Reviewable:end -->
