### PR TITLE
Chore(flags): Add disallow-dropall flag

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -203,6 +203,8 @@ they form a Raft group and provide synchronous replication.
 				"directive.").
 		Flag("mutations-nquad",
 			"The maximum number of nquads that can be inserted in a mutation request.").
+		Flag("disallow-dropall",
+			"Set disallow-dropall to true to block drop-all operation.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
@@ -716,6 +718,7 @@ func run() {
 		worker.LimitDefaults)
 	x.Config.LimitMutationsNquad = int(x.Config.Limit.GetInt64("mutations-nquad"))
 	x.Config.LimitQueryEdge = x.Config.Limit.GetUint64("query-edge")
+	x.Config.BlockDropAll = x.Config.Limit.GetBool("disallow-dropall")
 
 	x.Config.GraphQL = z.NewSuperFlag(Alpha.Conf.GetString("graphql")).MergeAndCheckDefault(
 		worker.GraphQLDefaults)

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -376,6 +376,10 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	// if it lies on some other machine. Let's get it for safety.
 	m := &pb.Mutations{StartTs: worker.State.GetTimestamp(false)}
 	if isDropAll(op) {
+		if x.Config.BlockDropAll {
+			glog.V(2).Info("Blocked drop-all because it is not permitted.")
+			return empty, errors.New("Drop all operation in not permitted.")
+		}
 		if err := AuthGuardianOfTheGalaxy(ctx); err != nil {
 			return empty, errors.Wrapf(err, "Drop all can only be called by the guardian of the"+
 				" galaxy")

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -378,7 +378,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	if isDropAll(op) {
 		if x.Config.BlockDropAll {
 			glog.V(2).Info("Blocked drop-all because it is not permitted.")
-			return empty, errors.New("Drop all operation in not permitted.")
+			return empty, errors.New("Drop all operation is not permitted.")
 		}
 		if err := AuthGuardianOfTheGalaxy(ctx); err != nil {
 			return empty, errors.Wrapf(err, "Drop all can only be called by the guardian of the"+

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -37,12 +37,13 @@ const (
 	//
 	//       For easy readability, keep the options without default values (if any) at the end of
 	//       the *Defaults string.
-	AclDefaults       = `access-ttl=6h; refresh-ttl=30d; secret-file=;`
-	AuditDefaults     = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
-	BadgerDefaults    = `compression=snappy; goroutines=8;`
-	RaftDefaults      = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
-	SecurityDefaults  = `token=; whitelist=;`
-	LimitDefaults     = `query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;`
+	AclDefaults      = `access-ttl=6h; refresh-ttl=30d; secret-file=;`
+	AuditDefaults    = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
+	BadgerDefaults   = `compression=snappy; goroutines=8;`
+	RaftDefaults     = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
+	SecurityDefaults = `token=; whitelist=;`
+	LimitDefaults    = `query-edge=1000000; normalize-node=10000; mutations-nquad=1000000;` +
+		`disallow-dropall=false`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
 	GraphQLDefaults   = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`

--- a/x/config.go
+++ b/x/config.go
@@ -35,9 +35,12 @@ type Options struct {
 	// normalize-node int - maximum number of nodes that can be returned in a query that uses the
 	//                      normalize directive
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
+	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
 	Limit               *z.SuperFlag
 	LimitMutationsNquad int
 	LimitQueryEdge      uint64
+	BlockDropAll        bool
+
 	// GraphQL options:
 	//
 	// extensions bool - Will be set to see extensions in GraphQL results


### PR DESCRIPTION
`disallow-dropall` flag can be used to disallow the drop all operations in the server. If set to true, all the drop-all requests
will be rejected.

To use this option you can start alpha as:
`dgraph alpha --limit="disallow-dropall=true" `
 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7549)
<!-- Reviewable:end -->
