### PR TITLE
fix(Mutation): Deeply-nested uid facets

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -500,14 +500,22 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			buf.PushPredHint(pred, pb.Metadata_SINGLE)
 		case []interface{}:
 			buf.PushPredHint(pred, pb.Metadata_LIST)
-			// TODO(Ashish): We need to call this only in case of scalarlist, for other lists
-			// this can be avoided.
-			facetsMapSlice, err := parseMapFacets(m, prefix)
-			if err != nil {
-				return mr, err
-			}
 
+			// NOTE: facetsMapSlice should be empty unless this is a scalar list
+			var facetsMapSlice []map[int]*api.Facet
 			for idx, item := range v {
+				if idx == 0 {
+					switch item.(type) {
+					case string, float64, json.Number, int64:
+						var err error
+						facetsMapSlice, err = parseMapFacets(m, prefix)
+						if err != nil {
+							return mr, err
+						}
+					default:
+					}
+				}
+
 				nq := api.NQuad{
 					Subject:   mr.uid,
 					Predicate: pred,

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -729,6 +729,38 @@ func TestNquadsFromJsonFacets4(t *testing.T) {
 	}
 }
 
+func TestNquadsFromJsonFacets5(t *testing.T) {
+	// Dave has uid facets which should go on the edge between Alice and Dave,
+	// AND Emily has uid facets which should go on the edge between Dave and Emily
+	json := `[
+		{
+			"name": "Alice",
+			"friend": [
+				{
+					"name": "Dave",
+					"friend|close": true,
+					"friend": [
+						{
+							"name": "Emily",
+							"friend|close": true
+						}
+					]
+				}
+			]
+		}
+	]`
+
+	nq, err := Parse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(nq))
+	checkCount(t, nq, "friend", 1)
+
+	fastNQ, err := FastParse([]byte(json), SetNquads)
+	require.NoError(t, err)
+	require.Equal(t, 5, len(fastNQ))
+	checkCount(t, fastNQ, "friend", 1)
+}
+
 func TestNquadsFromJsonError1(t *testing.T) {
 	p := Person{
 		Name: "Alice",

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -754,11 +754,6 @@ func TestNquadsFromJsonFacets5(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 5, len(nq))
 	checkCount(t, nq, "friend", 1)
-
-	fastNQ, err := FastParse([]byte(json), SetNquads)
-	require.NoError(t, err)
-	require.Equal(t, 5, len(fastNQ))
-	checkCount(t, fastNQ, "friend", 1)
 }
 
 func TestNquadsFromJsonError1(t *testing.T) {


### PR DESCRIPTION
Cherry-pick of #7455.

* only run `parseMapFacets` for JSON scalar arrays

(cherry picked from commit 5049092668a3354db1923368dbef40d0e55dd448)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7457)
<!-- Reviewable:end -->
