### PR TITLE
fix(dgraph): Make Read Replica enterprise only feature

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -579,18 +579,18 @@ func setupServer(closer *z.Closer) {
 	baseMux.Handle("/ui/keywords", http.HandlerFunc(keywordHandler))
 
 	// Initialize the servers.
-	admin.ServerCloser.AddRunning(3)
-	go serveGRPC(grpcListener, tlsCfg, admin.ServerCloser)
-	go x.StartListenHttpAndHttps(httpListener, tlsCfg, admin.ServerCloser)
+	x.ServerCloser.AddRunning(3)
+	go serveGRPC(grpcListener, tlsCfg, x.ServerCloser)
+	go x.StartListenHttpAndHttps(httpListener, tlsCfg, x.ServerCloser)
 
 	if Alpha.Conf.GetBool("telemetry") {
 		go edgraph.PeriodicallyPostTelemetry()
 	}
 
 	go func() {
-		defer admin.ServerCloser.Done()
+		defer x.ServerCloser.Done()
 
-		<-admin.ServerCloser.HasBeenClosed()
+		<-x.ServerCloser.HasBeenClosed()
 		// TODO - Verify why do we do this and does it have to be done for all namespaces.
 		e = globalEpoch[x.GalaxyNamespace]
 		atomic.StoreUint64(e, math.MaxUint64)
@@ -608,7 +608,7 @@ func setupServer(closer *z.Closer) {
 	glog.Infoln("HTTP server started.  Listening on port", httpPort())
 
 	atomic.AddUint32(&initDone, 1)
-	admin.ServerCloser.Wait()
+	x.ServerCloser.Wait()
 }
 
 func run() {
@@ -793,7 +793,7 @@ func run() {
 	go func() {
 		var numShutDownSig int
 		for range sdCh {
-			closer := admin.ServerCloser
+			closer := x.ServerCloser
 			select {
 			case <-closer.HasBeenClosed():
 			default:

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -72,7 +72,7 @@ func (n *node) updateEnterpriseState(closer *z.Closer) {
 
 	intervalsInDay := int64(24*time.Hour) / int64(interval)
 	var counter int64
-	crashLeaner := func() {
+	crashLearner := func() {
 		if n.RaftContext.IsLearner {
 			glog.Errorf("Enterprise License missing or expired. " +
 				"Read replicas need an Enterprise License.")
@@ -85,7 +85,7 @@ func (n *node) updateEnterpriseState(closer *z.Closer) {
 			counter++
 			license := n.server.license()
 			if !license.GetEnabled() {
-				crashLeaner()
+				crashLearner()
 				continue
 			}
 
@@ -106,7 +106,7 @@ func (n *node) updateEnterpriseState(closer *z.Closer) {
 				glog.Warningf("Your enterprise license has expired and enterprise features are " +
 					"disabled. To continue using enterprise features, apply a valid license. To receive " +
 					"a new license, contact us at https://dgraph.io/contact.")
-				crashLeaner()
+				crashLearner()
 			}
 		case <-closer.HasBeenClosed():
 			return

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -75,7 +75,8 @@ func (n *node) updateEnterpriseState(closer *z.Closer) {
 	crashLearner := func() {
 		if n.RaftContext.IsLearner {
 			glog.Errorf("Enterprise License missing or expired. " +
-				"Read replicas need an Enterprise License.")
+				"Learner nodes need an Enterprise License.")
+			// Signal the zero node to stop.
 			n.server.closer.Signal()
 		}
 	}
@@ -104,8 +105,8 @@ func (n *node) updateEnterpriseState(closer *z.Closer) {
 				audit.Close()
 
 				glog.Warningf("Your enterprise license has expired and enterprise features are " +
-					"disabled. To continue using enterprise features, apply a valid license. To receive " +
-					"a new license, contact us at https://dgraph.io/contact.")
+					"disabled. To continue using enterprise features, apply a valid license. " +
+					"To receive a new license, contact us at https://dgraph.io/contact.")
 				crashLearner()
 			}
 		case <-closer.HasBeenClosed():

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -443,7 +443,7 @@ func (s *Server) Connect(ctx context.Context,
 	}
 
 	if m.Learner && !ms.License.GetEnabled() {
-		// Update the "ShouldCrash" function in zero.go if you change the error message here.
+		// Update the "ShouldCrash" function in x/x.go if you change the error message here.
 		return nil, errors.New("Missing or expired Enterpise License. Cannot add Learner Node.")
 	}
 

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -444,7 +444,8 @@ func (s *Server) Connect(ctx context.Context,
 
 	if m.Learner && !ms.License.GetEnabled() {
 		// Update the "ShouldCrash" function in x/x.go if you change the error message here.
-		return nil, errors.New("Missing or expired Enterpise License. Cannot add Learner Node.")
+		return nil, errors.New("ENTERPRISE_ONLY_LEARNER - Missing or expired Enterpise License. " +
+			"Cannot add Learner Node.")
 	}
 
 	if m.ClusterInfoOnly {

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -441,6 +441,12 @@ func (s *Server) Connect(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+
+	if m.Learner && !ms.License.GetEnabled() {
+		// Update the "ShouldCrash" function in zero.go if you change the error message here.
+		return nil, errors.New("Missing or expired Enterpise License. Cannot add Learner Node.")
+	}
+
 	if m.ClusterInfoOnly {
 		// This request only wants to access the membership state, and nothing else. Most likely
 		// from our clients.

--- a/graphql/admin/shutdown.go
+++ b/graphql/admin/shutdown.go
@@ -21,20 +21,14 @@ import (
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
-)
-
-var (
-	// ServerCloser is used to signal and wait for other goroutines to return gracefully after user
-	// requests shutdown.
-	ServerCloser = z.NewCloser(0)
 )
 
 func resolveShutdown(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {
 	glog.Info("Got shutdown request through GraphQL admin API")
 
-	ServerCloser.Signal()
+	x.ServerCloser.Signal()
 
 	return resolve.DataResult(
 		m,

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -312,6 +312,14 @@ func (g *groupi) applyState(myId uint64, state *pb.MembershipState) {
 	if g.state != nil && g.state.Counter > state.Counter {
 		return
 	}
+
+	invalid := state.License != nil && !state.License.Enabled
+	if g.Node != nil && g.Node.RaftContext.IsLearner && invalid {
+		glog.Errorf("License Expired. Cannot run read replicas.")
+		x.ServerCloser.Signal()
+		return
+	}
+
 	oldState := g.state
 	g.state = state
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -315,7 +315,7 @@ func (g *groupi) applyState(myId uint64, state *pb.MembershipState) {
 
 	invalid := state.License != nil && !state.License.Enabled
 	if g.Node != nil && g.Node.RaftContext.IsLearner && invalid {
-		glog.Errorf("License Expired. Cannot run read replicas.")
+		glog.Errorf("ENTERPRISE_ONLY_LEARNER: License Expired. Cannot run learner nodes.")
 		x.ServerCloser.Signal()
 		return
 	}

--- a/x/server.go
+++ b/x/server.go
@@ -15,6 +15,12 @@ import (
 	"github.com/soheilhy/cmux"
 )
 
+var (
+	// ServerCloser is used to signal and wait for other goroutines to return gracefully after user
+	// requests shutdown.
+	ServerCloser = z.NewCloser(0)
+)
+
 func StartListenHttpAndHttps(l net.Listener, tlsCfg *tls.Config, closer *z.Closer) {
 	defer closer.Done()
 	m := cmux.New(l)

--- a/x/x.go
+++ b/x/x.go
@@ -181,7 +181,8 @@ func ShouldCrash(err error) bool {
 	return strings.Contains(errStr, "REUSE_RAFTID") ||
 		strings.Contains(errStr, "REUSE_ADDR") ||
 		strings.Contains(errStr, "NO_ADDR") ||
-		strings.Contains(errStr, "ENTERPRISE_LIMIT_REACHED")
+		strings.Contains(errStr, "ENTERPRISE_LIMIT_REACHED") ||
+		strings.Contains(errStr, "Cannot add Learner Node.")
 }
 
 // WhiteSpace Replacer removes spaces and tabs from a string.

--- a/x/x.go
+++ b/x/x.go
@@ -182,7 +182,7 @@ func ShouldCrash(err error) bool {
 		strings.Contains(errStr, "REUSE_ADDR") ||
 		strings.Contains(errStr, "NO_ADDR") ||
 		strings.Contains(errStr, "ENTERPRISE_LIMIT_REACHED") ||
-		strings.Contains(errStr, "Cannot add Learner Node.")
+		strings.Contains(errStr, "ENTERPRISE_ONLY_LEARNER")
 }
 
 // WhiteSpace Replacer removes spaces and tabs from a string.


### PR DESCRIPTION
A read replica will not be able to connect to zero until zero has a
valid license. If the license expires when the replica is running, the
replica will crash eventually.

Fixes DGRAPH-3000
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7454)
<!-- Reviewable:end -->
