### PR TITLE
chore(cdc): fix cdc events for drop type and drop predicate

### DIFF
--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -394,13 +394,13 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 	}
 
 	// If drop operation
-	// todo (aman): right now drop operations are still cluster wide.
+	// todo (aman): right now drop all and data operations are still cluster wide.
 	// Fix these once we have namespace specific operations.
 	if mutation.DropOp != pb.Mutations_NONE {
 		ns := make([]byte, 8)
 		binary.BigEndian.PutUint64(ns, 0)
 		var t string
-		if mutation.DropOp == pb.Mutations_TYPE && len(mutation.DropValue) > 0 {
+		if mutation.DropOp == pb.Mutations_TYPE {
 			// drop type are namespace specific.
 			ns, t = x.ParseNamespaceBytes(mutation.DropValue)
 		}

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -398,7 +398,7 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 	// Fix these once we have namespace specific operations.
 	if mutation.DropOp != pb.Mutations_NONE {
 		ns := make([]byte, 8)
-		binary.BigEndian.PutUint64(ns, 0)
+		binary.BigEndian.PutUint64(ns, x.GalaxyNamespace)
 		var t string
 		if mutation.DropOp == pb.Mutations_TYPE {
 			// drop type are namespace specific.

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -120,10 +120,8 @@ func (cdc *CDC) hasPending(attr string) bool {
 	defer cdc.Unlock()
 	for _, events := range cdc.pendingTxnEvents {
 		for _, e := range events {
-			if me, ok := e.Event.(*MutationEvent); ok {
-				if me.Attr == attr {
-					return true
-				}
+			if me, ok := e.Event.(*MutationEvent); ok && me.Attr == attr {
+				return true
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the cdc events in case of drop type or drop predicate.
In case of drop type, there is a nil pointer exception
in case of drop predicate, if there are some pending txns for that predicate, the mutation fails but cdc event was sent. This PR fixes that
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7531)
<!-- Reviewable:end -->
