### PR TITLE
fix(flags): Expose global flags to dgraph subcommands.

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -1352,6 +1352,9 @@ Available Commands: {{range .Commands}}{{if (or .IsAvailableCommand)}}
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `
 


### PR DESCRIPTION
This updates the subcommand --help template so that flags like `--config` show
up in the --help output under the "Global Flags:" section.

Example:

    $ dgraph alpha --help
    ...
    Global Flags:
          --alsologtostderr                  log to standard error as well as files
          --bindall                          Use 0.0.0.0 instead of localhost to bind to all addresses on local machine. (default true)
          --block_rate int                   Block profiling rate. Must be used along with block profile_mode
          --config string                    Configuration file. Takes precedence over default values, but is overridden to values set with environment variables and flags.
          --cwd string                       Change working directory to the path specified. The parent must exist.
          --expose_trace                     Allow trace endpoint to be accessible from remote
          --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
          --log_dir string                   If non-empty, write log files in this directory
          --logtostderr                      log to standard error instead of files
          --profile_mode string              Enable profiling mode, one of [cpu, mem, mutex, block]
      -v, --v Level                          log level for V logs
          --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7530)
<!-- Reviewable:end -->
