### PR TITLE
perf(GraphQL): JSON Part-6: Admin Server and custom HTTP query/mutation are now resolved separately (GRAPHQL-937)

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -166,6 +166,7 @@ func TestInvalidGetUser(t *testing.T) {
 	require.Equal(t, x.GqlErrorList{{
 		Message: "couldn't rewrite query getCurrentUser because unable to parse jwt token: token" +
 			" contains an invalid number of segments",
+		Path: []interface{}{"getCurrentUser"},
 	}}, currentUser.Errors)
 }
 
@@ -196,7 +197,7 @@ func TestPasswordReturn(t *testing.T) {
 
 func TestGetCurrentUser(t *testing.T) {
 	token := testutil.GrootHttpLogin(adminEndpoint)
-	
+
 	currentUser := getCurrentUser(t, token)
 	currentUser.RequireNoGraphQLErrors(t)
 	require.Equal(t, string(currentUser.Data), `{"getCurrentUser":{"name":"groot"}}`)
@@ -231,6 +232,7 @@ func TestCreateAndDeleteUsers(t *testing.T) {
 	require.Equal(t, x.GqlErrorList{{
 		Message: "couldn't rewrite query for mutation addUser because id alice already exists" +
 			" for type User",
+		Path: []interface{}{"addUser"},
 	}}, resp.Errors)
 	checkUserCount(t, resp.Data, 0)
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -716,54 +716,31 @@ func (as *adminServer) addConnectedAdminResolvers() {
 
 	as.rf.WithMutationResolver("updateGQLSchema",
 		func(m schema.Mutation) resolve.MutationResolver {
-			return &updateSchemaResolver{
-				admin: as,
-			}
+			return &updateSchemaResolver{admin: as}
 		}).
 		WithQueryResolver("getGQLSchema",
 			func(q schema.Query) resolve.QueryResolver {
-				return &getSchemaResolver{
-					admin: as,
-				}
+				return &getSchemaResolver{admin: as}
 			}).
 		WithQueryResolver("queryGroup",
 			func(q schema.Query) resolve.QueryResolver {
-				return resolve.NewQueryResolver(
-					qryRw,
-					dgEx,
-					resolve.StdQueryCompletion())
+				return resolve.NewQueryResolver(qryRw, dgEx)
 			}).
 		WithQueryResolver("queryUser",
 			func(q schema.Query) resolve.QueryResolver {
-				return resolve.NewQueryResolver(
-					qryRw,
-					dgEx,
-					resolve.StdQueryCompletion())
+				return resolve.NewQueryResolver(qryRw, dgEx)
 			}).
 		WithQueryResolver("getGroup",
 			func(q schema.Query) resolve.QueryResolver {
-				return resolve.NewQueryResolver(
-					qryRw,
-					dgEx,
-					resolve.StdQueryCompletion())
+				return resolve.NewQueryResolver(qryRw, dgEx)
 			}).
 		WithQueryResolver("getCurrentUser",
 			func(q schema.Query) resolve.QueryResolver {
-				cuResolver := &currentUserResolver{
-					baseRewriter: qryRw,
-				}
-
-				return resolve.NewQueryResolver(
-					cuResolver,
-					dgEx,
-					resolve.StdQueryCompletion())
+				return resolve.NewQueryResolver(&currentUserResolver{baseRewriter: qryRw}, dgEx)
 			}).
 		WithQueryResolver("getUser",
 			func(q schema.Query) resolve.QueryResolver {
-				return resolve.NewQueryResolver(
-					qryRw,
-					dgEx,
-					resolve.StdQueryCompletion())
+				return resolve.NewQueryResolver(qryRw, dgEx)
 			}).
 		WithQueryResolver("getAllowedCORSOrigins", func(q schema.Query) resolve.QueryResolver {
 			return resolve.QueryResolverFunc(resolveGetCors)
@@ -772,52 +749,31 @@ func (as *adminServer) addConnectedAdminResolvers() {
 			// Add the descending order to the created_at to get the schema history in
 			// descending order.
 			q.Arguments()["order"] = map[string]interface{}{"desc": "created_at"}
-			return resolve.NewQueryResolver(
-				qryRw,
-				dgEx,
-				resolve.StdQueryCompletion())
+			return resolve.NewQueryResolver(qryRw, dgEx)
 		}).
 		WithMutationResolver("addUser",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					resolve.NewAddRewriter(),
-					dgEx,
-					resolve.StdMutationCompletion(m.Name()))
+				return resolve.NewDgraphResolver(resolve.NewAddRewriter(), dgEx)
 			}).
 		WithMutationResolver("addGroup",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					NewAddGroupRewriter(),
-					dgEx,
-					resolve.StdMutationCompletion(m.Name()))
+				return resolve.NewDgraphResolver(NewAddGroupRewriter(), dgEx)
 			}).
 		WithMutationResolver("updateUser",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					resolve.NewUpdateRewriter(),
-					dgEx,
-					resolve.StdMutationCompletion(m.Name()))
+				return resolve.NewDgraphResolver(resolve.NewUpdateRewriter(), dgEx)
 			}).
 		WithMutationResolver("updateGroup",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					NewUpdateGroupRewriter(),
-					dgEx,
-					resolve.StdMutationCompletion(m.Name()))
+				return resolve.NewDgraphResolver(NewUpdateGroupRewriter(), dgEx)
 			}).
 		WithMutationResolver("deleteUser",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					resolve.NewDeleteRewriter(),
-					dgEx,
-					resolve.StdDeleteCompletion(m.Name()))
+				return resolve.NewDgraphResolver(resolve.NewDeleteRewriter(), dgEx)
 			}).
 		WithMutationResolver("deleteGroup",
 			func(m schema.Mutation) resolve.MutationResolver {
-				return resolve.NewDgraphResolver(
-					resolve.NewDeleteRewriter(),
-					dgEx,
-					resolve.StdDeleteCompletion(m.Name()))
+				return resolve.NewDgraphResolver(resolve.NewDeleteRewriter(), dgEx)
 			}).
 		WithMutationResolver("replaceAllowedCORSOrigins", func(m schema.Mutation) resolve.MutationResolver {
 			return resolve.MutationResolverFunc(resolveReplaceAllowedCORSOrigins)

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -347,11 +347,11 @@ var (
 		resolve.LoggingMWMutation,
 	}
 	adminQueryMWConfig = map[string]resolve.QueryMiddlewares{
-		"health":        {resolve.IpWhitelistingMW4Query, resolve.LoggingMWQuery}, // dgraph checks Guardian auth for health
-		"state":         {resolve.IpWhitelistingMW4Query, resolve.LoggingMWQuery}, // dgraph checks Guardian auth for state
-		"config":        commonAdminQueryMWs,
-		"listBackups":   commonAdminQueryMWs,
-		"getGQLSchema":  commonAdminQueryMWs,
+		"health":       {resolve.IpWhitelistingMW4Query, resolve.LoggingMWQuery}, // dgraph checks Guardian auth for health
+		"state":        {resolve.IpWhitelistingMW4Query, resolve.LoggingMWQuery}, // dgraph checks Guardian auth for state
+		"config":       commonAdminQueryMWs,
+		"listBackups":  commonAdminQueryMWs,
+		"getGQLSchema": commonAdminQueryMWs,
 		// for queries and mutations related to User/Group, dgraph handles Guardian auth,
 		// so no need to apply GuardianAuth Middleware
 		"queryGroup":            {resolve.IpWhitelistingMW4Query, resolve.LoggingMWQuery},
@@ -722,14 +722,9 @@ func (as *adminServer) addConnectedAdminResolvers() {
 		}).
 		WithQueryResolver("getGQLSchema",
 			func(q schema.Query) resolve.QueryResolver {
-				getResolver := &getSchemaResolver{
+				return &getSchemaResolver{
 					admin: as,
 				}
-
-				return resolve.NewQueryResolver(
-					getResolver,
-					getResolver,
-					resolve.StdQueryCompletion())
 			}).
 		WithQueryResolver("queryGroup",
 			func(q schema.Query) resolve.QueryResolver {
@@ -774,7 +769,7 @@ func (as *adminServer) addConnectedAdminResolvers() {
 			return resolve.QueryResolverFunc(resolveGetCors)
 		}).
 		WithQueryResolver("querySchemaHistory", func(q schema.Query) resolve.QueryResolver {
-			// Add the desceding order to the created_at to get the schema history in
+			// Add the descending order to the created_at to get the schema history in
 			// descending order.
 			q.Arguments()["order"] = map[string]interface{}{"desc": "created_at"}
 			return resolve.NewQueryResolver(

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -52,10 +52,11 @@ func resolveBackup(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 		return resolve.EmptyResult(m, err), false
 	}
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{m.Name(): response("Success", "Backup completed.")},
-		Field: m,
-	}, true
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{m.Name(): response("Success", "Backup completed.")},
+		nil,
+	), true
 }
 
 func getBackupInput(m schema.Mutation) (*backupInput, error) {

--- a/graphql/admin/config.go
+++ b/graphql/admin/config.go
@@ -54,10 +54,11 @@ func resolveUpdateConfig(ctx context.Context, m schema.Mutation) (*resolve.Resol
 		worker.UpdateLogRequest(*input.LogRequest)
 	}
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{m.Name(): response("Success", "Config updated successfully")},
-		Field: m,
-	}, true
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{m.Name(): response("Success", "Config updated successfully")},
+		nil,
+	), true
 }
 
 func resolveGetConfig(ctx context.Context, q schema.Query) *resolve.Resolved {
@@ -66,10 +67,11 @@ func resolveGetConfig(ctx context.Context, q schema.Query) *resolve.Resolved {
 	conf := make(map[string]interface{})
 	conf["cacheMb"] = float64(worker.Config.CacheMb)
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{q.Name(): conf},
-		Field: q,
-	}
+	return resolve.DataResult(
+		q,
+		map[string]interface{}{q.Name(): conf},
+		nil,
+	)
 
 }
 

--- a/graphql/admin/config.go
+++ b/graphql/admin/config.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
@@ -64,12 +65,11 @@ func resolveUpdateConfig(ctx context.Context, m schema.Mutation) (*resolve.Resol
 func resolveGetConfig(ctx context.Context, q schema.Query) *resolve.Resolved {
 	glog.Info("Got config query through GraphQL admin API")
 
-	conf := make(map[string]interface{})
-	conf["cacheMb"] = float64(worker.Config.CacheMb)
-
 	return resolve.DataResult(
 		q,
-		map[string]interface{}{q.Name(): conf},
+		map[string]interface{}{q.Name(): map[string]interface{}{
+			"cacheMb": json.Number(strconv.FormatInt(worker.Config.CacheMb, 10)),
+		}},
 		nil,
 	)
 

--- a/graphql/admin/cors.go
+++ b/graphql/admin/cors.go
@@ -47,23 +47,23 @@ func resolveReplaceAllowedCORSOrigins(ctx context.Context, m schema.Mutation) (*
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
-	// Aleast one origin is required to add allowlist. Since, no origin is provided, so we'll
-	// all origin to access dgraph.
+	// At-least one origin is required to add allowList. Since, no origin is provided, so we'll
+	// allow all origin to access dgraph.
 	if len(origins) == 0 {
 		origins = append(origins, "*")
 	}
 	if err = edgraph.AddCorsOrigins(ctx, origins); err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
-	return &resolve.Resolved{
-		Data: map[string]interface{}{
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{
 			m.Name(): map[string]interface{}{
-				"acceptedOrigins": arrayToInterface(origins),
+				"acceptedOrigins": toInterfaceSlice(origins),
 			},
 		},
-		Field: m,
-		Err:   nil,
-	}, true
+		nil,
+	), true
 }
 
 // resolveGetCors retrieves cors details from the database.
@@ -72,21 +72,12 @@ func resolveGetCors(ctx context.Context, q schema.Query) *resolve.Resolved {
 	if err != nil {
 		return resolve.EmptyResult(q, err)
 	}
-	return &resolve.Resolved{
-		Data: map[string]interface{}{
+	return resolve.DataResult(
+		q,
+		map[string]interface{}{
 			q.Name(): map[string]interface{}{
-				"acceptedOrigins": arrayToInterface(origins),
+				"acceptedOrigins": toInterfaceSlice(origins),
 			},
 		},
-		Field: q,
-	}
-}
-
-// arrayToInterface convers array string to array interface
-func arrayToInterface(in []string) []interface{} {
-	out := make([]interface{}, len(in))
-	for i, v := range in {
-		out[i] = v
-	}
-	return out
+		nil)
 }

--- a/graphql/admin/draining.go
+++ b/graphql/admin/draining.go
@@ -32,11 +32,13 @@ func resolveDraining(ctx context.Context, m schema.Mutation) (*resolve.Resolved,
 	enable := getDrainingInput(m)
 	x.UpdateDrainingMode(enable)
 
-	return &resolve.Resolved{
-		Data: map[string]interface{}{
-			m.Name(): response("Success", fmt.Sprintf("draining mode has been set to %v", enable))},
-		Field: m,
-	}, true
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{
+			m.Name(): response("Success", fmt.Sprintf("draining mode has been set to %v", enable)),
+		},
+		nil,
+	), true
 }
 
 func getDrainingInput(m schema.Mutation) bool {

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -63,20 +63,22 @@ func resolveExport(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 	}
 
 	responseData := response("Success", "Export completed.")
-	responseData["exportedFiles"] = toGraphQLArray(files)
+	responseData["exportedFiles"] = toInterfaceSlice(files)
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{m.Name(): responseData},
-		Field: m,
-	}, true
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{m.Name(): responseData},
+		nil,
+	), true
 }
 
-func toGraphQLArray(s []string) []interface{} {
-	outputFiles := make([]interface{}, 0, len(s))
-	for _, f := range s {
-		outputFiles = append(outputFiles, f)
+// toInterfaceSlice converts []string to []interface{}
+func toInterfaceSlice(in []string) []interface{} {
+	out := make([]interface{}, 0, len(in))
+	for _, s := range in {
+		out = append(out, s)
 	}
-	return outputFiles
+	return out
 }
 
 func getExportInput(m schema.Mutation) (*exportInput, error) {

--- a/graphql/admin/health.go
+++ b/graphql/admin/health.go
@@ -18,7 +18,6 @@ package admin
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -37,7 +36,7 @@ func resolveHealth(ctx context.Context, q schema.Query) *resolve.Resolved {
 	}
 
 	var health []map[string]interface{}
-	err = json.Unmarshal(resp.GetJson(), &health)
+	err = resolve.Unmarshal(resp.GetJson(), &health)
 
 	return resolve.DataResult(
 		q,

--- a/graphql/admin/health.go
+++ b/graphql/admin/health.go
@@ -39,10 +39,9 @@ func resolveHealth(ctx context.Context, q schema.Query) *resolve.Resolved {
 	var health []map[string]interface{}
 	err = json.Unmarshal(resp.GetJson(), &health)
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{q.Name(): health},
-		Field: q,
-		Err:   err,
-	}
-
+	return resolve.DataResult(
+		q,
+		map[string]interface{}{q.Name(): health},
+		err,
+	)
 }

--- a/graphql/admin/list_backups.go
+++ b/graphql/admin/list_backups.go
@@ -83,10 +83,11 @@ func resolveListBackups(ctx context.Context, q schema.Query) *resolve.Resolved {
 		results = append(results, result)
 	}
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{q.Name(): results},
-		Field: q,
-	}
+	return resolve.DataResult(
+		q,
+		map[string]interface{}{q.Name(): results},
+		nil,
+	)
 }
 
 func getLsBackupInput(q schema.Query) (*lsBackupInput, error) {

--- a/graphql/admin/list_backups.go
+++ b/graphql/admin/list_backups.go
@@ -76,7 +76,7 @@ func resolveListBackups(ctx context.Context, q schema.Query) *resolve.Resolved {
 			return resolve.EmptyResult(q, err)
 		}
 		var result map[string]interface{}
-		err = json.Unmarshal(b, &result)
+		err = resolve.Unmarshal(b, &result)
 		if err != nil {
 			return resolve.EmptyResult(q, err)
 		}

--- a/graphql/admin/login.go
+++ b/graphql/admin/login.go
@@ -50,15 +50,15 @@ func resolveLogin(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bo
 		return resolve.EmptyResult(m, err), false
 	}
 
-	return &resolve.Resolved{
-		Data: map[string]interface{}{
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{
 			m.Name(): map[string]interface{}{
 				"response": map[string]interface{}{
 					"accessJWT":  jwt.AccessJwt,
 					"refreshJWT": jwt.RefreshJwt}}},
-		Field: m,
-		Err:   nil,
-	}, true
+		nil,
+	), true
 
 }
 

--- a/graphql/admin/restore.go
+++ b/graphql/admin/restore.go
@@ -73,13 +73,13 @@ func resolveRestore(ctx context.Context, m schema.Mutation) (*resolve.Resolved, 
 	wg := &sync.WaitGroup{}
 	err = worker.ProcessRestoreRequest(context.Background(), &req, wg)
 	if err != nil {
-		return &resolve.Resolved{
-			Data: map[string]interface{}{m.Name(): map[string]interface{}{
+		return resolve.DataResult(
+			m,
+			map[string]interface{}{m.Name(): map[string]interface{}{
 				"code": "Failure",
 			}},
-			Field: m,
-			Err:   schema.GQLWrapLocationf(err, m.Location(), "resolving %s failed", m.Name()),
-		}, false
+			schema.GQLWrapLocationf(err, m.Location(), "resolving %s failed", m.Name()),
+		), false
 	}
 
 	go func() {
@@ -87,13 +87,14 @@ func resolveRestore(ctx context.Context, m schema.Mutation) (*resolve.Resolved, 
 		edgraph.ResetAcl(nil)
 	}()
 
-	return &resolve.Resolved{
-		Data: map[string]interface{}{m.Name(): map[string]interface{}{
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{m.Name(): map[string]interface{}{
 			"code":    "Success",
 			"message": "Restore operation started.",
 		}},
-		Field: m,
-	}, true
+		nil,
+	), true
 }
 
 func getRestoreInput(m schema.Mutation) (*restoreInput, error) {

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -17,26 +17,19 @@
 package admin
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 
-	dgoapi "github.com/dgraph-io/dgo/v200/protos/api"
-
 	"github.com/dgraph-io/dgraph/edgraph"
-	"github.com/dgraph-io/dgraph/gql"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/query"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgryski/go-farm"
 	"github.com/golang/glog"
 )
 
 type getSchemaResolver struct {
 	admin *adminServer
-
-	gqlQuery schema.Query
 }
 
 type updateGQLSchemaInput struct {
@@ -84,76 +77,36 @@ func (usr *updateSchemaResolver) Resolve(ctx context.Context, m schema.Mutation)
 		}
 	}
 
-	return &resolve.Resolved{
-		Data: map[string]interface{}{
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{
 			m.Name(): map[string]interface{}{
 				"gqlSchema": map[string]interface{}{
 					"id":              query.UidToHex(resp.Uid),
 					"schema":          input.Set.Schema,
 					"generatedSchema": schHandler.GQLSchema(),
 				}}},
-		Field: m,
-		Err:   nil,
-	}, true
+		nil), true
 }
 
-func (gsr *getSchemaResolver) Rewrite(ctx context.Context,
-	gqlQuery schema.Query) ([]*gql.GraphQuery, error) {
-	gsr.gqlQuery = gqlQuery
-	return nil, nil
-}
+func (gsr *getSchemaResolver) Resolve(ctx context.Context, q schema.Query) *resolve.Resolved {
+	var data map[string]interface{}
 
-func (gsr *getSchemaResolver) Execute(
-	ctx context.Context,
-	req *dgoapi.Request,
-	field schema.Field) (*dgoapi.Response, error) {
 	gsr.admin.mux.RLock()
 	defer gsr.admin.mux.RUnlock()
-	b, err := doQuery(gsr.admin.schema, gsr.gqlQuery)
-	return &dgoapi.Response{Json: b}, err
-}
 
-func (gsr *getSchemaResolver) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
-	return nil
-}
-
-func doQuery(gql *gqlSchema, field schema.Field) ([]byte, error) {
-
-	var buf bytes.Buffer
-	x.Check2(buf.WriteString(`{ "`))
-	x.Check2(buf.WriteString(field.Name()))
-
-	if gql.ID == "" {
-		x.Check2(buf.WriteString(`": null }`))
-		return buf.Bytes(), nil
+	if gsr.admin.schema.ID == "" {
+		data = map[string]interface{}{q.Name(): nil}
+	} else {
+		data = map[string]interface{}{
+			q.Name(): map[string]interface{}{
+				"id":              gsr.admin.schema.ID,
+				"schema":          gsr.admin.schema.Schema,
+				"generatedSchema": gsr.admin.schema.GeneratedSchema,
+			}}
 	}
 
-	x.Check2(buf.WriteString(`": {`))
-
-	for i, sel := range field.SelectionSet() {
-		var val []byte
-		var err error
-		switch sel.Name() {
-		case "id":
-			val, err = json.Marshal(gql.ID)
-		case "schema":
-			val, err = json.Marshal(gql.Schema)
-		case "generatedSchema":
-			val, err = json.Marshal(gql.GeneratedSchema)
-		}
-		x.Check2(val, err)
-
-		if i != 0 {
-			x.Check2(buf.WriteString(","))
-		}
-		x.Check2(buf.WriteString(`"`))
-		x.Check2(buf.WriteString(sel.Name()))
-		x.Check2(buf.WriteString(`":`))
-		x.Check2(buf.Write(val))
-	}
-	x.Check2(buf.WriteString("}}"))
-
-	return buf.Bytes(), nil
+	return resolve.DataResult(q, data, nil)
 }
 
 func getSchemaInput(m schema.Mutation) (*updateGQLSchemaInput, error) {

--- a/graphql/admin/shutdown.go
+++ b/graphql/admin/shutdown.go
@@ -36,8 +36,9 @@ func resolveShutdown(ctx context.Context, m schema.Mutation) (*resolve.Resolved,
 
 	ServerCloser.Signal()
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{m.Name(): response("Success", "Server is shutting down")},
-		Field: m,
-	}, true
+	return resolve.DataResult(
+		m,
+		map[string]interface{}{m.Name(): response("Success", "Server is shutting down")},
+		nil,
+	), true
 }

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -61,10 +61,11 @@ func resolveState(ctx context.Context, q schema.Query) *resolve.Resolved {
 		return resolve.EmptyResult(q, err)
 	}
 
-	return &resolve.Resolved{
-		Data:  map[string]interface{}{q.Name(): resultState},
-		Field: q,
-	}
+	return resolve.DataResult(
+		q,
+		map[string]interface{}{q.Name(): resultState},
+		nil,
+	)
 }
 
 // convertToGraphQLResp converts MembershipState proto to GraphQL layer response

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -56,7 +56,7 @@ func resolveState(ctx context.Context, q schema.Query) *resolve.Resolved {
 		return resolve.EmptyResult(q, err)
 	}
 	var resultState map[string]interface{}
-	err = json.Unmarshal(b, &resultState)
+	err = resolve.Unmarshal(b, &resultState)
 	if err != nil {
 		return resolve.EmptyResult(q, err)
 	}

--- a/graphql/resolve/auth_delete_test.yaml
+++ b/graphql/resolve/auth_delete_test.yaml
@@ -344,7 +344,7 @@
     }
   dgquerysec: |-
     query {
-      x as var()
+      var()
       DeleteLogPayload.log()
     }
 

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -734,7 +734,7 @@ func checkAddUpdateCase(
 		skipAuth:    tcase.SkipAuth,
 		length:      length,
 	}
-	resolver := NewDgraphResolver(rewriter(), ex, StdMutationCompletion(mut.ResponseName()))
+	resolver := NewDgraphResolver(rewriter(), ex)
 
 	// -- Act --
 	resolved, _ := resolver.Resolve(ctx, mut)

--- a/graphql/resolve/custom_mutation_test.yaml
+++ b/graphql/resolve/custom_mutation_test.yaml
@@ -59,7 +59,8 @@
         },
         {
           "id": "0x3",
-          "name": "Mov2"
+          "name": "Mov2",
+          "director": []
         }
       ]
     }

--- a/graphql/resolve/custom_query_test.yaml
+++ b/graphql/resolve/custom_query_test.yaml
@@ -46,7 +46,8 @@
         },
         {
           "id": "0x3",
-          "name": "Star Trek"
+          "name": "Star Trek",
+          "director": []
         }
       ]
     }
@@ -89,18 +90,11 @@
   resolvedresponse: |
     {
       "myFavoriteMoviesPart2": [
-        {
-          "id": "0x1",
-          "director": [
-            {
-              "id": "0x2",
-              "name": "George Lucas"
-            }
-          ]
-        },
+        null,
         {
           "id": "0x3",
-          "name": "Star Trek"
+          "name": "Star Trek",
+          "director": []
         }
       ]
     }

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -146,15 +146,10 @@ func (mr MutationResolverFunc) Resolve(ctx context.Context, m schema.Mutation) (
 // 2) execute the mutation with me (return error if failed)
 // 3) write a query for the mutation with mr (return error if failed)
 // 4) execute the query with qe (return error if failed)
-// 5) process the result with rc
-func NewDgraphResolver(
-	mr MutationRewriter,
-	ex DgraphExecutor,
-	rc ResultCompleter) MutationResolver {
+func NewDgraphResolver(mr MutationRewriter, ex DgraphExecutor) MutationResolver {
 	return &dgraphResolver{
 		mutationRewriter: mr,
 		executor:         ex,
-		resultCompleter:  rc,
 	}
 }
 
@@ -162,7 +157,6 @@ func NewDgraphResolver(
 type dgraphResolver struct {
 	mutationRewriter MutationRewriter
 	executor         DgraphExecutor
-	resultCompleter  ResultCompleter
 }
 
 func (mr *dgraphResolver) Resolve(ctx context.Context, m schema.Mutation) (*Resolved, bool) {
@@ -184,7 +178,6 @@ func (mr *dgraphResolver) Resolve(ctx context.Context, m schema.Mutation) (*Reso
 	defer timer.Stop()
 
 	resolved, success := mr.rewriteAndExecute(ctx, m)
-	mr.resultCompleter.Complete(ctx, resolved)
 	resolverTrace.Dgraph = resolved.Extensions.Tracing.Execution.Resolvers[0].Dgraph
 	resolved.Extensions.Tracing.Execution.Resolvers[0] = resolverTrace
 	return resolved, success

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -234,8 +234,9 @@ func (mr *dgraphResolver) rewriteAndExecute(ctx context.Context,
 
 	emptyResult := func(err error) *Resolved {
 		return &Resolved{
-			// all the standard mutations are nullable
-			Data:  []byte(`{"` + mutation.ResponseName() + `":null}`),
+			// all the standard mutations are nullable objects, so Data should pretty-much be
+			// {"mutAlias":null} everytime.
+			Data:  mutation.NullResponse(),
 			Field: mutation,
 			// there is no completion down the pipeline, so error's path should be prepended with
 			// mutation's alias before returning the response.
@@ -388,6 +389,7 @@ func completeMutationResult(mutation schema.Mutation, qryResult []byte, numUids 
 				x.Check2(buf.WriteString(`"Deleted"`))
 			}
 		case schema.NumUid:
+			// TODO: apply coercion here as per Int rules? or change the schema to Int64?
 			x.Check2(buf.WriteString(strconv.Itoa(numUids)))
 		default: // this has to be queryField
 			if len(qryResult) == 0 {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -382,13 +382,15 @@ func completeMutationResult(mutation schema.Mutation, qryResult []byte, numUids 
 				x.Check2(buf.WriteString(`"Deleted"`))
 			}
 		case schema.NumUid:
-			// TODO: apply coercion here as per Int rules? or change the schema to Int64?
-			// I think, changing the schema to Int64 is better.
+			// Although theoretically it is possible that numUids can be out of the int32 range but
+			// we don't need to apply coercion rules here as per Int type because carrying out a
+			// mutation which mutates more than 2 billion uids doesn't seem a practical case.
+			// So, we are skipping coercion here.
 			x.Check2(buf.WriteString(strconv.Itoa(numUids)))
 		default: // this has to be queryField
 			if len(qryResult) == 0 {
 				// don't write null, instead write [] as query field is always a nullable list
-				x.Check2(buf.WriteString("[]"))
+				x.Check2(buf.Write(schema.JsonEmptyList))
 			} else {
 				// need to write only the value returned for query field, so need to remove the JSON
 				// key till colon (:) and also the ending brace }.

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -390,6 +390,7 @@ func completeMutationResult(mutation schema.Mutation, qryResult []byte, numUids 
 			}
 		case schema.NumUid:
 			// TODO: apply coercion here as per Int rules? or change the schema to Int64?
+			// I think, changing the schema to Int64 is better.
 			x.Check2(buf.WriteString(strconv.Itoa(numUids)))
 		default: // this has to be queryField
 			if len(qryResult) == 0 {

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -328,13 +328,11 @@ func TestCustomHTTPMutation(t *testing.T) {
 			gqlMutation := test.GetMutation(t, op)
 
 			client := newClient(t, tcase)
-			resolver := NewHTTPMutationResolver(client, StdQueryCompletion())
+			resolver := NewHTTPMutationResolver(client)
 			resolved, isResolved := resolver.Resolve(context.Background(), gqlMutation)
 			require.True(t, isResolved)
 
-			b, err := json.Marshal(resolved.Data)
-			require.NoError(t, err)
-			testutil.CompareJSON(t, tcase.ResolvedResponse, string(b))
+			testutil.CompareJSON(t, tcase.ResolvedResponse, string(resolved.Data))
 		})
 	}
 }

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -103,14 +103,12 @@ func (qr *queryResolver) rewriteAndExecute(ctx context.Context, query schema.Que
 	}
 
 	emptyResult := func(err error) *Resolved {
-		var nullVal string
-		if query.Type().ListType() != nil {
-			nullVal = "[]"
-		} else {
-			nullVal = "null"
-		}
 		return &Resolved{
-			Data:       []byte(`{"` + query.ResponseName() + `":` + nullVal + `}`),
+			// all the auto-generated queries are nullable, but users may define queries with
+			// @custom(dql: ...) which may be non-nullable. So, we need to set the Data field
+			// only if the query was nullable and keep it nil if it was non-nullable.
+			// query.NullResponse() method handles that.
+			Data:       query.NullResponse(),
 			Field:      query,
 			Err:        schema.SetPathIfEmpty(err, query.ResponseName()),
 			Extensions: ext,

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -56,16 +56,14 @@ func (qr QueryResolverFunc) Resolve(ctx context.Context, query schema.Query) *Re
 // NewQueryResolver creates a new query resolver.  The resolver runs the pipeline:
 // 1) rewrite the query using qr (return error if failed)
 // 2) execute the rewritten query with ex (return error if failed)
-// 3) process the result with rc
-func NewQueryResolver(qr QueryRewriter, ex DgraphExecutor, rc ResultCompleter) QueryResolver {
-	return &queryResolver{queryRewriter: qr, executor: ex, resultCompleter: rc}
+func NewQueryResolver(qr QueryRewriter, ex DgraphExecutor) QueryResolver {
+	return &queryResolver{queryRewriter: qr, executor: ex}
 }
 
 // a queryResolver can resolve a single GraphQL query field.
 type queryResolver struct {
-	queryRewriter   QueryRewriter
-	executor        DgraphExecutor
-	resultCompleter ResultCompleter
+	queryRewriter QueryRewriter
+	executor      DgraphExecutor
 }
 
 func (qr *queryResolver) Resolve(ctx context.Context, query schema.Query) *Resolved {
@@ -84,7 +82,6 @@ func (qr *queryResolver) Resolve(ctx context.Context, query schema.Query) *Resol
 	defer timer.Stop()
 
 	resolved := qr.rewriteAndExecute(ctx, query)
-	qr.resultCompleter.Complete(ctx, resolved)
 	resolverTrace.Dgraph = resolved.Extensions.Tracing.Execution.Resolvers[0].Dgraph
 	resolved.Extensions.Tracing.Execution.Resolvers[0] = resolverTrace
 	return resolved

--- a/graphql/resolve/query_test.go
+++ b/graphql/resolve/query_test.go
@@ -155,11 +155,10 @@ func TestCustomHTTPQuery(t *testing.T) {
 			gqlQuery := test.GetQuery(t, op)
 
 			client := newClient(t, tcase)
-			resolver := NewHTTPQueryResolver(client, StdQueryCompletion())
+			resolver := NewHTTPQueryResolver(client)
 			resolved := resolver.Resolve(context.Background(), gqlQuery)
-			b, err := json.Marshal(resolved.Data)
-			require.NoError(t, err)
-			testutil.CompareJSON(t, tcase.ResolvedResponse, string(b))
+
+			testutil.CompareJSON(t, tcase.ResolvedResponse, string(resolved.Data))
 		})
 	}
 }

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -211,7 +211,7 @@ func (ec *executionContext) handleEnumValue(sel ast.SelectionSet, obj *introspec
 		if i != 0 {
 			x.Check2(ec.b.WriteRune(','))
 		}
-		ec.writeKey(field.Name)
+		ec.writeKey(field.Alias)
 		switch field.Name {
 		case Typename:
 			ec.writeStringValue("__EnumValue")
@@ -293,7 +293,7 @@ func (ec *executionContext) handleSchema(sel ast.SelectionSet, obj *introspectio
 		if i != 0 {
 			x.Check2(ec.b.WriteRune(','))
 		}
-		ec.writeKey(field.Name)
+		ec.writeKey(field.Alias)
 		switch field.Name {
 		case Typename:
 			ec.writeStringValue("__Schema")

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -90,7 +90,7 @@ func (ec *executionContext) writeStringValue(val string) {
 
 func (ec *executionContext) writeOptionalStringValue(val *string) {
 	if val == nil {
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 	} else {
 		ec.writeStringValue(*val)
 	}
@@ -390,7 +390,7 @@ func (ec *executionContext) marshalIntrospectionTypeSlice(sel ast.SelectionSet,
 func (ec *executionContext) marshalIntrospectionType(sel ast.SelectionSet, v *introspection.Type) {
 	if v == nil {
 		// TODO - This should be an error as this field is mandatory.
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 		return
 	}
 	ec.handleType(sel, v)
@@ -399,7 +399,7 @@ func (ec *executionContext) marshalIntrospectionType(sel ast.SelectionSet, v *in
 func (ec *executionContext) marshalOptionalEnumValueSlice(sel ast.SelectionSet,
 	v []introspection.EnumValue) {
 	if v == nil {
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 		return
 	}
 	x.Check2(ec.b.WriteRune('['))
@@ -415,7 +415,7 @@ func (ec *executionContext) marshalOptionalEnumValueSlice(sel ast.SelectionSet,
 func (ec *executionContext) marshalIntrospectionFieldSlice(sel ast.SelectionSet,
 	v []introspection.Field) {
 	if v == nil {
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 		return
 	}
 	x.Check2(ec.b.WriteRune('['))
@@ -447,7 +447,7 @@ func (ec *executionContext) marshalOptionalInputValueSlice(sel ast.SelectionSet,
 func (ec *executionContext) marshalOptionalItypeSlice(sel ast.SelectionSet,
 	v []introspection.Type) {
 	if v == nil {
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 		return
 	}
 
@@ -463,7 +463,7 @@ func (ec *executionContext) marshalOptionalItypeSlice(sel ast.SelectionSet,
 
 func (ec *executionContext) marshalType(sel ast.SelectionSet, v *introspection.Type) {
 	if v == nil {
-		x.Check2(ec.b.WriteString("null"))
+		x.Check2(ec.b.Write(JsonNull))
 		return
 	}
 	ec.handleType(sel, v)

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -54,6 +54,13 @@ const (
 		"GraphQL error propagation triggered."
 )
 
+var (
+	// JsonNull are the bytes to represent null in JSON.
+	JsonNull = []byte("null")
+	// JsonEmptyList are the bytes to represent an empty list in JSON.
+	JsonEmptyList = []byte("[]")
+)
+
 // GraphQL spec on response is here:
 // https://graphql.github.io/graphql-spec/June2018/#sec-Response
 
@@ -139,7 +146,7 @@ func (r *Response) AddData(p []byte) {
 func (r *Response) SetDataNull() {
 	r.dataIsNull = true
 	r.Data.Reset()
-	x.Check2(r.Data.WriteString("null"))
+	x.Check2(r.Data.Write(JsonNull))
 }
 
 // MergeExtensions merges the extensions given in ext to r.

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -189,7 +189,7 @@ func (r *Response) Output() interface{} {
 			Data   json.RawMessage `json:"data,omitempty"`
 		}{
 			Errors: []byte(`[{"message": "Internal error - no response to write."}]`),
-			Data:   []byte("null"),
+			Data:   JsonNull,
 		}
 	}
 

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -1098,7 +1098,8 @@ func (sg *SubGraph) toFastJSON(l *Latency, field gqlSchema.Field) ([]byte, error
 			buf:              &bufw,
 			dgraphTypeAttrId: enc.idForAttr("dgraph.type"),
 		}
-		if !enc.encodeGraphQL(gqlEncCtx, n, true, []gqlSchema.Field{field}, nil, nil) {
+		if !enc.encodeGraphQL(gqlEncCtx, n, true, []gqlSchema.Field{field}, nil,
+			make([]interface{}, 0, field.MaxPathLength())) {
 			// if enc.encodeGraphQL() didn't finish successfully here, that means we need to send
 			// data as null in the GraphQL response like this:
 			// 		{

--- a/query/outputnode_graphql.go
+++ b/query/outputnode_graphql.go
@@ -59,6 +59,7 @@ func cantCoerceScalar(val []byte, field gqlSchema.Field) bool {
 		// valToBytes() uses []byte(strconv.FormatInt(num, 10)) to convert int values to byte slice.
 		// so, we should do the reverse, parse the string back to int and check that it fits in the
 		// range of int32.
+		// TODO: think if we can do this check in a better way without parsing the bytes.
 		if _, err := strconv.ParseInt(string(val), 10, 32); err != nil {
 			return true
 		}


### PR DESCRIPTION
This PR:
* makes the admin server on `/admin` and `@custom(http: {...})` Query/Mutation work through a common pipeline separate from the queries/mutations resolved through Dgraph
* adds scalar coercion to queries resolved through Dgraph
* and, removes completion as a step from resolvers, as it is not needed anymore.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7317)
<!-- Reviewable:end -->
