### PR TITLE
fix: Calling Discard only adds to txn_discards metric, not txn_aborts.

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -102,12 +102,12 @@ var (
 	// TxnCommits records count of committed transactions.
 	TxnCommits = stats.Int64("txn_commits_total",
 		"Number of transaction commits", stats.UnitDimensionless)
-	// TxnDiscards records count of discarded transactions.
+	// TxnDiscards records count of discarded transactions by the client.
 	TxnDiscards = stats.Int64("txn_discards_total",
-		"Number of transaction discards", stats.UnitDimensionless)
-	// TxnAborts records count of aborted transactions.
+		"Number of transaction discards by the client", stats.UnitDimensionless)
+	// TxnAborts records count of aborted transactions by the server.
 	TxnAborts = stats.Int64("txn_aborts_total",
-		"Number of transaction aborts", stats.UnitDimensionless)
+		"Number of transaction aborts by the server", stats.UnitDimensionless)
 	// PBlockHitRatio records the hit ratio of posting store block cache.
 	PBlockHitRatio = stats.Float64("hit_ratio_postings_block",
 		"Hit ratio of p store block cache", stats.UnitDimensionless)


### PR DESCRIPTION
This PR is a follow-up to https://github.com/dgraph-io/dgraph/pull/7339 to update the way `dgraph_txn_discards_total` and `dgraph_txn_aborts_total` are tracked. When the client calls Discard, only the `dgraph_txn_discards_total` metric is incremented, not `dgraph_txn_aborts_total`. This makes it easy to see:

1. If the client is calling Discard
2. If the server is aborting transactions (e.g., because of transaction conflicts)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7365)
<!-- Reviewable:end -->
