### PR TITLE
fix(test): remove `dgraph.graphql.p_sha256hash` predicate from backup test

### DIFF
--- a/systest/backup/multi-tenancy/backup_test.go
+++ b/systest/backup/multi-tenancy/backup_test.go
@@ -116,9 +116,8 @@ func TestBackupMultiTenancy(t *testing.T) {
 	restored := runRestore(t, copyBackupDir, "", math.MaxUint64, []uint64{x.GalaxyNamespace, ns})
 
 	preds := []string{"dgraph.graphql.schema", "name", "dgraph.graphql.xid", "dgraph.type", "movie",
-		"dgraph.graphql.p_query", "dgraph.graphql.p_sha256hash", "dgraph.drop.op", "dgraph.xid",
-		"dgraph.acl.rule", "dgraph.password", "dgraph.user.group", "dgraph.rule.predicate",
-		"dgraph.rule.permission"} // ACL
+		"dgraph.graphql.p_query", "dgraph.drop.op", "dgraph.xid", "dgraph.acl.rule",
+		"dgraph.password", "dgraph.user.group", "dgraph.rule.predicate", "dgraph.rule.permission"}
 	preds = append(preds, preds...)
 	types := []string{"Node", "dgraph.graphql", "dgraph.graphql.persisted_query",
 		"dgraph.type.Rule", "dgraph.type.User", "dgraph.type.Group"} // ACL


### PR DESCRIPTION
https://github.com/dgraph-io/dgraph/pull/7451 removed `dgraph.graphql.p_sha256hash` predicate.
This PR removes it from the backup test as well.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7460)
<!-- Reviewable:end -->
