### PR TITLE
fix(GraphQL): Added error for case when multiple filter functions are used in filter.

### DIFF
--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -349,3 +349,17 @@
   errors:
     [ { "message": "Out of range value '2147483648', for type `Int`",
         "locations": [ { "line": 2, "column": 53 } ] } ]
+
+- name: "Error when multiple filter functions are used"
+  gqlrequest: |
+    query {
+      queryBook(filter:{bookId: {eq:2 le:2}})
+         {
+          bookId
+        }
+      }
+  gqlvariables: |
+    { }
+  errors:
+    [ { "message": "Multiple filter functions for Int64Filter not allowed",
+        "locations": [ { "line": 2, "column": 29 } ] } ]

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -47,6 +47,7 @@ func init() {
 	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
 	validator.AddRule("Check range for Int type", intRangeCheck)
 	validator.AddRule("Input Coercion to List", listInputCoercion)
+	validator.AddRule("Check filter functions", filterCheck)
 
 }
 


### PR DESCRIPTION
we were having indeterministic behavior in the filter when we have multiple filter functionsas below . 
```
query {
  queryFoo(filter:{value:{eq:2 le:2}})
     {
      value
    }
  }
  
```
It was because we were selecting the first filter function from the list of functions whose order is not guaranteed.
Now we are returning an error for this.





<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
