### PR TITLE
fix(GRAPHQL): fix duplicate xid error for multiple xid fields.

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -3682,6 +3682,173 @@
         }
 
 -
+  name: "Add mutation with multiple Xid fields shouldn't give error if xidName+xidVal is equal for two different xid fields in a type"
+  gqlmutation: |
+    mutation($input: [AddABCInput!]!) {
+    	addABC(input: $input) {
+    		aBC {
+    			ab
+    			abc
+    		}
+    	}
+    }
+
+  gqlvariables: |
+    {
+        "input": [
+            {
+                "ab": "cd",
+                "abc": "d"
+            }
+        ]
+    }
+  dgquery: |-
+    query {
+      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+        uid
+      }
+      ABC2(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
+        uid
+      }
+    }
+  explanation: "We should generate different variables as ABC1 and ABC2 if xidName+xidValue is same as in above case
+  i.e. ab+cd and abc+d both equals to abcd"
+  dgmutations:
+    - setjson: |
+        {
+            "ABC.ab": "cd",
+            "ABC.abc": "d",
+            "dgraph.type": [
+                "ABC"
+            ],
+            "uid":"_:ABC2"
+        }
+
+-
+  name: "Add mutation with multiple Xid fields shouldn't give error if xidName+xidVal is equal for two different xid fields in different objects"
+  gqlmutation: |
+    mutation($input: [AddABCInput!]!) {
+    	addABC(input: $input) {
+    		aBC {
+    			ab
+    			abc
+    		}
+    	}
+    }
+
+  gqlvariables: |
+    {
+        "input": [
+            {
+                "ab": "cd",
+                "abc": "de"
+            },
+            {
+                 "ab": "ef",
+                 "abc": "d"
+            }
+        ]
+    }
+  dgquery: |-
+    query {
+      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+        uid
+      }
+      ABC2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
+        uid
+      }
+      ABC3(func: eq(ABC.ab, "ef")) @filter(type(ABC)) {
+        uid
+      }
+      ABC4(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
+        uid
+      }
+    }
+  explanation: "We should generate different variables as ABC1 and ABC4 if xidName+xidValue is same in two different objects as in above case
+  i.e. ab+cd and abc+d both equals to abcd"
+  dgmutations:
+    - setjson: |
+        {
+            "ABC.ab": "cd",
+            "ABC.abc": "de",
+            "dgraph.type": [
+                "ABC"
+            ],
+            "uid":"_:ABC2"
+        }
+    - setjson: |
+        {
+            "ABC.ab": "ef",
+            "ABC.abc": "d",
+            "dgraph.type": [
+                "ABC"
+            ],
+            "uid":"_:ABC4"
+        }
+
+-
+  name: "Add mutation with multiple Xid fields shouldn't give error if typeName+xidName+xidVal is equal for two different xid fields in different types"
+  gqlmutation: |
+    mutation($input: [AddABCInput!]!) {
+    	addABC(input: $input) {
+    		aBC {
+    			ab
+    			abc
+                AB {
+                  Cab
+                  Cabc
+                }
+    		}
+    	}
+    }
+
+  gqlvariables: |
+    {
+        "input": [
+            {
+                "ab": "cd",
+                "abc": "de",
+                "AB": {
+                  "Cab": "cde",
+                  "Cabc":"d"
+                }
+            }
+        ]
+    }
+  dgquery: |-
+    query {
+      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+        uid
+      }
+      ABC2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
+        uid
+      }
+      AB3(func: eq(AB.Cab, "cde")) @filter(type(AB)) {
+        uid
+      }
+      AB4(func: eq(AB.Cabc, "d")) @filter(type(AB)) {
+        uid
+      }
+    }
+  explanation: "We should generate different variables as ABC1 and AB3, or ABC2 and AB4 if typename+xidName+xidValue is same in two different types as in above case
+  i.e. ABC+ab+cd and AB+Cabc+d both equals to ABCabcd"
+  dgmutations:
+    - setjson: |
+        {
+          "ABC.AB": {
+            "AB.Cab": "cde",
+            "AB.Cabc": "d",
+            "dgraph.type": ["AB"],
+            "uid": "_:AB4"
+          },
+          "ABC.ab": "cd",
+          "ABC.abc": "de",
+          "dgraph.type": ["ABC"],
+          "uid": "_:ABC2"
+        }
+
+
+-
   name: "Add type with multiple Xid fields at deep level"
   gqlmutation: |
     mutation($input: [AddauthorInput!]!) {

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -148,7 +148,7 @@ func (v *VariableGenerator) Next(typ schema.Type, xidName, xidVal string, auth b
 		//    }
 		//   }
 		// }
-		// The two generated kes for this case will be
+		// The two generated keys for this case will be
 		// ABC.ab.cd and ABC.abc.d
 		// It also ensures that xids from different types gets different variable names
 		// here we are using the assertion that field name or type name can't have "." in them

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -139,7 +139,20 @@ func (v *VariableGenerator) Next(typ schema.Type, xidName, xidVal string, auth b
 	if xidName == "" || xidVal == "" {
 		key = typ.Name()
 	} else {
-		key = typ.FieldOriginatedFrom(xidName) + xidName + xidVal
+		// We add "." between values while generating key to removes duplicate xidError from below type of cases
+		// mutation {
+		//  addABC(input: [{ ab: "cd", abc: "d" }]) {
+		//    aBC {
+		//      ab
+		//      abc
+		//    }
+		//   }
+		// }
+		// The two generated kes for this case will be
+		// ABC.ab.cd and ABC.abc.d
+		// It also ensures that xids from different types gets different variable names
+		// here we are using the assertion that field name or type name can't have "." in them
+		key = typ.FieldOriginatedFrom(xidName) + "." + xidName + "." + xidVal
 	}
 	if varName, ok := v.xidVarNameMap[key]; ok {
 		return varName

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -426,3 +426,15 @@ type Bar {
     id: String! @id
     foo: Foo!
 }
+
+type ABC {
+    ab: String! @id
+    abc: String! @id
+    AB: AB
+}
+
+type AB {
+    Cab: String! @id
+    Cabc: String! @id
+}
+


### PR DESCRIPTION
We were getting duplicate xid error for the multiple xid fields if `typeName+xidName+xidValue `is same for those fields. The reason for this is that we need to  generate unique query variables for the xids field while doing mutation rewriting and for that we use a map to variable names. 
we were using below key for that map 
`key = typ.FieldOriginatedFrom(xidName)  + xidName + xidVal`
This was generating same key for different xid fields. For example in below type we have two fields with id fields

```
type ABC {
    ab: String! @id
    abc: String! @id
}
```
And below mutation try to set them such that `key = typ.FieldOriginatedFrom(xidName)  + xidName + xidVal` will be same for both of them i.e. `ABC+ab+cd=ABC+abc+d=ABCabcd`
```
mutation {
		addABC(input: [{ ab: "cd", abc: "d" }]) {
		  aBC {
		        ab
		        abc
		       }
		  }
	 }
```
This error also occur in multiple types.
We now added "." between values to separate typename and xidname , and the xidValue.This will ensure unique keys for xid fields across types.
`key = typ.FieldOriginatedFrom(xidName) + "." + xidName + "." + xidVal`


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7546)
<!-- Reviewable:end -->
