### PR TITLE
fix(GRAPHQL): Added support for exact index on field having @id directive.

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1648,18 +1648,21 @@ func addHashIfRequired(fld *ast.FieldDefinition, indexes []string) []string {
 	id := fld.Directives.ForName(idDirective)
 	if id != nil {
 		// If @id directive is applied along with @search, we check if the search has hash as an
-		// arg. If it doesn't, then we add it.
-		containsHash := false
-		for _, index := range indexes {
-			if index == "hash" {
-				containsHash = true
-			}
-		}
-		if !containsHash {
+		// arg. If it doesn't and there is no exact arg, then we add hash in it.
+		if !hasIndex(indexes, "hash") && !hasIndex(indexes, "exact") {
 			indexes = append(indexes, "hash")
 		}
 	}
 	return indexes
+}
+
+func hasIndex(indexes []string, index string) bool {
+	for i := range indexes {
+		if indexes[i] == index {
+			return true
+		}
+	}
+	return false
 }
 
 func getDefaultSearchIndex(fldName string) string {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2838,6 +2838,12 @@ valid_schemas:
         f2: String! @id
       }
 
+  - name: "field with @id directive can have exact index"
+    input: |
+      type X {
+        f1: String! @id @search(by:[exact])
+      }
+
   - name: "Type implements from two interfaces where both have ID"
     input: |
       interface X {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -400,7 +400,6 @@ func NewHandler(input string, apolloServiceQuery bool) (Handler, error) {
 	if len(sch.Query.Fields) == 0 && len(sch.Mutation.Fields) == 0 {
 		return nil, gqlerror.Errorf("No query or mutation found in the generated schema")
 	}
-
 	// If Dgraph.Authorization header is parsed successfully and JWKUrl is present
 	// then initialise the http client and Fetch the JWKs from the JWKUrl
 	if metaInfo.authMeta != nil && metaInfo.authMeta.JWKUrl != "" {
@@ -637,6 +636,16 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 					var indexes []string
 					upsertStr := ""
 					search := f.Directives.ForName(searchDirective)
+					if search != nil {
+						arg := search.Arguments.ForName(searchArgs)
+						if arg != nil {
+							indexes = append(indexes, getAllSearchIndexes(arg.Value)...)
+						} else {
+							indexes = append(indexes, supportedSearches[defaultSearches[f.Type.
+								Name()]].dgIndex)
+						}
+					}
+
 					id := f.Directives.ForName(idDirective)
 					if id != nil || f.Type.Name() == "ID" {
 						upsertStr = "@upsert "
@@ -646,17 +655,9 @@ func genDgSchema(gqlSch *ast.Schema, definitions []string) string {
 						case "Float":
 							indexes = append(indexes, "float")
 						case "String", "ID":
-							indexes = append(indexes, "hash")
-						}
-					}
-
-					if search != nil {
-						arg := search.Arguments.ForName(searchArgs)
-						if arg != nil {
-							indexes = append(indexes, getAllSearchIndexes(arg.Value)...)
-						} else {
-							indexes = append(indexes, supportedSearches[defaultSearches[f.Type.
-								Name()]].dgIndex)
+							if !hasIndex(indexes, "exact") {
+								indexes = append(indexes, "hash")
+							}
 						}
 					}
 

--- a/graphql/schema/testdata/schemagen/input/exact-index-on-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/input/exact-index-on-id-field.graphql
@@ -1,0 +1,4 @@
+# This will add exact index on content field, overwriting the default "hash" index for field of type "String! @id".
+type Post {
+    content: String! @id @search(by:[exact])
+}

--- a/graphql/schema/testdata/schemagen/output/exact-index-on-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/exact-index-on-id-field.graphql
@@ -1,0 +1,347 @@
+#######################
+# Input Schema
+#######################
+
+type Post {
+	content: String! @id @search(by: [exact])
+}
+
+#######################
+# Extended Definitions
+#######################
+
+"""
+The Int64 scalar type represents a signed 64‐bit numeric non‐fractional value.
+Int64 can represent values in range [-(2^63),(2^63 - 1)].
+"""
+scalar Int64
+
+"""
+The DateTime scalar type represents date and time as a string in RFC3339 format.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+"""
+scalar DateTime
+
+input IntRange{
+	min: Int!
+	max: Int!
+}
+
+input FloatRange{
+	min: Float!
+	max: Float!
+}
+
+input Int64Range{
+	min: Int64!
+	max: Int64!
+}
+
+input DateTimeRange{
+	min: DateTime!
+	max: DateTime!
+}
+
+input StringRange{
+	min: String!
+	max: String!
+}
+
+enum DgraphIndex {
+	int
+	int64
+	float
+	bool
+	hash
+	exact
+	term
+	fulltext
+	trigram
+	regexp
+	year
+	month
+	day
+	hour
+	geo
+}
+
+input AuthRule {
+	and: [AuthRule]
+	or: [AuthRule]
+	not: AuthRule
+	rule: String
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
+
+enum Mode {
+	BATCH
+	SINGLE
+}
+
+input CustomHTTP {
+	url: String!
+	method: HTTPMethod!
+	body: String
+	graphql: String
+	mode: Mode
+	forwardHeaders: [String!]
+	secretHeaders: [String!]
+	introspectionHeaders: [String!]
+	skipIntrospection: Boolean
+}
+
+type Point {
+	longitude: Float!
+	latitude: Float!
+}
+
+input PointRef {
+	longitude: Float!
+	latitude: Float!
+}
+
+input NearFilter {
+	distance: Float!
+	coordinate: PointRef!
+}
+
+input PointGeoFilter {
+	near: NearFilter
+	within: WithinFilter
+}
+
+type PointList {
+	points: [Point!]!
+}
+
+input PointListRef {
+	points: [PointRef!]!
+}
+
+type Polygon {
+	coordinates: [PointList!]!
+}
+
+input PolygonRef {
+	coordinates: [PointListRef!]!
+}
+
+type MultiPolygon {
+	polygons: [Polygon!]!
+}
+
+input MultiPolygonRef {
+	polygons: [PolygonRef!]!
+}
+
+input WithinFilter {
+	polygon: PolygonRef!
+}
+
+input ContainsFilter {
+	point: PointRef
+	polygon: PolygonRef
+}
+
+input IntersectsFilter {
+	polygon: PolygonRef
+	multiPolygon: MultiPolygonRef
+}
+
+input PolygonGeoFilter {
+	near: NearFilter
+	within: WithinFilter
+	contains: ContainsFilter
+	intersects: IntersectsFilter
+}
+
+input GenerateQueryParams {
+	get: Boolean
+	query: Boolean
+	password: Boolean
+	aggregate: Boolean
+}
+
+input GenerateMutationParams {
+	add: Boolean
+	update: Boolean
+	delete: Boolean
+}
+
+directive @hasInverse(field: String!) on FIELD_DEFINITION
+directive @search(by: [DgraphIndex!]) on FIELD_DEFINITION
+directive @dgraph(type: String, pred: String) on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @id on FIELD_DEFINITION
+directive @withSubscription on OBJECT | INTERFACE | FIELD_DEFINITION
+directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
+directive @auth(
+	password: AuthRule
+	query: AuthRule,
+	add: AuthRule,
+	update: AuthRule,
+	delete: AuthRule) on OBJECT | INTERFACE
+directive @custom(http: CustomHTTP, dql: String) on FIELD_DEFINITION
+directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
+directive @remoteResponse(name: String) on FIELD_DEFINITION
+directive @cascade(fields: [String]) on FIELD
+directive @lambda on FIELD_DEFINITION
+directive @cacheControl(maxAge: Int!) on QUERY
+directive @generate(
+	query: GenerateQueryParams,
+	mutation: GenerateMutationParams,
+	subscription: Boolean) on OBJECT | INTERFACE
+
+input IntFilter {
+	eq: Int
+	in: [Int]
+	le: Int
+	lt: Int
+	ge: Int
+	gt: Int
+	between: IntRange
+}
+
+input Int64Filter {
+	eq: Int64
+	in: [Int64]
+	le: Int64
+	lt: Int64
+	ge: Int64
+	gt: Int64
+	between: Int64Range
+}
+
+input FloatFilter {
+	eq: Float
+	in: [Float]
+	le: Float
+	lt: Float
+	ge: Float
+	gt: Float
+	between: FloatRange
+}
+
+input DateTimeFilter {
+	eq: DateTime
+	in: [DateTime]
+	le: DateTime
+	lt: DateTime
+	ge: DateTime
+	gt: DateTime
+	between: DateTimeRange
+}
+
+input StringTermFilter {
+	allofterms: String
+	anyofterms: String
+}
+
+input StringRegExpFilter {
+	regexp: String
+}
+
+input StringFullTextFilter {
+	alloftext: String
+	anyoftext: String
+}
+
+input StringExactFilter {
+	eq: String
+	in: [String]
+	le: String
+	lt: String
+	ge: String
+	gt: String
+	between: StringRange
+}
+
+input StringHashFilter {
+	eq: String
+	in: [String]
+}
+
+#######################
+# Generated Types
+#######################
+
+type AddPostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	numUids: Int
+}
+
+type DeletePostPayload {
+	post(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	msg: String
+	numUids: Int
+}
+
+type PostAggregateResult {
+	count: Int
+	contentMin: String
+	contentMax: String
+}
+
+#######################
+# Generated Enums
+#######################
+
+enum PostHasFilter {
+	content
+}
+
+enum PostOrderable {
+	content
+}
+
+#######################
+# Generated Inputs
+#######################
+
+input AddPostInput {
+	content: String!
+}
+
+input PostFilter {
+	content: StringExactFilter
+	has: [PostHasFilter]
+	and: [PostFilter]
+	or: [PostFilter]
+	not: PostFilter
+}
+
+input PostOrder {
+	asc: PostOrderable
+	desc: PostOrderable
+	then: PostOrder
+}
+
+input PostRef {
+	content: String!
+}
+
+#######################
+# Generated Query
+#######################
+
+type Query {
+	getPost(content: String!): Post
+	queryPost(filter: PostFilter, order: PostOrder, first: Int, offset: Int): [Post]
+	aggregatePost(filter: PostFilter): PostAggregateResult
+}
+
+#######################
+# Generated Mutations
+#######################
+
+type Mutation {
+	addPost(input: [AddPostInput!]!, upsert: Boolean): AddPostPayload
+	deletePost(filter: PostFilter!): DeletePostPayload
+}
+


### PR DESCRIPTION
Currently we add hash index on a field of type String! @id by default. And as index exact and hash are not compatible , user can't add exact index on such field and can't take advantage of comparator functions like lt,le,gt,ge.

To allow this we now changing that behavior, i.e. for a field of type String! @id @search(by:[exact]) , we don't generate default hash index and only generate exact index.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7533)
<!-- Reviewable:end -->
