### PR TITLE
fix(GRAPHQL): Added support for exact index on field having @id directive.#7534

### DIFF
--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -494,6 +494,25 @@ schemas:
       }
       B.correct: bool @index(bool) .
 
+  - name: "Field with @id directive and a exact arg in search directive generates correct schema."
+    input: |
+      interface A {
+        id: String! @id @search(by: [exact])
+      }
+      type B implements A {
+        correct: Boolean @search
+      }
+    output: |
+      type A {
+        A.id
+      }
+      A.id: string @index(exact) @upsert .
+      type B {
+        A.id
+        B.correct
+      }
+      B.correct: bool @index(bool) .
+
   -
     name: "Field with reverse predicate in dgraph directive adds @reverse to predicate."
     input: |

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1472,14 +1472,8 @@ func addHashIfRequired(fld *ast.FieldDefinition, indexes []string) []string {
 	id := fld.Directives.ForName(idDirective)
 	if id != nil {
 		// If @id directive is applied along with @search, we check if the search has hash as an
-		// arg. If it doesn't, then we add it.
-		containsHash := false
-		for _, index := range indexes {
-			if index == "hash" {
-				containsHash = true
-			}
-		}
-		if !containsHash {
+		// arg. If it doesn't and there is no exact arg, then we add hash in it.
+		if !x.HasString(indexes, "hash") && !x.HasString(indexes, "exact") {
 			indexes = append(indexes, "hash")
 		}
 	}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2676,13 +2676,6 @@ invalid_schemas:
 
 
 valid_schemas:
-  - name: "Multiple fields with @id directive should be allowed"
-    input: |
-      type X {
-        f1: String! @id
-        f2: String! @id
-      }
-
   - name: "field with @id directive can have exact index"
     input: |
       type X {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2676,6 +2676,19 @@ invalid_schemas:
 
 
 valid_schemas:
+  - name: "Multiple fields with @id directive should be allowed"
+    input: |
+      type X {
+        f1: String! @id
+        f2: String! @id
+      }
+
+  - name: "field with @id directive can have exact index"
+    input: |
+      type X {
+        f1: String! @id @search(by:[exact])
+      }
+
   - name: "Type implements from two interfaces where both have ID"
     input: |
       interface X {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -93,15 +93,15 @@ func parseSecrets(sch string) (map[string]string, *authorization.AuthMeta, error
 		parts := strings.Fields(text)
 		const doubleQuotesCode = 34
 
-			if len(parts) < 4 {
-				return nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
-					"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
-			}
-			val := strings.Join(parts[3:], " ")
-			if strings.Count(val, `"`) != 2 || val[0] != doubleQuotesCode || val[len(val)-1] != doubleQuotesCode {
-				return nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
-					"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
-			}
+		if len(parts) < 4 {
+			return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
+				"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+		}
+		val := strings.Join(parts[3:], " ")
+		if strings.Count(val, `"`) != 2 || val[0] != doubleQuotesCode || val[len(val)-1] != doubleQuotesCode {
+			return nil, nil, errors.Errorf("incorrect format for specifying Dgraph secret found for "+
+				"comment: `%s`, it should be `# Dgraph.Secret key value`", text)
+		}
 
 		val = strings.Trim(val, `"`)
 		key := strings.Trim(parts[2], `"`)
@@ -111,7 +111,6 @@ func parseSecrets(sch string) (map[string]string, *authorization.AuthMeta, error
 	if err := scanner.Err(); err != nil {
 		return nil, nil, errors.Wrapf(err, "while trying to parse secrets from schema file")
 	}
-
 	if authSecret == "" {
 		return m, nil, nil
 	}

--- a/graphql/schema/testdata/schemagen/input/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/input/field-with-id-directive.graphql
@@ -13,5 +13,6 @@ type Author {
 }
 
 type Genre {
-    name: String! @id
+    # This will add exact index on name field, overwriting the default "hash" index for field of type "String! @id".
+    name: String! @id @search(by: [exact])
 }

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -18,7 +18,7 @@ type Author {
 }
 
 type Genre {
-	name: String! @id
+	name: String! @id @search(by: [exact])
 }
 
 #######################
@@ -425,7 +425,7 @@ input AuthorRef {
 }
 
 input GenreFilter {
-	name: StringHashFilter
+	name: StringExactFilter
 	has: GenreHasFilter
 	and: [GenreFilter]
 	or: [GenreFilter]


### PR DESCRIPTION
Currently we add hash index on a field of type String! @id by default. And as index exact and hash are not compatible , user can't add exact index on such field and can't take advantage of comparator functions like lt,le,gt,ge.

To allow this we now changing that behavior, i.e. for a field of type String! @id @search(by:[exact]) , we don't generate default hash index and only generate exact index.
(cherry picked from commit 195f247)
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7550)
<!-- Reviewable:end -->
