### PR TITLE
Fix(multi-tenancy): Format namespace to human readable form

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1036,7 +1036,16 @@ func filterTablets(ctx context.Context, ms *pb.MembershipState) error {
 		return errors.Errorf("Namespace not found in JWT.")
 	}
 	if namespace == x.GalaxyNamespace {
-		// For galaxy namespace, we don't want to filter out the predicates.
+		// For galaxy namespace, we don't want to filter out the predicates. We only format the
+		// namespace to human readable form.
+		for _, group := range ms.Groups {
+			tablets := make(map[string]*pb.Tablet)
+			for tabletName, tablet := range group.Tablets {
+				tablet.Predicate = x.FormatNsAttr(tablet.Predicate)
+				tablets[x.FormatNsAttr(tabletName)] = tablet
+			}
+			group.Tablets = tablets
+		}
 		return nil
 	}
 	for _, group := range ms.GetGroups() {

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1220,9 +1220,16 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (
 		return
 	}
 
-	// TODO(Ahsan): resp.Txn.Preds contain predicates of form gid-namespace|attr.
-	// Remove the namespace from the response.
-	// resp.Txn.Preds = x.ParseAttrList(resp.Txn.Preds)
+	// resp.Txn.Preds contain predicates of form gid-namespace|attr, the below code changes
+	// namespace to human-readable integer form.
+	var preds []string
+	for _, p := range resp.Txn.Preds {
+		splits := strings.SplitN(p, "-", 2)
+		x.AssertTrue(len(splits) == 2)
+		pred := splits[0] + "-" + x.FormatNsAttr(splits[1])
+		preds = append(preds, pred)
+	}
+	resp.Txn.Preds = preds
 
 	// TODO(martinmr): Include Transport as part of the latency. Need to do
 	// this separately since it involves modifying the API protos.

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1220,16 +1220,9 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (
 		return
 	}
 
-	// resp.Txn.Preds contain predicates of form gid-namespace|attr, the below code changes
-	// namespace to human-readable integer form.
-	var preds []string
-	for _, p := range resp.Txn.Preds {
-		splits := strings.SplitN(p, "-", 2)
-		x.AssertTrue(len(splits) == 2)
-		pred := splits[0] + "-" + x.FormatNsAttr(splits[1])
-		preds = append(preds, pred)
-	}
-	resp.Txn.Preds = preds
+	// TODO(Ahsan): resp.Txn.Preds contain predicates of form gid-namespace|attr.
+	// Remove the namespace from the response.
+	// resp.Txn.Preds = x.ParseAttrList(resp.Txn.Preds)
 
 	// TODO(martinmr): Include Transport as part of the latency. Need to do
 	// this separately since it involves modifying the API protos.

--- a/posting/index.go
+++ b/posting/index.go
@@ -592,7 +592,7 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 	glog.V(1).Infof(
 		"Rebuilding index for predicate %s: Starting process. StartTs=%d. Prefix=\n%s\n",
-		r.attr, r.startTs, hex.Dump(r.prefix))
+		x.FormatNsAttr(r.attr), r.startTs, hex.Dump(r.prefix))
 
 	// Counter is used here to ensure that all keys are committed at different timestamp.
 	// We set it to 1 in case there are no keys found and NewStreamAt is called with ts=0.
@@ -600,7 +600,8 @@ func (r *rebuilder) Run(ctx context.Context) error {
 
 	tmpWriter := tmpDB.NewManagedWriteBatch()
 	stream := pstore.NewStreamAt(r.startTs)
-	stream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (1/2):", r.attr)
+	stream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (1/2):",
+		x.FormatNsAttr(r.attr))
 	stream.Prefix = r.prefix
 	stream.KeyToList = func(key []byte, itr *badger.Iterator) (*bpb.KVList, error) {
 		// We should return quickly if the context is no longer valid.
@@ -662,19 +663,21 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		return err
 	}
 	glog.V(1).Infof("Rebuilding index for predicate %s: building temp index took: %v\n",
-		r.attr, time.Since(start))
+		x.FormatNsAttr(r.attr), time.Since(start))
 
 	// Now we write all the created posting lists to disk.
-	glog.V(1).Infof("Rebuilding index for predicate %s: writing index to badger", r.attr)
+	glog.V(1).Infof("Rebuilding index for predicate %s: writing index to badger",
+		x.FormatNsAttr(r.attr))
 	start = time.Now()
 	defer func() {
 		glog.V(1).Infof("Rebuilding index for predicate %s: writing index took: %v\n",
-			r.attr, time.Since(start))
+			x.FormatNsAttr(r.attr), time.Since(start))
 	}()
 
 	writer := pstore.NewManagedWriteBatch()
 	tmpStream := tmpDB.NewStreamAt(counter)
-	tmpStream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (2/2):", r.attr)
+	tmpStream.LogPrefix = fmt.Sprintf("Rebuilding index for predicate %s (2/2):",
+		x.FormatNsAttr(r.attr))
 	tmpStream.KeyToList = func(key []byte, itr *badger.Iterator) (*bpb.KVList, error) {
 		l, err := ReadPostingList(key, itr)
 		if err != nil {
@@ -717,7 +720,8 @@ func (r *rebuilder) Run(ctx context.Context) error {
 	if err := tmpStream.Orchestrate(ctx); err != nil {
 		return err
 	}
-	glog.V(1).Infof("Rebuilding index for predicate %s: Flushing all writes.\n", r.attr)
+	glog.V(1).Infof("Rebuilding index for predicate %s: Flushing all writes.\n",
+		x.FormatNsAttr(r.attr))
 	return writer.Flush()
 }
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -488,7 +488,7 @@ func (g *groupi) sendTablet(tablet *pb.Tablet) (*pb.Tablet, error) {
 	}
 
 	if out.GroupId == groups().groupId() {
-		glog.Infof("Serving tablet for: %v\n", tablet.GetPredicate())
+		glog.Infof("Serving tablet for: %v\n", x.FormatNsAttr(tablet.GetPredicate()))
 	}
 	return out, nil
 }

--- a/x/keys.go
+++ b/x/keys.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"math"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -118,6 +119,11 @@ func IsReverseAttr(attr string) bool {
 		return true
 	}
 	return false
+}
+
+func FormatNsAttr(attr string) string {
+	ns, attr := ParseNamespaceAttr(attr)
+	return strconv.FormatUint(ns, 10) + "-" + attr
 }
 
 func writeAttr(buf []byte, attr string) []byte {


### PR DESCRIPTION
This PR changes the logs to print namespace in human-readable form. This change doesn't fix all of them. 
We have left the cases where we print a struct and the fields in the struct contains predicate with namespace. 
We have also skipped logs of `SubscribeForUpdates` because we can't assume the prefix being logged will always contain namespace. 

This is not exhaustive, it fixes the things which are apparent on basic usage of dgraph. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7552)
<!-- Reviewable:end -->
