### PR TITLE
fix(schema): log error instead of panic if schema not found for predicate

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -335,7 +335,12 @@ func (s *state) Tokenizer(ctx context.Context, pred string) []tok.Tokenizer {
 			su = schema
 		}
 	}
-	x.AssertTruef(su != nil, "schema state not found for %s", pred)
+	if su == nil {
+		// This may happen when some query that needs indexing over this predicate is executing
+		// while the predicate is dropped from the state (using drop operation).
+		glog.Errorf("Schema state not found for %s.", pred)
+		return nil
+	}
 	tokenizers := make([]tok.Tokenizer, 0, len(su.Tokenizer))
 	for _, it := range su.Tokenizer {
 		t, found := tok.GetTokenizer(it)

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -84,6 +84,9 @@ func pickTokenizer(ctx context.Context, attr string, f string) (tok.Tokenizer, e
 	}
 
 	tokenizers := schema.State().Tokenizer(ctx, attr)
+	if tokenizers == nil {
+		return nil, errors.Errorf("Schema state not found for %s.", attr)
+	}
 	for _, t := range tokenizers {
 		// If function is eq and we found a tokenizer that's !Lossy(), lets return it
 		switch f {


### PR DESCRIPTION
This PR fixes alpha panic when drop operation and the query is run concurrently.
This may happen when some query that needs indexing over this predicate is executing while the predicate is dropped from the state (using drop operation).
```
I0226 23:00:24.621458      20 server.go:406] ALTER op: drop_all:true  done
I0226 23:00:24.623637      20 http.go:586] Got alter request via HTTP from 192.168.64.1:34114
I0226 23:00:24.623778      20 server.go:362] Received ALTER op: drop_all:true 
I0226 23:00:24.623808      20 server.go:1513] Got Alter request from: "192.168.64.1:34114"
I0226 23:00:24.625026      20 access_ee.go:1079] Successfully authorised the guardian of the galaxy
I0226 23:00:24.627030      20 log.go:34] DropAll called. Blocking writes...
I0226 23:00:24.627076      20 log.go:34] Writes flushed. Stopping compactions now...
2021/02/26 23:00:24 schema state not found for dgraph.type
github.com/dgraph-io/dgraph/x.AssertTruef
	/home/dmai/go/src/github.com/dgraph-io/dgraph/x/error.go:107
github.com/dgraph-io/dgraph/schema.(*state).Tokenizer
	/home/dmai/go/src/github.com/dgraph-io/dgraph/schema/schema.go:338
github.com/dgraph-io/dgraph/worker.pickTokenizer
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/tokens.go:86
github.com/dgraph-io/dgraph/worker.getInequalityTokens
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/tokens.go:128
github.com/dgraph-io/dgraph/worker.parseSrcFn
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/task.go:1772
github.com/dgraph-io/dgraph/worker.(*queryState).helpProcessTask
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/task.go:944
github.com/dgraph-io/dgraph/worker.processTask
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/task.go:926
github.com/dgraph-io/dgraph/worker.(*grpcWorker).ServeTask.func1
	/home/dmai/go/src/github.com/dgraph-io/dgraph/worker/task.go:1984
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1374
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7502)
<!-- Reviewable:end -->
