### PR TITLE
fix(Mutation): Deeply-nested uid facets

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -564,14 +564,22 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			buf.PushPredHint(pred, pb.Metadata_SINGLE)
 		case []interface{}:
 			buf.PushPredHint(pred, pb.Metadata_LIST)
-			// TODO(Ashish): We need to call this only in case of scalarlist, for other lists
-			// this can be avoided.
-			facetsMapSlice, err := parseMapFacets(mf, prefix)
-			if err != nil {
-				return mr, err
-			}
 
+			// NOTE: facetsMapSlice should be empty unless this is a scalar list
+			var facetsMapSlice []map[int]*api.Facet
 			for idx, item := range v {
+				if idx == 0 {
+					switch item.(type) {
+					case string, float64, json.Number, int64:
+						var err error
+						facetsMapSlice, err = parseMapFacets(mf, prefix)
+						if err != nil {
+							return mr, err
+						}
+					default:
+					}
+				}
+
 				nq := api.NQuad{
 					Subject:   mr.uid,
 					Predicate: pred,

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -925,15 +925,15 @@ func TestNquadsFromJsonFacets5(t *testing.T) {
 	// AND Emily has uid facets which should go on the edge between Dave and Emily
 	json := `[
 		{
-			"name":"Alice",
-			"friend":[
+			"name": "Alice",
+			"friend": [
 				{
-					"name":"Dave",
-					"friend|close":"true",
-					"friend":[
+					"name": "Dave",
+					"friend|close": "true",
+					"friend": [
 						{
-							"name":"Emily",
-							"friend|close":true
+							"name": "Emily",
+							"friend|close": true
 						}
 					]
 				}
@@ -943,13 +943,13 @@ func TestNquadsFromJsonFacets5(t *testing.T) {
 
 	nq, err := Parse([]byte(json), SetNquads)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(nq))
-	checkCount(t, nq, "friend", 2)
+	require.Equal(t, 5, len(nq))
+	checkCount(t, nq, "friend", 1)
 
 	fastNQ, err := FastParse([]byte(json), SetNquads)
 	require.NoError(t, err)
-	require.Equal(t, 3, len(fastNQ))
-	checkCount(t, fastNQ, "friend", 2)
+	require.Equal(t, 5, len(fastNQ))
+	checkCount(t, fastNQ, "friend", 1)
 }
 
 func TestNquadsFromJsonError1(t *testing.T) {

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -929,7 +929,7 @@ func TestNquadsFromJsonFacets5(t *testing.T) {
 			"friend": [
 				{
 					"name": "Dave",
-					"friend|close": "true",
+					"friend|close": true,
 					"friend": [
 						{
 							"name": "Emily",

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -713,38 +713,6 @@ func TestNquadsFromJsonFacets2(t *testing.T) {
 	checkCount(t, fastNQ, "friend", 1)
 }
 
-func TestNquadsFromJsonFacets20000000(t *testing.T) {
-	// Dave has uid facets which should go on the edge between Alice and Dave,
-	// AND Emily has uid facets which should go on the edge between Dave and Emily
-	json := `[
-		{
-			"name":"Alice",
-			"friend":[
-				{
-					"name":"Dave",
-					"friend|close":"true",
-					"friend":[
-						{
-							"name":"Emily",
-							"friend|close":true
-						}
-					]
-				}
-			]
-		}
-	]`
-
-	nq, err := Parse([]byte(json), SetNquads)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(nq))
-	checkCount(t, nq, "friend", 2)
-
-	fastNQ, err := FastParse([]byte(json), SetNquads)
-	require.NoError(t, err)
-	require.Equal(t, 3, len(fastNQ))
-	checkCount(t, fastNQ, "friend", 2)
-}
-
 // Test valid facets json.
 func TestNquadsFromJsonFacets3(t *testing.T) {
 	json := `
@@ -950,6 +918,38 @@ func TestNquadsFromJsonFacets4(t *testing.T) {
 			require.NoError(t, err, "TestNquadsFromJsonFacets4-%s", input.Name)
 		}
 	}
+}
+
+func TestNquadsFromJsonFacets5(t *testing.T) {
+	// Dave has uid facets which should go on the edge between Alice and Dave,
+	// AND Emily has uid facets which should go on the edge between Dave and Emily
+	json := `[
+		{
+			"name":"Alice",
+			"friend":[
+				{
+					"name":"Dave",
+					"friend|close":"true",
+					"friend":[
+						{
+							"name":"Emily",
+							"friend|close":true
+						}
+					]
+				}
+			]
+		}
+	]`
+
+	nq, err := Parse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(nq))
+	checkCount(t, nq, "friend", 2)
+
+	fastNQ, err := FastParse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(fastNQ))
+	checkCount(t, fastNQ, "friend", 2)
 }
 
 func TestNquadsFromJsonError1(t *testing.T) {

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -713,6 +713,38 @@ func TestNquadsFromJsonFacets2(t *testing.T) {
 	checkCount(t, fastNQ, "friend", 1)
 }
 
+func TestNquadsFromJsonFacets20000000(t *testing.T) {
+	// Dave has uid facets which should go on the edge between Alice and Dave,
+	// AND Emily has uid facets which should go on the edge between Dave and Emily
+	json := `[
+		{
+			"name":"Alice",
+			"friend":[
+				{
+					"name":"Dave",
+					"friend|close":"true",
+					"friend":[
+						{
+							"name":"Emily",
+							"friend|close":true
+						}
+					]
+				}
+			]
+		}
+	]`
+
+	nq, err := Parse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(nq))
+	checkCount(t, nq, "friend", 2)
+
+	fastNQ, err := FastParse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(fastNQ))
+	checkCount(t, fastNQ, "friend", 2)
+}
+
 // Test valid facets json.
 func TestNquadsFromJsonFacets3(t *testing.T) {
 	json := `

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
+	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v3 v3.0.0-20210209201111-6c35ad6c28e0
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2
 	github.com/dgraph-io/gqlgen v0.13.2

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/davecgh/go-spew v1.1.1
 	github.com/dgraph-io/badger/v3 v3.0.0-20210209201111-6c35ad6c28e0
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2
 	github.com/dgraph-io/gqlgen v0.13.2
@@ -72,5 +71,4 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.13.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4
-	src.techknowlogick.com/xgo v1.0.1-0.20200714173810-96de19c19b14
 )

--- a/go.sum
+++ b/go.sum
@@ -893,5 +893,3 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20180110180208-2cc67fd64755/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=
-src.techknowlogick.com/xgo v1.0.1-0.20200714173810-96de19c19b14 h1:e8P02bjvCTmi33s1MoinoTwMwrCq7+omCS3/3+GZWXA=
-src.techknowlogick.com/xgo v1.0.1-0.20200714173810-96de19c19b14/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

Between v20.03 and v20.11 (with https://github.com/dgraph-io/dgraph/pull/5424), dgraph lost the ability to handle deeply-nested uid facets. A JSON mutation with non-nested uid facets looks like this:

```json
{
  "set": [{
  	"title": "parent",
  	"children": [{
  		"title": "child",
  		"children|position": 1
		}]
	}]
}
```

A mutation with deeply-nested uid facets looks like this:

```json
{
  "set": [{
  	"title": "parent",
  	"children": [{
  		"title": "child",
  		"children|position": 1,
  		"children": [{
  			"title": "grandchild",
  			"children|position": 1
			}]
		}]
	}]
}
```

There's something about trying to set both `children` and `children|position` on the same JSON object that's causing it to error. The equivalent mutation in RDF succeeds:

```
{
  set {
    <_:parent> <title> "parent" .
    <_:parent> <children> <_:child> (position=1) .
    <_:child> <title> "child" .
    <_:child> <children> <_:grandchild> (position=1) .
    <_:grandchild> <title> "grandchild" .
  }
}
```

---

**Fix(karl):** The short explanation is there was an [old TODO](https://github.com/dgraph-io/dgraph/blob/160e922ef927335aea7ddb4a02a10502c1d21349/chunker/json_parser.go#L567-L568) mentioning that we should only run `parseMapFacets` if we are within a JSON scalar array, but we were running it from within JSON object arrays as well. [Only running it from within JSON scalar arrays](https://github.com/dgraph-io/dgraph/blob/93d8b0a4d7efed1f6764a23e304ffe5506b65599/chunker/json_parser.go#L568-L581) fixed the issue. 

Longer explanation: By calling `parseMapFacets` from within a JSON object array, the `"friend|close": true` facet was correctly assumed to have an object (map) value rather than its scalar value, and [this error](https://github.com/dgraph-io/dgraph/blob/93d8b0a4d7efed1f6764a23e304ffe5506b65599/chunker/json_parser.go#L137-L141) was returned. 

The reason [`"another_friend|close": true`](https://github.com/dgraph-io/dgraph/pull/7455#issuecomment-781522963) worked despite this is because `parseScalarMap` looks for facets on the same level as the predicate. For example, here's how map facets should look:

```json
{
    "nickname": ["alice", "bob", "josh"],
    "nickname|kind": {
        "0": "friends",
        "2": "official"
    }
}
```

So in the working `another_friend` example, `parseMapFacets` is called two times (once for each named JSON array declaration):

1. `parseMapFacets(map[string]interface{}{}, "friend|")`
    * `mapToNquads` encounters `"friend": [` on the current level and calls `parseMapFacets` with all facets found on the current level (none) and `"friend" + "|"` as the `prefix` parameter.
    * This works because [`m` is empty](https://github.com/dgraph-io/dgraph/blob/93d8b0a4d7efed1f6764a23e304ffe5506b65599/chunker/json_parser.go#L129) and `parseMapFacets` returns `nil`.
2. `parseMapFacets(map[string]interface{}{"friend|close": true}, "another_friend|")`
    * `mapToNquads` encounters `"another_friend": [` on the current level and calls `parseMapFacets` with all facets found on the current level and `"another_friend" + "|"` as the `prefix` parameter.
    * This works because [we check](https://github.com/dgraph-io/dgraph/blob/93d8b0a4d7efed1f6764a23e304ffe5506b65599/chunker/json_parser.go#L133-L135) if `prefix` (in this case, `another_friend|`) is in the facet name (in this case, `friend|close`) and `parseMapFacets` returns `nil`.

So `parseMapFacets` is only called two times, both times returning `nil`, and we pick up the facets with `parseScalarFacets` later. 

With this PR fix, we only call `parseMapFacets` for JSON scalar arrays and avoid everything mentioned above.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7455)
<!-- Reviewable:end -->
