### PR TITLE
chore(live): fixing live loader abort errors when using force-namespace

### DIFF
--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -191,8 +191,7 @@ func init() {
 		"specific namespace. Setting it to negative value will preserve the namespace.")
 }
 
-func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, ns uint64,
-	galaxyOperation bool) (*schema, error) {
+func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, galaxyOperation bool) (*schema, error) {
 	txn := dgraphClient.NewTxn()
 	defer txn.Discard(ctx)
 
@@ -207,7 +206,7 @@ func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, ns uint64,
 	}
 	// If we are not loading data across namespaces, the schema query result will not contain the
 	// namespace information. Set it inside the init function.
-	sch.init(ns, galaxyOperation)
+	sch.init(opt.namespaceToLoad, galaxyOperation)
 	return &sch, nil
 }
 
@@ -804,7 +803,7 @@ func run() error {
 		fmt.Printf("Processed schema file %q\n\n", opt.schemaFile)
 	}
 
-	if l.schema, err = getSchema(ctx, dg, opt.namespaceToLoad, galaxyOperation); err != nil {
+	if l.schema, err = getSchema(ctx, dg, galaxyOperation); err != nil {
 		fmt.Printf("Error while loading schema from alpha %s\n", err)
 		return err
 	}

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -106,11 +106,11 @@ type request struct {
 	conflicts []uint64
 }
 
-func (l *schema) init(ns uint64) {
+func (l *schema) init(ns uint64, galaxyOperation bool) {
 	l.preds = make(map[string]*predicate)
 	for _, i := range l.Predicates {
 		i.ValueType, _ = types.TypeForName(i.Type)
-		if !opt.preserveNs {
+		if !galaxyOperation {
 			i.Predicate = x.NamespaceAttr(ns, i.Predicate)
 		}
 		l.preds[i.Predicate] = i
@@ -191,7 +191,8 @@ func init() {
 		"specific namespace. Setting it to negative value will preserve the namespace.")
 }
 
-func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, ns uint64) (*schema, error) {
+func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, ns uint64,
+	galaxyOperation bool) (*schema, error) {
 	txn := dgraphClient.NewTxn()
 	defer txn.Discard(ctx)
 
@@ -206,7 +207,7 @@ func getSchema(ctx context.Context, dgraphClient *dgo.Dgraph, ns uint64) (*schem
 	}
 	// If we are not loading data across namespaces, the schema query result will not contain the
 	// namespace information. Set it inside the init function.
-	sch.init(ns)
+	sch.init(ns, galaxyOperation)
 	return &sch, nil
 }
 
@@ -724,8 +725,9 @@ func run() error {
 			opt.namespaceToLoad = uint64(forceNs)
 		}
 	default:
-		if Live.Conf.IsSet("force-namespace") && uint64(forceNs) != creds.GetUint64("namespace") {
-			return errors.Errorf("cannot load into namespace %#x", forceNs)
+		if Live.Conf.IsSet("force-namespace") {
+			return errors.Errorf("cannot force namespace %#x when provided creds are not of"+
+				" guardian of galaxy user", forceNs)
 		}
 		opt.namespaceToLoad = creds.GetUint64("namespace")
 	}
@@ -746,9 +748,11 @@ func run() error {
 		opt.namespaceToLoad != x.GalaxyNamespace {
 		singleNsOp = false
 	}
+	galaxyOperation := false
 	if !singleNsOp {
 		// Attach the galaxy to the context to specify that the query/mutations with this context
 		// will be galaxy-wide.
+		galaxyOperation = true
 		ctx = x.AttachGalaxyOperation(ctx, opt.namespaceToLoad)
 		// We don't support upsert predicate while loading data in multiple namespace.
 		if len(opt.upsertPredicate) > 0 {
@@ -800,7 +804,7 @@ func run() error {
 		fmt.Printf("Processed schema file %q\n\n", opt.schemaFile)
 	}
 
-	if l.schema, err = getSchema(ctx, dg, opt.namespaceToLoad); err != nil {
+	if l.schema, err = getSchema(ctx, dg, opt.namespaceToLoad, galaxyOperation); err != nil {
 		fmt.Printf("Error while loading schema from alpha %s\n", err)
 		return err
 	}

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -327,7 +327,7 @@ func TestLiveLoadMulti(t *testing.T) {
 		forceNs: -1,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot load into namespace")
+	require.Contains(t, err.Error(), "cannot force namespace")
 
 	err = liveLoadData(t, &liveOpts{
 		rdfs: `_:c <name> "ns hola" .`,
@@ -338,7 +338,7 @@ func TestLiveLoadMulti(t *testing.T) {
 		forceNs: 10,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "cannot load into namespace")
+	require.Contains(t, err.Error(), "cannot force namespace")
 
 	require.NoError(t, liveLoadData(t, &liveOpts{
 		rdfs: fmt.Sprintf(`


### PR DESCRIPTION
This PR fixes the issue of multiple txn aborts while live loading data with force-namespace enabled. The problem was if it's a galaxy operation, the schema will already have predicates with a namespace prefix. But we were appending it again in the schema.init function thus causing two namespaces in the predicate Name. This results in the wrong generation of conflict keys and thus txn aborts later

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7553)
<!-- Reviewable:end -->
