### PR TITLE
release/v20.11: opt(rollup): change the way rollups are done

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -330,14 +330,6 @@ func (l *List) updateMutationLayer(mpost *pb.Posting, singleUidUpdate bool) erro
 	l.AssertLock()
 	x.AssertTrue(mpost.Op == Set || mpost.Op == Del)
 
-	// Keys are added to the rollup batches here instead of at the point at which the
-	// transaction is committed because the transaction context does not keep track
-	// of the badger keys touched by mutations. It's useful to roll up lists even if
-	// the transaction is eventually aborted.
-	if len(l.mutationMap) > 0 {
-		IncrRollup.addKeyToBatch(l.key)
-	}
-
 	// If we have a delete all, then we replace the map entry with just one.
 	if hasDeleteAll(mpost) {
 		plist := &pb.PostingList{}


### PR DESCRIPTION
ISSUE:
In a load that has a lot of updations to a key, a lot of deltas accumulate over time. These keys are added to the batch for a rollup. Due to the lossy behavior of rollups, they get dropped while the dgraph is busy rolling up keys (that might have much smaller delta count).

FIX:
We now add keys to rollupBatch just after pushing the deltas over to badger.
We now have a priority inside the keys that we rollup. The keys for which the deltas have increased up to a certain limit (hard-coded 500), we add it to high priority rollupKeyPool so that it has high chances to get rolled up and does not get dropped due to lossy behavior of rollups.

Co-authored-by: Manish R Jain <manish@dgraph.io>
Co-authored-by: NamanJain8 <jnaman806@gmail.com>
(cherry picked from commit cbdc991f98b4b3fd800745565696f919cbd4e29d)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7277)
<!-- Reviewable:end -->
