### PR TITLE
fix(GraphQL):This PR will fix the graphl tests that were failing because of recent change in dgraph. 

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -714,7 +714,6 @@ func run() {
 	// schema before calling posting.Init().
 	schema.Init(worker.State.Pstore)
 	posting.Init(worker.State.Pstore, postingListCacheSize)
-	admin.Init(worker.State.Pstore)
 	defer posting.Cleanup()
 	worker.Init(worker.State.Pstore)
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -714,6 +714,7 @@ func run() {
 	// schema before calling posting.Init().
 	schema.Init(worker.State.Pstore)
 	posting.Init(worker.State.Pstore, postingListCacheSize)
+	admin.Init(worker.State.Pstore)
 	defer posting.Cleanup()
 	worker.Init(worker.State.Pstore)
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -506,6 +506,7 @@ func newAdminResolver(
 		// Last update contains the latest value. So, taking the last update.
 		lastIdx := len(kvs.GetKv()) - 1
 		kv := kvs.GetKv()[lastIdx]
+
 		glog.Infof("Updating GraphQL schema from subscription.")
 
 		// Unmarshal the incoming posting list.
@@ -522,11 +523,13 @@ func newAdminResolver(
 				len(pl.Postings))
 			return
 		}
+
 		pk, err := x.Parse(kv.GetKey())
 		if err != nil {
 			glog.Errorf("Unable to find uid of updated schema %s", err)
 			return
 		}
+
 		newSchema := &gqlSchema{
 			ID:      query.UidToHex(pk.Uid),
 			Version: kv.GetVersion(),
@@ -554,6 +557,7 @@ func newAdminResolver(
 
 		server.schema = newSchema
 		server.resetSchema(gqlSchema)
+
 		glog.Infof("Successfully updated GraphQL schema. Serving New GraphQL API.")
 	}, 1, closer)
 
@@ -639,6 +643,7 @@ func getCurrentGraphQLSchema() (*gqlSchema, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
 }
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -649,7 +649,7 @@ func getCurrentGraphQLSchema() (*gqlSchema, error) {
 		return nil, err
 	}
 	if graphQLSchema == "" {
-		return &gqlSchema{ID: uid, Version: 0, Schema: graphQLSchema}, nil
+		return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
 	}
 	//getting version of the current schema.
 	intUid, err := gql.ParseUid(uid)
@@ -659,7 +659,7 @@ func getCurrentGraphQLSchema() (*gqlSchema, error) {
 
 	prefix := x.DataKey(worker.GqlSchemaPred, intUid)
 	txn := pstore.NewTransactionAt(math.MaxUint64, false)
-	item, err := txn.Get(prefix) // This will get the item with the latest version.
+	item, err := txn.Get(prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -19,8 +19,6 @@ package admin
 import (
 	"context"
 	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/dgraph/gql"
-	"math"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -648,24 +646,7 @@ func getCurrentGraphQLSchema() (*gqlSchema, error) {
 	if err != nil {
 		return nil, err
 	}
-	if graphQLSchema == "" {
-		return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
-	}
-	//getting version of the current schema.
-	intUid, err := gql.ParseUid(uid)
-	if err != nil {
-		return nil, err
-	}
-
-	prefix := x.DataKey(worker.GqlSchemaPred, intUid)
-	txn := pstore.NewTransactionAt(math.MaxUint64, false)
-	item, err := txn.Get(prefix)
-	if err != nil {
-		return nil, err
-	}
-
-	version := item.Version()
-	return &gqlSchema{ID: uid, Version: version, Schema: graphQLSchema}, nil
+	return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
 }
 
 func generateGQLSchema(sch *gqlSchema) (schema.Schema, error) {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -426,6 +426,7 @@ func (g *GraphQLHealthStore) updatingSchema() {
 type gqlSchema struct {
 	ID              string `json:"id,omitempty"`
 	Schema          string `json:"schema,omitempty"`
+	Version         uint64
 	GeneratedSchema string
 }
 
@@ -528,14 +529,14 @@ func newAdminResolver(
 			glog.Errorf("Unable to find uid of updated schema %s", err)
 			return
 		}
-
 		newSchema := &gqlSchema{
-			ID:     query.UidToHex(pk.Uid),
-			Schema: string(pl.Postings[0].Value),
+			ID:      query.UidToHex(pk.Uid),
+			Version: kv.GetVersion(),
+			Schema:  string(pl.Postings[0].Value),
 		}
 		server.mux.RLock()
-		if newSchema.Schema == server.schema.Schema {
-			glog.Infof("Skipping GraphQL schema update as the new schema is the same as the current schema.")
+		if newSchema.Version <= server.schema.Version || newSchema.Schema == server.schema.Schema {
+			glog.Infof("Skipping GraphQL schema update because we got an old schema.")
 			server.mux.RUnlock()
 			return
 		}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -536,7 +536,8 @@ func newAdminResolver(
 		}
 		server.mux.RLock()
 		if newSchema.Version <= server.schema.Version || newSchema.Schema == server.schema.Schema {
-			glog.Infof("Skipping GraphQL schema update because we got an old schema.")
+			glog.Infof("Skipping GraphQL schema update because either we got same schema or schema with older" +
+				" version than version of current schema ")
 			server.mux.RUnlock()
 			return
 		}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -18,7 +18,6 @@ package admin
 
 import (
 	"context"
-	"github.com/dgraph-io/badger/v3"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -384,13 +383,7 @@ var (
 	}
 	// mainHealthStore stores the health of the main GraphQL server.
 	mainHealthStore = &GraphQLHealthStore{}
-	pstore          *badger.DB
 )
-
-// Init resets the schema state, setting the underlying DB to the given pointer.
-func Init(ps *badger.DB) {
-	pstore = ps
-}
 
 func SchemaValidate(sch string) error {
 	schHandler, err := schema.NewHandler(sch, true)


### PR DESCRIPTION
we have changed in Dgraph the way rollups are done in this PR. https://github.com/dgraph-io/dgraph/pull/7253
As a result of it, we were having below unexpected behavior in graphql while updating the schema.
**issue:**
suppose we send below schema requests,
```
1.schema1
2.schema2

```
Badger is supposed to return the following updates to graphql

1.schema1
1.schema1
1.schema1
2.schema2
2.schema2
2.schema2

If we get a schema update that is same as our previous schema then we are already ignoring that 
in graphql.For example, below multiple updates for schema1,schema2 from badger  gets ignored
```
1.schema1  //accepted,new update
2.schema1  //discarded,same as previous
3.schema1  //discarded,same as previous
4.schema1  //discared,same as previous
5.schema2  //accepted,new update 
6.schema2  //discarded,same as previous
7.schema2  //discarded,same as previous
```
But because of the recent change we are now sometimes getting older updates in random order like below.
```
1.schema1  //version1
2.schema2  //version2
3.schema1  //version1
```

so in this case graphql was assuming that we got an new schema which actually was old schema.
And due to that multiple errors were broken.

**Solution**
The solution is simple.Every update from the badger also have version associated to it.
And that version number is strictly increasing. Now, if we get an schema with version <=  current schema version
then we don't update the graphql schema.And that solve the issue

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7329)
<!-- Reviewable:end -->
