### PR TITLE
fix(GRAPHQL): fix empty remove in update mutation patch, that remove all the data for nodes in filter.

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -870,7 +870,7 @@ func RunAll(t *testing.T) {
 	t.Run("mutations have extensions", mutationsHaveExtensions)
 	t.Run("alias works for mutations", mutationsWithAlias)
 	t.Run("three level deep", threeLevelDeepMutation)
-	t.Run("update mutation without set & remove", updateMutationWithoutSetRemove)
+	t.Run("update mutation without set & remove", updateMutationTestsWithDifferentSetRemoveCases)
 	t.Run("Input coercing for int64 type", int64BoundaryTesting)
 	t.Run("List of integers", intWithList)
 	t.Run("Check cascade with mutation without ID field", checkCascadeWithMutationWithoutIDField)

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -3918,11 +3918,16 @@ func mutationsWithAlias(t *testing.T) {
 	require.JSONEq(t, multiMutationExpected, string(gqlResponse.Data))
 }
 
-func updateMutationWithoutSetRemove(t *testing.T) {
+func updateMutationTestsWithDifferentSetRemoveCases(t *testing.T) {
 	country := addCountry(t, postExecutor)
-
-	updateCountryParams := &GraphQLParams{
-		Query: `mutation updateCountry($id: ID!){
+	tcases := []struct {
+		name      string
+		query     string
+		variables map[string]interface{}
+		expected  string
+	}{{
+		name: "update mutation without set Remove",
+		query: `mutation updateCountry($id: ID!){
             updateCountry(input: {filter: {id: [$id]}}) {
                 numUids
                 country {
@@ -3931,19 +3936,46 @@ func updateMutationWithoutSetRemove(t *testing.T) {
                 }
             }
         }`,
-		Variables: map[string]interface{}{"id": country.ID},
+		variables: map[string]interface{}{"id": country.ID},
+		expected: `{
+             "updateCountry": {
+               "numUids": 0,
+               "country": []
+             }
+        }`,
+	}, {
+		name: "update mutation with empty remove",
+		query: `mutation updateCountry($id: ID!){
+            updateCountry(input: {filter: {id: [$id]},remove:{}}) {
+                numUids
+                country {
+                    id
+                    name
+                }
+            }
+        }`,
+		variables: map[string]interface{}{"id": country.ID},
+		expected: `{
+             "updateCountry": {
+               "numUids": 0,
+               "country": []
+             }
+        }`,
+	},
 	}
-	gqlResponse := updateCountryParams.ExecuteAsPost(t, GraphqlURL)
-	RequireNoGQLErrors(t, gqlResponse)
-
-	require.JSONEq(t, `{
-        "updateCountry": {
-            "numUids": 0,
-            "country": []
-        }
-    }`, string(gqlResponse.Data))
-
+	for _, tcase := range tcases {
+		t.Run(tcase.name, func(t *testing.T) {
+			params := &GraphQLParams{
+				Query:     tcase.query,
+				Variables: tcase.variables,
+			}
+			resp := params.ExecuteAsPost(t, GraphqlURL)
+			RequireNoGQLErrors(t, resp)
+			testutil.CompareJSON(t, tcase.expected, string(resp.Data))
+		})
+	}
 	// cleanup
+	// expectedNumUids:1 will ensures that no node has been deleted because of remove {}
 	deleteCountry(t, map[string]interface{}{"id": []string{country.ID}}, 1, nil)
 }
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -330,16 +330,18 @@ func (urw *UpdateRewriter) RewriteQueries(
 	// Write existence queries for remove
 	if delArg != nil {
 		obj := delArg.(map[string]interface{})
-		queries, errs := existenceQueries(ctx, mutatedType, nil, urw.VarGen, obj, urw.XidMetadata)
-		if len(errs) > 0 {
-			var gqlErrors x.GqlErrorList
-			for _, err := range errs {
-				gqlErrors = append(gqlErrors, schema.AsGQLErrors(err)...)
+		if len(obj) != 0 {
+			queries, errs := existenceQueries(ctx, mutatedType, nil, urw.VarGen, obj, urw.XidMetadata)
+			if len(errs) > 0 {
+				var gqlErrors x.GqlErrorList
+				for _, err := range errs {
+					gqlErrors = append(gqlErrors, schema.AsGQLErrors(err)...)
+				}
+				retErrors = schema.AppendGQLErrs(retErrors, schema.GQLWrapf(gqlErrors,
+					"failed to rewrite mutation payload"))
 			}
-			retErrors = schema.AppendGQLErrs(retErrors, schema.GQLWrapf(gqlErrors,
-				"failed to rewrite mutation payload"))
+			ret = append(ret, queries...)
 		}
-		ret = append(ret, queries...)
 	}
 	return ret, retErrors
 }
@@ -587,14 +589,14 @@ func (urw *UpdateRewriter) Rewrite(
 
 	upsertQuery := RewriteUpsertQueryFromMutation(m, authRw, MutationQueryVar, m.Name(), "")
 	srcUID := MutationQueryVarUID
-
-	if setArg == nil && delArg == nil {
+	objDel, ok := delArg.(map[string]interface{})
+	if setArg == nil && (delArg == nil || (len(objDel) == 0 && ok)) {
 		return ret, nil
 	}
 
 	if setArg != nil {
-		obj := setArg.(map[string]interface{})
-		fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, obj, xidMetadata, idExistence, UpdateWithSet)
+		objSet := setArg.(map[string]interface{})
+		fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, objSet, xidMetadata, idExistence, UpdateWithSet)
 		if len(errs) > 0 {
 			var gqlErrors x.GqlErrorList
 			for _, err := range errs {
@@ -610,23 +612,23 @@ func (urw *UpdateRewriter) Rewrite(
 	}
 
 	if delArg != nil {
-		obj := delArg.(map[string]interface{})
-		// Set additional deletes to false
-		fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, obj, xidMetadata, idExistence, UpdateWithRemove)
-		if len(errs) > 0 {
-			var gqlErrors x.GqlErrorList
-			for _, err := range errs {
-				gqlErrors = append(gqlErrors, schema.AsGQLErrors(err)...)
+		if len(objDel) != 0 {
+			// Set additional deletes to false
+			fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, objDel, xidMetadata, idExistence, UpdateWithRemove)
+			if len(errs) > 0 {
+				var gqlErrors x.GqlErrorList
+				for _, err := range errs {
+					gqlErrors = append(gqlErrors, schema.AsGQLErrors(err)...)
+				}
+				retErrors = schema.AppendGQLErrs(retErrors, schema.GQLWrapf(gqlErrors,
+					"failed to rewrite mutation payload"))
 			}
-			retErrors = schema.AppendGQLErrs(retErrors, schema.GQLWrapf(gqlErrors,
-				"failed to rewrite mutation payload"))
-		}
-		if fragment != nil {
-			delFrag = append(delFrag, fragment)
-			urw.delFrags = append(urw.delFrags, fragment)
+			if fragment != nil {
+				delFrag = append(delFrag, fragment)
+				urw.delFrags = append(urw.delFrags, fragment)
+			}
 		}
 	}
-
 	buildMutation := func(setFrag, delFrag []*mutationFragment) *UpsertMutation {
 		var mutSet, mutDel []*dgoapi.Mutation
 		queries := upsertQuery
@@ -655,22 +657,24 @@ func (urw *UpdateRewriter) Rewrite(
 		}
 
 		if delArg != nil {
-			addUpdateCondition(delFrag)
-			var errDel error
-			mutDel, errDel = mutationsFromFragments(
-				delFrag,
-				func(frag *mutationFragment) ([]byte, error) {
-					return nil, nil
-				},
-				func(frag *mutationFragment) ([]byte, error) {
-					return json.Marshal(frag.fragment)
-				})
+			if len(objDel) != 0 {
+				addUpdateCondition(delFrag)
+				var errDel error
+				mutDel, errDel = mutationsFromFragments(
+					delFrag,
+					func(frag *mutationFragment) ([]byte, error) {
+						return nil, nil
+					},
+					func(frag *mutationFragment) ([]byte, error) {
+						return json.Marshal(frag.fragment)
+					})
 
-			retErrors = schema.AppendGQLErrs(retErrors, errDel)
+				retErrors = schema.AppendGQLErrs(retErrors, errDel)
 
-			q2 := queryFromFragments(delFrag)
-			if q2 != nil {
-				queries = append(queries, q2.Children...)
+				q2 := queryFromFragments(delFrag)
+				if q2 != nil {
+					queries = append(queries, q2.Children...)
+				}
 			}
 		}
 

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -1891,3 +1891,100 @@
           "Book.publisher": "penguin"
         }
       cond: "@if(gt(len(x), 0))"
+
+-
+  name: "delete json shouldn't be generated for empty remove"
+  gqlmutation: |
+    mutation updateAuthor($patch: UpdateAuthorInput!) {
+      updateAuthor(input: $patch) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "patch": {
+        "filter": {
+          "id": ["0x123"]
+        },
+        "set": { "name": "Alice" },
+        "remove": {}
+      }
+    }
+
+  dgquerysec: |-
+    query {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid" : "uid(x)",
+          "Author.name": "Alice"
+        }
+      cond: "@if(gt(len(x), 0))"
+
+-
+  name: "delete json shouldn't be generated for empty remove and set"
+  gqlmutation: |
+    mutation updateAuthor($patch: UpdateAuthorInput!) {
+      updateAuthor(input: $patch) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "patch": {
+        "filter": {
+          "id": ["0x123"]
+        },
+        "set": {},
+        "remove": {}
+      }
+    }
+
+  dgquerysec: |-
+    query {
+      x as updateAuthor(func: uid(0x123)) @filter(type(Author)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid": "uid(x)" }
+      cond: "@if(gt(len(x), 0))"
+
+-
+  name: "delete json shouldn't be generated for empty filter, remove and set"
+  gqlmutation: |
+    mutation updateAuthor($patch: UpdateAuthorInput!) {
+      updateAuthor(input: $patch) {
+        author {
+          id
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "patch": {
+        "filter": {
+        },
+        "set": {},
+        "remove": {}
+      }
+    }
+
+  dgquerysec: |-
+    query {
+      x as updateAuthor(func: type(Author)) {
+        uid
+      }
+    }
+  dgmutations:
+    - setjson: |
+        { "uid": "uid(x)" }
+      cond: "@if(gt(len(x), 0))"


### PR DESCRIPTION
We have this behavior of update mutation where we are deleting all the data for nodes that are selected in the filter when we give empty remove {} in the update patch.
For example in the below case , we delete everything for node with id `0x123`
```
mutation updateAuthor($patch: UpdateAuthorInput!) {
      updateAuthor(input: $patch) {
        author {
          id
        }
      }
    }
```
  variables: 
 ```
   {
      "patch": {
        "filter": {
          "id": ["0x123"]
        },
        "remove": {}
      }
```
    }

This can be more dangeours if we apply filter also empty like below, in that case it will delete every node of type Author.
```
   {
      "patch": {
        "filter": {
          "id": ["0x123"]
        },
        "remove": {}
      }
```
We are now changing this behaviour , such that empty remove{}, doesn't have any effect.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7557)
<!-- Reviewable:end -->
