### PR TITLE
perf(backups): Reduce latency of list backups

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -205,7 +205,7 @@ func ListBackupManifests(l string, creds *x.MinioCredentials) (map[string]*Manif
 		g.Go(func() error {
 			var m Manifest
 			if err := h.ReadManifest(path, &m); err != nil {
-				return errors.Wrapf(err, "While reading %q", path)
+				return errors.Wrapf(err, "ReadManifest: path=%q", path)
 			}
 			m.Path = path
 			res.Lock()

--- a/worker/backup_handler_test.go
+++ b/worker/backup_handler_test.go
@@ -18,23 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetHandler(t *testing.T) {
-	tests := []struct {
-		in  string
-		out UriHandler
-	}{
-		{in: "file", out: &fileHandler{}},
-		{in: "minio", out: &s3Handler{}},
-		{in: "s3", out: &s3Handler{}},
-		{in: "", out: &fileHandler{}},
-		{in: "something", out: nil},
-	}
-	for _, tc := range tests {
-		actual := getHandler(tc.in, nil)
-		require.Equal(t, tc.out, actual)
-	}
-}
-
 func TestFilterManifestDefault(t *testing.T) {
 	manifests := []*Manifest{
 		{

--- a/worker/s3_handler.go
+++ b/worker/s3_handler.go
@@ -63,20 +63,24 @@ type s3Handler struct {
 	cerr                     chan error
 	creds                    *x.MinioCredentials
 	uri                      *url.URL
+	mc                       *x.MinioClient
 }
 
 // setup creates a new session, checks valid bucket at uri.Path, and configures a minio client.
 // setup also fills in values used by the handler in subsequent calls.
 // Returns a new S3 minio client, otherwise a nil client with an error.
-func (h *s3Handler) setup(uri *url.URL) (*x.MinioClient, error) {
-	mc, err := x.NewMinioClient(uri, h.creds)
+func NewS3Handler(uri *url.URL, creds *x.MinioCredentials) (*s3Handler, error) {
+	h := &s3Handler{
+		creds: creds,
+		uri:   uri,
+	}
+	mc, err := x.NewMinioClient(uri, creds)
 	if err != nil {
 		return nil, err
 	}
-
-	h.bucketName, h.objectPrefix, err = mc.ValidateBucket(uri)
-
-	return mc, err
+	h.mc = mc
+	h.bucketName, h.objectPrefix = mc.ParseBucketAndPrefix(uri.Path)
+	return h, nil
 }
 
 func (h *s3Handler) createObject(uri *url.URL, req *pb.BackupRequest, mc *x.MinioClient,
@@ -97,17 +101,12 @@ func (h *s3Handler) createObject(uri *url.URL, req *pb.BackupRequest, mc *x.Mini
 // GetLatestManifest reads the manifests at the given URL and returns the
 // latest manifest.
 func (h *s3Handler) GetLatestManifest(uri *url.URL) (*Manifest, error) {
-	mc, err := h.setup(uri)
-	if err != nil {
-		return nil, err
-	}
-
 	// Find the max Since value from the latest backup.
 	var lastManifest string
 	done := make(chan struct{})
 	defer close(done)
 	suffix := "/" + backupManifest
-	for object := range mc.ListObjects(h.bucketName, h.objectPrefix, true, done) {
+	for object := range h.mc.ListObjects(h.bucketName, h.objectPrefix, true, done) {
 		if strings.HasSuffix(object.Key, suffix) && object.Key > lastManifest {
 			lastManifest = object.Key
 		}
@@ -118,7 +117,7 @@ func (h *s3Handler) GetLatestManifest(uri *url.URL) (*Manifest, error) {
 		return &m, nil
 	}
 
-	if err := h.readManifest(mc, lastManifest, &m); err != nil {
+	if err := h.ReadManifest(lastManifest, &m); err != nil {
 		return nil, err
 	}
 	return &m, nil
@@ -133,13 +132,8 @@ func (h *s3Handler) GetLatestManifest(uri *url.URL) (*Manifest, error) {
 func (h *s3Handler) CreateBackupFile(uri *url.URL, req *pb.BackupRequest) error {
 	glog.V(2).Infof("S3Handler got uri: %+v. Host: %s. Path: %s\n", uri, uri.Host, uri.Path)
 
-	mc, err := h.setup(uri)
-	if err != nil {
-		return err
-	}
-
 	objectName := backupName(req.ReadTs, req.GroupId)
-	h.createObject(uri, req, mc, objectName)
+	h.createObject(uri, req, h.mc, objectName)
 	return nil
 }
 
@@ -147,39 +141,19 @@ func (h *s3Handler) CreateBackupFile(uri *url.URL, req *pb.BackupRequest) error 
 func (h *s3Handler) CreateManifest(uri *url.URL, req *pb.BackupRequest) error {
 	glog.V(2).Infof("S3Handler got uri: %+v. Host: %s. Path: %s\n", uri, uri.Host, uri.Path)
 
-	mc, err := h.setup(uri)
-	if err != nil {
-		return err
-	}
-
-	h.createObject(uri, req, mc, backupManifest)
+	h.createObject(uri, req, h.mc, backupManifest)
 	return nil
-}
-
-// readManifest reads a manifest file at path using the handler.
-// Returns nil on success, otherwise an error.
-func (h *s3Handler) readManifest(mc *x.MinioClient, object string, m *Manifest) error {
-	reader, err := mc.GetObject(h.bucketName, object, minio.GetObjectOptions{})
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-	return json.NewDecoder(reader).Decode(m)
 }
 
 func (h *s3Handler) GetManifests(uri *url.URL, backupId string,
 	backupNum uint64) ([]*Manifest, error) {
-	mc, err := h.setup(uri)
-	if err != nil {
-		return nil, err
-	}
 
 	var paths []string
 	doneCh := make(chan struct{})
 	defer close(doneCh)
 
 	suffix := "/" + backupManifest
-	for object := range mc.ListObjects(h.bucketName, h.objectPrefix, true, doneCh) {
+	for object := range h.mc.ListObjects(h.bucketName, h.objectPrefix, true, doneCh) {
 		if strings.HasSuffix(object.Key, suffix) {
 			paths = append(paths, object.Key)
 		}
@@ -194,7 +168,7 @@ func (h *s3Handler) GetManifests(uri *url.URL, backupId string,
 	var manifests []*Manifest
 	for _, path := range paths {
 		var m Manifest
-		if err := h.readManifest(mc, path, &m); err != nil {
+		if err := h.ReadManifest(path, &m); err != nil {
 			return nil, errors.Wrapf(err, "while reading %q", path)
 		}
 		m.Path = path
@@ -213,11 +187,6 @@ func (h *s3Handler) Load(uri *url.URL, backupId string, backupNum uint64, fn loa
 		return LoadResult{Err: errors.Wrapf(err, "while retrieving manifests")}
 	}
 
-	mc, err := h.setup(uri)
-	if err != nil {
-		return LoadResult{Err: err}
-	}
-
 	// since is returned with the max manifest Since value found.
 	var since uint64
 
@@ -233,7 +202,7 @@ func (h *s3Handler) Load(uri *url.URL, backupId string, backupNum uint64, fn loa
 		path := filepath.Dir(manifests[i].Path)
 		for gid := range manifest.Groups {
 			object := filepath.Join(path, backupName(manifest.Since, gid))
-			reader, err := mc.GetObject(h.bucketName, object, minio.GetObjectOptions{})
+			reader, err := h.mc.GetObject(h.bucketName, object, minio.GetObjectOptions{})
 			if err != nil {
 				return LoadResult{Err: errors.Wrapf(err, "Failed to get %q", object)}
 			}
@@ -281,10 +250,6 @@ func (h *s3Handler) Verify(uri *url.URL, req *pb.RestoreRequest, currentGroups [
 
 // ListManifests loads the manifests in the locations and returns them.
 func (h *s3Handler) ListManifests(uri *url.URL) ([]string, error) {
-	mc, err := h.setup(uri)
-	if err != nil {
-		return nil, err
-	}
 	h.uri = uri
 
 	var manifests []string
@@ -292,7 +257,7 @@ func (h *s3Handler) ListManifests(uri *url.URL) ([]string, error) {
 	defer close(doneCh)
 
 	suffix := "/" + backupManifest
-	for object := range mc.ListObjects(h.bucketName, h.objectPrefix, true, doneCh) {
+	for object := range h.mc.ListObjects(h.bucketName, h.objectPrefix, true, doneCh) {
 		if strings.HasSuffix(object.Key, suffix) {
 			manifests = append(manifests, object.Key)
 		}
@@ -305,12 +270,12 @@ func (h *s3Handler) ListManifests(uri *url.URL) ([]string, error) {
 }
 
 func (h *s3Handler) ReadManifest(path string, m *Manifest) error {
-	mc, err := h.setup(h.uri)
+	reader, err := h.mc.GetObject(h.bucketName, path, minio.GetObjectOptions{})
 	if err != nil {
 		return err
 	}
-
-	return h.readManifest(mc, path, m)
+	defer reader.Close()
+	return json.NewDecoder(reader).Decode(m)
 }
 
 // upload will block until it's done or an error occurs.


### PR DESCRIPTION
The list backups function was reading manifest files sequentially and
this is expensive. This PR improves the latency by parallelizing the
list backup calls.

For 10 backups stored in a single s3 bucket, list backups takes 31 seconds on master
```
dgraph lsbackup -l "s3:///amanbansal-test-bucket"  0.90s user 0.20s system 3% cpu 31.356 total
```
On this PR, it takes ~4.5 seconds
```
dgraph lsbackup -l "s3:///amanbansal-test-bucket"  0.74s user 0.08s system 18% cpu 4.566 total
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7435)
<!-- Reviewable:end -->
