### PR TITLE
fix(subscriptions): fix subscription to use the kv with the max version

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -808,15 +808,8 @@ func listenForCorsUpdate(closer *z.Closer) {
 	// Remove uid from the key, to get the correct prefix
 	prefix = prefix[:len(prefix)-8]
 	worker.SubscribeForUpdates([][]byte{prefix}, func(kvs *badgerpb.KVList) {
-		// Iterate over kvs to get the KV with the latest version. It is not necessary that the last
-		// KV contain the latest value.
-		var kv badgerpb.KV
-		for _, Kv := range kvs.GetKv() {
-			if Kv.GetVersion() > kv.GetVersion() {
-				kv = *Kv
-			}
-		}
 
+		kv := x.KvWithMaxVersion(kvs)
 		glog.Infof("Updating cors from subscription.")
 		// Unmarshal the incoming posting list.
 		pl := &pb.PostingList{}

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -809,7 +809,7 @@ func listenForCorsUpdate(closer *z.Closer) {
 	prefix = prefix[:len(prefix)-8]
 	worker.SubscribeForUpdates([][]byte{prefix}, func(kvs *badgerpb.KVList) {
 
-		kv := x.KvWithMaxVersion(kvs)
+		kv := x.KvWithMaxVersion(kvs, [][]byte{prefix}, "CORS Subscription")
 		glog.Infof("Updating cors from subscription.")
 		// Unmarshal the incoming posting list.
 		pl := &pb.PostingList{}

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -351,7 +351,13 @@ func RefreshAcls(closer *z.Closer) {
 		if kvs == nil || len(kvs.Kv) == 0 {
 			return
 		}
-		if err := retrieveAcls(kvs.Kv[0].Version); err != nil {
+		var maxVs uint64
+		for _, kv := range kvs.GetKv() {
+			if kv.Version > maxVs {
+				maxVs = kv.Version
+			}
+		}
+		if err := retrieveAcls(maxVs); err != nil {
 			glog.Errorf("Error while retrieving acls: %v", err)
 		}
 	}, 1, closer)

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -351,13 +351,8 @@ func RefreshAcls(closer *z.Closer) {
 		if kvs == nil || len(kvs.Kv) == 0 {
 			return
 		}
-		var maxVs uint64
-		for _, kv := range kvs.GetKv() {
-			if kv.Version > maxVs {
-				maxVs = kv.Version
-			}
-		}
-		if err := retrieveAcls(maxVs); err != nil {
+		kv := x.KvWithMaxVersion(kvs)
+		if err := retrieveAcls(kv.GetVersion()); err != nil {
 			glog.Errorf("Error while retrieving acls: %v", err)
 		}
 	}, 1, closer)

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -351,7 +351,7 @@ func RefreshAcls(closer *z.Closer) {
 		if kvs == nil || len(kvs.Kv) == 0 {
 			return
 		}
-		kv := x.KvWithMaxVersion(kvs)
+		kv := x.KvWithMaxVersion(kvs, aclPrefixes, "ACL Subscription")
 		if err := retrieveAcls(kv.GetVersion()); err != nil {
 			glog.Errorf("Error while retrieving acls: %v", err)
 		}

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -495,9 +495,14 @@ func newAdminResolver(
 	prefix = prefix[:len(prefix)-8]
 	// Listen for graphql schema changes in group 1.
 	go worker.SubscribeForUpdates([][]byte{prefix}, func(kvs *badgerpb.KVList) {
-		// Last update contains the latest value. So, taking the last update.
-		lastIdx := len(kvs.GetKv()) - 1
-		kv := kvs.GetKv()[lastIdx]
+		// Iterate over kvs to get the KV with the latest version. It is not necessary that the last
+		// KV contain the latest value.
+		var kv badgerpb.KV
+		for _, Kv := range kvs.GetKv() {
+			if Kv.GetVersion() > kv.GetVersion() {
+				kv = *Kv
+			}
+		}
 
 		glog.Infof("Updating GraphQL schema from subscription.")
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -495,15 +495,8 @@ func newAdminResolver(
 	prefix = prefix[:len(prefix)-8]
 	// Listen for graphql schema changes in group 1.
 	go worker.SubscribeForUpdates([][]byte{prefix}, func(kvs *badgerpb.KVList) {
-		// Iterate over kvs to get the KV with the latest version. It is not necessary that the last
-		// KV contain the latest value.
-		var kv badgerpb.KV
-		for _, Kv := range kvs.GetKv() {
-			if Kv.GetVersion() > kv.GetVersion() {
-				kv = *Kv
-			}
-		}
 
+		kv := x.KvWithMaxVersion(kvs)
 		glog.Infof("Updating GraphQL schema from subscription.")
 
 		// Unmarshal the incoming posting list.

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -496,7 +496,7 @@ func newAdminResolver(
 	// Listen for graphql schema changes in group 1.
 	go worker.SubscribeForUpdates([][]byte{prefix}, func(kvs *badgerpb.KVList) {
 
-		kv := x.KvWithMaxVersion(kvs)
+		kv := x.KvWithMaxVersion(kvs, [][]byte{prefix}, "GraphQL Schema Subscription")
 		glog.Infof("Updating GraphQL schema from subscription.")
 
 		// Unmarshal the incoming posting list.

--- a/x/x.go
+++ b/x/x.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	bo "github.com/dgraph-io/badger/v3/options"
+	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/ristretto/z"
@@ -1201,4 +1202,17 @@ func ToHex(i uint64, rdf bool) []byte {
 	}
 
 	return out
+}
+
+// KvWithMaxVersion returns a KV with the max version from the list of KVs.
+func KvWithMaxVersion(kvs *badgerpb.KVList) *badgerpb.KV {
+	// Iterate over kvs to get the KV with the latest version. It is not necessary that the last
+	// KV contain the latest value.
+	var kv badgerpb.KV
+	for _, Kv := range kvs.GetKv() {
+		if Kv.GetVersion() > kv.GetVersion() {
+			kv = *Kv
+		}
+	}
+	return &kv
 }

--- a/x/x.go
+++ b/x/x.go
@@ -1216,7 +1216,7 @@ func KvWithMaxVersion(kvs *badgerpb.KVList, prefixes [][]byte, tag string) *badg
 	}
 	// Iterate over kvs to get the KV with the latest version. It is not necessary that the last
 	// KV contain the latest value.
-	var maxKv badgerpb.KV
+	var maxKv *badgerpb.KV
 	for _, kv := range kvs.GetKv() {
 		if !hasAnyPrefix(kv.GetKey()) {
 			// Verify that we got the key which was subscribed. This shouldn't happen, but added for
@@ -1225,8 +1225,8 @@ func KvWithMaxVersion(kvs *badgerpb.KVList, prefixes [][]byte, tag string) *badg
 			continue
 		}
 		if maxKv.GetVersion() <= kv.GetVersion() {
-			maxKv = *kv
+			maxKv = kv
 		}
 	}
-	return &maxKv
+	return maxKv
 }

--- a/x/x.go
+++ b/x/x.go
@@ -1224,7 +1224,7 @@ func KvWithMaxVersion(kvs *badgerpb.KVList, prefixes [][]byte, tag string) *badg
 			glog.Errorf("[%s] Got key: %x which was not subscribed", tag, kv.GetKey())
 			continue
 		}
-		if maxKv.GetVersion() > kv.GetVersion() {
+		if maxKv.GetVersion() <= kv.GetVersion() {
 			maxKv = *kv
 		}
 	}


### PR DESCRIPTION
**Issue:**
The last KV from the list received from subscription need not be the latest update. This is because of the KVs written at the top due to value log rewrites or due to rollups. 
We were using the last KV from the updates received via subscription.

**Fix:**
Iterate over the KVs to get the KV with the latest version.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7349)
<!-- Reviewable:end -->
