### PR TITLE
feat(flags): Add query timeout as a limit config

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -133,10 +133,10 @@ func parseBool(r *http.Request, name string) (bool, error) {
 
 // parseDuration reads the value for given URL parameter from request and
 // parses it into time.Duration, empty string is converted into zero value
-func parseDuration(r *http.Request, name string, defaultVal time.Duration) (time.Duration, error) {
+func parseDuration(r *http.Request, name string) (time.Duration, error) {
 	value := r.URL.Query().Get(name)
 	if value == "" {
-		return defaultVal, nil
+		return 0, nil
 	}
 
 	durationValue, err := time.ParseDuration(value)
@@ -159,7 +159,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
 		return
 	}
-	queryTimeout, err := parseDuration(r, "timeout", x.Config.QueryTimeout)
+	queryTimeout, err := parseDuration(r, "timeout")
 	if err != nil {
 		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
 		return

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -133,10 +133,10 @@ func parseBool(r *http.Request, name string) (bool, error) {
 
 // parseDuration reads the value for given URL parameter from request and
 // parses it into time.Duration, empty string is converted into zero value
-func parseDuration(r *http.Request, name string) (time.Duration, error) {
+func parseDuration(r *http.Request, name string, defaultVal time.Duration) (time.Duration, error) {
 	value := r.URL.Query().Get(name)
 	if value == "" {
-		return 0, nil
+		return defaultVal, nil
 	}
 
 	durationValue, err := time.ParseDuration(value)
@@ -159,7 +159,7 @@ func queryHandler(w http.ResponseWriter, r *http.Request) {
 		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
 		return
 	}
-	queryTimeout, err := parseDuration(r, "timeout")
+	queryTimeout, err := parseDuration(r, "timeout", x.Config.QueryTimeout)
 	if err != nil {
 		x.SetStatus(w, x.ErrorInvalidRequest, err.Error())
 		return

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -204,6 +204,9 @@ they form a Raft group and provide synchronous replication.
 		Flag("disallow-drop",
 			"Set disallow-drop to true to block drop-all and drop-data operation. It still"+
 				" allows dropping attributes and types.").
+		Flag("query-timeout",
+			"Maximum time after which a query execution will fail. If set to"+
+				" 0, the timeout is infinite.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
@@ -731,6 +734,7 @@ func run() {
 	x.Config.LimitMutationsNquad = int(x.Config.Limit.GetInt64("mutations-nquad"))
 	x.Config.LimitQueryEdge = x.Config.Limit.GetUint64("query-edge")
 	x.Config.BlockClusterWideDrop = x.Config.Limit.GetBool("disallow-drop")
+	x.Config.QueryTimeout = x.Config.Limit.GetDuration("query-timeout")
 
 	x.Config.GraphQL = z.NewSuperFlag(Alpha.Conf.GetString("graphql")).MergeAndCheckDefault(
 		worker.GraphQLDefaults)

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -47,7 +47,7 @@ const (
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
-		`mutations-nquad=1000000; disallow-drop=false;`
+		`mutations-nquad=1000000; disallow-drop=false; query-timeout=500ms;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 )

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -47,7 +47,7 @@ const (
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
-		`mutations-nquad=1000000; disallow-drop=false; query-timeout=500ms;`
+		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 )

--- a/x/config.go
+++ b/x/config.go
@@ -36,10 +36,12 @@ type Options struct {
 	//                      normalize directive
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
 	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
-	Limit               *z.SuperFlag
-	LimitMutationsNquad int
-	LimitQueryEdge      uint64
-	BlockClusterWideDrop        bool
+	// query-timeout duration - Maximum time after which a query execution will fail.
+	Limit                *z.SuperFlag
+	LimitMutationsNquad  int
+	LimitQueryEdge       uint64
+	BlockClusterWideDrop bool
+	QueryTimeout         time.Duration
 
 	// GraphQL options:
 	//


### PR DESCRIPTION
In the case of a multi-tenant environment, long-running queries by tenants can consume all the resources, starving the request from other tenants. The change adds query-timeout as a config which will be applied to all the query requests sent without timeout param.

Fixes DGRAPH-3184

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7599)
<!-- Reviewable:end -->
