### PR TITLE
Fix(rollups): Fix splits in roll-up

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -966,8 +966,11 @@ func (l *List) ToBackupPostingList(bl *pb.BackupPostingList, alloc *z.Allocator)
 
 	ol := out.plist
 	bm := roaring64.New()
-	if err := bm.UnmarshalBinary(ol.Bitmap); err != nil {
-		return nil, errors.Wrapf(err, "failed when unmarshal binary bitmap")
+
+	if ol.Bitmap != nil {
+		if err := bm.UnmarshalBinary(ol.Bitmap); err != nil {
+			return nil, errors.Wrapf(err, "failed when unmarshal binary bitmap")
+		}
 	}
 
 	// Encode uids to []byte instead of []uint64 if we have more than 1000
@@ -1189,6 +1192,8 @@ func (l *List) encode(out *rollupOutput, readTs uint64, split bool) error {
 
 		out.parts[startUid] = plist
 	}
+
+	out.plist.Bitmap = codec.ToBytes(bm)
 
 	// Now pick up all the postings.
 	startUid, endUid := out.getRange(1)


### PR DESCRIPTION
There was an issue with split creation in roll-up. When a part `p` is split 
into two parts say `p1` and `p2` then the first UID of `p2` should be greater
than the last UID of p1. This was being violated because of removing UIDs 
until `maxInt64` instead of `maxUint64` from `p` in order to create `p1`. 

This PR fixes this issue and also removes some unwanted codes. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7609)
<!-- Reviewable:end -->
