### PR TITLE
[Breaking flag] ACL flags use SuperFlag

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -325,7 +325,7 @@ func getAlpha(idx int, raft string) service {
 		svc.Command += " --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 	}
 	if opts.Acl {
-		svc.Command += ` --acl "secret_file=/secret/hmac"`
+		svc.Command += ` --acl "secret-file=/secret/hmac"`
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   "./acl-secret",
@@ -334,7 +334,7 @@ func getAlpha(idx int, raft string) service {
 		})
 	}
 	if opts.AclSecret != "" {
-		svc.Command += ` --acl "secret_file=/secret/hmac"`
+		svc.Command += ` --acl "secret-file=/secret/hmac"`
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   opts.AclSecret,

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -325,7 +325,7 @@ func getAlpha(idx int, raft string) service {
 		svc.Command += " --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
 	}
 	if opts.Acl {
-		svc.Command += " --acl_secret_file=/secret/hmac"
+		svc.Command += ` --acl "secret_file=/secret/hmac"`
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   "./acl-secret",
@@ -334,7 +334,7 @@ func getAlpha(idx int, raft string) service {
 		})
 	}
 	if opts.AclSecret != "" {
-		svc.Command += " --acl_secret_file=/secret/hmac"
+		svc.Command += ` --acl "secret_file=/secret/hmac"`
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   opts.AclSecret,

--- a/contrib/config/backups/client/compose-setup.sh
+++ b/contrib/config/backups/client/compose-setup.sh
@@ -216,7 +216,7 @@ config_compose() {
 
   ## configure if user specifies
   [[ $ACL_ENABLED == "true" ]] && \
-    echo "acl_secret_file = '/dgraph/acl/hmac_secret_file'" >> "$CFGPATH/config.toml"
+    echo "--acl \"secret-file=/dgraph/acl/hmac_secret_file\"" >> "$CFGPATH/config.toml"
   [[ $TOKEN_ENABLED == "true" ]] && \
     echo "auth_token = '$(cat ./data/token/auth_token_file)'" >> "$CFGPATH/config.toml"
   [[ $ENC_ENABLED == "true" ]] && \

--- a/contrib/manual_tests/test.sh
+++ b/contrib/manual_tests/test.sh
@@ -296,7 +296,7 @@ function test::manual_start_acl() {
   local -r n_alphas=3
 
   dgraph::start_zeros "$n_zeros"
-  dgraph::start_alphas "$n_alphas" --acl_secret_file "$ACL_SECRET_PATH"
+  dgraph::start_alphas "$n_alphas" --acl "secret-file=$ACL_SECRET_PATH"
 
   for i in $(seq "$n_zeros"); do
     dgraph::healthcheck_zero "$i"

--- a/contrib/manual_tests/test.sh
+++ b/contrib/manual_tests/test.sh
@@ -407,7 +407,7 @@ function test::manual_start_encryption_acl_tls() {
 
   dgraph::start_zeros "$n_zeros"
   dgraph::start_alphas "$n_alphas" \
-    --acl_secret_file "$ACL_SECRET_PATH" \
+    --acl "secret_file=$ACL_SECRET_PATH" \
     --encryption_key_file "$ENCRYPTION_KEY_PATH" \
     --tls_cacert "$TLS_PATH"/ca.crt --tls_node_cert "$TLS_PATH"/node.crt --tls_node_key "$TLS_PATH"/node.key
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -149,18 +149,13 @@ they form a Raft group and provide synchronous replication.
 			" For Grpc, in auth-token key in the context.")
 
 	flag.String("acl", worker.AclDefaults,
-		`ACL options:
-	secret_file="" The file that stores the HMAC secret, which is used for signing the JWT and
+		`(Enterprise feature)
+		ACL options:
+	secret-file="" The file that stores the HMAC secret, which is used for signing the JWT and
 		should have at least 32 ASCII characters.
-		(Enterprise feature)
-	access_ttl=duration The TTL for the access JWT.
-		The duration format used is the same as time.ParseDuration with two added duration suffixes:
-		"12h" means 12 hours, and "30d" means 30 days.
-		(Enterprise feature)
-	refresh_ttl=duration The TTL for the refresh JWT.
-		The duration format used is the same as time.ParseDuration with two added duration suffixes:
-		"12h" means 12 hours, and "30d" means 30 days.
-		(Enterprise feature)`)
+	access-ttl=duration The TTL for the access JWT.
+	refresh-ttl=duration The TTL for the refresh JWT.
+		The duration format is the same as time.ParseDuration with an added 'd' suffix for days.`)
 
 	flag.String("mutations", "allow",
 		"Set mutation mode to allow, disallow, or strict.")
@@ -643,7 +638,7 @@ func run() {
 	}
 
 	acl := z.NewSuperFlag(Alpha.Conf.GetString("acl")).MergeAndCheckDefault(worker.AclDefaults)
-	secretFile := acl.GetString("secret_file")
+	secretFile := acl.GetString("secret-file")
 	if secretFile != "" {
 		hmacSecret, err := ioutil.ReadFile(secretFile)
 		if err != nil {
@@ -653,8 +648,8 @@ func run() {
 			glog.Fatalf("The HMAC secret file should contain at least 256 bits (32 ascii chars)")
 		}
 		opts.HmacSecret = hmacSecret
-		opts.AccessJwtTtl = acl.GetDuration("access_ttl")
-		opts.RefreshJwtTtl = acl.GetDuration("refresh_ttl")
+		opts.AccessJwtTtl = acl.GetDuration("access-ttl")
+		opts.RefreshJwtTtl = acl.GetDuration("refresh-ttl")
 		glog.Info("HMAC secret loaded successfully.")
 	}
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -149,10 +149,10 @@ they form a Raft group and provide synchronous replication.
 			" For Grpc, in auth-token key in the context.")
 
 	flag.String("acl", worker.AclDefaults,
-		`(Enterprise feature)
+		`This flag provides settings for Access Control Lists (Enterprise Feature)
 		ACL options:
-	secret-file="" The file that stores the HMAC secret, which is used for signing the JWT and
-		should have at least 32 ASCII characters.
+	secret-file=path The file that stores the HMAC secret, which is used for signing the JWT and
+		should have at least 32 ASCII characters. Required to enable ACLs.
 	access-ttl=duration The TTL for the access JWT.
 	refresh-ttl=duration The TTL for the refresh JWT.
 		The duration format is the same as time.ParseDuration with an added 'd' suffix for days.`)

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha2:
     image: dgraph/dgraph:latest
@@ -100,7 +100,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha3:
     image: dgraph/dgraph:latest
@@ -126,7 +126,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha4:
     image: dgraph/dgraph:latest
@@ -152,7 +152,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha5:
     image: dgraph/dgraph:latest
@@ -178,7 +178,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha6:
     image: dgraph/dgraph:latest
@@ -204,7 +204,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   minio:
     image: minio/minio:latest

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   alpha2:
     image: dgraph/dgraph:latest
@@ -100,7 +100,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   alpha3:
     image: dgraph/dgraph:latest
@@ -126,7 +126,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   alpha4:
     image: dgraph/dgraph:latest
@@ -152,7 +152,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   alpha5:
     image: dgraph/dgraph:latest
@@ -178,7 +178,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   alpha6:
     image: dgraph/dgraph:latest
@@ -204,7 +204,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 20s
+    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=20s;"
 
   minio:
     image: minio/minio:latest

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.1.4
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b
-	github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1
+	github.com/dgraph-io/ristretto v0.0.4-0.20210211152756-58fa1b4c59a7
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b h1:
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20200916064635-48589439591b/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1 h1:E+NH1+aTO3vgP/t01DvYbX8qnwBC0bPgPwK7y+y0vaE=
 github.com/dgraph-io/ristretto v0.0.4-0.20210205182321-f8e4908e34d1/go.mod h1:tv2ec8nA7vRpSYX7/MbP52ihrUMXIHit54CQMq8npXQ=
+github.com/dgraph-io/ristretto v0.0.4-0.20210211152756-58fa1b4c59a7 h1:qkOjAz54rhrCkLvzgkpXlpmJh9pWXNLpnVe4hrqPdNY=
+github.com/dgraph-io/ristretto v0.0.4-0.20210211152756-58fa1b4c59a7/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -34,4 +34,4 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=3s;" --auth_token itIsSecret
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" --auth_token itIsSecret

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -34,4 +34,4 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file /dgraph-acl/hmac-secret --acl_access_ttl 3s --auth_token itIsSecret
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --trace 1.0 --profile_mode block --block_rate 10 --logtostderr -v=2 --whitelist 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/dgraph-acl/hmac-secret; access_ttl=3s;" --auth_token itIsSecret

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -1,4 +1,4 @@
-# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl_secret ../../ee/acl/hmac-secret --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
+# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl "secret_file=../../ee/acl/hmac-secret;" --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
 #
 version: "3.5"
 services:
@@ -20,7 +20,7 @@ services:
       target: /secret/hmac
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
-      --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl_secret_file=/secret/hmac
+      --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/secret/hmac;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -1,4 +1,4 @@
-# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl "secret_file=../../ee/acl/hmac-secret;" --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
+# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl_secret_file=../../ee/acl/hmac-secret --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
 #
 version: "3.5"
 services:
@@ -20,7 +20,7 @@ services:
       target: /secret/hmac
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
-      --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret_file=/secret/hmac;"
+      --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 --acl "secret-file=/secret/hmac;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
       --tls_cacert /dgraph-tls/ca.crt --tls_node_cert /dgraph-tls/node.crt --tls_node_key /dgraph-tls/node.key
       --tls_internal_port_enabled=true --tls_cert /dgraph-tls/client.alpha1.crt --tls_key /dgraph-tls/client.alpha1.key
-      --tls_client_auth VERIFYIFGIVEN --acl "secret_file=/dgraph-acl/hmac-secret;"
+      --tls_client_auth VERIFYIFGIVEN --acl "secret-file=/dgraph-acl/hmac-secret;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       --logtostderr -v=2 --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
       --tls_cacert /dgraph-tls/ca.crt --tls_node_cert /dgraph-tls/node.crt --tls_node_key /dgraph-tls/node.key
       --tls_internal_port_enabled=true --tls_cert /dgraph-tls/client.alpha1.crt --tls_key /dgraph-tls/client.alpha1.key
-      --tls_client_auth VERIFYIFGIVEN --acl_secret_file /dgraph-acl/hmac-secret
+      --tls_client_auth VERIFYIFGIVEN --acl "secret_file=/dgraph-acl/hmac-secret;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -30,6 +30,10 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	AclDefaults = `secret_file=""; access_ttl=6; refresh_ttl=30;`
+)
+
 // ServerState holds the state of the Dgraph server.
 type ServerState struct {
 	FinishCh chan struct{} // channel to wait for all pending reqs to finish.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	AclDefaults = `secret_file=""; access_ttl=6; refresh_ttl=30;`
+	AclDefaults = `secret-file=""; access-ttl=6h; refresh-ttl=30d;`
 )
 
 // ServerState holds the state of the Dgraph server.


### PR DESCRIPTION


**acl_secret_file** remaining instances:

```
$ grep -r "acl_secret_file" .

./contrib/manual_tests/test.sh:readonly ACL_SECRET_PATH="$DGRAPH_PATH/acl_secret_file"
./systest/bgindex/docker-compose.yml:# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl_secret_file=../../ee/acl/hmac-secret --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
```

**acl_access_ttl** remaining instances:

```
$ grep -r "acl_access_ttl" .

./systest/bgindex/docker-compose.yml:# Auto-generated with: [./compose -l -a 6 -r 3 -z 3 --port_offset=0 --expose_ports=false --acl_secret_file=../../ee/acl/hmac-secret --extra_alpha_flags=--acl_access_ttl=300s --mem= --names=false -O ../systest/bgindex/docker-compose.yml]
```

**acl_refresh_ttl** remaining instances:

```
$ grep -r "acl_refresh_ttl" .

(none)
```


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7429)
<!-- Reviewable:end -->
