### PR TITLE
cherrypick(GraphQL): fix interface query with auth rules

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -492,6 +492,32 @@ func TestAuthOnInterfaces(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthOnInterfaceWithRBACPositive(t *testing.T) {
+	getVehicleParams := &common.GraphQLParams{
+		Query: `
+		query {
+			queryVehicle{
+				owner
+			}
+		}`,
+		Headers: common.GetJWT(t, "Alice", "ADMIN", metaInfo),
+	}
+	gqlResponse := getVehicleParams.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+
+	result := `
+	{
+		"queryVehicle": [
+		  {
+			"owner": "Bob"
+		  }
+		]
+	  }`
+
+	require.JSONEq(t, result, string(gqlResponse.Data))
+}
+
 func TestAuthRulesWithMissingJWT(t *testing.T) {
 	testCases := []TestCase{
 		{name: "Query non auth field without JWT Token",

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -754,3 +754,19 @@ type Todo {
     owner: String
     text: String
 }
+
+interface Vehicle @auth(
+    query:{
+        or:[
+            {rule: "{$ROLE: { eq: \"ADMIN\" } }"},
+            {rule: "query($USER: String!) { queryVehicle(filter: { owner: { eq: $USER }}) { owner } }"}
+        ]
+    }
+){
+    owner: String! @search(by: [exact])
+}
+
+type Car implements Vehicle {
+    id: ID!
+    manufacturer: String!
+}

--- a/graphql/e2e/auth/test_data.json
+++ b/graphql/e2e/auth/test_data.json
@@ -289,5 +289,9 @@
 	{"uid":"_:Question2","Question.answered":"true"},
 	{"uid":"_:Question3","Question.answered":"false"},
 	{"uid":"_:Answer1","Answer.markedUseful":"true"},
-	{"uid":"_:Answer2","Answer.markedUseful":"true"}
+	{"uid":"_:Answer2","Answer.markedUseful":"true"},
+	{"uid":"_:Car1","dgraph.type":"Vehicle"},
+	{"uid":"_:Car1","dgraph.type":"Car"},
+	{"uid":"_:Car1","Vehicle.owner":"Bob"},
+	{"uid":"_:Car1","Car.manufacturer":"Tesla"}
 ]

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1835,3 +1835,26 @@
         pwd as checkpwd(Post.pwd, "something")
       }
     }
+
+-
+  name: "Query interface should return all the nodes of a type if rbac rules of type are true"
+  gqlquery: |
+    query {
+      queryVehicle{
+        owner
+      }
+    }
+  jwtvar:
+    ROLE: "ADMIN"
+    USER: "user"
+  dgquery: |-
+    query {
+      queryVehicle(func: uid(VehicleRoot)) {
+        dgraph.type
+        Vehicle.owner : Vehicle.owner
+        dgraph.uid : uid
+      }
+      VehicleRoot as var(func: uid(Vehicle1)) @filter((uid(Car1)))
+      Vehicle1 as var(func: type(Vehicle))
+      Car1 as var(func: type(Car))
+    }

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -1851,7 +1851,7 @@
     query {
       queryVehicle(func: uid(VehicleRoot)) {
         dgraph.type
-        Vehicle.owner : Vehicle.owner
+        owner : Vehicle.owner
         dgraph.uid : uid
       }
       VehicleRoot as var(func: uid(Vehicle1)) @filter((uid(Car1)))

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -660,11 +660,14 @@ func (authRw *authRewriter) addAuthQueries(
 				hasAuthRules:  authRw.hasAuthRules,
 			}).rewriteAuthQueries(object)
 
-			// If there is no Auth Query for the Given type then it means that
+			// 1. If there is no Auth Query for the Given type then it means that
 			// neither the inherited interface, nor this type has any Auth rules.
 			// In this case the query must return all the nodes of this type.
 			// then simply we need to Put uid(Todo1) with OR in the main query filter.
-			if len(objAuthQueries) == 0 {
+			// 2. If rbac evaluates to `Positive` which means RBAC rule is satisfied.
+			// Either it is the only auth rule, or it is present with `OR`, which means
+			// query must return all the nodes of this type.
+			if len(objAuthQueries) == 0 || rbac == schema.Positive {
 				objfilter = &gql.FilterTree{
 					Func: &gql.Function{
 						Name: "uid",


### PR DESCRIPTION
cherry picked from commit 8b29efc513cc8c88177b5208fb3892db5602546c
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7408)
<!-- Reviewable:end -->
