### PR TITLE
Fix(GraphQL): Add extra checks for deleting UpdateTypeInput

### DIFF
--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -1060,13 +1060,20 @@ func cleanupInput(sch *ast.Schema, def *ast.Definition, seen map[string]bool) {
 	}
 	def.Fields = def.Fields[:i]
 
+	// Delete input type which contains no fields.
+	if len(def.Fields) == 0 {
+		delete(sch.Types, def.Name)
+	}
+
 	// In case of UpdateTypeInput, if TypePatch gets cleaned up then it becomes
 	// input UpdateTypeInput {
 	//		filter: TypeFilter!
 	// }
 	// In this case, UpdateTypeInput should also be deleted.
-	if len(def.Fields) == 0 || (strings.HasPrefix(def.Name, "Update") && len(def.Fields) == 1) {
-		delete(sch.Types, def.Name)
+	if strings.HasPrefix(def.Name, "Update") && len(def.Fields) == 1 {
+		if def.Fields[0].Name == "filter" {
+			delete(sch.Types, def.Name)
+		}
 	}
 }
 

--- a/graphql/schema/testdata/schemagen/input/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/input/custom-mutation.graphql
@@ -3,12 +3,12 @@ type User {
 	name: String!
 }
 
-input UserInput {
+input UpdateFavouriteUserInput {
 	name: String!
 }
 
 type Mutation {
-	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {
+	createMyFavouriteUsers(input: [UpdateFavouriteUserInput!]!): [User] @custom(http: {
 		url: "http://my-api.com",
 		method: "POST",
 		body: "{ data: $input }"

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -7,7 +7,7 @@ type User {
 	name: String!
 }
 
-input UserInput {
+input UpdateFavouriteUserInput {
 	name: String!
 }
 
@@ -362,7 +362,7 @@ type Query {
 #######################
 
 type Mutation {
-	createMyFavouriteUsers(input: [UserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"{ data: $input }"})
+	createMyFavouriteUsers(input: [UpdateFavouriteUserInput!]!): [User] @custom(http: {url:"http://my-api.com",method:"POST",body:"{ data: $input }"})
 	addUser(input: [AddUserInput!]!): AddUserPayload
 	updateUser(input: UpdateUserInput!): UpdateUserPayload
 	deleteUser(filter: UserFilter!): DeleteUserPayload


### PR DESCRIPTION
Motivation:
A user had reported panic on schema update. The reason was that `cleanupInput` function cleared any input types which had name of the form, `UpdateTInput` and contained exactly one field. This PR adds extra conditions to ensure that the input type is removed only when its generated by dgraph and contains a field by name, `filter`.

Testing:
Added unit test in graphql/schema/testdata/schemagen

Fixes GRAPHQL-1102
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7595)
<!-- Reviewable:end -->
