### PR TITLE
feat(acl): allow setting a password at the time of creation of namespace

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -911,7 +911,7 @@ func run() {
 		WithEncryptionKey(opt.key).
 		WithBlockCacheSize(1 << 30).
 		WithIndexCacheSize(1 << 30).
-		WithNamespaceOffset(1) // We don't want to see the banned data.
+		WithNamespaceOffset(x.NamespaceOffset) // We don't want to see the banned data.
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -138,7 +138,7 @@ func uidToVal(itr *badger.Iterator, prefix string) map[uint64]int {
 		lastKey = append(lastKey[:0], item.Key()...)
 		pk, err := x.Parse(item.Key())
 		x.Check(err)
-		if !pk.IsData() || !strings.HasPrefix(pk.Attr, prefix) {
+		if !pk.IsData() || !strings.HasPrefix(x.ParseAttr(pk.Attr), prefix) {
 			continue
 		}
 		if pk.IsSchema() {
@@ -280,7 +280,8 @@ func showAllPostingsAt(db *badger.DB, readTs uint64) {
 		}
 
 		var acc *account
-		if strings.HasPrefix(pk.Attr, "key_") || strings.HasPrefix(pk.Attr, "amount_") {
+		attr := x.ParseAttr(pk.Attr)
+		if strings.HasPrefix(attr, "key_") || strings.HasPrefix(attr, "amount_") {
 			var has bool
 			acc, has = keys[pk.Uid]
 			if !has {
@@ -302,9 +303,9 @@ func showAllPostingsAt(db *badger.DB, readTs uint64) {
 		}
 		if num > 0 && acc != nil {
 			switch {
-			case strings.HasPrefix(pk.Attr, "key_"):
+			case strings.HasPrefix(attr, "key_"):
 				acc.Key = num
-			case strings.HasPrefix(pk.Attr, "amount_"):
+			case strings.HasPrefix(attr, "amount_"):
 				acc.Amt = num
 			}
 		}
@@ -909,7 +910,8 @@ func run() {
 		WithReadOnly(opt.readOnly).
 		WithEncryptionKey(opt.key).
 		WithBlockCacheSize(1 << 30).
-		WithIndexCacheSize(1 << 30)
+		WithIndexCacheSize(1 << 30).
+		WithNamespaceOffset(1) // We don't want to see the banned data.
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")
 	fmt.Printf("Opening DB: %s\n", bopts.Dir)

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -419,7 +419,7 @@ func ResetAcl(closer *z.Closer) {
 		ctx, cancel := context.WithTimeout(closer.Ctx(), time.Minute)
 		defer cancel()
 		ctx = x.AttachNamespace(ctx, x.GalaxyNamespace)
-		if err := upsertGroot(ctx); err != nil {
+		if err := upsertGroot(ctx, "password"); err != nil {
 			glog.Infof("Unable to upsert the groot account. Error: %v", err)
 			time.Sleep(100 * time.Millisecond)
 			continue
@@ -495,7 +495,7 @@ func upsertGuardian(ctx context.Context) error {
 }
 
 // upsertGroot must be called after setting the namespace in the context.
-func upsertGroot(ctx context.Context) error {
+func upsertGroot(ctx context.Context, passwd string) error {
 	// groot is the default user of guardians group.
 	query := fmt.Sprintf(`
 			{
@@ -505,7 +505,7 @@ func upsertGroot(ctx context.Context) error {
 				guid as var(func: eq(dgraph.xid, "%s"))
 			}
 		`, x.GrootId, x.GuardiansId)
-	userNQuads := acl.CreateUserNQuads(x.GrootId, "password")
+	userNQuads := acl.CreateUserNQuads(x.GrootId, passwd)
 	userNQuads = append(userNQuads, &api.NQuad{
 		Subject:   "_:newuser",
 		Predicate: "dgraph.user.group",

--- a/edgraph/multi_tenancy.go
+++ b/edgraph/multi_tenancy.go
@@ -26,7 +26,7 @@ type ResetPasswordInput struct {
 	Namespace uint64
 }
 
-func (s *Server) CreateNamespace(ctx context.Context) (uint64, error) {
+func (s *Server) CreateNamespace(ctx context.Context, passwd string) (uint64, error) {
 	return 0, nil
 }
 

--- a/ee/acl/run_ee.go
+++ b/ee/acl/run_ee.go
@@ -27,8 +27,6 @@ var (
 	CmdAcl x.SubCommand
 )
 
-const gName = "guardian_name"
-const gPassword = "guardian_password"
 const defaultGroupList = "dgraph-unused-group"
 
 func init() {
@@ -40,8 +38,11 @@ func init() {
 	CmdAcl.Cmd.SetHelpTemplate(x.NonRootTemplate)
 	flag := CmdAcl.Cmd.PersistentFlags()
 	flag.StringP("alpha", "a", "127.0.0.1:9080", "Dgraph Alpha gRPC server address")
-	flag.StringP(gName, "w", x.GrootId, "Guardian username performing this operation")
-	flag.StringP(gPassword, "x", "", "Guardian password to authorize this operation")
+	flag.String("guardian-creds", "", `Login credentials for the guardian
+	user defines the username to login.
+	password defines the password of the user.
+	namespace defines the namespace to log into.
+	Sample flag could look like --guardian-creds user=username;password=mypass;namespace=2`)
 
 	// TLS configuration
 	x.RegisterClientTLSFlags(flag)

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
@@ -162,10 +163,11 @@ func UnmarshalGroups(input []byte, groupKey string) (group []Group, err error) {
 // options, and then login using groot id and password
 func getClientWithAdminCtx(conf *viper.Viper) (*dgo.Dgraph, x.CloseFunc, error) {
 	dg, closeClient := x.GetDgraphClient(conf, false)
+	creds := z.NewSuperFlag(conf.GetString("guardian-creds"))
 	err := x.GetPassAndLogin(dg, &x.CredOpt{
-		UserID:   conf.GetString(gName),
-		Password: conf.GetString(gPassword),
-		// TODO(Ahsan): Which namespace do we need to pass here?
+		UserID:    creds.GetString("user"),
+		Password:  creds.GetString("password"),
+		Namespace: creds.GetUint64("namespace"),
 	})
 	if err != nil {
 		return nil, nil, err

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -366,6 +366,7 @@ var (
 		"updateGQLSchema": commonAdminMutationMWs,
 		"addNamespace":    guardianOfTheGalaxyMutationMWs,
 		"deleteNamespace": guardianOfTheGalaxyMutationMWs,
+		"resetPassword":   guardianOfTheGalaxyMutationMWs,
 		// for queries and mutations related to User/Group, dgraph handles Guardian auth,
 		// so no need to apply GuardianAuth Middleware
 		"addUser":     {resolve.IpWhitelistingMW4Mutation, resolve.LoggingMWMutation},

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -415,7 +415,7 @@ const adminTypes = `
 	}
 
 	input AddNamespaceInput {
-		password: String!
+		password: String
 	}
 
 	input DeleteNamespaceInput {
@@ -493,7 +493,7 @@ const adminMutations = `
 	"""
 	Add a new namespace.
 	"""
-	addNamespace(input: AddNamespaceInput!): NamespacePayload
+	addNamespace(input: AddNamespaceInput): NamespacePayload
 
 	"""
 	Delete a namespace.

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -414,7 +414,11 @@ const adminTypes = `
 		numUids: Int
 	}
 
-	input NamespaceInput {
+	input AddNamespaceInput {
+		password: String!
+	}
+
+	input DeleteNamespaceInput {
 		namespaceId: Int!
 	}
 
@@ -489,12 +493,12 @@ const adminMutations = `
 	"""
 	Add a new namespace.
 	"""
-	addNamespace: NamespacePayload
+	addNamespace(input: AddNamespaceInput!): NamespacePayload
 
 	"""
 	Delete a namespace.
 	"""
-	deleteNamespace(input: NamespaceInput!): NamespacePayload
+	deleteNamespace(input: DeleteNamespaceInput!): NamespacePayload
 
 	"""
 	Reset password can only be used by the Guardians of the galaxy to reset password of

--- a/graphql/admin/namespace.go
+++ b/graphql/admin/namespace.go
@@ -39,6 +39,10 @@ func resolveAddNamespace(ctx context.Context, m schema.Mutation) (*resolve.Resol
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
+	if req.Password == "" {
+		// Use the default password, if the user does not specify.
+		req.Password = "password"
+	}
 	var ns uint64
 	if ns, err = (&edgraph.Server{}).CreateNamespace(ctx, req.Password); err != nil {
 		return resolve.EmptyResult(m, err), false

--- a/graphql/admin/namespace.go
+++ b/graphql/admin/namespace.go
@@ -26,14 +26,21 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/schema"
 )
 
-type namespaceInput struct {
+type addNamespaceInput struct {
+	Password string
+}
+
+type deleteNamespaceInput struct {
 	NamespaceId int
 }
 
 func resolveAddNamespace(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {
+	req, err := getAddNamespaceInput(m)
+	if err != nil {
+		return resolve.EmptyResult(m, err), false
+	}
 	var ns uint64
-	var err error
-	if ns, err = (&edgraph.Server{}).CreateNamespace(ctx); err != nil {
+	if ns, err = (&edgraph.Server{}).CreateNamespace(ctx, req.Password); err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
 	return resolve.DataResult(
@@ -47,7 +54,7 @@ func resolveAddNamespace(ctx context.Context, m schema.Mutation) (*resolve.Resol
 }
 
 func resolveDeleteNamespace(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {
-	req, err := getNamespaceInput(m)
+	req, err := getDeleteNamespaceInput(m)
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
@@ -64,14 +71,26 @@ func resolveDeleteNamespace(ctx context.Context, m schema.Mutation) (*resolve.Re
 	), true
 }
 
-func getNamespaceInput(m schema.Mutation) (*namespaceInput, error) {
+func getAddNamespaceInput(m schema.Mutation) (*addNamespaceInput, error) {
 	inputArg := m.ArgValue(schema.InputArgName)
 	inputByts, err := json.Marshal(inputArg)
 	if err != nil {
 		return nil, schema.GQLWrapf(err, "couldn't get input argument")
 	}
 
-	var input namespaceInput
+	var input addNamespaceInput
+	err = json.Unmarshal(inputByts, &input)
+	return &input, schema.GQLWrapf(err, "couldn't get input argument")
+}
+
+func getDeleteNamespaceInput(m schema.Mutation) (*deleteNamespaceInput, error) {
+	inputArg := m.ArgValue(schema.InputArgName)
+	inputByts, err := json.Marshal(inputArg)
+	if err != nil {
+		return nil, schema.GQLWrapf(err, "couldn't get input argument")
+	}
+
+	var input deleteNamespaceInput
 	err = json.Unmarshal(inputByts, &input)
 	return &input, schema.GQLWrapf(err, "couldn't get input argument")
 }

--- a/x/keys.go
+++ b/x/keys.go
@@ -54,6 +54,8 @@ const (
 	GalaxyNamespace = uint64(0)
 	// IgnoreBytes is the byte range which will be ignored while prefix match in subscription.
 	IgnoreBytes = "1-8"
+	// NamespaceOffset is the offset in badger key from which the next 8 bytes contain namespace.
+	NamespaceOffset = 1
 )
 
 func NamespaceToBytes(ns uint64) []byte {


### PR DESCRIPTION
- Fix dgraph debug tool
- Fix `dgraph acl` tool. TODO: Test it.
- Creation of a namespace requires a password to be set for groot.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7446)
<!-- Reviewable:end -->
