### PR TITLE
Fix(Dgraph): Change max open file descriptor dividing factor.

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -209,9 +209,9 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	}
 	glog.Infof("Max open files limit: %d", maxOpenFileLimit)
 	// Badger opens around 8 files for indexing per predicate.
-	// The throttle limit is set to maxOpenFileLimit/8 to ensure that indexing does not throw
+	// The throttle limit is set to maxOpenFileLimit/64 to ensure that indexing does not throw
 	// "Too many open files" error.
-	throttle := y.NewThrottle(maxOpenFileLimit / 8)
+	throttle := y.NewThrottle(maxOpenFileLimit / 64)
 
 	buildIndexes := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild) {
 		// In case background indexing is running, we should call it here again.


### PR DESCRIPTION
Currently, to reduce frequency of "Too many open files" error on schema update, we have a throttle which allows a maximum of maxOpenFiles / 8 files to open at a time.
After having an internal discussion, it was found out that a factor of 8 could be insufficient to prevent such errors. Moreover, a factor of 64 also found out to not change latency of updates much.

Benchmarks: (Update on empty schema with factors )
1. maxOpenfiles / 8 : 11.040 secs.
4. maxOpenFiles / 64: 8.673 secs.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7519)
<!-- Reviewable:end -->
