### PR TITLE
fix(live): fix usage of force-namespace parameter in live loader

### DIFF
--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -47,7 +47,9 @@ func LiveLoad(opts LiveOpts) error {
 		"--schema", opts.SchemaFile,
 		"--alpha", opts.Alpha,
 		"--zero", opts.Zero,
-		"--force-namespace", strconv.FormatInt(opts.ForceNs, 10),
+	}
+	if opts.ForceNs != 0 {
+		args = append(args, "--force-namespace", strconv.FormatInt(opts.ForceNs, 10))
 	}
 	if opts.Ludicrous {
 		args = append(args, "--ludicrous")


### PR DESCRIPTION
This PR fixes the behaviour of `--force-namespace` flag in live loader.
Earlier, we used to silently ignore this flag when passed by the non-galaxy user. Now, we throw an error if the force-namespace flag is used by the non-galaxy user. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7526)
<!-- Reviewable:end -->
