### PR TITLE
fix(indexing): use encrypted tmpDBs for index building if encryption is enabled (#6828)

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -574,6 +574,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		WithNumVersionsToKeep(math.MaxInt32).
 		WithLogger(&x.ToGlog{}).
 		WithCompression(options.None).
+		WithEncryptionKey(x.WorkerConfig.EncryptionKey).
 		WithLoggingLevel(badger.WARNING)
 
 	// Set cache if we have encryption.


### PR DESCRIPTION

If the encryption is enabled for cluster, we should enable encryption for temporary DBs used for reindexing.This PR adds that encryption option for temporary DBs,

(cherry picked from commit 31164dd6d6d21e0011cd030809bffe4102be2156)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
