### PR TITLE
Fix(GraphQL): Fix Upsert with Multiple IDs

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -915,7 +915,7 @@
       cond: "@if(gt(len(State3), 0))"
 
 -
-  name: "Multiple Upsert Mutation with multiple xids where both existence queries result exist"
+  name: "Upsert Mutation with multiple xids where both existence queries result exist"
   gqlmutation: |
     mutation addBook($input: [AddBookInput!]!) {
       addBook(input: $input, upsert: true) {
@@ -958,6 +958,56 @@
   dgmutations:
     - setjson: |
         { "uid" : "uid(Book2)",
+          "Book.publisher": "penguin"
+        }
+      cond: "@if(gt(len(Book2), 0))"
+
+-
+  name: "Upsert Mutation with multiple xids where only one of existence queries result exist"
+  explanation: "Book1 does not exist but Book2 exists. As Book2 exists, this is an upsert.
+    Even though, Book1 does not exist, the mutation should not update ISBN as it is also an XID."
+  gqlmutation: |
+    mutation addBook($input: [AddBookInput!]!) {
+      addBook(input: $input, upsert: true) {
+        book {
+          title
+          ISBN
+        }
+      }
+    }
+  gqlvariables: |
+    { "input":
+      [
+        {
+          "title": "Sapiens",
+          "ISBN": "NSW",
+          "publisher": "penguin"
+        }
+      ]
+    }
+  dgquery: |-
+    query {
+      Book1(func: eq(Book.ISBN, "NSW")) @filter(type(Book)) {
+        uid
+      }
+      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+        uid
+      }
+    }
+  qnametouid: |-
+    {
+      "Book2": "0x11"
+    }
+  dgquerysec: |-
+    query {
+      Book2 as addBook(func: uid(0x11)) @filter(type(Book)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        {
+          "uid" : "uid(Book2)",
           "Book.publisher": "penguin"
         }
       cond: "@if(gt(len(Book2), 0))"

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1413,8 +1413,6 @@ func rewriteObject(
 							// updating this node.
 							upsertVar = variable
 							srcUID = fmt.Sprintf("uid(%s)", variable)
-							// To ensure that xid is not added to the output json
-							delete(obj, xid.Name())
 						} else {
 							// We return an error as we are at top level of non-upsert mutation and the XID exists.
 							// We need to conceal the error because we might be leaking information to the user if it
@@ -1500,6 +1498,14 @@ func rewriteObject(
 					retErrors = append(retErrors, err)
 					return nil, upsertVar, retErrors
 				}
+			}
+		} else {
+			// In case this is known to be an Upsert. We delete all entries of XIDs
+			// from obj. This is done to prevent any XID entries in the json which is returned
+			// by rewriteObject and ensure that no XID value gets rewritten due to upsert.
+			for _, xid := range xids {
+				// To ensure that xid is not added to the output json in case of upsert
+				delete(obj, xid.Name())
 			}
 		}
 	}


### PR DESCRIPTION
Currently, if a node with one of the supplied XIDs does not exist also gets updated during Add with Upsert. This should not happen. Value of any of the XIDs should not change during an Upsert Mutation. This PR fixes this.

Testing:
1. yaml test added in add_mutation_test.yaml .
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7472)
<!-- Reviewable:end -->
