### PR TITLE
feat(cmd/debuginfo) add new metrics to be collected

### DIFF
--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -43,6 +43,8 @@ var metricTypes = []string{
 	"jemalloc",
 	"state",
 	"health",
+	"debug/vars",
+	"debug/prometheus_metrics",
 }
 
 func saveProfiles(addr, pathPrefix string, duration time.Duration, profiles []string) {
@@ -82,8 +84,7 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metrics []stri
 	for _, metricType := range metrics {
 		source := fmt.Sprintf("%s/%s", u.String(),
 			metricType)
-		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, metricType)
-
+		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, strings.ReplaceAll(metricType, "/", "_"))
 		if err := saveDebug(source, savePath, duration); err != nil {
 			glog.Errorf("error while saving metric from %s: %s", source, err)
 			continue

--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -42,8 +42,8 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []
 	for _, metricType := range metricTypes {
 		source := fmt.Sprintf("%s%s", u.String(),
 			metricMap[metricType])
-		savePath := fmt.Sprintf("%s%s.gz", pathPrefix)
-		if err := saveDebug(source, savePath, duration, metricTypes); err != nil {
+		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, metricType)
+		if err := saveDebug(source, savePath, duration); err != nil {
 			glog.Errorf("error while saving metric from %s: %s", source, err)
 			continue
 		}
@@ -54,14 +54,13 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []
 
 // saveDebug writes the debug specified in the argument fetching it from the host
 // provided in the configuration
-func saveDebug(sourceURL, filePath string, duration time.Duration, metricTypes []string) error {
+func saveDebug(sourceURL, filePath string, duration time.Duration) error {
 	var err error
 	var resp io.ReadCloser
-	for _, metricType := range metricTypes {
-		glog.Infof("fetching %s over HTTP from %s", metricType, sourceURL)
-		if duration > 0 {
-			glog.Info(fmt.Sprintf("please wait... (%v)", duration))
-		}
+
+	glog.Infof("fetching information over HTTP from %s", sourceURL)
+	if duration > 0 {
+		glog.Info(fmt.Sprintf("please wait... (%v)", duration))
 	}
 
 	timeout := duration + duration/2 + 2*time.Second

--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -29,25 +29,7 @@ import (
 	"github.com/golang/glog"
 )
 
-var pprofProfileTypes = []string{
-	"goroutine",
-	"heap",
-	"threadcreate",
-	"block",
-	"mutex",
-	"profile",
-	"trace",
-}
-
-var metricTypes = []string{
-	"jemalloc",
-	"state",
-	"health",
-	"debug/vars",
-	"debug/prometheus_metrics",
-}
-
-func saveProfiles(addr, pathPrefix string, duration time.Duration, profiles []string) {
+func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []string) {
 	u, err := url.Parse(addr)
 	if err != nil || (u.Host == "" && u.Scheme != "" && u.Scheme != "file") {
 		u, err = url.Parse("http://" + addr)
@@ -57,34 +39,10 @@ func saveProfiles(addr, pathPrefix string, duration time.Duration, profiles []st
 		return
 	}
 
-	for _, profileType := range profiles {
-		source := fmt.Sprintf("%s/debug/pprof/%s?duration=%d", u.String(),
-			profileType, int(duration.Seconds()))
-		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, profileType)
-
-		if err := saveDebug(source, savePath, duration); err != nil {
-			glog.Errorf("error while saving pprof profile from %s: %s", source, err)
-			continue
-		}
-
-		glog.Infof("saving %s profile in %s", profileType, savePath)
-	}
-}
-
-func saveMetrics(addr, pathPrefix string, duration time.Duration, metrics []string) {
-	u, err := url.Parse(addr)
-	if err != nil || (u.Host == "" && u.Scheme != "" && u.Scheme != "file") {
-		u, err = url.Parse("http://" + addr)
-	}
-	if err != nil || u.Host == "" {
-		glog.Errorf("error while parsing address %s: %s", addr, err)
-		return
-	}
-
-	for _, metricType := range metrics {
-		source := fmt.Sprintf("%s/%s", u.String(),
-			metricType)
-		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, strings.ReplaceAll(metricType, "/", "_"))
+	for _, metricType := range metricTypes {
+		source := fmt.Sprintf("%s%s", u.String(),
+			metricMap[metricType])
+		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, metricType)
 		if err := saveDebug(source, savePath, duration); err != nil {
 			glog.Errorf("error while saving metric from %s: %s", source, err)
 			continue

--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -42,8 +42,8 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []
 	for _, metricType := range metricTypes {
 		source := fmt.Sprintf("%s%s", u.String(),
 			metricMap[metricType])
-		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, metricType)
-		if err := saveDebug(source, savePath, duration); err != nil {
+		savePath := fmt.Sprintf("%s%s.gz", pathPrefix)
+		if err := saveDebug(source, savePath, duration, metricTypes); err != nil {
 			glog.Errorf("error while saving metric from %s: %s", source, err)
 			continue
 		}
@@ -54,13 +54,14 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []
 
 // saveDebug writes the debug specified in the argument fetching it from the host
 // provided in the configuration
-func saveDebug(sourceURL, filePath string, duration time.Duration) error {
+func saveDebug(sourceURL, filePath string, duration time.Duration, metricTypes []string) error {
 	var err error
 	var resp io.ReadCloser
-
-	glog.Infof("fetching information over HTTP from %s", sourceURL)
-	if duration > 0 {
-		glog.Info(fmt.Sprintf("please wait... (%v)", duration))
+	for _, metricType := range metricTypes {
+		glog.Infof("fetching %s over HTTP from %s", metricType, sourceURL)
+		if duration > 0 {
+			glog.Info(fmt.Sprintf("please wait... (%v)", duration))
+		}
 	}
 
 	timeout := duration + duration/2 + 2*time.Second

--- a/dgraph/cmd/debuginfo/debugging.go
+++ b/dgraph/cmd/debuginfo/debugging.go
@@ -56,11 +56,11 @@ func saveMetrics(addr, pathPrefix string, duration time.Duration, metricTypes []
 			cronPprofMap[pprofs], duration)
 		savePath := fmt.Sprintf("%s%s.gz", pathPrefix, pprofs)
 		if err := saveDebug(source, savePath, duration); err != nil {
-			glog.Errorf("error while saving metric from %s: %s", source, err)
+			glog.Errorf("error while saving pprof from %s: %s", source, err)
 			continue
 		}
 
-		glog.Infof("saving %s metric in %s", pprofs, savePath)
+		glog.Infof("saving %s pprof in %s", pprofs, savePath)
 	}
 
 }

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -44,18 +44,18 @@ var (
 )
 
 var metricMap = map[string]string{
-	"jemalloc":           "/jemalloc",
-	"state":              "/state",
-	"health":             "/health",
-	"vars":               "/debug/vars",
-	"prometheus_metrics": "/debug/prometheus_metrics",
-	"heap":               "/debug/pprof/heap",
-	"cpu_profile":        "/debug/pprof/profile",
-	"trace":              "/debug/pprof/trace",
-	"goroutine":          "/debug/pprof/goroutine",
-	"threadcreate":       "/debug/pprof/threadcreate",
-	"block":              "/debug/pprof/block",
-	"mutex":              "/debug/pprof/mutex",
+	"jemalloc":     "/jemalloc",
+	"state":        "/state",
+	"health":       "/health",
+	"vars":         "/debug/vars",
+	"metrics":      "/metrics",
+	"heap":         "/debug/pprof/heap",
+	"cpu_profile":  "/debug/pprof/profile",
+	"trace":        "/debug/pprof/trace",
+	"goroutine":    "/debug/pprof/goroutine",
+	"threadcreate": "/debug/pprof/threadcreate",
+	"block":        "/debug/pprof/block",
+	"mutex":        "/debug/pprof/mutex",
 }
 
 var metricList = []string{
@@ -63,7 +63,7 @@ var metricList = []string{
 	"state",
 	"health",
 	"vars",
-	"prometheus_metrics",
+	"metrics",
 	"heap",
 	"cpu_profile",
 	"trace",

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -44,18 +44,18 @@ var (
 )
 
 var metricMap = map[string]string{
-	"jemalloc":     "/jemalloc",
-	"state":        "/state",
-	"health":       "/health",
-	"vars":         "/debug/vars",
-	"metric":       "/metric",
-	"heap":         "/debug/pprof/heap",
-	"cpu_profile":  "/debug/pprof/profile",
-	"trace":        "/debug/pprof/trace",
-	"goroutine":    "/debug/pprof/goroutine",
-	"threadcreate": "/debug/pprof/threadcreate",
-	"block":        "/debug/pprof/block",
-	"mutex":        "/debug/pprof/mutex",
+	"jemalloc":           "/jemalloc",
+	"state":              "/state",
+	"health":             "/health",
+	"vars":               "/debug/vars",
+	"prometheus_metrics": "/debug/prometheus_metrics",
+	"heap":               "/debug/pprof/heap",
+	"cpu_profile":        "/debug/pprof/profile",
+	"trace":              "/debug/pprof/trace",
+	"goroutine":          "/debug/pprof/goroutine",
+	"threadcreate":       "/debug/pprof/threadcreate",
+	"block":              "/debug/pprof/block",
+	"mutex":              "/debug/pprof/mutex",
 }
 
 var metricList = []string{
@@ -63,7 +63,7 @@ var metricList = []string{
 	"state",
 	"health",
 	"vars",
-	"metric",
+	"prometheus_metrics",
 	"heap",
 	"cpu_profile",
 	"trace",

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -36,6 +36,7 @@ type debugInfoCmdOpts struct {
 	duration  uint32
 
 	pprofProfiles []string
+	metricTypes   []string
 }
 
 var (
@@ -70,6 +71,8 @@ func init() {
 		"Duration for time-based profile collection.")
 	flags.StringSliceVarP(&debugInfoCmd.pprofProfiles, "profiles", "p", pprofProfileTypes,
 		"List of pprof profiles to dump in the report.")
+	flags.StringSliceVarP(&debugInfoCmd.metricTypes, "metrics", "m", metricTypes,
+		"List of metrics profiles to dump in the report.")
 }
 
 func collectDebugInfo() (err error) {
@@ -100,11 +103,13 @@ func collectPProfProfiles() {
 	if debugInfoCmd.alphaAddr != "" {
 		filePrefix := filepath.Join(debugInfoCmd.directory, "alpha_")
 		saveProfiles(debugInfoCmd.alphaAddr, filePrefix, duration, debugInfoCmd.pprofProfiles)
+		saveMetrics(debugInfoCmd.alphaAddr, filePrefix, duration, debugInfoCmd.metricTypes)
 	}
 
 	if debugInfoCmd.zeroAddr != "" {
 		filePrefix := filepath.Join(debugInfoCmd.directory, "zero_")
 		saveProfiles(debugInfoCmd.zeroAddr, filePrefix, duration, debugInfoCmd.pprofProfiles)
+		saveMetrics(debugInfoCmd.zeroAddr, filePrefix, duration, debugInfoCmd.metricTypes)
 	}
 }
 

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -57,18 +57,19 @@ var metricMap = map[string]string{
 }
 
 var metricList = []string{
-	"jemalloc",
+	"heap",
+	"cpu",
 	"state",
 	"health",
-	"vars",
+	"jemalloc",
+	"trace",
 	"metrics",
-	"heap",
+	"vars",
+	"trace",
 	"goroutine",
-	"threadcreate",
 	"block",
 	"mutex",
-	"cpu",
-	"trace",
+	"threadcreate",
 }
 
 func init() {


### PR DESCRIPTION
- This PR adds 5 new metrics (/jemalloc, /state, /health, /debug/vars, /metrics) to be collected when running  the `debuginfo` 
- the flag `-p` has been changed to `-m` to reflect the change. This new flag will let you pick up one or multiple metrics/pprof to be collected:
```
-m, --metrics strings    List of metrics & profile to dump in the report. (default [jemalloc,state,health,vars,metrics,heap,cpu_profile,trace,goroutine,threadcreate,block,mutex])
```
- default value of `-s` flag is now 30sec since it requires 30s to collect a cpu profile
- when saving the metric/profile - it will log the metric/profile name and the path where it's saving to.
- added new flag for time based profiles that are cpu and trace profiles:
```
-c, --cron_pprof strings   time-based pprof (default [cpu_profile,trace])
```

output of running the `debuginfo` command:
```
 dgraph debuginfo -s 30
I0305 21:01:44.730085   10587 run.go:126] using directory /tmp/dgraph-debuginfo041885197 for debug info dump.
I0305 21:01:44.730251   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/jemalloc
I0305 21:01:44.730261   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.731077   10587 debugging.go:51] saving jemalloc metric in /tmp/dgraph-debuginfo041885197/alpha_jemalloc.gz
I0305 21:01:44.731086   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/state
I0305 21:01:44.731092   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.731720   10587 debugging.go:51] saving state metric in /tmp/dgraph-debuginfo041885197/alpha_state.gz
I0305 21:01:44.731731   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/health
I0305 21:01:44.731736   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.732048   10587 debugging.go:51] saving health metric in /tmp/dgraph-debuginfo041885197/alpha_health.gz
I0305 21:01:44.732058   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/vars
I0305 21:01:44.732065   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.732557   10587 debugging.go:51] saving vars metric in /tmp/dgraph-debuginfo041885197/alpha_vars.gz
I0305 21:01:44.732568   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/metrics
I0305 21:01:44.732573   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.734904   10587 debugging.go:51] saving metrics metric in /tmp/dgraph-debuginfo041885197/alpha_metrics.gz
I0305 21:01:44.734912   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/heap
I0305 21:01:44.734917   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.738036   10587 debugging.go:51] saving heap metric in /tmp/dgraph-debuginfo041885197/alpha_heap.gz
I0305 21:01:44.738048   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/goroutine?debug=2
I0305 21:01:44.738057   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.739136   10587 debugging.go:51] saving goroutine metric in /tmp/dgraph-debuginfo041885197/alpha_goroutine.gz
I0305 21:01:44.739145   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/threadcreate
I0305 21:01:44.739151   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.740182   10587 debugging.go:51] saving threadcreate metric in /tmp/dgraph-debuginfo041885197/alpha_threadcreate.gz
I0305 21:01:44.740192   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/block
I0305 21:01:44.740198   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.741154   10587 debugging.go:51] saving block metric in /tmp/dgraph-debuginfo041885197/alpha_block.gz
I0305 21:01:44.741163   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/mutex
I0305 21:01:44.741169   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.742330   10587 debugging.go:51] saving mutex metric in /tmp/dgraph-debuginfo041885197/alpha_mutex.gz
I0305 21:01:44.742341   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/profile?seconds=30s
I0305 21:01:44.742348   10587 debugging.go:76] please wait... (30s)
I0305 21:02:14.812492   10587 debugging.go:63] saving cpu_profile metric in /tmp/dgraph-debuginfo041885197/alpha_cpu_profile.gz
I0305 21:02:14.812570   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/trace?seconds=30s
I0305 21:02:14.812596   10587 debugging.go:76] please wait... (30s)
I0305 21:02:15.816449   10587 debugging.go:63] saving trace metric in /tmp/dgraph-debuginfo041885197/alpha_trace.gz
I0305 21:02:15.842375   10587 run.go:159] Debuginfo archive successful: dgraph-debuginfo041885197.tar.gz

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7439)
<!-- Reviewable:end -->
