### PR TITLE
fix(GraphQL):fix TestSchemaSubscribe test by always incrementing schema counter value on initialization if there is schema in DB.

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -706,7 +706,7 @@ func (as *adminServer) initServer() {
 			glog.Infof("Error processing GraphQL schema: %s.", err)
 			break
 		}
-
+		as.incrementSchemaUpdateCounter(x.GalaxyNamespace)
 		as.resetSchema(x.GalaxyNamespace, generatedSchema)
 
 		glog.Infof("Successfully loaded GraphQL schema.  Serving GraphQL API.")


### PR DESCRIPTION
If we have multiple alpha groups then sometimes it was happening that some alpha groups start a bit late compared to others.
If we send schema update to cluster it's received through badger subscription in the alpha's which has already started and we update the schema counter for those alphas.
But the alpha's which will start late get it from the DB while starting and in that case, we weren't incrementing the counter and tests were failing.
Now we fixed it by always incrementing the counter for `namespace 0` while starting alpha if there is already schema in DB
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7479)
<!-- Reviewable:end -->
