### PR TITLE
fix(state):  make state endpoint return the predicates of requestor's namespace

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1016,6 +1016,27 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 	return &api.Response{Json: jsonOut}, nil
 }
 
+// Filter out the tablets that do not belong to the requester's namespace.
+func filterTablets(ctx context.Context, ms *pb.MembershipState) error {
+	ns, err := x.ExtractJWTNamespace(ctx)
+	if err != nil {
+		return errors.Errorf("Namespace not found in JWT.")
+	}
+	if ns == x.GalaxyNamespace {
+		return nil
+	}
+	for _, group := range ms.GetGroups() {
+		for pred := range group.GetTablets() {
+			if x.ParseNamespace(pred) != ns {
+				delete(group.Tablets, pred)
+			} else {
+				group.Tablets[pred].Predicate = x.ParseAttr(pred)
+			}
+		}
+	}
+	return nil
+}
+
 // State handles state requests
 func (s *Server) State(ctx context.Context) (*api.Response, error) {
 	if ctx.Err() != nil {
@@ -1029,6 +1050,10 @@ func (s *Server) State(ctx context.Context) (*api.Response, error) {
 	ms := worker.GetMembershipState()
 	if ms == nil {
 		return nil, errors.Errorf("No membership state found")
+	}
+
+	if err := filterTablets(ctx, ms); err != nil {
+		return nil, err
 	}
 
 	m := jsonpb.Marshaler{EmitDefaults: true}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1018,18 +1018,21 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 
 // Filter out the tablets that do not belong to the requestor's namespace.
 func filterTablets(ctx context.Context, ms *pb.MembershipState) error {
+	if !x.WorkerConfig.AclEnabled {
+		return nil
+	}
 	namespace, err := x.ExtractJWTNamespace(ctx)
 	if err != nil {
 		return errors.Errorf("Namespace not found in JWT.")
 	}
 	if namespace == x.GalaxyNamespace {
+		// For galaxy namespace, we don't want to filter out the predicates.
 		return nil
 	}
 	for _, group := range ms.GetGroups() {
 		tablets := make(map[string]*pb.Tablet)
 		for pred, tablet := range group.GetTablets() {
-			ns, attr := x.ParseNamespaceAttr(pred)
-			if namespace == ns {
+			if ns, attr := x.ParseNamespaceAttr(pred); namespace == ns {
 				tablets[attr] = tablet
 				tablets[attr].Predicate = attr
 			}

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1016,7 +1016,7 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 	return &api.Response{Json: jsonOut}, nil
 }
 
-// Filter out the tablets that do not belong to the requester's namespace.
+// Filter out the tablets that do not belong to the requestor's namespace.
 func filterTablets(ctx context.Context, ms *pb.MembershipState) error {
 	namespace, err := x.ExtractJWTNamespace(ctx)
 	if err != nil {

--- a/x/jwt_helper.go
+++ b/x/jwt_helper.go
@@ -57,6 +57,9 @@ func ExtractUserName(jwtToken string) (string, error) {
 }
 
 func ExtractJWTNamespace(ctx context.Context) (uint64, error) {
+	if !WorkerConfig.AclEnabled {
+		return GalaxyNamespace, nil
+	}
 	jwtString, err := ExtractJwt(ctx)
 	if err != nil {
 		return 0, err

--- a/x/jwt_helper.go
+++ b/x/jwt_helper.go
@@ -57,9 +57,6 @@ func ExtractUserName(jwtToken string) (string, error) {
 }
 
 func ExtractJWTNamespace(ctx context.Context) (uint64, error) {
-	if !WorkerConfig.AclEnabled {
-		return GalaxyNamespace, nil
-	}
 	jwtString, err := ExtractJwt(ctx)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This enables user to see state of only its namespace. A; the guardians can see the rest of the fields. Only predicates are filtered out.
Guardian of Galaxy see all namespaces:
```
"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002person_name": {
          "groupId": 1,
          "predicate": "\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0002person_name",
          "force": false,
          "onDiskBytes": "0",
          "remove": false,
          "readOnly": false,
          "moveTs": "0",
          "uncompressedBytes": "0"
        },
```
Non-Galaxy
```
"person_name": {
          "groupId": 1,
          "predicate": "person_name",
          "force": false,
          "onDiskBytes": "0",
          "remove": false,
          "readOnly": false,
          "moveTs": "0",
          "uncompressedBytes": "0"
        }
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7424)
<!-- Reviewable:end -->
