### PR TITLE
cluster ID should be settable to alpha sentry via cluster-manager( GraphQL-service)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ test:
 
 image:
 	@GOOS=linux $(MAKE) dgraph
-	@mkdir linux
+	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:$(subst /,-,${BUILD_BRANCH}) .
 	@rm -r linux

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -530,6 +530,10 @@ func (n *node) proposeNewCID() {
 	// CID check is needed for the case when a leader assigns a CID to the new node and the new node is proposing a CID
 	for n.server.membershipState().Cid == "" {
 		id := uuid.New().String()
+		if len(n.server.cid) > 0 {
+			id = n.server.cid
+		}
+
 		err := n.proposeAndWait(context.Background(), &pb.ZeroProposal{Cid: id})
 		if err == nil {
 			glog.Infof("CID set for cluster: %v", id)

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -530,8 +530,9 @@ func (n *node) proposeNewCID() {
 	// CID check is needed for the case when a leader assigns a CID to the new node and the new node is proposing a CID
 	for n.server.membershipState().Cid == "" {
 		id := uuid.New().String()
-		if len(n.server.cid) > 0 {
-			id = n.server.cid
+
+		if zero_cid := Zero.Conf.GetString("cid"); len(zero_cid) > 0 {
+			id = zero_cid
 		}
 
 		err := n.proposeAndWait(context.Background(), &pb.ZeroProposal{Cid: id})

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -98,7 +98,7 @@ instances to achieve high-availability.
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
 	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
-	flag.String("cid", "", "Cid for alphas for cluster management")
+	flag.String("cid", "", "Cluster id for alphas")
 
 	flag.String("raft", raftDefaults, z.NewSuperFlagHelp(raftDefaults).
 		Head("Raft options").

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -98,6 +98,7 @@ instances to achieve high-availability.
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
 	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
+	flag.String("cid", "", "Cid for alphas for cluster management")
 
 	flag.String("raft", raftDefaults, z.NewSuperFlagHelp(raftDefaults).
 		Head("Raft options").

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -98,7 +98,7 @@ instances to achieve high-availability.
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
 	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
-	flag.String("cid", "", "Cluster id for alphas")
+	flag.String("cid", "", "Cluster ID")
 
 	flag.String("raft", raftDefaults, z.NewSuperFlagHelp(raftDefaults).
 		Head("Raft options").

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -55,6 +55,7 @@ type Server struct {
 	Node *node
 	orc  *Oracle
 
+	cid         string
 	NumReplicas int
 	state       *pb.MembershipState
 	nextRaftId  uint64

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -55,7 +55,6 @@ type Server struct {
 	Node *node
 	orc  *Oracle
 
-	cid         string
 	NumReplicas int
 	state       *pb.MembershipState
 	nextRaftId  uint64


### PR DESCRIPTION
cluster ID flag for providing the same via flag -- reason for dgraph/cmd/zero/run.go changes
provided cluster ID should be set to alphas from Zero.Conf -- reason for dgraph/cmd/zero/raft.go changes

(images aren't made if dir linux already exists, adding -p takes care of it -- reason for Makefile changes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7579)
<!-- Reviewable:end -->
