### PR TITLE
Fix(admin-endpoints): Error out if the request is rejected by the server

### DIFF
--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -152,8 +152,8 @@ func shutDownHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}`,
 	}
-	resp := resolveWithAdminServer(gqlReq, r, adminServer)
-	if len(resp.Errors) != 0 {
+
+	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
 		x.SetStatus(w, resp.Errors[0].Message, "Shutdown failed.")
 		return
 	}
@@ -192,8 +192,8 @@ func exportHandler(w http.ResponseWriter, r *http.Request) {
 		}`,
 		Variables: map[string]interface{}{},
 	}
-	resp := resolveWithAdminServer(gqlReq, r, adminServer)
-	if len(resp.Errors) != 0 {
+
+	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
 		x.SetStatus(w, resp.Errors[0].Message, "Export failed.")
 		return
 	}
@@ -251,8 +251,7 @@ func memoryLimitGetHandler(w http.ResponseWriter, r *http.Request) {
 		  }
 		}`,
 	}
-	resp := resolveWithAdminServer(gqlReq, r, adminServer)
-	if len(resp.Errors) != 0 {
+	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
 		x.SetStatus(w, resp.Errors[0].Message, "Get cache_mb failed")
 		return
 	}

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -131,7 +131,11 @@ func drainingHandler(w http.ResponseWriter, r *http.Request) {
 		}`,
 		Variables: map[string]interface{}{"enable": enable},
 	}
-	_ = resolveWithAdminServer(gqlReq, r, adminServer)
+	resp := resolveWithAdminServer(gqlReq, r, adminServer)
+	if len(resp.Errors) != 0 {
+		x.SetStatus(w, resp.Errors[0].Message, "Shutdown failed.")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	x.Check2(w.Write([]byte(fmt.Sprintf(`{"code": "Success",`+
 		`"message": "draining mode has been set to %v"}`, enable))))
@@ -148,7 +152,11 @@ func shutDownHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}`,
 	}
-	_ = resolveWithAdminServer(gqlReq, r, adminServer)
+	resp := resolveWithAdminServer(gqlReq, r, adminServer)
+	if len(resp.Errors) != 0 {
+		x.SetStatus(w, resp.Errors[0].Message, "Shutdown failed.")
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	x.Check2(w.Write([]byte(`{"code": "Success", "message": "Server is shutting down"}`)))
 }
@@ -244,6 +252,10 @@ func memoryLimitGetHandler(w http.ResponseWriter, r *http.Request) {
 		}`,
 	}
 	resp := resolveWithAdminServer(gqlReq, r, adminServer)
+	if len(resp.Errors) != 0 {
+		x.SetStatus(w, resp.Errors[0].Message, "Get cache_mb failed")
+		return
+	}
 	var data struct {
 		Config struct {
 			CacheMb float64

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -133,7 +133,7 @@ func drainingHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	resp := resolveWithAdminServer(gqlReq, r, adminServer)
 	if len(resp.Errors) != 0 {
-		x.SetStatus(w, resp.Errors[0].Message, "Shutdown failed.")
+		x.SetStatus(w, resp.Errors[0].Message, "draining mode request failed.")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -131,8 +131,7 @@ func drainingHandler(w http.ResponseWriter, r *http.Request) {
 		}`,
 		Variables: map[string]interface{}{"enable": enable},
 	}
-	resp := resolveWithAdminServer(gqlReq, r, adminServer)
-	if len(resp.Errors) != 0 {
+	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
 		x.SetStatus(w, resp.Errors[0].Message, "draining mode request failed.")
 		return
 	}

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -250,7 +250,8 @@ func memoryLimitGetHandler(w http.ResponseWriter, r *http.Request) {
 		  }
 		}`,
 	}
-	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
+	resp := resolveWithAdminServer(gqlReq, r, adminServer)
+	if len(resp.Errors) != 0 {
 		x.SetStatus(w, resp.Errors[0].Message, "Get cache_mb failed")
 		return
 	}

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1074,9 +1074,8 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	// AuthorizeGuardians will extract (user, []groups) from the JWT claims and will check if
 	// any of the group to which the user belongs is "guardians" or not.
 	if err := AuthorizeGuardians(ctx); err != nil {
-		return err
+		return errors.Wrap(err, "AuthGuradiansOfTheGalaxy, failed to authorize guarrdians")
 	}
-	glog.V(2).Info("Successfully authorised the guardian of the galaxy")
 	return nil
 }
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1074,7 +1074,7 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	// AuthorizeGuardians will extract (user, []groups) from the JWT claims and will check if
 	// any of the group to which the user belongs is "guardians" or not.
 	if err := AuthorizeGuardians(ctx); err != nil {
-		return errors.Wrap(err, "AuthGuradiansOfTheGalaxy, failed to authorize guarrdians")
+		return errors.Wrap(err, "AuthGuardianOfTheGalaxy, failed to authorize guardians")
 	}
 	glog.V(3).Info("Successfully authorised guardian of the galaxy")
 	return nil

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1076,7 +1076,7 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	if err := AuthorizeGuardians(ctx); err != nil {
 		return errors.Wrap(err, "AuthGuradiansOfTheGalaxy, failed to authorize guarrdians")
 	}
-	glog.V(3).Info("Successfully authorised guardians of the galaxy")
+	glog.V(3).Info("Successfully authorised guardian of the galaxy")
 	return nil
 }
 

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1076,6 +1076,7 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	if err := AuthorizeGuardians(ctx); err != nil {
 		return errors.Wrap(err, "AuthGuradiansOfTheGalaxy, failed to authorize guarrdians")
 	}
+	glog.V(3).Info("Successfully authorised guardians of the galaxy")
 	return nil
 }
 


### PR DESCRIPTION
A few admin endpoints such as `/admin/shutdown`, `/admin/drain`, `admin/config` sends a success response even if the server rejects the request. This PR fixes the issue. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7511)
<!-- Reviewable:end -->
