### PR TITLE
release/v20.11: debug(uidpack): add checks for uid pack in debug mode (#7250)

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -910,6 +910,7 @@ func (out *rollupOutput) marshalPostingListPart(alloc *z.Allocator,
 // MarshalPostingList returns a KV with the marshalled posting list. The caller
 // SHOULD SET the Key and Version for the returned KV.
 func MarshalPostingList(plist *pb.PostingList, alloc *z.Allocator) *bpb.KV {
+	x.VerifyPack(plist)
 	kv := y.NewKV(alloc)
 	if isPlistEmpty(plist) {
 		kv.Value = nil
@@ -1065,6 +1066,7 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 		}
 	} else {
 		// We already have a nicely packed posting list. Just use it.
+		x.VerifyPack(l.plist)
 		out.plist = l.plist
 	}
 

--- a/x/debug.go
+++ b/x/debug.go
@@ -26,8 +26,14 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 )
+
+// VerifyPack checks that the Pack should not be nil if the postings exist.
+func VerifyPack(plist *pb.PostingList) {
+	if plist.Pack == nil && len(plist.Postings) > 0 {
+		log.Panic("UID Pack verification failed: Pack is nil for posting list: %+v", plist)
+	}
+}
 
 // VerifySnapshot iterates over all the keys in badger. For all data keys it checks
 // if key is a split key and it verifies if all part are present in badger as well.
@@ -54,6 +60,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 			err := item.Value(func(v []byte) error {
 				plist := &pb.PostingList{}
 				Check(plist.Unmarshal(v))
+				VerifyPack(plist)
 				if len(plist.Splits) == 0 {
 					return nil
 				}
@@ -77,7 +84,7 @@ func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 				}
 				return nil
 			})
-			x.Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
+			Checkf(err, "Error getting value of key: %v version: %v", k, item.Version())
 
 			if item.DiscardEarlierVersions() {
 				break

--- a/x/nodebug.go
+++ b/x/nodebug.go
@@ -25,6 +25,10 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
+// VerifyPack works in debug mode. Check out the comment in debug_on.go
+func VerifyPack(plist *pb.PostingList) {
+}
+
 // VerifySnapshot works in debug mode. Check out the comment in debug_on.go
 func VerifySnapshot(pstore *badger.DB, readTs uint64) {
 }


### PR DESCRIPTION
This PR adds checks for verification of plist's uidpack when dgraph is run in debug mode.

(cherry picked from commit d42f881e43d2aa393cd4ed52b26274eadf28de28)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7332)
<!-- Reviewable:end -->
