### PR TITLE
Feat(GraphQL): Make XID node referencing invariant of order in which XIDs are referenced in Mutation Rewriting

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -3328,3 +3328,85 @@
     message: |-
       failed to rewrite mutation payload because value for field `favouriteMember` in type `Home` must have exactly one child, found 0 children
       failed to rewrite mutation payload because value for field `members` in type `Home` index `0` must have exactly one child, found 2 children
+
+-
+  name: "Add mutation for type Person1 referencing same node as closeFriends and friends"
+  explanation: "The mutation adds same node as friends and closeFriends. It should
+    work irrespective of the order in which the node is referenced."
+  gqlmutation: |
+    mutation($input: [AddPerson1Input!]!) {
+      addPerson1(input: $input) {
+        person1 {
+          id
+          name
+          friends {
+            id
+            name
+          }
+          closeFriends {
+            id
+            name
+          }
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "id": "1",
+          "name": "First Person",
+          "friends": [{
+            "id": "2",
+            "name": "Second Person"
+           }],
+          "closeFriends": [{
+            "id": "2"
+           }]
+        }
+      ]
+    }
+  dgquery: |-
+    query {
+      Person11(func: eq(Person1.id, "1")) @filter(type(Person1)) {
+        uid
+      }
+      Person12(func: eq(Person1.id, "2")) @filter(type(Person1)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "Person1.closeFriends": [
+            {
+              "Person1.closeFriends": [
+                {
+                  "uid": "_:Person11"
+                }
+              ],
+              "Person1.name": "Second Person",
+              "Person1.id": "2",
+              "dgraph.type": [
+                "Person1"
+              ],
+              "uid": "_:Person12"
+            }
+          ],
+          "Person1.friends": [
+            {
+              "uid": "_:Person12",
+              "Person1.friends": [
+                {
+                  "uid": "_:Person11"
+                }
+              ]
+            }
+          ],
+          "Person1.name": "First Person",
+          "Person1.id": "1",
+          "dgraph.type": [
+            "Person1"
+          ],
+          "uid": "_:Person11"
+        }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1610,7 +1610,7 @@ func existenceQueries(
 				}
 			} else {
 
-				// if not encountered till now, add it to the map
+				// if not encountered till now, add it to the map,
 				xidMetadata.variableObjMap[variable] = obj
 
 				// save if this node was seen at top level.

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -205,7 +205,12 @@ func (xidMetadata *xidMetadata) isDuplicateXid(atTopLevel bool, xidVar string,
 		}
 	}
 
-	if len(newXidObj) > 1 && !reflect.DeepEqual(xidMetadata.variableObjMap[xidVar], newXidObj) {
+	// We return an error if both occurrences of xid contain more than one values
+	// and are not equal.
+	// XID should be defined with all its values at one of the places and references with its
+	// XID from other places.
+	if len(newXidObj) > 1 && len(xidMetadata.variableObjMap[xidVar]) > 1 &&
+		!reflect.DeepEqual(xidMetadata.variableObjMap[xidVar], newXidObj) {
 		return true
 	}
 
@@ -1315,6 +1320,10 @@ func rewriteObject(
 						exclude = invField.Name()
 					}
 				}
+				// We replace obj with xidMetadata.variableObjMap[variable] in this case.
+				// This is done to ensure that the first time we encounter an XID node, we use
+				// its definition and later times, we just use its reference.
+				obj = xidMetadata.variableObjMap[variable]
 				if err := typ.EnsureNonNulls(obj, exclude); err != nil {
 					// This object does not contain XID. This is an error.
 					retErrors = append(retErrors, err)
@@ -1571,15 +1580,29 @@ func existenceQueries(
 			variable := varGen.Next(typ, xid.Name(), xidString, false)
 
 			if xidMetadata.variableObjMap[variable] != nil {
-				// if we already encountered an object with same xid earlier, and this object is
-				// considered a duplicate of the existing object, then return error.
+				// There are two cases:
+				// Case 1: We are at top level:
+				// 	       We return an error if the same node is referenced twice at top level.
+				// Case 2: We are not at top level:
+				//         We don't return an error if one of the occurrences of XID is a reference
+				//         and other is definition.
+				//         We return an error if both occurrences contain values other than XID and are
+				//         not equal.
 				if xidMetadata.isDuplicateXid(atTopLevel, variable, obj, srcField) {
 					err := errors.Errorf("duplicate XID found: %s", xidString)
 					retErrors = append(retErrors, err)
 					return nil, retErrors
 				}
-				// In the other case it is not duplicate. In this case we don't move ahead and
-				// stop processing.
+				// In the other case it is not duplicate, we update variableObjMap in case the new
+				// occurrence of XID is its description and the old occurrence was a reference.
+				// Example:
+				// obj = { "id": "1", "name": "name1"}
+				// xidMetadata.variableObjMap[variable] = { "id": "1" }
+				// In this case, as obj is the correct definition of the object, we update variableObjMap
+				oldObj := xidMetadata.variableObjMap[variable]
+				if len(oldObj) == 1 && len(obj) > 1 {
+					xidMetadata.variableObjMap[variable] = obj
+				}
 				return ret, retErrors
 			}
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1601,23 +1601,27 @@ func existenceQueries(
 				// In this case, as obj is the correct definition of the object, we update variableObjMap
 				oldObj := xidMetadata.variableObjMap[variable]
 				if len(oldObj) == 1 && len(obj) > 1 {
+					// Continue execution to perform dfs in this case. There may be more nodes
+					// in the subtree of this node.
 					xidMetadata.variableObjMap[variable] = obj
+				} else {
+					// This is just a node reference. No need to proceed further.
+					return ret, retErrors
 				}
-				return ret, retErrors
-			}
+			} else {
 
-			// if not encountered till now, add it to the map
-			xidMetadata.variableObjMap[variable] = obj
+				// if not encountered till now, add it to the map
+				xidMetadata.variableObjMap[variable] = obj
 
-			// save if this node was seen at top level.
-			if !xidMetadata.seenAtTopLevel[variable] {
+				// save if this node was seen at top level.
 				xidMetadata.seenAtTopLevel[variable] = atTopLevel
+
+				// Add the corresponding existence query. As this is the first time we have
+				// encountered this variable, the query is added only once per variable.
+				query := checkXIDExistsQuery(variable, xidString, xid.Name(), typ)
+				ret = append(ret, query)
+				// Don't return just over here as there maybe more nodes in the children tree.
 			}
-
-			query := checkXIDExistsQuery(variable, xidString, xid.Name(), typ)
-
-			ret = append(ret, query)
-			// Don't return just over here as there maybe more nodes in the children tree.
 		}
 	}
 

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -270,7 +270,9 @@ type Post1 {
 
 type Person1 {
   id: String! @id
-  name: String
+  friends: [Person1] @hasInverse(field: friends)
+  closeFriends: [Person1] @hasInverse(field: closeFriends)
+  name: String!
 }
 
 type Comment1 {


### PR DESCRIPTION
Currently, in `rewriteObject` function, the fields inside given Add / Update Mutations are sorted before iterating on them and recursively calling `rewriteObject` function. This behaviour ensures that the fields are considered in  the same order in rewriteObject and `existenceQueries` function.

The drawback this as is follows,
1. If a there is a node which is created and referenced in the same mutation, depending on the order in which the nodes (creation and reference) get visited, an error may be thrown.

This issue has been present even before the refactoring. This PR fixes this.

Testing:
Added unit test in .yaml
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7448)
<!-- Reviewable:end -->
