### PR TITLE
Fix(GraphQL): Ignore redundant references to inverse object in mutation rewriting

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -4016,3 +4016,155 @@
             ],
             "uid": "_:Person12"
         }
+
+- name: "Reference to inverse field should be ignored and not throw an error"
+  gqlmutation: |
+    mutation addDistrict($input: [AddDistrictInput!]!) {
+      addDistrict(input: $input) {
+        district {
+          name
+          code
+          cities {
+            name
+          }
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "name": "Dist1",
+          "code": "D1",
+          "cities": [{"name": "Bengaluru", "district": { "code": "non-existing" } }]
+        },
+        {
+          "name": "Dist2",
+          "code": "D2",
+          "cities": [{"name": "Pune", "district": { "code": "D2" } }]
+        }
+      ]
+    }
+  explanation: "As district is inverse of city. There is no need to supply district to
+    the city. In case it is supplied, it is simply ignored. The city is linked to D1 and
+    district with code non-existing is ignored. Not even its existence query is generated."
+  dgquery: |-
+    query {
+      District1(func: eq(District.code, "D1")) @filter(type(District)) {
+        uid
+      }
+      District2(func: eq(District.code, "D2")) @filter(type(District)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "District.cities":
+            [
+              {
+                "City.name":"Bengaluru",
+                "dgraph.type":["City"],
+                "City.district": {
+                  "uid": "_:District1"
+                },
+                "uid":"_:City3"
+              }
+            ],
+            "District.code":"D1",
+            "District.name":"Dist1",
+            "dgraph.type":["District"],
+            "uid":"_:District1"
+        }
+    - setjson: |
+        {
+          "District.cities":
+            [
+              {
+                "City.name":"Pune",
+                "dgraph.type":["City"],
+                "City.district": {
+                  "uid": "_:District2"
+                },
+                "uid":"_:City4"
+              }
+            ],
+            "District.code":"D2",
+            "District.name":"Dist2",
+            "dgraph.type":["District"],
+            "uid":"_:District2"
+        }
+
+- name: "Reference to inverse field should be ignored and not throw an error 2"
+  gqlmutation: |
+    mutation addFoo($input: [AddFooInput!]!) {
+      addFoo(input: $input) {
+        foo {
+          id
+          bar {
+            id
+          }
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "id": "123",
+          "bar": {"id": "1234", "foo": { "id": "123" } }
+        },
+        {
+          "id": "1",
+          "bar": {"id": "2", "foo": { "id": "3" } }
+        }
+      ]
+    }
+  explanation: "As foo is inverse of bar. There is no need to supply bar to
+    foo. In case it is supplied, it is simply ignored."
+  dgquery: |-
+    query {
+      Foo1(func: eq(Foo.id, "123")) @filter(type(Foo)) {
+        uid
+      }
+      Bar2(func: eq(Bar.id, "1234")) @filter(type(Bar)) {
+        uid
+      }
+      Foo3(func: eq(Foo.id, "1")) @filter(type(Foo)) {
+        uid
+      }
+      Bar4(func: eq(Bar.id, "2")) @filter(type(Bar)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "Foo.bar":
+              {
+                "Bar.id":"1234",
+                "dgraph.type":["Bar"],
+                "Bar.foo": {
+                  "uid": "_:Foo1"
+                },
+                "uid":"_:Bar2"
+              },
+            "Foo.id":"123",
+            "dgraph.type":["Foo"],
+            "uid":"_:Foo1"
+        }
+    - setjson: |
+        {
+          "Foo.bar":
+              {
+                "Bar.id":"2",
+                "dgraph.type":["Bar"],
+                "Bar.foo": {
+                  "uid": "_:Foo3"
+                },
+                "uid":"_:Bar4"
+              },
+            "Foo.id":"1",
+            "dgraph.type":["Foo"],
+            "uid":"_:Foo3"
+        }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1678,6 +1678,14 @@ func existenceQueries(
 	var ret []*gql.GraphQuery
 	var retErrors []error
 
+	// Inverse Object field is deleted. This is to ensure that we don't refer any conflicting
+	// inverse node as inverse of a field.
+	// Example: For the given mutation,
+	// addAuthor (input: [{name: ..., posts: [ {author: { id: "some id"}} ]} ] ),
+	// the part, author: { id: "some id"} is removed. This ensures that the author
+	// for the post is not set to something different but is set to the real author.
+	deleteInverseObject(obj, srcField)
+
 	id := typ.IDField()
 	if id != nil {
 		// Check if the ID field is referenced in the mutation

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -416,3 +416,13 @@ type SpaceShip @key(fields: "id") @extends {
     id: String! @id @external
     missions: [Mission]
 }
+
+type Foo {
+    id: String! @id
+    bar: Bar! @hasInverse(field: foo)
+}
+
+type Bar {
+    id: String! @id
+    foo: Foo!
+}


### PR DESCRIPTION
After the refactoring of mutation rewriting, references to inverse objects were not ignored in existenceQueries function. This PR fixes this.

This PR fixes https://discuss.dgraph.io/t/bug-not-sure-how-to-name-this-bug-please-help-out/12845 
Testing:
1. Basic yaml tests
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7469)
<!-- Reviewable:end -->
