### PR TITLE
fix(delete): Allow deleting reverse edges in strict mode

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -827,7 +827,12 @@ func (w *grpcWorker) proposeAndWait(ctx context.Context, txnCtx *api.TxnContext,
 	m *pb.Mutations) error {
 	if x.WorkerConfig.StrictMutations {
 		for _, edge := range m.Edges {
-			if _, err := schema.State().TypeOf(edge.Attr); err != nil {
+			// Trim the "~" from the attr because we never store reverse edges in the schema.
+			attr := edge.Attr
+			if len(edge.Attr) > 0 && edge.Attr[0] == '~' {
+				attr = attr[1:]
+			}
+			if _, err := schema.State().TypeOf(attr); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
The strict mode of mutations, alpha rejects any mutation that contains
predicates not present in the schema. Since the reverse edges are not
present in the schema, a mutation of the type `<0x1> <~friend> * .` would
fail in strict mode.

This PR fixes it.

Fixes - DGRAPH-3057
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7459)
<!-- Reviewable:end -->
