### PR TITLE
fix(telemetry): fix crash due to telemetry

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -80,16 +80,16 @@ func NewZero(ms *pb.MembershipState) *Telemetry {
 // NewAlpha returns a Telemetry struct that holds information about the state of alpha server.
 func NewAlpha(ms *pb.MembershipState) *Telemetry {
 	return &Telemetry{
-		Cid:     ms.GetCid(),
-		Version: x.Version(),
-		OS:      runtime.GOOS,
-		Arch:    runtime.GOARCH,
+		Cid:            ms.GetCid(),
+		Version:        x.Version(),
+		OS:             runtime.GOOS,
+		Arch:           runtime.GOARCH,
+		EEFeaturesList: worker.GetEEFeaturesList(),
 	}
 }
 
 // Post reports the Telemetry to the stats server.
 func (t *Telemetry) Post() error {
-	t.EEFeaturesList = worker.GetEEFeaturesList()
 	data, err := json.Marshal(t)
 	if err != nil {
 		return err


### PR DESCRIPTION
We are seeing a crash in zero. This PR fixes this.

```
panic: runtime error: integer divide by zero
goroutine 194 [running]:
github.com/dgraph-io/dgraph/worker.(*groupi).connToZeroLeader(0x31c07a0, 0x205af60)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:681 +0x452
github.com/dgraph-io/dgraph/worker.(*groupi).askZeroForEE.func1(0xc000136000)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1100 +0x75
github.com/dgraph-io/dgraph/worker.(*groupi).askZeroForEE(0x31c07a0, 0xc0000e6000)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1123 +0xa9
github.com/dgraph-io/dgraph/worker.EnterpriseEnabled(0x12e)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1090 +0x63
github.com/dgraph-io/dgraph/worker.GetEEFeaturesList(0xc00013c230, 0x12e, 0x1a1)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/worker/groups.go:1061 +0x26
github.com/dgraph-io/dgraph/telemetry.(*Telemetry).Post(0xc00077c5a0, 0x0, 0x0)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/telemetry/telemetry.go:92 +0x52
github.com/dgraph-io/dgraph/dgraph/cmd/zero.(*Server).periodicallyPostTelemetry(0xc0000f0c80)
	/home/ash/go/src/github.com/dgraph-io/dgraph-release/dgraph/cmd/zero/zero.go:130 +0x2b9
created by github.com/dgraph-io/dgraph/dgraph/cmd/zero.run
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7575)
<!-- Reviewable:end -->
