### PR TITLE
[cherry-pick] feat(cmd/debuginfo) add new metrics to be collected

### DIFF
--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
@@ -29,19 +28,49 @@ import (
 )
 
 type debugInfoCmdOpts struct {
-	alphaAddr string
-	zeroAddr  string
-	archive   bool
-	directory string
-	duration  uint32
-
-	pprofProfiles []string
+	alphaAddr   string
+	zeroAddr    string
+	archive     bool
+	directory   string
+	seconds     uint32
+	metricTypes []string
 }
 
 var (
 	DebugInfo    x.SubCommand
 	debugInfoCmd = debugInfoCmdOpts{}
 )
+
+var metricMap = map[string]string{
+	"jemalloc":     "/jemalloc",
+	"state":        "/state",
+	"health":       "/health",
+	"vars":         "/debug/vars",
+	"metrics":      "/metrics",
+	"heap":         "/debug/pprof/heap",
+	"goroutine":    "/debug/pprof/goroutine?debug=2",
+	"threadcreate": "/debug/pprof/threadcreate",
+	"block":        "/debug/pprof/block",
+	"mutex":        "/debug/pprof/mutex",
+	"cpu":          "/debug/pprof/profile",
+	"trace":        "/debug/pprof/trace",
+}
+
+var metricList = []string{
+	"heap",
+	"cpu",
+	"state",
+	"health",
+	"jemalloc",
+	"trace",
+	"metrics",
+	"vars",
+	"trace",
+	"goroutine",
+	"block",
+	"mutex",
+	"threadcreate",
+}
 
 func init() {
 	DebugInfo.Cmd = &cobra.Command{
@@ -54,6 +83,7 @@ func init() {
 			}
 		},
 	}
+
 	DebugInfo.EnvPrefix = "DGRAPH_AGENT_DEBUGINFO"
 
 	flags := DebugInfo.Cmd.Flags()
@@ -64,10 +94,11 @@ func init() {
 		"Directory to write the debug info into.")
 	flags.BoolVarP(&debugInfoCmd.archive, "archive", "x", true,
 		"Whether to archive the generated report")
-	flags.Uint32VarP(&debugInfoCmd.duration, "seconds", "s", 15,
-		"Duration for time-based profile collection.")
-	flags.StringSliceVarP(&debugInfoCmd.pprofProfiles, "profiles", "p", pprofProfileTypes,
-		"List of pprof profiles to dump in the report.")
+	flags.Uint32VarP(&debugInfoCmd.seconds, "seconds", "s", 30,
+		"Duration for time-based metric collection.")
+	flags.StringSliceVarP(&debugInfoCmd.metricTypes, "metrics", "m", metricList,
+		"List of metrics & profile to dump in the report.")
+
 }
 
 func collectDebugInfo() (err error) {
@@ -84,7 +115,7 @@ func collectDebugInfo() (err error) {
 	}
 	glog.Infof("using directory %s for debug info dump.", debugInfoCmd.directory)
 
-	collectPProfProfiles()
+	collectDebug()
 
 	if debugInfoCmd.archive {
 		return archiveDebugInfo()
@@ -92,17 +123,19 @@ func collectDebugInfo() (err error) {
 	return nil
 }
 
-func collectPProfProfiles() {
-	duration := time.Duration(debugInfoCmd.duration) * time.Second
-
+func collectDebug() {
 	if debugInfoCmd.alphaAddr != "" {
 		filePrefix := filepath.Join(debugInfoCmd.directory, "alpha_")
-		saveProfiles(debugInfoCmd.alphaAddr, filePrefix, duration, debugInfoCmd.pprofProfiles)
+
+		saveMetrics(debugInfoCmd.alphaAddr, filePrefix, debugInfoCmd.seconds, debugInfoCmd.metricTypes)
+
 	}
 
 	if debugInfoCmd.zeroAddr != "" {
 		filePrefix := filepath.Join(debugInfoCmd.directory, "zero_")
-		saveProfiles(debugInfoCmd.zeroAddr, filePrefix, duration, debugInfoCmd.pprofProfiles)
+
+		saveMetrics(debugInfoCmd.zeroAddr, filePrefix, debugInfoCmd.seconds, debugInfoCmd.metricTypes)
+
 	}
 }
 


### PR DESCRIPTION
- This PR adds 5 new metrics (/jemalloc, /state, /health, /debug/vars, /metrics) to be collected when running  the `debuginfo` 
- the flag `-p` has been changed to `-m` to reflect the change. This new flag will let you pick up one or multiple metrics/pprof to be collected:
```
-m, --metrics strings    List of metrics & profile to dump in the report. (default [jemalloc,state,health,vars,metrics,heap,cpu_profile,trace,goroutine,threadcreate,block,mutex])
```
- default value of `-s` flag is now 30sec since it requires 30s to collect a cpu profile
- when saving the metric/profile - it will log the metric/profile name and the path where it's saving to.
- added new flag for time based profiles that are cpu and trace profiles:
```
-c, --cron_pprof strings   time-based pprof (default [cpu_profile,trace])
```

output of running the `debuginfo` command:
```
 dgraph debuginfo -s 30
I0305 21:01:44.730085   10587 run.go:126] using directory /tmp/dgraph-debuginfo041885197 for debug info dump.
I0305 21:01:44.730251   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/jemalloc
I0305 21:01:44.730261   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.731077   10587 debugging.go:51] saving jemalloc metric in /tmp/dgraph-debuginfo041885197/alpha_jemalloc.gz
I0305 21:01:44.731086   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/state
I0305 21:01:44.731092   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.731720   10587 debugging.go:51] saving state metric in /tmp/dgraph-debuginfo041885197/alpha_state.gz
I0305 21:01:44.731731   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/health
I0305 21:01:44.731736   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.732048   10587 debugging.go:51] saving health metric in /tmp/dgraph-debuginfo041885197/alpha_health.gz
I0305 21:01:44.732058   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/vars
I0305 21:01:44.732065   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.732557   10587 debugging.go:51] saving vars metric in /tmp/dgraph-debuginfo041885197/alpha_vars.gz
I0305 21:01:44.732568   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/metrics
I0305 21:01:44.732573   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.734904   10587 debugging.go:51] saving metrics metric in /tmp/dgraph-debuginfo041885197/alpha_metrics.gz
I0305 21:01:44.734912   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/heap
I0305 21:01:44.734917   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.738036   10587 debugging.go:51] saving heap metric in /tmp/dgraph-debuginfo041885197/alpha_heap.gz
I0305 21:01:44.738048   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/goroutine?debug=2
I0305 21:01:44.738057   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.739136   10587 debugging.go:51] saving goroutine metric in /tmp/dgraph-debuginfo041885197/alpha_goroutine.gz
I0305 21:01:44.739145   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/threadcreate
I0305 21:01:44.739151   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.740182   10587 debugging.go:51] saving threadcreate metric in /tmp/dgraph-debuginfo041885197/alpha_threadcreate.gz
I0305 21:01:44.740192   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/block
I0305 21:01:44.740198   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.741154   10587 debugging.go:51] saving block metric in /tmp/dgraph-debuginfo041885197/alpha_block.gz
I0305 21:01:44.741163   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/mutex
I0305 21:01:44.741169   10587 debugging.go:76] please wait... (30s)
I0305 21:01:44.742330   10587 debugging.go:51] saving mutex metric in /tmp/dgraph-debuginfo041885197/alpha_mutex.gz
I0305 21:01:44.742341   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/profile?seconds=30s
I0305 21:01:44.742348   10587 debugging.go:76] please wait... (30s)
I0305 21:02:14.812492   10587 debugging.go:63] saving cpu_profile metric in /tmp/dgraph-debuginfo041885197/alpha_cpu_profile.gz
I0305 21:02:14.812570   10587 debugging.go:74] fetching information over HTTP from http://localhost:8080/debug/pprof/trace?seconds=30s
I0305 21:02:14.812596   10587 debugging.go:76] please wait... (30s)
I0305 21:02:15.816449   10587 debugging.go:63] saving trace metric in /tmp/dgraph-debuginfo041885197/alpha_trace.gz
I0305 21:02:15.842375   10587 run.go:159] Debuginfo archive successful: dgraph-debuginfo041885197.tar.gz

```

(cherry picked from commit 79ada0eaacdbe090851adfa50a34e3ae95a09927)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7562)
<!-- Reviewable:end -->
