### PR TITLE
Fix(GraphQL): This PR fix multi cors and multi schema nodes issue by selecting one of the latest added nodes, and add dgraph type to cors. (#7270)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -762,7 +762,7 @@ func run() {
 		edgraph.ResetCors(updaters)
 		// Update the accepted cors origins.
 		for updaters.Ctx().Err() == nil {
-			origins, err := edgraph.GetCorsOrigins(updaters.Ctx())
+			_, origins, err := edgraph.GetCorsOrigins(updaters.Ctx())
 			if err != nil {
 				glog.Errorf("Error while retrieving cors origins: %s", err.Error())
 				time.Sleep(time.Second)

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -196,7 +196,7 @@ func TestPasswordReturn(t *testing.T) {
 
 func TestGetCurrentUser(t *testing.T) {
 	token := testutil.GrootHttpLogin(adminEndpoint)
-	
+
 	currentUser := getCurrentUser(t, token)
 	currentUser.RequireNoGraphQLErrors(t)
 	require.Equal(t, string(currentUser.Data), `{"getCurrentUser":{"name":"groot"}}`)
@@ -2299,6 +2299,14 @@ func TestSchemaQueryWithACL(t *testing.T) {
         }
       ],
       "name": "dgraph.type.User"
+    },
+    {
+      "fields": [
+        {
+          "name": "dgraph.cors"
+        }
+      ],
+      "name": "dgraph.type.cors"
     }
   ]
 }`
@@ -2337,6 +2345,10 @@ func TestSchemaQueryWithACL(t *testing.T) {
     {
       "fields": [],
       "name": "dgraph.type.User"
+    },
+    {
+      "fields": [],
+      "name": "dgraph.type.cors"
     }
   ]
 }`

--- a/graphql/admin/cors.go
+++ b/graphql/admin/cors.go
@@ -68,7 +68,7 @@ func resolveReplaceAllowedCORSOrigins(ctx context.Context, m schema.Mutation) (*
 
 // resolveGetCors retrieves cors details from the database.
 func resolveGetCors(ctx context.Context, q schema.Query) *resolve.Resolved {
-	origins, err := edgraph.GetCorsOrigins(ctx)
+	_, origins, err := edgraph.GetCorsOrigins(ctx)
 	if err != nil {
 		return resolve.EmptyResult(q, err)
 	}

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -968,6 +968,56 @@
                 }
             ],
             "name": "test.dgraph.employee.en"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Book.name"
+                },
+                {
+                    "name": "Book.desc"
+                },
+                {
+                    "name": "Book.bookId"
+                }
+            ],
+            "name": "Book"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Chapter.name"
+                },
+                {
+                    "name": "Chapter.bookId"
+                },
+                {
+                    "name": "Chapter.chapterId"
+                }
+            ],
+            "name": "Chapter"
+        },
+        {
+            "fields": [
+                {
+                    "name": "Section.sectionId"
+                },
+                {
+                    "name": "Section.chapterId"
+                },
+                {
+                    "name": "Section.name"
+                }
+            ],
+            "name": "Section"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.cors"
+                }
+            ],
+            "name": "dgraph.type.cors"
         }
     ]
 }

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -972,48 +972,6 @@
         {
             "fields": [
                 {
-                    "name": "Book.name"
-                },
-                {
-                    "name": "Book.desc"
-                },
-                {
-                    "name": "Book.bookId"
-                }
-            ],
-            "name": "Book"
-        },
-        {
-            "fields": [
-                {
-                    "name": "Chapter.name"
-                },
-                {
-                    "name": "Chapter.bookId"
-                },
-                {
-                    "name": "Chapter.chapterId"
-                }
-            ],
-            "name": "Chapter"
-        },
-        {
-            "fields": [
-                {
-                    "name": "Section.sectionId"
-                },
-                {
-                    "name": "Section.chapterId"
-                },
-                {
-                    "name": "Section.name"
-                }
-            ],
-            "name": "Section"
-        },
-        {
-            "fields": [
-                {
                     "name": "dgraph.cors"
                 }
             ],

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -967,6 +967,14 @@
                 }
             ],
             "name": "post1"
+        },
+        {
+            "fields": [
+                {
+                    "name": "dgraph.cors"
+                }
+            ],
+            "name": "dgraph.type.cors"
         }
     ]
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -588,6 +588,14 @@ func initialTypesInternal(all bool) []*pb.TypeUpdate {
 					ValueType: pb.Posting_STRING,
 				},
 			},
+		}, &pb.TypeUpdate{
+			TypeName: "dgraph.type.cors",
+			Fields: []*pb.SchemaUpdate{
+				{
+					Predicate: "dgraph.cors",
+					ValueType: pb.Posting_STRING,
+				},
+			},
 		})
 
 	if all || x.WorkerConfig.AclEnabled {

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -334,7 +334,7 @@ func runRestore(t *testing.T, lastDir string, commitTs uint64) map[string]string
 
 	restoredTypes, err := testutil.GetTypeNames(pdir)
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}, restoredTypes)
+	require.ElementsMatch(t, []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query", "dgraph.type.cors"}, restoredTypes)
 
 	require.NoError(t, err)
 	t.Logf("--- Restored values: %+v\n", restored)

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -195,7 +195,7 @@ func TestBackupFilesystem(t *testing.T) {
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "name", "dgraph.graphql.xid",
 		"dgraph.type", "movie", "dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at",
 		"dgraph.graphql.p_query", "dgraph.graphql.p_sha256hash", "dgraph.drop.op"}
-	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}
+	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query", "dgraph.type.cors"}
 	testutil.CheckSchema(t, preds, types)
 
 	verifyUids := func(count int) {

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -125,7 +125,7 @@ func TestBackupMinio(t *testing.T) {
 	preds := []string{"dgraph.graphql.schema", "dgraph.cors", "dgraph.graphql.xid", "dgraph.type", "movie",
 		"dgraph.graphql.schema_history", "dgraph.graphql.schema_created_at", "dgraph.graphql.p_query",
 		"dgraph.graphql.p_sha256hash", "dgraph.drop.op"}
-	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query"}
+	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.history", "dgraph.graphql.persisted_query", "dgraph.type.cors"}
 	testutil.CheckSchema(t, preds, types)
 
 	checks := []struct {

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -93,6 +93,9 @@ type <dgraph.graphql> {
 	dgraph.graphql.schema
 	dgraph.graphql.xid
 }
+type <dgraph.type.cors> {
+	dgraph.cors
+}
 type <dgraph.graphql.history> {
 	dgraph.graphql.schema_history
 	dgraph.graphql.schema_created_at

--- a/testutil/schema.go
+++ b/testutil/schema.go
@@ -67,6 +67,9 @@ const (
 },{
 	"fields": [{"name": "dgraph.graphql.p_query"},{"name": "dgraph.graphql.p_sha256hash"}],
 	"name": "dgraph.graphql.persisted_query"
+},{
+	"fields": [{"name": "dgraph.cors"}],
+	"name": "dgraph.type.cors"
 }
 `
 )

--- a/x/keys.go
+++ b/x/keys.go
@@ -582,6 +582,7 @@ var preDefinedTypeMap = map[string]struct{}{
 	"dgraph.type.Rule":               {},
 	"dgraph.graphql.history":         {},
 	"dgraph.graphql.persisted_query": {},
+	"dgraph.type.cors":               {},
 }
 
 // IsGraphqlReservedPredicate returns true if it is the predicate is reserved by graphql.


### PR DESCRIPTION
Fixes GRAPHQL-948
We already fixed the issue which causes dgraph to have multiple schema or cores nodes. But there are some cases in which this bug can occur again, for example, someone restored a backup that was taken before the fix. This bug continuously fill the logs on alpha and blocks graphql layer. Then we can't do mutate/query or add schema.

Now, we are changing this behavior, if we have multiple schema or cores nodes then we will select the one which was added last.
In addition to it, we are adding dgraph.type.cors type to to the dgraph.cors node, which allow us to use delete (S * *) type mutation on it, in case we want to delete extra node manually.

(cherry picked from commit fde103177002cb0965b3163ebfcab010e6399e94)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7302)
<!-- Reviewable:end -->
