### PR TITLE
dgraph audit commad fix help output

### DIFF
--- a/ee/audit/run_ee.go
+++ b/ee/audit/run_ee.go
@@ -31,9 +31,11 @@ var CmdAudit x.SubCommand
 
 func init() {
 	CmdAudit.Cmd = &cobra.Command{
-		Use:   "audit",
-		Short: "Dgraph audit tool",
+		Use:         "audit",
+		Short:       "Dgraph audit tool",
+		Annotations: map[string]string{"group": "security"},
 	}
+	CmdAudit.Cmd.SetHelpTemplate(x.NonRootTemplate)
 
 	subcommands := initSubcommands()
 	for _, sc := range subcommands {


### PR DESCRIPTION
Currently the audit command is not shown when calling the help command (`dgraph -h`). Also we calling the help output for the audit command, the output is messed up:
```
dgraph audit -h 

Usage:
  dgraph audit [command] 

Generic:  

Available Commands:

Dgraph Core:  

Data Loading:  

Dgraph Security:  

Dgraph Debug:  

Dgraph Tools:  

Flags:
  -h, --help   help for audit


Use "dgraph audit [command] --help" for more information about a command.
```
This PR adds the audit command to the Dgraph Security section in the help output also it also fixes the help output when calling the help command for audit
```
dgraph -h
...
Dgraph Security:  
  acl           Run the Dgraph Enterprise Edition ACL tool  
  audit         Dgraph audit tool  
  cert          Dgraph TLS certificate management           
...
```
and
```
dgraph audit -h

 Dgraph audit tool 
Usage:
  dgraph audit [command] 

Available Commands: 
  decrypt     Run Dgraph Audit tool to decrypt audit files

Flags:
  -h, --help   help for audit
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7437)
<!-- Reviewable:end -->
