### PR TITLE
docs (20.11.1): Add docs about how errors are returned from custom endpoints

### DIFF
--- a/wiki/content/graphql/custom/directive.md
+++ b/wiki/content/graphql/custom/directive.md
@@ -314,7 +314,7 @@ When a query returns an error while resolving from a custom HTTP endpoint, the e
 
 When a field returns an error while resolving a custom HTTP endpoint, the field's value becomes `null` and the error is added to the `errors` JSON array. The rest of the fields are still resolved as required by the request.
 
-For example:
+For example, a query from a custom HTTP endpoint will return an error in the following format:
 
 ```json
 {

--- a/wiki/content/graphql/custom/directive.md
+++ b/wiki/content/graphql/custom/directive.md
@@ -308,6 +308,33 @@ then Dgraph expects a GraphQL call to `post` to return a valid GraphQL result li
 
 Similarly, Dgraph expects `postByAuthor` to return data like `{ "data": { "postByAuthor": [ {...}, ... ] } }` and will use the array value of `postByAuthor` to build its array of posts result.
 
+## How errors from custom endpoints are handled
+
+When a query returns an error while resolving from a custom HTTP endpoint, the error is added to the `errors` array and sent back to the user in the JSON response.
+
+When a field returns an error while resolving a custom HTTP endpoint, the field's value becomes `null` and the error is added to the `errors` JSON array. The rest of the fields are still resolved as required by the request.
+
+For example:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Rest API returns Error for myFavoriteMovies query",
+      "locations": [
+        {
+          "line": 5,
+          "column": 4
+        }
+      ],
+      "path": [
+        "Movies",
+        "name"
+      ]
+    }
+  ]
+}
+```
 
 ## How custom fields are resolved
 


### PR DESCRIPTION
Fixes GRAPHQL-813

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7290)
<!-- Reviewable:end -->
