### PR TITLE
chores(release) - modularized release.sh

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -187,19 +187,19 @@ build_windows() {
     pushd $basedir/dgraph/dgraph
       xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe -ldflags \
           "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-      mkdir $TMP/windows
-      mv dgraph-windows-4.0-$GOARCH.exe $TMP/windows/dgraph.exe
+      mkdir $TMP/$GOARCH/windows
+      mv dgraph-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph.exe
     popd
 
     pushd $basedir/badger/badger
       xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe .
-      mv badger-windows-4.0-$GOARCH.exe $TMP/windows/badger.exe
+      mv badger-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/badger.exe
     popd
 
     if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
       pushd $basedir/ratel
         xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version"  -buildmode=exe .
-        mv ratel-windows-4.0-$GOARCH.exe $TMP/windows/dgraph-ratel.exe
+        mv ratel-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph-ratel.exe
       popd
     fi
   fi
@@ -277,20 +277,20 @@ createSum () {
 
 export GOARCH=amd64
 # Build Binaries
-build_windows()
-build_darwin()
-build_linux()
+build_windows
+build_darwin
+build_linux
 
 # Build Checksums
 createSum linux
 [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
-[[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum windows
+[[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createSum windows
 
 # export GOARCH=arm64
 # Build Binaries
-# build_windows()
-# build_darwin()
-# build_linux()
+# build_windows
+# build_darwin
+# build_linux
 # Build Checksums
 # createSum linux
 # [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
@@ -336,7 +336,7 @@ createZip () {
 
 # Build Archives
 createTar linux
-[[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createZip windows
+[[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createZip windows
 [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createTar darwin
 
 # TODO: fork on $GOARCH

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -272,6 +272,7 @@ createSum () {
   fi
 }
 
+## TODO: Add arm64 buildkit support once xgo works for arm64
 build_docker_image() {
   if [[ "$GOARCH" == "amd64" ]]; then
     # Create Dgraph Docker image.
@@ -344,6 +345,9 @@ if [[ $DGRAPH_BUILD_AMD64 =~ 1|true ]]; then
   export GOARCH=amd64
   build_artifacts
 fi
+
+## Currently arm64 xgo fails for dgraph and badger
+## * https://github.com/techknowlogick/xgo/issues/105
 if [[ $DGRAPH_BUILD_ARM64 =~ 1|true ]]; then
   export GOARCH=arm64
   build_artifacts

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -312,8 +312,7 @@ createZip () {
   rm -Rf $TMP/$os/$GOARCH
 }
 
-export GOARCH=amd64
-build artifacts() {
+build_artifacts() {
   # Build Binaries
   [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && build_windows
   [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && build_darwin
@@ -338,7 +337,12 @@ build artifacts() {
   ls -alh $TMP
 }
 
+export GOARCH=amd64
 build_artifacts
+export GOARCH=arm64
+build_artifacts
+
+
 
 set +o xtrace
 echo "To release:"

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -340,11 +340,10 @@ build_artifacts() {
   ls -alh $TMP
 }
 
-DGRAPH_BUILD_AMD64=${DGRAPH_BUILD_AMD64:-1}
-DGRAPH_BUILD_ARM64=${DGRAPH_BUILD_ARM64:-0}
 if [[ $DGRAPH_BUILD_AMD64 =~ 1|true ]]; then
   export GOARCH=amd64
   build_artifacts
+fi
 if [[ $DGRAPH_BUILD_ARM64 =~ 1|true ]]; then
   export GOARCH=arm64
   build_artifacts

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -183,51 +183,46 @@ fi
 
 build_windows() {
   # Build Windows.
-  if [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]]; then
-    pushd $basedir/dgraph/dgraph
-      xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe -ldflags \
-          "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-      mkdir -p $TMP/$GOARCH/windows
-      mv dgraph-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph.exe
-    popd
+  pushd $basedir/dgraph/dgraph
+    xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe -ldflags \
+        "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+    mkdir -p $TMP/$GOARCH/windows
+    mv dgraph-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph.exe
+  popd
 
-    pushd $basedir/badger/badger
-      xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe .
-      mv badger-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/badger.exe
-    popd
+  pushd $basedir/badger/badger
+    xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe .
+    mv badger-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/badger.exe
+  popd
 
-    if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
-      pushd $basedir/ratel
-        xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version"  -buildmode=exe .
-        mv ratel-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph-ratel.exe
-      popd
-    fi
+  if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+    pushd $basedir/ratel
+      xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version"  -buildmode=exe .
+      mv ratel-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph-ratel.exe
+    popd
   fi
 }
 
 build_darwin() {
   # Build Darwin.
-  if [[ $DGRAPH_BUILD_MAC =~ 1|true ]]; then
-    pushd $basedir/dgraph/dgraph
-      xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags \
-      "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-      mkdir -p $TMP/darwin/$GOARCH
-      mv dgraph-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph
-    popd
+  pushd $basedir/dgraph/dgraph
+    xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags \
+    "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+    mkdir -p $TMP/darwin/$GOARCH
+    mv dgraph-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph
+  popd
 
-    pushd $basedir/badger/badger
-      xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE .
-      mv badger-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/badger
-    popd
+  pushd $basedir/badger/badger
+    xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE .
+    mv badger-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/badger
+  popd
 
-    if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
-      pushd $basedir/ratel
-        xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version" .
-        mv ratel-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph-ratel
-      popd
-    fi
+  if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+    pushd $basedir/ratel
+      xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version" .
+      mv ratel-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph-ratel
+    popd
   fi
-
 }
 
 build_linux() {
@@ -275,27 +270,6 @@ createSum () {
   fi
 }
 
-export GOARCH=amd64
-# Build Binaries
-build_windows
-build_darwin
-build_linux
-
-# Build Checksums
-createSum linux
-[[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
-[[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createSum windows
-
-# export GOARCH=arm64
-# Build Binaries
-# build_windows
-# build_darwin
-# build_linux
-# Build Checksums
-# createSum linux
-# [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
-# [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum windows
-
 build_docker_image() {
   if [[ "$GOARCH" == "amd64" ]]; then
     # Create Dgraph Docker image.
@@ -318,8 +292,6 @@ build_docker_image() {
   fi
 }
 
-build_docker_image
-
 # Create the tar and delete the binaries.
 createTar () {
   os=$1
@@ -340,15 +312,33 @@ createZip () {
   rm -Rf $TMP/$os/$GOARCH
 }
 
-# Build Archives
-createTar linux
-[[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createZip windows
-[[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createTar darwin
+export GOARCH=amd64
+build artifacts() {
+  # Build Binaries
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && build_windows
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && build_darwin
+  build_linux
 
-# TODO: fork on $GOARCH
-echo "Release $TAG is ready."
-docker run dgraph/dgraph:$DOCKER_TAG dgraph
-ls -alh $TMP
+  # Build Checksums
+  createSum linux
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createSum windows
+
+  # Build Docker images
+  build_docker_image
+
+  # Build Archives
+  createTar linux
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createZip windows
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createTar darwin
+
+  # TODO: fork on $GOARCH
+  echo "Release $TAG is ready."
+  docker run dgraph/dgraph:$DOCKER_TAG dgraph
+  ls -alh $TMP
+}
+
+build_artifacts
 
 set +o xtrace
 echo "To release:"


### PR DESCRIPTION
This is an update to the release.sh to modularize some of the process so that it can be repeated across different GOARCH environments, e.g. `arm64`.

Changes: 
* `build_docker_image()` to encapsulate building docker images
* `build_darwin()`, `build_windows()`, `build_linux()` to encapsulate process for building target platforms
* `build_artifacts()` to encapsulate building binaries on all target, checksum, archive, and docker image.
* added support for `$GOARCH` var for building archives, checksum, docker image, and building binaries with `xgo`

Not Goals:
* command line options for all of these
* updated makefiles and other build scripts outside of release + xgo
* support for arm64 with multi-platform docker images

Issues Found:
* `xgo` can build `amd64`, but has problem with `zstd` on `arm64` with dgraph and badger.
   * https://github.com/techknowlogick/xgo/issues/105

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7521)
<!-- Reviewable:end -->
