### PR TITLE
fix(super-flags): Use GetPath for path arguments in superflags

### DIFF
--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -15,7 +15,6 @@ package audit
 import (
 	"io/ioutil"
 	"math"
-	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -64,7 +63,7 @@ func GetAuditConf(conf string) *x.LoggerConf {
 		return nil
 	}
 	auditFlag := z.NewSuperFlag(conf).MergeAndCheckDefault(worker.AuditDefaults)
-	out := auditFlag.GetString("output")
+	out := auditFlag.GetPath("output")
 	x.AssertTruef(out != "", "out flag is not provided for the audit logs")
 	encBytes, err := readAuditEncKey(auditFlag)
 	x.Check(err)
@@ -79,15 +78,11 @@ func GetAuditConf(conf string) *x.LoggerConf {
 }
 
 func readAuditEncKey(conf *z.SuperFlag) ([]byte, error) {
-	encFile := conf.GetString("encrypt-file")
+	encFile := conf.GetPath("encrypt-file")
 	if encFile == "" {
 		return nil, nil
 	}
-	path, err := filepath.Abs(encFile)
-	if err != nil {
-		return nil, err
-	}
-	encKey, err := ioutil.ReadFile(path)
+	encKey, err := ioutil.ReadFile(encFile)
 	if err != nil {
 		return nil, err
 	}

--- a/ee/utils_ee.go
+++ b/ee/utils_ee.go
@@ -30,7 +30,7 @@ func GetKeys(config *viper.Viper) (x.SensitiveByteSlice, x.SensitiveByteSlice) {
 	aclKey, encKey := vault.GetKeys(config)
 	var err error
 
-	aclKeyFile := aclSuperFlag.GetString("secret-file")
+	aclKeyFile := aclSuperFlag.GetPath("secret-file")
 	if aclKeyFile != "" {
 		if aclKey != nil {
 			glog.Exit("flags: ACL secret key set in both vault and acl flags")

--- a/ee/vault/vault_ee.go
+++ b/ee/vault/vault_ee.go
@@ -186,15 +186,15 @@ func parseFlags(flag *z.SuperFlag) (*config, error) {
 	if err := validateRequired(flagAddr, addr); err != nil {
 		return nil, err
 	}
-	roleIdFile := flag.GetString(flagRoleIdFile)
+	roleIdFile := flag.GetPath(flagRoleIdFile)
 	if err := validateRequired(flagRoleIdFile, roleIdFile); err != nil {
 		return nil, err
 	}
-	secretIdFile := flag.GetString(flagSecretIdFile)
+	secretIdFile := flag.GetPath(flagSecretIdFile)
 	if err := validateRequired(flagSecretIdFile, secretIdFile); err != nil {
 		return nil, err
 	}
-	path := flag.GetString(flagPath)
+	path := flag.GetPath(flagPath)
 	if err := validateRequired(flagPath, path); err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.1.8
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed
-	github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a
+	github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a h1:1cMMkx3iegOzbAxVl1ZZQRHk+gaCf33Y5/4I3l0NNSg=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
+github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90 h1:arWVlUO9NhZ/2vWprIqpe825GISUPpgJhU/b0ep3j/M=
+github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/go.sum
+++ b/go.sum
@@ -128,7 +128,6 @@ github.com/dgraph-io/gqlparser/v2 v2.1.8 h1:d4CprjlDyMNGvnZG/pKqe6Oj6qQd4V0TVsuO
 github.com/dgraph-io/gqlparser/v2 v2.1.8/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:pgGMBoTtFhR+xkyzINaToLYRurHn+6pxMYffIGmmEPc=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
-github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a h1:1cMMkx3iegOzbAxVl1ZZQRHk+gaCf33Y5/4I3l0NNSg=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
 github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90 h1:arWVlUO9NhZ/2vWprIqpe825GISUPpgJhU/b0ep3j/M=
 github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=

--- a/worker/sink_handler.go
+++ b/worker/sink_handler.go
@@ -59,7 +59,7 @@ func GetSink(conf *z.SuperFlag) (Sink, error) {
 	switch {
 	case conf.GetString("kafka") != "":
 		return newKafkaSink(conf)
-	case conf.GetString("file") != "":
+	case conf.GetPath("file") != "":
 		return newFileSink(conf)
 	}
 	return nil, errors.New("sink config is not provided")
@@ -83,14 +83,14 @@ func newKafkaSink(config *z.SuperFlag) (Sink, error) {
 	saramaConf.Producer.Return.Successes = true
 	saramaConf.Producer.Return.Errors = true
 
-	if config.GetString("ca-cert") != "" {
+	if config.GetPath("ca-cert") != "" {
 		tlsCfg := &tls.Config{}
 		var pool *x509.CertPool
 		var err error
 		if pool, err = x509.SystemCertPool(); err != nil {
 			return nil, err
 		}
-		caFile, err := ioutil.ReadFile(config.GetString("ca-cert"))
+		caFile, err := ioutil.ReadFile(config.GetPath("ca-cert"))
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to read ca cert file")
 		}
@@ -98,8 +98,8 @@ func newKafkaSink(config *z.SuperFlag) (Sink, error) {
 			return nil, errors.New("not able to append certificates")
 		}
 		tlsCfg.RootCAs = pool
-		cert := config.GetString("client-cert")
-		key := config.GetString("client-key")
+		cert := config.GetPath("client-cert")
+		key := config.GetPath("client-key")
 		if cert != "" && key != "" {
 			cert, err := tls.LoadX509KeyPair(cert, key)
 			if err != nil {
@@ -173,7 +173,7 @@ func (f *fileSink) Close() error {
 }
 
 func newFileSink(path *z.SuperFlag) (Sink, error) {
-	dir := path.GetString("file")
+	dir := path.GetPath("file")
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, errors.Wrap(err, "unable to create directory for file sink")
 	}

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -115,10 +115,10 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 	conf := &TLSHelperConfig{}
 	conf.UseSystemCACerts = tlsFlag.GetBool("use-system-ca")
-	conf.RootCACert = tlsFlag.GetString("ca-cert")
+	conf.RootCACert = tlsFlag.GetPath("ca-cert")
 	conf.CertRequired = true
-	conf.Cert = tlsFlag.GetString("client-cert")
-	conf.Key = tlsFlag.GetString("client-key")
+	conf.Cert = tlsFlag.GetPath("client-cert")
+	conf.Key = tlsFlag.GetPath("client-key")
 	return GenerateClientTLSConfig(conf)
 }
 
@@ -135,10 +135,10 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 	}
 	conf := TLSHelperConfig{}
 	conf.UseSystemCACerts = tlsFlag.GetBool("use-system-ca")
-	conf.RootCACert = tlsFlag.GetString("ca-cert")
+	conf.RootCACert = tlsFlag.GetPath("ca-cert")
 	conf.CertRequired = true
-	conf.Cert = tlsFlag.GetString("server-cert")
-	conf.Key = tlsFlag.GetString("server-key")
+	conf.Cert = tlsFlag.GetPath("server-cert")
+	conf.Key = tlsFlag.GetPath("server-key")
 	conf.ClientAuth = "REQUIREANDVERIFY"
 	return GenerateServerTLSConfig(&conf)
 }

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -107,7 +107,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
 	}
-	if tlsFlag.GetString("client-cert") == "" || tlsFlag.GetString("client-key") == "" {
+	if tlsFlag.GetPath("client-cert") == "" || tlsFlag.GetPath("client-key") == "" {
 		return nil, errors.Errorf(`Inter-node TLS is enabled but client certs are not provided. ` +
 			`Inter-node TLS is always client authenticated. Please provide --tls ` +
 			`"client-cert=...; client-key=...;"`)
@@ -129,7 +129,7 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
 	}
-	if tlsFlag.GetString("server-cert") == "" || tlsFlag.GetString("server-key") == "" {
+	if tlsFlag.GetPath("server-cert") == "" || tlsFlag.GetPath("server-key") == "" {
 		return nil, errors.Errorf(`Inter-node TLS is enabled but server node certs are not provided. ` +
 			`Please provide --tls "server-cert=...; server-key=...;"`)
 	}
@@ -147,15 +147,15 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
-	if tlsFlag.GetString("server-cert") == "" && tlsFlag.GetString("server-key") == "" {
+	if tlsFlag.GetPath("server-cert") == "" && tlsFlag.GetPath("server-key") == "" {
 		return nil, nil
 	}
 
 	conf := TLSHelperConfig{}
-	conf.RootCACert = tlsFlag.GetString("ca-cert")
+	conf.RootCACert = tlsFlag.GetPath("ca-cert")
 	conf.CertRequired = true
-	conf.Cert = tlsFlag.GetString("server-cert")
-	conf.Key = tlsFlag.GetString("server-key")
+	conf.Cert = tlsFlag.GetPath("server-cert")
+	conf.Key = tlsFlag.GetPath("server-key")
 	conf.ClientAuth = tlsFlag.GetString("client-auth-type")
 	conf.UseSystemCACerts = tlsFlag.GetBool("use-system-ca")
 	return GenerateServerTLSConfig(&conf)
@@ -186,7 +186,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
 	// instead of plaintext. However the client cert files are optional, depending on whether the
 	// server requires a client certificate.
-	caCert := tlsFlag.GetString("ca-cert")
+	caCert := tlsFlag.GetPath("ca-cert")
 	if caCert != "" {
 		tlsCfg := tls.Config{}
 
@@ -201,8 +201,8 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		tlsCfg.ServerName = tlsFlag.GetString("server-name")
 
 		// 3. optionally load the client cert files
-		certFile := tlsFlag.GetString("client-cert")
-		keyFile := tlsFlag.GetString("client-key")
+		certFile := tlsFlag.GetPath("client-cert")
+		keyFile := tlsFlag.GetPath("client-key")
 		if certFile != "" && keyFile != "" {
 			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 			if err != nil {
@@ -217,8 +217,8 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	// Viper's own documentation, there's no way to tell whether an option value came from a
 	// command-line option or a built-it default.
 	if tlsFlag.GetString("server-name") != "" ||
-		tlsFlag.GetString("client-cert") != "" ||
-		tlsFlag.GetString("client-key") != "" {
+		tlsFlag.GetPath("client-cert") != "" ||
+		tlsFlag.GetPath("client-key") != "" {
 		return nil, errors.Errorf(`--tls "ca-cert=...;" is required for enabling TLS`)
 	}
 	return nil, nil


### PR DESCRIPTION
Use `Getpath()` method for path arguments in the super-flags.
`GetPath()` handles the path in a right way. It does two things more than what `GetString()` does.
1. It resolves `~` to `/home/user`
2. It cleans up the path to shortest absolute path.

Flags affected by this PR

**Zero**
- `--audit`
  - [x] `encrypt-file`
  - [x] `output`
- `--tls`
  - [x] `ca-cert`
  - [x] `client-cert` 
  - [x] `client-key`
  - [x] `server-cert`
  - [x] `server-key`

**Alpha**
- `--acl`
  - [x] `secret-file`
  
- `--audit`
  - [x] `encrypt-file`
  - [x] `output`
  
- `--cdc`
  - [x] `ca-cert`
  - [x] `client-cert` 
  - [x] `client-key`
  - [x] `file`
  
- `--tls`
  - [x] `ca-cert`
  - [x] `client-cert` 
  - [x] `client-key`
  - [x] `server-cert`
  - [x] `server-key`
  
- `--vault`
  - [x] `path`
  - [x] `role-id-file` 
  - [x] `secret-id-file`

**Bulk, Live and Restore**
- `--tls`
  - [x] `ca-cert`
  - [x] `client-cert` 
  - [x] `client-key`
  
- `--vault`
  - [x] `path`
  - [x] `role-id-file` 
  - [x] `secret-id-file`


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7541)
<!-- Reviewable:end -->
