### PR TITLE
chore(worker): Set initial schema and types directly to group-1 nodes.

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -334,18 +334,8 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 		if groups().groupId() == 1 {
 			initialSchema := schema.InitialSchema()
 			for _, s := range initialSchema {
-				if err := updateSchema(s); err != nil {
-					return err
-				}
-
-				if servesTablet, err := groups().ServesTablet(s.Predicate); err != nil {
-					return err
-				} else if !servesTablet {
-					return errors.Errorf("group 1 should always serve reserved predicate %s",
-						s.Predicate)
-				}
+				applySchema(s)
 			}
-
 		}
 
 		// Propose initial types as well after a drop all as they would have been cleared.

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -206,6 +206,9 @@ func (g *groupi) applyInitialTypes() {
 }
 
 func (g *groupi) applyInitialSchema() {
+	if g.groupId() != 1 {
+		return
+	}
 	initialSchema := schema.InitialSchema()
 	ctx := g.Ctx()
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -238,7 +238,7 @@ func (g *groupi) applyInitialSchema() {
 			applySchema(s)
 		} else {
 			// The schema for this predicate has already been proposed.
-			glog.V(1).Infof("Skipping initial schema upsert for predicate %s", s.Predicate)
+			glog.V(1).Infof("Schema found for predicate %s: ", s.Predicate)
 			continue
 		}
 	}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -238,7 +238,7 @@ func (g *groupi) applyInitialSchema() {
 			applySchema(s)
 		} else {
 			// The schema for this predicate has already been proposed.
-			glog.V(1).Infof("Schema found for predicate %s: %+v", s.Predicate, s)
+			glog.V(1).Infof("Schema found for predicate %s: %+v", s.Predicate, curr)
 			continue
 		}
 	}

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -238,7 +238,7 @@ func (g *groupi) applyInitialSchema() {
 			applySchema(s)
 		} else {
 			// The schema for this predicate has already been proposed.
-			glog.V(1).Infof("Schema found for predicate %s: ", s.Predicate)
+			glog.V(1).Infof("Schema found for predicate %s: %+v", s.Predicate, s)
 			continue
 		}
 	}


### PR DESCRIPTION
All internal predicates belong to group 1. Set the initial schemas/types directly on all the nodes which belong to group 1 rather than making a raft proposal for them.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7324)
<!-- Reviewable:end -->
