### PR TITLE
fix(flags): use GetString for vault path

### DIFF
--- a/ee/vault/vault_ee.go
+++ b/ee/vault/vault_ee.go
@@ -194,7 +194,7 @@ func parseFlags(flag *z.SuperFlag) (*config, error) {
 	if err := validateRequired(flagSecretIdFile, secretIdFile); err != nil {
 		return nil, err
 	}
-	path := flag.GetPath(flagPath)
+	path := flag.GetString(flagPath)
 	if err := validateRequired(flagPath, path); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
A recent commit erroneously changed Vault's `flagPath` from `GetString` to `GetPath`. This PR changes it back - Vault paths != UNIX paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7605)
<!-- Reviewable:end -->
