### PR TITLE
chore: update prometheus operator to work across namespaces

### DIFF
--- a/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
+++ b/contrib/config/monitoring/prometheus/chart-values/dgraph-prometheus-operator.yaml
@@ -60,11 +60,14 @@ prometheus:
       requests:
         memory: 400Mi
     enableAdminAPI: false
+
   additionalServiceMonitors:
     - name: zero-dgraph-io
       endpoints:
         - port: http-zero
           path: /debug/prometheus_metrics
+      namespaceSelector:
+        any: true
       selector:
         matchLabels:
           monitor: zero-dgraph-io
@@ -72,6 +75,8 @@ prometheus:
       endpoints:
         - port: http-alpha
           path: /debug/prometheus_metrics
+      namespaceSelector:
+        any: true
       selector:
         matchLabels:
           monitor: alpha-dgraph-io


### PR DESCRIPTION
This is a small update to allow prometheus installed in `monitoring` namespace to find Dgraph in different namespaces.  Before, Dgraph could only be scraped for metrics if it was in the same namespace as prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7394)
<!-- Reviewable:end -->
