### PR TITLE
chore: Fetch dependencies before regenerating protos.

### DIFF
--- a/protos/Makefile
+++ b/protos/Makefile
@@ -50,14 +50,11 @@ copy-protos:
 	@mkdir -p ${TMPDIR}/src/${DGO_PATH}/protos
 	@mkdir -p ${TMPDIR}/src/${BADGER_PATH}/pb
 	@mkdir -p ${TMPDIR}/src/${GOGO_PATH}/gogoproto
-	@cp $(shell go list -m -f "{{.Dir}}" \
-	 ${BADGER_PATH})/pb/badgerpb${BADGER_PB_VERSION}.proto \
+	@cp $(shell go list -m -f "{{.Dir}}" ${BADGER_PATH})/pb/badgerpb${BADGER_PB_VERSION}.proto \
 	 ${TMPDIR}/src/${BADGER_PATH}/pb/pb.proto
-	@cp $(shell go list -m -f "{{.Dir}}" \
-	 ${DGO_PATH})/protos/api.proto \
+	@cp $(shell go list -m -f "{{.Dir}}" ${DGO_PATH})/protos/api.proto \
 	 ${TMPDIR}/src/${DGO_PATH}/protos/api.proto
-	@cp $(shell go list -m -f "{{.Dir}}" \
-	 ${GOGO_PATH})/gogoproto/gogo.proto \
+	@cp $(shell go list -m -f "{{.Dir}}" ${GOGO_PATH})/gogoproto/gogo.proto \
 	 ${TMPDIR}/src/${GOGO_PATH}/gogoproto/gogo.proto
 
 .PHONY: regenerate

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -14,8 +14,11 @@
 # limitations under the License.
 #
 
+# Update BADGER_PB_VERSION when upgrading Badger major versions
+BADGER_PB_VERSION = 3
+
 DGO_PATH    := github.com/dgraph-io/dgo/v200
-BADGER_PATH := github.com/dgraph-io/badger/v3
+BADGER_PATH := github.com/dgraph-io/badger/v${BADGER_PB_VERSION}
 GOGO_PATH   := github.com/gogo/protobuf
 
 TMPDIR     := $(shell mktemp -d)
@@ -33,7 +36,7 @@ clean:
 
 .PHONY: get-deps
 get-deps:
-	go get -v github.com/dgraph-io/dgraph
+	go get -v github.com/dgraph-io/dgraph/dgraph
 
 .PHONY: check
 check:
@@ -47,9 +50,15 @@ copy-protos:
 	@mkdir -p ${TMPDIR}/src/${DGO_PATH}/protos
 	@mkdir -p ${TMPDIR}/src/${BADGER_PATH}/pb
 	@mkdir -p ${TMPDIR}/src/${GOGO_PATH}/gogoproto
-	@cp $(shell go list -m -f "{{.Dir}}" ${BADGER_PATH})/pb/badgerpb3.proto ${TMPDIR}/src/${BADGER_PATH}/pb/pb.proto
-	@cp $(shell go list -m -f "{{.Dir}}" ${DGO_PATH})/protos/api.proto ${TMPDIR}/src/${DGO_PATH}/protos/api.proto
-	@cp $(shell go list -m -f "{{.Dir}}" ${GOGO_PATH})/gogoproto/gogo.proto ${TMPDIR}/src/${GOGO_PATH}/gogoproto/gogo.proto
+	@cp $(shell go list -m -f "{{.Dir}}" \
+	 ${BADGER_PATH})/pb/badgerpb${BADGER_PB_VERSION}.proto \
+	 ${TMPDIR}/src/${BADGER_PATH}/pb/pb.proto
+	@cp $(shell go list -m -f "{{.Dir}}" \
+	 ${DGO_PATH})/protos/api.proto \
+	 ${TMPDIR}/src/${DGO_PATH}/protos/api.proto
+	@cp $(shell go list -m -f "{{.Dir}}" \
+	 ${GOGO_PATH})/gogoproto/gogo.proto \
+	 ${TMPDIR}/src/${GOGO_PATH}/gogoproto/gogo.proto
 
 .PHONY: regenerate
 regenerate: get-deps copy-protos check clean

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -34,9 +34,9 @@ help:
 clean:
 	@mkdir -p pb && rm -f pb/pb.pb.go
 
-.PHONY: get-deps
-get-deps:
-	go get -v github.com/dgraph-io/dgraph/dgraph
+.PHONY: tidy-deps
+tidy-deps:
+	@go mod tidy -v
 
 .PHONY: check
 check:
@@ -58,7 +58,7 @@ copy-protos:
 	 ${TMPDIR}/src/${GOGO_PATH}/gogoproto/gogo.proto
 
 .PHONY: regenerate
-regenerate: get-deps copy-protos check clean
+regenerate: tidy-deps copy-protos check clean
 	@protoc \
 		--proto_path=/usr/local/include \
 		--proto_path=/usr/include \

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -31,6 +31,10 @@ help:
 clean:
 	@mkdir -p pb && rm -f pb/pb.pb.go
 
+.PHONY: get-deps
+get-deps:
+	go get -v github.com/dgraph-io/dgraph
+
 .PHONY: check
 check:
 	@./depcheck.sh && \
@@ -48,7 +52,7 @@ copy-protos:
 	@cp $(shell go list -m -f "{{.Dir}}" ${GOGO_PATH})/gogoproto/gogo.proto ${TMPDIR}/src/${GOGO_PATH}/gogoproto/gogo.proto
 
 .PHONY: regenerate
-regenerate: copy-protos check clean
+regenerate: get-deps copy-protos check clean
 	@protoc \
 		--proto_path=/usr/local/include \
 		--proto_path=/usr/include \

--- a/protos/depcheck.sh
+++ b/protos/depcheck.sh
@@ -1,4 +1,19 @@
 #!/usr/bin/env bash
+#
+# Copyright 2019-2021 Dgraph Labs, Inc. and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -1,3 +1,18 @@
+/* Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package protos
 
 import (

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -16,6 +16,7 @@
 package protos
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +25,8 @@ import (
 )
 
 func TestProtosRegenerate(t *testing.T) {
+	d, _ := os.Getwd()
+	t.Logf("CWD: %v\n", d)
 	err := testutil.Exec("make", "regenerate")
 	require.NoError(t, err, "Got error while regenerating protos: %v\n", err)
 

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -16,7 +16,6 @@
 package protos
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -25,8 +24,6 @@ import (
 )
 
 func TestProtosRegenerate(t *testing.T) {
-	d, _ := os.Getwd()
-	t.Logf("CWD: %v\n", d)
 	err := testutil.Exec("make", "regenerate")
 	require.NoError(t, err, "Got error while regenerating protos: %v\n", err)
 

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -1,0 +1,13 @@
+package protos
+
+import (
+	"testing"
+
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtosRegenerate(t *testing.T) {
+	err := testutil.Exec("make", "regenerate")
+	require.NoError(t, err, "Got error while regenerating protos: %v\n", err)
+}

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -1,6 +1,7 @@
 package protos
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/testutil"
@@ -10,4 +11,8 @@ import (
 func TestProtosRegenerate(t *testing.T) {
 	err := testutil.Exec("make", "regenerate")
 	require.NoError(t, err, "Got error while regenerating protos: %v\n", err)
+
+	generatedProtos := filepath.Join("pb", "pb.pb.go")
+	err = testutil.Exec("git", "diff", "--quiet", "--", generatedProtos)
+	require.NoError(t, err, "pb.pb.go changed after regenerating")
 }


### PR DESCRIPTION
If the proto dependencies change, then they need to be fetched first before the
protos can be regenerated. For example, when Badger protos change then this
error can happen:

    $ make regenerate
    cp: cannot stat '/pb/badgerpb3.proto': No such file or directory
    make: *** [Makefile:46: copy-protos] Error 1

Calling `go get` or `go mod tidy` fixes this issue:

    $ go mod tidy
    ...
    go: downloading github.com/dgraph-io/badger/v3 v3.0.0-20210113052537-b69163b5c21b

The dependencies need to be fetched in order to pick up the correct proto files
from the `$GOMODCACHE` directory using `go list -m -f "{{.Dir}}"`.

Changes:
* Fetch dependencies (tidy-deps) before regenerating protos.
* Refactor Makefile with `BADGER_PB_VERSION` variable to make it
  easier to update Badger version
* Add Go tests to regenerate the protos and check for
  differences. This check originally added in CI in
  https://github.com/dgraph-io/dgraph/pull/7102#pullrequestreview-548948416.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7326)
<!-- Reviewable:end -->
