### PR TITLE
fix(restore): fix restoring of type keys from old version (20.11)

### DIFF
--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -148,8 +148,7 @@ func NewUriHandler(uri *url.URL, creds *x.MinioCredentials) (UriHandler, error) 
 // loadFn is a function that will receive the current file being read.
 // A reader, the backup groupId, and a map whose keys are the predicates to restore
 // are passed as arguments.
-type loadFn func(reader io.Reader, groupId uint32, preds predicateSet,
-	dropOperations []*pb.DropOperation) (uint64, uint64, error)
+type loadFn func(groupId uint32, in *loadBackupInput) (uint64, uint64, error)
 
 // LoadBackup will scan location l for backup files in the given backup series and load them
 // sequentially. Returns the maximum Since value on success, otherwise an error.

--- a/worker/s3_handler.go
+++ b/worker/s3_handler.go
@@ -252,7 +252,9 @@ func (h *s3Handler) Load(uri *url.URL, backupId string, backupNum uint64, fn loa
 			// of the last backup.
 			predSet := manifests[len(manifests)-1].getPredsInGroup(gid)
 
-			groupMaxUid, groupMaxNsId, err := fn(reader, gid, predSet, manifest.DropOperations)
+			groupMaxUid, groupMaxNsId, err := fn(gid,
+				&loadBackupInput{r: reader, preds: predSet, dropOperations: manifest.DropOperations,
+					isOld: manifest.Version == 0})
 			if err != nil {
 				return LoadResult{Err: err}
 			}


### PR DESCRIPTION
Type update expects that the fields of schema key contains the predicate with namespace appended.
When restoring a backup from the old version (say 20.11), we need to do that while restoring.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7456)
<!-- Reviewable:end -->
