### PR TITLE
chore(test): fixing flaky tests

### DIFF
--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -31,6 +31,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -43,11 +46,13 @@ func TestCountIndex(t *testing.T) {
 	edgeCount := make([]int, total+100000)
 	uidLocks := make([]sync.Mutex, total+100000)
 
-	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	if err != nil {
-		t.Fatalf("Error while getting a dgraph client: %v", err)
-	}
-
+	var dg *dgo.Dgraph
+	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+		var err error
+		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		return err
+	})
+	require.Nil(t, err)
 	testutil.DropAll(t, dg)
 	if err := dg.Alter(context.Background(), &api.Operation{
 		Schema: "value: [string] .",

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -47,7 +47,7 @@ func TestCountIndex(t *testing.T) {
 	uidLocks := make([]sync.Mutex, total+100000)
 
 	var dg *dgo.Dgraph
-	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
 		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
 		return err

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -102,24 +102,35 @@ func TestParallelIndexing(t *testing.T) {
 	}
 
 	fmt.Println("building indexes in background for int and string data")
-	if err := dg.Alter(context.Background(), &api.Operation{
-		Schema: `
+	// Wait until previous indexing is complete.
+	for {
+		if err := dg.Alter(context.Background(), &api.Operation{
+			Schema: `
 			balance_int: int @index(int) .
 			balance_str: string @index(fulltext, term, exact) .
 		`,
-		RunInBackground: true,
-	}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
-		t.Fatalf("error in adding indexes :: %v\n", err)
+			RunInBackground: true,
+		}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
+			t.Fatalf("error in adding indexes :: %v\n", err)
+		} else if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
 	}
-
-	if err := dg.Alter(context.Background(), &api.Operation{
-		Schema: `
+	// Wait until previous indexing is complete.
+	for {
+		if err := dg.Alter(context.Background(), &api.Operation{
+			Schema: `
 			balance_int: int @index(int) .
 			balance_str: string @index(fulltext, term, exact) .
 		`,
-		RunInBackground: true,
-	}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
-		t.Fatalf("error in adding indexes :: %v\n", err)
+			RunInBackground: true,
+		}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
+			t.Fatalf("error in adding indexes :: %v\n", err)
+		} else if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
 	}
 
 	// Wait until previous indexing is complete.

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -27,6 +27,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -63,10 +66,13 @@ func TestParallelIndexing(t *testing.T) {
 		t.Fatalf("error in assignig UIDs :: %v", err)
 	}
 
-	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	if err != nil {
-		t.Fatalf("Error while getting a dgraph client: %v", err)
-	}
+	var dg *dgo.Dgraph
+	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+		var err error
+		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		return err
+	})
+	require.Nil(t, err)
 
 	testutil.DropAll(t, dg)
 	if err := dg.Alter(context.Background(), &api.Operation{
@@ -102,7 +108,7 @@ func TestParallelIndexing(t *testing.T) {
 			balance_str: string @index(fulltext, term, exact) .
 		`,
 		RunInBackground: true,
-	}); err != nil {
+	}); err != nil && !strings.Contains(err.Error(), "errIndexingInProgress") {
 		t.Fatalf("error in adding indexes :: %v\n", err)
 	}
 

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -67,7 +67,7 @@ func TestParallelIndexing(t *testing.T) {
 	}
 
 	var dg *dgo.Dgraph
-	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
 		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
 		return err

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -30,6 +30,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
@@ -37,10 +40,13 @@ import (
 
 func TestReverseIndex(t *testing.T) {
 	total := 100000
-	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	if err != nil {
-		t.Fatalf("Error while getting a dgraph client: %v", err)
-	}
+	var dg *dgo.Dgraph
+	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+		var err error
+		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		return err
+	})
+	require.Nil(t, err)
 
 	testutil.DropAll(t, dg)
 	if err := dg.Alter(context.Background(), &api.Operation{

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -41,7 +41,7 @@ import (
 func TestReverseIndex(t *testing.T) {
 	total := 100000
 	var dg *dgo.Dgraph
-	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
 		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
 		return err

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -30,6 +30,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v200"
 	"github.com/dgraph-io/dgo/v200/protos/api"
@@ -42,10 +45,13 @@ func TestStringIndex(t *testing.T) {
 	acctsBal := make(map[int]int, numAccts)
 	var lock sync.Mutex
 
-	dg, err := testutil.DgraphClientWithGroot(testutil.SockAddr)
-	if err != nil {
-		t.Fatalf("Error while getting a dgraph client: %v", err)
-	}
+	var dg *dgo.Dgraph
+	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+		var err error
+		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
+		return err
+	})
+	require.Nil(t, err)
 
 	testutil.DropAll(t, dg)
 	if err := dg.Alter(context.Background(), &api.Operation{

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -46,7 +46,7 @@ func TestStringIndex(t *testing.T) {
 	var lock sync.Mutex
 
 	var dg *dgo.Dgraph
-	err := x.RetryUntilSuccess(100, 1*time.Second, func() error {
+	err := x.RetryUntilSuccess(10, time.Second, func() error {
 		var err error
 		dg, err = testutil.DgraphClientWithGroot(testutil.SockAddr)
 		return err

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -358,7 +358,7 @@ func TestLiveLoadMulti(t *testing.T) {
 		creds: &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns},
 	}))
 
-	err = x.RetryUntilSuccess(100, 1*time.Second, func() error {
+	err = x.RetryUntilSuccess(10, time.Second, func() error {
 		resp = testutil.QueryData(t, dc1, query3)
 		var o1 interface{}
 		var o2 interface{}

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -369,11 +369,11 @@ func TestLiveLoadMulti(t *testing.T) {
 		{"name": "ns hola"}]}`
 		err = json.Unmarshal([]byte(expected), &o1)
 		if err != nil {
-			return fmt.Errorf("Error mashalling string 1 :: %s", err.Error())
+			return fmt.Errorf("error unmarshalling string 1 :: %s", err.Error())
 		}
 		err = json.Unmarshal([]byte(string(resp)), &o2)
 		if err != nil {
-			return fmt.Errorf("Error mashalling string 2 :: %s", err.Error())
+			return fmt.Errorf("error unmarshalling string 2 :: %s", err.Error())
 		}
 
 		if reflect.DeepEqual(o1, o2) {

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -18,14 +18,11 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 
@@ -358,32 +355,10 @@ func TestLiveLoadMulti(t *testing.T) {
 		creds: &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns},
 	}))
 
-	err = x.RetryUntilSuccess(10, time.Second, func() error {
-		resp = testutil.QueryData(t, dc1, query3)
-		var o1 interface{}
-		var o2 interface{}
-
-		var err error
-		expected := `{"me": [{"name":"ns alice"}, {"name": "ns bob"},{"name":"ns chew"},
+	resp = testutil.QueryData(t, dc1, query3)
+	testutil.CompareJSON(t, `{"me": [{"name":"ns alice"}, {"name": "ns bob"},{"name":"ns chew"},
 		{"name": "ns dan"},{"name":"ns eon"}, {"name": "ns free"},{"name":"ns gary"},
-		{"name": "ns hola"}]}`
-		err = json.Unmarshal([]byte(expected), &o1)
-		if err != nil {
-			return fmt.Errorf("error unmarshalling string 1 :: %s", err.Error())
-		}
-		err = json.Unmarshal([]byte(string(resp)), &o2)
-		if err != nil {
-			return fmt.Errorf("error unmarshalling string 2 :: %s", err.Error())
-		}
-
-		if reflect.DeepEqual(o1, o2) {
-			return nil
-		}
-
-		return errors.New(fmt.Sprintf("Expected and actual doesnt match. "+
-			"Expected %s \n Actual %s \n", expected, string(resp)))
-	})
-	require.Nil(t, err)
+		{"name": "ns hola"}]}`, string(resp))
 }
 
 func postGqlSchema(t *testing.T, schema string, accessJwt string) {

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -87,7 +87,8 @@ func CreateNamespaceWithRetry(t *testing.T, token *HttpToken) (uint64, error) {
 		resp = MakeRequest(t, token, params)
 		if len(resp.Errors) > 0 {
 			// retry if necessary
-			if strings.Contains(resp.Errors.Error(), "Predicate dgraph.xid is not indexed") {
+			if strings.Contains(resp.Errors.Error(), "Predicate dgraph.xid is not indexed") ||
+				strings.Contains(resp.Errors.Error(), "opIndexing is already running") {
 				glog.Warningf("error while creating namespace %v", resp.Errors)
 				time.Sleep(100 * time.Millisecond)
 				continue


### PR DESCRIPTION
This PR fixes multiple test cases like TestLiveLoadMultiTenancy, Error in CreateNamespace, TestCountIndex, TestParallelIndex generally in case of tests when enabled with race flag. 
This also fixes one error in t.go where we are printing dgraph logs whenever a test fails.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7577)
<!-- Reviewable:end -->
