### PR TITLE
[Breaking] fix(GRAPHQL): fix input coercing for integers and make them GraphQL spec complaint.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.0.0-20210309075542-2245c18dfd1f
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2
 	github.com/dgraph-io/gqlgen v0.13.2
-	github.com/dgraph-io/gqlparser/v2 v2.1.8
+	github.com/dgraph-io/gqlparser/v2 v2.1.9
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed
 	github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90
 	github.com/dgraph-io/simdjson-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2/go.mod h1:zCf
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/gqlparser/v2 v2.1.8 h1:d4CprjlDyMNGvnZG/pKqe6Oj6qQd4V0TVsuOIjCKXWQ=
-github.com/dgraph-io/gqlparser/v2 v2.1.8/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
+github.com/dgraph-io/gqlparser/v2 v2.1.9 h1:rLmGvSY3ZAmHZEWHuus6CrXBLF2Ggdkg+Wu7niqAOUA=
+github.com/dgraph-io/gqlparser/v2 v2.1.9/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:pgGMBoTtFhR+xkyzINaToLYRurHn+6pxMYffIGmmEPc=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=

--- a/graphql/e2e/common/error_test.yaml
+++ b/graphql/e2e/common/error_test.yaml
@@ -174,24 +174,24 @@
     } ]
 
 -
-  name: "String value is Incompatible with Int64 type"
+  name: "String value is Incompatible with Int32 type given in variable"
   gqlrequest: |
-    mutation {
-      addPost(input:[{title:"Dgraph",author:{name:"Bob"},numViews:"180143985094"}]){
+    mutation($numLikes:Int) {
+      addPost(input:[{title:"Dgraph",author:{name:"Bob"},numLikes:$numLikes}]){
         post{
           title
-          numLikes
-          author{
-            name
+            numLikes
+            author{
+              name
+            }
           }
         }
       }
-    }
   gqlvariables: |
-    { }
+    { "numLikes": "21474836" }
   errors:
-    [ { "message": "Type mismatched for Value `180143985094`, expected: Int64, got: 'String'",
-        "locations": [ { "line": 2, "column": 64 } ] } ]
+    [ { "message": "cannot use string as Int",
+        "path": [ "variable","numLikes" ] } ]
 
 -
   name: "Float value is Incompatible with Int64 type"

--- a/graphql/schema/validation_rules.go
+++ b/graphql/schema/validation_rules.go
@@ -160,7 +160,7 @@ func intRangeCheck(observers *validator.Events, addError validator.AddErrFunc) {
 				}
 			}
 		case "Int64":
-			if value.Kind == ast.IntValue {
+			if value.Kind == ast.IntValue || value.Kind == ast.StringValue {
 				_, err := strconv.ParseInt(value.Raw, 10, 64)
 				if err != nil {
 					if errors.Is(err, strconv.ErrRange) {


### PR DESCRIPTION
GraphQL spec doesn't allow any value apart from `integer` to be passed to a variable of type `Int`. So we are disallowing strings to be passed as `Int` variables. Int64 is our own scalar data type, so we continue to accept `string` and `Integer` values for it.
This PR allows passing `strings` to `Int64` values when given directly in query/mutations and disallows `string` to be passed to `Int` in variables.

`So we will have below final behavior: `
```
`Int32` will accept only `Integer` values, and otherwise will give a coercion error.
`Int64` will accept `Integer` as well as `String` value and will return an error if any other value. And if we can only pass Integer in a string like "1234" otherwise it will give a coercion error.
```

`Int coercion rules in GraphQL spec:`
https://spec.graphql.org/June2018/#sec-Int

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7584)
<!-- Reviewable:end -->
