### PR TITLE
fix(learner nodes): Reconnect to learner nodes after restart

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1760,6 +1760,12 @@ func (n *node) InitAndStartNode() {
 					n.Connect(id, m.Addr)
 				}
 			}
+			for _, id := range sp.Metadata.ConfState.Learners {
+				m, ok := members[id]
+				if ok {
+					n.Connect(id, m.Addr)
+				}
+			}
 		}
 		n.SetRaft(raft.RestartNode(n.Cfg))
 		glog.V(2).Infoln("Restart node complete")


### PR DESCRIPTION
When an alpha would restart, it wasn't reconnecting to the learner
nodes. This PR fixes that.
Fixes DGRAPH-3125


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7554)
<!-- Reviewable:end -->
