### PR TITLE
Don't start a learner node with no peers

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1759,6 +1759,7 @@ func (n *node) InitAndStartNode() {
 			// zero-member Raft group.
 			n.SetConfState(&sp.Metadata.ConfState)
 
+			// TODO: Making connections here seems unnecessary, evaluate.
 			members := groups().members(n.gid)
 			for _, id := range sp.Metadata.ConfState.Nodes {
 				m, ok := members[id]

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1729,7 +1729,8 @@ func (n *node) InitAndStartNode() {
 	_, restart, err := n.PastLife()
 	x.Check(err)
 
-	if _, hasPeer := groups().MyPeer(); !restart && hasPeer {
+	_, hasPeer := groups().MyPeer()
+	if !restart && hasPeer {
 		// The node has other peers, it might have crashed after joining the cluster and before
 		// writing a snapshot. Check from leader, if it is part of the cluster. Consider this a
 		// restart if it is part of the cluster, else start a new node.
@@ -1740,6 +1741,10 @@ func (n *node) InitAndStartNode() {
 			glog.Errorf("Error while calling hasPeer: %v. Retrying...\n", err)
 			time.Sleep(time.Second)
 		}
+	}
+
+	if n.RaftContext.IsLearner && !hasPeer {
+		glog.Fatal("Cannot start a learner node without peer alpha nodes")
 	}
 
 	if restart {


### PR DESCRIPTION
When a learner node starts and there is no alpha peer then it promotes itself to a normal mode.
This PR makes it crash itself in this case.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7582)
<!-- Reviewable:end -->
