### PR TITLE
fix(GraphQL): fix the race conditions in GraphQL (GRAPHQL-1009)

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1048,7 +1048,7 @@ func getAuthMode(ctx context.Context) AuthMode {
 // QueryGraphQL handles only GraphQL queries, neither mutations nor DQL.
 func (s *Server) QueryGraphQL(ctx context.Context, req *api.Request,
 	field gqlSchema.Field) (*api.Response, error) {
-	ctx = x.AttachJWTNamespace(ctx)
+	// no need to attach namespace here, it is already done by GraphQL layer
 	return s.doQuery(ctx, &Request{req: req, gqlField: field, doAuth: getAuthMode(ctx)})
 }
 

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -304,7 +304,7 @@ func RetryProbeGraphQL(t *testing.T, authority string, header http.Header) *Prob
 // If it can't make the assertion with enough retries, it fails the test.
 func AssertSchemaUpdateCounterIncrement(t *testing.T, authority string, oldCounter uint64, header http.Header) {
 	var newCounter uint64
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		if newCounter = RetryProbeGraphQL(t, authority,
 			header).SchemaUpdateCounter; newCounter == oldCounter+1 {
 			return

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -367,6 +367,7 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 
 	// Pass in GraphQL @auth information
 	ctx = r.schema.Meta().AuthMeta().AttachAuthorizationJwt(ctx, gqlReq.Header)
+	ctx = x.AttachJWTNamespace(ctx)
 	op, err := r.schema.Operation(gqlReq)
 	if err != nil {
 		return schema.ErrorResponse(err)


### PR DESCRIPTION
This PR fixes the following race conditions with GraphQL:
  * JSON encoding of `@custom` GraphQL fields: There was one write-write race and two write-read races.
  * attaching namespace to context: one write-write race.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7443)
<!-- Reviewable:end -->
