### PR TITLE
Fix(GraphQL): Fix Upsert mutations in case of multiple upserts

### DIFF
--- a/graphql/admin/update_group.go
+++ b/graphql/admin/update_group.go
@@ -48,7 +48,7 @@ func (urw *updateGroupRewriter) Rewrite(
 		return nil, nil
 	}
 
-	upsertQuery := resolve.RewriteUpsertQueryFromMutation(m, nil, resolve.MutationQueryVar, "")
+	upsertQuery := resolve.RewriteUpsertQueryFromMutation(m, nil, resolve.MutationQueryVar, m.Name(), "")
 	srcUID := resolve.MutationQueryVarUID
 
 	var errSet, errDel error

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -857,10 +857,10 @@
     }
   dgquerysec: |-
     query {
-      State1 as addState(func: uid(0x11)) @filter(type(State)) {
+      State1 as State1(func: uid(0x11)) @filter(type(State)) {
         uid
       }
-      State3 as addState(func: uid(0x13)) @filter(type(State)) {
+      State3 as State3(func: uid(0x13)) @filter(type(State)) {
         uid
       }
       var(func: uid(State1)) {
@@ -951,7 +951,7 @@
     }
   dgquerysec: |-
     query {
-      Book2 as addBook(func: uid(0x11)) @filter(type(Book)) {
+      Book2 as Book2(func: uid(0x11)) @filter(type(Book)) {
         uid
       }
     }
@@ -1000,7 +1000,7 @@
     }
   dgquerysec: |-
     query {
-      Book2 as addBook(func: uid(0x11)) @filter(type(Book)) {
+      Book2 as Book2(func: uid(0x11)) @filter(type(Book)) {
         uid
       }
     }
@@ -1058,7 +1058,7 @@
     }
   dgquerysec: |-
     query {
-      State1 as addState(func: uid(0x11)) @filter(type(State)) {
+      State1 as State1(func: uid(0x11)) @filter(type(State)) {
         uid
       }
       var(func: uid(State1)) {

--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -1251,7 +1251,7 @@
     }
   dgquerysec: |-
     query {
-      Tweets1 as addTweets(func: uid(TweetsRoot)) {
+      Tweets1 as Tweets1(func: uid(TweetsRoot)) {
         uid
       }
       TweetsRoot as var(func: uid(Tweets2))
@@ -1333,7 +1333,7 @@
     }
   dgquerysec: |-
     query {
-      State1 as addState(func: uid(StateRoot)) {
+      State1 as State1(func: uid(StateRoot)) {
         uid
       }
       StateRoot as var(func: uid(State3)) @filter(uid(StateAuth4))


### PR DESCRIPTION
Fixes GRAPHQL-1052
Testing:
1. Modified yaml tests.
2. Added e2e test.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7515)
<!-- Reviewable:end -->
