### PR TITLE
Fix(Rollups): Don't try splitting a posting list with cardinality less than 2.

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -1088,11 +1088,14 @@ func (ro *rollupOutput) getRange(uid uint64) (uint64, uint64) {
 }
 
 func shouldSplit(plist *pb.PostingList) (bool, error) {
-	r := roaring64.New()
-	if err := codec.FromPostingList(r, plist); err != nil {
-		return false, err
+	if plist.Size() >= maxListSize {
+		r := roaring64.New()
+		if err := codec.FromPostingList(r, plist); err != nil {
+			return false, err
+		}
+		return r.GetCardinality() > 1, nil
 	}
-	return plist.Size() >= maxListSize && r.GetCardinality() > 1, nil
+	return false, nil
 }
 
 func (ro *rollupOutput) runSplits() error {

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -977,6 +977,26 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 	return ol, commits
 }
 
+func TestLargePlistSplit(t *testing.T) {
+	key := x.DataKey(uuid.New().String(), 1331)
+	ol, err := getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	b := make([]byte, 30<<20)
+	rand.Read(b)
+	for i := 1; i <= 2; i++ {
+		edge := &pb.DirectedEdge{
+			ValueId: uint64(i),
+			Facets:  []*api.Facet{{Key: strconv.Itoa(i)}},
+			Value:   b,
+		}
+		txn := Txn{StartTs: uint64(i)}
+		addMutationHelper(t, ol, edge, Set, &txn)
+		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+	}
+	_, err = ol.Rollup(nil)
+	require.NoError(t, err)
+}
+
 func TestDeleteStarMultiPartList(t *testing.T) {
 	numEdges := 10000
 


### PR DESCRIPTION
This PR fixes the issue of rollups getting hung. it happened because there was no check on the cardinality of the posting.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7525)
<!-- Reviewable:end -->
