### PR TITLE
fix(export): fix namespace parameter in export

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -196,7 +196,8 @@ const (
 		format: String
 
 		"""
-		Namespace for the export, if no value is given then it exports all namespaces.
+		Namespace for the export in multi-tenant cluster. Users from guardians of galaxy can export
+		all namespaces by passing a negative value or specific namespaceId to export that namespace.
 		"""
 		namespace: Int
 

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -72,7 +72,7 @@ func resolveExport(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 			return uint64(inputNs), nil
 		default:
 			if input.Namespace != notSet && uint64(input.Namespace) != ns {
-				return 0, errors.Errorf("Not allowed to export namespace %#x", ns)
+				return 0, errors.Errorf("not allowed to export namespace %#x", input.Namespace)
 			}
 		}
 		return ns, nil

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -30,9 +30,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const notSet = math.MaxInt64
+
 type exportInput struct {
 	Format    string
-	Namespace uint64
+	Namespace int64
 	DestinationFields
 }
 
@@ -53,18 +55,37 @@ func resolveExport(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 		}
 	}
 
-	// For the request made from non-galaxy user, use the namespace from the context.
-	ns, err := x.ExtractNamespace(ctx)
-	if err != nil {
-		return resolve.EmptyResult(m, err), false
+	validateAndGetNs := func(inputNs int64) (uint64, error) {
+		ns, err := x.ExtractNamespace(ctx)
+		if err != nil {
+			return 0, err
+		}
+		if input.Namespace == notSet {
+			// If namespace parameter is not set, use the namespace from the context.
+			return ns, nil
+		}
+		switch ns {
+		case x.GalaxyNamespace:
+			if input.Namespace < 0 { // export all namespaces.
+				return math.MaxUint64, nil
+			}
+			return uint64(inputNs), nil
+		default:
+			if input.Namespace != notSet && uint64(input.Namespace) != ns {
+				return 0, errors.Errorf("Not allowed to export namespace %#x", ns)
+			}
+		}
+		return ns, nil
 	}
-	if ns != x.GalaxyNamespace {
-		input.Namespace = ns
+
+	var exportNs uint64
+	if exportNs, err = validateAndGetNs(input.Namespace); err != nil {
+		return resolve.EmptyResult(m, err), false
 	}
 
 	files, err := worker.ExportOverNetwork(ctx, &pb.ExportRequest{
 		Format:       format,
-		Namespace:    input.Namespace,
+		Namespace:    exportNs,
 		Destination:  input.Destination,
 		AccessKey:    input.AccessKey,
 		SecretKey:    input.SecretKey,
@@ -107,7 +128,7 @@ func getExportInput(m schema.Mutation) (*exportInput, error) {
 	// Export everything if namespace is not specified.
 	if v, ok := inputArg.(map[string]interface{}); ok {
 		if _, ok := v["namespace"]; !ok {
-			input.Namespace = math.MaxUint64
+			input.Namespace = notSet
 		}
 	}
 	return &input, schema.GQLWrapf(err, "couldn't get input argument")


### PR DESCRIPTION
This PR fixes the `namespace` parameter in export mutation. 
Current behaviour:
- Guardian of galaxy: 
If nothing is passed, exports Galaxy Namespace. If negative value is passed, exports all namespaces, else exports the specified namespace.
- Guardian of other namespace(ns):
If nothing is passed, exports `ns`. If a negative value is passed or the value passed `nsPassed != ns`, error is returned.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7524)
<!-- Reviewable:end -->
