### PR TITLE
feat(Apollo): Add support for @provides and @requires directive. 

### DIFF
--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -5028,6 +5028,7 @@ func addMutationWithDeepExtendedTypeObjects(t *testing.T) {
 	varMap2 := map[string]interface{}{
 		"missionId":   "Mission2",
 		"astronautId": "Astronaut1",
+		"name":        "Gus Garrisom",
 		"des":         "Apollo2",
 	}
 	addMissionParams.Variables = varMap2

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -5067,10 +5067,11 @@ func addMutationWithDeepExtendedTypeObjects(t *testing.T) {
 
 func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 	addAstronautParams := &GraphQLParams{
-		Query: `mutation addAstronaut($id1: ID!, $missionId1: String!, $id2: ID!, $missionId2: String! ) {
-			addAstronaut(input: [{id: $id1, missions: [{id: $missionId1, designation: "Apollo1"}]}, {id: $id2, missions: [{id: $missionId2, designation: "Apollo2"}]}]) {
+		Query: `mutation addAstronaut($id1: ID!, name1: String!, $missionId1: String!, $id2: ID!, name2: String!, $missionId2: String! ) {
+			addAstronaut(input: [{id: $id1, name: $name1, missions: [{id: $missionId1, designation: "Apollo1"}]}, {id: $id2, name: $name2, missions: [{id: $missionId2, designation: "Apollo11"}]}]) {
 				astronaut(order: {asc: id}){
 					id
+					name
 					missions {
 						id
 						designation
@@ -5080,8 +5081,10 @@ func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 		}`,
 		Variables: map[string]interface{}{
 			"id1":        "Astronaut1",
+			"name1":      "Gus Grissom",
 			"missionId1": "Mission1",
 			"id2":        "Astronaut2",
+			"name2":      "Neil Armstrong",
 			"missionId2": "Mission2",
 		},
 	}
@@ -5094,6 +5097,7 @@ func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 		  "astronaut": [
 			{
 			  "id": "Astronaut1",
+			  "Gus Grissom",
 			  "missions": [
 				{
 				  "id": "Mission1",
@@ -5103,10 +5107,11 @@ func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 			},
 			{
 			  "id": "Astronaut2",
+			  "name": "Neil Armstrong",
 			  "missions": [
 				{
 				  "id": "Mission2",
-				  "designation": "Apollo2"
+				  "designation": "Apollo11"
 				}
 			  ]
 			}

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -5094,28 +5094,29 @@ func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 
 	expectedJSON := `{
 		"addAstronaut": {
-		  "astronaut": [
-			{
-			  "id": "Astronaut1",
-			  "Gus Grissom",
-			  "missions": [
-				{
-				  "id": "Mission1",
-				  "designation": "Apollo1"
-				}
-			  ]
-			},
-			{
-			  "id": "Astronaut2",
-			  "name": "Neil Armstrong",
-			  "missions": [
-				{
-				  "id": "Mission2",
-				  "designation": "Apollo11"
-				}
-			  ]
-			}
-		  ]
+			"astronaut": [
+			  {
+				"id": "Astronaut1",
+				"name": "Gus Grissom",
+				"missions": [
+				  {
+					"id": "Mission1",
+					"designation": "Apollo1"
+				  }
+				]
+			  },
+			  {
+				"id": "Astronaut2",
+				"name": "Neil Armstrong",
+				"missions": [
+				  {
+					"id": "Mission2",
+					"designation": "Apollo11"
+				  }
+				]
+			  }
+			]
+		  }
 		}
 	  }`
 

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4986,7 +4986,7 @@ func addMutationWithDeepExtendedTypeObjects(t *testing.T) {
 	}
 	addMissionParams := &GraphQLParams{
 		Query: `mutation addMission($missionId: String!, $astronautId: ID!, $name: String!, $des: String!) {
-			addMission(input: [{id: $missionId, designation: $des, crew: [{id: $astronautId}]}]) {
+			addMission(input: [{id: $missionId, designation: $des, crew: [{id: $astronautId, name: $name}]}]) {
 				mission{
 					id
 					crew {

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -5067,7 +5067,7 @@ func addMutationWithDeepExtendedTypeObjects(t *testing.T) {
 
 func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 	addAstronautParams := &GraphQLParams{
-		Query: `mutation addAstronaut($id1: ID!, name1: String!, $missionId1: String!, $id2: ID!, name2: String!, $missionId2: String! ) {
+		Query: `mutation addAstronaut($id1: ID!, $name1: String!, $missionId1: String!, $id2: ID!, $name2: String!, $missionId2: String! ) {
 			addAstronaut(input: [{id: $id1, name: $name1, missions: [{id: $missionId1, designation: "Apollo1"}]}, {id: $id2, name: $name2, missions: [{id: $missionId2, designation: "Apollo11"}]}]) {
 				astronaut(order: {asc: id}){
 					id

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4981,10 +4981,11 @@ func addMutationWithDeepExtendedTypeObjects(t *testing.T) {
 	varMap1 := map[string]interface{}{
 		"missionId":   "Mission1",
 		"astronautId": "Astronaut1",
+		"name":        "Guss Garissom",
 		"des":         "Apollo1",
 	}
 	addMissionParams := &GraphQLParams{
-		Query: `mutation addMission($missionId: String!, $astronautId: ID!, $des: String!) {
+		Query: `mutation addMission($missionId: String!, $astronautId: ID!, $name: String!, $des: String!) {
 			addMission(input: [{id: $missionId, designation: $des, crew: [{id: $astronautId}]}]) {
 				mission{
 					id
@@ -5117,7 +5118,6 @@ func addMutationOnExtendedTypeWithIDasKeyField(t *testing.T) {
 			  }
 			]
 		  }
-		}
 	  }`
 
 	testutil.CompareJSON(t, expectedJSON, string(gqlResponse.Data))

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -309,7 +309,7 @@ type Section {
 
 type Mission @key(fields: "id") {
     id: String! @id
-    crew: [Astronaut] @hasInverse(field: missions)
+    crew: [Astronaut] @provides(fields: "name") @hasInverse(field: missions)
     spaceShip: [SpaceShip]
     designation: String!
     startDate: String
@@ -318,6 +318,7 @@ type Mission @key(fields: "id") {
 
 type Astronaut @key(fields: "id") @extends {
     id: ID! @external
+    name: String @external
     missions: [Mission]
 }
 

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -68,6 +68,10 @@
       "type": "uid"
     },
     {
+      "predicate": "Astronaut.name",
+      "type": "string"
+    },
+    {
       "predicate": "Astronaut.missions",
       "type": "uid",
       "list": true

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -327,7 +327,7 @@ type Employer {
 
 type Mission @key(fields: "id") {
     id: String! @id
-    crew: [Astronaut] @hasInverse(field: missions)
+    crew: [Astronaut] @provides(fields: "name") @hasInverse(field: missions)
     spaceShip: [SpaceShip]
     designation: String!
     startDate: String
@@ -336,6 +336,7 @@ type Mission @key(fields: "id") {
 
 type Astronaut @key(fields: "id") @extends {
     id: ID! @external
+    name: String! @external
     missions: [Mission]
 }
 

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -46,6 +46,10 @@
       "upsert": true
     },
     {
+      "predicate": "Astronaut.name",
+      "type": "string"
+    },
+    {
       "predicate": "Astronaut.missions",
       "type": "uid",
       "list": true

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1605,7 +1605,10 @@ func isOrderable(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap
 }
 
 // Returns true if the field is of type which can be summed. Eg: int, int64, float
-func isSummable(fld *ast.FieldDefinition) bool {
+func isSummable(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap map[string]bool) bool {
+	if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+		return false
+	}
 	return summable[fld.Type.NamedType] && !hasCustomOrLambda(fld)
 }
 
@@ -1876,7 +1879,7 @@ func addAggregationResultType(schema *ast.Schema, defn *ast.Definition, provides
 
 		// Adds scoreSum and scoreAvg field for a field of name score.
 		// The type of scoreAvg is Float irrespective of the type of score.
-		if isSummable(fld) {
+		if isSummable(fld, defn, providesTypeMap) {
 			sumField := &ast.FieldDefinition{
 				Name: fld.Name + "Sum",
 				Type: aggregateFieldType,

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1379,7 +1379,8 @@ func addTypeHasFilter(schema *ast.Schema, defn *ast.Definition, providesTypeMap 
 			continue
 		}
 		// Ignore Fields with @external directives also excluding those which are present
-		// as an argument in @key directive=
+		// as an argument in @key directive. If the field is an argument to `@provides` directive
+		// then it can't be ignored.
 		if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
 			continue
 		}
@@ -1503,7 +1504,8 @@ func addFilterType(schema *ast.Schema, defn *ast.Definition, providesTypeMap map
 
 	for _, fld := range defn.Fields {
 		// Ignore Fields with @external directives also excluding those which are present
-		// as an argument in @key directive
+		// as an argument in @key directive. If the field is an argument to `@provides` directive
+		// then it can't be ignored.
 		if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
 			continue
 		}
@@ -1594,7 +1596,8 @@ func hasOrderables(defn *ast.Definition, providesTypeMap map[string]bool) bool {
 func isOrderable(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap map[string]bool) bool {
 	// lists can't be ordered and NamedType will be empty for lists,
 	// so it will return false for list fields
-	// External field can't be ordered except when it is a @key field
+	// External field can't be ordered except when it is a @key field or
+	// the field is an argument in `@provides` directive.
 	if !hasExternal(fld) {
 		return orderable[fld.Type.NamedType] && !hasCustomOrLambda(fld)
 	}
@@ -2165,7 +2168,8 @@ func getNonIDFields(schema *ast.Schema, defn *ast.Definition, providesTypeMap ma
 		}
 
 		// Ignore Fields with @external directives also as they shouldn't be present
-		// in the Patch Type Also.
+		// in the Patch Type also. If the field is an argument to `@provides` directive
+		// then it should be presnt.
 		if hasExternal(fld) && !providesTypeMap[fld.Name] {
 			continue
 		}
@@ -2248,7 +2252,8 @@ func getIDField(defn *ast.Definition, providesTypeMap map[string]bool) ast.Field
 	fldList := make([]*ast.FieldDefinition, 0)
 	for _, fld := range defn.Fields {
 		if isIDField(defn, fld) {
-			// Excluding those fields which are external and are not @key.
+			// Excluding those fields which are external and are not @key and are not
+			// used as an argument in `@provides` directive.
 			if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
 				continue
 			}
@@ -2280,7 +2285,8 @@ func getXIDField(defn *ast.Definition, providesTypeMap map[string]bool) ast.Fiel
 	fldList := make([]*ast.FieldDefinition, 0)
 	for _, fld := range defn.Fields {
 		if hasIDDirective(fld) {
-			// Excluding those fields which are external and are not @key.
+			// Excluding those fields which are external and are not @key and are not
+			// used as an argument in `@provides` directive.
 			if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
 				continue
 			}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -585,8 +585,10 @@ var directiveLocationMap = map[string]map[ast.DefinitionKind]bool{
 	customDirective:       nil,
 	remoteDirective: {ast.Object: true, ast.Interface: true, ast.Union: true,
 		ast.InputObject: true, ast.Enum: true},
-	cascadeDirective:  nil,
-	generateDirective: {ast.Object: true, ast.Interface: true},
+	cascadeDirective:        nil,
+	generateDirective:       {ast.Object: true, ast.Interface: true},
+	apolloRequiresDirective: nil,
+	apolloProvidesDirective: nil,
 }
 
 // Struct to store parameters of @generate directive

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1383,9 +1383,10 @@ func addTypeHasFilter(schema *ast.Schema, defn *ast.Definition, providesTypeMap 
 		// Ignore Fields with @external directives also excluding those which are present
 		// as an argument in @key directive. If the field is an argument to `@provides` directive
 		// then it can't be ignored.
-		if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+		if externalAndNonKeyField(fld, defn, providesTypeMap) {
 			continue
 		}
+
 		filter.EnumValues = append(filter.EnumValues,
 			&ast.EnumValueDefinition{Name: fld.Name})
 	}
@@ -1508,7 +1509,7 @@ func addFilterType(schema *ast.Schema, defn *ast.Definition, providesTypeMap map
 		// Ignore Fields with @external directives also excluding those which are present
 		// as an argument in @key directive. If the field is an argument to `@provides` directive
 		// then it can't be ignored.
-		if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+		if externalAndNonKeyField(fld, defn, providesTypeMap) {
 			continue
 		}
 
@@ -1608,7 +1609,7 @@ func isOrderable(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap
 
 // Returns true if the field is of type which can be summed. Eg: int, int64, float
 func isSummable(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap map[string]bool) bool {
-	if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+	if externalAndNonKeyField(fld, defn, providesTypeMap) {
 		return false
 	}
 	return summable[fld.Type.NamedType] && !hasCustomOrLambda(fld)
@@ -2175,7 +2176,7 @@ func getNonIDFields(schema *ast.Schema, defn *ast.Definition, providesTypeMap ma
 		// Ignore Fields with @external directives also as they shouldn't be present
 		// in the Patch Type also. If the field is an argument to `@provides` directive
 		// then it should be presnt.
-		if hasExternal(fld) && !providesTypeMap[fld.Name] {
+		if externalAndNonKeyField(fld, defn, providesTypeMap) {
 			continue
 		}
 		// Fields with @custom/@lambda directive should not be part of mutation input,
@@ -2221,7 +2222,7 @@ func getFieldsWithoutIDType(schema *ast.Schema, defn *ast.Definition, providesTy
 
 		// Ignore Fields with @external directives and excluding those which are present
 		// as an argument in @key directive
-		if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+		if externalAndNonKeyField(fld, defn, providesTypeMap) {
 			continue
 		}
 
@@ -2259,7 +2260,7 @@ func getIDField(defn *ast.Definition, providesTypeMap map[string]bool) ast.Field
 		if isIDField(defn, fld) {
 			// Excluding those fields which are external and are not @key and are not
 			// used as an argument in `@provides` directive.
-			if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+			if externalAndNonKeyField(fld, defn, providesTypeMap) {
 				continue
 			}
 			newFld := *fld
@@ -2292,7 +2293,7 @@ func getXIDField(defn *ast.Definition, providesTypeMap map[string]bool) ast.Fiel
 		if hasIDDirective(fld) {
 			// Excluding those fields which are external and are not @key and are not
 			// used as an argument in `@provides` directive.
-			if hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name] {
+			if externalAndNonKeyField(fld, defn, providesTypeMap) {
 				continue
 			}
 			newFld := *fld

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2702,9 +2702,9 @@ invalid_schemas:
   - name: "@extends directive without @key directive"
     input: |
       type Product  @extends{
-      id: ID! @external
-      name: String! @external
-      reviews: [Reviews]
+          id: ID! @external
+          name: String! @external
+          reviews: [Reviews]
       }
 
       type Reviews @key(fields: "id") {
@@ -2712,7 +2712,7 @@ invalid_schemas:
           review: String!
       }
     errlist: [
-      {"message": "Type Product; Type Extension cannot be defined without @key directive", "locations": [ { "line": 11, "column": 12} ] },
+      {"message": "Type Product; Type Extension cannot be defined without @key directive", "locations": [ { "line": 13, "column": 12} ] },
     ]
   - name: "@remote directive with @key"
     input: |
@@ -2744,7 +2744,48 @@ invalid_schemas:
     errlist: [
       {"message": "Type Product: Field name: @search directive can not be defined on @external fields that are not @key.", "locations": [ { "line": 3, "column": 18} ] },
     ]
-
+  - name: "@requires directive defined on type definitions"
+    input: |
+      type Product @key(fields: "id"){
+        id: ID!
+        name: String!
+        reviews: [Reviews] @requires(fields: "name")
+      }
+      type Reviews @key(fields: "id") {
+          id: ID!
+          review: String!
+      }
+    errlist: [
+      {"message": "Type Product: Field reviews: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", "locations": [ { "line": 4, "column": 23} ] }
+    ]
+  - name: "argument inside @requires directive is not an @external field."
+    input: |
+      extend type Product @key(fields: "id"){
+        id: ID! @external
+        name: String!
+        reviews: [Reviews] @requires(fields: "name")
+      }
+      type Reviews @key(fields: "id") {
+          id: ID!
+          review: String!
+      }
+    errlist: [
+      {"message": "Type Product; Field name must be @external.", "locations": [ { "line": 4, "column": 23} ] }
+    ]
+  - name: "@provides directive used on field with type that does not have a @key."
+    input: |
+      type Product @key(fields: "id"){
+        id: ID!
+        name: String!
+        reviews: [Reviews] @provides(fields: "name")
+      }
+      type Reviews {
+        id: ID!
+        name: String
+      }
+    errlist: [
+      {"message": "Type Product; Field reviews does not return a type that has a @key.", "locations": [ { "line": 4, "column": 23} ] }
+    ]
 
     
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1373,8 +1373,8 @@ func customDirectiveValidation(sch *ast.Schema,
 	}
 
 	defn := sch.Types[typ.Name]
-	id := getIDField(defn, make(map[string]bool))
-	xid := getXIDField(defn, make(map[string]bool))
+	id := getIDField(defn, nil)
+	xid := getXIDField(defn, nil)
 	if !isQueryOrMutationType(typ) {
 		if len(id) == 0 && len(xid) == 0 {
 			errs = append(errs, gqlerror.ErrorPosf(

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1373,8 +1373,8 @@ func customDirectiveValidation(sch *ast.Schema,
 	}
 
 	defn := sch.Types[typ.Name]
-	id := getIDField(defn)
-	xid := getXIDField(defn)
+	id := getIDField(defn, make(map[string]bool))
+	xid := getXIDField(defn, make(map[string]bool))
 	if !isQueryOrMutationType(typ) {
 		if len(id) == 0 && len(xid) == 0 {
 			errs = append(errs, gqlerror.ErrorPosf(
@@ -2065,6 +2065,77 @@ func apolloExtendsValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.List
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			remoteDirective.Definition.Position,
 			"Type %s; @remote directive cannot be defined with @extends directive", typ.Name)}
+	}
+	return nil
+}
+
+func apolloRequiresValidation(sch *ast.Schema,
+	typ *ast.Definition,
+	field *ast.FieldDefinition,
+	dir *ast.Directive,
+	secrets map[string]x.SensitiveByteSlice) gqlerror.List {
+
+	extendsDirective := typ.Directives.ForName(apolloExtendsDirective)
+	if extendsDirective == nil {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", typ.Name, field.Name)}
+	}
+
+	arg := dir.Arguments.ForName(apolloKeyArg)
+	if arg == nil || arg.Value.Raw == "" {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Argument %s inside @requires directive must be defined.", typ.Name, apolloKeyArg)}
+	}
+
+	fldList := strings.Fields(arg.Value.Raw)
+	for _, fld := range fldList {
+		fldDefn := typ.Fields.ForName(fld)
+		if fldDefn == nil {
+			return []*gqlerror.Error{gqlerror.ErrorPosf(
+				dir.Position,
+				"Type %s; @requires directive uses a field %s which is not defined inside the type.", typ.Name, fld)}
+		}
+		if !hasExternal(fldDefn) {
+			return []*gqlerror.Error{gqlerror.ErrorPosf(
+				dir.Position,
+				"Type %s; Field %s must be @external.", typ.Name, fld)}
+		}
+	}
+	return nil
+}
+
+func apolloProvidesValidation(sch *ast.Schema,
+	typ *ast.Definition,
+	field *ast.FieldDefinition,
+	dir *ast.Directive,
+	secrets map[string]x.SensitiveByteSlice) gqlerror.List {
+
+	typ.Directives.ForName(apolloKeyDirective)
+	fldTypeDefn := sch.Types[field.Type.Name()]
+	keyDirective := fldTypeDefn.Directives.ForName(apolloKeyDirective)
+	if keyDirective == nil {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Field %s does not return a type that has a @key.", typ.Name, field.Name)}
+	}
+
+	arg := dir.Arguments.ForName(apolloKeyArg)
+	if arg == nil || arg.Value.Raw == "" {
+		return []*gqlerror.Error{gqlerror.ErrorPosf(
+			dir.Position,
+			"Type %s; Argument %s inside @provides directive must be defined.", typ.Name, apolloKeyArg)}
+	}
+
+	fldList := strings.Fields(arg.Value.Raw)
+	for _, fld := range fldList {
+		fldDefn := fldTypeDefn.Fields.ForName(fld)
+		if fldDefn == nil {
+			return []*gqlerror.Error{gqlerror.ErrorPosf(
+				dir.Position,
+				"Type %s; Field %s: @provides field %s doesn't exist for type %s.", typ.Name, field.Name, fld, fldTypeDefn.Name)}
+		}
 	}
 	return nil
 }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -2112,7 +2112,6 @@ func apolloProvidesValidation(sch *ast.Schema,
 	dir *ast.Directive,
 	secrets map[string]x.SensitiveByteSlice) gqlerror.List {
 
-	typ.Directives.ForName(apolloKeyDirective)
 	fldTypeDefn := sch.Types[field.Type.Name()]
 	keyDirective := fldTypeDefn.Directives.ForName(apolloKeyDirective)
 	if keyDirective == nil {

--- a/graphql/schema/testdata/apolloservice/input/extended-types.graphql
+++ b/graphql/schema/testdata/apolloservice/input/extended-types.graphql
@@ -1,6 +1,6 @@
 type Mission @key(fields: "id") {
     id: ID!
-    crew: [Astronaut]
+    crew: [Astronaut] @provides(fields: "name age")
     designation: String!
     startDate: String
     endDate: String
@@ -8,5 +8,15 @@ type Mission @key(fields: "id") {
 
 type Astronaut @key(fields: "id") @extends {
     id: ID! @external
+    name: String @external
+    age: Int @external
     missions: [Mission]
 }
+
+ extend type Product @key(fields: "upc") {
+    upc: String! @id @external
+    price: Int @external
+    weight: Int @external
+    inStock: Boolean
+    shippingEstimate: Float @requires(fields: "price weight")
+  }

--- a/graphql/schema/testdata/apolloservice/output/extended-types.graphql
+++ b/graphql/schema/testdata/apolloservice/output/extended-types.graphql
@@ -4,7 +4,7 @@
 
 type Mission @key(fields: "id") {
 	id: ID!
-	crew: [Astronaut]
+	crew: [Astronaut] @provides(fields: "name age")
 	designation: String!
 	startDate: String
 	endDate: String
@@ -12,8 +12,18 @@ type Mission @key(fields: "id") {
 
 type Astronaut @key(fields: "id") @extends {
 	id: ID! @external
+	name: String @external
+	age: Int @external
 	missions(filter: MissionFilter, order: MissionOrder, first: Int, offset: Int): [Mission]
 	missionsAggregate(filter: MissionFilter): MissionAggregateResult
+}
+
+type Product @key(fields: "upc") @extends {
+	upc: String! @id @external
+	price: Int @external
+	weight: Int @external
+	inStock: Boolean
+	shippingEstimate: Float @requires(fields: "price weight")
 }
 
 #######################
@@ -280,10 +290,21 @@ type AddMissionPayload {
 	numUids: Int
 }
 
+type AddProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	numUids: Int
+}
+
 type AstronautAggregateResult {
 	count: Int
 	idMin: ID
 	idMax: ID
+	nameMin: String
+	nameMax: String
+	ageMin: Int
+	ageMax: Int
+	ageSum: Int
+	ageAvg: Float
 }
 
 type DeleteAstronautPayload {
@@ -298,6 +319,12 @@ type DeleteMissionPayload {
 	numUids: Int
 }
 
+type DeleteProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	msg: String
+	numUids: Int
+}
+
 type MissionAggregateResult {
 	count: Int
 	designationMin: String
@@ -306,6 +333,16 @@ type MissionAggregateResult {
 	startDateMax: String
 	endDateMin: String
 	endDateMax: String
+}
+
+type ProductAggregateResult {
+	count: Int
+	upcMin: String
+	upcMax: String
+	shippingEstimateMin: Float
+	shippingEstimateMax: Float
+	shippingEstimateSum: Float
+	shippingEstimateAvg: Float
 }
 
 type UpdateAstronautPayload {
@@ -318,16 +355,25 @@ type UpdateMissionPayload {
 	numUids: Int
 }
 
+type UpdateProductPayload {
+	product(filter: ProductFilter, order: ProductOrder, first: Int, offset: Int): [Product]
+	numUids: Int
+}
+
 #######################
 # Generated Enums
 #######################
 
 enum AstronautHasFilter {
+	name
+	age
 	missions
 }
 
 enum AstronautOrderable {
 	id
+	name
+	age
 }
 
 enum MissionHasFilter {
@@ -343,12 +389,25 @@ enum MissionOrderable {
 	endDate
 }
 
+enum ProductHasFilter {
+	upc
+	inStock
+	shippingEstimate
+}
+
+enum ProductOrderable {
+	upc
+	shippingEstimate
+}
+
 #######################
 # Generated Inputs
 #######################
 
 input AddAstronautInput {
 	id: ID!
+	name: String
+	age: Int
 	missions: [MissionRef]
 }
 
@@ -357,6 +416,12 @@ input AddMissionInput {
 	designation: String!
 	startDate: String
 	endDate: String
+}
+
+input AddProductInput {
+	upc: String!
+	inStock: Boolean
+	shippingEstimate: Float
 }
 
 input AstronautFilter {
@@ -374,11 +439,15 @@ input AstronautOrder {
 }
 
 input AstronautPatch {
+	name: String
+	age: Int
 	missions: [MissionRef]
 }
 
 input AstronautRef {
 	id: ID
+	name: String
+	age: Int
 	missions: [MissionRef]
 }
 
@@ -411,6 +480,31 @@ input MissionRef {
 	endDate: String
 }
 
+input ProductFilter {
+	upc: StringHashFilter
+	has: [ProductHasFilter]
+	and: [ProductFilter]
+	or: [ProductFilter]
+	not: ProductFilter
+}
+
+input ProductOrder {
+	asc: ProductOrderable
+	desc: ProductOrderable
+	then: ProductOrder
+}
+
+input ProductPatch {
+	inStock: Boolean
+	shippingEstimate: Float
+}
+
+input ProductRef {
+	upc: String
+	inStock: Boolean
+	shippingEstimate: Float
+}
+
 input UpdateAstronautInput {
 	filter: AstronautFilter!
 	set: AstronautPatch
@@ -421,6 +515,12 @@ input UpdateMissionInput {
 	filter: MissionFilter!
 	set: MissionPatch
 	remove: MissionPatch
+}
+
+input UpdateProductInput {
+	filter: ProductFilter!
+	set: ProductPatch
+	remove: ProductPatch
 }
 
 #######################
@@ -444,5 +544,8 @@ type Mutation {
 	addAstronaut(input: [AddAstronautInput!]!): AddAstronautPayload
 	updateAstronaut(input: UpdateAstronautInput!): UpdateAstronautPayload
 	deleteAstronaut(filter: AstronautFilter!): DeleteAstronautPayload
+	addProduct(input: [AddProductInput!]!, upsert: Boolean): AddProductPayload
+	updateProduct(input: UpdateProductInput!): UpdateProductPayload
+	deleteProduct(filter: ProductFilter!): DeleteProductPayload
 }
 

--- a/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/input/apollo-federation.graphql
@@ -1,12 +1,15 @@
 extend type Product @key(fields: "id") {
     id: ID! @external
     name: String! @external
-    reviews: [Reviews]
+    price: Int @external
+    weight: Int @external
+    reviews: [Reviews] @requires(fields: "price weight")
 }
 
 type Reviews @key(fields: "id") {
     id: ID!
     review: String!
+    user: User @provides(fields: "age")
 }
 
 type Student @key(fields: "id"){
@@ -17,12 +20,13 @@ type Student @key(fields: "id"){
 
 type School @key(fields: "id"){
     id: ID!
-    students: [Student]
+    students: [Student] @provides(fields: "name")
 }
 
 extend type User @key(fields: "name") {
     id: ID! @external
     name: String! @id @external
+    age: Int! @external
     reviews: [Reviews]
 }
 

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -5,6 +5,7 @@
 type Reviews @key(fields: "id") {
 	id: ID!
 	review: String!
+	user(filter: UserFilter): User @provides(fields: "age")
 }
 
 type Student @key(fields: "id") {
@@ -15,7 +16,7 @@ type Student @key(fields: "id") {
 
 type School @key(fields: "id") {
 	id: ID!
-	students(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student]
+	students(filter: StudentFilter, order: StudentOrder, first: Int, offset: Int): [Student] @provides(fields: "name")
 	studentsAggregate(filter: StudentFilter): StudentAggregateResult
 }
 
@@ -27,13 +28,16 @@ type Country {
 type Product @key(fields: "id") @extends {
 	id: ID! @external
 	name: String! @external
-	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
+	price: Int @external
+	weight: Int @external
+	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews] @requires(fields: "price weight")
 	reviewsAggregate(filter: ReviewsFilter): ReviewsAggregateResult
 }
 
 type User @key(fields: "name") @extends {
 	id: ID! @external
 	name: String! @id @external
+	age: Int! @external
 	reviews(filter: ReviewsFilter, order: ReviewsOrder, first: Int, offset: Int): [Reviews]
 	reviewsAggregate(filter: ReviewsFilter): ReviewsAggregateResult
 }
@@ -312,6 +316,8 @@ type _Service {
 }
 
 directive @external on FIELD_DEFINITION
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
 directive @key(fields: _FieldSet!) on OBJECT | INTERFACE
 directive @extends on OBJECT | INTERFACE
 
@@ -453,6 +459,10 @@ type UserAggregateResult {
 	count: Int
 	nameMin: String
 	nameMax: String
+	ageMin: Int
+	ageMax: Int
+	ageSum: Int
+	ageAvg: Float
 }
 
 #######################
@@ -479,6 +489,7 @@ enum ProductOrderable {
 
 enum ReviewsHasFilter {
 	review
+	user
 }
 
 enum ReviewsOrderable {
@@ -501,11 +512,13 @@ enum StudentOrderable {
 
 enum UserHasFilter {
 	name
+	age
 	reviews
 }
 
 enum UserOrderable {
 	name
+	age
 }
 
 #######################
@@ -524,6 +537,7 @@ input AddProductInput {
 
 input AddReviewsInput {
 	review: String!
+	user: UserRef
 }
 
 input AddSchoolInput {
@@ -537,6 +551,7 @@ input AddStudentInput {
 
 input AddUserInput {
 	name: String!
+	age: Int!
 	reviews: [ReviewsRef]
 }
 
@@ -602,11 +617,13 @@ input ReviewsOrder {
 
 input ReviewsPatch {
 	review: String
+	user: UserRef
 }
 
 input ReviewsRef {
 	id: ID
 	review: String
+	user: UserRef
 }
 
 input SchoolFilter {
@@ -702,11 +719,13 @@ input UserOrder {
 }
 
 input UserPatch {
+	age: Int
 	reviews: [ReviewsRef]
 }
 
 input UserRef {
 	name: String
+	age: Int
 	reviews: [ReviewsRef]
 }
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -815,6 +815,12 @@ func nonExternalAndKeyFields(defn *ast.Definition) ast.FieldList {
 	return fldList
 }
 
+// externalAndNonKeyField returns true for those fields which have @external directive and
+// are not @key fields and are not an arugment to the @provides directive.
+func externalAndNonKeyField(fld *ast.FieldDefinition, defn *ast.Definition, providesTypeMap map[string]bool) bool {
+	return hasExternal(fld) && !isKeyField(fld, defn) && !providesTypeMap[fld.Name]
+}
+
 // buildCustomDirectiveForLambda returns custom directive for the given field to be used for @lambda
 // The constructed @custom looks like this:
 //	@custom(http: {


### PR DESCRIPTION
Fixes GRAPHQL-1053.
This PR adds support for @provides and @requires directive for Apollo federation according to the [federation specs](https://www.apollographql.com/docs/federation/federation-spec/).
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7503)
<!-- Reviewable:end -->
