### PR TITLE
added type of backup (full/incremental) for lsbackup

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -15,9 +15,10 @@ package backup
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc/credentials"
 	"os"
 	"time"
+
+	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -37,13 +38,13 @@ var LsBackup x.SubCommand
 var ExportBackup x.SubCommand
 
 var opt struct {
-	backupId    string
-	location    string
-	pdir        string
-	zero        string
-	key         x.SensitiveByteSlice
-	forceZero   bool
-	format      string
+	backupId  string
+	location  string
+	pdir      string
+	zero      string
+	key       x.SensitiveByteSlice
+	forceZero bool
+	format    string
 }
 
 func init() {
@@ -257,7 +258,7 @@ func runLsbackupCmd() error {
 
 	fmt.Printf("Name\tSince\tGroups\tEncrypted\n")
 	for path, manifest := range manifests {
-		fmt.Printf("%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted)
+		fmt.Printf("%v\t%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted, manifest.Type)
 	}
 
 	return nil

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -256,7 +256,7 @@ func runLsbackupCmd() error {
 		return errors.Wrapf(err, "while listing manifests")
 	}
 
-	fmt.Printf("Name\tSince\tGroups\tEncrypted\n")
+	fmt.Printf("Name\tSince\tGroups\tEncrypted\tType\n")
 	for path, manifest := range manifests {
 		fmt.Printf("%v\t%v\t%v\t%v\t%v\n", path, manifest.Since, manifest.Groups, manifest.Encrypted, manifest.Type)
 	}


### PR DESCRIPTION
Let `lsbackup` command print the type of the backup.

e.g.
```
dgraph lsbackup -l ~/bkp/dgraph.20210208.123320.782                                  
[Decoder]: Using assembly version of decoder
Page Size: 4096
Listing backups from: /home/omar/Desktop/in_memory/bkp/dgraph.20210208.123320.782
Name	Since	Groups	Encrypted
/home/omar/Desktop/in_memory/bkp/dgraph.20210208.123320.782/manifest.json	5	map[1:[dgraph.graphql.xid dgraph.graphql.schema dgraph.graphql.p_sha256hash dgraph.graphql.schema_history dgraph.graphql.p_query dgraph.drop.op dgraph.graphql.schema_created_at dgraph.type dgraph.cors]]	false	full
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7426)
<!-- Reviewable:end -->
