### PR TITLE
release/v20.11 - fix(dgraph): Fix dgraph crash on windows (#7261)

### DIFF
--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -37,7 +37,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -349,7 +349,7 @@ func inCi() bool {
 }
 
 func saveJaegerTracesToJepsen(jepsenPath string) {
-	dst := path.Join(jepsenPath, "dgraph", "store", "current", "jaeger")
+	dst := filepath.Join(jepsenPath, "dgraph", "store", "current", "jaeger")
 	cmd := command("sudo", "docker", "cp", "jaeger:/working/jaeger", dst)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/dgraph/cmd/cert/create.go
+++ b/dgraph/cmd/cert/create.go
@@ -27,7 +27,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -278,7 +277,7 @@ func createCerts(opt *options) error {
 	}
 
 	// no path then save it in certsDir.
-	if path.Base(opt.caKey) == opt.caKey {
+	if filepath.Base(opt.caKey) == opt.caKey {
 		opt.caKey = filepath.Join(opt.dir, opt.caKey)
 	}
 	opt.caCert = filepath.Join(opt.dir, defaultCACert)

--- a/dgraph/cmd/live/load-json/load_test.go
+++ b/dgraph/cmd/live/load-json/load_test.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -174,7 +174,7 @@ func TestLiveLoadJSONMultipleFiles(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	_, thisFile, _, _ := runtime.Caller(0)
-	testDataDir = path.Dir(thisFile)
+	testDataDir = filepath.Dir(thisFile)
 
 	var err error
 	dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -375,7 +375,7 @@ func TestMain(m *testing.M) {
 	fmt.Printf("alphaExportPath: %s\n", alphaExportPath)
 
 	_, thisFile, _, _ := runtime.Caller(0)
-	testDataDir = path.Dir(thisFile)
+	testDataDir = filepath.Dir(thisFile)
 	fmt.Printf("Using test data dir: %s\n", testDataDir)
 
 	var err error

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.1.1
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b
-	github.com/dgraph-io/ristretto v0.0.4-0.20210104064432-d7c5d7a71e89
+	github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b h1:PDEhlwHpkEQ5WBfOOKZCNZTXFDGyCEWTYDhxGQbyIpk=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20201205013540-bafef7527542/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
-github.com/dgraph-io/ristretto v0.0.4-0.20210104064432-d7c5d7a71e89 h1:uYRSuTAviO9ijHJQ9Dycui3mKVUSBoxXKQTBjkZDhG0=
-github.com/dgraph-io/ristretto v0.0.4-0.20210104064432-d7c5d7a71e89/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2 h1:Ii2KMtC40rP1jJB08GVFfQh/NEca2LBjKokO45N7xes=
+github.com/dgraph-io/ristretto v0.0.4-0.20210108140656-b1486d8516f2/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/graphql/testdata/datagen/cmd/root.go
+++ b/graphql/testdata/datagen/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	"log"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -111,7 +111,7 @@ func initConfig() {
 		}
 
 		// Search config in home directory with name ".datagen" (without extension).
-		viper.AddConfigPath(path.Join(home, ".config", "datagen"))
+		viper.AddConfigPath(filepath.Join(home, ".config", "datagen"))
 		viper.SetConfigName("conf")
 	}
 

--- a/graphql/testdata/datagen/cmd/run.go
+++ b/graphql/testdata/datagen/cmd/run.go
@@ -4,18 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/viper"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
 const (
@@ -229,12 +229,12 @@ func generateDishes(rest *restaurant) []dish {
 
 func readRestaurantData() (dataFile, error) {
 	restaurantDataFile := viper.GetString(restaurantDataFilePath)
-	if !path.IsAbs(restaurantDataFile) {
+	if !filepath.IsAbs(restaurantDataFile) {
 		dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
 		if err != nil {
 			return nil, err
 		}
-		restaurantDataFile = path.Join(dir, restaurantDataFile)
+		restaurantDataFile = filepath.Join(dir, restaurantDataFile)
 	}
 
 	b, err := ioutil.ReadFile(restaurantDataFile)

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -22,7 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -92,7 +92,7 @@ type logFile struct {
 }
 
 func logFname(dir string, id int64) string {
-	return path.Join(dir, fmt.Sprintf("%05d%s", id, logSuffix))
+	return filepath.Join(dir, fmt.Sprintf("%05d%s", id, logSuffix))
 }
 
 // openLogFile opens a logFile in the given directory. The filename is
@@ -275,7 +275,7 @@ func getLogFiles(dir string) ([]*logFile, error) {
 	seen := make(map[int64]struct{})
 
 	for _, fpath := range entryFiles {
-		_, fname := path.Split(fpath)
+		_, fname := filepath.Split(fpath)
 		fname = strings.TrimSuffix(fname, logSuffix)
 
 		fid, err := strconv.ParseInt(fname, 10, 64)

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -9285,8 +9285,8 @@ func Test1Million(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	noschemaFile := path.Join(testutil.TestDataDirectory, "1million-noindex.schema")
-	rdfFile := path.Join(testutil.TestDataDirectory, "1million.rdf.gz")
+	noschemaFile := filepath.Join(testutil.TestDataDirectory, "1million-noindex.schema")
+	rdfFile := filepath.Join(testutil.TestDataDirectory, "1million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {
 		os.Exit(1)
 	}
@@ -9304,7 +9304,7 @@ func TestMain(m *testing.M) {
 		fmt.Printf("Error while bringin up alphas. Error: %v\n", err)
 		cleanupAndExit(1)
 	}
-	schemaFile := path.Join(testutil.TestDataDirectory, "1million.schema")
+	schemaFile := filepath.Join(testutil.TestDataDirectory, "1million.schema")
 	client, err := testutil.DgraphClient(testutil.ContainerAddr("alpha1", 9080))
 	if err != nil {
 		fmt.Printf("Error while creating client. Error: %v\n", err)

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -18,7 +18,7 @@ package bulk
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dgraph-io/dgraph/systest/21million/common"
 	"github.com/dgraph-io/dgraph/testutil"
@@ -31,8 +31,8 @@ func TestQueries(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	schemaFile := path.Join(testutil.TestDataDirectory, "21million.schema")
-	rdfFile := path.Join(testutil.TestDataDirectory, "21million.rdf.gz")
+	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")
+	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 	if err := testutil.MakeDirEmpty([]string{"out/0", "out/1", "out/2"}); err != nil {
 		os.Exit(1)
 	}

--- a/systest/21million/common/run_queries.go
+++ b/systest/21million/common/run_queries.go
@@ -19,7 +19,7 @@ package common
 import (
 	"context"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -39,7 +39,7 @@ import (
 
 func TestQueriesFor21Million(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
-	queryDir := path.Join(path.Dir(thisFile), "../queries")
+	queryDir := filepath.Join(filepath.Dir(thisFile), "../queries")
 
 	// For this test we DON'T want to start with an empty database.
 	dg, err := testutil.DgraphClient(testutil.ContainerAddr("alpha1", 9080))
@@ -59,7 +59,7 @@ func TestQueriesFor21Million(t *testing.T) {
 			continue
 		}
 		t.Run(file.Name(), func(t *testing.T) {
-			filename := path.Join(queryDir, file.Name())
+			filename := filepath.Join(queryDir, file.Name())
 			reader, cleanup := chunker.FileReader(filename, nil)
 			bytes, err := ioutil.ReadAll(reader)
 			if err != nil {
@@ -88,7 +88,7 @@ func TestQueriesFor21Million(t *testing.T) {
 
 				t.Logf("running %s", file.Name())
 				//if *savedir != "" {
-				//	savepath = path.Join(*savedir, file.Name())
+				//	savepath = filepath.Join(*savedir, file.Name())
 				//}
 
 				testutil.CompareJSON(t, bodies[1], string(resp.GetJson()))

--- a/systest/21million/live/run_test.go
+++ b/systest/21million/live/run_test.go
@@ -18,7 +18,7 @@ package bulk
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dgraph-io/dgraph/testutil"
 
@@ -32,8 +32,8 @@ func TestQueries(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	schemaFile := path.Join(testutil.TestDataDirectory, "21million.schema")
-	rdfFile := path.Join(testutil.TestDataDirectory, "21million.rdf.gz")
+	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")
+	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 	if err := testutil.LiveLoad(testutil.LiveOpts{
 		Alpha:      testutil.ContainerAddr("alpha1", 9080),
 		Zero:       testutil.SockAddrZero,

--- a/systest/21million/ludicrous/run_test.go
+++ b/systest/21million/ludicrous/run_test.go
@@ -18,7 +18,7 @@ package bulk
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/dgraph-io/dgraph/testutil"
 
@@ -31,8 +31,8 @@ import (
 //}
 
 func TestMain(m *testing.M) {
-	schemaFile := path.Join(testutil.TestDataDirectory, "21million.schema")
-	rdfFile := path.Join(testutil.TestDataDirectory, "21million.rdf.gz")
+	schemaFile := filepath.Join(testutil.TestDataDirectory, "21million.schema")
+	rdfFile := filepath.Join(testutil.TestDataDirectory, "21million.rdf.gz")
 
 	if err := testutil.LiveLoad(testutil.LiveOpts{
 		Alpha:      testutil.ContainerAddr("alpha1", 9080),

--- a/systest/ludicrous/run_test.go
+++ b/systest/ludicrous/run_test.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"flag"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -43,7 +43,7 @@ var quiet = flag.Bool("quiet", false,
 
 func TestQueries(t *testing.T) {
 	_, thisFile, _, _ := runtime.Caller(0)
-	queryDir := path.Join(path.Dir(thisFile), "queries")
+	queryDir := filepath.Join(filepath.Dir(thisFile), "queries")
 
 	// For this test we DON'T want to start with an empty database.
 	dg, err := testutil.DgraphClient(testutil.SockAddr)
@@ -63,7 +63,7 @@ func TestQueries(t *testing.T) {
 			continue
 		}
 		t.Run(file.Name(), func(t *testing.T) {
-			filename := path.Join(queryDir, file.Name())
+			filename := filepath.Join(queryDir, file.Name())
 			reader, cleanup := chunker.FileReader(filename, nil)
 			bytes, err := ioutil.ReadAll(reader)
 			if err != nil {
@@ -87,7 +87,7 @@ func TestQueries(t *testing.T) {
 
 			t.Logf("running %s", file.Name())
 			if *savedir != "" {
-				savepath = path.Join(*savedir, file.Name())
+				savepath = filepath.Join(*savedir, file.Name())
 			}
 
 			if !testutil.EqualJSON(t, bodies[1], string(resp.GetJson()), savepath, *quiet) {

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -100,7 +100,7 @@ func disableDraining(t *testing.T) {
 
 func runQueries(t *testing.T, dg *dgo.Dgraph, shouldFail bool) {
 	_, thisFile, _, _ := runtime.Caller(0)
-	queryDir := path.Join(path.Dir(thisFile), "queries")
+	queryDir := filepath.Join(filepath.Dir(thisFile), "queries")
 
 	files, err := ioutil.ReadDir(queryDir)
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func runQueries(t *testing.T, dg *dgo.Dgraph, shouldFail bool) {
 		if !strings.HasPrefix(file.Name(), "query-") {
 			continue
 		}
-		filename := path.Join(queryDir, file.Name())
+		filename := filepath.Join(queryDir, file.Name())
 		reader, cleanup := chunker.FileReader(filename, nil)
 		bytes, err := ioutil.ReadAll(reader)
 		require.NoError(t, err)

--- a/t/t.go
+++ b/t/t.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -211,7 +210,7 @@ func runTestsFor(ctx context.Context, pkg, prefix string) error {
 
 func hasTestFiles(pkg string) bool {
 	dir := strings.Replace(pkg, "github.com/dgraph-io/dgraph/", "", 1)
-	dir = path.Join(*baseDir, dir)
+	dir = filepath.Join(*baseDir, dir)
 
 	hasTests := false
 	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
@@ -245,7 +244,7 @@ func runTests(taskCh chan task, closer *z.Closer) error {
 		closer.Done()
 	}()
 
-	defaultCompose := path.Join(*baseDir, "dgraph/docker-compose.yml")
+	defaultCompose := filepath.Join(*baseDir, "dgraph/docker-compose.yml")
 	prefix := getClusterPrefix()
 
 	var started, stopped bool
@@ -344,7 +343,7 @@ func findPackagesFor(testName string) []string {
 	for scan.Scan() {
 		fname := scan.Text()
 		if strings.HasSuffix(fname, "_test.go") {
-			dir := strings.Replace(path.Dir(fname), *baseDir, "", 1)
+			dir := strings.Replace(filepath.Dir(fname), *baseDir, "", 1)
 			dirs = append(dirs, dir)
 		}
 	}
@@ -415,7 +414,7 @@ type task struct {
 
 func composeFileFor(pkg string) string {
 	dir := strings.Replace(pkg, "github.com/dgraph-io/dgraph/", "", 1)
-	return path.Join(*baseDir, dir, "docker-compose.yml")
+	return filepath.Join(*baseDir, dir, "docker-compose.yml")
 }
 
 func getPackages() []task {

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -508,7 +508,7 @@ func GetHttpsClient(t *testing.T) http.Client {
 func GetAlphaClientConfig(t *testing.T) *tls.Config {
 	_, filename, _, ok := runtime.Caller(0)
 	require.True(t, ok)
-	tlsDir := path.Join(path.Dir(filename), "../tlstest/mtls_internal/tls/live")
+	tlsDir := filepath.Join(filepath.Dir(filename), "../tlstest/mtls_internal/tls/live")
 	c := &x.TLSHelperConfig{
 		CertRequired:     true,
 		Cert:             tlsDir + "/client.liveclient.crt",

--- a/testutil/json.go
+++ b/testutil/json.go
@@ -23,7 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
@@ -107,7 +107,7 @@ func sdiffJSON(wantBuf, gotBuf []byte, savepath string, quiet bool) string {
 	var wantFile, gotFile *os.File
 
 	if savepath != "" {
-		_ = os.MkdirAll(path.Dir(savepath), 0700)
+		_ = os.MkdirAll(filepath.Dir(savepath), 0700)
 		wantFile, _ = os.Create(savepath + ".expected.json")
 		gotFile, _ = os.Create(savepath + ".received.json")
 	} else {

--- a/testutil/plugin.go
+++ b/testutil/plugin.go
@@ -19,7 +19,6 @@ package testutil
 import (
 	"fmt"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -47,7 +46,7 @@ func GeneratePlugins(raceEnabled bool) {
 		}
 		opts = append(opts, "-buildmode=plugin", "-o", so, src)
 		cmd := exec.Command("go", opts...)
-		cmd.Dir = path.Dir(curr)
+		cmd.Dir = filepath.Dir(curr)
 		if out, err := cmd.CombinedOutput(); err != nil {
 			fmt.Printf("Error: %v\n", err)
 			fmt.Printf("Output: %v\n", string(out))

--- a/worker/export.go
+++ b/worker/export.go
@@ -27,7 +27,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -412,7 +411,7 @@ type remoteExportStorage struct {
 }
 
 func newLocalExportStorage(destination, backupName string) (*localExportStorage, error) {
-	bdir, err := filepath.Abs(path.Join(destination, backupName))
+	bdir, err := filepath.Abs(filepath.Join(destination, backupName))
 	if err != nil {
 		return nil, err
 	}
@@ -425,9 +424,9 @@ func newLocalExportStorage(destination, backupName string) (*localExportStorage,
 }
 
 func (l *localExportStorage) openFile(fileName string) (*fileWriter, error) {
-	fw := &fileWriter{relativePath: path.Join(l.relativePath, fileName)}
+	fw := &fileWriter{relativePath: filepath.Join(l.relativePath, fileName)}
 
-	filePath, err := filepath.Abs(path.Join(l.destination, fw.relativePath))
+	filePath, err := filepath.Abs(filepath.Join(l.destination, fw.relativePath))
 	if err != nil {
 		return nil, err
 	}
@@ -505,7 +504,7 @@ func (r *remoteExportStorage) finishWriting(fs ...*fileWriter) (ExportedFiles, e
 		} else {
 			d = r.prefix + "/" + f
 		}
-		filePath := path.Join(r.les.destination, f)
+		filePath := filepath.Join(r.les.destination, f)
 		// FIXME: tejas [06/2020] - We could probably stream these results, but it's easier to copy for now
 		glog.Infof("Uploading from %s to %s\n", filePath, d)
 		_, err := r.mc.FPutObject(r.bucket, d, filePath, minio.PutObjectOptions{


### PR DESCRIPTION
There were two issues on windows

1. We were trying to delete a file with open file descriptors. This
doesn't work on windows. The PR dgraph-io/ristretto#242 in ristretto fixes this.
2. We were using path.Join instead of filepath.Join. The path package is
supposed to be used only on Unix systems. In windows the "" is the path
separator instead of "/".

(cherry picked from commit 5aec24394570706ee0b0bb49586119959ed6dd72)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7299)
<!-- Reviewable:end -->
