### PR TITLE
Revert "fix(telemetry): Track enterprise feature usage (#7495)"

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -33,20 +32,19 @@ import (
 
 // Telemetry holds information about the state of the zero and alpha server.
 type Telemetry struct {
-	Arch           string   `json:",omitempty"`
-	Cid            string   `json:",omitempty"`
-	ClusterSize    int      `json:",omitempty"`
-	DiskUsageMB    int64    `json:",omitempty"`
-	NumAlphas      int      `json:",omitempty"`
-	NumGroups      int      `json:",omitempty"`
-	NumTablets     int      `json:",omitempty"`
-	NumZeros       int      `json:",omitempty"`
-	OS             string   `json:",omitempty"`
-	SinceHours     int      `json:",omitempty"`
-	Version        string   `json:",omitempty"`
-	NumGraphQLPM   uint64   `json:",omitempty"`
-	NumGraphQL     uint64   `json:",omitempty"`
-	EEFeaturesList []string `json:",omitempty"`
+	Arch         string `json:",omitempty"`
+	Cid          string `json:",omitempty"`
+	ClusterSize  int    `json:",omitempty"`
+	DiskUsageMB  int64  `json:",omitempty"`
+	NumAlphas    int    `json:",omitempty"`
+	NumGroups    int    `json:",omitempty"`
+	NumTablets   int    `json:",omitempty"`
+	NumZeros     int    `json:",omitempty"`
+	OS           string `json:",omitempty"`
+	SinceHours   int    `json:",omitempty"`
+	Version      string `json:",omitempty"`
+	NumGraphQLPM uint64 `json:",omitempty"`
+	NumGraphQL   uint64 `json:",omitempty"`
 }
 
 const url = "https://ping.dgraph.io/3.0/projects/5b809dfac9e77c0001783ad0/events"
@@ -89,7 +87,6 @@ func NewAlpha(ms *pb.MembershipState) *Telemetry {
 
 // Post reports the Telemetry to the stats server.
 func (t *Telemetry) Post() error {
-	t.EEFeaturesList = worker.GetEEFeaturesList()
 	data, err := json.Marshal(t)
 	if err != nil {
 		return err


### PR DESCRIPTION
We are seeing a crash because of this change. So we are reverting it for now.
```
panic: runtime error: integer divide by zero
goroutine 194 [running]:
github.com/dgraph-io/dgraph/worker.(*groupi).connToZeroLeader(0x31c07a0, 0x205af60)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:681 +0x452
github.com/dgraph-io/dgraph/worker.(*groupi).askZeroForEE.func1(0xc000136000)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1100 +0x75
github.com/dgraph-io/dgraph/worker.(*groupi).askZeroForEE(0x31c07a0, 0xc0000e6000)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1123 +0xa9
github.com/dgraph-io/dgraph/worker.EnterpriseEnabled(0x12e)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1090 +0x63
github.com/dgraph-io/dgraph/worker.GetEEFeaturesList(0xc00013c230, 0x12e, 0x1a1)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1061 +0x26
github.com/dgraph-io/dgraph/telemetry.(*Telemetry).Post(0xc00077c5a0, 0x0, 0x0)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/telemetry/telemetry.go:92 +0x52
github.com/dgraph-io/dgraph/dgraph/cmd/zero.(*Server).periodicallyPostTelemetry(0xc0000f0c80)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/cmd/zero/zero.go:130 +0x2b9
created by github.com/dgraph-io/dgraph/dgraph/cmd/zero.run
```

This reverts commit 1cabd8662cfd4db2df0ef6308128c5f779f29116.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7574)
<!-- Reviewable:end -->
