### PR TITLE
fix(GRAPHQL): Add error handling for unrecognized args to generate directive.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.0.0-20210309075542-2245c18dfd1f
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2
 	github.com/dgraph-io/gqlgen v0.13.2
-	github.com/dgraph-io/gqlparser/v2 v2.1.9
+	github.com/dgraph-io/gqlparser/v2 v2.2.0
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed
 	github.com/dgraph-io/ristretto v0.0.4-0.20210310100713-a4346e5d1f90
 	github.com/dgraph-io/simdjson-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2/go.mod h1:zCf
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/gqlparser/v2 v2.1.9 h1:rLmGvSY3ZAmHZEWHuus6CrXBLF2Ggdkg+Wu7niqAOUA=
-github.com/dgraph-io/gqlparser/v2 v2.1.9/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
+github.com/dgraph-io/gqlparser/v2 v2.2.0 h1:fKSCW8OxoMogjDwUhO9OrFvrgIA0UZspTDbcm0QGk9M=
+github.com/dgraph-io/gqlparser/v2 v2.2.0/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:pgGMBoTtFhR+xkyzINaToLYRurHn+6pxMYffIGmmEPc=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.0.4-0.20210309073149-3836124cdc5a/go.mod h1:MIonLggsKgZLUSt414ExgwNtlOL5MuEoAJP514mwGe8=

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -2296,7 +2296,6 @@ func copyTypeMap(from, to map[string]schema.Type) {
 }
 
 func extractVal(xidVal interface{}, xidName, typeName string) (string, error) {
-	fmt.Println(typeName)
 	switch typeName {
 	case "Int":
 		switch xVal := xidVal.(type) {

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -999,12 +999,11 @@ invalid_schemas:
       }
 
       type Query {
-        getAuthor1(id: ID): Author! @custom(http: {url: "blah.com", method: "GET"}, extra: "random")
+        getAuthor1(id: ID): Author! @custom(http: {url: "blah.com", method: "GET"}, dql: "random")
       }
     errlist: [
     {"message": "Type Query; Field getAuthor1: has 2 arguments for @custom directive, it should contain exactly one of `http` or `dql` arguments.",
      "locations":[{"line":7, "column":32}]},
-    {"message" : "Type Query; Field getAuthor1; url field inside @custom directive is invalid.", "locations" : [{"line":7, "column":52}]}
     ]
 
   - name: "@custom directive without http or dql argument"
@@ -1018,7 +1017,7 @@ invalid_schemas:
         getAuthor1(id: ID): Author! @custom(https: {url: "blah.com", method: "GET"})
       }
     errlist: [
-      {"message": "Type Query; Field getAuthor1: one of `http` or `dql` arguments must be present for @custom directive.",
+      {"message": "https is not supported as an argument for custom directive.",
       "locations":[{"line":7, "column":32}]},
     ]
 

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2864,14 +2864,13 @@ invalid_schemas:
 
   - name: "@lambdaOnMutate with bad arg values"
     input: |
-      type TwitterUser @lambdaOnMutate(add: true, update: badValue, delete: "false", badArg: true) {
+      type TwitterUser @lambdaOnMutate(add: true, update: badValue, delete: "false") {
         id: ID!
         name: String
       }
     errlist: [
       { "message": "Type TwitterUser; update argument in @lambdaOnMutate directive can only be true/false, found: `badValue`.", "locations": [{"line": 1, "column": 45}]},
       { "message": "Type TwitterUser; delete argument in @lambdaOnMutate directive can only be true/false, found: `\"false\"`.", "locations": [{"line": 1, "column": 63}]},
-      { "message": "Type TwitterUser; @lambdaOnMutate directive doesn't support argument named: `badArg`.", "locations": [{"line": 1, "column": 80}]}
     ]
 
   - name: "@lambdaOnMutate isn't allowed on @remote types"

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1270,19 +1270,6 @@ func lambdaOnMutateValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.Lis
 	}
 
 	for _, arg := range dir.Arguments {
-		switch arg.Name {
-		case "add":
-		case "update":
-		case "delete":
-			// do nothing
-		default:
-			errs = append(errs, gqlerror.ErrorPosf(
-				arg.Position,
-				"Type %s; @lambdaOnMutate directive doesn't support argument named: `%s`.",
-				typ.Name, arg.Name))
-			continue // to next arg
-		}
-
 		// validate add/update/delete args
 		if arg.Value.Kind != ast.BooleanValue {
 			errs = append(errs, gqlerror.ErrorPosf(


### PR DESCRIPTION
DGRAPH PR Message:



### Motivation

1. Added error handling in gqlparser (https://github.com/dgraph-io/gqlparser/pull/16) and bumped the version of gqlparser used in dgraph. 
2. Removed stray printing of typeName which was polluting the logs

This PR fixes: GRAPHQL 1076, 1122


### Components affected by this PR <!-- (Optional) -->
GQL Parser






### Does this PR break backwards compatibility?

No


Fixes 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7612)
<!-- Reviewable:end -->
