### PR TITLE
[Breaking] snapshot_after flag moved inside --raft

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -309,6 +309,10 @@ func getAlpha(idx int, raft string) service {
 	if opts.LudicrousMode {
 		svc.Command += " --ludicrous_mode=true"
 	}
+
+	if opts.SnapshotAfter != "" {
+		raft = fmt.Sprintf("%s; snapshot-after=%s", raft, opts.SnapshotAfter)
+	}
 	svc.Command += fmt.Sprintf(` --raft='%s'`, raft)
 
 	// Don't assign idx, let it auto-assign.
@@ -327,9 +331,6 @@ func getAlpha(idx int, raft string) service {
 			Target:   "/secret/hmac",
 			ReadOnly: true,
 		})
-	}
-	if opts.SnapshotAfter != "" {
-		svc.Command += fmt.Sprintf(" --snapshot_after=%s", opts.SnapshotAfter)
 	}
 	if opts.AclSecret != "" {
 		svc.Command += " --acl_secret_file=/secret/hmac"

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -75,9 +75,9 @@ var (
 	Alpha x.SubCommand
 
 	// need this here to refer it in admin_backup.go
-	adminServer web.IServeGraphQL
-
-	initDone uint32
+	adminServer  web.IServeGraphQL
+	initDone     uint32
+	raftDefaults = "idx=0; group=0; learner=false; snapshot-after=10000"
 )
 
 func init() {
@@ -113,10 +113,6 @@ they form a Raft group and provide synchronous replication.
 	enc.RegisterFlags(flag)
 
 	// Snapshot and Transactions.
-	flag.Int("snapshot_after", 10000,
-		"Create a new Raft snapshot after this many number of Raft entries. The"+
-			" lower this number, the more frequent snapshot creation would be."+
-			" Also determines how often Rollups would happen.")
 	flag.String("abort_older_than", "5m",
 		"Abort any pending transactions older than this duration. The liveness of a"+
 			" transaction is determined by its last mutation.")
@@ -131,12 +127,15 @@ they form a Raft group and provide synchronous replication.
 		"Number of pending mutation proposals. Useful for rate limiting.")
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
 		"Comma separated list of Dgraph zero addresses of the form IP_ADDRESS:PORT.")
-	flag.String("raft", "idx=0; group=0; learner=false",
+
+	flag.String("raft", raftDefaults,
 		`Various raft options.
 	idx=N provides an optional Raft ID that this Dgraph Alpha would use to join Raft groups.
 	group=N provides an optional Raft Group ID that this Alpha would indicate to Zero to join.
 	learner=true would make this Alpha a "learner" node. In learner mode, the Alpha would
 		not participate in Raft elections. This can be used to achieve a read-only replica.
+	snapshot-after=N would create a new Raft snapshot after N number of Raft entries.
+		The lower this number, the more frequent snapshot creation would be.
 	`)
 	flag.Int("max_retries", -1,
 		"Commits to disk will give up after these number of retries to prevent locking the worker"+
@@ -153,9 +152,6 @@ they form a Raft group and provide synchronous replication.
 		"Enterprise feature.")
 	flag.Duration("acl_refresh_ttl", 30*24*time.Hour, "The TTL for the refresh jwt. "+
 		"Enterprise feature.")
-	flag.Float64P("lru_mb", "l", 0, // TODO: Remove this flag in the next release.
-		"[Deprecated] Estimated memory the LRU cache can take. "+
-			"Actual usage by the process would be more than specified here.")
 	flag.String("mutations", "allow",
 		"Set mutation mode to allow, disallow, or strict.")
 
@@ -656,7 +652,6 @@ func run() {
 		MaxRetries:           Alpha.Conf.GetInt("max_retries"),
 		StrictMutations:      opts.MutationsMode == worker.StrictMutations,
 		AclEnabled:           secretFile != "",
-		SnapshotAfter:        Alpha.Conf.GetInt("snapshot_after"),
 		AbortOlderThan:       abortDur,
 		StartTime:            startTime,
 		LudicrousMode:        Alpha.Conf.GetBool("ludicrous_mode"),
@@ -665,7 +660,7 @@ func run() {
 		TLSServerConfig:      tlsServerConf,
 	}
 	x.WorkerConfig.Parse(Alpha.Conf)
-	x.CheckFlag(x.WorkerConfig.Raft, "group", "idx", "learner")
+	x.CheckFlagOpts(x.WorkerConfig.Raft, "group", "idx", "learner", "snapshot-after")
 
 	// Set the directory for temporary buffers.
 	z.SetTmpDir(x.WorkerConfig.TmpDir)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -75,9 +75,8 @@ var (
 	Alpha x.SubCommand
 
 	// need this here to refer it in admin_backup.go
-	adminServer  web.IServeGraphQL
-	initDone     uint32
-	raftDefaults = "idx=0; group=0; learner=false; snapshot-after=10000"
+	adminServer web.IServeGraphQL
+	initDone    uint32
 )
 
 func init() {
@@ -128,7 +127,7 @@ they form a Raft group and provide synchronous replication.
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
 		"Comma separated list of Dgraph zero addresses of the form IP_ADDRESS:PORT.")
 
-	flag.String("raft", raftDefaults,
+	flag.String("raft", worker.RaftDefaults,
 		`Various raft options.
 	idx=N provides an optional Raft ID that this Dgraph Alpha would use to join Raft groups.
 	group=N provides an optional Raft Group ID that this Alpha would indicate to Zero to join.
@@ -642,8 +641,7 @@ func run() {
 	tlsServerConf, err := x.LoadServerTLSConfigForInternalPort(Alpha.Conf)
 	x.Check(err)
 
-	raft := x.NewSuperFlag(Alpha.Conf.GetString("raft"))
-	raft.CheckValid("group", "idx", "learner", "snapshot-after")
+	raft := x.NewSuperFlag(Alpha.Conf.GetString("raft")).MergeAndCheckDefault(worker.RaftDefaults)
 	x.WorkerConfig = x.WorkerOptions{
 		TmpDir:               Alpha.Conf.GetString("tmp"),
 		ExportPath:           Alpha.Conf.GetString("export"),

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -642,12 +642,14 @@ func run() {
 	tlsServerConf, err := x.LoadServerTLSConfigForInternalPort(Alpha.Conf)
 	x.Check(err)
 
+	raft := x.NewSuperFlag(Alpha.Conf.GetString("raft"))
+	raft.CheckValid("group", "idx", "learner", "snapshot-after")
 	x.WorkerConfig = x.WorkerOptions{
 		TmpDir:               Alpha.Conf.GetString("tmp"),
 		ExportPath:           Alpha.Conf.GetString("export"),
 		NumPendingProposals:  Alpha.Conf.GetInt("pending_proposals"),
 		ZeroAddr:             strings.Split(Alpha.Conf.GetString("zero"), ","),
-		Raft:                 Alpha.Conf.GetString("raft"),
+		Raft:                 raft,
 		WhiteListedIPRanges:  ips,
 		MaxRetries:           Alpha.Conf.GetInt("max_retries"),
 		StrictMutations:      opts.MutationsMode == worker.StrictMutations,
@@ -660,7 +662,6 @@ func run() {
 		TLSServerConfig:      tlsServerConf,
 	}
 	x.WorkerConfig.Parse(Alpha.Conf)
-	x.CheckFlagOpts(x.WorkerConfig.Raft, "group", "idx", "learner", "snapshot-after")
 
 	// Set the directory for temporary buffers.
 	z.SetTmpDir(x.WorkerConfig.TmpDir)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -41,6 +41,8 @@ import (
 	"go.etcd.io/etcd/raft/raftpb"
 )
 
+var raftDefault = "idx=1; learner=false"
+
 type node struct {
 	*conn.Node
 	server *Server

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -127,12 +127,12 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 	}
 	s := grpc.NewServer(grpcOpts...)
 
-	nodeId := x.GetFlagUint64(opts.raftOpts, "idx")
+	nodeId := x.GetOptUint64(opts.raftOpts, "idx")
 	rc := pb.RaftContext{
 		Id:        nodeId,
 		Addr:      x.WorkerConfig.MyAddr,
 		Group:     0,
-		IsLearner: x.GetFlagBool(opts.raftOpts, "learner"),
+		IsLearner: x.GetOptBool(opts.raftOpts, "learner"),
 	}
 	m := conn.NewNode(&rc, store, opts.tlsClientConfig)
 
@@ -196,7 +196,7 @@ func run() {
 	}
 	glog.Infof("Setting Config to: %+v", opts)
 	x.WorkerConfig.Parse(Zero.Conf)
-	x.CheckFlag(opts.raftOpts, "idx", "learner")
+	x.CheckFlagOpts(opts.raftOpts, "idx", "learner")
 
 	if !enc.EeBuild && Zero.Conf.GetString("enterprise_license") != "" {
 		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
@@ -231,7 +231,7 @@ func run() {
 		x.WorkerConfig.MyAddr = fmt.Sprintf("localhost:%d", x.PortZeroGrpc+opts.portOffset)
 	}
 
-	nodeId := x.GetFlagUint64(opts.raftOpts, "idx")
+	nodeId := x.GetOptUint64(opts.raftOpts, "idx")
 	if nodeId == 0 {
 		log.Fatalf("ERROR: raft.idx flag cannot be 0. Please set idx to a unique positive integer.")
 	}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -48,7 +48,7 @@ import (
 type options struct {
 	bindall           bool
 	portOffset        int
-	raft              *x.SuperFlag
+	Raft              *x.SuperFlag
 	numReplicas       int
 	peer              string
 	w                 string
@@ -127,12 +127,12 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 	}
 	s := grpc.NewServer(grpcOpts...)
 
-	nodeId := opts.raft.GetUint64("idx")
+	nodeId := opts.Raft.GetUint64("idx")
 	rc := pb.RaftContext{
 		Id:        nodeId,
 		Addr:      x.WorkerConfig.MyAddr,
 		Group:     0,
-		IsLearner: opts.raft.GetBool("learner"),
+		IsLearner: opts.Raft.GetBool("learner"),
 	}
 	m := conn.NewNode(&rc, store, opts.tlsClientConfig)
 
@@ -189,7 +189,7 @@ func run() {
 	opts = options{
 		bindall:           Zero.Conf.GetBool("bindall"),
 		portOffset:        Zero.Conf.GetInt("port_offset"),
-		raft:              raft,
+		Raft:              raft,
 		numReplicas:       Zero.Conf.GetInt("replicas"),
 		peer:              Zero.Conf.GetString("peer"),
 		w:                 Zero.Conf.GetString("wal"),
@@ -232,7 +232,7 @@ func run() {
 		x.WorkerConfig.MyAddr = fmt.Sprintf("localhost:%d", x.PortZeroGrpc+opts.portOffset)
 	}
 
-	nodeId := opts.raft.GetUint64("idx")
+	nodeId := opts.Raft.GetUint64("idx")
 	if nodeId == 0 {
 		log.Fatalf("ERROR: raft.idx flag cannot be 0. Please set idx to a unique positive integer.")
 	}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -48,7 +48,7 @@ import (
 type options struct {
 	bindall           bool
 	portOffset        int
-	raftOpts          string
+	raft              *x.SuperFlag
 	numReplicas       int
 	peer              string
 	w                 string
@@ -127,12 +127,12 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 	}
 	s := grpc.NewServer(grpcOpts...)
 
-	nodeId := x.GetOptUint64(opts.raftOpts, "idx")
+	nodeId := opts.raft.GetUint64("idx")
 	rc := pb.RaftContext{
 		Id:        nodeId,
 		Addr:      x.WorkerConfig.MyAddr,
 		Group:     0,
-		IsLearner: x.GetOptBool(opts.raftOpts, "learner"),
+		IsLearner: opts.raft.GetBool("learner"),
 	}
 	m := conn.NewNode(&rc, store, opts.tlsClientConfig)
 
@@ -187,7 +187,7 @@ func run() {
 	opts = options{
 		bindall:           Zero.Conf.GetBool("bindall"),
 		portOffset:        Zero.Conf.GetInt("port_offset"),
-		raftOpts:          Zero.Conf.GetString("raft"),
+		raft:              x.NewSuperFlag(Zero.Conf.GetString("raft")),
 		numReplicas:       Zero.Conf.GetInt("replicas"),
 		peer:              Zero.Conf.GetString("peer"),
 		w:                 Zero.Conf.GetString("wal"),
@@ -196,7 +196,7 @@ func run() {
 	}
 	glog.Infof("Setting Config to: %+v", opts)
 	x.WorkerConfig.Parse(Zero.Conf)
-	x.CheckFlagOpts(opts.raftOpts, "idx", "learner")
+	opts.raft.CheckValid("idx", "learner")
 
 	if !enc.EeBuild && Zero.Conf.GetString("enterprise_license") != "" {
 		log.Fatalf("ERROR: enterprise_license option cannot be applied to OSS builds. ")
@@ -231,7 +231,7 @@ func run() {
 		x.WorkerConfig.MyAddr = fmt.Sprintf("localhost:%d", x.PortZeroGrpc+opts.portOffset)
 	}
 
-	nodeId := x.GetOptUint64(opts.raftOpts, "idx")
+	nodeId := opts.raft.GetUint64("idx")
 	if nodeId == 0 {
 		log.Fatalf("ERROR: raft.idx flag cannot be 0. Please set idx to a unique positive integer.")
 	}

--- a/protos/pb/pb.pb.go
+++ b/protos/pb/pb.pb.go
@@ -7,6 +7,10 @@ import (
 	context "context"
 	encoding_binary "encoding/binary"
 	fmt "fmt"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+
 	pb "github.com/dgraph-io/badger/v3/pb"
 	api "github.com/dgraph-io/dgo/v200/protos/api"
 	_ "github.com/gogo/protobuf/gogoproto"
@@ -14,9 +18,6 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	io "io"
-	math "math"
-	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1339,13 +1340,14 @@ type ZeroProposal struct {
 	MaxLeaseId           uint64            `protobuf:"varint,4,opt,name=maxLeaseId,proto3" json:"maxLeaseId,omitempty"`
 	MaxTxnTs             uint64            `protobuf:"varint,5,opt,name=maxTxnTs,proto3" json:"maxTxnTs,omitempty"`
 	MaxRaftId            uint64            `protobuf:"varint,6,opt,name=maxRaftId,proto3" json:"maxRaftId,omitempty"`
-	Txn                  *api.TxnContext   `protobuf:"bytes,7,opt,name=txn,proto3" json:"txn,omitempty"`
-	Cid                  string            `protobuf:"bytes,9,opt,name=cid,proto3" json:"cid,omitempty"`
-	License              *License          `protobuf:"bytes,10,opt,name=license,proto3" json:"license,omitempty"`
-	Snapshot             *ZeroSnapshot     `protobuf:"bytes,11,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
-	XXX_unrecognized     []byte            `json:"-"`
-	XXX_sizecache        int32             `json:"-"`
+	MaxNamespaceId       uint64
+	Txn                  *api.TxnContext `protobuf:"bytes,7,opt,name=txn,proto3" json:"txn,omitempty"`
+	Cid                  string          `protobuf:"bytes,9,opt,name=cid,proto3" json:"cid,omitempty"`
+	License              *License        `protobuf:"bytes,10,opt,name=license,proto3" json:"license,omitempty"`
+	Snapshot             *ZeroSnapshot   `protobuf:"bytes,11,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
 }
 
 func (m *ZeroProposal) Reset()         { *m = ZeroProposal{} }

--- a/protos/pb/pb.pb.go
+++ b/protos/pb/pb.pb.go
@@ -7,10 +7,6 @@ import (
 	context "context"
 	encoding_binary "encoding/binary"
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	pb "github.com/dgraph-io/badger/v3/pb"
 	api "github.com/dgraph-io/dgo/v200/protos/api"
 	_ "github.com/gogo/protobuf/gogoproto"
@@ -18,6 +14,9 @@ import (
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -1340,14 +1339,13 @@ type ZeroProposal struct {
 	MaxLeaseId           uint64            `protobuf:"varint,4,opt,name=maxLeaseId,proto3" json:"maxLeaseId,omitempty"`
 	MaxTxnTs             uint64            `protobuf:"varint,5,opt,name=maxTxnTs,proto3" json:"maxTxnTs,omitempty"`
 	MaxRaftId            uint64            `protobuf:"varint,6,opt,name=maxRaftId,proto3" json:"maxRaftId,omitempty"`
-	MaxNamespaceId       uint64
-	Txn                  *api.TxnContext `protobuf:"bytes,7,opt,name=txn,proto3" json:"txn,omitempty"`
-	Cid                  string          `protobuf:"bytes,9,opt,name=cid,proto3" json:"cid,omitempty"`
-	License              *License        `protobuf:"bytes,10,opt,name=license,proto3" json:"license,omitempty"`
-	Snapshot             *ZeroSnapshot   `protobuf:"bytes,11,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `json:"-"`
-	XXX_sizecache        int32           `json:"-"`
+	Txn                  *api.TxnContext   `protobuf:"bytes,7,opt,name=txn,proto3" json:"txn,omitempty"`
+	Cid                  string            `protobuf:"bytes,9,opt,name=cid,proto3" json:"cid,omitempty"`
+	License              *License          `protobuf:"bytes,10,opt,name=license,proto3" json:"license,omitempty"`
+	Snapshot             *ZeroSnapshot     `protobuf:"bytes,11,opt,name=snapshot,proto3" json:"snapshot,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
 }
 
 func (m *ZeroProposal) Reset()         { *m = ZeroProposal{} }

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   alpha2:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha2
@@ -33,7 +33,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   alpha3:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha3
@@ -49,7 +49,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   alpha4:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha4
@@ -65,7 +65,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   alpha5:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha5
@@ -81,7 +81,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   alpha6:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha6
@@ -97,7 +97,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --jaeger.collector=http://jaeger:14268 --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-      --snapshot_after=100
+      --raft="snapshot-after=100"
   jaeger:
     image: jaegertracing/all-in-one:1.18
     working_dir: /working/jaeger

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -229,7 +229,7 @@ func GetOngoingTasks() []string {
 func newNode(store *raftwal.DiskStorage, gid uint32, id uint64, myAddr string) *node {
 	glog.Infof("Node ID: %#x with GroupID: %d\n", id, gid)
 
-	isLearner := x.GetOptBool(x.WorkerConfig.Raft, "learner")
+	isLearner := x.WorkerConfig.Raft.GetBool("learner")
 	rc := &pb.RaftContext{
 		Addr:      myAddr,
 		Group:     gid,
@@ -962,7 +962,7 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 	slowTicker := time.NewTicker(time.Minute)
 	defer slowTicker.Stop()
 
-	snapshotAfter := x.GetOptUint64(x.WorkerConfig.Raft, "snapshot-after")
+	snapshotAfter := x.WorkerConfig.Raft.GetUint64("snapshot-after")
 	x.AssertTruef(snapshotAfter > 10, "raft.snapshot-after must be a number greater than 10")
 
 	for {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -229,7 +229,7 @@ func GetOngoingTasks() []string {
 func newNode(store *raftwal.DiskStorage, gid uint32, id uint64, myAddr string) *node {
 	glog.Infof("Node ID: %#x with GroupID: %d\n", id, gid)
 
-	isLearner := x.GetFlagBool(x.WorkerConfig.Raft, "learner")
+	isLearner := x.GetOptBool(x.WorkerConfig.Raft, "learner")
 	rc := &pb.RaftContext{
 		Addr:      myAddr,
 		Group:     gid,
@@ -962,6 +962,9 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 	slowTicker := time.NewTicker(time.Minute)
 	defer slowTicker.Stop()
 
+	snapshotAfter := x.GetOptUint64(x.WorkerConfig.Raft, "snapshot-after")
+	x.AssertTruef(snapshotAfter > 10, "raft.snapshot-after must be a number greater than 10")
+
 	for {
 		select {
 		case <-slowTicker.C:
@@ -992,10 +995,10 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 					if first, err := n.Store.FirstIndex(); err == nil {
 						// Save some cycles by only calculating snapshot if the checkpoint has gone
 						// quite a bit further than the first index.
-						calculate = calculate || chk >= first+uint64(x.WorkerConfig.SnapshotAfter)
+						calculate = calculate || chk >= first+snapshotAfter
 						glog.V(3).Infof("Evaluating snapshot first:%d chk:%d (chk-first:%d) "+
 							"snapshotAfter:%d snap:%v", first, chk, chk-first,
-							x.WorkerConfig.SnapshotAfter, calculate)
+							snapshotAfter, calculate)
 					}
 				}
 				// We keep track of the applied index in the p directory. Even if we don't take

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -86,7 +86,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 			zeroAddr, x.WorkerConfig.MyAddr)
 	}
 
-	raftIdx := x.GetOptUint64(x.WorkerConfig.Raft, "idx")
+	raftIdx := x.WorkerConfig.Raft.GetUint64("idx")
 	if raftIdx == 0 {
 		raftIdx = walStore.Uint(raftwal.RaftId)
 
@@ -99,7 +99,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	glog.Infof("Current Raft Id: %#x\n", raftIdx)
 
 	if x.WorkerConfig.ProposedGroupId == 0 {
-		x.WorkerConfig.ProposedGroupId = x.GetOptUint32(x.WorkerConfig.Raft, "group")
+		x.WorkerConfig.ProposedGroupId = x.WorkerConfig.Raft.GetUint32("group")
 	}
 	// Successfully connect with dgraphzero, before doing anything else.
 	// Connect with Zero leader and figure out what group we should belong to.
@@ -107,7 +107,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 		Id:      raftIdx,
 		GroupId: x.WorkerConfig.ProposedGroupId,
 		Addr:    x.WorkerConfig.MyAddr,
-		Learner: x.GetOptBool(x.WorkerConfig.Raft, "learner"),
+		Learner: x.WorkerConfig.Raft.GetBool("learner"),
 	}
 	if m.GroupId > 0 {
 		m.ForceGroupId = true

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -86,7 +86,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 			zeroAddr, x.WorkerConfig.MyAddr)
 	}
 
-	raftIdx := x.GetFlagUint64(x.WorkerConfig.Raft, "idx")
+	raftIdx := x.GetOptUint64(x.WorkerConfig.Raft, "idx")
 	if raftIdx == 0 {
 		raftIdx = walStore.Uint(raftwal.RaftId)
 
@@ -99,7 +99,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	glog.Infof("Current Raft Id: %#x\n", raftIdx)
 
 	if x.WorkerConfig.ProposedGroupId == 0 {
-		x.WorkerConfig.ProposedGroupId = x.GetFlagUint32(x.WorkerConfig.Raft, "group")
+		x.WorkerConfig.ProposedGroupId = x.GetOptUint32(x.WorkerConfig.Raft, "group")
 	}
 	// Successfully connect with dgraphzero, before doing anything else.
 	// Connect with Zero leader and figure out what group we should belong to.
@@ -107,7 +107,7 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 		Id:      raftIdx,
 		GroupId: x.WorkerConfig.ProposedGroupId,
 		Addr:    x.WorkerConfig.MyAddr,
-		Learner: x.GetFlagBool(x.WorkerConfig.Raft, "learner"),
+		Learner: x.GetOptBool(x.WorkerConfig.Raft, "learner"),
 	}
 	if m.GroupId > 0 {
 		m.ForceGroupId = true

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -60,6 +60,8 @@ var gr = &groupi{
 	tablets:      make(map[string]*pb.Tablet),
 }
 
+var RaftDefaults = "idx=0; group=0; learner=false; snapshot-after=10000"
+
 func groups() *groupi {
 	return gr
 }

--- a/x/config.go
+++ b/x/config.go
@@ -89,9 +89,6 @@ type WorkerOptions struct {
 	AclEnabled bool
 	// AbortOlderThan tells Dgraph to discard transactions that are older than this duration.
 	AbortOlderThan time.Duration
-	// SnapshotAfter indicates the number of entries in the RAFT logs that are needed
-	// to allow a snapshot to be created.
-	SnapshotAfter int
 	// ProposedGroupId will be used if there's a file in the p directory called group_id with the
 	// proposed group ID for this server.
 	ProposedGroupId uint32

--- a/x/config.go
+++ b/x/config.go
@@ -78,7 +78,7 @@ type WorkerOptions struct {
 	// TLS server config which will be used to initiate server internal port
 	TLSServerConfig *tls.Config
 	// Raft stores options related to Raft.
-	Raft string
+	Raft *SuperFlag
 	// WhiteListedIPRanges is a list of IP ranges from which requests will be allowed.
 	WhiteListedIPRanges []IPRange
 	// MaxRetries is the maximum number of times to retry a commit before giving up.

--- a/x/flags.go
+++ b/x/flags.go
@@ -85,27 +85,24 @@ func (sf *SuperFlag) String() string {
 	}
 	return strings.Join(kvs, "; ")
 }
-func (sf *SuperFlag) CheckValid(opts ...string) {
-	parsed := len(sf.m)
-	for _, k := range opts {
+func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
+	numKeys := len(sf.m)
+	src := parseFlag(flag)
+	for k := range src {
 		if _, ok := sf.m[k]; ok {
-			parsed--
+			numKeys--
 		}
 	}
-	if parsed != 0 {
-		msg := fmt.Sprintf("Found invalid options in %s. Valid options: %v", sf, opts)
+	if numKeys != 0 {
+		msg := fmt.Sprintf("Found invalid options in %s. Valid options: %v", sf, flag)
 		panic(msg)
 	}
-}
-
-// SetIfAbsent is the equivalent of Merge.
-func (sf *SuperFlag) SetIfAbsent(flag string) {
-	src := parseFlag(flag)
 	for k, v := range src {
 		if _, ok := sf.m[k]; !ok {
 			sf.m[k] = v
 		}
 	}
+	return sf
 }
 func (sf *SuperFlag) Get(opt string) string {
 	return sf.m[opt]

--- a/x/flags.go
+++ b/x/flags.go
@@ -79,6 +79,9 @@ func NewSuperFlag(flag string) *SuperFlag {
 	}
 }
 func (sf *SuperFlag) String() string {
+	if sf == nil {
+		return ""
+	}
 	var kvs []string
 	for k, v := range sf.m {
 		kvs = append(kvs, fmt.Sprintf("%s=%s", k, v))
@@ -86,6 +89,12 @@ func (sf *SuperFlag) String() string {
 	return strings.Join(kvs, "; ")
 }
 func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
+	if sf == nil {
+		sf = &SuperFlag{
+			m: parseFlag(flag),
+		}
+		return sf
+	}
 	numKeys := len(sf.m)
 	src := parseFlag(flag)
 	for k := range src {
@@ -105,6 +114,9 @@ func (sf *SuperFlag) MergeAndCheckDefault(flag string) *SuperFlag {
 	return sf
 }
 func (sf *SuperFlag) Get(opt string) string {
+	if sf == nil {
+		return ""
+	}
 	return sf.m[opt]
 }
 func (sf *SuperFlag) GetBool(opt string) bool {

--- a/x/flags.go
+++ b/x/flags.go
@@ -54,9 +54,9 @@ func FillCommonFlags(flag *pflag.FlagSet) {
 	flag.Bool("enable_sentry", true, "Turn on/off sending crash events to Sentry.")
 }
 
-func parseFlag(opt string) map[string]string {
+func parseFlag(flag string) map[string]string {
 	kvm := make(map[string]string)
-	for _, kv := range strings.Split(opt, ";") {
+	for _, kv := range strings.Split(flag, ";") {
 		if strings.TrimSpace(kv) == "" {
 			continue
 		}
@@ -68,47 +68,84 @@ func parseFlag(opt string) map[string]string {
 	}
 	return kvm
 }
-func GetFlag(opt, key string) string {
-	kv := parseFlag(opt)
-	return kv[key]
+
+type SuperFlag struct {
+	m map[string]string
 }
-func CheckFlag(opt string, keys ...string) {
-	kv := parseFlag(opt)
-	for _, k := range keys {
-		if _, ok := kv[k]; ok {
-			delete(kv, k)
-		} else {
+
+func NewSuperFlag(flag string) *SuperFlag {
+	return &SuperFlag{
+		m: parseFlag(flag),
+	}
+}
+func (sf *SuperFlag) String() string {
+	var kvs []string
+	for k, v := range sf.m {
+		kvs = append(kvs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(kvs, "; ")
+}
+func (sf *SuperFlag) CheckValid(opts ...string) {
+	parsed := len(sf.m)
+	for _, k := range opts {
+		if _, ok := sf.m[k]; ok {
+			parsed--
 		}
 	}
-	if len(kv) > 0 {
-		msg := fmt.Sprintf("Found invalid options from %q: %+v\n", opt, kv)
+	if parsed != 0 {
+		msg := fmt.Sprintf("Found invalid options in %s. Valid options: %v", sf, opts)
 		panic(msg)
 	}
 }
-func GetFlagBool(opt, key string) bool {
-	val := GetFlag(opt, key)
+
+// SetIfAbsent is the equivalent of Merge.
+func (sf *SuperFlag) SetIfAbsent(flag string) {
+	src := parseFlag(flag)
+	for k, v := range src {
+		if _, ok := sf.m[k]; !ok {
+			sf.m[k] = v
+		}
+	}
+}
+func (sf *SuperFlag) Get(opt string) string {
+	return sf.m[opt]
+}
+func (sf *SuperFlag) GetBool(opt string) bool {
+	val := sf.Get(opt)
 	if val == "" {
 		return false
 	}
 	b, err := strconv.ParseBool(val)
-	Checkf(err, "Unable to parse %s as bool for key: %s. Options: %s\n", val, key, opt)
+	Checkf(err, "Unable to parse %s as bool for key: %s. Options: %s\n", val, opt, sf)
 	return b
 }
-func GetFlagUint64(opt, key string) uint64 {
-	val := GetFlag(opt, key)
+func (sf *SuperFlag) GetUint64(opt string) uint64 {
+	val := sf.Get(opt)
 	if val == "" {
 		return 0
 	}
 	u, err := strconv.ParseUint(val, 0, 64)
-	Checkf(err, "Unable to parse %s as uint64 for key: %s. Options: %s\n", val, key, opt)
+	Checkf(err, "Unable to parse %s as uint64 for key: %s. Options: %s\n", val, opt, sf)
 	return u
 }
-func GetFlagUint32(opt, key string) uint32 {
-	val := GetFlag(opt, key)
+func (sf *SuperFlag) GetUint32(opt string) uint32 {
+	val := sf.Get(opt)
 	if val == "" {
 		return 0
 	}
 	u, err := strconv.ParseUint(val, 0, 32)
-	Checkf(err, "Unable to parse %s as uint32 for key: %s. Options: %s\n", val, key, opt)
+	Checkf(err, "Unable to parse %s as uint32 for key: %s. Options: %s\n", val, opt, sf)
 	return uint32(u)
+}
+func CheckFlagOpts(flag string, opts ...string) {
+	kv := parseFlag(flag)
+	for _, k := range opts {
+		if _, ok := kv[k]; ok {
+			delete(kv, k)
+		}
+	}
+	if len(kv) > 0 {
+		msg := fmt.Sprintf("Found invalid options from %q: %+v\n", flag, kv)
+		panic(msg)
+	}
 }

--- a/x/flags.go
+++ b/x/flags.go
@@ -134,15 +134,3 @@ func (sf *SuperFlag) GetUint32(opt string) uint32 {
 	Checkf(err, "Unable to parse %s as uint32 for key: %s. Options: %s\n", val, opt, sf)
 	return uint32(u)
 }
-func CheckFlagOpts(flag string, opts ...string) {
-	kv := parseFlag(flag)
-	for _, k := range opts {
-		if _, ok := kv[k]; ok {
-			delete(kv, k)
-		}
-	}
-	if len(kv) > 0 {
-		msg := fmt.Sprintf("Found invalid options from %q: %+v\n", flag, kv)
-		panic(msg)
-	}
-}

--- a/x/flags_test.go
+++ b/x/flags_test.go
@@ -27,18 +27,14 @@ func TestFlag(t *testing.T) {
 	sf := NewSuperFlag(opt)
 	t.Logf("Got SuperFlag: %s\n", sf)
 
-	// Should pass.
-	sf.CheckValid("bool-key", "int-key", "string-key", "float-key")
-
-	// Add an extra undefined key.
-	sf.CheckValid("bool-key", "int-key", "string-key", "float-key", "other-key")
+	def := `bool_key=false; int-key=0; float-key=1.0; string-key=; other-key=5`
 
 	// bool-key and int-key should not be overwritten. Only other-key should be set.
-	sf.SetIfAbsent("bool-key=false; int-key=7; other-key=5")
+	sf.MergeAndCheckDefault(def)
 
 	c := func() {
 		// Has a typo.
-		sf.CheckValid("boolo-key", "int-key", "string-key", "float-key")
+		NewSuperFlag("boolo-key=true").MergeAndCheckDefault(def)
 	}
 	require.Panics(t, c)
 	require.Equal(t, true, sf.GetBool("bool-key"))

--- a/x/flags_test.go
+++ b/x/flags_test.go
@@ -24,17 +24,25 @@ import (
 
 func TestFlag(t *testing.T) {
 	opt := `bool_key=true; int-key=5; float-key=0.05; string_key=value; ;`
-	kvm := parseFlag(opt)
-	t.Logf("Got kvm: %+v\n", kvm)
-	CheckFlag(opt, "bool-key", "int-key", "string-key", "float-key")
-	CheckFlag(opt, "bool-key", "int-key", "string-key", "float-key", "other-key")
-	// Has a typo.
+	sf := NewSuperFlag(opt)
+	t.Logf("Got SuperFlag: %s\n", sf)
+
+	// Should pass.
+	sf.CheckValid("bool-key", "int-key", "string-key", "float-key")
+
+	// Add an extra undefined key.
+	sf.CheckValid("bool-key", "int-key", "string-key", "float-key", "other-key")
+
+	// bool-key and int-key should not be overwritten. Only other-key should be set.
+	sf.SetIfAbsent("bool-key=false; int-key=7; other-key=5")
 
 	c := func() {
-		CheckFlag(opt, "boolo-key", "int-key", "string-key", "float-key")
+		// Has a typo.
+		sf.CheckValid("boolo-key", "int-key", "string-key", "float-key")
 	}
 	require.Panics(t, c)
-	require.Equal(t, true, GetFlagBool(opt, "bool-key"))
-	require.Equal(t, uint64(5), GetFlagUint64(opt, "int-key"))
-	require.Equal(t, "value", GetFlag(opt, "string-key"))
+	require.Equal(t, true, sf.GetBool("bool-key"))
+	require.Equal(t, uint64(5), sf.GetUint64("int-key"))
+	require.Equal(t, "value", sf.Get("string-key"))
+	require.Equal(t, uint64(5), sf.GetUint64("other-key"))
 }


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

This PR introduces a new SuperFlag struct, which makes flag handling easier. The setting of the default values for the raft flag is moved within the worker package, so Alpha doesn't need to know about it.

The breaking change here is the move of snapshot_after flag to within raft, considering they are logically together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7337)
<!-- Reviewable:end -->
