### PR TITLE
chore(tests): retry on login into namespace

### DIFF
--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -59,7 +60,12 @@ func Login(t *testing.T, loginParams *LoginParams) *HttpToken {
 	if loginParams.Endpoint == "" {
 		loginParams.Endpoint = AdminUrl()
 	}
-	token, err := HttpLogin(loginParams)
+	var token *HttpToken
+	err := x.RetryUntilSuccess(10, 100*time.Millisecond, func() error {
+		var err error
+		token, err = HttpLogin(loginParams)
+		return err
+	})
 	require.NoError(t, err, "login failed")
 	return token
 }
@@ -308,10 +314,10 @@ func AddRulesToGroup(t *testing.T, token *HttpToken, group string, rules []Rule)
 func DgClientWithLogin(t *testing.T, id, password string, ns uint64) *dgo.Dgraph {
 	userClient, err := DgraphClient(SockAddr)
 	require.NoError(t, err)
-	time.Sleep(1 * time.Second)
 
-	err = userClient.LoginIntoNamespace(context.Background(), id, password, ns)
-	require.NoError(t, err)
+	require.NoError(t, x.RetryUntilSuccess(10, 100*time.Millisecond, func() error {
+		return userClient.LoginIntoNamespace(context.Background(), id, password, ns)
+	}))
 	return userClient
 }
 


### PR DESCRIPTION
ResetAck() runs in a separate go routine on alpha start. https://github.com/dgraph-io/dgraph/blob/c1d74c752092661d1c1af6c6d1d2f9cb413fab88/dgraph/cmd/alpha/run.go#L876-L884
The server is accepting the request even before complete initialization. This leads to the failure of login.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7497)
<!-- Reviewable:end -->
