### PR TITLE
chore(flag): Change disallow-dropall flag to also block drop data operation

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -203,7 +203,7 @@ they form a Raft group and provide synchronous replication.
 			"The maximum number of nquads that can be inserted in a mutation request.").
 		Flag("disallow-drop",
 			"Set disallow-drop to true to block drop-all and drop-data operation. It still"+
-				" permits dropping attribute and types.").
+				" allows dropping attributes and types.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -201,8 +201,9 @@ they form a Raft group and provide synchronous replication.
 			"[allow, disallow, strict] The mutations mode to use.").
 		Flag("mutations-nquad",
 			"The maximum number of nquads that can be inserted in a mutation request.").
-		Flag("disallow-dropall",
-			"Set disallow-dropall to true to block drop-all operation.").
+		Flag("disallow-drop",
+			"Set disallow-drop to true to block drop-all and drop-data operation. It still"+
+				" permits dropping attribute and types.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
@@ -719,7 +720,7 @@ func run() {
 	x.Config.PortOffset = Alpha.Conf.GetInt("port_offset")
 	x.Config.LimitMutationsNquad = int(x.Config.Limit.GetInt64("mutations-nquad"))
 	x.Config.LimitQueryEdge = x.Config.Limit.GetUint64("query-edge")
-	x.Config.BlockDropAll = x.Config.Limit.GetBool("disallow-dropall")
+	x.Config.BlockClusterWideDrop = x.Config.Limit.GetBool("disallow-drop")
 
 	x.Config.GraphQL = z.NewSuperFlag(Alpha.Conf.GetString("graphql")).MergeAndCheckDefault(
 		worker.GraphQLDefaults)

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -376,7 +376,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	// if it lies on some other machine. Let's get it for safety.
 	m := &pb.Mutations{StartTs: worker.State.GetTimestamp(false)}
 	if isDropAll(op) {
-		if x.Config.BlockDropAll {
+		if x.Config.BlockClusterWideDrop {
 			glog.V(2).Info("Blocked drop-all because it is not permitted.")
 			return empty, errors.New("Drop all operation is not permitted.")
 		}
@@ -409,6 +409,10 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	}
 
 	if op.DropOp == api.Operation_DATA {
+		if x.Config.BlockClusterWideDrop {
+			glog.V(2).Info("Blocked drop-data because it is not permitted.")
+			return empty, errors.New("Drop data operation is not permitted.")
+		}
 		if err := AuthGuardianOfTheGalaxy(ctx); err != nil {
 			return empty, errors.Wrapf(err, "Drop data can only be called by the guardian of the"+
 				" galaxy")

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -47,7 +47,7 @@ const (
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
-		`mutations-nquad=1000000;`
+		`mutations-nquad=1000000; disallow-drop=false;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 )

--- a/x/config.go
+++ b/x/config.go
@@ -39,7 +39,7 @@ type Options struct {
 	Limit               *z.SuperFlag
 	LimitMutationsNquad int
 	LimitQueryEdge      uint64
-	BlockDropAll        bool
+	BlockClusterWideDrop        bool
 
 	// GraphQL options:
 	//


### PR DESCRIPTION
Add `disallow-drop` flag which if set to true, then drop-all and drop-data will not be allowed in the alpha node.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7566)
<!-- Reviewable:end -->
