### PR TITLE
feat(GraphQL): Allow Multiple JWKUrls for auth.

### DIFF
--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -74,10 +74,11 @@ type AuthMeta struct {
 func (a *AuthMeta) validate() error {
 	var fields string
 
-	// If JWKUrl is provided, we don't expect (VerificationKey, Algo),
-	// they are needed only if JWKUrl is not present there.
+	// If JWKUrl/JWKUrls is provided, we don't expect (VerificationKey, Algo),
+	// they are needed only if JWKUrl/JWKUrls is not present there.
 	if len(a.JWKUrls) != 0 || a.JWKUrl != "" {
 
+		// User cannot provide both JWKUrl and JWKUrls.
 		if len(a.JWKUrls) != 0 && a.JWKUrl != "" {
 			return fmt.Errorf("expecting either JWKUrl or JWKUrls, both were given")
 		}
@@ -344,11 +345,10 @@ func GetJwtToken(ctx context.Context) string {
 	return jwtToken[0]
 }
 
+// validateThroughJWKUrl validates the JWT token against the given list of JWKUrls.
+// It returns an error only if the token is not validated against even one of the
+// JWKUrl.
 func (a *AuthMeta) validateThroughJWKUrl(jwtStr string) (*jwt.Token, error) {
-	if len(a.JWKUrls) == 0 {
-		return nil, errors.Errorf("no JWKUrl present")
-	}
-
 	var err error
 	var token *jwt.Token
 	for i := 0; i < len(a.JWKUrls); i++ {

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -57,8 +57,9 @@ var (
 type AuthMeta struct {
 	VerificationKey string
 	JWKUrl          string
-	jwkSet          *jose.JSONWebKeySet
-	expiryTime      time.Time
+	JWKUrls         []string
+	jwkSet          []*jose.JSONWebKeySet
+	expiryTime      []time.Time
 	RSAPublicKey    *rsa.PublicKey `json:"-"` // Ignoring this field
 	Header          string
 	Namespace       string
@@ -75,9 +76,14 @@ func (a *AuthMeta) validate() error {
 
 	// If JWKUrl is provided, we don't expect (VerificationKey, Algo),
 	// they are needed only if JWKUrl is not present there.
-	if a.JWKUrl != "" {
+	if len(a.JWKUrls) != 0 || a.JWKUrl != "" {
+
+		if len(a.JWKUrls) != 0 && a.JWKUrl != "" {
+			return fmt.Errorf("expecting either JWKUrl or JWKUrls, both were given")
+		}
+
 		if a.VerificationKey != "" || a.Algo != "" {
-			return fmt.Errorf("expecting either JWKUrl or (VerificationKey, Algo), both were given")
+			return fmt.Errorf("expecting either JWKUrl/JWKUrls or (VerificationKey, Algo), both were given")
 		}
 
 		// Audience should be a required field if JWKUrl is provided.
@@ -86,7 +92,7 @@ func (a *AuthMeta) validate() error {
 		}
 	} else {
 		if a.VerificationKey == "" {
-			fields = " `Verification key`/`JWKUrl`"
+			fields = " `Verification key`/`JWKUrl`/`JWKUrls`"
 		}
 
 		if a.Algo == "" {
@@ -125,6 +131,15 @@ func Parse(schema string) (*AuthMeta, error) {
 			return nil, algoErr
 		}
 
+		if meta.JWKUrl != "" {
+			meta.JWKUrls = append(meta.JWKUrls, meta.JWKUrl)
+			meta.JWKUrl = ""
+		}
+
+		if len(meta.JWKUrls) != 0 {
+			meta.expiryTime = make([]time.Time, len(meta.JWKUrls))
+			meta.jwkSet = make([]*jose.JSONWebKeySet, len(meta.JWKUrls))
+		}
 		return &meta, nil
 	}
 
@@ -329,16 +344,18 @@ func GetJwtToken(ctx context.Context) string {
 	return jwtToken[0]
 }
 
-func (a *AuthMeta) validateJWTCustomClaims(jwtStr string) (*CustomClaims, error) {
-	var token *jwt.Token
+func (a *AuthMeta) validateThroughJWKUrl(jwtStr string) (*jwt.Token, error) {
+	if len(a.JWKUrls) == 0 {
+		return nil, errors.Errorf("no JWKUrl present")
+	}
+
 	var err error
-	// Verification through JWKUrl
-	if a.JWKUrl != "" {
-		if a.isExpired() {
-			err = a.refreshJWK()
-			if err != nil {
-				return nil, errors.Wrap(err, "while refreshing JWK from the URL")
-			}
+	var token *jwt.Token
+	for i := 0; i < len(a.JWKUrls); i++ {
+		a.isExpired(i)
+		err = a.refreshJWK(i)
+		if err != nil {
+			return nil, errors.Wrap(err, "while refreshing JWK from the URL")
 		}
 
 		token, err =
@@ -348,12 +365,26 @@ func (a *AuthMeta) validateJWTCustomClaims(jwtStr string) (*CustomClaims, error)
 					return nil, errors.Errorf("kid not present in JWT")
 				}
 
-				signingKeys := a.jwkSet.Key(kid.(string))
+				signingKeys := a.jwkSet[0].Key(kid.(string))
 				if len(signingKeys) == 0 {
 					return nil, errors.Errorf("Invalid kid")
 				}
 				return signingKeys[0].Key, nil
 			}, jwt.WithoutAudienceValidation())
+
+		if err == nil {
+			return token, nil
+		}
+	}
+	return nil, err
+}
+
+func (a *AuthMeta) validateJWTCustomClaims(jwtStr string) (*CustomClaims, error) {
+	var token *jwt.Token
+	var err error
+	// Verification through JWKUrl
+	if len(a.JWKUrls) != 0 {
+		token, err = a.validateThroughJWKUrl(jwtStr)
 	} else {
 		if a.Algo == "" {
 			return nil, fmt.Errorf(
@@ -399,12 +430,16 @@ func (a *AuthMeta) validateJWTCustomClaims(jwtStr string) (*CustomClaims, error)
 
 // FetchJWKs fetches the JSON Web Key set from a JWKUrl. It acquires a Lock over a as some of the
 // properties of AuthMeta are modified in the process.
-func (a *AuthMeta) FetchJWKs() error {
-	if a.JWKUrl == "" {
+func (a *AuthMeta) FetchJWKs(i int) error {
+	if len(a.JWKUrls) == 0 {
 		return errors.Errorf("No JWKUrl supplied")
 	}
 
-	req, err := http.NewRequest("GET", a.JWKUrl, nil)
+	if len(a.JWKUrls) <= i {
+		return errors.Errorf("not enough JWKUrls")
+	}
+
+	req, err := http.NewRequest("GET", a.JWKUrls[i], nil)
 	if err != nil {
 		return err
 	}
@@ -430,9 +465,9 @@ func (a *AuthMeta) FetchJWKs() error {
 		return err
 	}
 
-	a.jwkSet = &jose.JSONWebKeySet{Keys: make([]jose.JSONWebKey, len(jwkArray.JWKs))}
-	for i, jwk := range jwkArray.JWKs {
-		err = a.jwkSet.Keys[i].UnmarshalJSON(jwk)
+	a.jwkSet[i] = &jose.JSONWebKeySet{Keys: make([]jose.JSONWebKey, len(jwkArray.JWKs))}
+	for k, jwk := range jwkArray.JWKs {
+		err = a.jwkSet[i].Keys[k].UnmarshalJSON(jwk)
 		if err != nil {
 			return err
 		}
@@ -447,18 +482,18 @@ func (a *AuthMeta) FetchJWKs() error {
 	}
 
 	if maxAge == 0 {
-		a.expiryTime = time.Time{}
+		a.expiryTime[i] = time.Time{}
 	} else {
-		a.expiryTime = time.Now().Add(time.Duration(maxAge) * time.Second)
+		a.expiryTime[i] = time.Now().Add(time.Duration(maxAge) * time.Second)
 	}
 
 	return nil
 }
 
-func (a *AuthMeta) refreshJWK() error {
+func (a *AuthMeta) refreshJWK(i int) error {
 	var err error
 	for i := 0; i < 3; i++ {
-		err = a.FetchJWKs()
+		err = a.FetchJWKs(i)
 		if err == nil {
 			return nil
 		}
@@ -471,18 +506,18 @@ func (a *AuthMeta) refreshJWK() error {
 // if expiryTime is equal to 0 which means there
 // is no expiry time of the JWKs, so it always
 // returns false
-func (a *AuthMeta) isExpired() bool {
-	if a.expiryTime.IsZero() {
+func (a *AuthMeta) isExpired(i int) bool {
+	if a.expiryTime[i].IsZero() {
 		return false
 	}
-	return time.Now().After(a.expiryTime)
+	return time.Now().After(a.expiryTime[i])
 }
 
 // initSigningMethod takes the current Algo value, validates it's a supported SigningMethod, then sets the SigningMethod
 // field.
 func (a *AuthMeta) initSigningMethod() error {
 	// configurations using JWK URLs do not use signing methods.
-	if a.JWKUrl != "" {
+	if len(a.JWKUrls) != 0 || a.JWKUrl != "" {
 		return nil
 	}
 

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -352,10 +352,11 @@ func (a *AuthMeta) validateThroughJWKUrl(jwtStr string) (*jwt.Token, error) {
 	var err error
 	var token *jwt.Token
 	for i := 0; i < len(a.JWKUrls); i++ {
-		a.isExpired(i)
-		err = a.refreshJWK(i)
-		if err != nil {
-			return nil, errors.Wrap(err, "while refreshing JWK from the URL")
+		if a.isExpired(i) {
+			err = a.refreshJWK(i)
+			if err != nil {
+				return nil, errors.Wrap(err, "while refreshing JWK from the URL")
+			}
 		}
 
 		token, err =
@@ -365,7 +366,7 @@ func (a *AuthMeta) validateThroughJWKUrl(jwtStr string) (*jwt.Token, error) {
 					return nil, errors.Errorf("kid not present in JWT")
 				}
 
-				signingKeys := a.jwkSet[0].Key(kid.(string))
+				signingKeys := a.jwkSet[i].Key(kid.(string))
 				if len(signingKeys) == 0 {
 					return nil, errors.Errorf("Invalid kid")
 				}

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -264,7 +264,7 @@ func TestInvalidAuthInfo(t *testing.T) {
 	authSchema, err := testutil.AppendJWKAndVerificationKey(sch)
 	require.NoError(t, err)
 	_, err = schema.NewHandler(string(authSchema), false)
-	require.Error(t, err, fmt.Errorf("Expecting either JWKUrl or (VerificationKey, Algo), both were given"))
+	require.Error(t, err, fmt.Errorf("Expecting either JWKUrl/JWKUrls or (VerificationKey, Algo), both were given"))
 }
 
 func TestMissingAudienceWithJWKUrl(t *testing.T) {
@@ -293,7 +293,8 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 	require.Equal(t, metainfo.Header, "X-Test-Auth")
 	require.Equal(t, metainfo.Namespace, "https://xyz.io/jwt/claims")
 	require.Equal(t, metainfo.VerificationKey, "")
-	require.Equal(t, metainfo.JWKUrl, "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com")
+	require.Equal(t, metainfo.JWKUrl, "")
+	require.Equal(t, metainfo.JWKUrls, []string{"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"})
 
 	testCase := struct {
 		name  string

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -281,7 +281,7 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 	sch, err := ioutil.ReadFile("../e2e/auth/schema.graphql")
 	require.NoError(t, err, "Unable to read schema file")
 
-	authSchema, err := testutil.AppendAuthInfoWithJWKUrl(sch)
+	authSchema, err := testutil.AppendAuthInfoWithJWKUrls(sch)
 	require.NoError(t, err)
 
 	schema := test.LoadSchemaFromString(t, string(authSchema))
@@ -294,21 +294,38 @@ func TestVerificationWithJWKUrl(t *testing.T) {
 	require.Equal(t, metainfo.Namespace, "https://xyz.io/jwt/claims")
 	require.Equal(t, metainfo.VerificationKey, "")
 	require.Equal(t, metainfo.JWKUrl, "")
-	require.Equal(t, metainfo.JWKUrls, []string{"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"})
+	require.Equal(t, metainfo.JWKUrls, []string{"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "https://dev-hr2kugfp.us.auth0.com/.well-known/jwks.json"})
 
-	testCase := struct {
-		name  string
-		token string
+	testCases := []struct {
+		name    string
+		token   string
+		invalid bool
 	}{
-		name:  `Expired Token`,
-		token: "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE2NzUwM2UwYWVjNTJkZGZiODk2NTIxYjkxN2ZiOGUyMGMxZjMzMDAiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZmlyLXByb2plY3QxLTI1OWU3IiwiYXVkIjoiZmlyLXByb2plY3QxLTI1OWU3IiwiYXV0aF90aW1lIjoxNjAxNDQ0NjM0LCJ1c2VyX2lkIjoiMTdHb3h2dU5CWlc5YTlKU3Z3WXhROFc0bjE2MyIsInN1YiI6IjE3R294dnVOQlpXOWE5SlN2d1l4UThXNG4xNjMiLCJpYXQiOjE2MDE0NDQ2MzQsImV4cCI6MTYwMTQ0ODIzNCwiZW1haWwiOiJtaW5oYWpAZGdyYXBoLmlvIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7ImVtYWlsIjpbIm1pbmhhakBkZ3JhcGguaW8iXX0sInNpZ25faW5fcHJvdmlkZXIiOiJwYXNzd29yZCJ9fQ.q5YmOzOUkZHNjlz53hgLNSVg-brIU9tLJ4jLC0_Xurl5wEbyZ6D_KQ9-UFqbl2HR6R1V5kpaf6eDFR3c83i1PpCbJ4LTjHAf_njQvL75ByERld23lZtKZyEeE6ujdFXL8ne4fI2qenD1Xeqx9AnXbLf7U_CvZpbX3l1wj7p0Lpn7qixi0AztuLSJMLkMfFpaiwyFZQivi4cqtnI25VIsK6a4KIpl1Sk0AHT-lv9PRadd_JDjWAIzD0SfhpZOskaeA9PljVMp-Y3Xscwg_Qc6u1MIBPg1jKO-ngjhWkgEWBoz5F836P7phT60LVBHhYuk-jRN6HSSNWQ3ineuN-jBkg",
+		{
+			name:    `Expired Token`,
+			token:   "eyJhbGciOiJSUzI1NiIsImtpZCI6IjE2NzUwM2UwYWVjNTJkZGZiODk2NTIxYjkxN2ZiOGUyMGMxZjMzMDAiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL3NlY3VyZXRva2VuLmdvb2dsZS5jb20vZmlyLXByb2plY3QxLTI1OWU3IiwiYXVkIjoiZmlyLXByb2plY3QxLTI1OWU3IiwiYXV0aF90aW1lIjoxNjAxNDQ0NjM0LCJ1c2VyX2lkIjoiMTdHb3h2dU5CWlc5YTlKU3Z3WXhROFc0bjE2MyIsInN1YiI6IjE3R294dnVOQlpXOWE5SlN2d1l4UThXNG4xNjMiLCJpYXQiOjE2MDE0NDQ2MzQsImV4cCI6MTYwMTQ0ODIzNCwiZW1haWwiOiJtaW5oYWpAZGdyYXBoLmlvIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7ImVtYWlsIjpbIm1pbmhhakBkZ3JhcGguaW8iXX0sInNpZ25faW5fcHJvdmlkZXIiOiJwYXNzd29yZCJ9fQ.q5YmOzOUkZHNjlz53hgLNSVg-brIU9tLJ4jLC0_Xurl5wEbyZ6D_KQ9-UFqbl2HR6R1V5kpaf6eDFR3c83i1PpCbJ4LTjHAf_njQvL75ByERld23lZtKZyEeE6ujdFXL8ne4fI2qenD1Xeqx9AnXbLf7U_CvZpbX3l1wj7p0Lpn7qixi0AztuLSJMLkMfFpaiwyFZQivi4cqtnI25VIsK6a4KIpl1Sk0AHT-lv9PRadd_JDjWAIzD0SfhpZOskaeA9PljVMp-Y3Xscwg_Qc6u1MIBPg1jKO-ngjhWkgEWBoz5F836P7phT60LVBHhYuk-jRN6HSSNWQ3ineuN-jBkg",
+			invalid: true,
+		},
+		{
+			name:    `Valid Token`,
+			token:   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IjJKdVZuRkc0Q2JBX0E1VVNkenlDMyJ9.eyJnaXZlbl9uYW1lIjoibWluaGFqIiwiZmFtaWx5X25hbWUiOiJzaGFrZWVsIiwibmlja25hbWUiOiJtc3JpaXRkIiwibmFtZSI6Im1pbmhhaiBzaGFrZWVsIiwicGljdHVyZSI6Imh0dHBzOi8vbGgzLmdvb2dsZXVzZXJjb250ZW50LmNvbS9hLS9BT2gxNEdnYzVEZ2cyQThWZFNzWUNnc2RlR3lFMHM1d01Gdmd2X1htZDA4Q3B3PXM5Ni1jIiwibG9jYWxlIjoiZW4iLCJ1cGRhdGVkX2F0IjoiMjAyMS0wMy0wOVQxMDowOTozNi4yMDNaIiwiZW1haWwiOiJtc3JpaXRkQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpc3MiOiJodHRwczovL2Rldi1ocjJrdWdmcC51cy5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMDM2NTgyNjIxNzU2NDczNzEwNjQiLCJhdWQiOiJIaGFYa1FWUkJuNWUwSzNEbU1wMnpiakk4aTF3Y3YyZSIsImlhdCI6MTYxNTI4NDU3NywiZXhwIjo1MjE1Mjg0NTc3LCJub25jZSI6IlVtUk9NbTV0WWtoR2NGVjVOWGRhVGtKV1UyWm5ZM0pKUzNSR1ZsWk1jRzFLZUVkMGQzWkdkVTFuYXc9PSJ9.rlVl0tGOCypIts0C52g1qyiNaFV3UnDafJETXTGbt-toWvtCyZsa-JySgwG0DD1rMYm-gdwyJcjJlgwVPQD3ZlkJqbFFNvY4cX5injiOljpVFOHKXdi7tehY9We_vv1KYYpvhGMsE4u7o8tz2wEctdLTXT7omEq7gSdHuDgpM-h-K2RLApU8oyu8YOIqQlrqGgJ7Q8jy-jxMlU7BoZVz38FokjmkSapAAVORsbdEqPgQjeDnjaDQ5bRhxZUMSeKvvpvtVlPaeM1NI4S0R3g0qUGvX6L6qsLZqIilSQUiUaOEo8bLNBFHOxhBbocF-R-x40nSYjdjrEz60A99mz5XAA",
+			invalid: false,
+		},
 	}
 
-	md := metadata.New(map[string]string{"authorizationJwt": testCase.token})
-	ctx := metadata.NewIncomingContext(context.Background(), md)
+	for _, tcase := range testCases {
+		t.Run(tcase.name, func(t *testing.T) {
+			md := metadata.New(map[string]string{"authorizationJwt": tcase.token})
+			ctx := metadata.NewIncomingContext(context.Background(), md)
 
-	_, err = metainfo.ExtractCustomClaims(ctx)
-	require.True(t, strings.Contains(err.Error(), "unable to parse jwt token:token is unverifiable: Keyfunc returned an error"))
+			_, err := metainfo.ExtractCustomClaims(ctx)
+			if tcase.invalid {
+				require.True(t, strings.Contains(err.Error(), "unable to parse jwt token:token is unverifiable: Keyfunc returned an error"))
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
 }
 
 // TODO(arijit): Generate the JWT token instead of using pre generated token.

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -401,8 +401,8 @@ func NewHandler(input string, apolloServiceQuery bool) (Handler, error) {
 		return nil, gqlerror.Errorf("No query or mutation found in the generated schema")
 	}
 
-	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
-	// then initialise the http client and Fetch the JWKs from the JWKUrl
+	// If Dgraph.Authorization header is parsed successfully and JWKUrls is present
+	// then initialise the http client and Fetch the JWKs from the JWKUrls.
 	if metaInfo.authMeta != nil && len(metaInfo.authMeta.JWKUrls) != 0 {
 		metaInfo.authMeta.InitHttpClient()
 		for i := 0; i < len(metaInfo.authMeta.JWKUrls); i++ {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -403,11 +403,13 @@ func NewHandler(input string, apolloServiceQuery bool) (Handler, error) {
 
 	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
 	// then initialise the http client and Fetch the JWKs from the JWKUrl
-	if metaInfo.authMeta != nil && metaInfo.authMeta.JWKUrl != "" {
+	if metaInfo.authMeta != nil && len(metaInfo.authMeta.JWKUrls) != 0 {
 		metaInfo.authMeta.InitHttpClient()
-		fetchErr := metaInfo.authMeta.FetchJWKs()
-		if fetchErr != nil {
-			return nil, fetchErr
+		for i := 0; i < len(metaInfo.authMeta.JWKUrls); i++ {
+			fetchErr := metaInfo.authMeta.FetchJWKs(i)
+			if fetchErr != nil {
+				return nil, fetchErr
+			}
 		}
 	}
 

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -405,11 +405,9 @@ func NewHandler(input string, apolloServiceQuery bool) (Handler, error) {
 	// then initialise the http client and Fetch the JWKs from the JWKUrls.
 	if metaInfo.authMeta != nil && len(metaInfo.authMeta.JWKUrls) != 0 {
 		metaInfo.authMeta.InitHttpClient()
-		for i := 0; i < len(metaInfo.authMeta.JWKUrls); i++ {
-			fetchErr := metaInfo.authMeta.FetchJWKs(i)
-			if fetchErr != nil {
-				return nil, fetchErr
-			}
+		fetchErr := metaInfo.authMeta.FetchJWKs()
+		if fetchErr != nil {
+			return nil, fetchErr
 		}
 	}
 

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -1231,7 +1231,7 @@ func TestParseSecrets(t *testing.T) {
 			nil,
 			"",
 			nil,
-			errors.New("required field missing in Dgraph.Authorization: `Verification key`/`JWKUrl` `Algo` `Header` `Namespace`"),
+			errors.New("required field missing in Dgraph.Authorization: `Verification key`/`JWKUrl`/`JWKUrls` `Algo` `Header` `Namespace`"),
 		},
 		{
 			"Should be able to parse  Dgraph.Authorization irrespective of spacing between # and Dgraph.Authorization",

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -248,7 +248,12 @@ func AppendAuthInfo(schema []byte, algo, publicKeyFile string, closedByDefault b
 	return append(schema, []byte(authInfo)...), nil
 }
 
-func AppendAuthInfoWithJWKUrls(schema []byte) ([]byte, error) {
+func AppendAuthInfoWithJWKUrl(schema []byte) ([]byte, error) {
+	authInfo := `#   Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://dev-hr2kugfp.us.auth0.com/.well-known/jwks.json", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":[ "HhaXkQVRBn5e0K3DmMp2zbjI8i1wcv2e"]}`
+	return append(schema, []byte(authInfo)...), nil
+}
+
+func AppendAuthInfoWithMultipleJWKUrls(schema []byte) ([]byte, error) {
 	authInfo := `#   Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurls":["https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com","https://dev-hr2kugfp.us.auth0.com/.well-known/jwks.json"], "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7", "HhaXkQVRBn5e0K3DmMp2zbjI8i1wcv2e"]}`
 	return append(schema, []byte(authInfo)...), nil
 }

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -248,8 +248,8 @@ func AppendAuthInfo(schema []byte, algo, publicKeyFile string, closedByDefault b
 	return append(schema, []byte(authInfo)...), nil
 }
 
-func AppendAuthInfoWithJWKUrl(schema []byte) ([]byte, error) {
-	authInfo := `#   Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurl":"https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com", "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7"]}`
+func AppendAuthInfoWithJWKUrls(schema []byte) ([]byte, error) {
+	authInfo := `#   Dgraph.Authorization {"VerificationKey":"","Header":"X-Test-Auth","jwkurls":["https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com","https://dev-hr2kugfp.us.auth0.com/.well-known/jwks.json"], "Namespace":"https://xyz.io/jwt/claims","Algo":"","Audience":["fir-project1-259e7", "HhaXkQVRBn5e0K3DmMp2zbjI8i1wcv2e"]}`
 	return append(schema, []byte(authInfo)...), nil
 }
 


### PR DESCRIPTION
Fixes GRAPHQL-1048.
This PR adds support for Passing multiple JWKUrls in the authorization header.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7528)
<!-- Reviewable:end -->
