### PR TITLE
fix(GRAPHQL): fix error message when dgraph and graphql schema differ.

### DIFF
--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -35,9 +35,8 @@ import (
 
 const (
 	errGraphQLSchemaCommitFailed = "error occurred updating GraphQL schema, please retry"
-	ErrGraphQLSchemaAlterFailed  = "succeeded in saving GraphQL schema but failed to alter Dgraph" +
-		" schema - this indicates a bug in Dgraph schema generation. Please let us know by" +
-		" filing an issue. Don't forget to post your old and new schemas in the issue description."
+	ErrGraphQLSchemaAlterFailed  = "succeeded in saving GraphQL schema but failed to alter Dgraph schema - " +
+		"GraphQL layer may exhibit unexpected behaviour, reapplying the old GraphQL schema may prevent any issues"
 
 	GqlSchemaPred    = "dgraph.graphql.schema"
 	gqlSchemaXidPred = "dgraph.graphql.xid"


### PR DESCRIPTION
we were generating below error message when there is difference in GraphQL and Dgraph schema. It is caused when we are able to change GraphQL schema and there is error from dgraph , and Dgraph schema wasn't changed.

 `
resolving updateGQLSchema failed because succeeded in saving GraphQL schema but failed to alter Dgraph schema - this indicates a bug in Dgraph schema generation. Please let us know by filing an issue. Don't forget to post your old and new schemas in the issue description.: Schema change not allowed from scalar to uid or vice versa while there is data for pred: State.country (Locations: [{Line: 3, Column: 4}])`

We now changed this message to below, which removes the bug part because it's not a bug and also added a comment to  prevent this issue.
`
  "resolving updateGQLSchema failed because succeeded in saving GraphQL schema but failed to alter Dgraph schema - GraphQL layer may exhibit unexpected behaviour, reapplying the old GraphQL schema may prevent any issues: Schema change not allowed from scalar to uid or vice versa while there is data for pred: State.country (Locations: [{Line: 3, Column: 4}])"`

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7587)
<!-- Reviewable:end -->
