### PR TITLE
fix(acl): make create and delete namespace available only if ACL is enabled

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -327,6 +327,14 @@ var (
 		resolve.GuardianOfTheGalaxyAuthMW4Mutation,
 		resolve.LoggingMWMutation,
 	}
+	// guardianOfTheGalaxyMutaionWithAclMWs are the middlewares which should be applied to mutations
+	// served by the admin server for guardian of galaxy with ACL enabled.
+	guardianOfTheGalaxyMutaionWithAclMWs = resolve.MutationMiddlewares{
+		resolve.IpWhitelistingMW4Mutation,
+		resolve.AclOnlyMW4Mutation,
+		resolve.GuardianOfTheGalaxyAuthMW4Mutation,
+		resolve.LoggingMWMutation,
+	}
 	// commonAdminQueryMWs are the middlewares which should be applied to queries served by admin
 	// server unless some exceptional behaviour is required
 	commonAdminQueryMWs = resolve.QueryMiddlewares{
@@ -364,9 +372,9 @@ var (
 		"restore":         guardianOfTheGalaxyMutationMWs,
 		"shutdown":        guardianOfTheGalaxyMutationMWs,
 		"updateGQLSchema": commonAdminMutationMWs,
-		"addNamespace":    append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
-		"deleteNamespace": append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
-		"resetPassword":   append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
+		"addNamespace":    guardianOfTheGalaxyMutaionWithAclMWs,
+		"deleteNamespace": guardianOfTheGalaxyMutaionWithAclMWs,
+		"resetPassword":   guardianOfTheGalaxyMutaionWithAclMWs,
 		// for queries and mutations related to User/Group, dgraph handles Guardian auth,
 		// so no need to apply GuardianAuth Middleware
 		"addUser":     {resolve.IpWhitelistingMW4Mutation, resolve.LoggingMWMutation},

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -364,9 +364,9 @@ var (
 		"restore":         guardianOfTheGalaxyMutationMWs,
 		"shutdown":        guardianOfTheGalaxyMutationMWs,
 		"updateGQLSchema": commonAdminMutationMWs,
-		"addNamespace":    guardianOfTheGalaxyMutationMWs,
-		"deleteNamespace": guardianOfTheGalaxyMutationMWs,
-		"resetPassword":   guardianOfTheGalaxyMutationMWs,
+		"addNamespace":    append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
+		"deleteNamespace": append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
+		"resetPassword":   append(guardianOfTheGalaxyMutationMWs, resolve.AclOnlyMW4Mutation),
 		// for queries and mutations related to User/Group, dgraph handles Guardian auth,
 		// so no need to apply GuardianAuth Middleware
 		"addUser":     {resolve.IpWhitelistingMW4Mutation, resolve.LoggingMWMutation},

--- a/graphql/resolve/middlewares.go
+++ b/graphql/resolve/middlewares.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 // QueryMiddleware represents a middleware for queries
@@ -207,6 +208,16 @@ func LoggingMWMutation(resolver MutationResolver) MutationResolver {
 	return MutationResolverFunc(func(ctx context.Context, mutation schema.Mutation) (*Resolved,
 		bool) {
 		glog.Infof("GraphQL admin mutation. Name =  %v", mutation.Name())
+		return resolver.Resolve(ctx, mutation)
+	})
+}
+
+func AclOnlyMW4Mutation(resolver MutationResolver) MutationResolver {
+	return MutationResolverFunc(func(ctx context.Context, mutation schema.Mutation) (*Resolved,
+		bool) {
+		if !x.WorkerConfig.AclEnabled {
+			return EmptyResult(mutation, errors.New("Enable ACL to use this mutation")), false
+		}
 		return resolver.Resolve(ctx, mutation)
 	})
 }


### PR DESCRIPTION
APIs like create/delete namespace and reset password should honour ACL.

Fixes DGRAPH-3051

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7464)
<!-- Reviewable:end -->
