### PR TITLE
[release/v20.11] fix(export-backup): fix memory leak in backup export (#7452)

### DIFF
--- a/worker/file_handler.go
+++ b/worker/file_handler.go
@@ -366,7 +366,6 @@ func (h *fileHandler) ExportBackup(backupDir, exportDir, format string,
 				ch <- errors.Wrapf(err, "cannot open DB at %s", dir)
 				return
 			}
-			defer db.Close()
 
 			req := &pb.ExportRequest{
 				GroupId:     group,
@@ -377,6 +376,9 @@ func (h *fileHandler) ExportBackup(backupDir, exportDir, format string,
 			}
 
 			_, err = exportInternal(context.Background(), req, db, true)
+			// It is important to close the db before sending err to ch. Else, we will see a memory
+			// leak.
+			db.Close()
 			ch <- errors.Wrapf(err, "cannot export data inside DB at %s", dir)
 		}(gid)
 	}


### PR DESCRIPTION
There was a memory leak because the program exits before DB close.

(cherry picked from commit 2eb7bc8772db7a384289ee85fe28e52cf0ea3404)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7453)
<!-- Reviewable:end -->
