### PR TITLE
fix(audit): logs not getting deleted after N days

### DIFF
--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -50,7 +50,7 @@ const (
 	Http             = "Http"
 )
 
-var auditor *auditLogger = &auditLogger{}
+var auditor = &auditLogger{}
 
 type auditLogger struct {
 	log    *x.Logger

--- a/x/keys.go
+++ b/x/keys.go
@@ -114,10 +114,7 @@ func ParseAttrList(attrs []string) []string {
 
 func IsReverseAttr(attr string) bool {
 	AssertTrue(len(attr) >= 8)
-	if attr[8] == '~' {
-		return true
-	}
-	return false
+	return attr[8] == '~'
 }
 
 func writeAttr(buf []byte, attr string) []byte {

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -373,8 +373,8 @@ func (l *LogWriter) manageOldLogs() {
 	}
 }
 
-// prefixAndExt extracts the filename (without the extension) as well its
-// extension (including the `.`) from a filepath.
+// prefixAndExt extracts the filename and extension from a filepath.
+// eg. prefixAndExt("/home/foo/file.ext") would return ("file", ".ext").
 func prefixAndExt(file string) (prefix, ext string) {
 	filename := filepath.Base(file)
 	ext = filepath.Ext(filename)
@@ -395,8 +395,8 @@ func processOldLogFiles(fp string, maxAge int64) ([]string, []string, error) {
 	toRemove := make([]string, 0)
 	toKeep := make([]string, 0)
 
-	diff := time.Duration(int64(24*time.Hour) * maxAge)
-	cutoff := time.Now().Add(-1 * diff)
+	diff := 24 * time.Hour * time.Duration(maxAge)
+	cutoff := time.Now().Add(-diff)
 
 	for _, f := range files {
 		if f.IsDir() || // f is directory
@@ -406,7 +406,8 @@ func processOldLogFiles(fp string, maxAge int64) ([]string, []string, error) {
 		}
 
 		_, e := prefixAndExt(fp)
-		ts, err := time.Parse(backupTimeFormat, f.Name()[len(defPrefix):len(f.Name())-len(e)])
+		tsString := f.Name()[len(defPrefix) : len(f.Name())-len(e)]
+		ts, err := time.ParseInLocation(backupTimeFormat, tsString, time.Local)
 		if err != nil {
 			continue
 		}

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -341,7 +341,7 @@ func (l *LogWriter) manageOldLogs() {
 		return
 	}
 
-	toRemove, toKeep, err := processOldLogFiles(l.FilePath, l.MaxSize)
+	toRemove, toKeep, err := processOldLogFiles(l.FilePath, l.MaxAge)
 	if err != nil {
 		return
 	}
@@ -373,6 +373,8 @@ func (l *LogWriter) manageOldLogs() {
 	}
 }
 
+// prefixAndExt extracts the filename (without the extension) as well its
+// extension (including the `.`) from a filepath.
 func prefixAndExt(file string) (prefix, ext string) {
 	filename := filepath.Base(file)
 	ext = filepath.Ext(filename)
@@ -393,7 +395,7 @@ func processOldLogFiles(fp string, maxAge int64) ([]string, []string, error) {
 	toRemove := make([]string, 0)
 	toKeep := make([]string, 0)
 
-	diff := time.Duration(int64(24*time.Hour) * int64(maxAge))
+	diff := time.Duration(int64(24*time.Hour) * maxAge)
 	cutoff := time.Now().Add(-1 * diff)
 
 	for _, f := range files {

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -302,7 +302,7 @@ func (l *LogWriter) open() error {
 func backupName(name string) string {
 	dir := filepath.Dir(name)
 	prefix, ext := prefixAndExt(name)
-	timestamp := time.Now().Format(backupTimeFormat)
+	timestamp := time.Now().UTC().Format(backupTimeFormat)
 	return filepath.Join(dir, fmt.Sprintf("%s-%s%s", prefix, timestamp, ext))
 }
 
@@ -407,7 +407,7 @@ func processOldLogFiles(fp string, maxAge int64) ([]string, []string, error) {
 
 		_, e := prefixAndExt(fp)
 		tsString := f.Name()[len(defPrefix) : len(f.Name())-len(e)]
-		ts, err := time.ParseInLocation(backupTimeFormat, tsString, time.Local)
+		ts, err := time.Parse(backupTimeFormat, tsString)
 		if err != nil {
 			continue
 		}

--- a/x/logger.go
+++ b/x/logger.go
@@ -86,7 +86,7 @@ func (l *Logger) AuditI(msg string, args ...interface{}) {
 	if l == nil {
 		return
 	}
-	flds := make([]zap.Field, 0)
+	flds := make([]zap.Field, 0, len(args))
 	for i := 0; i < len(args); i = i + 2 {
 		flds = append(flds, zap.Any(args[i].(string), args[i+1]))
 	}
@@ -97,7 +97,7 @@ func (l *Logger) AuditE(msg string, args ...interface{}) {
 	if l == nil {
 		return
 	}
-	flds := make([]zap.Field, 0)
+	flds := make([]zap.Field, 0, len(args))
 	for i := 0; i < len(args); i = i + 2 {
 		flds = append(flds, zap.Any(args[i].(string), args[i+1]))
 	}


### PR DESCRIPTION
Fixes DGRAPH-3139.

There were two bugs fixed here:
- The wrong parameter was being passed to `processOldLogFiles` (`l.MaxSize` instead of `l.MaxAge`).
- When formatting the closing timestamp of an audit log file, we use the local timezone. However, when parsing it back, we were assuming a UTC timezone. I changed this to assume local timezone.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7567)
<!-- Reviewable:end -->
