### PR TITLE
fix(Bug): Update Dgraph Alias to work with GQL aliases

### DIFF
--- a/graphql/e2e/common/lambda.go
+++ b/graphql/e2e/common/lambda.go
@@ -29,7 +29,7 @@ func lambdaOnTypeField(t *testing.T) {
 	query := `
 		query {
 			queryAuthor {
-				name
+				dob : name
 				bio
 				rank
 			}
@@ -41,17 +41,17 @@ func lambdaOnTypeField(t *testing.T) {
 	expectedResponse := `{
 		"queryAuthor": [
 			{
-				"name":"Three Author",
+				"dob":"Three Author",
 				"bio":"My name is Three Author and I was born on 2001-01-01T00:00:00Z.",
 				"rank":1
 			},
 			{
-				"name":"Ann Author",
+				"dob":"Ann Author",
 				"bio":"My name is Ann Author and I was born on 2000-01-01T00:00:00Z.",
 				"rank":3
 			},
 			{
-				"name":"Ann Other Author",
+				"dob":"Ann Other Author",
 				"bio":"My name is Ann Other Author and I was born on 1988-01-01T00:00:00Z.",
 				"rank":2
 			}

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2596,11 +2596,7 @@
       getComment(id: "0x1") {
         author
         title
-        content
         ups
-        relatedUsers {
-          name
-        }
       }
     }
   dgquery: |-
@@ -2609,9 +2605,7 @@
         Comment.author : Comment.author
         Comment.title : Comment.title
         Comment.ups : Comment.ups
-        Comment._.author : Comment.author
-        Comment._.id : uid
-        Comment._.url : Comment.url
+        dgraph.uid : uid
       }
     }
 
@@ -2620,7 +2614,7 @@
     query {
       getComment(id: "0x1") {
         content
-        author
+        url: author
         relatedUsers {
           name
         }
@@ -2629,7 +2623,7 @@
   dgquery: |-
     query {
       getComment(func: uid(0x1)) @filter(type(Comment)) {
-        Comment.author : Comment.author
+        Comment.url : Comment.author
         Comment._.author : Comment.author
         Comment._.id : uid
         Comment._.url : Comment.url
@@ -2644,12 +2638,8 @@
           id
           author
           title
-          content
           ups
           url
-          relatedUsers {
-            name
-          }
         }
       }
     }
@@ -2663,9 +2653,6 @@
           Comment.title : Comment.title
           Comment.ups : Comment.ups
           Comment.url : Comment.url
-          Comment._.author : Comment.author
-          Comment._.id : uid
-          Comment._.url : Comment.url
         }
       }
     }
@@ -2675,7 +2662,7 @@
       getPost(postID: "0x1") {
         postID
         comments {
-          author
+          url : author
           title
           content
           ups
@@ -2690,7 +2677,7 @@
       getPost(func: uid(0x1)) @filter(type(Post)) {
         Post.postID : uid
         Post.comments : Post.comments {
-          Comment.author : Comment.author
+          Comment.url : Comment.author
           Comment.title : Comment.title
           Comment.ups : Comment.ups
           Comment._.author : Comment.author

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2609,8 +2609,9 @@
         Comment.author : Comment.author
         Comment.title : Comment.title
         Comment.ups : Comment.ups
-        Comment.id : uid
-        Comment.url : Comment.url
+        Comment._.author : Comment.author
+        Comment._.id : uid
+        Comment._.url : Comment.url
       }
     }
 
@@ -2619,6 +2620,7 @@
     query {
       getComment(id: "0x1") {
         content
+        author
         relatedUsers {
           name
         }
@@ -2628,8 +2630,9 @@
     query {
       getComment(func: uid(0x1)) @filter(type(Comment)) {
         Comment.author : Comment.author
-        Comment.id : uid
-        Comment.url : Comment.url
+        Comment._.author : Comment.author
+        Comment._.id : uid
+        Comment._.url : Comment.url
       }
     }
 - name: "Rewrite without custom fields deep"
@@ -2660,6 +2663,9 @@
           Comment.title : Comment.title
           Comment.ups : Comment.ups
           Comment.url : Comment.url
+          Comment._.author : Comment.author
+          Comment._.id : uid
+          Comment._.url : Comment.url
         }
       }
     }
@@ -2687,8 +2693,9 @@
           Comment.author : Comment.author
           Comment.title : Comment.title
           Comment.ups : Comment.ups
-          Comment.id : uid
-          Comment.url : Comment.url
+          Comment._.author : Comment.author
+          Comment._.id : uid
+          Comment._.url : Comment.url
         }
       }
     }

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -2282,7 +2282,7 @@ func (fd *fieldDefinition) Name() string {
 }
 
 func (fd *fieldDefinition) DgraphAlias() string {
-	return fd.parentType.Name() + "." + fd.fieldDef.Name
+	return fd.parentType.Name() + "._." + fd.fieldDef.Name
 }
 
 func (fd *fieldDefinition) DgraphPredicate() string {


### PR DESCRIPTION
### Motivation

This PR fixes: GRAPHQL-1078
Before this fix following query used to append aliase'd predicate in lambda resolved field.
```
query {
  queryUser {
    id
    actualName: name
    name: email # email field has been aliased as name which is another field in this type and is used by lambda
    intro
  }
}
```


### Components affected by this PR <!-- (Optional) -->

GraphQL resolver





### Does this PR break backwards compatibility?

No



### Testing

Added following tests in:

1. e2e test with alias
2. Resolver test with alias



### Fixes <!-- (Optional) -->

Fixes GRAPHQL-1078


<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7572)
<!-- Reviewable:end -->
