### PR TITLE
fix(Flags): remove unused badger.max-retries option from bulk command

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -47,7 +47,7 @@ var Bulk x.SubCommand
 
 var defaultOutDir = "./out"
 
-const BulkBadgerDefaults = worker.BadgerDefaults +
+const BulkBadgerDefaults = "compression=snappy; goroutines=8;" +
 	" cache_mb=64; cache_percentage=70,30;"
 
 func init() {
@@ -142,7 +142,8 @@ func init() {
 }
 
 func run() {
-	badger := z.NewSuperFlag(Bulk.Conf.GetString("badger")).MergeAndCheckDefault(BulkBadgerDefaults)
+	badger := z.NewSuperFlag(Bulk.Conf.GetString("badger")).MergeAndCheckDefault(
+		BulkBadgerDefaults)
 	ctype, clevel := x.ParseCompression(badger.GetString("compression"))
 	opt := options{
 		DataFiles:        Bulk.Conf.GetString("files"),


### PR DESCRIPTION
(#7591)

"max-retries=-1" was showing up in the default string for badger in Bulk --help output, despite not being used / applied in Bulk

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7592)
<!-- Reviewable:end -->
