### PR TITLE
breaking(metrics): Rename Badger metrics.

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -180,12 +180,12 @@ func TestMetrics(t *testing.T) {
 		"go_memstats_heap_idle_bytes", "go_memstats_heap_inuse_bytes", "dgraph_latency_bucket",
 
 		// Badger Metrics
-		"badger_v3_disk_reads_total", "badger_v3_disk_writes_total", "badger_v3_gets_total",
-		"badger_v3_memtable_gets_total", "badger_v3_puts_total", "badger_v3_read_bytes",
-		"badger_v3_written_bytes",
+		"badger_disk_reads_total", "badger_disk_writes_total", "badger_gets_total",
+		"badger_memtable_gets_total", "badger_puts_total", "badger_read_bytes",
+		"badger_written_bytes",
 		// The following metrics get exposed after 1 minute from Badger, so
 		// they're not available in time for this test
-		// "badger_v3_lsm_size_bytes", "badger_v3_vlog_size_bytes",
+		// "badger_lsm_size_bytes", "badger_vlog_size_bytes",
 
 		// Transaction Metrics
 		"dgraph_txn_aborts_total", "dgraph_txn_commits_total", "dgraph_txn_discards_total",

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -446,57 +446,57 @@ func init() {
 func NewBadgerCollector() prometheus.Collector {
 	return prometheus.NewExpvarCollector(map[string]*prometheus.Desc{
 		"badger_v3_disk_reads_total": prometheus.NewDesc(
-			"badger_v3_disk_reads_total",
+			"badger_disk_reads_total",
 			"Number of cumulative reads by Badger",
 			nil, nil,
 		),
 		"badger_v3_disk_writes_total": prometheus.NewDesc(
-			"badger_v3_disk_writes_total",
+			"badger_disk_writes_total",
 			"Number of cumulative writes by Badger",
 			nil, nil,
 		),
 		"badger_v3_read_bytes": prometheus.NewDesc(
-			"badger_v3_read_bytes",
+			"badger_read_bytes",
 			"Number of cumulative bytes read by Badger",
 			nil, nil,
 		),
 		"badger_v3_written_bytes": prometheus.NewDesc(
-			"badger_v3_written_bytes",
+			"badger_written_bytes",
 			"Number of cumulative bytes written by Badger",
 			nil, nil,
 		),
 		"badger_v3_lsm_level_gets_total": prometheus.NewDesc(
-			"badger_v3_lsm_level_gets_total",
+			"badger_lsm_level_gets_total",
 			"Total number of LSM gets",
 			[]string{"level"}, nil,
 		),
 		"badger_v3_lsm_bloom_hits_total": prometheus.NewDesc(
-			"badger_v3_lsm_bloom_hits_total",
+			"badger_lsm_bloom_hits_total",
 			"Total number of LSM bloom hits",
 			[]string{"level"}, nil,
 		),
 		"badger_v3_gets_total": prometheus.NewDesc(
-			"badger_v3_gets_total",
+			"badger_gets_total",
 			"Total number of gets",
 			nil, nil,
 		),
 		"badger_v3_puts_total": prometheus.NewDesc(
-			"badger_v3_puts_total",
+			"badger_puts_total",
 			"Total number of puts",
 			nil, nil,
 		),
 		"badger_v3_memtable_gets_total": prometheus.NewDesc(
-			"badger_v3_memtable_gets_total",
+			"badger_memtable_gets_total",
 			"Total number of memtable gets",
 			nil, nil,
 		),
 		"badger_v3_lsm_size_bytes": prometheus.NewDesc(
-			"badger_v3_lsm_size_bytes",
+			"badger_lsm_size_bytes",
 			"Size of the LSM in bytes",
 			[]string{"dir"}, nil,
 		),
 		"badger_v3_vlog_size_bytes": prometheus.NewDesc(
-			"badger_v3_vlog_size_bytes",
+			"badger_vlog_size_bytes",
 			"Size of the value log in bytes",
 			[]string{"dir"}, nil,
 		),


### PR DESCRIPTION
This renames the Badger metrics in the /metrics endpoint to remove the
Badger version in the metric names. This allows the metric name to
remain the same across Badger major versions.

| Previous Name                   | New Name                     |
| ------------------------------- | ---------------------------- |
| badger_v3_disk_reads_total      | badger_disk_reads_total      |
| badger_v3_disk_writes_total     | badger_disk_writes_total     |
| badger_v3_read_bytes            | badger_read_bytes            |
| badger_v3_written_bytes         | badger_written_bytes         |
| badger_v3_lsm_bloom_hits_total  | badger_lsm_bloom_hits_total  |
| badger_v3_gets_total            | badger_gets_total            |
| badger_v3_puts_total            | badger_puts_total            |
| badger_v3_memtable_gets_total   | badger_memtable_gets_total    |
| badger_v3_lsm_size_bytes        | badger_lsm_size_bytes        |
| badger_v3_vlog_size_bytes       | badger_vlog_size_bytes       |

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7507)
<!-- Reviewable:end -->
