### PR TITLE
fix(multi-tenancy): fix live loader for case when namespace does not exist for data

### DIFF
--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -84,10 +84,11 @@ type loader struct {
 	conflicts map[uint64]struct{}
 	uidsLock  sync.RWMutex
 
-	reqNum   uint64
-	reqs     chan *request
-	zeroconn *grpc.ClientConn
-	schema   *schema
+	reqNum     uint64
+	reqs       chan *request
+	zeroconn   *grpc.ClientConn
+	schema     *schema
+	namespaces map[uint64]struct{}
 
 	upsertLock sync.RWMutex
 }

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -259,6 +259,7 @@ func (l *loader) processSchemaFile(ctx context.Context, file string, key x.Sensi
 	op := &api.Operation{}
 	op.Schema = string(b)
 	if opt.namespaceToLoad == math.MaxUint64 {
+		// Verify schema if we are loding into multiple namespaces.
 		if err := validateSchema(op.Schema, l.namespaces); err != nil {
 			return err
 		}
@@ -733,7 +734,7 @@ func run() error {
 		}
 	}()
 	ctx := context.Background()
-	galaxyOp := false
+	var galaxyOp bool
 	if len(creds.GetString("user")) > 0 && creds.GetUint64("namespace") == x.GalaxyNamespace &&
 		opt.namespaceToLoad != x.GalaxyNamespace {
 		galaxyOp = true
@@ -768,7 +769,7 @@ func run() error {
 	defer l.zeroconn.Close()
 
 	if err := l.populateNamespaces(ctx, dg, galaxyOp); err != nil {
-		fmt.Printf("Error while populating namespaces %v", err)
+		fmt.Printf("Error while populating namespaces %s\n", err)
 		return err
 	}
 
@@ -792,8 +793,7 @@ func run() error {
 		fmt.Printf("Processed schema file %q\n\n", opt.schemaFile)
 	}
 
-	l.schema, err = getSchema(ctx, dg, opt.namespaceToLoad)
-	if err != nil {
+	if l.schema, err = getSchema(ctx, dg, opt.namespaceToLoad); err != nil {
 		fmt.Printf("Error while loading schema from alpha %s\n", err)
 		return err
 	}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -655,6 +655,9 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 // populateNamespace fetches the schema and extracts the information about the existing namespaces.
 func (l *loader) populateNamespaces(ctx context.Context, dc *dgo.Dgraph, isGalaxyOp bool) error {
 	if !isGalaxyOp {
+		// The below schema query returns the predicates without the namespace if context does not
+		// have the galaxy operation set. As we are not loading data across namespaces, so existence
+		// of namespace is verified when the user logs in.
 		l.namespaces[opt.namespaceToLoad] = struct{}{}
 		return nil
 	}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -651,8 +651,9 @@ func setup(opts batchMutationOptions, dc *dgo.Dgraph, conf *viper.Viper) *loader
 	return l
 }
 
-func (l *loader) populateNamespaces(ctx context.Context, dc *dgo.Dgraph, loginNs uint64) error {
-	if loginNs != x.GalaxyNamespace {
+// populateNamespace fetches the schema and extracts the information about the existing namespaces.
+func (l *loader) populateNamespaces(ctx context.Context, dc *dgo.Dgraph) error {
+	if !x.IsGalaxyOperation(ctx) {
 		l.namespaces[opt.namespaceToLoad] = struct{}{}
 		return nil
 	}
@@ -762,7 +763,7 @@ func run() error {
 	l := setup(bmOpts, dg, Live.Conf)
 	defer l.zeroconn.Close()
 
-	if err := l.populateNamespaces(ctx, dg, creds.GetUint64("namespace")); err != nil {
+	if err := l.populateNamespaces(ctx, dg); err != nil {
 		fmt.Printf("Error while populating namespaces %v", err)
 		return err
 	}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -719,6 +719,7 @@ func run() error {
 		ns := Live.Conf.GetInt64("force-namespace")
 		if ns < 0 {
 			opt.preserveNs = true
+			opt.namespaceToLoad = math.MaxUint64
 		} else {
 			opt.namespaceToLoad = uint64(ns)
 		}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -259,7 +259,7 @@ func (l *loader) processSchemaFile(ctx context.Context, file string, key x.Sensi
 
 	op := &api.Operation{}
 	op.Schema = string(b)
-	if opt.namespaceToLoad == preserveNs {
+	if opt.preserveNs {
 		// Verify schema if we are loding into multiple namespaces.
 		if err := validateSchema(op.Schema, l.namespaces); err != nil {
 			return err

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -18,13 +18,14 @@ package testutil
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net"
 	"os"
 	"os/exec"
 	"strconv"
+
+	"github.com/pkg/errors"
 )
 
 type LiveOpts struct {
@@ -65,11 +66,11 @@ func LiveLoad(opts LiveOpts) error {
 		liveCmd.Env = append(os.Environ(), opts.Env...)
 	}
 
-	out, err := liveCmd.Output()
+	out, err := liveCmd.CombinedOutput()
 	if err != nil {
 		fmt.Printf("Error %v\n", err)
 		fmt.Printf("Output %v\n", string(out))
-		return err
+		return errors.Wrapf(err, string(out))
 	}
 	if CheckIfRace(out) {
 		return errors.New("race condition detected. check logs for more details")


### PR DESCRIPTION
Fixes DGRAPH-3075

Earlier, when live-loading data through Guardians of Galaxy, the NQuads make their way to the DB even if the namespace does not exist for them. This might lead to very interesting bugs.

This PR fixes it by extracting the namespaces by querying the schema. If we encounter a Nquad or schema for which namespace does not exist, we error out and live loader stops.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7505)
<!-- Reviewable:end -->
