### PR TITLE
fix(sort): Fix multi-sort with nils

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -786,6 +786,48 @@ func populateCluster() {
 		<69> <pname> "nameI" .
 		<70> <pname> "nameJ" .
 
+		<61> <pred1> "A" .
+		<62> <pred1> "A" .
+		<63> <pred1> "A" .
+		<64> <pred1> "B" .
+		<65> <pred1> "B" .
+		<66> <pred1> "B" .
+		<67> <pred1> "C" .
+		<68> <pred1> "C" .
+		<69> <pred1> "C" .
+		<70> <pred1> "C" .
+
+		<61> <pred2> "I" .
+		<62> <pred2> "J" .
+
+		<64> <pred2> "I" .
+		<65> <pred2> "J" .
+
+		<67> <pred2> "I" .
+		<68> <pred2> "J" .
+		<69> <pred2> "K" .
+
+
+		<61> <index-pred1> "A" .
+		<62> <index-pred1> "A" .
+		<63> <index-pred1> "A" .
+		<64> <index-pred1> "B" .
+		<65> <index-pred1> "B" .
+		<66> <index-pred1> "B" .
+		<67> <index-pred1> "C" .
+		<68> <index-pred1> "C" .
+		<69> <index-pred1> "C" .
+		<70> <index-pred1> "C" .
+
+		<61> <index-pred2> "I" .
+		<62> <index-pred2> "J" .
+
+		<64> <index-pred2> "I" .
+		<65> <index-pred2> "J" .
+
+		<67> <index-pred2> "I" .
+		<68> <index-pred2> "J" .
+		<69> <index-pred2> "K" .
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1933,7 +1933,7 @@ func TestMultiSort4(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	// Null value for third Alice comes at last.
-	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":75},{"name":"Bob","age":75},{"name":"Bob","age":25},{"name":"Colin","age":25},{"name":"Elizabeth","age":75},{"name":"Elizabeth","age":25}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
 }
 
 func TestMultiSort5(t *testing.T) {
@@ -1947,7 +1947,7 @@ func TestMultiSort5(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	// Null value for third Alice comes at first.
-	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":75},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":25,"salary":10000.000000},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
 }
 
 func TestMultiSort6Paginate(t *testing.T) {

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -2134,73 +2134,133 @@ func TestMultiSortWithNulls(t *testing.T) {
 		index  int32
 		offset int32
 		first  int32
+		desc   bool
 		result string
 	}{
-		{0, -1, -1, `{"data": {"me":[
-			{"pname":"nameC","pred1":"A"},
+		{0, -1, -1, true, `{"data": {"me":[
 			{"pname":"nameB","pred1":"A", "pred2":"J"},
 			{"pname":"nameA","pred1":"A", "pred2":"I"},
-			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameC","pred1":"A"},
 			{"pname":"nameE","pred1":"B", "pred2":"J"},
 			{"pname":"nameD","pred1":"B", "pred2":"I"},
-			{"pname":"nameJ","pred1":"C"},
+			{"pname":"nameF","pred1":"B"},
 			{"pname":"nameI","pred1":"C", "pred2":"K"},
 			{"pname":"nameH","pred1":"C", "pred2":"J"},
-			{"pname":"nameG","pred1":"C", "pred2":"I"}]}}`,
-		},
-		{1, -1, 2, `{"data": {"me":[
-			{"pname":"nameC","pred1":"A"},
-			{"pname":"nameB","pred1":"A", "pred2":"J"}]}}`,
-		},
-		{2, -1, 7, `{"data": {"me":[
-			{"pname":"nameC","pred1":"A"},
-			{"pname":"nameB","pred1":"A", "pred2":"J"},
-			{"pname":"nameA","pred1":"A", "pred2":"I"},
-			{"pname":"nameF","pred1":"B"},
-			{"pname":"nameE","pred1":"B", "pred2":"J"},
-			{"pname":"nameD","pred1":"B", "pred2":"I"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
 			{"pname":"nameJ","pred1":"C"}]}}`,
 		},
-		{3, 2, 7, `{"data": {"me":[
+		{1, -1, -1, false, `{"data": {"me":[
 			{"pname":"nameA","pred1":"A", "pred2":"I"},
-			{"pname":"nameF","pred1":"B"},
-			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameB","pred1":"A", "pred2":"J"},
+			{"pname":"nameC","pred1":"A"},
 			{"pname":"nameD","pred1":"B", "pred2":"I"},
-			{"pname":"nameJ","pred1":"C"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameH","pred1":"C", "pred2":"J"},
 			{"pname":"nameI","pred1":"C", "pred2":"K"},
-			{"pname":"nameH","pred1":"C", "pred2":"J"}]}}`,
+			{"pname":"nameJ","pred1":"C"}]}}`,
 		},
-		{4, 2, 100, `{"data": {"me":[
+		{2, -1, 2, true, `{"data": {"me":[
+			{"pname":"nameB","pred1":"A", "pred2":"J"},
+			{"pname":"nameA","pred1":"A", "pred2":"I"}]}}`,
+		},
+		{3, -1, 2, false, `{"data": {"me":[
 			{"pname":"nameA","pred1":"A", "pred2":"I"},
-			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameB","pred1":"A", "pred2":"J"}]}}`,
+		},
+		{4, -1, 7, true, `{"data": {"me":[
+			{"pname":"nameB","pred1":"A", "pred2":"J"},
+			{"pname":"nameA","pred1":"A", "pred2":"I"},
+			{"pname":"nameC","pred1":"A"},
 			{"pname":"nameE","pred1":"B", "pred2":"J"},
 			{"pname":"nameD","pred1":"B", "pred2":"I"},
-			{"pname":"nameJ","pred1":"C"},
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameI","pred1":"C", "pred2":"K"}]}}`,
+		},
+		{5, -1, 7, false, `{"data": {"me":[
+			{"pname":"nameA","pred1":"A", "pred2":"I"},
+			{"pname":"nameB","pred1":"A", "pred2":"J"},
+			{"pname":"nameC","pred1":"A"},
+			{"pname":"nameD","pred1":"B", "pred2":"I"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"}]}}`,
+		},
+		{6, 2, 7, true, `{"data": {"me":[
+			{"pname":"nameC","pred1":"A"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameD","pred1":"B", "pred2":"I"},
+			{"pname":"nameF","pred1":"B"},
 			{"pname":"nameI","pred1":"C", "pred2":"K"},
 			{"pname":"nameH","pred1":"C", "pred2":"J"},
 			{"pname":"nameG","pred1":"C", "pred2":"I"}]}}`,
 		},
-		{5, 5, 5, `{"data": {"me":[
+		{7, 2, 7, false, `{"data": {"me":[
+			{"pname":"nameC","pred1":"A"},
 			{"pname":"nameD","pred1":"B", "pred2":"I"},
-			{"pname":"nameJ","pred1":"C"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameH","pred1":"C", "pred2":"J"},
+			{"pname":"nameI","pred1":"C", "pred2":"K"}]}}`,
+		},
+		{8, 2, 100, true, `{"data": {"me":[
+			{"pname":"nameC","pred1":"A"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameD","pred1":"B", "pred2":"I"},
+			{"pname":"nameF","pred1":"B"},
 			{"pname":"nameI","pred1":"C", "pred2":"K"},
 			{"pname":"nameH","pred1":"C", "pred2":"J"},
-			{"pname":"nameG","pred1":"C", "pred2":"I"}]}}`,
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameJ","pred1":"C"}]}}`,
 		},
-		{0, 9, 5, `{"data": {"me":[
-			{"pname":"nameG","pred1":"C", "pred2":"I"}]}}`,
+		{9, 2, 100, false, `{"data": {"me":[
+			{"pname":"nameC","pred1":"A"},
+			{"pname":"nameD","pred1":"B", "pred2":"I"},
+			{"pname":"nameE","pred1":"B", "pred2":"J"},
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameH","pred1":"C", "pred2":"J"},
+			{"pname":"nameI","pred1":"C", "pred2":"K"},
+			{"pname":"nameJ","pred1":"C"}]}}`,
 		},
-		{0, 12, 5, `{"data": {"me":[]}}`},
+		{10, 5, 5, true, `{"data": {"me":[
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameI","pred1":"C", "pred2":"K"},
+			{"pname":"nameH","pred1":"C", "pred2":"J"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameJ","pred1":"C"}]}}`,
+		},
+		{11, 5, 5, false, `{"data": {"me":[
+			{"pname":"nameF","pred1":"B"},
+			{"pname":"nameG","pred1":"C", "pred2":"I"},
+			{"pname":"nameH","pred1":"C", "pred2":"J"},
+			{"pname":"nameI","pred1":"C", "pred2":"K"},
+			{"pname":"nameJ","pred1":"C"}]}}`,
+		},
+		{12, 9, 5, true, `{"data": {"me":[
+			{"pname":"nameJ","pred1":"C"}]}}`,
+		},
+		{13, 9, 5, false, `{"data": {"me":[
+			{"pname":"nameJ","pred1":"C"}]}}`,
+		},
+		{14, 12, 5, true, `{"data": {"me":[]}}`},
+		{15, 12, 5, false, `{"data": {"me":[]}}`},
 	}
-	makeQuery := func(offset, first int32, index bool) string {
+	makeQuery := func(offset, first int32, desc, index bool) string {
 		pred1 := "pred1"
 		pred2 := "pred2"
 		if index {
 			pred1 = "index-pred1"
 			pred2 = "index-pred2"
 		}
+		order := ",orderasc: "
+		if desc {
+			order = ",orderdesc: "
+		}
 		q := "me(func: uid(61, 62, 63, 64, 65, 66, 67, 68, 69, 70), orderasc: " + pred1 +
-			",orderdesc: " + pred2
+			order + pred2
 		if offset != -1 {
 			q += fmt.Sprintf(", offset: %d", offset)
 		}
@@ -2213,11 +2273,11 @@ func TestMultiSortWithNulls(t *testing.T) {
 
 	for _, tc := range tests {
 		// Case of sort with Index.
-		actual := makeQuery(tc.offset, tc.first, true)
+		actual := makeQuery(tc.offset, tc.first, tc.desc, true)
 		require.JSONEqf(t, tc.result, actual, "Failed on index-testcase: %d\n", tc.index)
 
 		// Case of sort without index
-		actual = makeQuery(tc.offset, tc.first, false)
+		actual = makeQuery(tc.offset, tc.first, tc.desc, false)
 		require.JSONEqf(t, tc.result, actual, "Failed on testcase: %d\n", tc.index)
 	}
 }

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -1933,7 +1933,7 @@ func TestMultiSort4(t *testing.T) {
 	}`
 	js := processQueryNoErr(t, query)
 	// Null value for third Alice comes at last.
-	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":75},{"name":"Bob","age":25},{"name":"Bob","age":75},{"name":"Colin","age":25},{"name":"Elizabeth","age":25},{"name":"Elizabeth","age":75}]}}`, js)
+	require.JSONEq(t, `{"data": {"me":[{"name":"Alice","age":25,"salary":10000.000000},{"name":"Alice","age":75,"salary":10002.000000},{"name":"Alice","age":75},{"name":"Bob","age":75},{"name":"Bob","age":25},{"name":"Colin","age":25},{"name":"Elizabeth","age":75},{"name":"Elizabeth","age":25}]}}`, js)
 }
 
 func TestMultiSort5(t *testing.T) {

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -600,15 +600,15 @@ func SortFacetsReturnNil(t *testing.T, c *dgo.Dgraph) {
 					"name":"Michael",
 					"friend":[
 						{
-							"name":"Charlie"
-						},
-						{
 							"name":"Alice",
 							"friend|since":"2014-01-02T00:00:00Z"
 						},
 						{
 							"name":"Sang Hyun",
 							"friend|since":"2012-01-02T00:00:00Z"
+						},
+						{
+							"name":"Charlie"
 						}
 					]
 				}

--- a/types/sort.go
+++ b/types/sort.go
@@ -60,6 +60,12 @@ func (s byValue) Less(i, j int) bool {
 	}
 	for vidx := range first {
 		// Null values are appended at the end of the sort result for both ascending and descending.
+		// If both first and second has nil values, then we assume first to be less than second,
+		// this is done in order to maintain the order by UID in case both the values are nil.
+		if first[vidx].Value == nil && second[vidx].Value == nil {
+			return true
+		}
+
 		if first[vidx].Value == nil {
 			return false
 		}

--- a/types/sort.go
+++ b/types/sort.go
@@ -60,10 +60,9 @@ func (s byValue) Less(i, j int) bool {
 	}
 	for vidx := range first {
 		// Null values are appended at the end of the sort result for both ascending and descending.
-		// If both first and second has nil values, then we assume first to be less than second,
-		// this is done in order to maintain the order by UID in case both the values are nil.
+		// If both first and second has nil values, then maintain the order by UID.
 		if first[vidx].Value == nil && second[vidx].Value == nil {
-			return true
+			return s.desc[vidx]
 		}
 
 		if first[vidx].Value == nil {

--- a/types/sort.go
+++ b/types/sort.go
@@ -59,14 +59,13 @@ func (s byValue) Less(i, j int) bool {
 		return false
 	}
 	for vidx := range first {
-		// Null value is considered greatest hence comes at first place while doing descending sort
-		// and at last place while doing ascending sort.
+		// Null values are appended at the end of the sort result for both ascending and descending.
 		if first[vidx].Value == nil {
-			return s.desc[vidx]
+			return false
 		}
 
 		if second[vidx].Value == nil {
-			return !s.desc[vidx]
+			return true
 		}
 
 		// We have to look at next value to decide.

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -336,6 +336,10 @@ BUCKETS:
 		remainingCount := int(ts.Count) - len(r.UidMatrix[i].Uids)
 		canAppend := x.Min(uint64(remainingCount), uint64(len(nullNodes)))
 		r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, nullNodes[:canAppend]...)
+
+		// The value list also need to contain null values for the appended uids.
+		nullVals := make([]types.Val, canAppend)
+		values[i] = append(values[i], nullVals...)
 	}
 
 	select {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -338,8 +338,10 @@ BUCKETS:
 		r.UidMatrix[i].Uids = append(r.UidMatrix[i].Uids, nullNodes[:canAppend]...)
 
 		// The value list also need to contain null values for the appended uids.
-		nullVals := make([]types.Val, canAppend)
-		values[i] = append(values[i], nullVals...)
+		if len(ts.Order) > 1 {
+			nullVals := make([]types.Val, canAppend)
+			values[i] = append(values[i], nullVals...)
+		}
 	}
 
 	select {


### PR DESCRIPTION
Multi-sort with some predicates with null values was broken ([Discuss post](https://discuss.dgraph.io/t/sorting-on-multiple-predicates-broken-on-20-11-1/12724)). This PR fixes it. 

Tests are also added for multi-sort with null values.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7432)
<!-- Reviewable:end -->
