### PR TITLE
fix(GraphQL): Fix panic caused by incorrect input coercion of scalar to list (#7405)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6
 	github.com/dgraph-io/gqlgen v0.13.2
-	github.com/dgraph-io/gqlparser/v2 v2.1.4
+	github.com/dgraph-io/gqlparser/v2 v2.1.5
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b
 	github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/dgraph-io/dgo/v200 v200.0.0-20200805103119-a3544c464dd6/go.mod h1:rHa
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/gqlparser/v2 v2.1.4 h1:yMj5848fLCiJQX6/qEHtMl46i2mr7HzrD8fwHI86Svg=
-github.com/dgraph-io/gqlparser/v2 v2.1.4/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
+github.com/dgraph-io/gqlparser/v2 v2.1.5 h1:FNFSzyOEZ8gs97SLBtn2Pez9f12emvsQ6Vv6oNtg5rc=
+github.com/dgraph-io/gqlparser/v2 v2.1.5/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b h1:PDEhlwHpkEQ5WBfOOKZCNZTXFDGyCEWTYDhxGQbyIpk=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20210122082011-bb5d392ed82d h1:eQYOG6A4td1tht0NdJB9Ls6DsXRGb2Ft6X9REU/MbbE=

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -718,6 +718,7 @@ func RunAll(t *testing.T) {
 	t.Run("two levels linked to one XID", twoLevelsLinkedToXID)
 	t.Run("cyclically linked mutation", cyclicMutation)
 	t.Run("parallel mutations", parallelMutations)
+	t.Run("input coercion to list", inputCoerciontoList)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -8,7 +8,7 @@
     { }
   errors:
     [ { "message": "Cannot query field \"getAuthorszzz\" on type \"Query\". Did you mean
-       \"getAuthor\"?",
+       \"getAuthor\" or \"getauthor1\"?",
       "locations": [ { "line": 2, "column": 3 } ] } ]
     
 -

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -5068,3 +5068,145 @@ func twoLevelsLinkedToXID(t *testing.T) {
 	DeleteGqlType(t, "Owner", map[string]interface{}{}, 1, nil)
 	DeleteGqlType(t, "Dataset", map[string]interface{}{}, 1, nil)
 }
+
+func inputCoerciontoList(t *testing.T) {
+
+	tcases := []struct {
+		name      string
+		query     string
+		variables string
+		expected  string
+	}{
+		{name: "Coercion of Scalar value at root to list ",
+			query: ` mutation {
+						addpost1(input: { title: "GraphQL", commentsByMonth: 1 }) {
+							post1 {
+								title
+								commentsByMonth
+							}
+						}
+					}`,
+			expected: `{
+							"addpost1": {
+								"post1": [
+            						{
+               							 "title": "GraphQL",
+                						"commentsByMonth": [
+											1
+                						]
+            						}
+        						]
+    						}
+						}`,
+		},
+		{name: "Coercion of Scalar value at root to list using variables",
+			query: ` mutation($post1: [Addpost1Input!]!) {
+						addpost1(input: $post1) {
+							post1 {
+								title
+								commentsByMonth
+							}
+						}
+					}`,
+			expected: `{
+							"addpost1": {
+        						"post1": [
+            						{
+                						"title": "Dgraph",
+										"commentsByMonth": [
+                    						1
+										]
+          							  }
+        						]
+    						}
+						}`,
+			variables: `{"post1": {"title":"Dgraph","commentsByMonth":1}}`,
+		},
+		{name: "Coercing nested scalar value to list ",
+			query: ` mutation {
+						addauthor1(
+							input: { name: "Jack", posts: { title: "RDBMS", commentsByMonth: 1 } }
+						) {
+							author1 {
+								name
+								posts {
+									title
+									commentsByMonth
+								}
+							}
+						}
+					}`,
+			expected: `{
+							"addauthor1": {
+       	 						"author1": [
+            						{
+                						"name": "Jack",
+                						"posts": [
+                    						{
+                        						"title": "RDBMS",
+                        						"commentsByMonth": [
+                            						1
+                        						]
+                    						}
+                						]
+            						}
+        						]
+    						}
+						}`,
+		},
+		{name: "Coercing nested scalar value to list using variables",
+			query: `mutation($author: [Addauthor1Input!]!) {
+						addauthor1(input: $author) {
+							author1 {
+								name
+								posts {
+									title
+									commentsByMonth
+								}
+							}
+						}
+					}`,
+			expected: `{
+    						"addauthor1": {
+        						"author1": [
+            						{
+                						"name": "Jackob",
+                						"posts": [
+                    						{
+                        						"title": "DB",
+                        						"commentsByMonth": [
+                            						1
+                        						]
+                    						}
+										]
+            						}
+        						]
+    						}
+						}`,
+			variables: `{"author": {"name": "Jackob","posts":{"title":"DB","commentsByMonth":1}}}`,
+		},
+	}
+
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			var vars map[string]interface{}
+			if tcase.variables != "" {
+				err := json.Unmarshal([]byte(tcase.variables), &vars)
+				require.NoError(t, err)
+			}
+			params := &GraphQLParams{
+				Query:     tcase.query,
+				Variables: vars,
+			}
+			resp := params.ExecuteAsPost(t, GraphqlURL)
+			RequireNoGQLErrors(t, resp)
+			testutil.CompareJSON(t, tcase.expected, string(resp.Data))
+		})
+	}
+
+	author1DeleteFilter := map[string]interface{}{"name": map[string]interface{}{"in": []string{"Jack", "Jackob"}}}
+	DeleteGqlType(t, "author1", author1DeleteFilter, 2, nil)
+	posts1DeleteFilter := map[string]interface{}{"title": map[string]interface{}{"in": []string{"Dgraph", "GraphQL", "RDBMS", "DB"}}}
+	DeleteGqlType(t, "post1", posts1DeleteFilter, 4, nil)
+
+}

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -201,6 +201,7 @@ type post1{
     numLikes: Int64 @search
     commentsByMonth: [Int]
     likesByMonth: [Int64]
+    author: author1 @hasInverse(field: posts)
 }
 
 type Person1 {
@@ -314,4 +315,9 @@ type Dataset {
     owner: Owner!
     project: Project!
     name: String! @search(by: [hash])
+}
+
+type author1{
+    name:String! @id @search(by: [regexp])
+    posts:[post1] @hasInverse(field: author)
 }

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -9,6 +9,61 @@
       ]
     },
     {
+      "predicate": "post1.author",
+      "type": "uid"
+    },
+    {
+      "index": true,
+      "predicate": "author1.name",
+      "tokenizer": [
+        "hash",
+        "trigram"
+      ],
+      "type": "string",
+      "upsert": true
+    },
+    {
+      "predicate": "Astronaut.id",
+      "type": "string",
+      "index": true,
+      "tokenizer": [
+        "hash"
+      ],
+      "upsert": true
+    },
+    {
+      "list": true,
+      "predicate": "author1.posts",
+      "type": "uid"
+    },
+    {
+      "predicate": "Astronaut.missions",
+      "type": "uid",
+      "list": true
+    },
+    {
+      "predicate": "Book.bookId",
+      "type": "int",
+      "index": true,
+      "tokenizer": [
+        "int"
+      ],
+      "upsert": true
+    },
+    {
+      "predicate": "Book.chapters",
+      "type": "uid",
+      "list": true
+    },
+    {
+      "predicate": "Book.desc",
+      "type": "string"
+    },
+    {
+      "predicate": "Book.name",
+      "type": "string"
+    },
+    {
       "predicate": "Category.name",
       "type": "string"
     },
@@ -1087,6 +1142,9 @@
     {
       "fields": [
         {
+          "name": "post1.author"
+        },
+        {
           "name": "post1.title"
         },
         {
@@ -1114,6 +1172,17 @@
         }
       ],
       "name": "roboDroid"
+    },
+    {
+      "fields": [
+        {
+          "name": "author1.name"
+        },
+        {
+          "name": "author1.posts"
+        }
+      ],
+      "name": "author1"
     },
     {
       "fields": [

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -23,45 +23,9 @@
       "upsert": true
     },
     {
-      "predicate": "Astronaut.id",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "hash"
-      ],
-      "upsert": true
-    },
-    {
       "list": true,
       "predicate": "author1.posts",
       "type": "uid"
-    },
-    {
-      "predicate": "Astronaut.missions",
-      "type": "uid",
-      "list": true
-    },
-    {
-      "predicate": "Book.bookId",
-      "type": "int",
-      "index": true,
-      "tokenizer": [
-        "int"
-      ],
-      "upsert": true
-    },
-    {
-      "predicate": "Book.chapters",
-      "type": "uid",
-      "list": true
-    },
-    {
-      "predicate": "Book.desc",
-      "type": "string"
-    },
-    {
-      "predicate": "Book.name",
-      "type": "string"
     },
     {
       "predicate": "Category.name",

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -196,12 +196,18 @@ type Comment1 {
       replies: [Comment1]
 }
 
+type author1{
+      name:String! @id @search(by: [regexp])
+      posts:[post1] @hasInverse(field: author)
+}
+
 type post1{
         id: ID
         title: String! @id @search(by: [regexp])
         numLikes: Int64 @search
         commentsByMonth: [Int]
         likesByMonth: [Int64]
+        author:author1 @hasInverse(field: posts)
 }
 
 type Person1 {

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -28,20 +28,6 @@
       "type": "uid"
     },
     {
-      "predicate": "Astronaut.id",
-      "type": "string",
-      "index": true,
-      "tokenizer": [
-        "hash"
-      ],
-      "upsert": true
-    },
-    {
-      "predicate": "Astronaut.missions",
-      "type": "uid",
-      "list": true
-    },
-    {
       "predicate": "Author.country",
       "type": "uid"
     },

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -9,6 +9,39 @@
       ]
     },
     {
+      "predicate": "post1.author",
+      "type": "uid"
+    },
+    {
+      "index": true,
+      "predicate": "author1.name",
+      "tokenizer": [
+        "hash",
+        "trigram"
+      ],
+      "type": "string",
+      "upsert": true
+    },
+    {
+      "list": true,
+      "predicate": "author1.posts",
+      "type": "uid"
+    },
+    {
+      "predicate": "Astronaut.id",
+      "type": "string",
+      "index": true,
+      "tokenizer": [
+        "hash"
+      ],
+      "upsert": true
+    },
+    {
+      "predicate": "Astronaut.missions",
+      "type": "uid",
+      "list": true
+    },
+    {
       "predicate": "Author.country",
       "type": "uid"
     },
@@ -1143,6 +1176,9 @@
     {
       "fields": [
         {
+          "name": "post1.author"
+        },
+        {
           "name": "post1.title"
         },
         {
@@ -1156,6 +1192,17 @@
         }
       ],
       "name": "post1"
+    },
+    {
+      "fields": [
+        {
+          "name": "author1.name"
+        },
+        {
+          "name": "author1.posts"
+        }
+      ],
+      "name": "author1"
     }
   ]
 }

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -17,13 +17,8 @@
 package schema
 
 import (
-	"net/http"
-	"reflect"
-	"strconv"
-
-	"github.com/dgraph-io/gqlparser/v2/gqlerror"
-
 	"github.com/pkg/errors"
+	"net/http"
 
 	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/parser"
@@ -90,10 +85,6 @@ func (s *schema) Operation(req *Request) (Operation, error) {
 	if gqlErr != nil {
 		return nil, gqlErr
 	}
-	err := variableValidateInt(s.schema, op, req.Variables)
-	if err != nil {
-		return nil, err
-	}
 
 	operation := &operation{op: op,
 		vars:                    vars,
@@ -110,110 +101,6 @@ func (s *schema) Operation(req *Request) (Operation, error) {
 	}
 
 	return operation, nil
-}
-
-// This function validates the value of variables for fields of type Int and Int64.
-// Ideally this should happen in the gqlparser library.
-// There is an issue created with this dgraph-io/gqlparser#134.
-// The code here is inspired by https://github.com/dgraph-io/gqlparser/blob/master/validator/vars.go#L76.
-func variableValidateInt(schema *ast.Schema, op *ast.OperationDefinition, variables map[string]interface{}) *gqlerror.Error {
-	path := ast.Path{ast.PathName("variable")}
-	for _, v := range op.VariableDefinitions {
-		path = append(path, ast.PathName(v.Variable))
-		val, hasValue := variables[v.Variable]
-		if !hasValue {
-			if v.DefaultValue != nil {
-				val, _ = v.DefaultValue.Value(nil)
-				hasValue = true
-			}
-		}
-		if hasValue {
-			rv := reflect.ValueOf(val)
-			if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
-				rv = rv.Elem()
-			}
-			err := variableValidateIntRecursive(schema, v.Type, rv, path)
-			if err != nil {
-				return err
-			}
-		}
-		path = path[0 : len(path)-1]
-	}
-	return nil
-}
-
-func variableValidateIntRecursive(schema *ast.Schema, typ *ast.Type, val reflect.Value, path ast.Path) *gqlerror.Error {
-	currentPath := path
-	resetPath := func() {
-		path = currentPath
-	}
-	defer resetPath()
-	if typ.Elem != nil {
-		for i := 0; i < val.Len(); i++ {
-			resetPath()
-			path = append(path, ast.PathIndex(i))
-			field := val.Index(i)
-			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
-				field = field.Elem()
-			}
-			err := variableValidateIntRecursive(schema, typ.Elem, field, path)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-	def := schema.Types[typ.NamedType]
-	if !typ.NonNull && !val.IsValid() {
-		// If the type is not null and we got a invalid value namely null/nil, then it's valid
-		return nil
-	}
-	switch def.Kind {
-	case ast.Scalar:
-		switch typ.NamedType {
-		case "Int", "Int64":
-			var errIntCoerce error
-			if typ.NamedType == "Int" {
-				_, errIntCoerce = strconv.ParseInt(val.String(), 10, 32)
-			} else {
-				_, errIntCoerce = strconv.ParseInt(val.String(), 10, 64)
-			}
-			if errIntCoerce != nil {
-				if errors.Is(errIntCoerce, strconv.ErrRange) {
-					return gqlerror.ErrorPathf(path, "Out of range value '%s', for type `%s`", val.String(), typ.NamedType)
-
-				} else {
-					return gqlerror.ErrorPathf(path, "Type mismatched for Value `%s`, expected:`%s`", val.String(), typ.NamedType)
-				}
-			}
-		}
-
-	case ast.InputObject:
-		// check for unknown fields
-
-		for _, fieldDef := range def.Fields {
-			resetPath()
-			path = append(path, ast.PathName(fieldDef.Name))
-
-			field := val.MapIndex(reflect.ValueOf(fieldDef.Name))
-			if !field.IsValid() {
-				continue
-			}
-			if field.Kind() == reflect.Ptr || field.Kind() == reflect.Interface {
-				if !fieldDef.Type.NonNull && field.IsNil() {
-					continue
-				}
-				field = field.Elem()
-			}
-			err := variableValidateIntRecursive(schema, fieldDef.Type, field, path)
-			if err != nil {
-				return err
-			}
-		}
-	default:
-		return nil
-	}
-	return nil
 }
 
 // recursivelyExpandFragmentSelections puts a fragment's selection set directly inside this


### PR DESCRIPTION
Fixes-GRAPHQl-1006
We have moved some of the input coercion code to the library as part of the commit. I have also added tests to verify the fix.

(cherry picked from commit a26993aa18228177f5524cb4f147fa6f9b1454c2)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7428)
<!-- Reviewable:end -->
