### PR TITLE
fix(GraphQl):This PR fix a panic when we pass a single ID as a integer and expected type is [ID].We now coerce that to type array of string.  (#7325)

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -655,7 +655,7 @@ func RunAll(t *testing.T) {
 	t.Run("query aggregate and other fields at child level", queryAggregateAndOtherFieldsAtChildLevel)
 	t.Run("query at child level with multiple alias on scalar field", queryChildLevelWithMultipleAliasOnScalarField)
 	t.Run("checkUserPassword query", passwordTest)
-	t.Run("query using single ID in a filter that will be coerced to list", queryFilterSingleIDListCoercion)
+	t.Run("query filter ID values coercion to List", queryFilterWithIDInputCoercion)
 	// mutation tests
 	t.Run("add mutation", addMutation)
 	t.Run("update mutation by ids", updateMutationByIds)

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -19,6 +19,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/spf13/cast"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -3284,7 +3285,7 @@ func passwordTest(t *testing.T) {
 	deleteUser(t, *newUser)
 }
 
-func queryFilterSingleIDListCoercion(t *testing.T) {
+func queryFilterWithIDInputCoercion(t *testing.T) {
 	authors := addMultipleAuthorFromRef(t, []*author{
 		{
 			Name:          "George",
@@ -3301,25 +3302,27 @@ func queryFilterSingleIDListCoercion(t *testing.T) {
 	authorIds := []string{authors[0].ID, authors[1].ID}
 	postIds := []string{authors[0].Posts[0].PostID, authors[1].Posts[0].PostID}
 	countryIds := []string{authors[1].Country.ID}
-	tcase := struct {
+	authorIdsDecimal := []string{cast.ToString(cast.ToInt(authorIds[0])), cast.ToString(cast.ToInt(authorIds[1]))}
+	tcases := []struct {
 		name      string
 		query     string
 		variables map[string]interface{}
 		respData  string
 	}{
+		{
 
-		name: "Query using single ID in a filter",
-		query: `query($filter:AuthorFilter){
+			name: "Query using single ID in a filter",
+			query: `query($filter:AuthorFilter){
                       queryAuthor(filter:$filter){
                         name
-						reputation
+                        reputation
                         posts {
                           text
                         }
                       }
 				    }`,
-		variables: map[string]interface{}{"filter": map[string]interface{}{"id": authors[0].ID}},
-		respData: `{
+			variables: map[string]interface{}{"filter": map[string]interface{}{"id": authors[0].ID}},
+			respData: `{
 						  "queryAuthor": [
 							{
 							  "name": "George",
@@ -3332,17 +3335,144 @@ func queryFilterSingleIDListCoercion(t *testing.T) {
 							}
 						  ]
 						}`,
+		},
+		{
+
+			name: "Query using single ID given in variable of type integer coerced to string ",
+			query: `query($filter:AuthorFilter){
+                      queryAuthor(filter:$filter){
+                        name
+                        reputation
+                        posts {
+                          text
+                        }
+                      }
+				    }`,
+			variables: map[string]interface{}{"filter": map[string]interface{}{"id": cast.ToInt(authors[0].ID)}},
+			respData: `{
+						  "queryAuthor": [
+							{
+							  "name": "George",
+							  "reputation": 4.5,
+							  "posts": [
+								{
+								  "text": "Got ya!"
+								}
+							  ]
+							}
+						  ]
+						}`,
+		},
+		{
+
+			name: "Query using multiple ID given in variable of type integer coerced to string",
+			query: `query($filter:AuthorFilter){
+                      queryAuthor(filter:$filter){
+                        name
+                        reputation
+                        posts {
+                          title
+                        }
+                      }
+				    }`,
+			variables: map[string]interface{}{"filter": map[string]interface{}{"id": []int{cast.ToInt(authors[0].ID), cast.ToInt(authors[1].ID)}}},
+			respData: `{
+						  "queryAuthor": [
+							{
+							  "name": "George",
+							  "reputation": 4.5,
+							  "posts": [
+								{
+								  "title": "A show about nothing"
+								}
+							  ]
+							},
+							{
+							  "name": "Jerry",
+							  "reputation": 4.6,
+							  "posts": [
+								{
+								  "title": "Outside"
+								}
+							  ]
+							}
+						  ]
+						}`,
+		},
+		{
+
+			name: "Query using single ID in a filter of type integer coerced to string",
+			query: `query{
+			         queryAuthor(filter:{id:` + authorIdsDecimal[0] + `}){
+			           name
+					   reputation
+			           posts {
+			             title
+			           }
+			         }
+				    }`,
+			respData: `{
+						  "queryAuthor": [
+							{
+							  "name": "George",
+							  "reputation": 4.5,
+							  "posts": [
+								{
+								  "title": "A show about nothing"
+								}
+							  ]
+							}
+						  ]
+						}`,
+		},
+		{
+
+			name: "Query using multiple ID in a filter of type integer coerced to string",
+			query: `query{
+			         queryAuthor(filter:{id:[` + authorIdsDecimal[0] + `,` + authorIdsDecimal[1] + `]}){
+			           name
+                       reputation
+			           posts {
+			             title
+			           }
+			         }
+				    }`,
+			respData: `{
+						  "queryAuthor": [
+							{
+							  "name": "George",
+							  "reputation": 4.5,
+							  "posts": [
+								{
+								  "title": "A show about nothing"
+								}
+							  ]
+							},
+							{
+							  "name": "Jerry",
+							  "reputation": 4.6,
+							  "posts": [
+								{
+								  "title": "Outside"
+								}
+							  ]
+							}
+						  ]
+						}`,
+		},
 	}
 
-	t.Run(tcase.name, func(t *testing.T) {
-		params := &GraphQLParams{
-			Query:     tcase.query,
-			Variables: tcase.variables,
-		}
-		resp := params.ExecuteAsPost(t, GraphqlURL)
-		RequireNoGQLErrors(t, resp)
-		testutil.CompareJSON(t, tcase.respData, string(resp.Data))
-	})
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			params := &GraphQLParams{
+				Query:     tcase.query,
+				Variables: tcase.variables,
+			}
+			resp := params.ExecuteAsPost(t, GraphqlURL)
+			RequireNoGQLErrors(t, resp)
+			testutil.CompareJSON(t, tcase.respData, string(resp.Data))
+		})
+	}
 
 	// cleanup
 	deleteAuthors(t, authorIds, nil)

--- a/graphql/schema/validation_rules.go
+++ b/graphql/schema/validation_rules.go
@@ -33,11 +33,16 @@ func listInputCoercion(observers *validator.Events, addError validator.AddErrFun
 		if value.Kind == ast.Variable {
 			return
 		}
+		if value.ExpectedType.NamedType == IDType {
+			value.Kind = ast.StringValue
+		}
 		// If the expected value is a list (ExpectedType.Elem != nil) && the value is not of list type,
 		// then we need to coerce the value to a list, otherwise, we can return here as we do below.
-
 		if !(value.ExpectedType.Elem != nil && value.Kind != ast.ListValue) {
 			return
+		}
+		if value.ExpectedType.Elem.NamedType == IDType {
+			value.Kind = ast.StringValue
 		}
 		val := *value
 		child := &ast.ChildValue{Value: &val}


### PR DESCRIPTION
The following query was giving panic because here we passed ID as an int which is expected to be a string.
```

query allStories {
      queryUser(filter: {
        id: 22
      }) {
        stories {
          id
          text
        }
      }
    }
```

We now added input coercion so that the ID type value will be coerced to string type. And if we give a slice of integer values
to ID type variable then that will be coerced to slice of integer values.

(cherry picked from commit 5fa67969890d05a4a069ca25f5216f14dcb8ae36)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7353)
<!-- Reviewable:end -->
