### PR TITLE
fix(backup): Fix perf issues with full backups

### DIFF
--- a/worker/backup_processor.go
+++ b/worker/backup_processor.go
@@ -70,7 +70,7 @@ func NewBackupProcessor(db *badger.DB, req *pb.BackupRequest) *BackupProcessor {
 		Request: req,
 		threads: make([]*threadLocal, backupNumGo),
 	}
-	if db != nil {
+	if req.SinceTs > 0 && db != nil {
 		bp.txn = db.NewTransactionAt(req.ReadTs, false)
 	}
 	for i := range bp.threads {
@@ -98,6 +98,9 @@ type LoadResult struct {
 }
 
 func (pr *BackupProcessor) Close() {
+	if pr.txn == nil {
+		return
+	}
 	for _, th := range pr.threads {
 		th.itr.Close()
 	}
@@ -158,8 +161,13 @@ func (pr *BackupProcessor) WriteBackup(ctx context.Context) (*pb.BackupResponse,
 		tl := pr.threads[itr.ThreadId]
 		tl.alloc = itr.Alloc
 
-		bitr := tl.itr // Use the threadlocal iterator because "itr" has the sinceTs set.
-		bitr.Seek(key)
+		bitr := itr
+		// Use the threadlocal iterator because "itr" has the sinceTs set and
+		// it will not be able to read all the data.
+		if tl.itr != nil {
+			bitr = tl.itr
+			bitr.Seek(key)
+		}
 
 		kvList, dropOp, err := tl.toBackupList(key, bitr)
 		if err != nil {


### PR DESCRIPTION
The recent change https://github.com/dgraph-io/dgraph/pull/7392 improved
the incremental backups but degraded the performance of full backups.
This PR fixes that.

With this PR, we use the thread local iterator only for the incremental
backups. Using the thread local iterator for full backups causes a 10x
slowdown in performance.

Fixes - DGRAPH-3039

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7434)
<!-- Reviewable:end -->
