### PR TITLE
docs: remove "--shufflers" flag reference in bulk loader docs

### DIFF
--- a/wiki/content/deploy/fast-data-loading/bulk-loader.md
+++ b/wiki/content/deploy/fast-data-loading/bulk-loader.md
@@ -286,6 +286,3 @@ higher CPU utilization.
 - The `--map_shards` flag controls the number of separate map output shards.
   Increasing this increases memory consumption but balances the resultant
 Dgraph alpha instances more evenly.
-
-- The `--shufflers` controls the level of parallelism in the shuffle/reduce
-  stage. Increasing this increases memory consumption.


### PR DESCRIPTION
The `--shufflers` flag (for bulk loader) has been removed with this [commit](https://github.com/dgraph-io/dgraph/commit/d336e41dea7aed518204b11acc5d655d74a575b6) on Jun 11, 2019 

Our docs are still reporting this flag, hence removing it with this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7294)
<!-- Reviewable:end -->
