### PR TITLE
fix(GraphQL): This PR allow to use __typename in mutation.

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -693,7 +693,7 @@ func RunAll(t *testing.T) {
 	t.Run("numUids test", testNumUids)
 	t.Run("empty delete", mutationEmptyDelete)
 	t.Run("duplicate xid in single mutation", deepMutationDuplicateXIDsSameObjectTest)
-	t.Run("query typename in mutation payload", queryTypenameInMutationPayload)
+	t.Run("query typename in mutation", queryTypenameInMutation)
 	t.Run("ensure alias in mutation payload", ensureAliasInMutationPayload)
 	t.Run("mutations have extensions", mutationsHaveExtensions)
 	t.Run("alias works for mutations", mutationsWithAlias)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -710,6 +710,7 @@ func RunAll(t *testing.T) {
 	t.Run("mutation id directive with int", idDirectiveWithIntMutation)
 	t.Run("mutation id directive with int64", idDirectiveWithInt64Mutation)
 	t.Run("mutation id directive with float", idDirectiveWithFloatMutation)
+	t.Run("mutation with typename", mutationWithTypename)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -710,7 +710,6 @@ func RunAll(t *testing.T) {
 	t.Run("mutation id directive with int", idDirectiveWithIntMutation)
 	t.Run("mutation id directive with int64", idDirectiveWithInt64Mutation)
 	t.Run("mutation id directive with float", idDirectiveWithFloatMutation)
-	t.Run("mutation with typename", mutationWithTypename)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -3483,9 +3483,11 @@ func getXidFilter(xidKey string, xidVals []string) map[string]interface{} {
 	return filter
 }
 
-func queryTypenameInMutationPayload(t *testing.T) {
+func queryTypenameInMutation(t *testing.T) {
 	addStateParams := &GraphQLParams{
 		Query: `mutation {
+            __typename
+			a:__typename
 			addState(input: [{xcode: "S1", name: "State1"}]) {
 				state {
 					__typename
@@ -3501,6 +3503,8 @@ func queryTypenameInMutationPayload(t *testing.T) {
 	RequireNoGQLErrors(t, gqlResponse)
 
 	addStateExpected := `{
+		"__typename":"Mutation",
+		"a":"Mutation",
 		"addState": {
 			"state": [{
 				"__typename": "State",
@@ -4669,41 +4673,4 @@ func idDirectiveWithFloatMutation(t *testing.T) {
 	require.Contains(t, response.Errors.Error(), "already exists")
 
 	DeleteGqlType(t, "Section", map[string]interface{}{}, 4, nil)
-}
-
-func mutationWithTypename(t *testing.T) {
-	addPost1Params := &GraphQLParams{
-		Query: `mutation {
-            __typename
-			a:__typename
-			addpost1(input: [{title: "Dgraph", numLikes: 92233720 }]) {
-    			__typename
-				post1 {
-					__typename
-					title
-					numLikes
-				}
-			}
-		}`,
-	}
-
-	gqlResponse := addPost1Params.ExecuteAsPost(t, GraphqlURL)
-	RequireNoGQLErrors(t, gqlResponse)
-
-	addPost1Expected := `{
-        "__typename":"Mutation",
-		"a":"Mutation",	
-		"addpost1": {
-            "__typename":"Addpost1Payload",
-			"post1": [{
-				"__typename":"post1",
-				"title": "Dgraph",
-				"numLikes": 92233720
-
-			}]
-		}
-	}`
-	testutil.CompareJSON(t, addPost1Expected, string(gqlResponse.Data))
-	filter := map[string]interface{}{"title": map[string]interface{}{"eq": "Dgraph"}}
-	DeleteGqlType(t, "post1", filter, 1, nil)
 }

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4675,6 +4675,7 @@ func mutationWithTypename(t *testing.T) {
 	addPost1Params := &GraphQLParams{
 		Query: `mutation {
             __typename
+			a:__typename
 			addpost1(input: [{title: "Dgraph", numLikes: 92233720 }]) {
     			__typename
 				post1 {
@@ -4691,6 +4692,7 @@ func mutationWithTypename(t *testing.T) {
 
 	addPost1Expected := `{
         "__typename":"Mutation",
+		"a":"Mutation",	
 		"addpost1": {
             "__typename":"Addpost1Payload",
 			"post1": [{

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4670,3 +4670,38 @@ func idDirectiveWithFloatMutation(t *testing.T) {
 
 	DeleteGqlType(t, "Section", map[string]interface{}{}, 4, nil)
 }
+
+func mutationWithTypename(t *testing.T) {
+	addPost1Params := &GraphQLParams{
+		Query: `mutation {
+            __typename
+			addpost1(input: [{title: "Dgraph", numLikes: 92233720 }]) {
+    			__typename
+				post1 {
+					__typename
+					title
+					numLikes
+				}
+			}
+		}`,
+	}
+
+	gqlResponse := addPost1Params.ExecuteAsPost(t, GraphqlURL)
+	RequireNoGQLErrors(t, gqlResponse)
+
+	addPost1Expected := `{
+        "__typename":"Mutation",
+		"addpost1": {
+            "__typename":"Addpost1Payload",
+			"post1": [{
+				"__typename":"post1",
+				"title": "Dgraph",
+				"numLikes": 92233720
+
+			}]
+		}
+	}`
+	testutil.CompareJSON(t, addPost1Expected, string(gqlResponse.Data))
+	filter := map[string]interface{}{"title": map[string]interface{}{"eq": "Dgraph"}}
+	DeleteGqlType(t, "post1", filter, 1, nil)
+}

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -257,6 +257,17 @@ func (rf *resolverFactory) WithSchemaIntrospection() ResolverFactory {
 		WithQueryResolver("__typename",
 			func(q schema.Query) QueryResolver {
 				return QueryResolverFunc(resolveIntrospection)
+			}).
+		WithMutationResolver("__typename",
+			func(m schema.Mutation) MutationResolver {
+				return MutationResolverFunc(func(ctx context.Context, m schema.Mutation) (*Resolved, bool) {
+					return &Resolved{
+						Data:       map[string]interface{}{"__typename": "Mutation"},
+						Field:      m,
+						Err:        nil,
+						Extensions: nil,
+					}, resolverSucceeded
+				})
 			})
 }
 
@@ -375,7 +386,6 @@ func (rf *resolverFactory) queryResolverFor(query schema.Query) QueryResolver {
 	if resolver, ok := rf.queryResolvers[query.Name()]; ok {
 		return mws.Then(resolver(query))
 	}
-
 	return rf.queryError
 }
 
@@ -386,7 +396,6 @@ func (rf *resolverFactory) mutationResolverFor(mutation schema.Mutation) Mutatio
 	if resolver, ok := rf.mutationResolvers[mutation.Name()]; ok {
 		return mws.Then(resolver(mutation))
 	}
-
 	return rf.mutationError
 }
 


### PR DESCRIPTION
Fixes GRAPHQL-921

The first mutation below will now return the "Mutation" type, which previously was giving an error.
`Mutation`:
```
mutation {
                       __typename
			addpost1(input: [{title: "Dgraph", numLikes: 92233720 }]) {
				post1 {
					title
					numLikes
				}
			}
		}

`Response:`
      {
                "__typename":"Mutation",
		"addpost1": {
			"post1": [{
				"title": "Dgraph",
				"numLikes": 92233720

			}]
		}
	}
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7285)
<!-- Reviewable:end -->
