### PR TITLE
fix(GraphQL): fix custom DQL (GRAPHQL-1020)

### DIFF
--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -2569,7 +2569,6 @@ func TestRestCustomLogicInDeepNestedField(t *testing.T) {
 }
 
 func TestCustomDQL(t *testing.T) {
-	t.Skipf("enable after fixing @custom(dql: ...)")
 	common.SafelyDropAll(t)
 
 	schema := `

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -236,7 +236,7 @@ func (rf *resolverFactory) WithConventionResolvers(
 	for _, q := range s.Queries(schema.DQLQuery) {
 		rf.WithQueryResolver(q, func(q schema.Query) QueryResolver {
 			// DQL queries don't need any QueryRewriter
-			return NewQueryResolver(nil, fns.Ex)
+			return NewCustomDQLQueryResolver(fns.Ex)
 		})
 	}
 


### PR DESCRIPTION
This PR makes `@custom(dql: ...)` work again after the GraphQL response JSON generation changes went in and broke it in #7371.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7449)
<!-- Reviewable:end -->
