### PR TITLE
fix(ludicrous_mode): fixing type inversion in ludicrous mode

### DIFF
--- a/worker/executor.go
+++ b/worker/executor.go
@@ -70,16 +70,25 @@ func newExecutor(applied *y.WaterMark, conc int) *executor {
 func generateTokenKeys(nq *pb.DirectedEdge, tokenizers []tok.Tokenizer) ([]uint64, error) {
 	keys := make([]uint64, 0, len(tokenizers))
 	errs := make([]string, 0)
-	for _, token := range tokenizers {
-		storageVal := types.Val{
-			Tid:   types.TypeID(nq.GetValueType()),
-			Value: nq.GetValue(),
-		}
+	if len(tokenizers) == 0 {
+		return keys, nil
+	}
 
-		schemaVal, err := types.Convert(storageVal, types.TypeID(nq.GetValueType()))
-		if err != nil {
-			errs = append(errs, err.Error())
-		}
+	storageVal := types.Val{
+		Tid:   types.TypeID(nq.GetValueType()),
+		Value: nq.GetValue(),
+	}
+	stt, ok := schema.State().Get(context.Background(), nq.Attr)
+	if !ok { // predicate definition is not available
+		return keys, nil
+	}
+	schemaVal, err := types.Convert(storageVal, types.TypeID(stt.GetValueType()))
+	// In case value cannot be type casted into correct format, no need
+	// to generate tokens as they will be either invalid or fail.
+	if err != nil {
+		return keys, err
+	}
+	for _, token := range tokenizers {
 		toks, err := tok.BuildTokens(schemaVal.Value, tok.GetTokenizerForLang(token,
 			nq.Lang))
 		if err != nil {
@@ -109,11 +118,11 @@ func generateConflictKeys(ctx context.Context, p *subMutation) map[uint64]struct
 		}
 
 		keys[posting.GetConflictKey(pk, key, edge)] = struct{}{}
-		stt, _ := schema.State().Get(ctx, edge.Attr)
+		hasCount := schema.State().HasCount(ctx, edge.Attr)
 		tokenizers := schema.State().Tokenizer(ctx, edge.Attr)
 		isReverse := schema.State().IsReversed(ctx, edge.Attr)
 
-		if stt.Count || isReverse {
+		if hasCount || isReverse {
 			keys[0] = struct{}{}
 		}
 


### PR DESCRIPTION
This PR aims to solve the crashes we have seen in ludicrous mode due to type inversion error. One such crash is 
```
I0315 18:37:10.987252      18 log.go:34] 2 [logterm: 45, index: 1734160, vote: 2] rejected MsgPreVote from 1 [logterm: 44, index: 1734158] at term 45
panic: interface conversion: interface {} is string, not time.Time
goroutine 3766 [running]:
github.com/dgraph-io/dgraph/tok.DayTokenizer.Tokens(0x1b661e0, 0xc01646c470, 0x1e, 0x1e, 0xdb1ac1f11fa1c8e2, 0x7f1300000000, 0x1b661e0)
	/ext-go/1/src/github.com/dgraph-io/dgraph/tok/tok.go:249 +0x2f8
github.com/dgraph-io/dgraph/tok.BuildTokens(0x1b661e0, 0xc01646c470, 0x1fb6c20, 0x2e2ff78, 0x1fb6c20, 0x2e2ff78, 0xc01646c470, 0x0, 0x0)
	/ext-go/1/src/github.com/dgraph-io/dgraph/tok/tok.go:108 +0x63
github.com/dgraph-io/dgraph/worker.generateTokenKeys(0xc00e546c00, 0xc01646c450, 0x1, 0x1, 0x12, 0xc01646c400, 0x1, 0x1, 0xc00ebf6e00)
	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/executor.go:83 +0x237
github.com/dgraph-io/dgraph/worker.generateConflictKeys(0x1faf2e0, 0xc000046070, 0xc0a093a300, 0x0)
	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/executor.go:120 +0x47d
github.com/dgraph-io/dgraph/worker.(*executor).processMutationCh(0xc00e3bf220, 0x1faf2e0, 0xc000046070, 0xc02ae403c0)
	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/executor.go:220 +0x46d
created by github.com/dgraph-io/dgraph/worker.(*executor).getChannel
	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/executor.go:279 +0x130
[Sentry] 2021/03/15 18:37:12 Sending fatal event [215c647f319d41d2aa93a0e0d4d01b84] to o318308.ingest.sentry.io project: 5208688
[Sentry] 2021/03/15 18:37:13 Buffer flushed successfully.
```
The catch here is that, if there is no way to type cast values, do create tokens, skip it. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7614)
<!-- Reviewable:end -->
