### PR TITLE
feat(Apollo): Add "_entities" resolver.

### DIFF
--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -137,7 +137,7 @@ func writeUIDFunc(b *strings.Builder, uids []uint64, args []gql.Arg) {
 // writeRoot writes the root function as well as any ordering and paging
 // specified in q.
 //
-// Only uid(0x123, 0x124) and type(...) functions are supported at root.
+// Only uid(0x123, 0x124), type(...) and eq(Type.Predicate, ...) functions are supported at root.
 func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	if q.Func == nil {
 		return
@@ -149,9 +149,10 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 		writeUIDFunc(b, q.Func.UID, q.Func.Args)
 	case q.Func.Name == "type" && len(q.Func.Args) == 1:
 		x.Check2(b.WriteString(fmt.Sprintf("(func: type(%s)", q.Func.Args[0].Value)))
-	case q.Func.Name == "eq" && len(q.Func.Args) == 2:
-		x.Check2(b.WriteString(fmt.Sprintf("(func: eq(%s, %s)", q.Func.Args[0].Value,
-			q.Func.Args[1].Value)))
+	case q.Func.Name == "eq":
+		x.Check2(b.WriteString("(func: eq("))
+		writeFilterArguments(b, q.Func.Args)
+		x.Check2(b.WriteRune(')'))
 	}
 	writeOrderAndPage(b, q, true)
 	x.Check2(b.WriteRune(')'))

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -775,3 +775,31 @@ type Book @auth(
     name: String!
     desc: String!
 }
+
+
+type Mission @key(fields: "id") @auth(
+    query:{ rule: """
+            query($USER: String!) { 
+              queryMission(filter: { supervisorName: {eq: $USER} } ) { 
+                id 
+              } 
+            }""" }
+){
+    id: String! @id
+    crew: [Astronaut]
+    supervisorName: String @search(by: [exact])
+    spaceShip: [SpaceShip]
+    designation: String!
+    startDate: String
+    endDate: String
+}
+
+type Astronaut @key(fields: "id") @extends @auth(
+    query: { rule: "{$ROLE: { eq: \"admin\" } }"},
+    add: { rule: "{$USER: { eq: \"foo\" } }"},
+    delete: { rule: "{$USER: { eq: \"foo\" } }"},
+    update: { rule: "{$USER: { eq: \"foo\" } }"}
+){
+    id: ID! @external
+    missions: [Mission]
+}

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -788,7 +788,6 @@ type Mission @key(fields: "id") @auth(
     id: String! @id
     crew: [Astronaut]
     supervisorName: String @search(by: [exact])
-    spaceShip: [SpaceShip]
     designation: String!
     startDate: String
     endDate: String

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -627,6 +627,7 @@ func RunAll(t *testing.T) {
 	t.Run("query only typename", queryOnlyTypename)
 	t.Run("query nested only typename", querynestedOnlyTypename)
 	t.Run("test onlytypename for interface types", onlytypenameForInterface)
+	t.Run("entitites Query on extended type", entitiesQuery)
 
 	t.Run("get state by xid", getStateByXid)
 	t.Run("get state without args", getStateWithoutArgs)

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -411,7 +411,7 @@ func entitiesQuery(t *testing.T) {
 		Variables: map[string]interface{}{
 			"typeName": "SpaceShip",
 			"id1":      "SpaceShip1",
-			"id2":      "SpapceShip2",
+			"id2":      "SpaceShip2",
 		},
 	}
 

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -399,7 +399,7 @@ func entitiesQuery(t *testing.T) {
 
 	entitiesQueryParams := &GraphQLParams{
 		Query: `query _entities($typeName: String!, $id1: String!, $id2: String!){
-			_entities(representations: [{__typename: $typeName, id: $id1}, {_typename: $typeName, id: $id2 }]) {
+			_entities(representations: [{__typename: $typeName, id: $id1}, {__typename: $typeName, id: $id2 }]) {
 				... on SpaceShip {
 					missions {
 						id

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -302,3 +302,24 @@ type Section {
     name: String!
     chapterId: Int! @search
 }
+
+# test for entities resolver
+
+type Mission @key(fields: "id") {
+    id: String! @id
+    crew: [Astronaut]
+    spaceShip: [SpaceShip]
+    designation: String!
+    startDate: String
+    endDate: String
+}
+
+type Astronaut @key(fields: "id") @extends {
+    id: ID! @external
+    missions: [Mission]
+}
+
+type SpaceShip @key(fields: "id") @extends {
+    id: String! @id @external
+    missions: [Mission]
+}

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -314,6 +314,8 @@ type Mission @key(fields: "id") {
     endDate: String
 }
 
+# Todo(Minhaj): Add test case for entities resolver
+# for objects of Astronaut type. 
 type Astronaut @key(fields: "id") @extends {
     id: ID! @external
     missions: [Mission]

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -315,6 +315,8 @@ type Mission @key(fields: "id") {
     endDate: String
 }
 
+# Todo(Minhaj): Add test case for entities resolver
+# for objects of Astronaut type. 
 type Astronaut @key(fields: "id") @extends {
     id: ID! @external
     missions: [Mission]

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -303,3 +303,24 @@ type Section {
         name: String!
         chapterId: Int! @search
 }
+
+# test for entities resolver
+
+type Mission @key(fields: "id") {
+    id: String! @id
+    crew: [Astronaut]
+    spaceShip: [SpaceShip]
+    designation: String!
+    startDate: String
+    endDate: String
+}
+
+type Astronaut @key(fields: "id") @extends {
+    id: ID! @external
+    missions: [Mission]
+}
+
+type SpaceShip @key(fields: "id") @extends {
+    id: String! @id @external
+    missions: [Mission]
+}

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1835,3 +1835,81 @@
         pwd as checkpwd(Post.pwd, "something")
       }
     }
+
+
+- name: "Entities query with all levels of @auth rule true"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {
+        ... on Astronaut {
+          missions {
+            designation
+          }
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "admin"
+    USER: "user"
+  dgquery: |-
+    query {
+      _entities(func: uid(_EntityRoot)) {
+        dgraph.type
+        Astronaut.missions : Astronaut.missions @filter(uid(Mission1)) {
+          designation : Mission.designation
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+      _EntityRoot as var(func: uid(Astronaut4))
+      Astronaut4 as var(func: uid(0x1, 0x2, 0x3)) @filter(type(Astronaut))
+      var(func: uid(_EntityRoot)) {
+        Mission2 as Astronaut.missions
+      }
+      Mission1 as var(func: uid(Mission2)) @filter(uid(MissionAuth3))
+      MissionAuth3 as var(func: uid(Mission2)) @filter(eq(Mission.supervisorName, "user")) @cascade {
+        Mission.id : Mission.id
+      }
+    }
+
+- name: "Entities query with all levels of @auth rule false"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {
+        ... on Astronaut {
+          missions {
+            designation
+          }
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "user"
+  dgquery: |-
+    query {
+      _entities()
+    }
+
+- name: "Entities query with Deep @auth rules false"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {
+        ... on Astronaut {
+          missions {
+            designation
+          }
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "admin"
+  dgquery: |-
+    query {
+      _entities(func: uid(_EntityRoot)) {
+        dgraph.type
+        dgraph.uid : uid
+      }
+      _EntityRoot as var(func: uid(Astronaut3))
+      Astronaut3 as var(func: uid(0x1, 0x2, 0x3)) @filter(type(Astronaut))
+    }
+

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1836,8 +1836,35 @@
       }
     }
 
-
-- name: "Entities query with all levels of @auth rule true"
+- name: "Entities query with query auth rules"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "Mission", id: "0x1"}{__typename: "Mission", id: "0x2"}, {__typename: "Mission", id: "0x3"}]) {
+        ... on Mission {
+          id
+          designation
+          startDate
+        }
+      }
+    }
+  jwtvar:
+    USER: "user"
+  dgquery: |-
+    query {
+      _entities(func: uid(_EntityRoot)) {
+        dgraph.type
+        id : Mission.id
+        designation : Mission.designation
+        startDate : Mission.startDate
+        dgraph.uid : uid
+      }
+      _EntityRoot as var(func: uid(Mission1)) @filter(uid(MissionAuth2))
+      Mission1 as var(func: eq(Mission.id, "0x1", "0x2", "0x3")) @filter(type(Mission))
+      MissionAuth2 as var(func: uid(Mission1)) @filter(eq(Mission.supervisorName, "user")) @cascade {
+        id : Mission.id
+      }
+    }
+- name: "Entities query with top level RBAC rule true and level 1 query auth rule"
   gqlquery: |
     query {
       _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {
@@ -1855,7 +1882,7 @@
     query {
       _entities(func: uid(_EntityRoot)) {
         dgraph.type
-        Astronaut.missions : Astronaut.missions @filter(uid(Mission1)) {
+        missions : Astronaut.missions @filter(uid(Mission1)) {
           designation : Mission.designation
           dgraph.uid : uid
         }
@@ -1868,11 +1895,11 @@
       }
       Mission1 as var(func: uid(Mission2)) @filter(uid(MissionAuth3))
       MissionAuth3 as var(func: uid(Mission2)) @filter(eq(Mission.supervisorName, "user")) @cascade {
-        Mission.id : Mission.id
+        id : Mission.id
       }
     }
 
-- name: "Entities query with all levels of @auth rule false"
+- name: "Entities query with RBAC rule false"
   gqlquery: |
     query {
       _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {
@@ -1890,7 +1917,7 @@
       _entities()
     }
 
-- name: "Entities query with Deep @auth rules false"
+- name: "Entities query with top RBAC rules true and missing JWT variable for level 1 query auth rule"
   gqlquery: |
     query {
       _entities(representations: [{__typename: "Astronaut", id: "0x1"},{__typename: "Astronaut", id: "0x2"},{__typename: "Astronaut", id: "0x3"}]) {

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -3145,3 +3145,51 @@
         dgraph.uid : uid
       }
     }
+
+- 
+  name: "entities query for extended type having @key field of ID type"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "Astronaut", id: "0x1" },{__typename: "Astronaut", id: "0x2" }]) {
+        ... on Astronaut {
+          missions {
+            designation
+          }
+        }
+      }
+    }
+  dgquery:  |-
+    query {
+      _entities(func: uid(0x1, 0x2)) @filter(type(Astronaut)) {
+        dgraph.type
+        Astronaut.missions : Astronaut.missions {
+          designation : Mission.designation
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "entities query for extended type having @key field of string type with @id directive"
+  gqlquery: |
+    query {
+      _entities(representations: [{__typename: "SpaceShip", id: "0x1" },{__typename: "SpaceShip", id: "0x2" }]) {
+        ... on SpaceShip {
+          missions {
+            designation
+          }
+        }
+      }
+    }
+  dgquery:  |-
+    query {
+      _entities(func: eq(SpaceShip.id, "0x1", "0x2")) @filter(type(SpaceShip)) {
+        dgraph.type
+        SpaceShip.missions : SpaceShip.missions {
+          designation : Mission.designation
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -338,7 +338,11 @@ func (rf *resolverFactory) WithConventionResolvers(
 			// 2. We are using filter Query to resolve the Fields so filter queries must not be turned off in the Schema.
 			// Once we get it all working, later we should do it by adding new rewriter so that we don't have to depend on
 			// @generate directive turning off the filter query.
-			ConstructEntitiesQuery(keyFieldValueList, typeNames[0], query)
+			var typeName string
+			for k := range typeNames {
+				typeName = k
+			}
+			qr, err := schema.ConstructEntitiesQuery(keyFieldValueList, typeName, query)
 			if err != nil {
 				return EmptyResult(q, err)
 			}

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -379,3 +379,24 @@ type Workflow {
 type Node {
     name: String!
 }
+
+# test for entities resolver
+
+type Mission @key(fields: "id") {
+    id: ID!
+    crew: [Astronaut]
+    spaceShip: [SpaceShip]
+    designation: String!
+    startDate: String
+    endDate: String
+}
+
+type Astronaut @key(fields: "id") @extends {
+    id: ID! @external
+    missions: [Mission]
+}
+
+type SpaceShip @key(fields: "id") @extends {
+    id: String! @id @external
+    missions: [Mission]
+}

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -383,7 +383,7 @@ type Node {
 # test for entities resolver
 
 type Mission @key(fields: "id") {
-    id: ID!
+    id: String! @id
     crew: [Astronaut]
     spaceShip: [SpaceShip]
     designation: String!

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1140,11 +1140,9 @@ func (f *field) IDArgValue() (xid *string, uid uint64, err error) {
 
 func (q *query) BuildType(typeName string) Type {
 	t := &ast.Type{}
-	t.NamedType = q.op.inSchema.schema.Types[typeName].Name
+	t.NamedType = typeName
 	return &astType{
-		typ: &ast.Type{
-			Elem: t,
-		},
+		typ:             t,
 		inSchema:        q.op.inSchema,
 		dgraphPredicate: q.op.inSchema.dgraphPredicate,
 	}
@@ -1497,7 +1495,6 @@ func (q *query) EnumValues() []string {
 	return nil
 }
 
-// Todo , modify to return isIDType
 func (q *query) KeyField(typeName string) (string, bool, error) {
 	typ := q.op.inSchema.schema.Types[typeName]
 	keyDir := typ.Directives.ForName(apolloKeyDirective)

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -1497,6 +1497,9 @@ func (q *query) EnumValues() []string {
 
 func (q *query) KeyField(typeName string) (string, bool, error) {
 	typ := q.op.inSchema.schema.Types[typeName]
+	if typ == nil {
+		return "", false, fmt.Errorf("Type %s not found in the schema", typeName)
+	}
 	keyDir := typ.Directives.ForName(apolloKeyDirective)
 	if keyDir == nil {
 		return "", false, fmt.Errorf("Type %s  doesn't have a key Directive", typeName)


### PR DESCRIPTION
Fixes GRAPHQL-922.
This PR adds `entity` resolver which resolves `_entities(representation: [Any]!)` queries which are sent by the gateway to the graphql service.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7334)
<!-- Reviewable:end -->
