### PR TITLE
fix(persistent): make persistent query namespace aware

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -81,6 +81,10 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	return nil
 }
 
+func validateToken(jwtStr string) ([]string, error) {
+	return nil, nil
+}
+
 func upsertGuardian(ctx context.Context) error {
 	return nil
 }

--- a/edgraph/graphql.go
+++ b/edgraph/graphql.go
@@ -23,8 +23,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/golang/glog"
@@ -68,7 +66,6 @@ func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 		},
 		doAuth: NoAuthorize,
 	}
-	ctx = x.AttachNamespace(ctx, x.GalaxyNamespace)
 	storedQuery, err := (&Server{}).doQuery(ctx, req)
 
 	if err != nil {
@@ -120,11 +117,10 @@ func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 				},
 				CommitNow: true,
 			},
-			doAuth: NoAuthorize,
+			doAuth: NeedAuthorize,
 		}
 
 		ctx := context.WithValue(ctx, IsGraphql, true)
-		ctx = x.AttachNamespace(ctx, x.GalaxyNamespace)
 		_, err := (&Server{}).doQuery(ctx, req)
 		return err
 

--- a/edgraph/graphql.go
+++ b/edgraph/graphql.go
@@ -64,7 +64,6 @@ func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 			Vars:     variables,
 			ReadOnly: true,
 		},
-		doAuth: NoAuthorize,
 	}
 	storedQuery, err := (&Server{}).doQuery(ctx, req)
 
@@ -117,7 +116,6 @@ func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 				},
 				CommitNow: true,
 			},
-			doAuth: NeedAuthorize,
 		}
 
 		ctx := context.WithValue(ctx, IsGraphql, true)

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,6 +29,8 @@ import (
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/ee/acl"
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
@@ -357,6 +360,70 @@ func TestLiveLoadMulti(t *testing.T) {
 		{"name": "ns dan"},{"name":"ns eon"}, {"name": "ns free"},{"name":"ns gary"},
 		{"name": "ns hola"}]}`, string(resp))
 
+}
+
+func postGqlSchema(t *testing.T, schema string, accessJwt string) {
+	groupOneHTTP := testutil.ContainerAddr("alpha1", 8080)
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", accessJwt)
+	common.SafelyUpdateGQLSchema(t, groupOneHTTP, schema, header)
+}
+
+func postPersistentQuery(t *testing.T, query, sha, accessJwt string) *common.GraphQLResponse {
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", accessJwt)
+	queryCountryParams := &common.GraphQLParams{
+		Query: query,
+		Extensions: &schema.RequestExtensions{PersistedQuery: schema.PersistedQuery{
+			Sha256Hash: sha,
+		}},
+		Headers: header,
+	}
+	url := "http://" + testutil.ContainerAddr("alpha1", 8080) + "/graphql"
+	return queryCountryParams.ExecuteAsPost(t, url)
+}
+
+func TestPersistentQuery(t *testing.T) {
+	prepare(t)
+	galaxyToken := testutil.Login(t,
+		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
+
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+
+	token := testutil.Login(t,
+		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
+
+	sch := `type Product {
+			productID: ID!
+			name: String @search(by: [term])
+		}`
+	postGqlSchema(t, sch, galaxyToken.AccessJwt)
+	postGqlSchema(t, sch, token.AccessJwt)
+
+	p1 := "query {queryProduct{productID}}"
+	sha1 := "7a8ff7a69169371c1eb52a8921387079ca281bb2d55feb4b535cbf0ab3896be5"
+	resp := postPersistentQuery(t, p1, sha1, galaxyToken.AccessJwt)
+	require.Zerof(t, len(resp.Errors), resp.Errors.Error())
+
+	p2 := "query {queryProduct{name}}"
+	sha2 := "0efcdde144167b1046360b73c7f6bec325d9f555099a2ae9b820a13328d270e4"
+	resp = postPersistentQuery(t, p2, sha2, token.AccessJwt)
+	require.Zerof(t, len(resp.Errors), resp.Errors.Error())
+
+	// User cannnot see persistent query from other namespace.
+	resp = postPersistentQuery(t, "", sha2, galaxyToken.AccessJwt)
+	require.Equal(t, 1, len(resp.Errors))
+	require.Contains(t, resp.Errors[0].Message, "PersistedQueryNotFound")
+
+	resp = postPersistentQuery(t, "", sha1, token.AccessJwt)
+	require.Equal(t, 1, len(resp.Errors))
+	require.Contains(t, resp.Errors[0].Message, "PersistedQueryNotFound")
+
+	resp = postPersistentQuery(t, "", sha1, "")
+	require.Equal(t, 1, len(resp.Errors))
+	require.Contains(t, resp.Errors[0].Message, "no accessJwt available")
 }
 
 func TestMain(m *testing.M) {

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -405,12 +405,12 @@ func TestPersistentQuery(t *testing.T) {
 	p1 := "query {queryProduct{productID}}"
 	sha1 := "7a8ff7a69169371c1eb52a8921387079ca281bb2d55feb4b535cbf0ab3896be5"
 	resp := postPersistentQuery(t, p1, sha1, galaxyToken.AccessJwt)
-	require.Zerof(t, len(resp.Errors), resp.Errors.Error())
+	common.RequireNoGQLErrors(t, resp)
 
 	p2 := "query {queryProduct{name}}"
 	sha2 := "0efcdde144167b1046360b73c7f6bec325d9f555099a2ae9b820a13328d270e4"
 	resp = postPersistentQuery(t, p2, sha2, token.AccessJwt)
-	require.Zerof(t, len(resp.Errors), resp.Errors.Error())
+	common.RequireNoGQLErrors(t, resp)
 
 	// User cannnot see persistent query from other namespace.
 	resp = postPersistentQuery(t, "", sha2, galaxyToken.AccessJwt)


### PR DESCRIPTION
This PR makes Persistent query namespace-aware. Also, there was a bug in a persistent query where an unauthorized user can add persistent queries.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7570)
<!-- Reviewable:end -->
