### PR TITLE
release/v20.11: fix(schema): log error instead of panic if schema not found for predicate (#7502)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -313,7 +313,12 @@ func (s *state) Tokenizer(ctx context.Context, pred string) []tok.Tokenizer {
 			su = schema
 		}
 	}
-	x.AssertTruef(su != nil, "schema state not found for %s", pred)
+	if su == nil {
+		// This may happen when some query that needs indexing over this predicate is executing
+		// while the predicate is dropped from the state (using drop operation).
+		glog.Errorf("Schema state not found for %s.", pred)
+		return nil
+	}
 	tokenizers := make([]tok.Tokenizer, 0, len(su.Tokenizer))
 	for _, it := range su.Tokenizer {
 		t, found := tok.GetTokenizer(it)

--- a/worker/tokens.go
+++ b/worker/tokens.go
@@ -84,6 +84,9 @@ func pickTokenizer(ctx context.Context, attr string, f string) (tok.Tokenizer, e
 	}
 
 	tokenizers := schema.State().Tokenizer(ctx, attr)
+	if tokenizers == nil {
+		return nil, errors.Errorf("Schema state not found for %s.", attr)
+	}
 	for _, t := range tokenizers {
 		// If function is eq and we found a tokenizer that's !Lossy(), lets return it
 		switch f {


### PR DESCRIPTION

This PR fixes alpha panic when drop operation and the query is run concurrently.
This may happen when some query that needs indexing over this predicate is executing while the predicate is dropped from the state (using drop operation).

(cherry picked from commit 96073fcf52c527fa16addf3bc08b6c57100ee73e)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7509)
<!-- Reviewable:end -->
