### PR TITLE
[Breaking] fix(Flags): consolidation and help text improvements

### DIFF
--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -1,5 +1,5 @@
 # Auto-generated with: [/home/mrjn/go/bin/compose -a3 -z3 --mem= --names=false -o=0 --expose_ports=false]
-# And manually modified to add --mutations flags in Alphas.
+# And manually modified to add --limit "mutations=<mode>;" flags in Alphas.
 #
 version: "3.5"
 services:
@@ -17,8 +17,9 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
-      --logtostderr -v=2 --mutations=disallow
+      --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --limit "mutations=disallow;"
   alpha2:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha2
@@ -33,8 +34,9 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
-      --logtostderr -v=2 --mutations=strict 
+      --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --limit "mutations=strict;"
   alpha3:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha3
@@ -49,8 +51,9 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
-      --logtostderr -v=2 --mutations=strict
+      --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --limit "mutations=strict;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1
@@ -64,7 +67,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   zero2:
     image: dgraph/dgraph:latest
@@ -81,7 +84,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=2" --my=zero2:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:latest
@@ -98,6 +101,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=3" --my=zero3:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
 volumes: {}

--- a/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
+++ b/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Tests in this file require a cluster running with the --mutations=<mode> option.
+// Tests in this file require a cluster running with the --limit "mutations=<mode>;" flag.
 
 func runOn(conn *grpc.ClientConn, fn func(*testing.T, *dgo.Dgraph)) func(*testing.T) {
 	return func(t *testing.T) {

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -208,7 +208,7 @@ they form a Raft group and provide synchronous replication.
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
 		Head("Ludicrous options").
 		Flag("enabled",
-			"Run Dgraph in Ludicrous mode.").
+			"Set enabled to true to run Dgraph in Ludicrous mode.").
 		Flag("concurrency",
 			"The number of concurrent threads to use in Ludicrous mode.").
 		String())
@@ -246,7 +246,7 @@ they form a Raft group and provide synchronous replication.
 			"The path to client key file for TLS encryption.").
 		String())
 
-	flag.String("audit", "", z.NewSuperFlagHelp(worker.AuditDefaults).
+	flag.String("audit", worker.AuditDefaults, z.NewSuperFlagHelp(worker.AuditDefaults).
 		Head("Audit options").
 		Flag("output",
 			`[stdout, /path/to/dir] This specifies where audit logs should be output to.

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -701,7 +701,7 @@ func run() {
 		HmacSecret:          opts.HmacSecret,
 		Audit:               opts.Audit != nil,
 		Badger:              badger,
-		BadgerMaxRetries:    badger.GetInt("max-retries"),
+		BadgerMaxRetries:    int(badger.GetInt64("max-retries")),
 	}
 	x.WorkerConfig.Parse(Alpha.Conf)
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -105,7 +105,7 @@ they form a Raft group and provide synchronous replication.
 	x.FillCommonFlags(flag)
 	// --tls SuperFlag
 	x.RegisterServerTLSFlags(flag)
-	// --encryption_key_file
+	// --encryption-key-file
 	enc.RegisterFlags(flag)
 
 	flag.String("cache_percentage", "0,65,35,0",
@@ -129,9 +129,9 @@ they form a Raft group and provide synchronous replication.
 	flag.IntP("port_offset", "o", 0,
 		"Value added to all listening port numbers. [Internal=7080, HTTP=8080, Grpc=9080]")
 
-	//Custom plugins.
+	// Custom plugins.
 	flag.String("custom_tokenizers", "",
-		"Comma separated list of tokenizer plugins")
+		"Comma separated list of tokenizer plugins for custom indices.")
 
 	// By default Go GRPC traces all requests.
 	grpc.EnableTracing = false

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -701,6 +701,7 @@ func run() {
 		HmacSecret:          opts.HmacSecret,
 		Audit:               opts.Audit != nil,
 		Badger:              badger,
+		BadgerMaxRetries:    badger.GetInt("max-retries"),
 	}
 	x.WorkerConfig.Parse(Alpha.Conf)
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -226,7 +226,7 @@ they form a Raft group and provide synchronous replication.
 			"The URL of a lambda server that implements custom GraphQL Javascript resolvers.").
 		String())
 
-	flag.String("cdc", "", z.NewSuperFlagHelp(worker.CDCDefaults).
+	flag.String("cdc", worker.CDCDefaults, z.NewSuperFlagHelp(worker.CDCDefaults).
 		Head("Change Data Capture options").
 		Flag("file",
 			"The path where audit logs will be stored.").

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -105,7 +105,7 @@ they form a Raft group and provide synchronous replication.
 	x.FillCommonFlags(flag)
 	// --tls SuperFlag
 	x.RegisterServerTLSFlags(flag)
-	// --encryption-key-file
+	// --encryption_key_file
 	enc.RegisterFlags(flag)
 
 	flag.String("cache_percentage", "0,65,35,0",

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -590,13 +590,17 @@ func setupServer(closer *z.Closer) {
 
 func run() {
 	var err error
-	if Alpha.Conf.GetBool("enable_sentry") {
+
+	telemetry := z.NewSuperFlag(Alpha.Conf.GetString("telemetry")).MergeAndCheckDefault(
+		x.TelemetryDefaults)
+	if telemetry.GetBool("sentry") {
 		x.InitSentry(enc.EeBuild)
 		defer x.FlushSentry()
 		x.ConfigureSentryScope("alpha")
 		x.WrapPanics()
 		x.SentryOptOutNote()
 	}
+
 	bindall = Alpha.Conf.GetBool("bindall")
 
 	totalCache := int64(Alpha.Conf.GetInt("cache_mb"))
@@ -675,8 +679,6 @@ func run() {
 	tlsServerConf, err := x.LoadServerTLSConfigForInternalPort(Alpha.Conf)
 	x.Check(err)
 
-	telemetry := z.NewSuperFlag(Alpha.Conf.GetString("telemetry")).MergeAndCheckDefault(
-		x.TelemetryDefaults)
 	ludicrous := z.NewSuperFlag(Alpha.Conf.GetString("ludicrous")).MergeAndCheckDefault(
 		worker.LudicrousDefaults)
 	raft := z.NewSuperFlag(Alpha.Conf.GetString("raft")).MergeAndCheckDefault(worker.RaftDefaults)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -683,7 +683,6 @@ func run() {
 		worker.LudicrousDefaults)
 	raft := z.NewSuperFlag(Alpha.Conf.GetString("raft")).MergeAndCheckDefault(worker.RaftDefaults)
 	x.WorkerConfig = x.WorkerOptions{
-		Telemetry:           telemetry,
 		TmpDir:              Alpha.Conf.GetString("tmp"),
 		ExportPath:          Alpha.Conf.GetString("export"),
 		ZeroAddr:            strings.Split(Alpha.Conf.GetString("zero"), ","),
@@ -701,11 +700,10 @@ func run() {
 		HmacSecret:          opts.HmacSecret,
 		Audit:               opts.Audit != nil,
 		Badger:              badger,
-		BadgerMaxRetries:    int(badger.GetInt64("max-retries")),
 	}
 	x.WorkerConfig.Parse(Alpha.Conf)
 
-	if x.WorkerConfig.Telemetry.GetBool("reports") {
+	if telemetry.GetBool("reports") {
 		go edgraph.PeriodicallyPostTelemetry()
 	}
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -125,10 +125,6 @@ they form a Raft group and provide synchronous replication.
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
 		"Comma separated list of Dgraph Zero addresses of the form IP_ADDRESS:PORT.")
 
-	flag.Int("max_retries", -1,
-		"Commits to disk will give up after these number of retries to prevent locking the worker"+
-			" in a failed state. Use -1 to retry infinitely.")
-
 	// Useful for running multiple servers on the same machine.
 	flag.IntP("port_offset", "o", 0,
 		"Value added to all listening port numbers. [Internal=7080, HTTP=8080, Grpc=9080]")
@@ -148,6 +144,9 @@ they form a Raft group and provide synchronous replication.
 			compression, while "zstd:1" would set zstd compression at level 1.`).
 		Flag("goroutines",
 			"The number of goroutines to use in badger.Stream.").
+		Flag("max-retries",
+			"Commits to disk will give up after these number of retries to prevent locking the "+
+				"worker in a failed state. Use -1 to retry infinitely.").
 		String())
 
 	flag.String("raft", worker.RaftDefaults, z.NewSuperFlagHelp(worker.RaftDefaults).
@@ -690,7 +689,6 @@ func run() {
 		ZeroAddr:            strings.Split(Alpha.Conf.GetString("zero"), ","),
 		Raft:                raft,
 		WhiteListedIPRanges: ips,
-		MaxRetries:          Alpha.Conf.GetInt("max_retries"),
 		StrictMutations:     opts.MutationsMode == worker.StrictMutations,
 		AclEnabled:          aclKey != nil,
 		AbortOlderThan:      abortDur,

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -47,7 +47,8 @@ var Bulk x.SubCommand
 
 var defaultOutDir = "./out"
 
-const bulkBadgerDefaults = " cache_mb=64; cache_percentage=70,30;"
+const BulkBadgerDefaults = worker.BadgerDefaults +
+	" cache_mb=64; cache_percentage=70,30;"
 
 func init() {
 	Bulk.Cmd = &cobra.Command{
@@ -120,23 +121,20 @@ func init() {
 	flag.Uint64("force-namespace", math.MaxUint64,
 		"Namespace onto which to load the data. If not set, will preserve the namespace.")
 
-	// Bulk has some extra defaults for Badger SuperFlag. These should only be applied in this
-	// package.
-	flag.String("badger", worker.BadgerDefaults+bulkBadgerDefaults,
-		z.NewSuperFlagHelp(worker.BadgerDefaults+bulkBadgerDefaults).
-			Head("Badger options").
-			Flag("compression",
-				"Specifies the compression algorithm and compression level (if applicable) for the "+
-					`postings directory. "none" would disable compression, while "zstd:1" would set `+
-					"zstd compression at level 1.").
-			Flag("goroutines",
-				"The number of goroutines to use in badger.Stream.").
-			Flag("cache-mb",
-				"Total size of cache (in MB) per shard in the reducer.").
-			Flag("cache-percentage",
-				"Cache percentages summing up to 100 for various caches. (FORMAT: BlockCacheSize,"+
-					"IndexCacheSize)").
-			String())
+	flag.String("badger", BulkBadgerDefaults, z.NewSuperFlagHelp(BulkBadgerDefaults).
+		Head("Badger options").
+		Flag("compression",
+			"Specifies the compression algorithm and compression level (if applicable) for the "+
+				`postings directory. "none" would disable compression, while "zstd:1" would set `+
+				"zstd compression at level 1.").
+		Flag("goroutines",
+			"The number of goroutines to use in badger.Stream.").
+		Flag("cache-mb",
+			"Total size of cache (in MB) per shard in the reducer.").
+		Flag("cache-percentage",
+			"Cache percentages summing up to 100 for various caches. (FORMAT: BlockCacheSize,"+
+				"IndexCacheSize)").
+		String())
 
 	x.RegisterClientTLSFlags(flag)
 	// Encryption and Vault options
@@ -144,8 +142,7 @@ func init() {
 }
 
 func run() {
-	badger := z.NewSuperFlag(Bulk.Conf.GetString("badger")).MergeAndCheckDefault(
-		worker.BadgerDefaults + bulkBadgerDefaults)
+	badger := z.NewSuperFlag(Bulk.Conf.GetString("badger")).MergeAndCheckDefault(BulkBadgerDefaults)
 	ctype, clevel := x.ParseCompression(badger.GetString("compression"))
 	opt := options{
 		DataFiles:        Bulk.Conf.GetString("files"),

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/ee/audit"
+	"github.com/dgraph-io/dgraph/worker"
 
 	"go.opencensus.io/plugin/ocgrpc"
 	otrace "go.opencensus.io/trace"
@@ -107,9 +108,7 @@ instances to achieve high-availability.
 				"in Raft elections. This can be used to achieve a read-only replica.").
 		String())
 
-	// NOTE: audit needs an empty default string otherwise it would panic with an empty "dir"
-	//       option.
-	flag.String("audit", "", z.NewSuperFlagHelp("").
+	flag.String("audit", worker.AuditDefaults, z.NewSuperFlagHelp(worker.AuditDefaults).
 		Head("Audit options").
 		Flag("output",
 			`[stdout, /path/to/dir] This specifies where audit logs should be output to.

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -201,7 +201,9 @@ func (st *state) serveGRPC(l net.Listener, store *raftwal.DiskStorage) {
 }
 
 func run() {
-	if Zero.Conf.GetBool("enable_sentry") {
+	telemetry := z.NewSuperFlag(Zero.Conf.GetString("telemetry")).MergeAndCheckDefault(
+		x.TelemetryDefaults)
+	if telemetry.GetBool("sentry") {
 		x.InitSentry(enc.EeBuild)
 		defer x.FlushSentry()
 		x.ConfigureSentryScope("zero")
@@ -213,8 +215,6 @@ func run() {
 	tlsConf, err := x.LoadClientTLSConfigForInternalPort(Zero.Conf)
 	x.Check(err)
 
-	telemetry := z.NewSuperFlag(Zero.Conf.GetString("telemetry")).MergeAndCheckDefault(
-		x.TelemetryDefaults)
 	raft := z.NewSuperFlag(Zero.Conf.GetString("raft")).MergeAndCheckDefault(
 		raftDefaults)
 	conf := audit.GetAuditConf(Zero.Conf.GetString("audit"))

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -60,12 +60,12 @@ type auditLogger struct {
 }
 
 func GetAuditConf(conf string) *x.LoggerConf {
-	if conf == "" {
+	if conf == "" || conf == worker.AuditDefaults {
 		return nil
 	}
 	auditFlag := z.NewSuperFlag(conf).MergeAndCheckDefault(worker.AuditDefaults)
 	out := auditFlag.GetString("output")
-	x.AssertTruef(out != "", "out flag is not provided for the audit logs")
+	x.AssertTruef(out != "", "output flag is not provided for the audit logs")
 	encBytes, err := readAuditEncKey(auditFlag)
 	x.Check(err)
 	return &x.LoggerConf{

--- a/ee/enc/flags.go
+++ b/ee/enc/flags.go
@@ -21,15 +21,12 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const (
-	encKeyFile = "encryption_key_file"
-)
-
 // RegisterFlags registers the required encryption flags.
 func RegisterFlags(flag *pflag.FlagSet) {
-	flag.String(encKeyFile, "",
-		"The file that stores the symmetric key of length 16, 24, or 32 bytes. "+
-			"The key size determines the chosen AES cipher "+
-			"(AES-128, AES-192, and AES-256 respectively). Enterprise feature.")
+	flag.String("encryption_key_file", "",
+		"[Enterprise Feature] Encryption At Rest: The file that stores the symmetric key of "+
+			"length 16, 24, or 32 bytes. The key size determines the chosen AES cipher "+
+			"(AES-128, AES-192, and AES-256 respectively).")
+
 	vault.RegisterFlags(flag)
 }

--- a/ee/vault/flags.go
+++ b/ee/vault/flags.go
@@ -32,9 +32,9 @@ const (
 	flagEncField     = "enc-field"
 	flagEncFormat    = "enc-format"
 
-	defaultConfig = "addr=http://localhost:8200;" +
-		"path=secret/data/dgraph;" +
-		"acl-format=base64;" +
+	defaultConfig = "addr=http://localhost:8200; " +
+		"path=secret/data/dgraph; " +
+		"acl-format=base64; " +
 		"enc-format=base64;"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ go 1.12
 // replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
 // replace github.com/dgraph-io/roaring => /home/mrjn/go/src/github.com/dgraph-io/roaring
 
-replace github.com/dgraph-io/ristretto => /home/karl/go/src/github.com/dgraph-io/ristretto
-
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
@@ -25,7 +23,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.1.8
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed
-	github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a
+	github.com/dgraph-io/ristretto v0.0.4-0.20210309225856-f18e3903e3e0
 	github.com/dgraph-io/roaring v0.5.6-0.20210227175938-766b897233a5
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ go 1.12
 // replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
 // replace github.com/dgraph-io/roaring => /home/mrjn/go/src/github.com/dgraph-io/roaring
 
+replace github.com/dgraph-io/ristretto => /home/karl/go/src/github.com/dgraph-io/ristretto
+
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,9 @@ github.com/dgraph-io/gqlparser/v2 v2.1.8 h1:d4CprjlDyMNGvnZG/pKqe6Oj6qQd4V0TVsuO
 github.com/dgraph-io/gqlparser/v2 v2.1.8/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:pgGMBoTtFhR+xkyzINaToLYRurHn+6pxMYffIGmmEPc=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
-github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a h1:1cMMkx3iegOzbAxVl1ZZQRHk+gaCf33Y5/4I3l0NNSg=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
+github.com/dgraph-io/ristretto v0.0.4-0.20210309225856-f18e3903e3e0 h1:JfwafU+dBO3Nn7vvNYtp5ACy8QxlpYCrKsyOM0AiFB8=
+github.com/dgraph-io/ristretto v0.0.4-0.20210309225856-f18e3903e3e0/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=
 github.com/dgraph-io/roaring v0.5.6-0.20210227175938-766b897233a5 h1:9t3OKcvsQlxU9Cu0U55tgvNtaRYVGDr6rUb95P8cSbg=
 github.com/dgraph-io/roaring v0.5.6-0.20210227175938-766b897233a5/go.mod h1:I8kxPBtSQW3OdQFWonumQdCx2DTmq2WjdnTjGXz3uTM=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -32,7 +32,6 @@ import (
 )
 
 const (
-	CDCDefaults       = "file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; client_key="
 	defaultEventTopic = "dgraph-cdc"
 )
 

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	defaultCDCConfig  = "file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; client_key="
+	CDCDefaults       = "file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; client_key="
 	defaultEventTopic = "dgraph-cdc"
 )
 
@@ -64,14 +64,14 @@ type CDC struct {
 }
 
 func newCDC() *CDC {
-	if Config.ChangeDataConf == "" {
+	if Config.ChangeDataConf == "" || Config.ChangeDataConf == CDCDefaults {
 		return nil
 	}
 	if x.WorkerConfig.LudicrousEnabled {
 		x.Fatalf("cdc is not supported in ludicrous mode")
 	}
 
-	cdcFlag := z.NewSuperFlag(Config.ChangeDataConf).MergeAndCheckDefault(defaultCDCConfig)
+	cdcFlag := z.NewSuperFlag(Config.ChangeDataConf).MergeAndCheckDefault(CDCDefaults)
 	sink, err := GetSink(cdcFlag)
 	x.Check(err)
 	cdc := &CDC{

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -776,14 +776,15 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 			return
 		}
 		txn.Update()
-		err := x.RetryUntilSuccess(x.WorkerConfig.BadgerMaxRetries, 10*time.Millisecond, func() error {
-			err := txn.CommitToDisk(writer, commit)
-			if err == badger.ErrBannedKey {
-				glog.Errorf("Error while writing to banned namespace.")
-				return nil
-			}
-			return err
-		})
+		err := x.RetryUntilSuccess(int(x.WorkerConfig.Badger.GetInt64("max-retries")),
+			10*time.Millisecond, func() error {
+				err := txn.CommitToDisk(writer, commit)
+				if err == badger.ErrBannedKey {
+					glog.Errorf("Error while writing to banned namespace.")
+					return nil
+				}
+				return err
+			})
 
 		if err != nil {
 			glog.Errorf("Error while applying txn status to disk (%d -> %d): %v",

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -776,7 +776,7 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 			return
 		}
 		txn.Update()
-		err := x.RetryUntilSuccess(x.WorkerConfig.MaxRetries, 10*time.Millisecond, func() error {
+		err := x.RetryUntilSuccess(x.WorkerConfig.BadgerMaxRetries, 10*time.Millisecond, func() error {
 			err := txn.CommitToDisk(writer, commit)
 			if err == badger.ErrBannedKey {
 				glog.Errorf("Error while writing to banned namespace.")

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -44,7 +44,9 @@ const (
 	RaftDefaults      = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
 	SecurityDefaults  = `token=; whitelist=;`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
-	LimitDefaults     = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
+	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
+		`client_key=;`
+	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -36,15 +36,17 @@ const (
 	//       than fail during runtime while trying to retrieve an option that isn't there.
 	//
 	//       For easy readability, keep the options without default values (if any) at the end of
-	//       the *Defaults string.
+	//       the *Defaults string. Also, since these strings are printed in --help text, avoid line
+	//       breaks.
 	AclDefaults       = `access-ttl=6h; refresh-ttl=30d; secret-file=;`
 	AuditDefaults     = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
-	BadgerDefaults    = `compression=snappy; goroutines=8;`
+	BadgerDefaults    = `compression=snappy; goroutines=8; max-retries=-1;`
 	RaftDefaults      = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
 	SecurityDefaults  = `token=; whitelist=;`
-	LimitDefaults     = `mutations=allow; query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
-	GraphQLDefaults   = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
+	LimitDefaults     = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
+		`mutations-nquad=1000000;`
+	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 	CDCDefaults = `file=; kafka=; sasl-user=; sasl-password=; ca-cert=; client-cert=; ` +
 		`client-key=;`

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -48,8 +48,6 @@ const (
 		`mutations-nquad=1000000;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
-	CDCDefaults = `file=; kafka=; sasl-user=; sasl-password=; ca-cert=; client-cert=; ` +
-		`client-key=;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -42,7 +42,7 @@ const (
 	BadgerDefaults    = `compression=snappy; goroutines=8;`
 	RaftDefaults      = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
 	SecurityDefaults  = `token=; whitelist=;`
-	LimitDefaults     = `query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;`
+	LimitDefaults     = `mutations=allow; query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
 	GraphQLDefaults   = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`

--- a/x/config.go
+++ b/x/config.go
@@ -59,6 +59,8 @@ type IPRange struct {
 // WorkerOptions stores the options for the worker package. It's declared here
 // since it's used by multiple packages.
 type WorkerOptions struct {
+	// TODO(karl): document
+	Telemetry *z.SuperFlag
 	// TmpDir is a directory to store temporary buffers.
 	TmpDir string
 	// ExportPath indicates the folder to which exported data will be saved.

--- a/x/config.go
+++ b/x/config.go
@@ -59,11 +59,6 @@ type IPRange struct {
 // WorkerOptions stores the options for the worker package. It's declared here
 // since it's used by multiple packages.
 type WorkerOptions struct {
-	// Telemetry options:
-	//
-	// reports bool - send anonymous telemetry data to Dgraph devs
-	// sentry bool - send crash events to Sentry
-	Telemetry *z.SuperFlag
 	// TmpDir is a directory to store temporary buffers.
 	TmpDir string
 	// ExportPath indicates the folder to which exported data will be saved.
@@ -87,8 +82,7 @@ type WorkerOptions struct {
 	// Raft stores options related to Raft.
 	Raft *z.SuperFlag
 	// Badger stores options related to Badger.
-	Badger           *z.SuperFlag
-	BadgerMaxRetries int
+	Badger *z.SuperFlag
 	// WhiteListedIPRanges is a list of IP ranges from which requests will be allowed.
 	WhiteListedIPRanges []IPRange
 	// StrictMutations will cause mutations to unknown predicates to fail if set to true.

--- a/x/config.go
+++ b/x/config.go
@@ -84,11 +84,10 @@ type WorkerOptions struct {
 	// Raft stores options related to Raft.
 	Raft *z.SuperFlag
 	// Badger stores options related to Badger.
-	Badger *z.SuperFlag
+	Badger           *z.SuperFlag
+	BadgerMaxRetries int
 	// WhiteListedIPRanges is a list of IP ranges from which requests will be allowed.
 	WhiteListedIPRanges []IPRange
-	// MaxRetries is the maximum number of times to retry a commit before giving up.
-	MaxRetries int
 	// StrictMutations will cause mutations to unknown predicates to fail if set to true.
 	StrictMutations bool
 	// AclEnabled indicates whether the enterprise ACL feature is turned on.

--- a/x/config.go
+++ b/x/config.go
@@ -59,7 +59,10 @@ type IPRange struct {
 // WorkerOptions stores the options for the worker package. It's declared here
 // since it's used by multiple packages.
 type WorkerOptions struct {
-	// TODO(karl): document
+	// Telemetry options:
+	//
+	// reports bool - send anonymous telemetry data to Dgraph devs
+	// sentry bool - send crash events to Sentry
 	Telemetry *z.SuperFlag
 	// TmpDir is a directory to store temporary buffers.
 	TmpDir string

--- a/x/flags.go
+++ b/x/flags.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	TraceDefaults = `ratio=0.01; jaeger=; datadog=;`
+	TraceDefaults     = `ratio=0.01; jaeger=; datadog=;`
+	TelemetryDefaults = `reports=true; sentry=true;`
 )
 
 // FillCommonFlags stores flags common to Alpha and Zero.
@@ -56,7 +57,11 @@ func FillCommonFlags(flag *pflag.FlagSet) {
 	// Cache flags.
 	flag.Int64("cache_mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
 
-	// Telemetry.
-	flag.Bool("telemetry", true, "Send anonymous telemetry data to Dgraph devs.")
-	flag.Bool("enable_sentry", true, "Turn on/off sending crash events to Sentry.")
+	flag.String("telemetry", TelemetryDefaults, z.NewSuperFlagHelp(TelemetryDefaults).
+		Head("Telemetry (diagnostic) options").
+		Flag("reports",
+			"Send anonymous telemetry data to Dgraph devs.").
+		Flag("sentry",
+			"Send crash events to Sentry.").
+		String())
 }

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -47,7 +47,7 @@ const (
 func SentryOptOutNote() {
 	glog.Infof("This instance of Dgraph will send anonymous reports of panics back " +
 		"to Dgraph Labs via Sentry. No confidential information is sent. These reports " +
-		"help improve Dgraph. To opt-out, restart your instance with the --enable_sentry=false " +
+		`help improve Dgraph. To opt-out, restart your instance with the --telemetry "sentry=false;" ` +
 		"flag. For more info, see https://dgraph.io/docs/howto/#data-handling.")
 }
 

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -40,9 +40,6 @@ type TLSHelperConfig struct {
 }
 
 const (
-	TLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
-		`ca-cert=; server-name=; server-cert=; server-key=; client-cert=; client-key=;`
-
 	TLSServerDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
 		`server-cert=; server-key=; ca-cert=; client-cert=; client-key=;`
 
@@ -52,55 +49,51 @@ const (
 
 // RegisterServerTLSFlags registers the required flags to set up a TLS server.
 func RegisterServerTLSFlags(flag *pflag.FlagSet) {
-	// TODO: clean the default string / location
-	flag.String("tls", "use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false;",
-		z.NewSuperFlagHelp(TLSServerDefaults).
-			Head("TLS Server options").
-			Flag("internal-port",
-				"(Optional) Enable inter-node TLS encryption between cluster nodes.").
-			Flag("server-cert",
-				"The server Cert file which is needed to initiate the server in the cluster.").
-			Flag("server-key",
-				"The server Key file which is needed to initiate the server in the cluster.").
-			Flag("ca-cert",
-				"The CA cert file used to verify server certificates. Required for enabling TLS.").
-			Flag("use-system-ca",
-				"Includes System CA into CA Certs.").
-			Flag("client-auth-type",
-				"The TLS client authentication method.").
-			Flag("client-cert",
-				"(Optional) The client Cert file which is needed to connect as a client with the other "+
-					"nodes in the cluster.").
-			Flag("client-key",
-				"(Optional) The private client Key file which is needed to connect as a client with the "+
-					"other nodes in the cluster.").
-			String())
+	flag.String("tls", TLSServerDefaults, z.NewSuperFlagHelp(TLSServerDefaults).
+		Head("TLS Server options").
+		Flag("internal-port",
+			"(Optional) Enable inter-node TLS encryption between cluster nodes.").
+		Flag("server-cert",
+			"The server Cert file which is needed to initiate the server in the cluster.").
+		Flag("server-key",
+			"The server Key file which is needed to initiate the server in the cluster.").
+		Flag("ca-cert",
+			"The CA cert file used to verify server certificates. Required for enabling TLS.").
+		Flag("use-system-ca",
+			"Includes System CA into CA Certs.").
+		Flag("client-auth-type",
+			"The TLS client authentication method.").
+		Flag("client-cert",
+			"(Optional) The client Cert file which is needed to connect as a client with the other "+
+				"nodes in the cluster.").
+		Flag("client-key",
+			"(Optional) The private client Key file which is needed to connect as a client with the "+
+				"other nodes in the cluster.").
+		String())
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
 func RegisterClientTLSFlags(flag *pflag.FlagSet) {
-	// TODO: clean the default string / location
-	flag.String("tls", "use-system-ca=true; internal-port=false;",
-		z.NewSuperFlagHelp(TLSClientDefaults).
-			Head("TLS Client options").
-			Flag("internal-port",
-				"(Optional) Enable inter-node TLS encryption between cluster nodes.").
-			Flag("server-name",
-				"Used to verify the server hostname.").
-			Flag("ca-cert",
-				"The CA cert file used to verify server certificates. Required for enabling TLS.").
-			Flag("use-system-ca",
-				"Includes System CA into CA Certs.").
-			Flag("client-cert",
-				"(Optional) The Cert file provided by the client to the server.").
-			Flag("client-key",
-				"(Optional) The private Key file provided by the clients to the server.").
-			String())
+	flag.String("tls", TLSClientDefaults, z.NewSuperFlagHelp(TLSClientDefaults).
+		Head("TLS Client options").
+		Flag("internal-port",
+			"(Optional) Enable inter-node TLS encryption between cluster nodes.").
+		Flag("server-name",
+			"Used to verify the server hostname.").
+		Flag("ca-cert",
+			"The CA cert file used to verify server certificates. Required for enabling TLS.").
+		Flag("use-system-ca",
+			"Includes System CA into CA Certs.").
+		Flag("client-cert",
+			"(Optional) The Cert file provided by the client to the server.").
+		Flag("client-key",
+			"(Optional) The private Key file provided by the clients to the server.").
+		String())
 }
 
 // LoadClientTLSConfigForInternalPort loads tls config for connecting to internal ports of cluster
 func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -122,7 +115,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
 func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -143,7 +136,7 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
 
 	if tlsFlag.GetString("server-cert") == "" && tlsFlag.GetString("server-key") == "" {
 		return nil, nil
@@ -179,7 +172,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
 	}
 
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
 
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
 	// instead of plaintext. However the client cert files are optional, depending on whether the

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -40,7 +40,7 @@ type TLSHelperConfig struct {
 }
 
 const (
-	AllTLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
+	TLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
 		`ca-cert=; server-name=; server-cert=; server-key=; client-cert=; client-key=;`
 
 	TLSServerDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
@@ -100,7 +100,7 @@ func RegisterClientTLSFlags(flag *pflag.FlagSet) {
 
 // LoadClientTLSConfigForInternalPort loads tls config for connecting to internal ports of cluster
 func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -122,7 +122,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
 func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -143,7 +143,7 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if tlsFlag.GetString("server-cert") == "" && tlsFlag.GetString("server-key") == "" {
 		return nil, nil
@@ -179,7 +179,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
 	}
 
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
 	// instead of plaintext. However the client cert files are optional, depending on whether the

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -40,6 +40,9 @@ type TLSHelperConfig struct {
 }
 
 const (
+	TLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
+		`ca-cert=; server-name=; server-cert=; server-key=; client-cert=; client-key=;`
+
 	TLSServerDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
 		`server-cert=; server-key=; ca-cert=; client-cert=; client-key=;`
 
@@ -49,51 +52,53 @@ const (
 
 // RegisterServerTLSFlags registers the required flags to set up a TLS server.
 func RegisterServerTLSFlags(flag *pflag.FlagSet) {
-	flag.String("tls", TLSServerDefaults, z.NewSuperFlagHelp(TLSServerDefaults).
-		Head("TLS Server options").
-		Flag("internal-port",
-			"(Optional) Enable inter-node TLS encryption between cluster nodes.").
-		Flag("server-cert",
-			"The server Cert file which is needed to initiate the server in the cluster.").
-		Flag("server-key",
-			"The server Key file which is needed to initiate the server in the cluster.").
-		Flag("ca-cert",
-			"The CA cert file used to verify server certificates. Required for enabling TLS.").
-		Flag("use-system-ca",
-			"Includes System CA into CA Certs.").
-		Flag("client-auth-type",
-			"The TLS client authentication method.").
-		Flag("client-cert",
-			"(Optional) The client Cert file which is needed to connect as a client with the other "+
-				"nodes in the cluster.").
-		Flag("client-key",
-			"(Optional) The private client Key file which is needed to connect as a client with the "+
-				"other nodes in the cluster.").
-		String())
+	flag.String("tls", "use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false;",
+		z.NewSuperFlagHelp(TLSServerDefaults).
+			Head("TLS Server options").
+			Flag("internal-port",
+				"(Optional) Enable inter-node TLS encryption between cluster nodes.").
+			Flag("server-cert",
+				"The server Cert file which is needed to initiate the server in the cluster.").
+			Flag("server-key",
+				"The server Key file which is needed to initiate the server in the cluster.").
+			Flag("ca-cert",
+				"The CA cert file used to verify server certificates. Required for enabling TLS.").
+			Flag("use-system-ca",
+				"Includes System CA into CA Certs.").
+			Flag("client-auth-type",
+				"The TLS client authentication method.").
+			Flag("client-cert",
+				"(Optional) The client Cert file which is needed to connect as a client with the other "+
+					"nodes in the cluster.").
+			Flag("client-key",
+				"(Optional) The private client Key file which is needed to connect as a client with the "+
+					"other nodes in the cluster.").
+			String())
 }
 
 // RegisterClientTLSFlags registers the required flags to set up a TLS client.
 func RegisterClientTLSFlags(flag *pflag.FlagSet) {
-	flag.String("tls", TLSClientDefaults, z.NewSuperFlagHelp(TLSClientDefaults).
-		Head("TLS Client options").
-		Flag("internal-port",
-			"(Optional) Enable inter-node TLS encryption between cluster nodes.").
-		Flag("server-name",
-			"Used to verify the server hostname.").
-		Flag("ca-cert",
-			"The CA cert file used to verify server certificates. Required for enabling TLS.").
-		Flag("use-system-ca",
-			"Includes System CA into CA Certs.").
-		Flag("client-cert",
-			"(Optional) The Cert file provided by the client to the server.").
-		Flag("client-key",
-			"(Optional) The private Key file provided by the clients to the server.").
-		String())
+	flag.String("tls", "use-system-ca=true; internal-port=false;",
+		z.NewSuperFlagHelp(TLSClientDefaults).
+			Head("TLS Client options").
+			Flag("internal-port",
+				"(Optional) Enable inter-node TLS encryption between cluster nodes.").
+			Flag("server-name",
+				"Used to verify the server hostname.").
+			Flag("ca-cert",
+				"The CA cert file used to verify server certificates. Required for enabling TLS.").
+			Flag("use-system-ca",
+				"Includes System CA into CA Certs.").
+			Flag("client-cert",
+				"(Optional) The Cert file provided by the client to the server.").
+			Flag("client-key",
+				"(Optional) The private Key file provided by the clients to the server.").
+			String())
 }
 
 // LoadClientTLSConfigForInternalPort loads tls config for connecting to internal ports of cluster
 func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -115,7 +120,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
 func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -136,7 +141,7 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	if tlsFlag.GetString("server-cert") == "" && tlsFlag.GetString("server-key") == "" {
 		return nil, nil
@@ -172,7 +177,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
 	}
 
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
 
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
 	// instead of plaintext. However the client cert files are optional, depending on whether the

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -40,9 +40,7 @@ type TLSHelperConfig struct {
 }
 
 const (
-	// TODO: clean/organize this to make it clearer
-
-	TLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
+	AllTLSDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
 		`ca-cert=; server-name=; server-cert=; server-key=; client-cert=; client-key=;`
 
 	TLSServerDefaults = `use-system-ca=true; client-auth-type=VERIFYIFGIVEN; internal-port=false; ` +
@@ -102,7 +100,7 @@ func RegisterClientTLSFlags(flag *pflag.FlagSet) {
 
 // LoadClientTLSConfigForInternalPort loads tls config for connecting to internal ports of cluster
 func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -124,7 +122,7 @@ func LoadClientTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfigForInternalPort loads the TLS config for the internal ports of the cluster
 func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
 
 	if !tlsFlag.GetBool("internal-port") {
 		return nil, nil
@@ -145,7 +143,7 @@ func LoadServerTLSConfigForInternalPort(v *viper.Viper) (*tls.Config, error) {
 
 // LoadServerTLSConfig loads the TLS config into the server with the given parameters.
 func LoadServerTLSConfig(v *viper.Viper) (*tls.Config, error) {
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSServerDefaults)
 
 	if tlsFlag.GetString("server-cert") == "" && tlsFlag.GetString("server-key") == "" {
 		return nil, nil
@@ -181,7 +179,7 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 		return SlashTLSConfig(v.GetString("slash_grpc_endpoint"))
 	}
 
-	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSDefaults)
+	tlsFlag := z.NewSuperFlag(v.GetString("tls")).MergeAndCheckDefault(TLSClientDefaults)
 
 	// When the --tls ca-cert="..."; option is specified, the connection will be set up using TLS
 	// instead of plaintext. However the client cert files are optional, depending on whether the


### PR DESCRIPTION
DGRAPH-3172

| Old Name | New Name | Type | Subcommands |
|--------------:|----------------:|:-------:|:--------------------|
| | **`--telemetry`** | | | |
| `telemetry` | `reports` | bool | alpha, zero |
| `enable_sentry` | `sentry` | bool | alpha, zero |
| | **`--limit`** | | |
| `mutations` | `mutations` | string | alpha |
| | **`--badger`** | | |
| `max_retries` | `max-retries` | int | alpha |

These are the only flag names changed. They've all been moved into their respective SuperFlags, and only `--telemetry` is new. 

**Note**: In DGRAPH-3172 it says to move `max_retries` into `--badger` "only after verifying if that flag is used only in commitToDisk." I made sure the only time the flag is used is [here](https://github.com/dgraph-io/dgraph/blob/8de50d65b99aa6a498b8fe7471ae0864dd3db6e8/worker/draft.go#L779) in the `toDisk` function, but I'm not sure if that's exactly what the ticket is referring to. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7544)
<!-- Reviewable:end -->
