### PR TITLE
fix(rollup): don't do rollup for a key inserted for first time

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -243,7 +243,9 @@ func (txn *Txn) CommitToDisk(writer *TxnWriter, commitTs uint64) error {
 		// Add these keys to be rolled up after we're done writing. This is the right place for them
 		// to be rolled up, because we just pushed these deltas over to Badger.
 		for _, key := range keys {
-			IncrRollup.addKeyToBatch([]byte(key), 1)
+			if vs := txn.cache.maxVersions[key]; vs != 0 {
+				IncrRollup.addKeyToBatch([]byte(key), 1)
+			}
 		}
 	}()
 


### PR DESCRIPTION
We made a recent change in how rollups work. https://github.com/dgraph-io/dgraph/pull/7277 
We were adding the keys to the rollup batch, even on their first write. In this PR, we don't do the rollup when the key is inserted for the first time. This helps reducing flakiness in GraphQL.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7327)
<!-- Reviewable:end -->
