### PR TITLE
fix(dgraph): Add X-Dgraph-AuthToken to list of access control allowed headers

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -123,7 +123,7 @@ const (
 	// bulk load.
 	GroupIdFileName = "group_id"
 
-	AccessControlAllowedHeaders = "X-Dgraph-AccessToken, " +
+	AccessControlAllowedHeaders = "X-Dgraph-AccessToken, X-Dgraph-AuthToken, " +
 		"Content-Type, Content-Length, Accept-Encoding, Cache-Control, " +
 		"X-CSRF-Token, X-Auth-Token, X-Requested-With"
 	DgraphCostHeader = "Dgraph-TouchedUids"


### PR DESCRIPTION
Fixes GRAPHQL-928

This would allow the user to do schema alter operations from the browser when they have Poor Man's auth enabled on Alpha.

(cherry picked from commit 4b3b2d93468205a555f051dfc93018b06b78baac)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7311)
<!-- Reviewable:end -->
