### PR TITLE
feat(GraphQL): Add support for passing OAuth Bearer token as authorization JWT

### DIFF
--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -366,7 +366,11 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 	ctx = context.WithValue(ctx, resolveStartTime, startTime)
 
 	// Pass in GraphQL @auth information
-	ctx = r.schema.Meta().AuthMeta().AttachAuthorizationJwt(ctx, gqlReq.Header)
+	ctx, err := r.schema.Meta().AuthMeta().AttachAuthorizationJwt(ctx, gqlReq.Header)
+	if err != nil {
+		return schema.ErrorResponse(err)
+	}
+
 	ctx = x.AttachJWTNamespace(ctx)
 	op, err := r.schema.Operation(gqlReq)
 	if err != nil {

--- a/graphql/subscription/poller.go
+++ b/graphql/subscription/poller.go
@@ -79,8 +79,11 @@ func (p *Poller) AddSubscriber(req *schema.Request) (*SubscriberResponse, error)
 	// find out the custom claims for auth, if any. As,
 	// We also need to use authVariables in generating the hashed bucketID
 	authMeta := resolver.Schema().Meta().AuthMeta()
-	customClaims, err := authMeta.ExtractCustomClaims(authMeta.AttachAuthorizationJwt(context.
-		Background(), req.Header))
+	ctx, err := authMeta.AttachAuthorizationJwt(context.Background(), req.Header)
+	if err != nil {
+		return nil, err
+	}
+	customClaims, err := authMeta.ExtractCustomClaims(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes: [Discuss Issue](https://discuss.dgraph.io/t/authorization-bearer-token/9133).
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7490)
<!-- Reviewable:end -->
