### PR TITLE
added type of backup (full/incremental) for lsbackup

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -264,7 +264,7 @@ func runLsbackupCmd() error {
 		return errors.Wrapf(err, "while listing manifests")
 	}
 
-	fmt.Printf("Name\tSince\tGroups\tEncrypted\n")
+	fmt.Printf("Name\tSince\tGroups\tEncrypted\tType\n")
 	for path, manifest := range manifests {
 		fmt.Printf("%v\t%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted, manifest.Type)
 	}

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -266,7 +266,7 @@ func runLsbackupCmd() error {
 
 	fmt.Printf("Name\tSince\tGroups\tEncrypted\n")
 	for path, manifest := range manifests {
-		fmt.Printf("%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted)
+		fmt.Printf("%v\t%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted, manifest.Type)
 	}
 
 	return nil


### PR DESCRIPTION
Let `lsbackup` command print the type of the backup.

e.g.
```
dgraph lsbackup -l ~/bkp/dgraph.20210208.123320.782                                  
[Decoder]: Using assembly version of decoder
Page Size: 4096
Listing backups from: /home/omar/Desktop/in_memory/bkp/dgraph.20210208.123320.782
Name	Since	Groups	Encrypted
/home/omar/Desktop/in_memory/bkp/dgraph.20210208.123320.782/manifest.json	5	map[1:[dgraph.graphql.xid dgraph.graphql.schema dgraph.graphql.p_sha256hash dgraph.graphql.schema_history dgraph.graphql.p_query dgraph.drop.op dgraph.graphql.schema_created_at dgraph.type dgraph.cors]]	false	full
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7425)
<!-- Reviewable:end -->
