### PR TITLE
Fix(dql): Fix error message in case of wrong argument to val()

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2435,12 +2435,12 @@ loop:
 			break loop
 		case itemComma:
 			if expectArg {
-				return item.Errorf("Expected a variable but got %s", item.Val)
+				return item.Errorf("Expected a variable but got comma")
 			}
 			expectArg = true
 		case itemName:
 			if !expectArg {
-				return item.Errorf("Expected a variable but got comma")
+				return item.Errorf("Expected a variable but got %s", item.Val)
 			}
 			typeList = fmt.Sprintf("%s,%s", typeList, item.Val)
 			expectArg = false

--- a/gql/parser.go
+++ b/gql/parser.go
@@ -2407,7 +2407,7 @@ loop:
 			expectArg = true
 		case itemName:
 			if !expectArg {
-				return count, item.Errorf("Expected a variable but got comma")
+				return count, item.Errorf("Expected a variable but got %s", item.Val)
 			}
 			count++
 			gq.NeedsVar = append(gq.NeedsVar, VarContext{
@@ -2435,7 +2435,7 @@ loop:
 			break loop
 		case itemComma:
 			if expectArg {
-				return item.Errorf("Expected a variable but got comma")
+				return item.Errorf("Expected a variable but got %s", item.Val)
 			}
 			expectArg = true
 		case itemName:


### PR DESCRIPTION
This PR fixes a wrong error message in DQL query. Consider the following query
```
query {
  foo(func: uid("0x1")) {
    x: val(math(1))
  }
}
```
Before this change:
```
"message": "line 3 column 16: Expected a variable but got comma"
```

After this change:
```
"message": "line 3 column 16: Expected a variable but got 1"
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7543)
<!-- Reviewable:end -->
