### PR TITLE
Chore(GraphQL): Fix flaky behaviour of TestLargeSchemaUpdate

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -1138,7 +1138,7 @@ func (params *GraphQLParams) createApplicationGQLPost(url string) (*http.Request
 
 // RunGQLRequest runs a HTTP GraphQL request and returns the data or any errors.
 func RunGQLRequest(req *http.Request) ([]byte, error) {
-	client := &http.Client{Timeout: 50 * time.Second}
+	client := &http.Client{Timeout: 200 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -553,7 +553,7 @@ func TestUpdateGQLSchemaFields(t *testing.T) {
 // TestLargeSchemaUpdate makes sure that updating large schemas (4000 fields with indexes) does not
 // throw any error
 func TestLargeSchemaUpdate(t *testing.T) {
-	numFields := 1000
+	numFields := 250
 
 	schema := "type LargeSchema {"
 	for i := 1; i <= numFields; i++ {


### PR DESCRIPTION
Motivatoin:
TestLargeSchemaUpdate test was failing when race flag is set to true in "Periodic Test All" tests. This PR reduce the size of large schema from 1000 to 250 fields. It also changes the time out of update gql schema request from 50 seconds to 200 seconds.

It took around 80 seconds for the test to run locally with race = true. The timeout has been set to 200 seconds to keep a buffe on slower machinesr.

Testing:
1. Tested locally with race flag set to true.
2. Tested without the throttling of indexing code (the test fails in this case as expected)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7522)
<!-- Reviewable:end -->
