### PR TITLE
chore(enterprise): making cdc and audit to work with multi tenancy + audit flag change with days and size

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -200,9 +200,11 @@ they form a Raft group and provide synchronous replication.
 		`Various audit options.
 	dir=/path/to/audits to define the path where to store the audit logs.
 	compress=true/false to enabled the compression of old audit logs (default behaviour is false).
-	encrypt_file=enc/key/file enables the audit log encryption with the key path provided with the
+	encrypt-file=enc/key/file enables the audit log encryption with the key path provided with the
 	flag.
-	Sample flag could look like --audit dir=aa;encrypt_file=/filepath;compress=true`)
+	days=10 is the number of days audit logs will be preserved (default 10).
+	size=100 is the size of each file in mb after which it will be rolled over (default 100).
+	Sample flag would be --audit dir=aa;encrypt-file=/filepath;compress=true;days=10;size=100`)
 
 	flag.String("cdc", "",
 		`Various change data capture options.

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -57,7 +57,7 @@ type options struct {
 	w                 string
 	rebalanceInterval time.Duration
 	tlsClientConfig   *tls.Config
-	audit             *audit.AuditConf
+	audit             *x.LoggerConf
 }
 
 var opts options
@@ -106,9 +106,11 @@ instances to achieve high-availability.
 		`Various audit options.
 	dir=/path/to/audits to define the path where to store the audit logs.
 	compress=true/false to enabled the compression of old audit logs (default behaviour is false).
-	encrypt_file=enc/key/file enables the audit log encryption with the key path provided with the
+	encrypt-file=enc/key/file enables the audit log encryption with the key path provided with the
 	flag.
-	Sample flag could look like --audit dir=aa;encrypt_file=/filepath;compress=true`)
+	days=10 is the number of days audit logs will be preserved (default 10).
+	size=100 is the size of each file in mb after which it will be rolled over (default 100).
+	Sample flag would be --audit dir=aa;encrypt-file=/filepath;compress=true;days=10;size=100`)
 
 	// TLS configurations
 	x.RegisterServerTLSFlags(flag)

--- a/ee/audit/audit.go
+++ b/ee/audit/audit.go
@@ -18,19 +18,21 @@
 
 package audit
 
+import "github.com/dgraph-io/dgraph/x"
+
 type AuditConf struct {
 	Dir string
 }
 
-func GetAuditConf(conf string) *AuditConf {
+func GetAuditConf(conf string) *x.LoggerConf {
 	return nil
 }
 
-func InitAuditorIfNecessary(conf *AuditConf, eeEnabled func() bool) error {
+func InitAuditorIfNecessary(conf *x.LoggerConf, eeEnabled func() bool) error {
 	return nil
 }
 
-func InitAuditor(conf *AuditConf) error {
+func InitAuditor(conf *x.LoggerConf) error {
 	return nil
 }
 

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -14,6 +14,7 @@ package audit
 
 import (
 	"io/ioutil"
+	"math"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -46,6 +47,7 @@ type AuditEvent struct {
 const (
 	UnauthorisedUser = "UnauthorisedUser"
 	UnknownUser      = "UnknownUser"
+	UnknownNamespace = math.MaxUint64
 	PoorManAuth      = "PoorManAuth"
 	Grpc             = "Grpc"
 	Http             = "Http"

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -14,7 +14,6 @@ package audit
 
 import (
 	"io/ioutil"
-	"math"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -46,7 +45,6 @@ type AuditEvent struct {
 
 const (
 	UnauthorisedUser = "UnauthorisedUser"
-	UnknownNamespace = math.MaxUint64
 	UnknownUser      = "UnknownUser"
 	PoorManAuth      = "PoorManAuth"
 	Grpc             = "Grpc"

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -39,6 +39,7 @@ type AuditConf struct {
 
 type AuditEvent struct {
 	User        string
+	Namespace   uint64
 	ServerHost  string
 	ClientHost  string
 	Endpoint    string
@@ -50,6 +51,7 @@ type AuditEvent struct {
 
 const (
 	UnauthorisedUser = "UnauthorisedUser"
+	UnknownNamespace = -1
 	UnknownUser      = "UnknownUser"
 	PoorManAuth      = "PoorManAuth"
 	Grpc             = "Grpc"
@@ -179,6 +181,7 @@ func Close() {
 func (a *auditLogger) Audit(event *AuditEvent) {
 	a.log.AuditI(event.Endpoint,
 		"user", event.User,
+		"namespace", event.Namespace,
 		"server", event.ServerHost,
 		"client", event.ClientHost,
 		"req_type", event.ReqType,

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -14,6 +14,7 @@ package audit
 
 import (
 	"io/ioutil"
+	"math"
 	"path/filepath"
 	"sync/atomic"
 	"time"
@@ -25,17 +26,11 @@ import (
 )
 
 const (
-	defaultAuditConf     = "dir=; compress=false; encrypt-file="
+	defaultAuditConf     = "dir=; compress=false; encrypt-file=; days=10; size=100"
 	defaultAuditFilename = "dgraph_audit.log"
 )
 
 var auditEnabled uint32
-
-type AuditConf struct {
-	Compress     bool
-	Dir          string
-	EncryptBytes []byte
-}
 
 type AuditEvent struct {
 	User        string
@@ -51,7 +46,7 @@ type AuditEvent struct {
 
 const (
 	UnauthorisedUser = "UnauthorisedUser"
-	UnknownNamespace = -1
+	UnknownNamespace = math.MaxUint64
 	UnknownUser      = "UnknownUser"
 	PoorManAuth      = "PoorManAuth"
 	Grpc             = "Grpc"
@@ -66,7 +61,7 @@ type auditLogger struct {
 	closer *z.Closer
 }
 
-func GetAuditConf(conf string) *AuditConf {
+func GetAuditConf(conf string) *x.LoggerConf {
 	if conf == "" {
 		return nil
 	}
@@ -75,10 +70,12 @@ func GetAuditConf(conf string) *AuditConf {
 	x.AssertTruef(dir != "", "dir flag is not provided for the audit logs")
 	encBytes, err := readAuditEncKey(auditFlag)
 	x.Check(err)
-	return &AuditConf{
-		Compress:     auditFlag.GetBool("compress"),
-		Dir:          dir,
-		EncryptBytes: encBytes,
+	return &x.LoggerConf{
+		Compress:      auditFlag.GetBool("compress"),
+		Dir:           dir,
+		EncryptionKey: encBytes,
+		Days:          auditFlag.GetInt64("days"),
+		Size:          auditFlag.GetInt64("size"),
 	}
 }
 
@@ -101,7 +98,7 @@ func readAuditEncKey(conf *z.SuperFlag) ([]byte, error) {
 // InitAuditorIfNecessary accepts conf and enterprise edition check function.
 // This method keep tracks whether cluster is part of enterprise edition or not.
 // It pools eeEnabled function every five minutes to check if the license is still valid or not.
-func InitAuditorIfNecessary(conf *AuditConf, eeEnabled func() bool) error {
+func InitAuditorIfNecessary(conf *x.LoggerConf, eeEnabled func() bool) error {
 	if conf == nil {
 		return nil
 	}
@@ -119,10 +116,9 @@ func InitAuditorIfNecessary(conf *AuditConf, eeEnabled func() bool) error {
 // InitAuditor initializes the auditor.
 // This method doesnt keep track of whether cluster is part of enterprise edition or not.
 // Client has to keep track of that.
-func InitAuditor(conf *AuditConf) error {
+func InitAuditor(conf *x.LoggerConf) error {
 	var err error
-	if auditor.log, err = x.InitLogger(conf.Dir, defaultAuditFilename, conf.EncryptBytes,
-		conf.Compress); err != nil {
+	if auditor.log, err = x.InitLogger(conf, defaultAuditFilename); err != nil {
 		return err
 	}
 	atomic.StoreUint32(&auditEnabled, 1)
@@ -133,7 +129,7 @@ func InitAuditor(conf *AuditConf) error {
 // trackIfEEValid tracks enterprise license of the cluster.
 // Right now alpha doesn't know about the enterprise/licence.
 // That's why we needed to track if the current node is part of enterprise edition cluster
-func trackIfEEValid(conf *AuditConf, eeEnabledFunc func() bool) {
+func trackIfEEValid(conf *x.LoggerConf, eeEnabledFunc func() bool) {
 	defer auditor.closer.Done()
 	var err error
 	for {
@@ -147,8 +143,7 @@ func trackIfEEValid(conf *AuditConf, eeEnabledFunc func() bool) {
 			}
 
 			if atomic.LoadUint32(&auditEnabled) != 1 {
-				if auditor.log, err = x.InitLogger(conf.Dir, defaultAuditFilename,
-					conf.EncryptBytes, conf.Compress); err != nil {
+				if auditor.log, err = x.InitLogger(conf, defaultAuditFilename); err != nil {
 					continue
 				}
 				atomic.StoreUint32(&auditEnabled, 1)

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -34,7 +34,6 @@ import (
 const (
 	defaultCDCConfig  = "file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; client_key="
 	defaultEventTopic = "dgraph-cdc"
-	defaultEventKey   = "dgraph-cdc-event"
 )
 
 // CDC struct is being used to send out change data capture events. There are two ways to do this:
@@ -176,7 +175,6 @@ func (cdc *CDC) processCDCEvents() {
 			e.Meta.CommitTs = commitTs
 			b, err := json.Marshal(e)
 			x.Check(err)
-			// todo(aman bansal): use namespace for key.
 			batch[i] = SinkMessage{
 				Meta: SinkMeta{
 					Topic: defaultEventTopic,
@@ -364,6 +362,8 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 	}
 
 	// If drop operation
+	// todo (aman): right now drop operations are still cluster wide.
+	// Fix these once we have namespace specific operations.
 	if mutation.DropOp != pb.Mutations_NONE {
 		return []CDCEvent{
 			{

--- a/worker/config.go
+++ b/worker/config.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	bo "github.com/dgraph-io/badger/v3/options"
-	"github.com/dgraph-io/dgraph/ee/audit"
 	"github.com/dgraph-io/dgraph/x"
 )
 
@@ -71,7 +70,7 @@ type Options struct {
 	// CacheMb is the total memory allocated between all the caches.
 	CacheMb int64
 
-	Audit *audit.AuditConf
+	Audit *x.LoggerConf
 
 	// Define different ChangeDataCapture configurations
 	ChangeDataConf string

--- a/worker/sink_handler.go
+++ b/worker/sink_handler.go
@@ -19,6 +19,7 @@ package worker
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -158,8 +159,8 @@ type fileSink struct {
 
 func (f *fileSink) Send(messages []SinkMessage) error {
 	for _, m := range messages {
-		_, err := f.fileWriter.Write([]byte(fmt.Sprintf("{ \"key\": \"%s\", \"value\": %s}\n",
-			string(m.Key), string(m.Value))))
+		_, err := f.fileWriter.Write([]byte(fmt.Sprintf("{ \"key\": \"%d\", \"value\": %s}\n",
+			binary.BigEndian.Uint64(m.Key), string(m.Value))))
 		if err != nil {
 			return errors.Wrap(err, "unable to add message in the file sink")
 		}

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -47,7 +47,7 @@ var _ io.WriteCloser = (*LogWriter)(nil)
 type LogWriter struct {
 	FilePath      string
 	MaxSize       int64
-	MaxAge        int // number of days
+	MaxAge        int64 // number of days
 	Compress      bool
 	EncryptionKey []byte
 

--- a/x/logger.go
+++ b/x/logger.go
@@ -24,24 +24,32 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-func InitLogger(dir string, filename string, key []byte, compress bool) (*Logger, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+type LoggerConf struct {
+	Compress      bool
+	Dir           string
+	EncryptionKey SensitiveByteSlice
+	Size          int64
+	Days          int64
+}
+
+func InitLogger(conf *LoggerConf, filename string) (*Logger, error) {
+	if err := os.MkdirAll(conf.Dir, 0700); err != nil {
 		return nil, err
 	}
-	if key != nil {
+	if conf.EncryptionKey != nil {
 		filename = filename + ".enc"
 	}
 
-	path, err := filepath.Abs(filepath.Join(dir, filename))
+	path, err := filepath.Abs(filepath.Join(conf.Dir, filename))
 	if err != nil {
 		return nil, err
 	}
 	w := &LogWriter{
 		FilePath:      path,
-		MaxSize:       100,
-		MaxAge:        10,
-		EncryptionKey: key,
-		Compress:      compress,
+		MaxSize:       conf.Size,
+		MaxAge:        conf.Days,
+		EncryptionKey: conf.EncryptionKey,
+		Compress:      conf.Compress,
 	}
 	if w, err = w.Init(); err != nil {
 		return nil, err


### PR DESCRIPTION
This PR add the support of namespaces in CDC and audits. For audit logs, namespaces will be logged along with all requests. For cdc namespaces will be used as key that will define partitions for the kafka.
This pr also change audit flag to include days and size

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7447)
<!-- Reviewable:end -->
