### PR TITLE
fix(GRAPHQL): fix query rewriting for multiple order on nested field.

### DIFF
--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -219,7 +219,7 @@ func writeOrderAndPage(b *strings.Builder, query *gql.GraphQuery, root bool) {
 	var wroteOrder, wroteFirst bool
 
 	for _, ord := range query.Order {
-		if root {
+		if root || wroteOrder {
 			x.Check2(b.WriteString(", "))
 		}
 		if ord.Desc {

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1357,7 +1357,7 @@
     query {
       queryAuthor {
         name
-        posts(filter: { title: { anyofterms: "GraphQL" } }, order: { asc: numLikes,then:{desc:title}}, first: 10, offset: 10) {
+        posts(filter: { title: { anyofterms: "GraphQL" } }, order: { asc: numLikes, then: { desc: title } }, first: 10, offset: 10) {
           title
         }
       }

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -1352,6 +1352,29 @@
     }
 
 -
+  name: "Deep filter with multiple order, first and offset"
+  gqlquery: |
+    query {
+      queryAuthor {
+        name
+        posts(filter: { title: { anyofterms: "GraphQL" } }, order: { asc: numLikes,then:{desc:title}}, first: 10, offset: 10) {
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryAuthor(func: type(Author)) {
+        Author.name : Author.name
+        Author.posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) (orderasc: Post.numLikes, orderdesc: Post.title, first: 10, offset: 10) {
+          Post.title : Post.title
+          dgraph.uid : uid
+        }
+        dgraph.uid : uid
+      }
+    }
+
+-
   name: "Float with large exponentiation"
   gqlquery: |
     query {


### PR DESCRIPTION
We were not adding the `, ` in-between multiple orders in query rewriting for the nested field.
For example the order given in this filter 

posts(filter: { title: { anyofterms: "GraphQL" } }, `order: { asc: numLikes, then: { desc: title } }`, first: 10, offset: 10) got written to below dgraph statement

Author.posts : Author.posts @filter(anyofterms(Post.title, "GraphQL")) (`orderasc: Post.numLikesorderdesc: Post.title`, first: 10, offset: 10)

where there is no comma between two orders. We have fixed it in this PR.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7523)
<!-- Reviewable:end -->
