### PR TITLE
propose key same cause assert panic[Found existing proposal with key: [7d02e530d09]]

### DIFF
--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -19,6 +19,7 @@ package worker
 import (
 	"context"
 	"encoding/binary"
+	"github.com/golang/glog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -218,7 +219,13 @@ func (n *node) proposeAndWait(ctx context.Context, proposal *pb.Proposal) (perr 
 			ErrCh: errCh,
 			Ctx:   cctx,
 		}
-		x.AssertTruef(n.Proposals.Store(key, pctx), "Found existing proposal with key: [%x]", key)
+
+		for !n.Proposals.Store(key, pctx) {
+			glog.Warningf("Found existing proposal with key: [%v]", key)
+			key = uniqueKey()
+			binary.BigEndian.PutUint64(data, key)
+		}
+
 		defer n.Proposals.Delete(key) // Ensure that it gets deleted on return.
 
 		span.Annotatef(nil, "Proposing with key: %d. Timeout: %v", key, timeout)


### PR DESCRIPTION
```
2021/02/02 13:09:51 Found existing proposal with key: [7d02e530d09]
github.com/dgraph-io/dgraph/x.AssertTruef
        /export/working/src/github.com/dgraph-io/dgraph/x/error.go:107
github.com/dgraph-io/dgraph/worker.(*node).proposeAndWait.func3
        /export/working/src/github.com/dgraph-io/dgraph/worker/proposal.go:221
github.com/dgraph-io/dgraph/worker.(*node).proposeAndWait.func4
        /export/working/src/github.com/dgraph-io/dgraph/worker/proposal.go:289
github.com/dgraph-io/dgraph/worker.(*node).proposeAndWait
        /export/working/src/github.com/dgraph-io/dgraph/worker/proposal.go:293
github.com/dgraph-io/dgraph/worker.(*grpcWorker).proposeAndWait
        /export/working/src/github.com/dgraph-io/dgraph/worker/mutation.go:814
github.com/dgraph-io/dgraph/worker.proposeOrSend
        /export/working/src/github.com/dgraph-io/dgraph/worker/mutation.go:538
runtime.goexit
        /export/go/src/runtime/asm_amd64.s:1373
[Decoder]: Using assembly version of decoder
Page Size: 4096
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7484)
<!-- Reviewable:end -->
