### PR TITLE
fix(GraphQL): Added error for case when multiple filter functions are  used in filter. (#7368)

### DIFF
--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -349,3 +349,17 @@
   errors:
     [ { "message": "Out of range value '2147483648', for type `Int`",
         "locations": [ { "line": 2, "column": 53 } ] } ]
+
+- name: "Error when multiple filter functions are used"
+  gqlrequest: |
+    query {
+      queryBook(filter:{bookId: {eq:2 le:2}})
+         {
+          bookId
+        }
+      }
+  gqlvariables: |
+    { }
+  errors:
+    [ { "message": "Int64Filter filter expects only one filter function, got: 2",
+        "locations": [ { "line": 2, "column": 29 } ] } ]

--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -353,13 +353,13 @@
 - name: "Error when multiple filter functions are used"
   gqlrequest: |
     query {
-      queryBook(filter:{bookId: {eq:2 le:2}})
+      querypost1(filter:{numLikes: {eq:2 le:2}})
          {
-          bookId
+          numLikes
         }
       }
   gqlvariables: |
     { }
   errors:
     [ { "message": "Int64Filter filter expects only one filter function, got: 2",
-        "locations": [ { "line": 2, "column": 29 } ] } ]
+        "locations": [ { "line": 2, "column": 32 } ] } ]

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -47,6 +47,7 @@ func init() {
 	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
 	validator.AddRule("Check range for Int type", intRangeCheck)
 	validator.AddRule("Input Coercion to List", listInputCoercion)
+	validator.AddRule("Check filter functions", filterCheck)
 
 }
 

--- a/graphql/schema/validation_rules.go
+++ b/graphql/schema/validation_rules.go
@@ -18,11 +18,16 @@ package schema
 
 import (
 	"errors"
+	"github.com/dgraph-io/dgraph/x"
 	"strconv"
 
 	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/validator"
 )
+
+var allowedFilters = []string{"StringHashFilter", "StringExactFilter", "StringFullTextFilter",
+	"StringRegExpFilter", "StringTermFilter", "DateTimeFilter", "FloatFilter", "Int64Filter", "IntFilter", "PointGeoFilter",
+	"ContainsFilter", "IntersectsFilter", "PolygonGeoFilter"}
 
 func listInputCoercion(observers *validator.Events, addError validator.AddErrFunc) {
 	observers.OnValue(func(walker *validator.Walker, value *ast.Value) {
@@ -43,6 +48,18 @@ func listInputCoercion(observers *validator.Events, addError validator.AddErrFun
 		child := &ast.ChildValue{Value: &val}
 		valueNew := ast.Value{Children: []*ast.ChildValue{child}, Kind: ast.ListValue, Position: val.Position, Definition: val.Definition}
 		*value = valueNew
+	})
+}
+
+func filterCheck(observers *validator.Events, addError validator.AddErrFunc) {
+	observers.OnValue(func(walker *validator.Walker, value *ast.Value) {
+		if value.Definition == nil {
+			return
+		}
+
+		if x.HasString(allowedFilters, value.Definition.Name) && len(value.Children) > 1 {
+			addError(validator.Message("%s filter expects only one filter function, got: %d", value.Definition.Name, len(value.Children)), validator.At(value.Position))
+		}
 	})
 }
 


### PR DESCRIPTION
we were having indeterministic behavior in the filter when we have multiple filter functions as below .

```
query {
  queryFoo(filter:{value:{eq:2 le:2}})
     {
      value
    }
  }

```
It was because we were selecting the first filter function from the list of functions whose order is not guaranteed.
Now we are returning an error for this.

(cherry picked from commit de2f4ab197b45f7cd8ac303f32b62e25f10f2634)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7384)
<!-- Reviewable:end -->
