### PR TITLE
feat(GraphQL): Dgraph.Authorization should with irrespective of number of spaces after #

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -152,6 +152,9 @@ func Parse(schema string) (*AuthMeta, error) {
 		return nil, gqlerror.Errorf("JWT parsing failed: %v", err)
 	}
 
+	// authInfo with be like `Dgraph.Authorization ...`, we append prefix `# ` to authinfo
+	// to make it work with the regex matching algorithm.
+	authInfo = "# " + authInfo
 	idx := authMetaRegex.FindAllStringSubmatchIndex(authInfo, -1)
 	if len(idx) != 1 || len(idx[0]) != 12 ||
 		!strings.HasPrefix(authInfo, authInfo[idx[0][0]:idx[0][1]]) {

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -43,7 +43,7 @@ type authVariablekey string
 const (
 	AuthJwtCtxKey  = ctxKey("authorizationJwt")
 	AuthVariables  = authVariablekey("authVariable")
-	AuthMetaHeader = "Dgraph.Authorization "
+	AuthMetaHeader = "Dgraph.Authorization"
 )
 
 var (

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -43,7 +43,7 @@ type authVariablekey string
 const (
 	AuthJwtCtxKey  = ctxKey("authorizationJwt")
 	AuthVariables  = authVariablekey("authVariable")
-	AuthMetaHeader = "# Dgraph.Authorization "
+	AuthMetaHeader = "Dgraph.Authorization "
 )
 
 var (

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -177,7 +177,7 @@ func parseSecrets(sch string) (map[string]string, *authorization.AuthMeta, error
 
 		if strings.HasPrefix(text, "#") {
 			header := strings.TrimSpace(text[1:])
-			if strings.HasPrefix(header, "Dgraph.Autorization") {
+			if strings.HasPrefix(header, "Dgraph.Authorization") {
 				if authSecret != "" {
 					return nil, nil, errors.Errorf("Dgraph.Authorization should be only be specified once in "+
 						"a schema, found second mention: %v", text)

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -175,39 +175,41 @@ func parseSecrets(sch string) (map[string]string, *authorization.AuthMeta, error
 	for scanner.Scan() {
 		text := strings.TrimSpace(scanner.Text())
 
-		if strings.HasPrefix(text, "# Dgraph.Authorization") {
-			if authSecret != "" {
-				return nil, nil, errors.Errorf("Dgraph.Authorization should be only be specified once in "+
-					"a schema, found second mention: %v", text)
+		if strings.HasPrefix(text, "#") {
+			header := strings.TrimSpace(text[1:])
+			if strings.HasPrefix(header, "Dgraph.Autorization") {
+				if authSecret != "" {
+					return nil, nil, errors.Errorf("Dgraph.Authorization should be only be specified once in "+
+						"a schema, found second mention: %v", text)
+				}
+				authSecret = text
+				continue
 			}
-			authSecret = text
-			continue
-		}
-		if !strings.HasPrefix(text, "# Dgraph.Secret") {
-			continue
-		}
-		parts := strings.Fields(text)
-		const doubleQuotesCode = 34
+			if !strings.HasPrefix(header, "Dgraph.Secret") {
+				continue
+			}
+			parts := strings.Fields(text)
+			const doubleQuotesCode = 34
 
-		if len(parts) < 4 {
-			return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
-				"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
-		}
-		val := strings.Join(parts[3:], " ")
-		if strings.Count(val, `"`) != 2 || val[0] != doubleQuotesCode || val[len(val)-1] != doubleQuotesCode {
-			return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
-				"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+			if len(parts) < 4 {
+				return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
+					"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+			}
+			val := strings.Join(parts[3:], " ")
+			if strings.Count(val, `"`) != 2 || val[0] != doubleQuotesCode || val[len(val)-1] != doubleQuotesCode {
+				return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
+					"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+			}
+
+			val = strings.Trim(val, `"`)
+			key := strings.Trim(parts[2], `"`)
+			m[key] = val
 		}
 
-		val = strings.Trim(val, `"`)
-		key := strings.Trim(parts[2], `"`)
-		m[key] = val
+		if err := scanner.Err(); err != nil {
+			return nil, nil, errors.Wrapf(err, "while trying to parse secrets from schema file")
+		}
 	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, nil, errors.Wrapf(err, "while trying to parse secrets from schema file")
-	}
-
 	if authSecret == "" {
 		return m, nil, nil
 	}

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1190,7 +1190,7 @@ func TestParseSecrets(t *testing.T) {
 			`,
 			nil,
 			"",
-			errors.New("input: Invalid `Dgraph.Authorization` format: Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims \"key\""),
+			errors.New("input: Invalid `Dgraph.Authorization` format: # Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims \"key\""),
 		},
 		{
 			"should throw an error if multiple authorization values are specified",

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1111,71 +1111,6 @@ func TestParseSecrets(t *testing.T) {
 		expectedAuthHeader string
 		err                error
 	}{
-		{"should be able to parse secrets",
-			`
-			type User {
-				id: ID!
-				name: String!
-			}
-
-			# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
-			# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
-			`,
-			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
-				"STRIPE_API_KEY": "stripe-api-key-value"},
-			"",
-			nil,
-		},
-		{"should be able to parse secret where schema also has other comments.",
-			`
-		# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
-
-		type User {
-			id: ID!
-			name: String!
-		}
-
-		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
-		# random comment
-		`,
-			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
-				"STRIPE_API_KEY": "stripe-api-key-value"},
-			"",
-			nil,
-		},
-		{
-			"should throw an error if the secret is not in the correct format",
-			`
-			type User {
-				id: ID!
-				name: String!
-			}
-
-			# Dgraph.Secret RANDOM_TOKEN
-			`,
-			nil,
-			"",
-			errors.New("incorrect format for specifying Dgraph secret found for " +
-				"comment: `# Dgraph.Secret RANDOM_TOKEN`, it should " +
-				"be `# Dgraph.Secret key value`"),
-		},
-		{
-			"Dgraph.Authorization old format",
-			`
-			type User {
-				id: ID!
-				name: String!
-			}
-
-			# Dgraph.Secret  "GITHUB_API_TOKEN"   "some-super-secret-token"
-			# Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims HS256 "key"
-			# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
-			`,
-			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
-				"STRIPE_API_KEY": "stripe-api-key-value"},
-			"X-Test-Dgraph",
-			nil,
-		},
 		{
 			"Dgraph.Authorization old format error",
 			`
@@ -1190,7 +1125,7 @@ func TestParseSecrets(t *testing.T) {
 			`,
 			nil,
 			"",
-			errors.New("input: Invalid `Dgraph.Authorization` format: # Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims \"key\""),
+			errors.New("input: Invalid `Dgraph.Authorization` format: Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims \"key\""),
 		},
 		{
 			"should throw an error if multiple authorization values are specified",

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1111,6 +1111,71 @@ func TestParseSecrets(t *testing.T) {
 		expectedAuthHeader string
 		err                error
 	}{
+		{"should be able to parse secrets",
+			`
+		type User {
+			id: ID!
+			name: String!
+		}
+
+		# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
+		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+		`,
+			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
+				"STRIPE_API_KEY": "stripe-api-key-value"},
+			"",
+			nil,
+		},
+		{"should be able to parse secret where schema also has other comments.",
+			`
+	# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
+
+	type User {
+		id: ID!
+		name: String!
+	}
+
+	# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+	# random comment
+	`,
+			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
+				"STRIPE_API_KEY": "stripe-api-key-value"},
+			"",
+			nil,
+		},
+		{
+			"should throw an error if the secret is not in the correct format",
+			`
+		type User {
+			id: ID!
+			name: String!
+		}
+
+		# Dgraph.Secret RANDOM_TOKEN
+		`,
+			nil,
+			"",
+			errors.New("incorrect format for specifying Dgraph secret found for " +
+				"comment: `# Dgraph.Secret RANDOM_TOKEN`, it should " +
+				"be `# Dgraph.Secret key value`"),
+		},
+		{
+			"Dgraph.Authorization old format",
+			`
+		type User {
+			id: ID!
+			name: String!
+		}
+
+		# Dgraph.Secret  "GITHUB_API_TOKEN"   "some-super-secret-token"
+		# Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims HS256 "key"
+		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+		`,
+			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
+				"STRIPE_API_KEY": "stripe-api-key-value"},
+			"X-Test-Dgraph",
+			nil,
+		},
 		{
 			"Dgraph.Authorization old format error",
 			`
@@ -1156,6 +1221,20 @@ func TestParseSecrets(t *testing.T) {
 			nil,
 			"",
 			errors.New("required field missing in Dgraph.Authorization: `Verification key`/`JWKUrl` `Algo` `Header` `Namespace`"),
+		},
+		{
+			"Should be able to parse  Dgraph.Authorization irrespective of spacing between # and Dgraph.Authorization",
+			`
+			type User {
+				id: ID!
+				name: String!
+			}
+
+			#Dgraph.Authorization {"VerificationKey":"secretkey","Header":"X-Test-Auth","Namespace":"https://xyz.io/jwt/claims","Algo":"HS256","Audience":["aud1","63do0q16n6ebjgkumu05kkeian","aud5"]}
+			`,
+			map[string]string{},
+			"X-Test-Auth",
+			nil,
 		},
 		{
 			"Valid Dgraph.Authorization with audience field",

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1113,13 +1113,13 @@ func TestParseSecrets(t *testing.T) {
 	}{
 		{"should be able to parse secrets",
 			`
-		type User {
-			id: ID!
-			name: String!
-		}
+			type User {
+				id: ID!
+				name: String!
+			}
 
-		# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
-		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+			# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
+			# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
 		`,
 			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
 				"STRIPE_API_KEY": "stripe-api-key-value"},
@@ -1128,15 +1128,15 @@ func TestParseSecrets(t *testing.T) {
 		},
 		{"should be able to parse secret where schema also has other comments.",
 			`
-	# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
+		# Dgraph.Secret  GITHUB_API_TOKEN   "some-super-secret-token"
 
-	type User {
-		id: ID!
-		name: String!
-	}
+		type User {
+			id: ID!
+			name: String!
+		}
 
-	# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
-	# random comment
+		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+		# random comment
 	`,
 			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
 				"STRIPE_API_KEY": "stripe-api-key-value"},
@@ -1162,15 +1162,15 @@ func TestParseSecrets(t *testing.T) {
 		{
 			"Dgraph.Authorization old format",
 			`
-		type User {
-			id: ID!
-			name: String!
-		}
+			type User {
+				id: ID!
+				name: String!
+			}
 
-		# Dgraph.Secret  "GITHUB_API_TOKEN"   "some-super-secret-token"
-		# Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims HS256 "key"
-		# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
-		`,
+			# Dgraph.Secret  "GITHUB_API_TOKEN"   "some-super-secret-token"
+			# Dgraph.Authorization X-Test-Dgraph https://dgraph.io/jwt/claims HS256 "key"
+			# Dgraph.Secret STRIPE_API_KEY "stripe-api-key-value"
+			`,
 			map[string]string{"GITHUB_API_TOKEN": "some-super-secret-token",
 				"STRIPE_API_KEY": "stripe-api-key-value"},
 			"X-Test-Dgraph",

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -263,7 +263,7 @@ func AppendAuthInfoWithJWKUrlAndWithoutAudience(schema []byte) ([]byte, error) {
 // Add JWKUrl and (VerificationKey, Algo) in the same Authorization JSON
 // Adding Dummy values as this should result in validation error
 func AppendJWKAndVerificationKey(schema []byte) ([]byte, error) {
-	authInfo := `# Dgraph.Authorization {"VerificationKey":"some-key","Header":"X-Test-Auth","jwkurl":"some-url", "Namespace":"https://xyz.io/jwt/claims","Algo":"algo","Audience":["fir-project1-259e7"]}`
+	authInfo := `#Dgraph.Authorization{"VerificationKey":"some-key","Header":"X-Test-Auth","jwkurl":"some-url", "Namespace":"https://xyz.io/jwt/claims","Algo":"algo","Audience":["fir-project1-259e7"]}`
 	return append(schema, []byte(authInfo)...), nil
 }
 

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -251,7 +251,7 @@ func AppendAuthInfo(schema []byte, algo, publicKeyFile string, closedByDefault b
 }
 
 func AppendAuthInfoWithJWKUrl(schema []byte) ([]byte, error) {
-	authInfo := `# Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7"]}`
+	authInfo := `#   Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7"]}`
 	return append(schema, []byte(authInfo)...), nil
 }
 


### PR DESCRIPTION
Fixes GRAPHQ-960.
This PR ignores the spacing between `#` and `Dgraph.Authorization` in the GraphQL schema. Now the user can give any number of spaces or no space between it. For example, the header `#Dgraph.Authorization.....` will also be valid which was earlier not the case.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7410)
<!-- Reviewable:end -->
