### PR TITLE
chore(audit): making audit files unique for each alpha/zero node in a dgraph cluster

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -599,7 +599,6 @@ func setupServer(closer *z.Closer) {
 		x.Check(audit.InitAuditorIfNecessary(worker.Config.Audit, worker.EnterpriseEnabled))
 		break
 	}
-	glog.Info("waiting for the server to get closed aman")
 	x.ServerCloser.Wait()
 }
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -597,7 +597,7 @@ func setupServer(closer *z.Closer) {
 			x.Check(audit.InitAuditorIfNecessary(worker.Config.Audit, worker.EnterpriseEnabled))
 			break
 		}
-		time.Sleep(time.Millisecond)
+		time.Sleep(500 * time.Millisecond)
 	}
 	x.ServerCloser.Wait()
 }

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -431,7 +431,7 @@ func (n *node) applyProposal(e raftpb.Entry) (uint64, error) {
 		expiry := time.Unix(state.License.ExpiryTs, 0).UTC()
 		state.License.Enabled = time.Now().UTC().Before(expiry)
 		if state.License.Enabled && opts.audit != nil {
-			if err := audit.InitAuditor(opts.audit); err != nil {
+			if err := audit.InitAuditor(opts.audit, 0, n.Id); err != nil {
 				glog.Errorf("error while initializing audit logs %+v", err)
 			}
 		}

--- a/ee/audit/audit.go
+++ b/ee/audit/audit.go
@@ -32,7 +32,7 @@ func InitAuditorIfNecessary(conf *x.LoggerConf, eeEnabled func() bool) error {
 	return nil
 }
 
-func InitAuditor(conf *x.LoggerConf) error {
+func InitAuditor(conf *x.LoggerConf, gId, nId uint64) error {
 	return nil
 }
 

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -101,10 +101,8 @@ func InitAuditorIfNecessary(conf *x.LoggerConf, eeEnabled func() bool) error {
 	if conf == nil {
 		return nil
 	}
-	if eeEnabled() {
-		if err := InitAuditor(conf, uint64(worker.GroupId()), worker.NodeId()); err != nil {
-			return err
-		}
+	if err := InitAuditor(conf, uint64(worker.GroupId()), worker.NodeId()); err != nil {
+		return err
 	}
 	auditor.tick = time.NewTicker(time.Minute * 5)
 	auditor.closer = z.NewCloser(1)

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -26,7 +26,11 @@ import (
 	"github.com/golang/glog"
 )
 
-const defaultAuditFilenamef = "dgraph_audit_%d_%d.log"
+const (
+	defaultAuditFilenameF = "%s_audit_%d_%d.log"
+	NodeTypeAlpha         = "alpha"
+	NodeTypeZero          = "zero"
+)
 
 var auditEnabled uint32
 
@@ -112,9 +116,13 @@ func InitAuditorIfNecessary(conf *x.LoggerConf, eeEnabled func() bool) error {
 // This method doesnt keep track of whether cluster is part of enterprise edition or not.
 // Client has to keep track of that.
 func InitAuditor(conf *x.LoggerConf, gId, nId uint64) error {
+	ntype := NodeTypeAlpha
+	if gId == 0 {
+		ntype = NodeTypeZero
+	}
 	var err error
 	if auditor.log, err = x.InitLogger(conf,
-		fmt.Sprintf(defaultAuditFilenamef, gId, nId)); err != nil {
+		fmt.Sprintf(defaultAuditFilenameF, ntype, gId, nId)); err != nil {
 		return err
 	}
 	atomic.StoreUint32(&auditEnabled, 1)
@@ -140,7 +148,8 @@ func trackIfEEValid(conf *x.LoggerConf, eeEnabledFunc func() bool) {
 
 			if atomic.LoadUint32(&auditEnabled) != 1 {
 				if auditor.log, err = x.InitLogger(conf,
-					fmt.Sprintf(defaultAuditFilenamef, worker.GroupId(), worker.NodeId())); err != nil {
+					fmt.Sprintf(defaultAuditFilenameF, NodeTypeAlpha, worker.GroupId(),
+						worker.NodeId())); err != nil {
 					continue
 				}
 				atomic.StoreUint32(&auditEnabled, 1)

--- a/systest/audit/audit_test.go
+++ b/systest/audit/audit_test.go
@@ -30,7 +30,10 @@ import (
 )
 
 func TestZeroAudit(t *testing.T) {
-	defer os.RemoveAll("audit_dir/za/dgraph_audit.log")
+	state, err := testutil.GetState()
+	require.NoError(t, err)
+	nId := state.Zeros["1"].Id
+	defer os.RemoveAll(fmt.Sprintf("audit_dir/za/zero_audit_0_%s.log", nId))
 	zeroCmd := map[string][]string{
 		"/removeNode": []string{`--location`, "--request", "GET",
 			fmt.Sprintf("%s/removeNode?id=3&group=1", testutil.SockAddrZeroHttp)},
@@ -52,10 +55,16 @@ func TestZeroAudit(t *testing.T) {
 		}
 	}
 
-	verifyLogs(t, "./audit_dir/za/dgraph_audit.log", msgs)
+	verifyLogs(t, fmt.Sprintf("audit_dir/za/zero_audit_0_%s.log", nId), msgs)
 }
 func TestAlphaAudit(t *testing.T) {
-	defer os.Remove("audit_dir/aa/dgraph_audit.log")
+	state, err := testutil.GetState()
+	require.NoError(t, err)
+	var nId string
+	for key := range state.Groups["1"].Members {
+		nId = key
+	}
+	defer os.Remove(fmt.Sprintf("audit_dir/aa/alpha_audit_1_%s.log", nId))
 	testCommand := map[string][]string{
 		"/admin": []string{"--location", "--request", "POST",
 			fmt.Sprintf("%s/admin", testutil.SockAddrHttp),
@@ -106,7 +115,7 @@ input: {destination: \"/Users/sankalanparajuli/work/backup\"}) {\n    response {
 			}
 		}
 	}
-	verifyLogs(t, "./audit_dir/aa/dgraph_audit.log", msgs)
+	verifyLogs(t, fmt.Sprintf("audit_dir/aa/alpha_audit_1_%s.log", nId), msgs)
 }
 
 func verifyLogs(t *testing.T, path string, cmds []string) {

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - type: bind
         source: ./audit_dir/aa
         target: /audit_dir
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph alpha --raft="idx=1;" --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --audit "output=/audit_dir;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -1,24 +1,5 @@
 version: "3.5"
 services:
-  alpha1:
-    image: dgraph/dgraph:latest
-    working_dir: /data/alpha1
-    labels:
-      cluster: test
-    ports:
-      - "8080"
-      - "9080"
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
-        source: ./audit_dir/aa
-        target: /audit_dir
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
-      --audit "output=/audit_dir;" -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1
@@ -37,4 +18,26 @@ services:
         target: /audit_dir
     command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --audit "output=/audit_dir;"
+  alpha1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/alpha1
+    depends_on:
+      - zero1
+    labels:
+      cluster: test
+    ports:
+      - "8080"
+      - "9080"
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ./audit_dir/aa
+        target: /audit_dir
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+      --audit "output=/audit_dir;" -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+
 volumes: {}

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -1,5 +1,22 @@
 version: "3.5"
 services:
+  alpha1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/alpha1
+    ports:
+      - "8080"
+      - "9080"
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ./audit_dir/aa
+        target: /audit_dir
+    command: /gobin/dgraph alpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
+      --logtostderr --audit "output=/audit_dir;" -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1
@@ -18,26 +35,4 @@ services:
         target: /audit_dir
     command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --audit "output=/audit_dir;"
-  alpha1:
-    image: dgraph/dgraph:latest
-    working_dir: /data/alpha1
-    depends_on:
-      - zero1
-    labels:
-      cluster: test
-    ports:
-      - "8080"
-      - "9080"
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
-        source: ./audit_dir/aa
-        target: /audit_dir
-    command: /gobin/dgraph alpha --raft="idx=1;" --my=alpha1:7080 --zero=zero1:5080 --logtostderr
-      --audit "output=/audit_dir;" -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-
 volumes: {}

--- a/testutil/zero.go
+++ b/testutil/zero.go
@@ -41,6 +41,9 @@ type Member struct {
 // StateResponse represents the structure of the JSON object returned by calling
 // the /state endpoint in zero.
 type StateResponse struct {
+	Zeros map[string]struct {
+		Id string `json:"id"`
+	} `json:"zeros"`
 	Groups map[string]struct {
 		Members map[string]Member `json:"members"`
 		Tablets map[string]struct {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -628,6 +628,11 @@ func GroupId() uint32 {
 	return groups().groupId()
 }
 
+// NodeId returns the raft id of the node.
+func NodeId() uint64 {
+	return groups().Node.RaftContext.Id
+}
+
 func (g *groupi) triggerMembershipSync() {
 	// It's ok if we miss the trigger, periodic membership sync runs every minute.
 	select {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -630,7 +630,7 @@ func GroupId() uint32 {
 
 // NodeId returns the raft id of the node.
 func NodeId() uint64 {
-	return groups().Node.RaftContext.Id
+	return groups().Node.Id
 }
 
 func (g *groupi) triggerMembershipSync() {

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -124,7 +124,7 @@ func (l *LogWriter) Close() error {
 	if l == nil {
 		return nil
 	}
-	// closeFile all go routines first before acquiring the lock to avoid contention
+	// close all go routines first before acquiring the lock to avoid contention
 	l.closer.SignalAndWait()
 
 	l.mu.Lock()
@@ -221,7 +221,7 @@ func (l *LogWriter) open() error {
 	}
 
 	openNew := func() error {
-		f, err := os.OpenFile(l.FilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModeExclusive)
+		f, err := os.OpenFile(l.FilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ func (l *LogWriter) open() error {
 		return openNew()
 	}
 
-	f, err := os.OpenFile(l.FilePath, os.O_APPEND|os.O_RDWR, os.ModeExclusive)
+	f, err := os.OpenFile(l.FilePath, os.O_APPEND|os.O_RDWR, os.ModePerm)
 	if err != nil {
 		return openNew()
 	}
@@ -294,7 +294,7 @@ func compress(src string) error {
 		os.Remove(src + ".gz")
 		return err
 	}
-	// closeFile the descriptors because we need to delete the file
+	// close the descriptors because we need to delete the file
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION

this PR aims to put exclusive locks on files the alpha or zero opens to add audit logs. each logwriter keeps track of data it adds to the file and thus sharing the same file will break rollup and compression logic.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7561)
<!-- Reviewable:end -->
