### PR TITLE
Fix(GraphQL): Change variable name generation from Type<Num> to Type_<Num>

### DIFF
--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -22,7 +22,7 @@
   explanation: "Add mutation should convert the Point type mutation to corresponding Dgraph JSON mutation"
   dgmutations:
     - setjson: |
-        { "uid":"_:Hotel1",
+        { "uid":"_:Hotel_1",
           "dgraph.type":["Hotel"],
           "Hotel.name":"Taj Hotel",
           "Hotel.location": {
@@ -83,7 +83,7 @@
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Hotel1",
+          "uid":"_:Hotel_1",
           "dgraph.type":["Hotel"],
           "Hotel.name":"Taj Hotel",
           "Hotel.area": {
@@ -172,7 +172,7 @@
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Hotel1",
+          "uid":"_:Hotel_1",
           "dgraph.type":["Hotel"],
           "Hotel.name":"Taj Hotel",
           "Hotel.branches": {
@@ -202,7 +202,7 @@
     underlying Dgraph edge names"
   dgmutations:
     - setjson: |
-        { "uid":"_:Author1",
+        { "uid":"_:Author_1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
           "Author.dob":"2000-01-01",
@@ -253,37 +253,37 @@
     underlying Dgraph edge names. Some PostSecrets are present and are not created."
   dgquery: |-
     query {
-      PostSecret1(func: eq(PostSecret.title, "ps1")) @filter(type(PostSecret)) {
+      PostSecret_1(func: eq(PostSecret.title, "ps1")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret2(func: eq(PostSecret.title, "ps2")) @filter(type(PostSecret)) {
+      PostSecret_2(func: eq(PostSecret.title, "ps2")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret3(func: eq(PostSecret.title, "ps3")) @filter(type(PostSecret)) {
+      PostSecret_3(func: eq(PostSecret.title, "ps3")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret4(func: eq(PostSecret.title, "ps4")) @filter(type(PostSecret)) {
+      PostSecret_4(func: eq(PostSecret.title, "ps4")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret5(func: eq(PostSecret.title, "ps5")) @filter(type(PostSecret)) {
+      PostSecret_5(func: eq(PostSecret.title, "ps5")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret6(func: eq(PostSecret.title, "ps6")) @filter(type(PostSecret)) {
+      PostSecret_6(func: eq(PostSecret.title, "ps6")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret7(func: eq(PostSecret.title, "ps7")) @filter(type(PostSecret)) {
+      PostSecret_7(func: eq(PostSecret.title, "ps7")) @filter(type(PostSecret)) {
         uid
       }
-      PostSecret8(func: eq(PostSecret.title, "ps8")) @filter(type(PostSecret)) {
+      PostSecret_8(func: eq(PostSecret.title, "ps8")) @filter(type(PostSecret)) {
         uid
       }
     }
   qnametouid: |
     {
-      "PostSecret1":"0x1",
-      "PostSecret2":"0x2",
-      "PostSecret3":"0x3",
-      "PostSecret4":"0x4"
+      "PostSecret_1":"0x1",
+      "PostSecret_2":"0x2",
+      "PostSecret_3":"0x3",
+      "PostSecret_4":"0x4"
     }
   dgmutations:
     - setjson: |
@@ -294,7 +294,7 @@
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
@@ -302,12 +302,12 @@
                   },
                 "Post.title":"post1",
                 "dgraph.type":["Post"],
-                "uid":"_:Post10"
+                "uid":"_:Post_10"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
@@ -315,12 +315,12 @@
                   },
                 "Post.title":"post2",
                 "dgraph.type":["Post"],
-                "uid":"_:Post11"
+                "uid":"_:Post_11"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
@@ -328,12 +328,12 @@
                   },
                 "Post.title":"post3",
                 "dgraph.type":["Post"],
-                "uid":"_:Post12"
+                "uid":"_:Post_12"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
@@ -341,71 +341,71 @@
                   },
                 "Post.title":"post4",
                 "dgraph.type":["Post"],
-                "uid":"_:Post13"
+                "uid":"_:Post_13"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
                     "PostSecret.title":"ps5",
                     "dgraph.type":["PostSecret"],
-                    "uid":"_:PostSecret5"
+                    "uid":"_:PostSecret_5"
                   },
                 "Post.title":"post5",
                 "dgraph.type":["Post"],
-                "uid":"_:Post14"
+                "uid":"_:Post_14"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
                     "PostSecret.title":"ps6",
                     "dgraph.type":["PostSecret"],
-                    "uid":"_:PostSecret6"
+                    "uid":"_:PostSecret_6"
                   },
                 "Post.title":"post6",
                 "dgraph.type":["Post"],
-                "uid":"_:Post15"
+                "uid":"_:Post_15"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
                     "PostSecret.title":"ps7",
                     "dgraph.type":["PostSecret"],
-                    "uid":"_:PostSecret7"
+                    "uid":"_:PostSecret_7"
                   },
                 "Post.title":"post7",
                 "dgraph.type":["Post"],
-                "uid":"_:Post16"
+                "uid":"_:Post_16"
               },
               {
                 "Post.author":
                   {
-                    "uid":"_:Author9"
+                    "uid":"_:Author_9"
                   },
                 "Post.ps":
                   {
                     "PostSecret.title":"ps8",
                     "dgraph.type":["PostSecret"],
-                    "uid":"_:PostSecret8"
+                    "uid":"_:PostSecret_8"
                   },
                 "Post.title":"post8",
                 "dgraph.type":["Post"],
-                "uid":"_:Post17"
+                "uid":"_:Post_17"
               }
             ],
           "dgraph.type":["Author"],
-          "uid":"_:Author9"
+          "uid":"_:Author_9"
         }
 
 -
@@ -422,7 +422,7 @@
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Message1",
+          "uid":"_:Message_1",
           "dgraph.type":["Message"],
           "职业":"author1",
           "post":"content1"
@@ -452,12 +452,12 @@
     underlying Dgraph edge names"
   dgmutations:
     - setjson: |
-        { "uid":"_:Author1",
+        { "uid":"_:Author_1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author"
         }
     - setjson: |
-        { "uid":"_:Author2",
+        { "uid":"_:Author_2",
           "dgraph.type":["Author"],
           "Author.name":"Different Author"
         }
@@ -476,7 +476,7 @@
   for input objects."
   dgmutations:
     - setjson: |
-        { "uid":"_:Author1",
+        { "uid":"_:Author_1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author"
         }
@@ -496,7 +496,7 @@
     injected and all data transformed to underlying Dgraph edge names"
   dgmutations:
     - setjson: |
-        { "uid":"_:Author1",
+        { "uid":"_:Author_1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
           "Author.posts":[]
@@ -518,14 +518,14 @@
     getting injected and all data transformed to underlying Dgraph edge names"
   dgquery: |-
     query {
-      User1(func: eq(User.name, "A.N. Author")) @filter(type(User)) {
+      User_1(func: eq(User.name, "A.N. Author")) @filter(type(User)) {
         uid
       }
     }
   dgmutations:
     - setjson: |
         {
-          "uid":"_:User1",
+          "uid":"_:User_1",
           "dgraph.type":["User"],
           "User.name":"A.N. Author",
           "User.pwd":"Password"
@@ -547,14 +547,14 @@
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Author1",
+          "uid":"_:Author_1",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
           "Author.posts":[]
         }
     - setjson: |
         {
-          "uid":"_:Author2",
+          "uid":"_:Author_2",
           "dgraph.type":["Author"],
           "Author.name":"Different Author",
           "Author.posts":[]
@@ -581,18 +581,18 @@
     Dgraph JSON mutation"
   dgquery: |-
     query {
-      Country1(func: uid(0x123)) @filter(type(Country)) {
+      Country_1(func: uid(0x123)) @filter(type(Country)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Country1":"0x123"
+      "Country_1":"0x123"
     }
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Author2",
+          "uid":"_:Author_2",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
           "Author.country":
@@ -622,7 +622,7 @@
   explanation: "This should throw an error as 0x123 is not a valid Country node"
   dgquery: |-
     query {
-      Country1(func: uid(0x123)) @filter(type(Country)) {
+      Country_1(func: uid(0x123)) @filter(type(Country)) {
         uid
       }
     }
@@ -674,23 +674,23 @@
     a new 'posts' edge."
   dgquery: |-
     query {
-      Author1(func: uid(0x2)) @filter(type(Author)) {
+      Author_1(func: uid(0x2)) @filter(type(Author)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Author1": "0x2"
+      "Author_1": "0x2"
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:Post2",
+        { "uid" : "_:Post_2",
           "dgraph.type" : ["Post"],
           "Post.title" : "Exciting post",
           "Post.text" : "A really good post",
           "Post.author": {
             "uid" : "0x2",
-            "Author.posts" : [ { "uid": "_:Post2" } ]
+            "Author.posts" : [ { "uid": "_:Post_2" } ]
           }
         }
 
@@ -717,7 +717,7 @@
   explanation: "The mutation should get rewritten with correct edges from the interface."
   dgmutations:
     - setjson: |
-        { "uid" : "_:Human1",
+        { "uid" : "_:Human_1",
           "Character.name": "Bob",
           "Employee.ename": "employee no. 1",
           "Human.dob": "2000-01-01",
@@ -746,26 +746,26 @@
   explanation: "The add mutation should get rewritten into a Dgraph upsert mutation"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "nsw")) @filter(type(State)) {
+      State_1(func: eq(State.code, "nsw")) @filter(type(State)) {
         uid
       }
-      Country2(func: uid(0x12)) @filter(type(Country)) {
+      Country_2(func: uid(0x12)) @filter(type(Country)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Country2": "0x12"
+      "Country_2": "0x12"
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:State1",
+        { "uid" : "_:State_1",
           "dgraph.type": ["State"],
           "State.name": "NSW",
           "State.code": "nsw",
           "State.country": {
             "uid": "0x12",
-            "Country.states": [ { "uid": "_:State1" } ]
+            "Country.states": [ { "uid": "_:State_1" } ]
           }
         }
 
@@ -790,17 +790,17 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "nsw")) @filter(type(State)) {
+      State_1(func: eq(State.code, "nsw")) @filter(type(State)) {
         uid
       }
-      Country2(func: uid(0x12)) @filter(type(Country)) {
+      Country_2(func: uid(0x12)) @filter(type(Country)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1": "0x11",
-      "Country2": "0x12"
+      "State_1": "0x11",
+      "Country_2": "0x12"
     }
   error2:
     {
@@ -835,84 +835,84 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "nsw")) @filter(type(State)) {
+      State_1(func: eq(State.code, "nsw")) @filter(type(State)) {
         uid
       }
-      Country2(func: uid(0x12)) @filter(type(Country)) {
+      Country_2(func: uid(0x12)) @filter(type(Country)) {
         uid
       }
-      State3(func: eq(State.code, "mh")) @filter(type(State)) {
+      State_3(func: eq(State.code, "mh")) @filter(type(State)) {
         uid
       }
-      Country4(func: uid(0x14)) @filter(type(Country)) {
+      Country_4(func: uid(0x14)) @filter(type(Country)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1": "0x11",
-      "Country2": "0x12",
-      "State3": "0x13",
-      "Country4": "0x14"
+      "State_1": "0x11",
+      "Country_2": "0x12",
+      "State_3": "0x13",
+      "Country_4": "0x14"
     }
   dgquerysec: |-
     query {
-      State1 as State1(func: uid(0x11)) @filter(type(State)) {
+      State_1 as State_1(func: uid(0x11)) @filter(type(State)) {
         uid
       }
-      State3 as State3(func: uid(0x13)) @filter(type(State)) {
+      State_3 as State_3(func: uid(0x13)) @filter(type(State)) {
         uid
       }
-      var(func: uid(State1)) {
-        Country5 as State.country @filter(NOT (uid(0x12)))
+      var(func: uid(State_1)) {
+        Country_5 as State.country @filter(NOT (uid(0x12)))
       }
-      var(func: uid(State3)) {
-        Country7 as State.country @filter(NOT (uid(0x14)))
+      var(func: uid(State_3)) {
+        Country_7 as State.country @filter(NOT (uid(0x14)))
       }
     }
   dgmutations:
     - setjson: |
-        { "uid" : "uid(State1)",
+        { "uid" : "uid(State_1)",
           "State.name": "NSW",
           "State.country": {
             "uid": "0x12",
-            "Country.states": [ { "uid": "uid(State1)" } ]
+            "Country.states": [ { "uid": "uid(State_1)" } ]
           }
         }
       deletejson: |
         [
           {
-            "uid":"uid(Country5)",
+            "uid":"uid(Country_5)",
             "Country.states":
               [
                 {
-                  "uid":"uid(State1)"
+                  "uid":"uid(State_1)"
                 }
               ]
           }
         ]
-      cond: "@if(gt(len(State1), 0))"
+      cond: "@if(gt(len(State_1), 0))"
     - setjson: |
-        { "uid" : "uid(State3)",
+        { "uid" : "uid(State_3)",
           "State.name": "Maharashtra",
           "State.country": {
             "uid": "0x14",
-            "Country.states": [ { "uid": "uid(State3)" } ]
+            "Country.states": [ { "uid": "uid(State_3)" } ]
           }
         }
       deletejson: |
         [
           {
-            "uid":"uid(Country7)",
+            "uid":"uid(Country_7)",
             "Country.states":
               [
                 {
-                  "uid":"uid(State3)"
+                  "uid":"uid(State_3)"
                 }
               ]
           }
         ]
-      cond: "@if(gt(len(State3), 0))"
+      cond: "@if(gt(len(State_3), 0))"
 
 -
   name: "Upsert Mutation with multiple xids where both existence queries result exist"
@@ -937,30 +937,30 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "NSW")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "NSW")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Book1": "0x11",
-      "Book2": "0x11"
+      "Book_1": "0x11",
+      "Book_2": "0x11"
     }
   dgquerysec: |-
     query {
-      Book2 as Book2(func: uid(0x11)) @filter(type(Book)) {
+      Book_2 as Book_2(func: uid(0x11)) @filter(type(Book)) {
         uid
       }
     }
   dgmutations:
     - setjson: |
-        { "uid" : "uid(Book2)",
+        { "uid" : "uid(Book_2)",
           "Book.publisher": "penguin"
         }
-      cond: "@if(gt(len(Book2), 0))"
+      cond: "@if(gt(len(Book_2), 0))"
 
 -
   name: "Upsert Mutation with multiple xids where only one of existence queries result exist"
@@ -987,30 +987,30 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "NSW")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "NSW")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Book2": "0x11"
+      "Book_2": "0x11"
     }
   dgquerysec: |-
     query {
-      Book2 as Book2(func: uid(0x11)) @filter(type(Book)) {
+      Book_2 as Book_2(func: uid(0x11)) @filter(type(Book)) {
         uid
       }
     }
   dgmutations:
     - setjson: |
         {
-          "uid" : "uid(Book2)",
+          "uid" : "uid(Book_2)",
           "Book.publisher": "penguin"
         }
-      cond: "@if(gt(len(Book2), 0))"
+      cond: "@if(gt(len(Book_2), 0))"
 
 -
   name: "Multiple Upsert Mutation 2"
@@ -1041,62 +1041,62 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "nsw")) @filter(type(State)) {
+      State_1(func: eq(State.code, "nsw")) @filter(type(State)) {
         uid
       }
-      Country2(func: uid(0x12)) @filter(type(Country)) {
+      Country_2(func: uid(0x12)) @filter(type(Country)) {
         uid
       }
-      State3(func: eq(State.code, "mh")) @filter(type(State)) {
+      State_3(func: eq(State.code, "mh")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1": "0x11",
-      "Country2": "0x12"
+      "State_1": "0x11",
+      "Country_2": "0x12"
     }
   dgquerysec: |-
     query {
-      State1 as State1(func: uid(0x11)) @filter(type(State)) {
+      State_1 as State_1(func: uid(0x11)) @filter(type(State)) {
         uid
       }
-      var(func: uid(State1)) {
-        Country4 as State.country @filter(NOT (uid(0x12)))
+      var(func: uid(State_1)) {
+        Country_4 as State.country @filter(NOT (uid(0x12)))
       }
     }
   dgmutations:
     - setjson: |
-        { "uid" : "uid(State1)",
+        { "uid" : "uid(State_1)",
           "State.name": "NSW",
           "State.country": {
             "uid": "0x12",
-            "Country.states": [ { "uid": "uid(State1)" } ]
+            "Country.states": [ { "uid": "uid(State_1)" } ]
           }
         }
       deletejson: |
         [
           {
-            "uid":"uid(Country4)",
+            "uid":"uid(Country_4)",
             "Country.states":
               [
                 {
-                  "uid":"uid(State1)"
+                  "uid":"uid(State_1)"
                 }
               ]
           }
         ]
-      cond: "@if(gt(len(State1), 0))"
+      cond: "@if(gt(len(State_1), 0))"
     - setjson: |
-        { "uid" : "_:State3",
+        { "uid" : "_:State_3",
           "dgraph.type": ["State"],
           "State.name": "Maharashtra",
           "State.code": "mh",
           "State.country": {
-            "uid": "_:Country6",
+            "uid": "_:Country_6",
             "dgraph.type": ["Country"],
             "Country.name": "India",
-            "Country.states": [ { "uid": "_:State3" } ]
+            "Country.states": [ { "uid": "_:State_3" } ]
           }
         }
 
@@ -1120,14 +1120,14 @@
   explanation: "The add mutation should get rewritten into a Dgraph upsert mutation"
   dgquery: |-
     query {
-      Editor1(func: eq(Editor.code, "editor")) @filter(type(Editor)) {
+      Editor_1(func: eq(Editor.code, "editor")) @filter(type(Editor)) {
         uid
       }
     }
   dgmutations:
     - setjson: |
         {
-          "uid" : "_:Editor1",
+          "uid" : "_:Editor_1",
           "dgraph.type": ["Editor"],
           "Editor.name": "A.N. Editor",
           "Editor.code": "editor"
@@ -1157,18 +1157,18 @@
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:Author1",
+        { "uid" : "_:Author_1",
           "dgraph.type" : [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post2",
+              "uid": "_:Post_2",
               "dgraph.type" : [ "Post" ],
               "Post.title" : "New post",
               "Post.text" : "A really new post",
               "Post.author": {
-                "uid" : "_:Author1"
+                "uid" : "_:Author_1"
               }
             }
           ]
@@ -1207,35 +1207,35 @@
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:Author1",
+        { "uid" : "_:Author_1",
           "dgraph.type" : [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post2",
+              "uid": "_:Post_2",
               "dgraph.type" : [ "Post" ],
               "Post.title" : "New post",
               "Post.text" : "A really new post",
               "Post.author": {
-                "uid" : "_:Author1"
+                "uid" : "_:Author_1"
               }
             }
           ]
         }
     - setjson: |
-        { "uid" : "_:Author3",
+        { "uid" : "_:Author_3",
           "dgraph.type" : [ "Author" ],
           "Author.name": "Different Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post4",
+              "uid": "_:Post_4",
               "dgraph.type" : [ "Post" ],
               "Post.title" : "New New post",
               "Post.text" : "A wonderful post",
               "Post.author": {
-                "uid" : "_:Author3"
+                "uid" : "_:Author_3"
               }
             }
           ]
@@ -1270,41 +1270,41 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x123)) @filter(type(Post)) {
+      Post_1(func: uid(0x123)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Post1":"0x123"
+      "Post_1":"0x123"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x123)) {
-        Author4 as Post.author
+        Author_4 as Post.author
       }
     }
   dgmutations:
     - setjson: |
-        { "uid": "_:Author2",
+        { "uid": "_:Author_2",
           "dgraph.type": [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post3",
+              "uid": "_:Post_3",
               "dgraph.type": [ "Post" ],
               "Post.title": "New post",
               "Post.text": "A really new post",
               "Post.author": {
-                "uid": "_:Author2"
+                "uid": "_:Author_2"
               }
             },
             {
               "uid": "0x123",
               "Post.author": {
-                "uid": "_:Author2"
+                "uid": "_:Author_2"
               }
             }
           ]
@@ -1312,7 +1312,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [{"uid": "0x123"}]
           }
         ]
@@ -1360,47 +1360,47 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x123)) @filter(type(Post)) {
+      Post_1(func: uid(0x123)) @filter(type(Post)) {
         uid
       }
-      Post2(func: uid(0x124)) @filter(type(Post)) {
+      Post_2(func: uid(0x124)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Post1":"0x123",
-      "Post2":"0x124"
+      "Post_1":"0x123",
+      "Post_2":"0x124"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x123)) {
-        Author5 as Post.author
+        Author_5 as Post.author
       }
       var(func: uid(0x124)) {
-        Author8 as Post.author
+        Author_8 as Post.author
       }
     }
   dgmutations:
     - setjson: |
-        { "uid": "_:Author3",
+        { "uid": "_:Author_3",
           "dgraph.type": [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post4",
+              "uid": "_:Post_4",
               "dgraph.type": [ "Post" ],
               "Post.title": "New post",
               "Post.text": "A really new post",
               "Post.author": {
-                "uid": "_:Author3"
+                "uid": "_:Author_3"
               }
             },
             {
               "uid": "0x123",
               "Post.author": {
-                "uid": "_:Author3"
+                "uid": "_:Author_3"
               }
             }
           ]
@@ -1408,7 +1408,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author5)",
+            "uid": "uid(Author_5)",
             "Author.posts": [
               {
               "uid": "0x123"
@@ -1418,24 +1418,24 @@
         ]
     - setjson: |
         {
-          "uid": "_:Author6",
+          "uid": "_:Author_6",
           "dgraph.type": [ "Author" ],
           "Author.name": "Different Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post7",
+              "uid": "_:Post_7",
               "dgraph.type": [ "Post" ],
               "Post.title": "New new post",
               "Post.text": "A wonderful post",
               "Post.author": {
-                "uid": "_:Author6"
+                "uid": "_:Author_6"
               }
             },
             {
               "uid": "0x124",
               "Post.author": {
-                "uid": "_:Author6"
+                "uid": "_:Author_6"
               }
             }
           ]
@@ -1443,7 +1443,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author8)",
+            "uid": "uid(Author_8)",
             "Author.posts": [
               {
                 "uid": "0x124"
@@ -1480,30 +1480,30 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x123)) @filter(type(Post)) {
+      Post_1(func: uid(0x123)) @filter(type(Post)) {
         uid
       }
-      Post2(func: uid(0x456)) @filter(type(Post)) {
+      Post_2(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Post1":"0x123",
-      "Post2":"0x456"
+      "Post_1":"0x123",
+      "Post_2":"0x456"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x123)) {
-        Author4 as Post.author
+        Author_4 as Post.author
       }
       var(func: uid(0x456)) {
-        Author5 as Post.author
+        Author_5 as Post.author
       }
     }
   dgmutations:
     - setjson: |
-        { "uid": "_:Author3",
+        { "uid": "_:Author_3",
           "dgraph.type": [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
@@ -1511,13 +1511,13 @@
             {
               "uid": "0x123",
               "Post.author": {
-                "uid": "_:Author3"
+                "uid": "_:Author_3"
               }
             },
             {
               "uid": "0x456",
               "Post.author": {
-                "uid": "_:Author3"
+                "uid": "_:Author_3"
               }
             }
           ]
@@ -1525,11 +1525,11 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [{"uid": "0x123"}]
           },
           {
-            "uid": "uid(Author5)",
+            "uid": "uid(Author_5)",
             "Author.posts": [{"uid": "0x456"}]
           }
         ]
@@ -1559,18 +1559,18 @@
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:Author1",
+        { "uid" : "_:Author_1",
           "dgraph.type" : [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post2",
+              "uid": "_:Post_2",
               "dgraph.type" : [ "Post" ],
               "Post.title" : "New post",
               "Post.text" : "A really new post",
               "Post.author": {
-                "uid" : "_:Author1"
+                "uid" : "_:Author_1"
               }
             }
           ]
@@ -1603,25 +1603,25 @@
     }
   dgmutations:
     - setjson: |
-        { "uid": "_:Author1",
+        { "uid": "_:Author_1",
           "dgraph.type": [ "Author" ],
           "Author.name": "A.N. Author",
           "Author.dob": "2000-01-01",
           "Author.posts": [
             {
-              "uid": "_:Post2",
+              "uid": "_:Post_2",
               "dgraph.type": [ "Post" ],
               "Post.title": "Exciting post",
               "Post.text": "A really good post",
               "Post.author": {
-                "uid": "_:Author1"
+                "uid": "_:Author_1"
               },
               "Post.category": {
-                "uid": "_:Category3",
+                "uid": "_:Category_3",
                 "dgraph.type": [ "Category" ],
                 "Category.name": "New Category",
                 "Category.posts": [
-                  { "uid": "_:Post2" }
+                  { "uid": "_:Post_2" }
                 ]
               }
             }
@@ -1651,7 +1651,7 @@
   explanation: "No nodes exist. Both nodes are created."
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
@@ -1665,15 +1665,15 @@
                 "State.code":"dg",
                 "State.country":
                   {
-                    "uid":"_:Country2"
+                    "uid":"_:Country_2"
                   },
                 "State.name":"Dgraph",
                 "dgraph.type":["State"],
-                "uid":"_:State1"
+                "uid":"_:State_1"
               }
             ],
           "dgraph.type":["Country"],
-          "uid":"_:Country2"
+          "uid":"_:Country_2"
         }
 
 -
@@ -1699,18 +1699,18 @@
   explanation: "The state exists. It is linked to the new Country. Its link to old country is deleted."
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1":"0x12"
+      "State_1":"0x12"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x12)) {
-        Country3 as State.country
+        Country_3 as State.country
       }
     }
   dgmutations:
@@ -1722,18 +1722,18 @@
               {
                 "State.country":
                   {
-                    "uid":"_:Country2"
+                    "uid":"_:Country_2"
                   },
                 "uid":"0x12"
               }
             ],
           "dgraph.type":["Country"],
-          "uid":"_:Country2"
+          "uid":"_:Country_2"
         }
       deletejson: |
         [
           {
-            "uid":"uid(Country3)",
+            "uid":"uid(Country_3)",
             "Country.states":
               [
                 {
@@ -1766,24 +1766,24 @@
     because it's missing required field name"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1":"0x12"
+      "State_1":"0x12"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x12)) {
-        Country3 as State.country
+        Country_3 as State.country
       }
     }
   dgmutations:
     - setjson: |
         {
-          "uid": "_:Country2",
+          "uid": "_:Country_2",
           "dgraph.type": ["Country"],
           "Country.name": "Dgraph Land",
           "Country.states":
@@ -1792,7 +1792,7 @@
                 "uid": "0x12",
                 "State.country":
                   {
-                    "uid": "_:Country2"
+                    "uid": "_:Country_2"
                   }
               }
             ]
@@ -1800,7 +1800,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Country3)",
+            "uid": "uid(Country_3)",
             "Country.states": [{"uid": "0x12"}]
           }
         ]
@@ -1827,7 +1827,7 @@
   explanation: "Error is thrown as State with code dg does not exist"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
@@ -1856,7 +1856,7 @@
     }
   dgmutations:
     - setjson: |
-        { "uid": "_:Category1",
+        { "uid": "_:Category_1",
           "dgraph.type": ["Category"],
           "Category.name": "A Category",
           "Category.iAmDeprecated": "but I can be written to"
@@ -1881,17 +1881,17 @@
   explanation: "Movie node exists and is not created"
   dgquery: |-
     query {
-      Movie1(func: uid(0x2)) @filter(type(Movie)) {
+      Movie_1(func: uid(0x2)) @filter(type(Movie)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Movie1":"0x2"
+      "Movie_1":"0x2"
     }
   dgmutations:
     - setjson: |
-        { "uid" : "_:MovieDirector2",
+        { "uid" : "_:MovieDirector_2",
           "dgraph.type" : ["MovieDirector"],
           "MovieDirector.name" : "Steven Spielberg",
           "directed.movies": [{
@@ -1977,7 +1977,7 @@
   is same or contains just xid, it should not return error."
   dgquery: |-
     query {
-      District1(func: eq(District.code, "D1")) @filter(type(District)) {
+      District_1(func: eq(District.code, "D1")) @filter(type(District)) {
         uid
       }
     }
@@ -1989,17 +1989,17 @@
               "District.cities":
                 [
                   {
-                    "uid":"_:City2"
+                    "uid":"_:City_2"
                   }
                 ],
               "District.code":"D1",
               "District.name":"Dist1",
               "dgraph.type":["District"],
-              "uid":"_:District1"
+              "uid":"_:District_1"
             },
           "City.name":"Bengaluru",
           "dgraph.type":["City"],
-          "uid":"_:City2"
+          "uid":"_:City_2"
         }
     - setjson: |
         {
@@ -2008,14 +2008,14 @@
               "District.cities":
                 [
                   {
-                    "uid":"_:City3"
+                    "uid":"_:City_3"
                   }
                 ],
-              "uid":"_:District1"
+              "uid":"_:District_1"
             },
           "City.name":"NY",
           "dgraph.type":["City"],
-          "uid":"_:City3"
+          "uid":"_:City_3"
         }
     - setjson: |
         {
@@ -2024,14 +2024,14 @@
               "District.cities":
                 [
                   {
-                    "uid":"_:City4"
+                    "uid":"_:City_4"
                   }
                 ],
-              "uid":"_:District1"
+              "uid":"_:District_1"
             },
           "City.name":"Sydney",
           "dgraph.type":["City"],
-          "uid":"_:City4"
+          "uid":"_:City_4"
         }
 
 - name: "Deep Mutation Duplicate XIDs with same object with @hasInverse Test"
@@ -2243,43 +2243,43 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "Post1": "0x456"
+      "Post_1": "0x456"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x456)) {
-        Author3 as Post.author
+        Author_3 as Post.author
       }
     }
   dgmutations:
     - setjson: |
         {
-          "uid":"_:Author2",
+          "uid":"_:Author_2",
           "dgraph.type":["Author"],
           "Author.name":"A.N. Author",
           "Author.posts": [
             {
               "uid": "0x456",
-              "Post.author": { "uid": "_:Author2" }
+              "Post.author": { "uid": "_:Author_2" }
             },
             {
-              "uid": "_:Post4",
+              "uid": "_:Post_4",
               "dgraph.type": ["Post"],
               "Post.title": "New Post",
-              "Post.author": { "uid": "_:Author2" }
+              "Post.author": { "uid": "_:Author_2" }
             }
           ]
         }
       deletejson: |
         [
           {
-            "uid": "uid(Author3)",
+            "uid": "uid(Author_3)",
             "Author.posts": [ { "uid": "0x456" } ]
           }
         ]
@@ -2306,21 +2306,21 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "abc")) @filter(type(State)) {
+      State_1(func: eq(State.code, "abc")) @filter(type(State)) {
         uid
       }
-      State2(func: eq(State.code, "def")) @filter(type(State)) {
+      State_2(func: eq(State.code, "def")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "State1": "0x1234"
+      "State_1": "0x1234"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x1234)) {
-        Country4 as State.country
+        Country_4 as State.country
       }
     }
   dgmutations:
@@ -2332,7 +2332,7 @@
               {
                 "State.country":
                   {
-                    "uid":"_:Country3"
+                    "uid":"_:Country_3"
                   },
                 "uid":"0x1234"
               },
@@ -2340,20 +2340,20 @@
                 "State.code":"def",
                 "State.country":
                   {
-                    "uid":"_:Country3"
+                    "uid":"_:Country_3"
                   },
                 "State.name":"Vowel",
                 "dgraph.type":["State"],
-                "uid":"_:State2"
+                "uid":"_:State_2"
               }
             ],
           "dgraph.type":["Country"],
-          "uid":"_:Country3"
+          "uid":"_:Country_3"
         }
       deletejson: |
         [
           {
-            "uid":"uid(Country4)",
+            "uid":"uid(Country_4)",
             "Country.states":
               [
                 {"uid":"0x1234"}
@@ -2392,16 +2392,16 @@
     }
   dgquery: |-
     query {
-      Student1(func: eq(People.xid, "S0")) @filter(type(Student)) {
+      Student_1(func: eq(People.xid, "S0")) @filter(type(Student)) {
         uid
       }
-      Teacher2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
+      Teacher_2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
         uid
       }
-      Student3(func: eq(People.xid, "S1")) @filter(type(Student)) {
+      Student_3(func: eq(People.xid, "S1")) @filter(type(Student)) {
         uid
       }
-      Teacher4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
+      Teacher_4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
         uid
       }
     }
@@ -2418,7 +2418,7 @@
                 "Teacher.teaches":
                   [
                     {
-                      "uid":"_:Student1"
+                      "uid":"_:Student_1"
                     },
                     {
                       "People.name":"Student1",
@@ -2426,7 +2426,7 @@
                       "Student.taughtBy":
                         [
                           {
-                            "uid":"_:Teacher2"
+                            "uid":"_:Teacher_2"
                           },
                           {
                             "People.name":"teacher1",
@@ -2434,23 +2434,23 @@
                             "Teacher.teaches":
                               [
                                 {
-                                  "uid":"_:Student3"
+                                  "uid":"_:Student_3"
                                 }
                               ],
                             "dgraph.type":["Teacher","People"],
-                            "uid":"_:Teacher4"
+                            "uid":"_:Teacher_4"
                           }
                         ],
                       "dgraph.type":["Student","People"],
-                      "uid":"_:Student3"
+                      "uid":"_:Student_3"
                     }
                   ],
                 "dgraph.type":["Teacher","People"],
-                "uid":"_:Teacher2"
+                "uid":"_:Teacher_2"
               }
             ],
           "dgraph.type":["Student","People"],
-          "uid":"_:Student1"
+          "uid":"_:Student_1"
         }
 
 - name: "Deep XID 4 level deep 2"
@@ -2487,16 +2487,16 @@
     }
   dgquery: |-
     query {
-      Student1(func: eq(People.xid, "S0")) @filter(type(Student)) {
+      Student_1(func: eq(People.xid, "S0")) @filter(type(Student)) {
         uid
       }
-      Teacher2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
+      Teacher_2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
         uid
       }
-      Student3(func: eq(People.xid, "S1")) @filter(type(Student)) {
+      Student_3(func: eq(People.xid, "S1")) @filter(type(Student)) {
         uid
       }
-      Teacher4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
+      Teacher_4(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
         uid
       }
     }
@@ -2513,7 +2513,7 @@
                 "Teacher.teaches":
                   [
                     {
-                      "uid":"_:Student1"
+                      "uid":"_:Student_1"
                     },
                     {
                       "People.name":"Student1",
@@ -2521,7 +2521,7 @@
                       "Student.taughtBy":
                         [
                           {
-                            "uid":"_:Teacher2"
+                            "uid":"_:Teacher_2"
                           },
                           {
                             "People.name":"teacher1",
@@ -2529,32 +2529,32 @@
                             "Teacher.teaches":
                               [
                                 {
-                                  "uid":"_:Student3"
+                                  "uid":"_:Student_3"
                                 },
                                 {
-                                  "uid":"_:Student1",
+                                  "uid":"_:Student_1",
                                   "Student.taughtBy":
                                     [
                                       {
-                                        "uid":"_:Teacher4"
+                                        "uid":"_:Teacher_4"
                                       }
                                     ]
                                 }
                               ],
                             "dgraph.type":["Teacher","People"],
-                            "uid":"_:Teacher4"
+                            "uid":"_:Teacher_4"
                           }
                         ],
                       "dgraph.type":["Student","People"],
-                      "uid":"_:Student3"
+                      "uid":"_:Student_3"
                     }
                   ],
                 "dgraph.type":["Teacher","People"],
-                "uid":"_:Teacher2"
+                "uid":"_:Teacher_2"
               }
             ],
           "dgraph.type":["Student","People"],
-          "uid":"_:Student1"
+          "uid":"_:Student_1"
         }
 
 - name: "Deep XID Add top level hasInverse 1"
@@ -2584,13 +2584,13 @@
     }
   dgquery: |-
     query {
-      Student1(func: eq(People.xid, "S0")) @filter(type(Student)) {
+      Student_1(func: eq(People.xid, "S0")) @filter(type(Student)) {
         uid
       }
-      Teacher2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
+      Teacher_2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
         uid
       }
-      Student3(func: eq(People.xid, "S1")) @filter(type(Student)) {
+      Student_3(func: eq(People.xid, "S1")) @filter(type(Student)) {
         uid
       }
     }
@@ -2608,7 +2608,7 @@
                 "Teacher.teaches":
                   [
                     {
-                      "uid":"_:Student1"
+                      "uid":"_:Student_1"
                     },
                     {
                       "People.name":"Student1",
@@ -2616,19 +2616,19 @@
                       "Student.taughtBy":
                         [
                           {
-                            "uid":"_:Teacher2"
+                            "uid":"_:Teacher_2"
                           }
                         ],
                       "dgraph.type":["Student","People"],
-                      "uid":"_:Student3"
+                      "uid":"_:Student_3"
                     }
                   ],
                 "dgraph.type":["Teacher","People"],
-                "uid":"_:Teacher2"
+                "uid":"_:Teacher_2"
               }
             ],
           "dgraph.type":["Student","People"],
-          "uid":"_:Student1"
+          "uid":"_:Student_1"
         }
 
 - name: "Deep XID Add top level hasInverse 2"
@@ -2658,19 +2658,19 @@
     }
   dgquery: |-
     query {
-      Student1(func: eq(People.xid, "S0")) @filter(type(Student)) {
+      Student_1(func: eq(People.xid, "S0")) @filter(type(Student)) {
         uid
       }
-      Teacher2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
+      Teacher_2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
         uid
       }
-      Student3(func: eq(People.xid, "S1")) @filter(type(Student)) {
+      Student_3(func: eq(People.xid, "S1")) @filter(type(Student)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Teacher2": "0x987"
+      "Teacher_2": "0x987"
     }
   dgmutations:
     - setjson: |
@@ -2683,14 +2683,14 @@
                 "Teacher.teaches":
                   [
                     {
-                      "uid":"_:Student1"
+                      "uid":"_:Student_1"
                     }
                   ],
                 "uid":"0x987"
               }
             ],
           "dgraph.type":["Student","People"],
-          "uid":"_:Student1"
+          "uid":"_:Student_1"
         }
 
 - name: "Deep XID Add top level hasInverse 3"
@@ -2720,19 +2720,19 @@
     }
   dgquery: |-
     query {
-      Student1(func: eq(People.xid, "S0")) @filter(type(Student)) {
+      Student_1(func: eq(People.xid, "S0")) @filter(type(Student)) {
         uid
       }
-      Teacher2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
+      Teacher_2(func: eq(People.xid, "T0")) @filter(type(Teacher)) {
         uid
       }
-      Student3(func: eq(People.xid, "S1")) @filter(type(Student)) {
+      Student_3(func: eq(People.xid, "S1")) @filter(type(Student)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Student3": "0x123"
+      "Student_3": "0x123"
     }
   dgmutations:
     - setjson: |
@@ -2747,24 +2747,24 @@
                 "Teacher.teaches":
                   [
                     {
-                      "uid":"_:Student1"
+                      "uid":"_:Student_1"
                     },
                     {
                       "Student.taughtBy":
                         [
                           {
-                            "uid":"_:Teacher2"
+                            "uid":"_:Teacher_2"
                           }
                         ],
                       "uid":"0x123"
                     }
                   ],
                 "dgraph.type":["Teacher","People"],
-                "uid":"_:Teacher2"
+                "uid":"_:Teacher_2"
               }
             ],
           "dgraph.type":["Student","People"],
-          "uid":"_:Student1"
+          "uid":"_:Student_1"
         }
 
 
@@ -2792,13 +2792,13 @@
     }
   dgquery: |-
     query {
-      Lab1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
+      Lab_1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
         uid
       }
-      Computer2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
+      Computer_2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
         uid
       }
-      ComputerOwner3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
+      ComputerOwner_3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
         uid
       }
     }
@@ -2814,20 +2814,20 @@
                     {
                       "ComputerOwner.computers":
                         {
-                          "uid":"_:Computer2"
+                          "uid":"_:Computer_2"
                         },
                       "ComputerOwner.name":"owner1",
                       "dgraph.type":["ComputerOwner"],
-                      "uid":"_:ComputerOwner3"
+                      "uid":"_:ComputerOwner_3"
                     }
                   ],
                 "dgraph.type":["Computer"],
-                "uid":"_:Computer2"
+                "uid":"_:Computer_2"
               }
             ],
           "Lab.name":"Lab1",
           "dgraph.type":["Lab"],
-          "uid":"_:Lab1"
+          "uid":"_:Lab_1"
         }
 
 - name: "Deep XID Add lower level hasInvsere 2"
@@ -2854,19 +2854,19 @@
     }
   dgquery: |-
     query {
-      Lab1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
+      Lab_1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
         uid
       }
-      Computer2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
+      Computer_2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
         uid
       }
-      ComputerOwner3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
+      ComputerOwner_3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Computer2": "0x234"
+      "Computer_2": "0x234"
     }
   dgmutations:
     - setjson: |
@@ -2879,7 +2879,7 @@
             ],
           "Lab.name":"Lab1",
           "dgraph.type":["Lab"],
-          "uid":"_:Lab1"
+          "uid":"_:Lab_1"
         }
 
 - name: "Deep XID Add lower level hasInvsere 3"
@@ -2906,24 +2906,24 @@
     }
   dgquery: |-
     query {
-      Lab1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
+      Lab_1(func: eq(Lab.name, "Lab1")) @filter(type(Lab)) {
         uid
       }
-      Computer2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
+      Computer_2(func: eq(Computer.name, "computer1")) @filter(type(Computer)) {
         uid
       }
-      ComputerOwner3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
+      ComputerOwner_3(func: eq(ComputerOwner.name, "owner1")) @filter(type(ComputerOwner)) {
         uid
       }
     }
   qnametouid: |
     {
-      "ComputerOwner3": "0x123"
+      "ComputerOwner_3": "0x123"
     }
   dgquerysec: |-
     query {
       var(func: uid(0x123)) {
-        Computer4 as ComputerOwner.computers
+        Computer_4 as ComputerOwner.computers
       }
     }
   dgmutations:
@@ -2938,18 +2938,18 @@
                     {
                       "ComputerOwner.computers":
                         {
-                          "uid":"_:Computer2"
+                          "uid":"_:Computer_2"
                         },
                       "uid":"0x123"
                     }
                   ],
                 "dgraph.type":["Computer"],
-                "uid":"_:Computer2"
+                "uid":"_:Computer_2"
               }
             ],
           "Lab.name":"Lab1",
           "dgraph.type":["Lab"],
-          "uid":"_:Lab1"
+          "uid":"_:Lab_1"
         }
       deletejson: |-
         [{
@@ -2958,7 +2958,7 @@
                     "uid": "0x123"
                 }
             ],
-            "uid": "uid(Computer4)"
+            "uid": "uid(Computer_4)"
         }]
 
 - name: "Deep mutation alternate id xid"
@@ -2994,7 +2994,7 @@
     }
   dgquery: |-
     query {
-      District1(func: eq(District.code, "d1")) @filter(type(District)) {
+      District_1(func: eq(District.code, "d1")) @filter(type(District)) {
         uid
       }
     }
@@ -3006,26 +3006,26 @@
               "District.cities":
                 [
                   {
-                    "uid":"_:City2"
+                    "uid":"_:City_2"
                   },
                   {
                     "City.district":
                       {
-                        "uid":"_:District1"
+                        "uid":"_:District_1"
                       },
                       "City.name":"c2",
                       "dgraph.type":["City"],
-                      "uid":"_:City3"
+                      "uid":"_:City_3"
                   }
                 ],
               "District.code":"d1",
               "District.name":"d1",
               "dgraph.type":["District"],
-              "uid":"_:District1"
+              "uid":"_:District_1"
             },
           "City.name":"c1",
           "dgraph.type":["City"],
-          "uid":"_:City2"
+          "uid":"_:City_2"
         }
 
 - name: "Deep mutation alternate id xid with existing XID"
@@ -3061,13 +3061,13 @@
     }
   dgquery: |-
     query {
-      District1(func: eq(District.code, "d1")) @filter(type(District)) {
+      District_1(func: eq(District.code, "d1")) @filter(type(District)) {
         uid
       }
     }
   qnametouid: |-
     {
-      "District1": "0x123"
+      "District_1": "0x123"
     }
   dgmutations:
     - setjson: |
@@ -3077,14 +3077,14 @@
               "District.cities":
                 [
                   {
-                    "uid":"_:City2"
+                    "uid":"_:City_2"
                   }
                 ],
               "uid":"0x123"
             },
           "City.name":"c1",
           "dgraph.type":["City"],
-          "uid":"_:City2"
+          "uid":"_:City_2"
         }
 
 
@@ -3109,7 +3109,7 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "abc")) @filter(type(State)) {
+      State_1(func: eq(State.code, "abc")) @filter(type(State)) {
         uid
       }
     }
@@ -3123,18 +3123,18 @@
                 [
                   {
                     "State.code":"abc",
-                    "State.country": {"uid":"_:Country3"},
+                    "State.country": {"uid":"_:Country_3"},
                     "State.name":"Alphabet",
                     "dgraph.type":["State"],
-                    "uid":"_:State1"
+                    "uid":"_:State_1"
                   }
                 ],
               "dgraph.type":["Country"],
-              "uid":"_:Country3"
+              "uid":"_:Country_3"
             },
           "Author.name":"A.N. Author",
           "dgraph.type":["Author"],
-          "uid":"_:Author2"
+          "uid":"_:Author_2"
         }
 
 - name: "Deep mutation three level xid with no initial XID"
@@ -3176,19 +3176,19 @@
     }
   dgquery: |-
     query {
-      Post11(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
+      Post1_1(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
         uid
       }
-      Comment12(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
+      Comment1_2(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
         uid
       }
-      Comment13(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
+      Comment1_3(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
         uid
       }
-      Post14(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
+      Post1_4(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
         uid
       }
-      Comment15(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
+      Comment1_5(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
         uid
       }
     }
@@ -3204,16 +3204,16 @@
                     {
                      "Comment1.id":"reply1",
                      "dgraph.type": ["Comment1"],
-                     "uid":"_:Comment13"
+                     "uid":"_:Comment1_3"
                     }
                   ],
                 "dgraph.type":["Comment1"],
-                "uid":"_:Comment12"
+                "uid":"_:Comment1_2"
               }
             ],
           "Post1.id":"post1",
           "dgraph.type":["Post1"],
-          "uid":"_:Post11"
+          "uid":"_:Post1_1"
         }
     - setjson: |
         {
@@ -3224,16 +3224,16 @@
                 "Comment1.replies":
                   [
                     {
-                      "uid":"_:Comment13"
+                      "uid":"_:Comment1_3"
                     }
                   ],
                 "dgraph.type":["Comment1"],
-                "uid":"_:Comment15"
+                "uid":"_:Comment1_5"
               }
             ],
           "Post1.id":"post2",
           "dgraph.type":["Post1"],
-          "uid":"_:Post14"
+          "uid":"_:Post1_4"
         }
 
 - name: "Deep mutation three level xid with existing XIDs 1"
@@ -3276,26 +3276,26 @@
     }
   dgquery: |-
     query {
-      Post11(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
+      Post1_1(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
         uid
       }
-      Comment12(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
+      Comment1_2(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
         uid
       }
-      Comment13(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
+      Comment1_3(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
         uid
       }
-      Post14(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
+      Post1_4(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
         uid
       }
-      Comment15(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
+      Comment1_5(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Comment12": "0x110",
-      "Comment13": "0x111"
+      "Comment1_2": "0x110",
+      "Comment1_3": "0x111"
     }
   dgmutations:
     - setjson: |
@@ -3308,7 +3308,7 @@
             ],
           "Post1.id":"post1",
           "dgraph.type":["Post1"],
-          "uid":"_:Post11"
+          "uid":"_:Post1_1"
         }
     - setjson: |
         {
@@ -3323,12 +3323,12 @@
                     }
                   ],
                 "dgraph.type":["Comment1"],
-                "uid":"_:Comment15"
+                "uid":"_:Comment1_5"
               }
             ],
           "Post1.id":"post2",
           "dgraph.type":["Post1"],
-          "uid":"_:Post14"
+          "uid":"_:Post1_4"
         }
 
 - name: "Deep mutation three level xid with existing XIDs 2"
@@ -3371,26 +3371,26 @@
     }
   dgquery: |-
     query {
-      Post11(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
+      Post1_1(func: eq(Post1.id, "post1")) @filter(type(Post1)) {
         uid
       }
-      Comment12(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
+      Comment1_2(func: eq(Comment1.id, "comment1")) @filter(type(Comment1)) {
         uid
       }
-      Comment13(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
+      Comment1_3(func: eq(Comment1.id, "reply1")) @filter(type(Comment1)) {
         uid
       }
-      Post14(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
+      Post1_4(func: eq(Post1.id, "post2")) @filter(type(Post1)) {
         uid
       }
-      Comment15(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
+      Comment1_5(func: eq(Comment1.id, "comment2")) @filter(type(Comment1)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Comment12": "0x110",
-      "Comment15": "0x111"
+      "Comment1_2": "0x110",
+      "Comment1_5": "0x111"
     }
   dgmutations:
     - setjson: |
@@ -3403,7 +3403,7 @@
             ],
           "Post1.id":"post1",
           "dgraph.type":["Post1"],
-          "uid":"_:Post11"
+          "uid":"_:Post1_1"
         }
     - setjson: |
         {
@@ -3415,7 +3415,7 @@
             ],
           "Post1.id":"post2",
           "dgraph.type":["Post1"],
-          "uid":"_:Post14"
+          "uid":"_:Post1_4"
         }
 
 -
@@ -3492,33 +3492,33 @@
             {
               "Person.friends": [
                 {
-                  "uid": "_:Person1"
+                  "uid": "_:Person_1"
                 },
                 {
                   "Person.friends": [
                     {
-                      "uid": "_:Person2"
+                      "uid": "_:Person_2"
                     }
                   ],
                   "Person.name": "Justin",
                   "dgraph.type": [
                     "Person"
                   ],
-                  "uid": "_:Person3"
+                  "uid": "_:Person_3"
                 }
               ],
               "Person.name": "Michal",
               "dgraph.type": [
                 "Person"
               ],
-              "uid": "_:Person2"
+              "uid": "_:Person_2"
             }
           ],
           "Person.name": "Or",
           "dgraph.type": [
             "Person"
           ],
-          "uid": "_:Person1"
+          "uid": "_:Person_1"
         }
 
 -
@@ -3550,15 +3550,15 @@
         }
       ]
     }
-  qnametouid: |-
-    {
-      "Parrot1" : "0x123"
-    }
   dgquery: |-
     query {
-      Parrot1(func: uid(0x123)) @filter(type(Parrot)) {
+      Parrot_1(func: uid(0x123)) @filter(type(Parrot)) {
         uid
       }
+    }
+  qnametouid: |-
+    {
+      "Parrot_1" : "0x123"
     }
   dgmutations:
     - setjson: |
@@ -3571,20 +3571,20 @@
             "Animal.category": "Mammal",
             "Dog.breed": "German Shephard",
             "dgraph.type": ["Dog", "Animal"],
-            "uid": "_:Dog3"
+            "uid": "_:Dog_3"
           }, {
             "Animal.category": "Bird",
             "Parrot.repeatsWords": ["squawk"],
             "dgraph.type": ["Parrot", "Animal"],
-            "uid": "_:Parrot4"
+            "uid": "_:Parrot_4"
           }, {
             "Character.name": "Han Solo",
             "Employee.ename": "Han_emp",
             "dgraph.type": ["Human", "Character", "Employee"],
-            "uid": "_:Human5"
+            "uid": "_:Human_5"
           }],
           "dgraph.type": ["Home"],
-          "uid": "_:Home2"
+          "uid": "_:Home_2"
         }
 
 -
@@ -3651,10 +3651,10 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
       }
     }
@@ -3665,20 +3665,20 @@
                 "author.name": "Yuval Noah Harari",
                 "author.book": [
                     {
-                        "uid": "_:Book2"
+                        "uid": "_:Book_2"
                     }
                 ],
                 "dgraph.type": [
                     "author"
                 ],
-                "uid": "_:author3"
+                "uid": "_:author_3"
             },
             "Book.ISBN": "2312SB",
             "Book.title": "Sapiens",
             "dgraph.type": [
                 "Book"
             ],
-            "uid": "_:Book2"
+            "uid": "_:Book_2"
         }
 
 -
@@ -3704,14 +3704,14 @@
     }
   dgquery: |-
     query {
-      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+      ABC_1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
         uid
       }
-      ABC2(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
+      ABC_2(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
         uid
       }
     }
-  explanation: "We should generate different variables as ABC1 and ABC2 if xidName+xidValue is same as in above case
+  explanation: "We should generate different variables as ABC_1 and ABC_2 if xidName+xidValue is same as in above case
   i.e. ab+cd and abc+d both equals to abcd"
   dgmutations:
     - setjson: |
@@ -3721,7 +3721,7 @@
             "dgraph.type": [
                 "ABC"
             ],
-            "uid":"_:ABC2"
+            "uid":"_:ABC_2"
         }
 
 -
@@ -3751,20 +3751,20 @@
     }
   dgquery: |-
     query {
-      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+      ABC_1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
         uid
       }
-      ABC2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
+      ABC_2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
         uid
       }
-      ABC3(func: eq(ABC.ab, "ef")) @filter(type(ABC)) {
+      ABC_3(func: eq(ABC.ab, "ef")) @filter(type(ABC)) {
         uid
       }
-      ABC4(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
+      ABC_4(func: eq(ABC.abc, "d")) @filter(type(ABC)) {
         uid
       }
     }
-  explanation: "We should generate different variables as ABC1 and ABC4 if xidName+xidValue is same in two different objects as in above case
+  explanation: "We should generate different variables as ABC_1 and ABC_4 if xidName+xidValue is same in two different objects as in above case
   i.e. ab+cd and abc+d both equals to abcd"
   dgmutations:
     - setjson: |
@@ -3774,7 +3774,7 @@
             "dgraph.type": [
                 "ABC"
             ],
-            "uid":"_:ABC2"
+            "uid":"_:ABC_2"
         }
     - setjson: |
         {
@@ -3783,7 +3783,7 @@
             "dgraph.type": [
                 "ABC"
             ],
-            "uid":"_:ABC4"
+            "uid":"_:ABC_4"
         }
 
 -
@@ -3817,20 +3817,20 @@
     }
   dgquery: |-
     query {
-      ABC1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
+      ABC_1(func: eq(ABC.ab, "cd")) @filter(type(ABC)) {
         uid
       }
-      ABC2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
+      ABC_2(func: eq(ABC.abc, "de")) @filter(type(ABC)) {
         uid
       }
-      AB3(func: eq(AB.Cab, "cde")) @filter(type(AB)) {
+      AB_3(func: eq(AB.Cab, "cde")) @filter(type(AB)) {
         uid
       }
-      AB4(func: eq(AB.Cabc, "d")) @filter(type(AB)) {
+      AB_4(func: eq(AB.Cabc, "d")) @filter(type(AB)) {
         uid
       }
     }
-  explanation: "We should generate different variables as ABC1 and AB3, or ABC2 and AB4 if typename+xidName+xidValue is same in two different types as in above case
+  explanation: "We should generate different variables as ABC_1 and AB_3, or ABC_2 and AB_4 if typename+xidName+xidValue is same in two different types as in above case
   i.e. ABC+ab+cd and AB+Cabc+d both equals to ABCabcd"
   dgmutations:
     - setjson: |
@@ -3839,12 +3839,12 @@
             "AB.Cab": "cde",
             "AB.Cabc": "d",
             "dgraph.type": ["AB"],
-            "uid": "_:AB4"
+            "uid": "_:AB_4"
           },
           "ABC.ab": "cd",
           "ABC.abc": "de",
           "dgraph.type": ["ABC"],
-          "uid": "_:ABC2"
+          "uid": "_:ABC_2"
         }
 
 
@@ -3877,10 +3877,10 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
       }
     }
@@ -3891,18 +3891,18 @@
             "dgraph.type": [
                 "author"
             ],
-            "uid": "_:author3",
+            "uid": "_:author_3",
             "author.book": [
                 {
                     "Book.ISBN": "2312SB",
                     "Book.title": "Sapiens",
                     "Book.author": {
-                        "uid": "_:author3"
+                        "uid": "_:author_3"
                     },
                     "dgraph.type": [
                         "Book"
                     ],
-                    "uid": "_:Book2"
+                    "uid": "_:Book_2"
                 }
             ]
         }
@@ -3946,16 +3946,16 @@
     }
   dgquery: |-
     query {
-      Person11(func: eq(Person1.id, "1")) @filter(type(Person1)) {
+      Person1_1(func: eq(Person1.id, "1")) @filter(type(Person1)) {
         uid
       }
-      Person12(func: eq(Person1.name, "First Person")) @filter(type(Person1)) {
+      Person1_2(func: eq(Person1.name, "First Person")) @filter(type(Person1)) {
         uid
       }
-      Person13(func: eq(Person1.id, "2")) @filter(type(Person1)) {
+      Person1_3(func: eq(Person1.id, "2")) @filter(type(Person1)) {
         uid
       }
-      Person14(func: eq(Person1.name, "Second Person")) @filter(type(Person1)) {
+      Person1_4(func: eq(Person1.name, "Second Person")) @filter(type(Person1)) {
         uid
       }
     }
@@ -3966,7 +3966,7 @@
             {
               "Person1.closeFriends": [
                 {
-                  "uid": "_:Person12"
+                  "uid": "_:Person1_2"
                 }
               ],
               "Person1.name": "Second Person",
@@ -3974,15 +3974,15 @@
               "dgraph.type": [
                 "Person1"
               ],
-              "uid": "_:Person14"
+              "uid": "_:Person1_4"
             }
           ],
           "Person1.friends": [
             {
-              "uid": "_:Person14",
+              "uid": "_:Person1_4",
               "Person1.friends": [
                 {
-                  "uid": "_:Person12"
+                  "uid": "_:Person1_2"
                 }
               ]
             }
@@ -3992,7 +3992,7 @@
           "dgraph.type": [
             "Person1"
           ],
-          "uid": "_:Person12"
+          "uid": "_:Person1_2"
         }
 
 -
@@ -4024,23 +4024,23 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
       }
     }
   dgquerysec: |-
     query {
       var(func: uid(0x117)) {
-        author4 as Book.author
+        author_4 as Book.author
       }
     }
   qnametouid: |
     {
-      "Book1": "0x117",
-      "Book2": "0x116"
+      "Book_1": "0x117",
+      "Book_2": "0x116"
     }
   dgmutations:
     - setjson: |
@@ -4049,11 +4049,11 @@
             "dgraph.type": [
                 "author"
             ],
-            "uid": "_:author3",
+            "uid": "_:author_3",
             "author.book": [
                 {
                     "Book.author": {
-                        "uid": "_:author3"
+                        "uid": "_:author_3"
                     },
                     "uid": "0x117"
                 }
@@ -4067,7 +4067,7 @@
                         "uid": "0x117"
                     }
                 ],
-                "uid": "uid(author4)"
+                "uid": "uid(author_4)"
             }
         ]
 
@@ -4100,22 +4100,22 @@
     }
   dgquery: |-
     query {
-      Book1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
+      Book_1(func: eq(Book.ISBN, "2312SB")) @filter(type(Book)) {
         uid
       }
-      Book2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
+      Book_2(func: eq(Book.title, "Sapiens")) @filter(type(Book)) {
         uid
-      }
-    }
-  dgquerysec: |-
-    query {
-      var(func: uid(0x119)) {
-        author4 as Book.author
       }
     }
   qnametouid: |
     {
-      "Book2": "0x119"
+      "Book_2": "0x119"
+    }
+  dgquerysec: |-
+    query {
+      var(func: uid(0x119)) {
+        author_4 as Book.author
+      }
     }
   dgmutations:
     - setjson: |
@@ -4124,11 +4124,11 @@
             "dgraph.type": [
                 "author"
             ],
-            "uid": "_:author3",
+            "uid": "_:author_3",
             "author.book": [
                 {
                     "Book.author": {
-                        "uid": "_:author3"
+                        "uid": "_:author_3"
                     },
                     "uid": "0x119"
                 }
@@ -4142,7 +4142,7 @@
                         "uid": "0x119"
                     }
                 ],
-                "uid": "uid(author4)"
+                "uid": "uid(author_4)"
             }
         ]
 
@@ -4185,16 +4185,16 @@
     }
   dgquery: |-
     query {
-      Person11(func: eq(Person1.id, "1")) @filter(type(Person1)) {
+      Person1_1(func: eq(Person1.id, "1")) @filter(type(Person1)) {
         uid
       }
-      Person12(func: eq(Person1.name, "First Person")) @filter(type(Person1)) {
+      Person1_2(func: eq(Person1.name, "First Person")) @filter(type(Person1)) {
         uid
       }
-      Person13(func: eq(Person1.id, "2")) @filter(type(Person1)) {
+      Person1_3(func: eq(Person1.id, "2")) @filter(type(Person1)) {
         uid
       }
-      Person14(func: eq(Person1.name, "Second Person")) @filter(type(Person1)) {
+      Person1_4(func: eq(Person1.name, "Second Person")) @filter(type(Person1)) {
         uid
       }
     }
@@ -4205,7 +4205,7 @@
                 {
                     "Person1.closeFriends": [
                         {
-                            "uid": "_:Person12"
+                            "uid": "_:Person1_2"
                         }
                     ],
                     "Person1.id": "2",
@@ -4213,17 +4213,17 @@
                     "dgraph.type": [
                         "Person1"
                     ],
-                    "uid": "_:Person14"
+                    "uid": "_:Person1_4"
                 }
             ],
             "Person1.friends": [
                 {
                     "Person1.friends": [
                         {
-                            "uid": "_:Person12"
+                            "uid": "_:Person1_2"
                         }
                     ],
-                    "uid": "_:Person14"
+                    "uid": "_:Person1_4"
                 }
             ],
             "Person1.id": "1",
@@ -4231,7 +4231,7 @@
             "dgraph.type": [
                 "Person1"
             ],
-            "uid": "_:Person12"
+            "uid": "_:Person1_2"
         }
 
 - name: "Reference to inverse field should be ignored and not throw an error"
@@ -4267,10 +4267,10 @@
     district with code non-existing is ignored. Not even its existence query is generated."
   dgquery: |-
     query {
-      District1(func: eq(District.code, "D1")) @filter(type(District)) {
+      District_1(func: eq(District.code, "D1")) @filter(type(District)) {
         uid
       }
-      District2(func: eq(District.code, "D2")) @filter(type(District)) {
+      District_2(func: eq(District.code, "D2")) @filter(type(District)) {
         uid
       }
     }
@@ -4283,15 +4283,15 @@
                 "City.name":"Bengaluru",
                 "dgraph.type":["City"],
                 "City.district": {
-                  "uid": "_:District1"
+                  "uid": "_:District_1"
                 },
-                "uid":"_:City3"
+                "uid":"_:City_3"
               }
             ],
             "District.code":"D1",
             "District.name":"Dist1",
             "dgraph.type":["District"],
-            "uid":"_:District1"
+            "uid":"_:District_1"
         }
     - setjson: |
         {
@@ -4301,15 +4301,15 @@
                 "City.name":"Pune",
                 "dgraph.type":["City"],
                 "City.district": {
-                  "uid": "_:District2"
+                  "uid": "_:District_2"
                 },
-                "uid":"_:City4"
+                "uid":"_:City_4"
               }
             ],
             "District.code":"D2",
             "District.name":"Dist2",
             "dgraph.type":["District"],
-            "uid":"_:District2"
+            "uid":"_:District_2"
         }
 
 - name: "Reference to inverse field should be ignored and not throw an error 2"
@@ -4341,16 +4341,16 @@
     foo. In case it is supplied, it is simply ignored."
   dgquery: |-
     query {
-      Foo1(func: eq(Foo.id, "123")) @filter(type(Foo)) {
+      Foo_1(func: eq(Foo.id, "123")) @filter(type(Foo)) {
         uid
       }
-      Bar2(func: eq(Bar.id, "1234")) @filter(type(Bar)) {
+      Bar_2(func: eq(Bar.id, "1234")) @filter(type(Bar)) {
         uid
       }
-      Foo3(func: eq(Foo.id, "1")) @filter(type(Foo)) {
+      Foo_3(func: eq(Foo.id, "1")) @filter(type(Foo)) {
         uid
       }
-      Bar4(func: eq(Bar.id, "2")) @filter(type(Bar)) {
+      Bar_4(func: eq(Bar.id, "2")) @filter(type(Bar)) {
         uid
       }
     }
@@ -4362,13 +4362,13 @@
                 "Bar.id":"1234",
                 "dgraph.type":["Bar"],
                 "Bar.foo": {
-                  "uid": "_:Foo1"
+                  "uid": "_:Foo_1"
                 },
-                "uid":"_:Bar2"
+                "uid":"_:Bar_2"
               },
             "Foo.id":"123",
             "dgraph.type":["Foo"],
-            "uid":"_:Foo1"
+            "uid":"_:Foo_1"
         }
     - setjson: |
         {
@@ -4377,11 +4377,11 @@
                 "Bar.id":"2",
                 "dgraph.type":["Bar"],
                 "Bar.foo": {
-                  "uid": "_:Foo3"
+                  "uid": "_:Foo_3"
                 },
-                "uid":"_:Bar4"
+                "uid":"_:Bar_4"
               },
             "Foo.id":"1",
             "dgraph.type":["Foo"],
-            "uid":"_:Foo3"
+            "uid":"_:Foo_3"
         }

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -4385,3 +4385,139 @@
             "dgraph.type":["Foo"],
             "uid":"_:Foo_3"
         }
+
+-
+  name: "Add mutation for Friend, Friend1 should not generated same variable name for existence queries"
+  gqlmutation: |
+    mutation($input: [AddFriend1Input!]!) {
+      addFriend1(input: $input) {
+        friend1 {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "id": "Main Friend",
+          "friends": [
+            { "id": "Friend1" },
+            { "id": "Friend2" },
+            { "id": "Friend3" },
+            { "id": "Friend4" },
+            { "id": "Friend5" },
+            { "id": "Friend6" },
+            { "id": "Friend7" },
+            { "id": "Friend8" },
+            { "id": "Friend9" },
+            { "id": "Friend10" },
+            { "id": "Friend11" }
+          ]
+        }
+      ]
+    }
+  dgquery: |-
+    query {
+      Friend1_1(func: eq(Friend1.id, "Main Friend")) @filter(type(Friend1)) {
+        uid
+      }
+      Friend_2(func: eq(Friend.id, "Friend1")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_3(func: eq(Friend.id, "Friend2")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_4(func: eq(Friend.id, "Friend3")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_5(func: eq(Friend.id, "Friend4")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_6(func: eq(Friend.id, "Friend5")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_7(func: eq(Friend.id, "Friend6")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_8(func: eq(Friend.id, "Friend7")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_9(func: eq(Friend.id, "Friend8")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_10(func: eq(Friend.id, "Friend9")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_11(func: eq(Friend.id, "Friend10")) @filter(type(Friend)) {
+        uid
+      }
+      Friend_12(func: eq(Friend.id, "Friend11")) @filter(type(Friend)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+       {
+          "Friend1.friends":
+            [
+              {
+                "Friend.id":"Friend1",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_2"
+              },
+              {
+                "Friend.id":"Friend2",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_3"
+              },
+              {
+                "Friend.id":"Friend3",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_4"
+              },
+              {
+                "Friend.id":"Friend4",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_5"
+              },
+              {
+                "Friend.id":"Friend5",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_6"
+              },
+              {
+                "Friend.id":"Friend6",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_7"
+              },
+              {
+                "Friend.id":"Friend7",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_8"
+              },
+              {
+                "Friend.id":"Friend8",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_9"
+              },
+              {
+                "Friend.id":"Friend9",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_10"
+              },
+              {
+                "Friend.id":"Friend10",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_11"
+              },
+              {
+                "Friend.id":"Friend11",
+                "dgraph.type":["Friend"],
+                "uid":"_:Friend_12"
+              }
+            ],
+          "Friend1.id":"Main Friend",
+          "dgraph.type":["Friend1"],
+          "uid":"_:Friend1_1"
+       }

--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -16,14 +16,14 @@
       }
     }
   uids: |
-    { "UserSecret1": "0x123" }
+    { "UserSecret_1": "0x123" }
   authquery: |-
     query {
-      UserSecret(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2)) {
+      UserSecret(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2)) {
         uid
       }
-      UserSecret1 as var(func: uid(0x123))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecret_1 as var(func: uid(0x123))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   authjson: |
     {
@@ -50,16 +50,16 @@
     }
   uids: |
     {
-      "UserSecret1": "0x123",
-      "UserSecret2": "0x456"
+      "UserSecret_1": "0x123",
+      "UserSecret_2": "0x456"
     }
   authquery: |-
     query {
-      UserSecret(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2)) {
+      UserSecret(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2)) {
         uid
       }
-      UserSecret1 as var(func: uid(0x123, 0x456))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecret_1 as var(func: uid(0x123, 0x456))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   authjson: |
     {
@@ -87,15 +87,15 @@
     }
   uids: |
     {
-      "UserSecret1": "0x123"
+      "UserSecret_1": "0x123"
     }
   authquery: |-
     query {
-      UserSecret(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2)) {
+      UserSecret(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2)) {
         uid
       }
-      UserSecret1 as var(func: uid(0x123))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecret_1 as var(func: uid(0x123))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   authjson: |
     {
@@ -124,16 +124,16 @@
     }
   uids: |
     {
-      "UserSecret1": "0x123",
-      "UserSecret2": "0x456"
+      "UserSecret_1": "0x123",
+      "UserSecret_2": "0x456"
     }
   authquery: |-
     query {
-      UserSecret(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2)) {
+      UserSecret(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2)) {
         uid
       }
-      UserSecret1 as var(func: uid(0x123, 0x456))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecret_1 as var(func: uid(0x123, 0x456))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   authjson: |
     {
@@ -162,37 +162,37 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Column2": "0x456",
-      "Ticket3": "0x789"
+      "Column_2": "0x456",
+      "Ticket_3": "0x789"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
+      Ticket(func: uid(Ticket_3)) @filter(uid(Ticket_Auth4)) {
         uid
       }
-      Ticket3 as var(func: uid(0x789))
-      TicketAuth4 as var(func: uid(Ticket3)) @cascade {
+      Ticket_3 as var(func: uid(0x789))
+      Ticket_Auth4 as var(func: uid(Ticket_3)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -229,37 +229,37 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Column2": "0x456",
-      "Ticket3": "0x789"
+      "Column_2": "0x456",
+      "Ticket_3": "0x789"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
+      Ticket(func: uid(Ticket_3)) @filter(uid(Ticket_Auth4)) {
         uid
       }
-      Ticket3 as var(func: uid(0x789))
-      TicketAuth4 as var(func: uid(Ticket3)) @cascade {
+      Ticket_3 as var(func: uid(0x789))
+      Ticket_Auth4 as var(func: uid(Ticket_3)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -301,39 +301,39 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Column2": "0x456",
-      "Ticket3": "0x789",
-      "Column4": "0x459",
-      "Ticket5": "0x799"
+      "Column_2": "0x456",
+      "Ticket_3": "0x789",
+      "Column_4": "0x459",
+      "Ticket_5": "0x799"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456, 0x459))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456, 0x459))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
+      Ticket(func: uid(Ticket_3)) @filter(uid(Ticket_Auth4)) {
         uid
       }
-      Ticket3 as var(func: uid(0x789, 0x799))
-      TicketAuth4 as var(func: uid(Ticket3)) @cascade {
+      Ticket_3 as var(func: uid(0x789, 0x799))
+      Ticket_Auth4 as var(func: uid(Ticket_3)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -374,39 +374,39 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Column2": "0x456",
-      "Ticket3": "0x789",
-      "Column4": "0x459",
-      "Ticket5": "0x799"
+      "Column_2": "0x456",
+      "Ticket_3": "0x789",
+      "Column_4": "0x459",
+      "Ticket_5": "0x799"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456, 0x459))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456, 0x459))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Ticket(func: uid(Ticket3)) @filter(uid(TicketAuth4)) {
+      Ticket(func: uid(Ticket_3)) @filter(uid(Ticket_Auth4)) {
         uid
       }
-      Ticket3 as var(func: uid(0x789, 0x799))
-      TicketAuth4 as var(func: uid(Ticket3)) @cascade {
+      Ticket_3 as var(func: uid(0x789, 0x799))
+      Ticket_Auth4 as var(func: uid(Ticket_3)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -449,30 +449,30 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
-      Ticket2(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_2(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ],
-      "Ticket2": [ { "uid": "0x789" } ]
+      "Project_1": [ { "uid": "0x123" } ],
+      "Ticket_2": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       var(func: uid(0x789)) {
-        Column4 as Ticket.onColumn
+        Column_4 as Ticket.onColumn
       }
-      Column4(func: uid(Column4)) {
+      Column_4(func: uid(Column_4)) {
         uid
       }
-      Column4.auth(func: uid(Column4)) @filter(uid(ColumnAuth5)) {
+      Column_4.auth(func: uid(Column_4)) @filter(uid(Column_Auth5)) {
         uid
       }
-      ColumnAuth5 as var(func: uid(Column4)) @cascade {
+      Column_Auth5 as var(func: uid(Column_4)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -482,20 +482,20 @@
     }
   uids: |
     {
-      "Column3": "0x456"
+      "Column_3": "0x456"
     }
   json: |
     {
-      "Column4":  [ { "uid": "0x799" } ],
-      "Column4.auth": [ { "uid": "0x799" } ]
+      "Column_4":  [ { "uid": "0x799" } ],
+      "Column_4.auth": [ { "uid": "0x799" } ]
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -528,30 +528,30 @@
     }
   dgquery: |-
     query {
-      Project1(func: uid(0x123)) @filter(type(Project)) {
+      Project_1(func: uid(0x123)) @filter(type(Project)) {
         uid
       }
-      Ticket2(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_2(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Project1": [ { "uid": "0x123" } ],
-      "Ticket2": [ { "uid": "0x789" } ]
+      "Project_1": [ { "uid": "0x123" } ],
+      "Ticket_2": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       var(func: uid(0x789)) {
-        Column4 as Ticket.onColumn
+        Column_4 as Ticket.onColumn
       }
-      Column4(func: uid(Column4)) {
+      Column_4(func: uid(Column_4)) {
         uid
       }
-      Column4.auth(func: uid(Column4)) @filter(uid(ColumnAuth5)) {
+      Column_4.auth(func: uid(Column_4)) @filter(uid(Column_Auth5)) {
         uid
       }
-      ColumnAuth5 as var(func: uid(Column4)) @cascade {
+      Column_Auth5 as var(func: uid(Column_4)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -561,19 +561,19 @@
     }
   json: |
     {
-      "Column4":  [ { "uid": "0x799" } ]
+      "Column_4":  [ { "uid": "0x799" } ]
     }
   uids: |
     {
-      "Column3": "0x456"
+      "Column_3": "0x456"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -602,7 +602,7 @@
   variables: |
     {
       "proj": {
-        "name": "Project1",
+        "name": "Project_1",
         "pwd": "Password",
         "columns": [ {
           "name": "a column",
@@ -612,26 +612,26 @@
     }
   dgquery: |-
     query {
-      Ticket1(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_1(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Ticket1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       var(func: uid(0x789)) {
-        Column4 as Ticket.onColumn
+        Column_4 as Ticket.onColumn
       }
-      Column4(func: uid(Column4)) {
+      Column_4(func: uid(Column_4)) {
         uid
       }
-      Column4.auth(func: uid(Column4)) @filter(uid(ColumnAuth5)) {
+      Column_4.auth(func: uid(Column_4)) @filter(uid(Column_Auth5)) {
         uid
       }
-      ColumnAuth5 as var(func: uid(Column4)) @cascade {
+      Column_Auth5 as var(func: uid(Column_4)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -641,32 +641,32 @@
     }
   json: |
     {
-      "Column4":  [ { "uid": "0x799" } ],
-      "Column4.auth": [ { "uid": "0x799" } ]
+      "Column_4":  [ { "uid": "0x799" } ],
+      "Column_4.auth": [ { "uid": "0x799" } ]
     }
   uids: |
     {
-      "Project2": "0x123",
-      "Column3": "0x456"
+      "Project_2": "0x123",
+      "Column_3": "0x456"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Project(func: uid(Project3)) @filter(uid(ProjectAuth4)) {
+      Project(func: uid(Project_3)) @filter(uid(Project_Auth4)) {
         uid
       }
-      Project3 as var(func: uid(0x123))
-      ProjectAuth4 as var(func: uid(Project3)) @cascade {
+      Project_3 as var(func: uid(0x123))
+      Project_Auth4 as var(func: uid(Project_3)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
@@ -702,26 +702,26 @@
     }
   dgquery: |-
     query {
-      Ticket1(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_1(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Ticket1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       var(func: uid(0x789)) {
-        Column4 as Ticket.onColumn
+        Column_4 as Ticket.onColumn
       }
-      Column4(func: uid(Column4)) {
+      Column_4(func: uid(Column_4)) {
         uid
       }
-      Column4.auth(func: uid(Column4)) @filter(uid(ColumnAuth5)) {
+      Column_4.auth(func: uid(Column_4)) @filter(uid(Column_Auth5)) {
         uid
       }
-      ColumnAuth5 as var(func: uid(Column4)) @cascade {
+      Column_Auth5 as var(func: uid(Column_4)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -731,31 +731,31 @@
     }
   json: |
     {
-      "Column4":  [ { "uid": "0x799" } ]
+      "Column_4":  [ { "uid": "0x799" } ]
     }
   uids: |
     {
-      "Project2": "0x123",
-      "Column3": "0x456"
+      "Project_2": "0x123",
+      "Column_3": "0x456"
     }
   authquery: |-
     query {
-      Column(func: uid(Column1)) @filter(uid(ColumnAuth2)) {
+      Column(func: uid(Column_1)) @filter(uid(Column_Auth2)) {
         uid
       }
-      Column1 as var(func: uid(0x456))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      Column_1 as var(func: uid(0x456))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
           }
         }
       }
-      Project(func: uid(Project3)) @filter(uid(ProjectAuth4)) {
+      Project(func: uid(Project_3)) @filter(uid(Project_Auth4)) {
         uid
       }
-      Project3 as var(func: uid(0x123))
-      ProjectAuth4 as var(func: uid(Project3)) @cascade {
+      Project_3 as var(func: uid(0x123))
+      Project_Auth4 as var(func: uid(Project_3)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
@@ -789,7 +789,7 @@
       }
     }
   uids: |
-    { "Log1": "0x123" }
+    { "Log_1": "0x123" }
   error:
     { "message": "mutation failed because authorization failed"}
 
@@ -816,7 +816,7 @@
     }
   uids: |
     {
-      "Log1": "0x123"
+      "Log_1": "0x123"
     }
   skipauth: true
 
@@ -841,7 +841,7 @@
     }
   uids: |
     {
-      "Project1": "0x123"
+      "Project_1": "0x123"
     }
   skipauth: true
 
@@ -866,15 +866,15 @@
     }
   uids: |
     {
-      "Project1": "0x123"
+      "Project_1": "0x123"
     }
   authquery: |-
     query {
-      Project(func: uid(Project1)) @filter(uid(ProjectAuth2)) {
+      Project(func: uid(Project_1)) @filter(uid(Project_Auth2)) {
         uid
       }
-      Project1 as var(func: uid(0x123))
-      ProjectAuth2 as var(func: uid(Project1)) @cascade {
+      Project_1 as var(func: uid(0x123))
+      Project_Auth2 as var(func: uid(Project_1)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
@@ -908,25 +908,25 @@
     }
   dgquery: |-
     query {
-      User1(func: eq(User.username, "user1")) @filter(type(User)) {
+      User_1(func: eq(User.username, "user1")) @filter(type(User)) {
         uid
       }
     }
   queryjson: |
     {
-      "User1": [ { "uid": "0x123" } ]
+      "User_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Issue2": "0x789"
+      "Issue_2": "0x789"
     }
   authquery: |-
     query {
-      Issue(func: uid(Issue1)) @filter(uid(IssueAuth2)) {
+      Issue(func: uid(Issue_1)) @filter(uid(Issue_Auth2)) {
         uid
       }
-      Issue1 as var(func: uid(0x789))
-      IssueAuth2 as var(func: uid(Issue1)) @cascade {
+      Issue_1 as var(func: uid(0x789))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -958,25 +958,25 @@
     }
   dgquery: |-
     query {
-      User1(func: eq(User.username, "user1")) @filter(type(User)) {
+      User_1(func: eq(User.username, "user1")) @filter(type(User)) {
         uid
       }
     }
   queryjson: |
     {
-      "User1": [ { "uid": "0x123" } ]
+      "User_1": [ { "uid": "0x123" } ]
     }
   uids: |
     {
-      "Issue2": "0x789"
+      "Issue_2": "0x789"
     }
   authquery: |-
     query {
-      Issue(func: uid(Issue1)) @filter(uid(Issue2)) {
+      Issue(func: uid(Issue_1)) @filter(uid(Issue_2)) {
         uid
       }
-      Issue1 as var(func: uid(0x789))
-      Issue2 as var(func: uid(Issue1)) @cascade {
+      Issue_1 as var(func: uid(0x789))
+      Issue_2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -1003,7 +1003,7 @@
     }
   uids: |
     {
-      "ComplexLog1": "0x123"
+      "ComplexLog_1": "0x123"
     }
   error:
     { "message": "mutation failed because authorization failed"}
@@ -1028,7 +1028,7 @@
     }
   uids: |
     {
-      "ComplexLog1": "0x123"
+      "ComplexLog_1": "0x123"
     }
   skipauth: true
 
@@ -1061,19 +1061,19 @@
     }
   uids: |
     {
-      "Question1": "0x123",
-      "Author1": "0x456"
+      "Question_1": "0x123",
+      "Author_1": "0x456"
     }
   authquery: |-
     query {
-      Question(func: uid(Question1)) @filter((uid(QuestionAuth2) AND uid(QuestionAuth3))) {
+      Question(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3))) {
         uid
       }
-      Question1 as var(func: uid(0x123))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      Question_1 as var(func: uid(0x123))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -1114,19 +1114,19 @@
     }
   uids: |
     {
-      "Question1": "0x123",
-      "Author1": "0x456"
+      "Question_1": "0x123",
+      "Author_1": "0x456"
     }
   authquery: |-
     query {
-      Question(func: uid(Question1)) @filter((uid(QuestionAuth2) AND uid(QuestionAuth3))) {
+      Question(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3))) {
         uid
       }
-      Question1 as var(func: uid(0x123))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      Question_1 as var(func: uid(0x123))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -1167,16 +1167,16 @@
     }
   uids: |
     {
-      "FbPost1": "0x123",
-      "Author1": "0x456"
+      "FbPost_1": "0x123",
+      "Author_1": "0x456"
     }
   authquery: |-
     query {
-      FbPost(func: uid(FbPost1)) @filter(uid(FbPostAuth2)) {
+      FbPost(func: uid(FbPost_1)) @filter(uid(FbPost_Auth2)) {
         uid
       }
-      FbPost1 as var(func: uid(0x123))
-      FbPostAuth2 as var(func: uid(FbPost1)) @cascade {
+      FbPost_1 as var(func: uid(0x123))
+      FbPost_Auth2 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -1215,8 +1215,8 @@
     }
   uids: |
     {
-      "FbPost1": "0x123",
-      "Author1": "0x456"
+      "FbPost_1": "0x123",
+      "Author_1": "0x456"
     }
   error:
     {"message" : "mutation failed because authorization failed"}
@@ -1241,21 +1241,21 @@
     }
   dgquery: |-
     query {
-      Tweets1(func: eq(Tweets.id, "existing ID")) @filter(type(Tweets)) {
+      Tweets_1(func: eq(Tweets.id, "existing ID")) @filter(type(Tweets)) {
         uid
       }
     }
   queryjson: |
     {
-      "Tweets1": [ { "uid": "0x123" } ]
+      "Tweets_1": [ { "uid": "0x123" } ]
     }
   dgquerysec: |-
     query {
-      Tweets1 as Tweets1(func: uid(TweetsRoot)) {
+      Tweets_1 as Tweets_1(func: uid(TweetsRoot)) {
         uid
       }
-      TweetsRoot as var(func: uid(Tweets2))
-      Tweets2 as var(func: uid(0x123)) @filter(type(Tweets))
+      TweetsRoot as var(func: uid(Tweets_2))
+      Tweets_2 as var(func: uid(0x123)) @filter(type(Tweets))
     }
 
 - name: "Upsert Add Mutation with RBAC false"
@@ -1278,17 +1278,17 @@
     }
   dgquery: |-
     query {
-      Tweets1(func: eq(Tweets.id, "existing ID")) @filter(type(Tweets)) {
+      Tweets_1(func: eq(Tweets.id, "existing ID")) @filter(type(Tweets)) {
         uid
       }
     }
   queryjson: |
     {
-      "Tweets1": [ { "uid": "0x123" } ]
+      "Tweets_1": [ { "uid": "0x123" } ]
     }
   dgquerysec: |-
     query {
-      Tweets1 as addTweets()
+      Tweets_1 as addTweets()
     }
 
 - name: "Upsert with Deep Auth"
@@ -1320,42 +1320,42 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "mh")) @filter(type(State)) {
+      State_1(func: eq(State.code, "mh")) @filter(type(State)) {
         uid
       }
-      Country2(func: eq(Country.id, "in")) @filter(type(Country)) {
+      Country_2(func: eq(Country.id, "in")) @filter(type(Country)) {
         uid
       }
     }
   queryjson: |
     {
-      "State1": [ { "uid": "0x123" } ]
+      "State_1": [ { "uid": "0x123" } ]
     }
   dgquerysec: |-
     query {
-      State1 as State1(func: uid(StateRoot)) {
+      State_1 as State_1(func: uid(StateRoot)) {
         uid
       }
-      StateRoot as var(func: uid(State3)) @filter(uid(StateAuth4))
-      State3 as var(func: uid(0x123)) @filter(type(State))
-      StateAuth4 as var(func: uid(State3)) @filter(eq(State.ownedBy, "user1")) @cascade
+      StateRoot as var(func: uid(State_3)) @filter(uid(State_Auth4))
+      State_3 as var(func: uid(0x123)) @filter(type(State))
+      State_Auth4 as var(func: uid(State_3)) @filter(eq(State.ownedBy, "user1")) @cascade
     }
   uids: |
     {
-      "Country2": "0x456"
+      "Country_2": "0x456"
     }
   json: |
     {
-      "Country2":  [ { "uid": "0x456" } ],
-      "Country2.auth": [ { "uid": "0x456" } ]
+      "Country_2":  [ { "uid": "0x456" } ],
+      "Country_2.auth": [ { "uid": "0x456" } ]
     }
   authquery: |-
     query {
-      Country(func: uid(Country1)) @filter(uid(CountryAuth2)) {
+      Country(func: uid(Country_1)) @filter(uid(Country_Auth2)) {
         uid
       }
-      Country1 as var(func: uid(0x456))
-      CountryAuth2 as var(func: uid(Country1)) @filter(eq(Country.ownedBy, "user1")) @cascade
+      Country_1 as var(func: uid(0x456))
+      Country_Auth2 as var(func: uid(Country_1)) @filter(eq(Country.ownedBy, "user1")) @cascade
     }
   authjson: |
     {

--- a/graphql/resolve/auth_delete_test.yaml
+++ b/graphql/resolve/auth_delete_test.yaml
@@ -19,9 +19,9 @@
       x as deleteUserSecret(func: uid(UserSecretRoot)) {
         uid
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret)) @filter(anyofterms(UserSecret.aSecret, "auth is applied"))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: type(UserSecret)) @filter(anyofterms(UserSecret.aSecret, "auth is applied"))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Delete with inverse field and RBAC true"
@@ -45,29 +45,29 @@
           { "uid": "uid(x)" },
           {
             "User.tweets" : [{"uid":"uid(x)"}],
-            "uid" : "uid(User2)"
+            "uid" : "uid(User_2)"
           }
         ]
   dgquery: |-
     query {
       x as deleteTweets(func: uid(TweetsRoot)) {
         uid
-        User2 as Tweets.user
+        User_2 as Tweets.user
       }
-      TweetsRoot as var(func: uid(Tweets1))
-      Tweets1 as var(func: type(Tweets)) @filter(anyoftext(Tweets.text, "abc"))
+      TweetsRoot as var(func: uid(Tweets_1))
+      Tweets_1 as var(func: type(Tweets)) @filter(anyoftext(Tweets.text, "abc"))
     }
   dgquerysec: |-
     query {
       x as var(func: uid(TweetsRoot))
-      TweetsRoot as var(func: uid(Tweets1))
-      Tweets1 as var(func: type(Tweets)) @filter(anyoftext(Tweets.text, "abc"))
-      DeleteTweetsPayload.tweets(func: uid(Tweets3)) {
+      TweetsRoot as var(func: uid(Tweets_1))
+      Tweets_1 as var(func: type(Tweets)) @filter(anyoftext(Tweets.text, "abc"))
+      DeleteTweetsPayload.tweets(func: uid(Tweets_3)) {
         Tweets.text : Tweets.text
         dgraph.uid : uid
       }
-      Tweets3 as var(func: uid(Tweets4))
-      Tweets4 as var(func: uid(x))
+      Tweets_3 as var(func: uid(Tweets_4))
+      Tweets_4 as var(func: uid(x))
     }
 
 - name: "Delete with inverse field and RBAC false"
@@ -96,12 +96,12 @@
   dgquerysec: |-
     query {
       x as var()
-      DeleteTweetsPayload.tweets(func: uid(Tweets1)) {
+      DeleteTweetsPayload.tweets(func: uid(Tweets_1)) {
         Tweets.text : Tweets.text
         dgraph.uid : uid
       }
-      Tweets1 as var(func: uid(Tweets2))
-      Tweets2 as var(func: uid(x))
+      Tweets_1 as var(func: uid(Tweets_2))
+      Tweets_2 as var(func: uid(x))
     }
 
 - name: "Delete with deep auth"
@@ -120,11 +120,11 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid":"uid(Column3)",
+            "uid":"uid(Column_3)",
             "Column.tickets": [ { "uid":"uid(x)" } ]
           },
           {
-            "uid":"uid(User4)",
+            "uid":"uid(User_4)",
             "User.tickets": [ { "uid":"uid(x)" } ]
           }
         ]
@@ -132,12 +132,12 @@
     query {
       x as deleteTicket(func: uid(TicketRoot)) {
         uid
-        Column3 as Ticket.onColumn
-        User4 as Ticket.assignedTo
+        Column_3 as Ticket.onColumn
+        User_4 as Ticket.assignedTo
       }
-      TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      TicketRoot as var(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2))
+      Ticket_1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -179,11 +179,11 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid":"uid(Column3)",
+            "uid":"uid(Column_3)",
             "Column.tickets": [ { "uid":"uid(x)" } ]
           },
           {
-            "uid":"uid(User4)",
+            "uid":"uid(User_4)",
             "User.tickets": [ { "uid":"uid(x)" } ]
           }
         ]
@@ -191,12 +191,12 @@
     query {
       x as deleteTicket(func: uid(TicketRoot)) {
         uid
-        Column3 as Ticket.onColumn
-        User4 as Ticket.assignedTo
+        Column_3 as Ticket.onColumn
+        User_4 as Ticket.assignedTo
       }
-      TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      TicketRoot as var(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2))
+      Ticket_1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -209,9 +209,9 @@
   dgquerysec: |-
     query {
       x as var(func: uid(TicketRoot))
-      TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      TicketRoot as var(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2))
+      Ticket_1 as var(func: type(Ticket)) @filter(anyofterms(Ticket.title, "auth is applied"))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -220,12 +220,12 @@
           }
         }
       }
-      DeleteTicketPayload.ticket(func: uid(Ticket5)) {
+      DeleteTicketPayload.ticket(func: uid(Ticket_5)) {
         Ticket.title : Ticket.title
-        Ticket.onColumn : Ticket.onColumn @filter(uid(Column6)) {
-          Column.inProject : Column.inProject @filter(uid(Project8)) {
-            Project.roles : Project.roles @filter(uid(Role10)) {
-              Role.assignedTo : Role.assignedTo @filter(uid(User12)) {
+        Ticket.onColumn : Ticket.onColumn @filter(uid(Column_6)) {
+          Column.inProject : Column.inProject @filter(uid(Project_8)) {
+            Project.roles : Project.roles @filter(uid(Role_10)) {
+              Role.assignedTo : Role.assignedTo @filter(uid(User_12)) {
                 User.username : User.username
                 User.age : User.age
                 dgraph.uid : uid
@@ -238,9 +238,9 @@
         }
         dgraph.uid : uid
       }
-      Ticket5 as var(func: uid(Ticket16)) @filter(uid(TicketAuth17))
-      Ticket16 as var(func: uid(x))
-      TicketAuth17 as var(func: uid(Ticket16)) @cascade {
+      Ticket_5 as var(func: uid(Ticket_16)) @filter(uid(Ticket_Auth17))
+      Ticket_16 as var(func: uid(x))
+      Ticket_Auth17 as var(func: uid(Ticket_16)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -249,28 +249,28 @@
           }
         }
       }
-      var(func: uid(Ticket5)) {
-        Column7 as Ticket.onColumn
+      var(func: uid(Ticket_5)) {
+        Column_7 as Ticket.onColumn
       }
-      Column6 as var(func: uid(Column7)) @filter(uid(ColumnAuth15))
-      var(func: uid(Column6)) {
-        Project9 as Column.inProject
+      Column_6 as var(func: uid(Column_7)) @filter(uid(Column_Auth15))
+      var(func: uid(Column_6)) {
+        Project_9 as Column.inProject
       }
-      Project8 as var(func: uid(Project9)) @filter(uid(ProjectAuth14))
-      var(func: uid(Project8)) {
-        Role11 as Project.roles
+      Project_8 as var(func: uid(Project_9)) @filter(uid(Project_Auth14))
+      var(func: uid(Project_8)) {
+        Role_11 as Project.roles
       }
-      Role10 as var(func: uid(Role11))
-      var(func: uid(Role10)) {
-        User13 as Role.assignedTo
+      Role_10 as var(func: uid(Role_11))
+      var(func: uid(Role_10)) {
+        User_13 as Role.assignedTo
       }
-      User12 as var(func: uid(User13))
-      ProjectAuth14 as var(func: uid(Project9)) @cascade {
+      User_12 as var(func: uid(User_13))
+      Project_Auth14 as var(func: uid(Project_9)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
       }
-      ColumnAuth15 as var(func: uid(Column7)) @cascade {
+      Column_Auth15 as var(func: uid(Column_7)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -302,14 +302,14 @@
            "Column.inProject": {
              "uid": "uid(x)"
            },
-           "uid": "uid(Column2)"
+           "uid": "uid(Column_2)"
          }
         ]
   dgquery: |-
     query {
       x as deleteProject(func: uid(0x1, 0x2)) @filter(type(Project)) {
         uid
-        Column2 as Project.columns
+        Column_2 as Project.columns
       }
     }
 
@@ -369,24 +369,24 @@
           { "uid" : "uid(x)" },
           {
             "Ticket.assignedTo" : [ {"uid":"uid(x)"} ],
-            "uid" : "uid(Ticket4)"
+            "uid" : "uid(Ticket_4)"
           },
           {
             "Tweets.user" : {"uid":"uid(x)"},
-            "uid" : "uid(Tweets5)"
+            "uid" : "uid(Tweets_5)"
           }
         ]
   dgquery: |-
     query {
       x as deleteUser(func: uid(UserRoot)) {
         uid
-        Ticket4 as User.tickets
-        Tweets5 as User.tweets
+        Ticket_4 as User.tickets
+        Tweets_5 as User.tweets
       }
-      UserRoot as var(func: uid(User1)) @filter((uid(UserAuth2) AND uid(UserAuth3)))
-      User1 as var(func: type(User)) @filter(eq(User.username, "userxyz"))
-      UserAuth2 as var(func: uid(User1)) @filter(eq(User.username, "user1")) @cascade
-      UserAuth3 as var(func: uid(User1)) @filter(eq(User.isPublic, true)) @cascade
+      UserRoot as var(func: uid(User_1)) @filter((uid(User_Auth2) AND uid(User_Auth3)))
+      User_1 as var(func: type(User)) @filter(eq(User.username, "userxyz"))
+      User_Auth2 as var(func: uid(User_1)) @filter(eq(User.username, "user1")) @cascade
+      User_Auth3 as var(func: uid(User_1)) @filter(eq(User.isPublic, true)) @cascade
     }
 
 - name: "Filtering by ID"
@@ -414,9 +414,9 @@
       x as deleteRegion(func: uid(RegionRoot)) {
         uid
       }
-      RegionRoot as var(func: uid(Region1)) @filter(uid(RegionAuth2))
-      Region1 as var(func: uid(0x1, 0x2)) @filter(type(Region))
-      RegionAuth2 as var(func: uid(Region1)) @filter(eq(Region.global, true)) @cascade
+      RegionRoot as var(func: uid(Region_1)) @filter(uid(Region_Auth2))
+      Region_1 as var(func: uid(0x1, 0x2)) @filter(type(Region))
+      Region_Auth2 as var(func: uid(Region_1)) @filter(eq(Region.global, true)) @cascade
     }
 
 - name: "Delete with top level RBAC false."
@@ -475,21 +475,21 @@
       x as deleteLog(func: uid(LogRoot)) {
         uid
       }
-      LogRoot as var(func: uid(Log1))
-      Log1 as var(func: uid(0x1, 0x2)) @filter(type(Log))
+      LogRoot as var(func: uid(Log_1))
+      Log_1 as var(func: uid(0x1, 0x2)) @filter(type(Log))
     }
   dgquerysec: |-
     query {
       x as var(func: uid(LogRoot))
-      LogRoot as var(func: uid(Log1))
-      Log1 as var(func: uid(0x1, 0x2)) @filter(type(Log))
-      DeleteLogPayload.log(func: uid(Log2), orderasc: Log.logs) {
+      LogRoot as var(func: uid(Log_1))
+      Log_1 as var(func: uid(0x1, 0x2)) @filter(type(Log))
+      DeleteLogPayload.log(func: uid(Log_2), orderasc: Log.logs) {
         Log.logs : Log.logs
         Log.random : Log.random
         dgraph.uid : uid
       }
-      Log2 as var(func: uid(Log3), orderasc: Log.logs)
-      Log3 as var(func: uid(x))
+      Log_2 as var(func: uid(Log_3), orderasc: Log.logs)
+      Log_3 as var(func: uid(x))
     }
 
 - name: "Delete with top level OR RBAC true."
@@ -514,8 +514,8 @@
       x as deleteComplexLog(func: uid(ComplexLogRoot)) {
         uid
       }
-      ComplexLogRoot as var(func: uid(ComplexLog1))
-      ComplexLog1 as var(func: uid(0x1, 0x2)) @filter(type(ComplexLog))
+      ComplexLogRoot as var(func: uid(ComplexLog_1))
+      ComplexLog_1 as var(func: uid(0x1, 0x2)) @filter(type(ComplexLog))
     }
 
 - name: "Delete with top level OR RBAC false."
@@ -539,9 +539,9 @@
       x as deleteComplexLog(func: uid(ComplexLogRoot)) {
         uid
       }
-      ComplexLogRoot as var(func: uid(ComplexLog1)) @filter(uid(ComplexLogAuth2))
-      ComplexLog1 as var(func: uid(0x1, 0x2)) @filter(type(ComplexLog))
-      ComplexLogAuth2 as var(func: uid(ComplexLog1)) @filter(eq(ComplexLog.visible, true)) @cascade
+      ComplexLogRoot as var(func: uid(ComplexLog_1)) @filter(uid(ComplexLog_Auth2))
+      ComplexLog_1 as var(func: uid(0x1, 0x2)) @filter(type(ComplexLog))
+      ComplexLog_Auth2 as var(func: uid(ComplexLog_1)) @filter(eq(ComplexLog.visible, true)) @cascade
     }
 
 - name: "Delete with top level AND RBAC true."
@@ -568,9 +568,9 @@
       x as deleteIssue(func: uid(IssueRoot)) {
         uid
       }
-      IssueRoot as var(func: uid(Issue1)) @filter(uid(IssueAuth2))
-      Issue1 as var(func: uid(0x1, 0x2)) @filter(type(Issue))
-      IssueAuth2 as var(func: uid(Issue1)) @cascade {
+      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      Issue_1 as var(func: uid(0x1, 0x2)) @filter(type(Issue))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -671,28 +671,28 @@
            "Author.posts": [
              {"uid": "uid(x)"}
            ],
-           "uid": "uid(Author5)"
+           "uid": "uid(Author_5)"
          }]
   dgquery: |-
     query {
       x as deletePost(func: uid(PostRoot)) {
         uid
-        Author5 as Post.author
+        Author_5 as Post.author
       }
-      PostRoot as var(func: uid(Post1)) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(AnswerAuth4)))
-      Post1 as var(func: uid(0x1, 0x2)) @filter(type(Post))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(Answer_Auth4)))
+      Post_1 as var(func: uid(0x1, 0x2)) @filter(type(Post))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth4 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth4 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -745,9 +745,9 @@
       x as deleteA(func: uid(ARoot)) {
         uid
       }
-      ARoot as var(func: uid(A1)) @filter((uid(B1)))
-      A1 as var(func: uid(0x1, 0x2)) @filter(type(A))
-      B1 as var(func: type(B))
+      ARoot as var(func: uid(A_1)) @filter((uid(B_1)))
+      A_1 as var(func: uid(0x1, 0x2)) @filter(type(A))
+      B_1 as var(func: type(B))
     }
 
 - name: "Delete Type Having Graph Traversal Auth Rules on Interface."
@@ -772,20 +772,20 @@
            "Author.posts": [
              {"uid": "uid(x)"}
            ],
-           "uid": "uid(Author4)"
+           "uid": "uid(Author_4)"
          }]
   dgquery: |-
     query {
       x as deleteQuestion(func: uid(QuestionRoot)) {
         uid
-        Author4 as Post.author
+        Author_4 as Post.author
       }
-      QuestionRoot as var(func: uid(Question1)) @filter((uid(QuestionAuth2) AND uid(QuestionAuth3)))
-      Question1 as var(func: uid(0x1, 0x2)) @filter(type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      QuestionRoot as var(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3)))
+      Question_1 as var(func: uid(0x1, 0x2)) @filter(type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -862,17 +862,17 @@
            "Author.posts": [
              {"uid": "uid(x)"}
            ],
-           "uid": "uid(Author3)"
+           "uid": "uid(Author_3)"
          }]
   dgquery: |-
     query {
       x as deleteFbPost(func: uid(FbPostRoot)) {
         uid
-        Author3 as Post.author
+        Author_3 as Post.author
       }
-      FbPostRoot as var(func: uid(FbPost1)) @filter(uid(FbPostAuth2))
-      FbPost1 as var(func: uid(0x1, 0x2)) @filter(type(FbPost))
-      FbPostAuth2 as var(func: uid(FbPost1)) @cascade {
+      FbPostRoot as var(func: uid(FbPost_1)) @filter(uid(FbPost_Auth2))
+      FbPost_1 as var(func: uid(0x1, 0x2)) @filter(type(FbPost))
+      FbPost_Auth2 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -23,27 +23,27 @@
       queryContact(func: uid(ContactRoot)) {
         Contact.id : uid
         Contact.nickName : Contact.nickName
-        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask1)) {
+        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask_1)) {
           AdminTask.id : uid
           AdminTask.name : AdminTask.name
-          AdminTask.occurrences : AdminTask.occurrences @filter(uid(TaskOccurrence3)) {
+          AdminTask.occurrences : AdminTask.occurrences @filter(uid(TaskOccurrence_3)) {
             TaskOccurrence.due : TaskOccurrence.due
             TaskOccurrence.comp : TaskOccurrence.comp
             dgraph.uid : uid
           }
         }
       }
-      ContactRoot as var(func: uid(Contact6))
-      Contact6 as var(func: type(Contact))
+      ContactRoot as var(func: uid(Contact_6))
+      Contact_6 as var(func: type(Contact))
       var(func: uid(ContactRoot)) {
-        AdminTask2 as Contact.adminTasks
+        AdminTask_2 as Contact.adminTasks
       }
-      AdminTask1 as var(func: uid(AdminTask2))
-      var(func: uid(AdminTask1)) {
-        TaskOccurrence4 as AdminTask.occurrences
+      AdminTask_1 as var(func: uid(AdminTask_2))
+      var(func: uid(AdminTask_1)) {
+        TaskOccurrence_4 as AdminTask.occurrences
       }
-      TaskOccurrence3 as var(func: uid(TaskOccurrence4)) @filter(uid(TaskOccurrenceAuth5))
-      TaskOccurrenceAuth5 as var(func: uid(TaskOccurrence4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
+      TaskOccurrence_3 as var(func: uid(TaskOccurrence_4)) @filter(uid(TaskOccurrence_Auth5))
+      TaskOccurrence_Auth5 as var(func: uid(TaskOccurrence_4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
     }
 
 - name: "Deep RBAC rule - Level 0 false"
@@ -97,8 +97,8 @@
         Contact.id : uid
         Contact.nickName : Contact.nickName
       }
-      ContactRoot as var(func: uid(Contact6))
-      Contact6 as var(func: type(Contact))
+      ContactRoot as var(func: uid(Contact_6))
+      Contact_6 as var(func: type(Contact))
     }
 
 - name: "Deep RBAC rule with cascade - Level 1 false"
@@ -126,28 +126,28 @@
       queryContact(func: uid(ContactRoot)) @cascade {
         Contact.id : uid
         Contact.nickName : Contact.nickName
-        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask1)) {
+        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask_1)) {
           AdminTask.id : uid
           AdminTask.name : AdminTask.name
-          AdminTask.occurrences : AdminTask.occurrences @filter(uid(TaskOccurrence3)) {
+          AdminTask.occurrences : AdminTask.occurrences @filter(uid(TaskOccurrence_3)) {
             TaskOccurrence.due : TaskOccurrence.due
             TaskOccurrence.comp : TaskOccurrence.comp
             dgraph.uid : uid
           }
         }
       }
-      ContactRoot as var(func: uid(Contact7))
-      Contact7 as var(func: type(Contact))
+      ContactRoot as var(func: uid(Contact_7))
+      Contact_7 as var(func: type(Contact))
       var(func: uid(ContactRoot)) {
-        AdminTask2 as Contact.adminTasks
+        AdminTask_2 as Contact.adminTasks
       }
-      AdminTask1 as var(func: uid(AdminTask2)) @filter(uid(AdminTask6))
-      var(func: uid(AdminTask1)) {
-        TaskOccurrence4 as AdminTask.occurrences
+      AdminTask_1 as var(func: uid(AdminTask_2)) @filter(uid(AdminTask_6))
+      var(func: uid(AdminTask_1)) {
+        TaskOccurrence_4 as AdminTask.occurrences
       }
-      TaskOccurrence3 as var(func: uid(TaskOccurrence4)) @filter(uid(TaskOccurrenceAuth5))
-      TaskOccurrenceAuth5 as var(func: uid(TaskOccurrence4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
-      AdminTask6 as var(func: uid())
+      TaskOccurrence_3 as var(func: uid(TaskOccurrence_4)) @filter(uid(TaskOccurrence_Auth5))
+      TaskOccurrence_Auth5 as var(func: uid(TaskOccurrence_4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
+      AdminTask_6 as var(func: uid())
     }
 
 - name: "Deep RBAC rule - Level 2 false"
@@ -175,17 +175,17 @@
       queryContact(func: uid(ContactRoot)) {
         Contact.id : uid
         Contact.nickName : Contact.nickName
-        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask1)) {
+        Contact.adminTasks : Contact.adminTasks @filter(uid(AdminTask_1)) {
           AdminTask.id : uid
           AdminTask.name : AdminTask.name
         }
       }
-      ContactRoot as var(func: uid(Contact5))
-      Contact5 as var(func: type(Contact))
+      ContactRoot as var(func: uid(Contact_5))
+      Contact_5 as var(func: type(Contact))
       var(func: uid(ContactRoot)) {
-        AdminTask2 as Contact.adminTasks
+        AdminTask_2 as Contact.adminTasks
       }
-      AdminTask1 as var(func: uid(AdminTask2))
+      AdminTask_1 as var(func: uid(AdminTask_2))
     }
 
 - name: "Deep RBAC rule - Level 1 type without auth."
@@ -213,27 +213,27 @@
       queryContact(func: uid(ContactRoot)) {
         Contact.id : uid
         Contact.nickName : Contact.nickName
-        Contact.tasks : Contact.tasks @filter(uid(Task1)) {
+        Contact.tasks : Contact.tasks @filter(uid(Task_1)) {
           Task.id : uid
           Task.name : Task.name
-          Task.occurrences : Task.occurrences @filter(uid(TaskOccurrence3)) {
+          Task.occurrences : Task.occurrences @filter(uid(TaskOccurrence_3)) {
             TaskOccurrence.due : TaskOccurrence.due
             TaskOccurrence.comp : TaskOccurrence.comp
             dgraph.uid : uid
           }
         }
       }
-      ContactRoot as var(func: uid(Contact6))
-      Contact6 as var(func: type(Contact))
+      ContactRoot as var(func: uid(Contact_6))
+      Contact_6 as var(func: type(Contact))
       var(func: uid(ContactRoot)) {
-        Task2 as Contact.tasks
+        Task_2 as Contact.tasks
       }
-      Task1 as var(func: uid(Task2))
-      var(func: uid(Task1)) {
-        TaskOccurrence4 as Task.occurrences
+      Task_1 as var(func: uid(Task_2))
+      var(func: uid(Task_1)) {
+        TaskOccurrence_4 as Task.occurrences
       }
-      TaskOccurrence3 as var(func: uid(TaskOccurrence4)) @filter(uid(TaskOccurrenceAuth5))
-      TaskOccurrenceAuth5 as var(func: uid(TaskOccurrence4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
+      TaskOccurrence_3 as var(func: uid(TaskOccurrence_4)) @filter(uid(TaskOccurrence_Auth5))
+      TaskOccurrence_Auth5 as var(func: uid(TaskOccurrence_4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
     }
 
 - name: "Auth query with @dgraph pred."
@@ -252,9 +252,9 @@
         Student.email : IOw80vnV
         dgraph.uid : uid
       }
-      StudentRoot as var(func: uid(Student1)) @filter(uid(StudentAuth2))
-      Student1 as var(func: type(is7sowSm))
-      StudentAuth2 as var(func: uid(Student1)) @filter(eq(IOw80vnV, "user1")) @cascade
+      StudentRoot as var(func: uid(Student_1)) @filter(uid(Student_Auth2))
+      Student_1 as var(func: type(is7sowSm))
+      Student_Auth2 as var(func: uid(Student_1)) @filter(eq(IOw80vnV, "user1")) @cascade
     }
 
 - name: "Auth query with @dgraph pred (Test RBAC)."
@@ -289,23 +289,23 @@
     query {
       getProject(func: uid(ProjectRoot)) @filter(type(Project)) {
         Project.projID : uid
-        Project.columns : Project.columns @filter(uid(Column1)) {
+        Project.columns : Project.columns @filter(uid(Column_1)) {
           Column.name : Column.name
           Column.colID : uid
         }
       }
-      ProjectRoot as var(func: uid(Project4)) @filter(uid(ProjectAuth5))
-      Project4 as var(func: uid(0x123))
-      ProjectAuth5 as var(func: uid(Project4)) @cascade {
+      ProjectRoot as var(func: uid(Project_4)) @filter(uid(Project_Auth5))
+      Project_4 as var(func: uid(0x123))
+      Project_Auth5 as var(func: uid(Project_4)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
       }
       var(func: uid(ProjectRoot)) {
-        Column2 as Project.columns
+        Column_2 as Project.columns
       }
-      Column1 as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-      ColumnAuth3 as var(func: uid(Column2)) @cascade {
+      Column_1 as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+      Column_Auth3 as var(func: uid(Column_2)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -330,9 +330,9 @@
         UserSecret.id : uid
         UserSecret.ownedBy : UserSecret.ownedBy
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: type(UserSecret))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Auth with Aggregate Root Query"
@@ -357,9 +357,9 @@
         countVar as count(uid)
         aSecretVar as UserSecret.aSecret
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: type(UserSecret))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Auth with top level filter : get"
@@ -378,9 +378,9 @@
         UserSecret.id : uid
         UserSecret.ownedBy : UserSecret.ownedBy
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: uid(0x123))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: uid(0x123))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Auth with top level filter : query and filter"
@@ -399,9 +399,9 @@
         UserSecret.id : uid
         UserSecret.ownedBy : UserSecret.ownedBy
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret)) @filter(eq(UserSecret.ownedBy, "user2"))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: type(UserSecret)) @filter(eq(UserSecret.ownedBy, "user2"))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Deep RBAC rules true"
@@ -419,18 +419,18 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        User.issues : User.issues @filter(uid(Issue1)) {
+        User.issues : User.issues @filter(uid(Issue_1)) {
           Issue.id : uid
         }
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User4))
-      User4 as var(func: type(User))
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        Issue2 as User.issues
+        Issue_2 as User.issues
       }
-      Issue1 as var(func: uid(Issue2)) @filter(uid(IssueAuth3))
-      IssueAuth3 as var(func: uid(Issue2)) @cascade {
+      Issue_1 as var(func: uid(Issue_2)) @filter(uid(Issue_Auth3))
+      Issue_Auth3 as var(func: uid(Issue_2)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -454,8 +454,8 @@
         User.username : User.username
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User3))
-      User3 as var(func: type(User))
+      UserRoot as var(func: uid(User_3))
+      User_3 as var(func: type(User))
     }
 
 - name: "Auth with top level AND rbac true"
@@ -474,9 +474,9 @@
         Issue.msg : Issue.msg
         dgraph.uid : uid
       }
-      IssueRoot as var(func: uid(Issue1)) @filter(uid(IssueAuth2))
-      Issue1 as var(func: type(Issue))
-      IssueAuth2 as var(func: uid(Issue1)) @cascade {
+      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      Issue_1 as var(func: type(Issue))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -497,8 +497,8 @@
         ComplexLog.logs : ComplexLog.logs
         dgraph.uid : uid
       }
-      ComplexLogRoot as var(func: uid(ComplexLog1))
-      ComplexLog1 as var(func: type(ComplexLog))
+      ComplexLogRoot as var(func: uid(ComplexLog_1))
+      ComplexLog_1 as var(func: type(ComplexLog))
     }
 
 - name: "Auth with complex rbac rules, false"
@@ -532,8 +532,8 @@
         Log.logs : Log.logs
         dgraph.uid : uid
       }
-      LogRoot as var(func: uid(Log1))
-      Log1 as var(func: type(Log))
+      LogRoot as var(func: uid(Log_1))
+      Log_1 as var(func: type(Log))
     }
 
 - name: "Auth with top level rbac false"
@@ -598,8 +598,8 @@
         Project.name : Project.name
         dgraph.uid : uid
       }
-      ProjectRoot as var(func: uid(Project1))
-      Project1 as var(func: type(Project))
+      ProjectRoot as var(func: uid(Project_1))
+      Project_1 as var(func: type(Project))
     }
 
 - name: "Aggregate on Auth with top level OR rbac true"
@@ -626,8 +626,8 @@
         countVar as count(uid)
         randomVar as Project.random
       }
-      ProjectRoot as var(func: uid(Project1))
-      Project1 as var(func: type(Project))
+      ProjectRoot as var(func: uid(Project_1))
+      Project_1 as var(func: type(Project))
     }
 
 - name: "Query with missing jwt variables"
@@ -644,12 +644,12 @@
       queryGroup(func: uid(GroupRoot)) {
         Group.id : uid
       }
-      GroupRoot as var(func: uid(Group1)) @filter((uid(GroupAuth2) OR uid(GroupAuth3)))
-      Group1 as var(func: type(Group))
-      GroupAuth2 as var(func: uid(Group1)) @cascade {
+      GroupRoot as var(func: uid(Group_1)) @filter((uid(Group_Auth2) OR uid(Group_Auth3)))
+      Group_1 as var(func: type(Group))
+      Group_Auth2 as var(func: uid(Group_1)) @cascade {
         Group.users : Group.users @filter(eq(User.username, "user1"))
       }
-      GroupAuth3 as var(func: uid(Group1)) @cascade {
+      Group_Auth3 as var(func: uid(Group_1)) @cascade {
         Group.createdBy : Group.createdBy @filter(eq(User.username, "user1"))
       }
     }
@@ -670,9 +670,9 @@
         Project.name : Project.name
         dgraph.uid : uid
       }
-      ProjectRoot as var(func: uid(Project1)) @filter(uid(ProjectAuth2))
-      Project1 as var(func: type(Project))
-      ProjectAuth2 as var(func: uid(Project1)) @cascade {
+      ProjectRoot as var(func: uid(Project_1)) @filter(uid(Project_Auth2))
+      Project_1 as var(func: type(Project))
+      Project_Auth2 as var(func: uid(Project_1)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
@@ -695,9 +695,9 @@
         UserSecret.id : uid
         UserSecret.ownedBy : UserSecret.ownedBy
       }
-      UserSecretRoot as var(func: uid(UserSecret1), orderasc: UserSecret.aSecret, first: 1) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: type(UserSecret)) @filter(eq(UserSecret.ownedBy, "user2"))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1), orderasc: UserSecret.aSecret, first: 1) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: type(UserSecret)) @filter(eq(UserSecret.ownedBy, "user2"))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Auth with deep filter : query top-level"
@@ -716,9 +716,9 @@
         Ticket.id : uid
         Ticket.title : Ticket.title
       }
-      TicketRoot as var(func: uid(Ticket1)) @filter(uid(TicketAuth2))
-      Ticket1 as var(func: type(Ticket))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      TicketRoot as var(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2))
+      Ticket_1 as var(func: type(Ticket))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -746,19 +746,19 @@
     query {
       queryUser(func: uid(UserRoot)) {
         User.username : User.username
-        User.tickets : User.tickets @filter(uid(Ticket1)) {
+        User.tickets : User.tickets @filter(uid(Ticket_1)) {
           Ticket.id : uid
           Ticket.title : Ticket.title
         }
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User4))
-      User4 as var(func: type(User))
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        Ticket2 as User.tickets
+        Ticket_2 as User.tickets
       }
-      Ticket1 as var(func: uid(Ticket2)) @filter(uid(TicketAuth3))
-      TicketAuth3 as var(func: uid(Ticket2)) @cascade {
+      Ticket_1 as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -786,19 +786,19 @@
     query {
       queryUser(func: uid(UserRoot)) {
         User.username : User.username
-        User.tickets : User.tickets @filter(uid(Ticket1)) {
+        User.tickets : User.tickets @filter(uid(Ticket_1)) {
           Ticket.id : uid
           Ticket.title : Ticket.title
         }
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User4))
-      User4 as var(func: type(User))
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        Ticket2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
+        Ticket_2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
       }
-      Ticket1 as var(func: uid(Ticket2)) @filter(uid(TicketAuth3))
-      TicketAuth3 as var(func: uid(Ticket2)) @cascade {
+      Ticket_1 as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -824,15 +824,15 @@
         Movie.content : Movie.content
         dgraph.uid : uid
       }
-      MovieRoot as var(func: uid(Movie1), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(MovieAuth2)) AND (uid(MovieAuth3) OR uid(MovieAuth4))))
-      Movie1 as var(func: type(Movie)) @filter(eq(Movie.content, "A. N. Author"))
-      MovieAuth2 as var(func: uid(Movie1)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth3 as var(func: uid(Movie1)) @cascade {
+      MovieRoot as var(func: uid(Movie_1), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(Movie_Auth2)) AND (uid(Movie_Auth3) OR uid(Movie_Auth4))))
+      Movie_1 as var(func: type(Movie)) @filter(eq(Movie.content, "A. N. Author"))
+      Movie_Auth2 as var(func: uid(Movie_1)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth3 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable {
           Region.users : Region.users @filter(eq(User.username, "user1"))
         }
       }
-      MovieAuth4 as var(func: uid(Movie1)) @cascade {
+      Movie_Auth4 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
     }
@@ -854,28 +854,28 @@
     query {
       queryMovie(func: uid(MovieRoot), orderasc: Movie.content) @cascade {
         Movie.content : Movie.content
-        Movie.regionsAvailable : Movie.regionsAvailable @filter(uid(Region1)) (orderasc: Region.name, first: 10, offset: 10) {
+        Movie.regionsAvailable : Movie.regionsAvailable @filter(uid(Region_1)) (orderasc: Region.name, first: 10, offset: 10) {
           Region.name : Region.name
           Region.global : Region.global
           dgraph.uid : uid
         }
         dgraph.uid : uid
       }
-      MovieRoot as var(func: uid(Movie3), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(MovieAuth4)) AND (uid(MovieAuth5) OR uid(MovieAuth6))))
-      Movie3 as var(func: type(Movie)) @filter(eq(Movie.content, "MovieXYZ"))
-      MovieAuth4 as var(func: uid(Movie3)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth5 as var(func: uid(Movie3)) @cascade {
+      MovieRoot as var(func: uid(Movie_3), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(Movie_Auth4)) AND (uid(Movie_Auth5) OR uid(Movie_Auth6))))
+      Movie_3 as var(func: type(Movie)) @filter(eq(Movie.content, "MovieXYZ"))
+      Movie_Auth4 as var(func: uid(Movie_3)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth5 as var(func: uid(Movie_3)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable {
           Region.users : Region.users @filter(eq(User.username, "user1"))
         }
       }
-      MovieAuth6 as var(func: uid(Movie3)) @cascade {
+      Movie_Auth6 as var(func: uid(Movie_3)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
       var(func: uid(MovieRoot)) {
-        Region2 as Movie.regionsAvailable @filter(eq(Region.name, "Region123"))
+        Region_2 as Movie.regionsAvailable @filter(eq(Region.name, "Region123"))
       }
-      Region1 as var(func: uid(Region2))
+      Region_1 as var(func: uid(Region_2))
     }
 
 - name: "Auth deep query - 3 level"
@@ -904,14 +904,14 @@
     query {
       queryMovie(func: uid(MovieRoot), orderasc: Movie.content) {
         Movie.content : Movie.content
-        Movie.regionsAvailable : Movie.regionsAvailable @filter(uid(Region1)) (orderasc: Region.name, first: 10, offset: 10) @cascade {
+        Movie.regionsAvailable : Movie.regionsAvailable @filter(uid(Region_1)) (orderasc: Region.name, first: 10, offset: 10) @cascade {
           Region.name : Region.name
           Region.global : Region.global
-          Region.users : Region.users @filter(uid(User3)) (orderasc: User.username, first: 10, offset: 10) {
+          Region.users : Region.users @filter(uid(User_3)) (orderasc: User.username, first: 10, offset: 10) {
             User.username : User.username
             User.age : User.age
             User.isPublic : User.isPublic
-            User.secrets : User.secrets @filter(uid(UserSecret5)) (orderasc: UserSecret.aSecret, first: 10, offset: 10) {
+            User.secrets : User.secrets @filter(uid(UserSecret_5)) (orderasc: UserSecret.aSecret, first: 10, offset: 10) {
               UserSecret.aSecret : UserSecret.aSecret
               UserSecret.ownedBy : UserSecret.ownedBy
               dgraph.uid : uid
@@ -922,30 +922,30 @@
         }
         dgraph.uid : uid
       }
-      MovieRoot as var(func: uid(Movie8), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(MovieAuth9)) AND (uid(MovieAuth10) OR uid(MovieAuth11))))
-      Movie8 as var(func: type(Movie)) @filter(eq(Movie.content, "MovieXYZ"))
-      MovieAuth9 as var(func: uid(Movie8)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth10 as var(func: uid(Movie8)) @cascade {
+      MovieRoot as var(func: uid(Movie_8), orderasc: Movie.content, first: 10, offset: 10) @filter((NOT (uid(Movie_Auth9)) AND (uid(Movie_Auth10) OR uid(Movie_Auth11))))
+      Movie_8 as var(func: type(Movie)) @filter(eq(Movie.content, "MovieXYZ"))
+      Movie_Auth9 as var(func: uid(Movie_8)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth10 as var(func: uid(Movie_8)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable {
           Region.users : Region.users @filter(eq(User.username, "user1"))
         }
       }
-      MovieAuth11 as var(func: uid(Movie8)) @cascade {
+      Movie_Auth11 as var(func: uid(Movie_8)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
       var(func: uid(MovieRoot)) {
-        Region2 as Movie.regionsAvailable @filter(eq(Region.name, "Region123"))
+        Region_2 as Movie.regionsAvailable @filter(eq(Region.name, "Region123"))
       }
-      Region1 as var(func: uid(Region2))
-      var(func: uid(Region1)) {
-        User4 as Region.users @filter(eq(User.username, "User321"))
+      Region_1 as var(func: uid(Region_2))
+      var(func: uid(Region_1)) {
+        User_4 as Region.users @filter(eq(User.username, "User321"))
       }
-      User3 as var(func: uid(User4))
-      var(func: uid(User3)) {
-        UserSecret6 as User.secrets @filter(allofterms(UserSecret.aSecret, "Secret132"))
+      User_3 as var(func: uid(User_4))
+      var(func: uid(User_3)) {
+        UserSecret_6 as User.secrets @filter(allofterms(UserSecret.aSecret, "Secret132"))
       }
-      UserSecret5 as var(func: uid(UserSecret6)) @filter(uid(UserSecretAuth7))
-      UserSecretAuth7 as var(func: uid(UserSecret6)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecret_5 as var(func: uid(UserSecret_6)) @filter(uid(UserSecret_Auth7))
+      UserSecret_Auth7 as var(func: uid(UserSecret_6)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
 
 - name: "Auth with complex filter"
@@ -963,15 +963,15 @@
         Movie.content : Movie.content
         dgraph.uid : uid
       }
-      MovieRoot as var(func: uid(Movie1)) @filter((NOT (uid(MovieAuth2)) AND (uid(MovieAuth3) OR uid(MovieAuth4))))
-      Movie1 as var(func: type(Movie))
-      MovieAuth2 as var(func: uid(Movie1)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth3 as var(func: uid(Movie1)) @cascade {
+      MovieRoot as var(func: uid(Movie_1)) @filter((NOT (uid(Movie_Auth2)) AND (uid(Movie_Auth3) OR uid(Movie_Auth4))))
+      Movie_1 as var(func: type(Movie))
+      Movie_Auth2 as var(func: uid(Movie_1)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth3 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable {
           Region.users : Region.users @filter(eq(User.username, "user1"))
         }
       }
-      MovieAuth4 as var(func: uid(Movie1)) @cascade {
+      Movie_Auth4 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
     }
@@ -996,15 +996,15 @@
         countVar as count(uid)
         contentVar as Movie.content
       }
-      MovieRoot as var(func: uid(Movie1)) @filter((NOT (uid(MovieAuth2)) AND (uid(MovieAuth3) OR uid(MovieAuth4))))
-      Movie1 as var(func: type(Movie))
-      MovieAuth2 as var(func: uid(Movie1)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth3 as var(func: uid(Movie1)) @cascade {
+      MovieRoot as var(func: uid(Movie_1)) @filter((NOT (uid(Movie_Auth2)) AND (uid(Movie_Auth3) OR uid(Movie_Auth4))))
+      Movie_1 as var(func: type(Movie))
+      Movie_Auth2 as var(func: uid(Movie_1)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth3 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable {
           Region.users : Region.users @filter(eq(User.username, "user1"))
         }
       }
-      MovieAuth4 as var(func: uid(Movie1)) @cascade {
+      Movie_Auth4 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
     }
@@ -1066,8 +1066,8 @@
         User.username : User.username
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User3))
-      User3 as var(func: type(User))
+      UserRoot as var(func: uid(User_3))
+      User_3 as var(func: type(User))
     }
 
 - name: "Query with null variable - deep query"
@@ -1089,8 +1089,8 @@
         User.username : User.username
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User3))
-      User3 as var(func: type(User))
+      UserRoot as var(func: uid(User_3))
+      User_3 as var(func: type(User))
     }
 
 - name: "Query with missing variable - partial jwt token"
@@ -1108,8 +1108,8 @@
         Project.name : Project.name
         dgraph.uid : uid
       }
-      ProjectRoot as var(func: uid(Project1))
-      Project1 as var(func: type(Project))
+      ProjectRoot as var(func: uid(Project_1))
+      Project_1 as var(func: type(Project))
     }
 
 - name: "Query with missing jwt token - type without auth directive"
@@ -1140,10 +1140,10 @@
         Movie.content : Movie.content
         dgraph.uid : uid
       }
-      MovieRoot as var(func: uid(Movie1)) @filter((NOT (uid(MovieAuth2)) AND uid(MovieAuth3)))
-      Movie1 as var(func: type(Movie))
-      MovieAuth2 as var(func: uid(Movie1)) @filter(eq(Movie.hidden, true)) @cascade
-      MovieAuth3 as var(func: uid(Movie1)) @cascade {
+      MovieRoot as var(func: uid(Movie_1)) @filter((NOT (uid(Movie_Auth2)) AND uid(Movie_Auth3)))
+      Movie_1 as var(func: type(Movie))
+      Movie_Auth2 as var(func: uid(Movie_1)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth3 as var(func: uid(Movie_1)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
       }
     }
@@ -1179,22 +1179,22 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        User.ticketsAggregate : User.tickets @filter(uid(TicketAggregateResult1)) {
+        User.ticketsAggregate : User.tickets @filter(uid(TicketAggregateResult_1)) {
           User.ticketsAggregate_titleVar as Ticket.title
           dgraph.uid : uid
         }
-        TicketAggregateResult.count_User.ticketsAggregate : count(User.tickets) @filter(uid(TicketAggregateResult1))
+        TicketAggregateResult.count_User.ticketsAggregate : count(User.tickets) @filter(uid(TicketAggregateResult_1))
         TicketAggregateResult.titleMin_User.ticketsAggregate : min(val(User.ticketsAggregate_titleVar))
         TicketAggregateResult.titleMax_User.ticketsAggregate : max(val(User.ticketsAggregate_titleVar))
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User4))
-      User4 as var(func: type(User))
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        TicketAggregateResult2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
+        TicketAggregateResult_2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
       }
-      TicketAggregateResult1 as var(func: uid(TicketAggregateResult2)) @filter(uid(TicketAuth3))
-      TicketAuth3 as var(func: uid(TicketAggregateResult2)) @cascade {
+      TicketAggregateResult_1 as var(func: uid(TicketAggregateResult_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(TicketAggregateResult_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -1227,30 +1227,30 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        User.ticketsAggregate : User.tickets @filter(uid(TicketAggregateResult1)) {
+        User.ticketsAggregate : User.tickets @filter(uid(TicketAggregateResult_1)) {
           User.ticketsAggregate_titleVar as Ticket.title
           dgraph.uid : uid
         }
         TicketAggregateResult.titleMin_User.ticketsAggregate : min(val(User.ticketsAggregate_titleVar))
-        User.issuesAggregate : User.issues @filter(uid(IssueAggregateResult4)) {
+        User.issuesAggregate : User.issues @filter(uid(IssueAggregateResult_4)) {
           User.issuesAggregate_msgVar as Issue.msg
           dgraph.uid : uid
         }
-        IssueAggregateResult.count_User.issuesAggregate : count(User.issues) @filter(uid(IssueAggregateResult4))
+        IssueAggregateResult.count_User.issuesAggregate : count(User.issues) @filter(uid(IssueAggregateResult_4))
         IssueAggregateResult.msgMax_User.issuesAggregate : max(val(User.issuesAggregate_msgVar))
-        User.tickets : User.tickets @filter(uid(Ticket7)) {
+        User.tickets : User.tickets @filter(uid(Ticket_7)) {
           Ticket.title : Ticket.title
           dgraph.uid : uid
         }
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User10))
-      User10 as var(func: type(User))
+      UserRoot as var(func: uid(User_10))
+      User_10 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        TicketAggregateResult2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
+        TicketAggregateResult_2 as User.tickets @filter(anyofterms(Ticket.title, "graphql"))
       }
-      TicketAggregateResult1 as var(func: uid(TicketAggregateResult2)) @filter(uid(TicketAuth3))
-      TicketAuth3 as var(func: uid(TicketAggregateResult2)) @cascade {
+      TicketAggregateResult_1 as var(func: uid(TicketAggregateResult_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(TicketAggregateResult_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -1260,17 +1260,17 @@
         }
       }
       var(func: uid(UserRoot)) {
-        IssueAggregateResult5 as User.issues
+        IssueAggregateResult_5 as User.issues
       }
-      IssueAggregateResult4 as var(func: uid(IssueAggregateResult5)) @filter(uid(IssueAuth6))
-      IssueAuth6 as var(func: uid(IssueAggregateResult5)) @cascade {
+      IssueAggregateResult_4 as var(func: uid(IssueAggregateResult_5)) @filter(uid(Issue_Auth6))
+      Issue_Auth6 as var(func: uid(IssueAggregateResult_5)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
       var(func: uid(UserRoot)) {
-        Ticket8 as User.tickets @filter(anyofterms(Ticket.title, "graphql2"))
+        Ticket_8 as User.tickets @filter(anyofterms(Ticket.title, "graphql2"))
       }
-      Ticket7 as var(func: uid(Ticket8)) @filter(uid(TicketAuth9))
-      TicketAuth9 as var(func: uid(Ticket8)) @cascade {
+      Ticket_7 as var(func: uid(Ticket_8)) @filter(uid(Ticket_Auth9))
+      Ticket_Auth9 as var(func: uid(Ticket_8)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -1297,21 +1297,21 @@
   dgquery: |-
     query {
       queryUser(func: uid(UserRoot)) {
-        User.issuesAggregate : User.issues @filter(uid(IssueAggregateResult1)) {
+        User.issuesAggregate : User.issues @filter(uid(IssueAggregateResult_1)) {
           User.issuesAggregate_msgVar as Issue.msg
           dgraph.uid : uid
         }
-        IssueAggregateResult.count_User.issuesAggregate : count(User.issues) @filter(uid(IssueAggregateResult1))
+        IssueAggregateResult.count_User.issuesAggregate : count(User.issues) @filter(uid(IssueAggregateResult_1))
         IssueAggregateResult.msgMin_User.issuesAggregate : min(val(User.issuesAggregate_msgVar))
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User4))
-      User4 as var(func: type(User))
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
       var(func: uid(UserRoot)) {
-        IssueAggregateResult2 as User.issues
+        IssueAggregateResult_2 as User.issues
       }
-      IssueAggregateResult1 as var(func: uid(IssueAggregateResult2)) @filter(uid(IssueAuth3))
-      IssueAuth3 as var(func: uid(IssueAggregateResult2)) @cascade {
+      IssueAggregateResult_1 as var(func: uid(IssueAggregateResult_2)) @filter(uid(Issue_Auth3))
+      Issue_Auth3 as var(func: uid(IssueAggregateResult_2)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -1336,8 +1336,8 @@
         User.username : User.username
         dgraph.uid : uid
       }
-      UserRoot as var(func: uid(User1))
-      User1 as var(func: type(User))
+      UserRoot as var(func: uid(User_1))
+      User_1 as var(func: type(User))
     }
 
 - name: "Type should apply Interface's query rules and along with its own auth rules"
@@ -1357,12 +1357,12 @@
         Question.id : uid
         Question.text : Post.text
       }
-      QuestionRoot as var(func: uid(Question1)) @filter((uid(QuestionAuth2) AND uid(QuestionAuth3)))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      QuestionRoot as var(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3)))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1386,9 +1386,9 @@
         Answer.id : uid
         Answer.text : Post.text
       }
-      AnswerRoot as var(func: uid(Answer1)) @filter(uid(AnswerAuth2))
-      Answer1 as var(func: type(Answer))
-      AnswerAuth2 as var(func: uid(Answer1)) @cascade {
+      AnswerRoot as var(func: uid(Answer_1)) @filter(uid(Answer_Auth2))
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth2 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1413,9 +1413,9 @@
         FbPost.id : uid
         FbPost.postCount : FbPost.postCount
       }
-      FbPostRoot as var(func: uid(FbPost1)) @filter(uid(FbPostAuth2))
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth2 as var(func: uid(FbPost1)) @cascade {
+      FbPostRoot as var(func: uid(FbPost_1)) @filter(uid(FbPost_Auth2))
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth2 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1457,27 +1457,27 @@
         Post.text : Post.text
         dgraph.uid : uid
       }
-      PostRoot as var(func: uid(Post1)) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(FbPostAuth4) OR uid(AnswerAuth5)))
-      Post1 as var(func: type(Post))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(FbPost_Auth4) OR uid(Answer_Auth5)))
+      Post_1 as var(func: type(Post))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth4 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth5 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth5 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1503,27 +1503,27 @@
         Post.text : Post.text
         dgraph.uid : uid
       }
-      PostRoot as var(func: uid(Post1), orderdesc: Post.text, first: 10, offset: 5) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(FbPostAuth4) OR uid(AnswerAuth5)))
-      Post1 as var(func: type(Post)) @filter(eq(Post.text, "A Post"))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1), orderdesc: Post.text, first: 10, offset: 5) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(FbPost_Auth4) OR uid(Answer_Auth5)))
+      Post_1 as var(func: type(Post)) @filter(eq(Post.text, "A Post"))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth4 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth5 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth5 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1563,20 +1563,20 @@
         Post.text : Post.text
         dgraph.uid : uid
       }
-      PostRoot as var(func: uid(Post1)) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(AnswerAuth4)))
-      Post1 as var(func: type(Post))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(Answer_Auth4)))
+      Post_1 as var(func: type(Post))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth4 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth4 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1601,20 +1601,20 @@
         Post.text : Post.text
         dgraph.uid : uid
       }
-      PostRoot as var(func: uid(Post1)) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(AnswerAuth4)))
-      Post1 as var(func: uid(0x1))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(Answer_Auth4)))
+      Post_1 as var(func: uid(0x1))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth4 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth4 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "Random")) {
           Author.name : Author.name
@@ -1651,11 +1651,11 @@
         A.fieldA : A.fieldA
         dgraph.uid : uid
       }
-      ARoot as var(func: uid(A1)) @filter((uid(B1) OR uid(CAuth2)))
-      A1 as var(func: type(A))
-      B1 as var(func: type(B))
-      C1 as var(func: type(C))
-      CAuth2 as var(func: uid(C1)) @filter(eq(C.fieldC, true)) @cascade {
+      ARoot as var(func: uid(A_1)) @filter((uid(B_1) OR uid(C_Auth2)))
+      A_1 as var(func: type(A))
+      B_1 as var(func: type(B))
+      C_1 as var(func: type(C))
+      C_Auth2 as var(func: uid(C_1)) @filter(eq(C.fieldC, true)) @cascade {
         C.id : uid
       }
     }
@@ -1675,9 +1675,9 @@
         A.fieldA : A.fieldA
         dgraph.uid : uid
       }
-      ARoot as var(func: uid(A1)) @filter((uid(B1)))
-      A1 as var(func: type(A))
-      B1 as var(func: type(B))
+      ARoot as var(func: uid(A_1)) @filter((uid(B_1)))
+      A_1 as var(func: type(A))
+      B_1 as var(func: type(B))
     }
 
 -
@@ -1718,8 +1718,8 @@
         Log.logs : Log.logs
         Log.random : Log.random
       }
-      LogRoot as var(func: uid(Log1))
-      Log1 as var(func: uid(0x123))
+      LogRoot as var(func: uid(Log_1))
+      Log_1 as var(func: uid(0x123))
       checkPwd(func: uid(LogRoot)) @filter(type(Log)) {
         pwd as checkpwd(Log.pwd, "something")
       }
@@ -1761,23 +1761,23 @@
       checkProjectPassword(func: uid(ProjectRoot)) @filter((eq(val(pwd), 1) AND type(Project))) {
         Project.name : Project.name
         Project.projID : uid
-        Project.columns : Project.columns @filter(uid(Column1)) {
+        Project.columns : Project.columns @filter(uid(Column_1)) {
           Column.name : Column.name
           Column.colID : uid
         }
       }
-      ProjectRoot as var(func: uid(Project4)) @filter(uid(ProjectAuth5))
-      Project4 as var(func: uid(0x123))
-      ProjectAuth5 as var(func: uid(Project4)) @cascade {
+      ProjectRoot as var(func: uid(Project_4)) @filter(uid(Project_Auth5))
+      Project_4 as var(func: uid(0x123))
+      Project_Auth5 as var(func: uid(Project_4)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
       }
       var(func: uid(ProjectRoot)) {
-        Column2 as Project.columns
+        Column_2 as Project.columns
       }
-      Column1 as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-      ColumnAuth3 as var(func: uid(Column2)) @cascade {
+      Column_1 as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+      Column_Auth3 as var(func: uid(Column_2)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -1807,9 +1807,9 @@
         Question.id : uid
         Question.text : Post.text
       }
-      QuestionRoot as var(func: uid(Question1)) @filter(uid(QuestionAuth2))
-      Question1 as var(func: uid(0x123))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      QuestionRoot as var(func: uid(Question_1)) @filter(uid(Question_Auth2))
+      Question_1 as var(func: uid(0x123))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
         Question.text : Post.text
       }
@@ -1853,20 +1853,20 @@
         Post.text : Post.text
         dgraph.uid : uid
       }
-      PostRoot as var(func: uid(Post1)) @filter((uid(QuestionAuth2) OR uid(FbPostAuth3) OR uid(Answer1)))
-      Post1 as var(func: uid(0x123))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter((uid(Question_Auth2) OR uid(FbPost_Auth3) OR uid(Answer_1)))
+      Post_1 as var(func: uid(0x123))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
         Question.text : Post.text
       }
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth3 as var(func: uid(FbPost1)) @cascade {
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth3 as var(func: uid(FbPost_1)) @cascade {
         FbPost.author : Post.author @filter(eq(Author.name, "ADMIN")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
+      Answer_1 as var(func: type(Answer))
       checkPwd(func: uid(PostRoot)) @filter(type(Post)) {
         pwd as checkpwd(Post.pwd, "something")
       }
@@ -1894,9 +1894,9 @@
         Mission.startDate : Mission.startDate
         dgraph.uid : uid
       }
-      _EntityRoot as var(func: uid(Mission1)) @filter(uid(MissionAuth2))
-      Mission1 as var(func: eq(Mission.id, "0x1", "0x2", "0x3")) @filter(type(Mission))
-      MissionAuth2 as var(func: uid(Mission1)) @filter(eq(Mission.supervisorName, "user")) @cascade {
+      _EntityRoot as var(func: uid(Mission_1)) @filter(uid(Mission_Auth2))
+      Mission_1 as var(func: eq(Mission.id, "0x1", "0x2", "0x3")) @filter(type(Mission))
+      Mission_Auth2 as var(func: uid(Mission_1)) @filter(eq(Mission.supervisorName, "user")) @cascade {
         Mission.id : Mission.id
       }
     }
@@ -1918,19 +1918,19 @@
     query {
       _entities(func: uid(_EntityRoot)) {
         dgraph.type
-        Astronaut.missions : Astronaut.missions @filter(uid(Mission1)) {
+        Astronaut.missions : Astronaut.missions @filter(uid(Mission_1)) {
           Mission.designation : Mission.designation
           dgraph.uid : uid
         }
         dgraph.uid : uid
       }
-      _EntityRoot as var(func: uid(Astronaut4))
-      Astronaut4 as var(func: eq(Astronaut.id, "0x1", "0x2", "0x3")) @filter(type(Astronaut))
+      _EntityRoot as var(func: uid(Astronaut_4))
+      Astronaut_4 as var(func: eq(Astronaut.id, "0x1", "0x2", "0x3")) @filter(type(Astronaut))
       var(func: uid(_EntityRoot)) {
-        Mission2 as Astronaut.missions
+        Mission_2 as Astronaut.missions
       }
-      Mission1 as var(func: uid(Mission2)) @filter(uid(MissionAuth3))
-      MissionAuth3 as var(func: uid(Mission2)) @filter(eq(Mission.supervisorName, "user")) @cascade {
+      Mission_1 as var(func: uid(Mission_2)) @filter(uid(Mission_Auth3))
+      Mission_Auth3 as var(func: uid(Mission_2)) @filter(eq(Mission.supervisorName, "user")) @cascade {
         Mission.id : Mission.id
       }
     }
@@ -1972,8 +1972,8 @@
         dgraph.type
         dgraph.uid : uid
       }
-      _EntityRoot as var(func: uid(Astronaut3))
-      Astronaut3 as var(func: eq(Astronaut.id, "0x1", "0x2", "0x3")) @filter(type(Astronaut))
+      _EntityRoot as var(func: uid(Astronaut_3))
+      Astronaut_3 as var(func: eq(Astronaut.id, "0x1", "0x2", "0x3")) @filter(type(Astronaut))
     }
 
 -
@@ -1994,9 +1994,9 @@
         Vehicle.owner : Vehicle.owner
         dgraph.uid : uid
       }
-      VehicleRoot as var(func: uid(Vehicle1)) @filter((uid(Car1)))
-      Vehicle1 as var(func: type(Vehicle))
-      Car1 as var(func: type(Car))
+      VehicleRoot as var(func: uid(Vehicle_1)) @filter((uid(Car_1)))
+      Vehicle_1 as var(func: type(Vehicle))
+      Car_1 as var(func: type(Car))
     }
 
 -
@@ -2014,9 +2014,9 @@
         Home.id : uid
         Home.address : Home.address
       }
-      HomeRoot as var(func: uid(Home1)) @filter((uid(HomeAuth2) OR uid(HomeAuth3)))
-      Home1 as var(func: type(Home))
-      HomeAuth2 as var(func: uid(Home1)) @cascade(Home.members) {
+      HomeRoot as var(func: uid(Home_1)) @filter((uid(Home_Auth2) OR uid(Home_Auth3)))
+      Home_1 as var(func: type(Home))
+      Home_Auth2 as var(func: uid(Home_1)) @cascade(Home.members) {
         Home.members : Home.members @filter((type(Dog))) @cascade {
           dgraph.type
           Dog.eats : Dog.eats {
@@ -2026,7 +2026,7 @@
           }
         }
       }
-      HomeAuth3 as var(func: uid(Home1)) @cascade {
+      Home_Auth3 as var(func: uid(Home_1)) @cascade {
         Home.members : Home.members @filter((type(Plant))) {
           dgraph.type
           Plant.breed : Plant.breed

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -430,20 +430,20 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
 				}
 			  }`,
 			rewriter:    NewAddRewriter,
-			assigned:    map[string]string{"Ticket2": "0x4"},
-			idExistence: map[string]string{"Column1": "0x1"},
+			assigned:    map[string]string{"Ticket_2": "0x4"},
+			idExistence: map[string]string{"Column_1": "0x1"},
 			dgQuery: `query {
   AddTicketPayload.ticket(func: uid(TicketRoot)) {
     Ticket.id : uid
     Ticket.title : Ticket.title
-    Ticket.onColumn : Ticket.onColumn @filter(uid(Column1)) {
+    Ticket.onColumn : Ticket.onColumn @filter(uid(Column_1)) {
       Column.colID : uid
       Column.name : Column.name
     }
   }
-  TicketRoot as var(func: uid(Ticket4)) @filter(uid(TicketAuth5))
-  Ticket4 as var(func: uid(0x4))
-  TicketAuth5 as var(func: uid(Ticket4)) @cascade {
+  TicketRoot as var(func: uid(Ticket_4)) @filter(uid(Ticket_Auth5))
+  Ticket_4 as var(func: uid(0x4))
+  Ticket_Auth5 as var(func: uid(Ticket_4)) @cascade {
     Ticket.onColumn : Ticket.onColumn {
       Column.inProject : Column.inProject {
         Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -453,10 +453,10 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
     }
   }
   var(func: uid(TicketRoot)) {
-    Column2 as Ticket.onColumn
+    Column_2 as Ticket.onColumn
   }
-  Column1 as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-  ColumnAuth3 as var(func: uid(Column2)) @cascade {
+  Column_1 as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+  Column_Auth3 as var(func: uid(Column_2)) @cascade {
     Column.inProject : Column.inProject {
       Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
         Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -486,14 +486,14 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
   UpdateTicketPayload.ticket(func: uid(TicketRoot)) {
     Ticket.id : uid
     Ticket.title : Ticket.title
-    Ticket.onColumn : Ticket.onColumn @filter(uid(Column1)) {
+    Ticket.onColumn : Ticket.onColumn @filter(uid(Column_1)) {
       Column.colID : uid
       Column.name : Column.name
     }
   }
-  TicketRoot as var(func: uid(Ticket4)) @filter(uid(TicketAuth5))
-  Ticket4 as var(func: uid(0x4))
-  TicketAuth5 as var(func: uid(Ticket4)) @cascade {
+  TicketRoot as var(func: uid(Ticket_4)) @filter(uid(Ticket_Auth5))
+  Ticket_4 as var(func: uid(0x4))
+  Ticket_Auth5 as var(func: uid(Ticket_4)) @cascade {
     Ticket.onColumn : Ticket.onColumn {
       Column.inProject : Column.inProject {
         Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
@@ -503,10 +503,10 @@ func mutationQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMet
     }
   }
   var(func: uid(TicketRoot)) {
-    Column2 as Ticket.onColumn
+    Column_2 as Ticket.onColumn
   }
-  Column1 as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-  ColumnAuth3 as var(func: uid(Column2)) @cascade {
+  Column_1 as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+  Column_Auth3 as var(func: uid(Column_2)) @cascade {
     Column.inProject : Column.inProject {
       Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
         Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))

--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -20,9 +20,9 @@
       x as updateUserSecret(func: uid(UserSecretRoot)) {
         uid
       }
-      UserSecretRoot as var(func: uid(UserSecret1)) @filter(uid(UserSecretAuth2))
-      UserSecret1 as var(func: uid(0x123)) @filter(type(UserSecret))
-      UserSecretAuth2 as var(func: uid(UserSecret1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
+      UserSecretRoot as var(func: uid(UserSecret_1)) @filter(uid(UserSecret_Auth2))
+      UserSecret_1 as var(func: uid(0x123)) @filter(type(UserSecret))
+      UserSecret_Auth2 as var(func: uid(UserSecret_1)) @filter(eq(UserSecret.ownedBy, "user1")) @cascade
     }
   uids: |
     { }
@@ -53,9 +53,9 @@
       x as updateColumn(func: uid(ColumnRoot)) {
         uid
       }
-      ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: uid(0x123)) @filter(type(Column))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      ColumnRoot as var(func: uid(Column_1)) @filter(uid(Column_Auth2))
+      Column_1 as var(func: uid(0x123)) @filter(type(Column))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -64,16 +64,16 @@
       }
     }
   uids: |
-    { "Ticket4": "0x789" }
+    { "Ticket_4": "0x789" }
   json: |
     {  }
   authquery: |-
     query {
-      Ticket(func: uid(Ticket1)) @filter(uid(TicketAuth2)) {
+      Ticket(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2)) {
         uid
       }
-      Ticket1 as var(func: uid(0x789))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      Ticket_1 as var(func: uid(0x789))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -115,9 +115,9 @@
       x as updateColumn(func: uid(ColumnRoot)) {
         uid
       }
-      ColumnRoot as var(func: uid(Column1)) @filter(uid(ColumnAuth2))
-      Column1 as var(func: uid(0x123)) @filter(type(Column))
-      ColumnAuth2 as var(func: uid(Column1)) @cascade {
+      ColumnRoot as var(func: uid(Column_1)) @filter(uid(Column_Auth2))
+      Column_1 as var(func: uid(0x123)) @filter(type(Column))
+      Column_Auth2 as var(func: uid(Column_1)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -126,16 +126,16 @@
       }
     }
   uids: |
-    { "Ticket4": "0x789" }
+    { "Ticket_4": "0x789" }
   json: |
     {  }
   authquery: |-
     query {
-      Ticket(func: uid(Ticket1)) @filter(uid(TicketAuth2)) {
+      Ticket(func: uid(Ticket_1)) @filter(uid(Ticket_Auth2)) {
         uid
       }
-      Ticket1 as var(func: uid(0x789))
-      TicketAuth2 as var(func: uid(Ticket1)) @cascade {
+      Ticket_1 as var(func: uid(0x789))
+      Ticket_Auth2 as var(func: uid(Ticket_1)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -177,22 +177,22 @@
     }
   dgquery: |-
     query {
-      Ticket1(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_1(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Ticket1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       x as updateColumn(func: uid(ColumnRoot)) {
         uid
       }
-      ColumnRoot as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-      Column2 as var(func: uid(0x123)) @filter(type(Column))
-      ColumnAuth3 as var(func: uid(Column2)) @cascade {
+      ColumnRoot as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+      Column_2 as var(func: uid(0x123)) @filter(type(Column))
+      Column_Auth3 as var(func: uid(Column_2)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -200,15 +200,15 @@
         }
       }
       var(func: uid(0x789)) {
-        Column5 as Ticket.onColumn @filter(NOT (uid(x)))
+        Column_5 as Ticket.onColumn @filter(NOT (uid(x)))
       }
-      Column5(func: uid(Column5)) {
+      Column_5(func: uid(Column_5)) {
         uid
       }
-      Column5.auth(func: uid(Column5)) @filter(uid(ColumnAuth6)) {
+      Column_5.auth(func: uid(Column_5)) @filter(uid(Column_Auth6)) {
         uid
       }
-      ColumnAuth6 as var(func: uid(Column5)) @cascade {
+      Column_Auth6 as var(func: uid(Column_5)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -218,10 +218,10 @@
     }
   json: |
     {
-      "Column1": [ { "uid": "0x123" } ],
-      "Ticket4": [ { "uid": "0x789" } ],
-      "Column5":  [ { "uid": "0x456" } ],
-      "Column5.auth": [ { "uid": "0x456" } ]
+      "Column_1": [ { "uid": "0x123" } ],
+      "Ticket_4": [ { "uid": "0x789" } ],
+      "Column_5":  [ { "uid": "0x456" } ],
+      "Column_5.auth": [ { "uid": "0x456" } ]
     }
 
 - name: "update with auth on additional delete that fails (updt list edge)"
@@ -247,22 +247,22 @@
     }
   dgquery: |-
     query {
-      Ticket1(func: uid(0x789)) @filter(type(Ticket)) {
+      Ticket_1(func: uid(0x789)) @filter(type(Ticket)) {
         uid
       }
     }
   queryjson: |
     {
-      "Ticket1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789" } ]
     }
   dgquerysec: |-
     query {
       x as updateColumn(func: uid(ColumnRoot)) {
         uid
       }
-      ColumnRoot as var(func: uid(Column2)) @filter(uid(ColumnAuth3))
-      Column2 as var(func: uid(0x123)) @filter(type(Column))
-      ColumnAuth3 as var(func: uid(Column2)) @cascade {
+      ColumnRoot as var(func: uid(Column_2)) @filter(uid(Column_Auth3))
+      Column_2 as var(func: uid(0x123)) @filter(type(Column))
+      Column_Auth3 as var(func: uid(Column_2)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -270,15 +270,15 @@
         }
       }
       var(func: uid(0x789)) {
-        Column5 as Ticket.onColumn @filter(NOT (uid(x)))
+        Column_5 as Ticket.onColumn @filter(NOT (uid(x)))
       }
-      Column5(func: uid(Column5)) {
+      Column_5(func: uid(Column_5)) {
         uid
       }
-      Column5.auth(func: uid(Column5)) @filter(uid(ColumnAuth6)) {
+      Column_5.auth(func: uid(Column_5)) @filter(uid(Column_Auth6)) {
         uid
       }
-      ColumnAuth6 as var(func: uid(Column5)) @cascade {
+      Column_Auth6 as var(func: uid(Column_5)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -288,9 +288,9 @@
     }
   json: |
     {
-      "Column1": [ { "uid": "0x123" } ],
-      "Ticket4": [ { "uid": "0x789" } ],
-      "Column5":  [ { "uid": "0x456" } ]
+      "Column_1": [ { "uid": "0x123" } ],
+      "Ticket_4": [ { "uid": "0x789" } ],
+      "Column_5":  [ { "uid": "0x456" } ]
     }
   authquery: |-
     query {
@@ -323,22 +323,22 @@
     }
   dgquery: |-
     query {
-      Column1(func: uid(0x456)) @filter(type(Column)) {
+      Column_1(func: uid(0x456)) @filter(type(Column)) {
         uid
       }
     }
   queryjson: |
     {
-      "Column1": [ { "uid": "0x456" } ]
+      "Column_1": [ { "uid": "0x456" } ]
     }
   dgquerysec: |-
     query {
       x as updateTicket(func: uid(TicketRoot)) {
         uid
       }
-      TicketRoot as var(func: uid(Ticket2)) @filter(uid(TicketAuth3))
-      Ticket2 as var(func: uid(0x123)) @filter(type(Ticket))
-      TicketAuth3 as var(func: uid(Ticket2)) @cascade {
+      TicketRoot as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_2 as var(func: uid(0x123)) @filter(type(Ticket))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -348,15 +348,15 @@
         }
       }
       var(func: uid(x)) {
-        Column5 as Ticket.onColumn @filter(NOT (uid(0x456)))
+        Column_5 as Ticket.onColumn @filter(NOT (uid(0x456)))
       }
-      Column5(func: uid(Column5)) {
+      Column_5(func: uid(Column_5)) {
         uid
       }
-      Column5.auth(func: uid(Column5)) @filter(uid(ColumnAuth6)) {
+      Column_5.auth(func: uid(Column_5)) @filter(uid(Column_Auth6)) {
         uid
       }
-      ColumnAuth6 as var(func: uid(Column5)) @cascade {
+      Column_Auth6 as var(func: uid(Column_5)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -366,9 +366,9 @@
     }
   json: |
     {
-      "Column4": [ { "uid": "0x456" } ],
-      "Column5":  [ { "uid": "0x499" } ],
-      "Column5.auth": [ { "uid": "0x499" } ]
+      "Column_4": [ { "uid": "0x456" } ],
+      "Column_5":  [ { "uid": "0x499" } ],
+      "Column_5.auth": [ { "uid": "0x499" } ]
     }
 
 - name: "update with auth on additional delete that fails (updt single edge)"
@@ -394,22 +394,22 @@
     }
   dgquery: |-
     query {
-      Column1(func: uid(0x456)) @filter(type(Column)) {
+      Column_1(func: uid(0x456)) @filter(type(Column)) {
         uid
       }
     }
   queryjson: |
     {
-      "Column1": [ { "uid": "0x456" } ]
+      "Column_1": [ { "uid": "0x456" } ]
     }
   dgquerysec: |-
     query {
       x as updateTicket(func: uid(TicketRoot)) {
         uid
       }
-      TicketRoot as var(func: uid(Ticket2)) @filter(uid(TicketAuth3))
-      Ticket2 as var(func: uid(0x123)) @filter(type(Ticket))
-      TicketAuth3 as var(func: uid(Ticket2)) @cascade {
+      TicketRoot as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_2 as var(func: uid(0x123)) @filter(type(Ticket))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
         Ticket.onColumn : Ticket.onColumn {
           Column.inProject : Column.inProject {
             Project.roles : Project.roles @filter(eq(Role.permission, "EDIT")) {
@@ -419,15 +419,15 @@
         }
       }
       var(func: uid(x)) {
-        Column5 as Ticket.onColumn @filter(NOT (uid(0x456)))
+        Column_5 as Ticket.onColumn @filter(NOT (uid(0x456)))
       }
-      Column5(func: uid(Column5)) {
+      Column_5(func: uid(Column_5)) {
         uid
       }
-      Column5.auth(func: uid(Column5)) @filter(uid(ColumnAuth6)) {
+      Column_5.auth(func: uid(Column_5)) @filter(uid(Column_Auth6)) {
         uid
       }
-      ColumnAuth6 as var(func: uid(Column5)) @cascade {
+      Column_Auth6 as var(func: uid(Column_5)) @cascade {
         Column.inProject : Column.inProject {
           Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
             Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
@@ -437,8 +437,8 @@
     }
   json: |
     {
-      "Column4": [ { "uid": "0x456" } ],
-      "Column5":  [ { "uid": "0x499" } ]
+      "Column_4": [ { "uid": "0x456" } ],
+      "Column_5":  [ { "uid": "0x499" } ]
     }
   error:
     { "message": "couldn't rewrite query for mutation updateTicket because authorization failed" }
@@ -497,8 +497,8 @@
       x as updateLog(func: uid(LogRoot)) {
         uid
       }
-      LogRoot as var(func: uid(Log1))
-      Log1 as var(func: uid(0x123)) @filter(type(Log))
+      LogRoot as var(func: uid(Log_1))
+      Log_1 as var(func: uid(0x123)) @filter(type(Log))
     }
 
 - name: "Update with top level OR RBAC false."
@@ -527,9 +527,9 @@
       x as updateProject(func: uid(ProjectRoot)) {
         uid
       }
-      ProjectRoot as var(func: uid(Project1)) @filter(uid(ProjectAuth2))
-      Project1 as var(func: uid(0x123)) @filter(type(Project))
-      ProjectAuth2 as var(func: uid(Project1)) @cascade {
+      ProjectRoot as var(func: uid(Project_1)) @filter(uid(Project_Auth2))
+      Project_1 as var(func: uid(0x123)) @filter(type(Project))
+      Project_Auth2 as var(func: uid(Project_1)) @cascade {
         Project.roles : Project.roles @filter(eq(Role.permission, "ADMIN")) {
           Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
         }
@@ -562,8 +562,8 @@
       x as updateProject(func: uid(ProjectRoot)) {
         uid
       }
-      ProjectRoot as var(func: uid(Project1))
-      Project1 as var(func: uid(0x123)) @filter(type(Project))
+      ProjectRoot as var(func: uid(Project_1))
+      Project_1 as var(func: uid(0x123)) @filter(type(Project))
     }
 
 - name: "Update with top level And RBAC true."
@@ -592,9 +592,9 @@
       x as updateIssue(func: uid(IssueRoot)) {
         uid
       }
-      IssueRoot as var(func: uid(Issue1)) @filter(uid(IssueAuth2))
-      Issue1 as var(func: uid(0x123)) @filter(type(Issue))
-      IssueAuth2 as var(func: uid(Issue1)) @cascade {
+      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      Issue_1 as var(func: uid(0x123)) @filter(type(Issue))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
@@ -651,8 +651,8 @@
       x as updateComplexLog(func: uid(ComplexLogRoot)) {
         uid
       }
-      ComplexLogRoot as var(func: uid(ComplexLog1))
-      ComplexLog1 as var(func: uid(0x123)) @filter(type(ComplexLog))
+      ComplexLogRoot as var(func: uid(ComplexLog_1))
+      ComplexLog_1 as var(func: uid(0x123)) @filter(type(ComplexLog))
     }
 
 - name: "Update with top level not RBAC false."
@@ -708,12 +708,12 @@
       x as updateQuestion(func: uid(QuestionRoot)) {
         uid
       }
-      QuestionRoot as var(func: uid(Question1)) @filter((uid(QuestionAuth2) AND uid(QuestionAuth3)))
-      Question1 as var(func: uid(0x123)) @filter(type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      QuestionRoot as var(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3)))
+      Question_1 as var(func: uid(0x123)) @filter(type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -772,9 +772,9 @@
       x as updateFbPost(func: uid(FbPostRoot)) {
         uid
       }
-      FbPostRoot as var(func: uid(FbPost1)) @filter(uid(FbPostAuth2))
-      FbPost1 as var(func: uid(0x123)) @filter(type(FbPost))
-      FbPostAuth2 as var(func: uid(FbPost1)) @cascade {
+      FbPostRoot as var(func: uid(FbPost_1)) @filter(uid(FbPost_Auth2))
+      FbPost_1 as var(func: uid(0x123)) @filter(type(FbPost))
+      FbPost_Auth2 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -837,27 +837,27 @@
       x as updatePost(func: uid(PostRoot)) {
         uid
       }
-      PostRoot as var(func: uid(Post1)) @filter(((uid(QuestionAuth2) AND uid(QuestionAuth3)) OR uid(FbPostAuth4) OR uid(AnswerAuth5)))
-      Post1 as var(func: uid(0x123, 0x456)) @filter(type(Post))
-      Question1 as var(func: type(Question))
-      QuestionAuth2 as var(func: uid(Question1)) @filter(eq(Question.answered, true)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter(((uid(Question_Auth2) AND uid(Question_Auth3)) OR uid(FbPost_Auth4) OR uid(Answer_Auth5)))
+      Post_1 as var(func: uid(0x123, 0x456)) @filter(type(Post))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
         Question.id : uid
       }
-      QuestionAuth3 as var(func: uid(Question1)) @cascade {
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
         }
       }
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth4 as var(func: uid(FbPost1)) @cascade {
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth4 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth5 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth5 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -892,17 +892,17 @@
       x as updatePost(func: uid(PostRoot)) {
         uid
       }
-      PostRoot as var(func: uid(Post1)) @filter((uid(FbPostAuth2) OR uid(AnswerAuth3)))
-      Post1 as var(func: uid(0x123, 0x456)) @filter(type(Post))
-      FbPost1 as var(func: type(FbPost))
-      FbPostAuth2 as var(func: uid(FbPost1)) @cascade {
+      PostRoot as var(func: uid(Post_1)) @filter((uid(FbPost_Auth2) OR uid(Answer_Auth3)))
+      Post_1 as var(func: uid(0x123, 0x456)) @filter(type(Post))
+      FbPost_1 as var(func: type(FbPost))
+      FbPost_Auth2 as var(func: uid(FbPost_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
         }
       }
-      Answer1 as var(func: type(Answer))
-      AnswerAuth3 as var(func: uid(Answer1)) @cascade {
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth3 as var(func: uid(Answer_1)) @cascade {
         dgraph.type
         Post.author : Post.author @filter(eq(Author.name, "user1")) {
           Author.name : Author.name
@@ -964,8 +964,8 @@
       x as updateA(func: uid(ARoot)) {
         uid
       }
-      ARoot as var(func: uid(A1)) @filter((uid(B1) OR uid(C1)))
-      A1 as var(func: uid(0x123, 0x456)) @filter(type(A))
-      B1 as var(func: type(B))
-      C1 as var(func: type(C))
+      ARoot as var(func: uid(A_1)) @filter((uid(B_1) OR uid(C_1)))
+      A_1 as var(func: uid(0x123, 0x456)) @filter(type(A))
+      B_1 as var(func: type(B))
+      C_1 as var(func: type(C))
     }

--- a/graphql/resolve/delete_mutation_test.yaml
+++ b/graphql/resolve/delete_mutation_test.yaml
@@ -16,7 +16,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Post2)",
+            "uid": "uid(Post_2)",
             "Post.author": { "uid": "uid(x)" }
           }
         ]
@@ -24,7 +24,7 @@
     query {
       x as deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author)) {
         uid
-        Post2 as Author.posts
+        Post_2 as Author.posts
       }
     }
 
@@ -59,7 +59,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Post2)",
+            "uid": "uid(Post_2)",
             "Post.author": { "uid": "uid(x)" }
           }
         ]
@@ -67,7 +67,7 @@
     query {
       x as deleteAuthor(func: uid(0x1, 0x2)) @filter(type(Author)) {
         uid
-        Post2 as Author.posts
+        Post_2 as Author.posts
       }
     }
   dgquerysec: |-
@@ -110,7 +110,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Post2)",
+            "uid": "uid(Post_2)",
             "Post.author": { "uid": "uid(x)" }
           }
         ]
@@ -118,7 +118,7 @@
     query {
       x as deleteAuthor(func: uid(0x1, 0x2)) @filter((eq(Author.name, "A.N. Author") AND type(Author))) {
         uid
-        Post2 as Author.posts
+        Post_2 as Author.posts
       }
     }
 
@@ -143,7 +143,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Post2)",
+            "uid": "uid(Post_2)",
             "Post.author": { "uid": "uid(x)" }
           }
         ]
@@ -151,7 +151,7 @@
     query {
       x as deleteAuthor(func: type(Author)) @filter((eq(Author.dob, "2000-01-01") AND eq(Author.name, "A.N. Author"))) {
         uid
-        Post2 as Author.posts
+        Post_2 as Author.posts
       }
     }
 
@@ -173,7 +173,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Country2)",
+            "uid": "uid(Country_2)",
             "Country.states": [{ "uid": "uid(x)" }]
           }
         ]
@@ -181,7 +181,7 @@
     query {
       x as deleteState(func: type(State)) @filter(eq(State.code, "abc")) {
         uid
-        Country2 as State.country
+        Country_2 as State.country
       }
     }
 
@@ -203,11 +203,11 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(Author2)",
+            "uid": "uid(Author_2)",
             "Author.posts": [{ "uid": "uid(x)" }]
           },
           {
-            "uid": "uid(Category3)",
+            "uid": "uid(Category_3)",
             "Category.posts": [{ "uid": "uid(x)" }]
           }
         ]
@@ -215,8 +215,8 @@
     query {
       x as deletePost(func: uid(0x1, 0x2)) @filter(type(Post)) {
         uid
-        Author2 as Post.author
-        Category3 as Post.category
+        Author_2 as Post.author
+        Category_3 as Post.category
       }
     }
 
@@ -238,7 +238,7 @@
         [
           { "uid": "uid(x)" },
           {
-            "uid": "uid(MovieDirector2)",
+            "uid": "uid(MovieDirector_2)",
             "directed.movies": [{ "uid": "uid(x)" }]
           }
         ]
@@ -246,7 +246,7 @@
     query {
       x as deleteMovie(func: uid(0x1, 0x2)) @filter(type(Movie)) {
         uid
-        MovieDirector2 as ~directed.movies
+        MovieDirector_2 as ~directed.movies
       }
     }
 -
@@ -310,7 +310,7 @@
                 "uid": "uid(x)"
             },
             {
-                "uid": "uid(author2)",
+                "uid": "uid(author_2)",
                 "author.book": [
                     {
                         "uid": "uid(x)"
@@ -322,6 +322,6 @@
     query {
       x as deleteBook(func: type(Book)) @filter((eq(Book.title, "Sapiens") OR eq(Book.ISBN, "2SB1Q"))) {
         uid
-        author2 as Book.author
+        author_2 as Book.author
       }
     }

--- a/graphql/resolve/extensions_test.go
+++ b/graphql/resolve/extensions_test.go
@@ -133,8 +133,8 @@ func TestMutationsPropagateExtensions(t *testing.T) {
 
 	resp := resolveWithClient(gqlSchema, mutation, nil,
 		&executor{
-			assigned:             map[string]string{"Post2": "0x2"},
-			existenceQueriesResp: `{ "Author1": [{"uid":"0x1"}]}`,
+			assigned:             map[string]string{"Post_2": "0x2"},
+			existenceQueriesResp: `{ "Author_1": [{"uid":"0x1"}]}`,
 			queryTouched:         2,
 			mutationTouched:      5,
 		})
@@ -189,8 +189,8 @@ func TestMultipleMutationsPropagateExtensionsCorrectly(t *testing.T) {
 
 	resp := resolveWithClient(gqlSchema, mutation, nil,
 		&executor{
-			assigned:             map[string]string{"Post2": "0x2"},
-			existenceQueriesResp: `{ "Author1": [{"uid":"0x1"}]}`,
+			assigned:             map[string]string{"Post_2": "0x2"},
+			existenceQueriesResp: `{ "Author_1": [{"uid":"0x1"}]}`,
 			queryTouched:         2,
 			mutationTouched:      5,
 		})

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -154,6 +154,7 @@ func (v *VariableGenerator) Next(typ schema.Type, xidName, xidVal string, auth b
 		// here we are using the assertion that field name or type name can't have "." in them
 		key = typ.FieldOriginatedFrom(xidName) + "." + xidName + "." + xidVal
 	}
+
 	if varName, ok := v.xidVarNameMap[key]; ok {
 		return varName
 	}
@@ -162,9 +163,9 @@ func (v *VariableGenerator) Next(typ schema.Type, xidName, xidVal string, auth b
 	v.counter++
 	var varName string
 	if auth {
-		varName = fmt.Sprintf("%sAuth%v", typ.Name(), v.counter)
+		varName = fmt.Sprintf("%s_Auth%v", typ.Name(), v.counter)
 	} else {
-		varName = fmt.Sprintf("%s%v", typ.Name(), v.counter)
+		varName = fmt.Sprintf("%s_%v", typ.Name(), v.counter)
 	}
 
 	// save it, if it was created for xidVal

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -331,8 +331,8 @@ func TestMutationQueryRewriting(t *testing.T) {
 			mut:         `addPost(input: [{title: "A Post", author: {id: "0x1"}}])`,
 			payloadType: "AddPostPayload",
 			rewriter:    NewAddRewriter,
-			idExistence: map[string]string{"Author1": "0x1"},
-			assigned:    map[string]string{"Post2": "0x4"},
+			idExistence: map[string]string{"Author_1": "0x1"},
+			assigned:    map[string]string{"Post_2": "0x4"},
 		},
 		"Update Post ": {
 			mut: `updatePost(input: {filter: {postID

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -774,7 +774,7 @@ func (authRw *authRewriter) addAuthQueries(
 			}
 
 			// Form Query Like Todo1 as var(func: type(Todo))
-			queryVar := object.Name() + "1"
+			queryVar := object.Name() + "_1"
 			varQry := &gql.GraphQuery{
 				Attr: "var",
 				Var:  queryVar,

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -253,7 +253,7 @@ func TestAddMutationUsesErrorPropagation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resp := resolveWithClient(gqlSchema, mutation, nil,
 				&executor{
-					existenceQueriesResp: `{ "Author1": [{"uid":"0x1"}]}`,
+					existenceQueriesResp: `{ "Author_1": [{"uid":"0x1"}]}`,
 					resp:                 tcase.queryResponse,
 					assigned:             tcase.mutResponse,
 					result:               tcase.mutQryResp,
@@ -379,7 +379,7 @@ func TestManyMutationsWithError(t *testing.T) {
 		"Dgraph fail": {
 			explanation: "a Dgraph, network or error in rewritten query failed the mutation",
 			idValue:     "0x1",
-			mutResponse: map[string]string{"Post2": "0x2"},
+			mutResponse: map[string]string{"Post_2": "0x2"},
 			mutQryResp: map[string]interface{}{
 				"Author1": []interface{}{map[string]string{"uid": "0x1"}}},
 			queryResponse: `{"post": [{ "title": "A Post" } ] }`,
@@ -400,7 +400,7 @@ func TestManyMutationsWithError(t *testing.T) {
 		"Rewriting error": {
 			explanation: "The reference ID is not a uint64, so can't be converted to a uid",
 			idValue:     "hi",
-			mutResponse: map[string]string{"Post2": "0x2"},
+			mutResponse: map[string]string{"Post_2": "0x2"},
 			mutQryResp: map[string]interface{}{
 				"Author1": []interface{}{map[string]string{"uid": "0x1"}}},
 			queryResponse: `{"post": [{ "title": "A Post" } ] }`,
@@ -430,7 +430,7 @@ func TestManyMutationsWithError(t *testing.T) {
 				multiMutation,
 				map[string]interface{}{"id": tcase.idValue},
 				&executor{
-					existenceQueriesResp: `{ "Author1": [{"uid":"0x1"}]}`,
+					existenceQueriesResp: `{ "Author_1": [{"uid":"0x1"}]}`,
 					resp:                 tcase.queryResponse,
 					assigned:             tcase.mutResponse,
 					failMutation:         2})

--- a/graphql/resolve/resolver_test.go
+++ b/graphql/resolve/resolver_test.go
@@ -410,7 +410,7 @@ func TestMutationAlias(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			resp := resolveWithClient(gqlSchema, tcase.gqlQuery, nil,
 				&executor{
-					existenceQueriesResp: `{ "Author1": [{"uid":"0x1"}]}`,
+					existenceQueriesResp: `{ "Author_1": [{"uid":"0x1"}]}`,
 					resp:                 tcase.queryResponse,
 					assigned:             tcase.mutResponse,
 					result:               tcase.mutQryResp,

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -438,3 +438,11 @@ type AB {
     Cabc: String! @id
 }
 
+type Friend1 {
+    id: String! @id
+    friends: [Friend]
+}
+
+type Friend {
+    id: String! @id
+}

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -531,13 +531,13 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x456"
+      "Post_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -545,7 +545,7 @@
         uid
       }
       var(func: uid(0x456)) {
-        Author4 as Post.author @filter(NOT (uid(x)))
+        Author_4 as Post.author @filter(NOT (uid(x)))
       }
     }
   dgmutations:
@@ -561,7 +561,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [{"uid": "0x456"}]
           }
         ]
@@ -619,13 +619,13 @@
     }
   dgquery: |-
     query {
-      ComputerOwner1(func: eq(ComputerOwner.name, "computerOwnerName")) @filter(type(ComputerOwner)) {
+      ComputerOwner_1(func: eq(ComputerOwner.name, "computerOwnerName")) @filter(type(ComputerOwner)) {
         uid
       }
     }
   qnametouid: |
     {
-      "ComputerOwner1": "0x123"
+      "ComputerOwner_1": "0x123"
     }
   dgquerysec: |-
     query {
@@ -668,13 +668,13 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x124)) @filter(type(Post)) {
+      Post_1(func: uid(0x124)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x124"
+      "Post_1": "0x124"
     }
   dgquerysec: |-
     query {
@@ -717,13 +717,13 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x456"
+      "Post_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -795,17 +795,17 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
-      Post2(func: uid(0x789)) @filter(type(Post)) {
+      Post_2(func: uid(0x789)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x456",
-      "Post2": "0x789"
+      "Post_1": "0x456",
+      "Post_2": "0x789"
     }
   dgquerysec: |-
     query {
@@ -813,7 +813,7 @@
         uid
       }
       var(func: uid(0x456)) {
-        Author5 as Post.author @filter(NOT (uid(x)))
+        Author_5 as Post.author @filter(NOT (uid(x)))
       }
     }
   dgmutations:
@@ -829,7 +829,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author5)",
+            "uid": "uid(Author_5)",
             "Author.posts": [{"uid": "0x456"}]
           }
         ]
@@ -872,13 +872,13 @@
   explanation: "updateAuthor doesn't update posts except where references are removed"
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x456"
+      "Post_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -886,7 +886,7 @@
         uid
       }
       var(func: uid(0x456)) {
-        Author4 as Post.author @filter(NOT (uid(x)))
+        Author_4 as Post.author @filter(NOT (uid(x)))
       }
     }
   dgmutations:
@@ -902,7 +902,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [{"uid": "0x456"}]
           }
         ]
@@ -941,7 +941,7 @@
     - setjson: |
         { "uid" : "uid(x)",
           "Author.country": {
-            "uid": "_:Country3",
+            "uid": "_:Country_3",
             "dgraph.type": ["Country"],
             "Country.name": "New Country"
           }
@@ -977,7 +977,7 @@
   explanation: "The update creates a new state"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
@@ -991,7 +991,7 @@
     - setjson: |
         { "uid" : "uid(x)",
           "Author.country": {
-            "uid": "_:Country4",
+            "uid": "_:Country_4",
             "dgraph.type": ["Country"],
             "Country.name": "New Country",
             "Country.states": [ {
@@ -1000,9 +1000,9 @@
               "dgraph.type": [
                 "State"
               ],
-              "uid": "_:State1",
+              "uid": "_:State_1",
               "State.country": {
-                "uid": "_:Country4"
+                "uid": "_:Country_4"
               }
             } ]
           }
@@ -1038,13 +1038,13 @@
   explanation: "The update links to existing state"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |
     {
-      "State1": "0x987"
+      "State_1": "0x987"
     }
   dgquerysec: |-
     query {
@@ -1052,20 +1052,20 @@
         uid
       }
       var(func: uid(0x987)) {
-        Country5 as State.country
+        Country_5 as State.country
       }
     }
   dgmutations:
     - setjson: |
         { "uid" : "uid(x)",
           "Author.country": {
-            "uid": "_:Country4",
+            "uid": "_:Country_4",
             "dgraph.type": ["Country"],
             "Country.name": "New Country",
             "Country.states": [ {
               "uid": "0x987",
               "State.country": {
-                "uid": "_:Country4"
+                "uid": "_:Country_4"
               }
             } ]
           }
@@ -1073,7 +1073,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Country5)",
+            "uid": "uid(Country_5)",
             "Country.states": [{"uid": "0x987"}]
           }
         ]
@@ -1108,13 +1108,13 @@
   explanation: "The update must link to the existing state"
   dgquery: |-
     query {
-      State1(func: eq(State.code, "dg")) @filter(type(State)) {
+      State_1(func: eq(State.code, "dg")) @filter(type(State)) {
         uid
       }
     }
   qnametouid: |
     {
-      "State1": "0x234"
+      "State_1": "0x234"
     }
   dgquerysec: |-
     query {
@@ -1122,20 +1122,20 @@
         uid
       }
       var(func: uid(0x234)) {
-        Country5 as State.country
+        Country_5 as State.country
       }
     }
   dgmutations:
     - setjson: |
         { "uid" : "uid(x)",
           "Author.country": {
-            "uid": "_:Country4",
+            "uid": "_:Country_4",
             "dgraph.type": ["Country"],
             "Country.name": "New Country",
             "Country.states": [ {
               "uid": "0x234",
               "State.country": {
-                "uid": "_:Country4"
+                "uid": "_:Country_4"
               }
             } ]
           }
@@ -1143,7 +1143,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Country5)",
+            "uid": "uid(Country_5)",
             "Country.states": [{"uid": "0x234"}]
           }
         ]
@@ -1174,13 +1174,13 @@
   explanation: " Owner 0x123"
   dgquery: |-
     query {
-      House1(func: uid(0x456)) @filter(type(House)) {
+      House_1(func: uid(0x456)) @filter(type(House)) {
         uid
       }
     }
   qnametouid: |
     {
-      "House1": "0x456"
+      "House_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -1188,10 +1188,10 @@
         uid
       }
       var(func: uid(0x456)) {
-        Owner4 as House.owner @filter(NOT (uid(x)))
+        Owner_4 as House.owner @filter(NOT (uid(x)))
       }
       var(func: uid(x)) {
-        House5 as Owner.house @filter(NOT (uid(0x456)))
+        House_5 as Owner.house @filter(NOT (uid(0x456)))
       }
     }
   dgmutations:
@@ -1205,11 +1205,11 @@
       deletejson: |
         [
           {
-            "uid": "uid(Owner4)",
+            "uid": "uid(Owner_4)",
             "Owner.house": {"uid": "0x456"}
           },
           {
-            "uid": "uid(House5)",
+            "uid": "uid(House_5)",
             "House.owner": {"uid": "uid(x)"}
           }
         ]
@@ -1237,13 +1237,13 @@
     }
   dgquery: |-
     query {
-      Movie1(func: uid(0x456)) @filter(type(Movie)) {
+      Movie_1(func: uid(0x456)) @filter(type(Movie)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Movie1": "0x456"
+      "Movie_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -1284,13 +1284,13 @@
     }
   dgquery: |-
     query {
-      Movie1(func: uid(0x456)) @filter(type(Movie)) {
+      Movie_1(func: uid(0x456)) @filter(type(Movie)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Movie1": "0x456"
+      "Movie_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -1342,7 +1342,7 @@
   is same, it should not return error."
   dgquery: |-
     query {
-      Teacher1(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
+      Teacher_1(func: eq(People.xid, "T1")) @filter(type(Teacher)) {
         uid
       }
     }
@@ -1363,10 +1363,10 @@
               "Teacher",
               "People"
             ],
-            "uid": "_:Teacher1"
+            "uid": "_:Teacher_1"
           },{
               "Teacher.teaches":[{"uid":"uid(x)"}],
-              "uid":"_:Teacher1"
+              "uid":"_:Teacher_1"
           }],
           "uid": "uid(x)"
         }
@@ -1494,16 +1494,16 @@
 #
 # and existing edge
 #
-# Post1 --- author --> Author1
+# Post_1 --- author --> Author_1
 #
 # there must also exist edge
 #
-# Author1 --- posts --> Post1
+# Author_1 --- posts --> Post_1
 #
-# So if we did an update that changes the author of Post1 to Author2, we need to
-#  * add edge Post1 --- author --> Author2 (done by asIDReference/asXIDReference)
-#  * add edge Author2 --- posts --> Post1 (done by addInverseLink)
-#  * delete edge Author1 --- posts --> Post1 (done by addAdditionalDeletes)
+# So if we did an update that changes the author of Post_1 to Author2, we need to
+#  * add edge Post_1 --- author --> Author2 (done by asIDReference/asXIDReference)
+#  * add edge Author2 --- posts --> Post_1 (done by addInverseLink)
+#  * delete edge Author_1 --- posts --> Post_1 (done by addAdditionalDeletes)
 #
 # This delete only needs to be done when there is a singular edge in the mutation:
 # i.e. if both directions of the edge are [], then it's just an add.  We also need
@@ -1546,13 +1546,13 @@
     }
   dgquery: |-
     query {
-      Post1(func: uid(0x456)) @filter(type(Post)) {
+      Post_1(func: uid(0x456)) @filter(type(Post)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Post1": "0x456"
+      "Post_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -1560,7 +1560,7 @@
         uid
       }
       var(func: uid(0x456)) {
-        Author4 as Post.author @filter(NOT (uid(x)))
+        Author_4 as Post.author @filter(NOT (uid(x)))
       }
     }
   dgmutations:
@@ -1577,7 +1577,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [{"uid": "0x456"}]
           }
         ]
@@ -1605,13 +1605,13 @@
     }
   dgquery: |-
     query {
-      Author1(func: uid(0x456)) @filter(type(Author)) {
+      Author_1(func: uid(0x456)) @filter(type(Author)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Author1": "0x456"
+      "Author_1": "0x456"
     }
   dgquerysec: |-
     query {
@@ -1619,7 +1619,7 @@
         uid
       }
       var(func: uid(x)) {
-        Author4 as Post.author @filter(NOT (uid(0x456)))
+        Author_4 as Post.author @filter(NOT (uid(0x456)))
       }
     }
   dgmutations:
@@ -1634,7 +1634,7 @@
       deletejson: |
         [
           {
-            "uid": "uid(Author4)",
+            "uid": "uid(Author_4)",
             "Author.posts": [ { "uid": "uid(x)" } ]
           }
         ]
@@ -1662,7 +1662,7 @@
     }
   dgquery: |-
     query {
-      State1(func: eq(State.code, "abc")) @filter(type(State)) {
+      State_1(func: eq(State.code, "abc")) @filter(type(State)) {
         uid
       }
     }
@@ -1678,7 +1678,7 @@
           "uid" : "uid(x)",
           "Country.states": [
             {
-              "uid": "_:State1",
+              "uid": "_:State_1",
               "dgraph.type": ["State"],
               "State.code": "abc",
               "State.name": "Alphabet",
@@ -1731,7 +1731,7 @@
     }
   dgquery: |-
     query {
-      Computer1(func: eq(Computer.name, "Comp")) @filter(type(Computer)) {
+      Computer_1(func: eq(Computer.name, "Comp")) @filter(type(Computer)) {
         uid
       }
     }
@@ -1745,7 +1745,7 @@
     - setjson: |
         { "uid" : "uid(x)",
           "ComputerOwner.computers": {
-            "uid": "_:Computer1",
+            "uid": "_:Computer_1",
             "dgraph.type": ["Computer"],
             "Computer.name": "Comp",
             "Computer.owners": [ { "uid": "uid(x)" } ]
@@ -1790,17 +1790,17 @@
     }
   dgquery: |-
     query {
-      Parrot1(func: uid(0x124)) @filter(type(Parrot)) {
+      Parrot_1(func: uid(0x124)) @filter(type(Parrot)) {
         uid
       }
-      Parrot2(func: uid(0x125)) @filter(type(Parrot)) {
+      Parrot_2(func: uid(0x125)) @filter(type(Parrot)) {
         uid
       }
     }
   qnametouid: |
     {
-      "Parrot1": "0x124",
-      "Parrot2": "0x125"
+      "Parrot_1": "0x124",
+      "Parrot_2": "0x125"
     }
   dgquerysec: |-
     query {
@@ -1819,17 +1819,17 @@
             "Animal.category": "Mammal",
             "Dog.breed": "German Shephard",
             "dgraph.type": ["Dog", "Animal"],
-            "uid": "_:Dog5"
+            "uid": "_:Dog_5"
           }, {
             "Animal.category": "Bird",
             "Parrot.repeatsWords": ["squawk"],
             "dgraph.type": ["Parrot", "Animal"],
-            "uid": "_:Parrot6"
+            "uid": "_:Parrot_6"
           }, {
             "Character.name": "Han Solo",
             "Employee.ename": "Han_emp",
             "dgraph.type": ["Human", "Character", "Employee"],
-            "uid": "_:Human7"
+            "uid": "_:Human_7"
           }],
           "uid": "uid(x)"
         }


### PR DESCRIPTION
Motivation:
While rewriting GraphQL queries and mutations to DQL, different variable names are used to generate query names, blank node names. Exam ple: While rewriting `addProject` mutation, the variable `Project1` is used while writing existence queries. This is problematic as same variable name could get generated for two different nodes like `Person1` + `1` and `Person` + `11`, both generating `Person11`. 

To avoid this, this PR adds `_` in variable generation between type name and number. 

Testing:
Added test to add_mutation_test.yaml

Fixes GRAPHQL-1079
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7556)
<!-- Reviewable:end -->
