### PR TITLE
fix(restore): skip the depreciated predicates and types in restore

### DIFF
--- a/worker/restore.go
+++ b/worker/restore.go
@@ -100,14 +100,6 @@ type loadBackupInput struct {
 	isOld          bool
 }
 
-var depreciatedPreds = map[string]struct{}{
-	"dgraph.cors":                      {},
-	"dgraph.graphql.schema_created_at": {},
-	"dgraph.graphql.schema_history":    {},
-	"dgraph.graphql.p_sha256hash":      {},
-	"dgraph.type.cors":                 {},
-}
-
 // loadFromBackup reads the backup, converts the keys and values to the required format,
 // and loads them to the given badger DB. The set of predicates is used to avoid restoring
 // values from predicates no longer assigned to this group.
@@ -178,17 +170,13 @@ func loadFromBackup(db *badger.DB, in *loadBackupInput) (uint64, uint64, error) 
 				continue
 			}
 
-			if in.isOld {
-				// Skip restoring the data for the depreciated predicates from the backup taken from
-				// versions < 21.03.
-				if _, ok := depreciatedPreds[x.ParseAttr(parsedKey.Attr)]; ok {
-					continue
-				}
-			}
-
 			// Update the max uid and namespace id that has been seen while restoring this backup.
-			maxUid = x.Max(maxUid, parsedKey.Uid)
-			maxNsId = x.Max(maxNsId, namespace)
+			if parsedKey.Uid > maxUid {
+				maxUid = parsedKey.Uid
+			}
+			if namespace > maxNsId {
+				maxNsId = namespace
+			}
 
 			// Override the version if requested. Should not be done for type and schema predicates,
 			// which always have their version set to 1.
@@ -243,20 +231,14 @@ func loadFromBackup(db *badger.DB, in *loadBackupInput) (uint64, uint64, error) 
 				appendNamespace := func() error {
 					// If the backup was taken on old version, we need to append the namespace to
 					// the fields of TypeUpdate.
-					var update, updateCopy pb.TypeUpdate
+					var update pb.TypeUpdate
 					if err := update.Unmarshal(kv.Value); err != nil {
 						return err
 					}
-					updateCopy.TypeName = update.TypeName
 					for _, sch := range update.Fields {
-						if _, ok := depreciatedPreds[sch.Predicate]; ok {
-							// This predicate has been removed from versions >= 21.03.
-							continue
-						}
 						sch.Predicate = x.GalaxyAttr(sch.Predicate)
-						updateCopy.Fields = append(updateCopy.Fields, sch)
 					}
-					kv.Value, err = updateCopy.Marshal()
+					kv.Value, err = update.Marshal()
 					return err
 				}
 				if in.isOld && parsedKey.IsType() {

--- a/worker/restore.go
+++ b/worker/restore.go
@@ -249,7 +249,7 @@ func loadFromBackup(db *badger.DB, in *loadBackupInput) (uint64, uint64, error) 
 					}
 					updateCopy.TypeName = update.TypeName
 					for _, sch := range update.Fields {
-						if sch.Predicate == "dgraph.graphql.p_sha256hash" {
+						if _, ok := depreciatedPreds[sch.Predicate]; ok {
 							// This predicate has been removed from versions >= 21.03.
 							continue
 						}


### PR DESCRIPTION
Some of the internal predicates have been removed in https://github.com/dgraph-io/dgraph/pull/7431 and https://github.com/dgraph-io/dgraph/pull/7451. 
When restoring from a backup taken on a version older than 21.03, we should skip restoring them. 
Else they will lie around with no use and show up through `/state` endpoint. 
Also, its export will fail in data loading(bulk/live load).
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7473)
<!-- Reviewable:end -->
