### PR TITLE
cherry-pick v21.03: feat(GraphQL): Webhooks on add/update/delete mutations (GRAPHQL-1045)…

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -579,7 +579,7 @@ func extractUserAndGroups(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return validateToken(accessJwt[0])
+	return validateToken(accessJwt)
 }
 
 type authPredResult struct {

--- a/edgraph/graphql.go
+++ b/edgraph/graphql.go
@@ -54,7 +54,7 @@ func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 		if err != nil {
 			return err
 		}
-		if _, err := validateToken(accessJwt[0]); err != nil {
+		if _, err := validateToken(accessJwt); err != nil {
 			return err
 		}
 	}

--- a/graphql/admin/add_group.go
+++ b/graphql/admin/add_group.go
@@ -60,6 +60,13 @@ func (mrw *addGroupRewriter) FromMutationResult(
 	return ((*resolve.AddRewriter)(mrw)).FromMutationResult(ctx, mutation, assigned, result)
 }
 
+func (mrw *addGroupRewriter) MutatedRootUIDs(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	result map[string]interface{}) []string {
+	return ((*resolve.AddRewriter)(mrw)).MutatedRootUIDs(mutation, assigned, result)
+}
+
 // removeDuplicateRuleRef removes duplicate rules based on predicate value.
 // for duplicate rules, only the last rule with duplicate predicate name is preserved.
 func removeDuplicateRuleRef(rules []interface{}) ([]interface{}, x.GqlErrorList) {

--- a/graphql/admin/current_user.go
+++ b/graphql/admin/current_user.go
@@ -35,7 +35,7 @@ func extractName(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return x.ExtractUserName(accessJwt[0])
+	return x.ExtractUserName(accessJwt)
 }
 
 func (gsr *currentUserResolver) Rewrite(ctx context.Context,

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -55,7 +55,8 @@ func (usr *updateSchemaResolver) Resolve(ctx context.Context, m schema.Mutation)
 		return resolve.EmptyResult(m, err), false
 	}
 
-	if _, err = schema.FromString(schHandler.GQLSchema()); err != nil {
+	// we don't need the correct namespace for validation, so passing the Galaxy namespace
+	if _, err = schema.FromString(schHandler.GQLSchema(), x.GalaxyNamespace); err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
 

--- a/graphql/admin/update_group.go
+++ b/graphql/admin/update_group.go
@@ -155,6 +155,13 @@ func (urw *updateGroupRewriter) FromMutationResult(
 	return ((*resolve.UpdateRewriter)(urw)).FromMutationResult(ctx, mutation, assigned, result)
 }
 
+func (urw *updateGroupRewriter) MutatedRootUIDs(
+	mutation schema.Mutation,
+	assigned map[string]string,
+	result map[string]interface{}) []string {
+	return ((*resolve.UpdateRewriter)(urw)).MutatedRootUIDs(mutation, assigned, result)
+}
+
 // addAclRuleQuery adds a *gql.GraphQuery to upsertQuery.Children to query a rule inside a group
 // based on its predicate value.
 func addAclRuleQuery(upsertQuery []*gql.GraphQuery, predicate, variable string) {

--- a/graphql/dgraph/execute.go
+++ b/graphql/dgraph/execute.go
@@ -64,7 +64,7 @@ func (dg *DgraphEx) Execute(ctx context.Context, req *dgoapi.Request,
 }
 
 // CommitOrAbort is the underlying dgraph implementation for committing a Dgraph transaction
-func (dg *DgraphEx) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
-	_, err := (&edgraph.Server{}).CommitOrAbort(ctx, tc)
-	return err
+func (dg *DgraphEx) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
+	return (&edgraph.Server{}).CommitOrAbort(ctx, tc)
 }

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -51,6 +51,9 @@ var (
 	dgraphHealthURL = "http://" + Alpha1HTTP + "/health?all"
 	dgraphStateURL  = "http://" + Alpha1HTTP + "/state"
 
+	// this port is used on the host machine to spin up a test HTTP server
+	lambdaHookServerAddr = ":8888"
+
 	retryableUpdateGQLSchemaErrors = []string{
 		"errIndexingInProgress",
 		"is already running",
@@ -797,8 +800,8 @@ func RunAll(t *testing.T) {
 	t.Run("query only typename", queryOnlyTypename)
 	t.Run("query nested only typename", querynestedOnlyTypename)
 	t.Run("test onlytypename for interface types", onlytypenameForInterface)
-	t.Run("entitites Query on extended type with key field of type String", entitiesQueryWithKeyFieldOfTypeString)
-	t.Run("entitites Query on extended type with key field of type Int", entitiesQueryWithKeyFieldOfTypeInt)
+	t.Run("entities Query on extended type with key field of type String", entitiesQueryWithKeyFieldOfTypeString)
+	t.Run("entities Query on extended type with key field of type Int", entitiesQueryWithKeyFieldOfTypeInt)
 
 	t.Run("get state by xid", getStateByXid)
 	t.Run("get state without args", getStateWithoutArgs)
@@ -913,6 +916,7 @@ func RunAll(t *testing.T) {
 	t.Run("lambda on mutation using graphql", lambdaOnMutationUsingGraphQL)
 	t.Run("query lambda field in a mutation with duplicate @id", lambdaInMutationWithDuplicateId)
 	t.Run("lambda with apollo federation", lambdaWithApolloFederation)
+	t.Run("lambdaOnMutate hooks", lambdaOnMutateHooks)
 }
 
 func gunzipData(data []byte) ([]byte, error) {

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -319,8 +319,9 @@ func (dg *panicClient) Execute(ctx context.Context, req *dgoapi.Request,
 	return nil, nil
 }
 
-func (dg *panicClient) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
-	return nil
+func (dg *panicClient) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
+	return &dgoapi.TxnContext{}, nil
 }
 
 // clientInfoLogin check whether the client info(IP address) is propagated in the request.

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -335,7 +335,8 @@ type Region {
     district: District
 }
 
-type District {
+type District @lambdaOnMutate(add: true, update: true, delete: true) {
+    dgId: ID!
     id: String! @id
     name: String!
 }

--- a/graphql/e2e/directives/script.js
+++ b/graphql/e2e/directives/script.js
@@ -53,3 +53,19 @@ async function rank({parents}) {
 self.addMultiParentGraphQLResolvers({
     "Author.rank": rank
 })
+
+async function districtWebhook({ dql, graphql, authHeader, event }) {
+    // forward the event to the changelog server running on the host machine
+    await fetch(`http://172.17.0.1:8888/changelog`, {
+        method: "POST",
+        body: JSON.stringify(event)
+    })
+    // just return, nothing else to do with response
+}
+
+self.addWebHookResolvers({
+    "District.add": districtWebhook,
+    "District.update": districtWebhook,
+    "District.delete": districtWebhook,
+})
+

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -354,7 +354,8 @@ type Region {
         district: District
 }
 
-type District {
+type District @lambdaOnMutate(add: true, update: true, delete: true) {
+        dgId: ID!
         id: String! @id
         name: String!
 }

--- a/graphql/e2e/normal/script.js
+++ b/graphql/e2e/normal/script.js
@@ -53,3 +53,23 @@ async function rank({parents}) {
 self.addMultiParentGraphQLResolvers({
     "Author.rank": rank
 })
+
+// TODO(GRAPHQL-1123): need to find a way to make it work on TeamCity machines.
+// The host `172.17.0.1` used to connect to host machine from within docker, doesn't seem to
+// work in teamcity machines, neither does `host.docker.internal` works there. So, we are
+// skipping the related test for now.
+async function districtWebhook({ dql, graphql, authHeader, event }) {
+    // forward the event to the changelog server running on the host machine
+    await fetch(`http://172.17.0.1:8888/changelog`, {
+        method: "POST",
+        body: JSON.stringify(event)
+    })
+    // just return, nothing else to do with response
+}
+
+self.addWebHookResolvers({
+    "District.add": districtWebhook,
+    "District.update": districtWebhook,
+    "District.delete": districtWebhook,
+})
+

--- a/graphql/e2e/schema/apollo_service_response.graphql
+++ b/graphql/e2e/schema/apollo_service_response.graphql
@@ -204,6 +204,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/e2e/schema/generatedSchema.graphql
+++ b/graphql/e2e/schema/generatedSchema.graphql
@@ -193,6 +193,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -165,8 +165,9 @@ func (ex *authExecutor) Execute(ctx context.Context, req *dgoapi.Request,
 	panic("test failed")
 }
 
-func (ex *authExecutor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
-	return nil
+func (ex *authExecutor) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
+	return &dgoapi.TxnContext{}, nil
 }
 
 func TestStringCustomClaim(t *testing.T) {

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -178,7 +178,8 @@ func (aex *adminExecutor) Execute(ctx context.Context, req *dgoapi.Request, fiel
 	return aex.dg.Execute(ctx, req, field)
 }
 
-func (aex *adminExecutor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
+func (aex *adminExecutor) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
 	return aex.dg.CommitOrAbort(ctx, tc)
 }
 
@@ -187,7 +188,8 @@ func (de *dgraphExecutor) Execute(ctx context.Context, req *dgoapi.Request, fiel
 	return de.dg.Execute(ctx, req, field)
 }
 
-func (de *dgraphExecutor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
+func (de *dgraphExecutor) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
 	return de.dg.CommitOrAbort(ctx, tc)
 }
 

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -131,8 +131,9 @@ func (ex *executor) Execute(ctx context.Context, req *dgoapi.Request,
 
 }
 
-func (ex *executor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) error {
-	return nil
+func (ex *executor) CommitOrAbort(ctx context.Context,
+	tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
+	return &dgoapi.TxnContext{}, nil
 }
 
 func complete(t *testing.T, gqlSchema schema.Schema, gqlQuery, dgResponse string) *schema.Response {

--- a/graphql/resolve/webhook.go
+++ b/graphql/resolve/webhook.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resolve
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/graphql/authorization"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+type webhookPayload struct {
+	Resolver   string             `json:"resolver"`
+	AccessJWT  string             `json:"X-Dgraph-AccessToken,omitempty"`
+	AuthHeader *authHeaderPayload `json:"authHeader,omitempty"`
+	Event      eventPayload       `json:"event"`
+}
+
+type authHeaderPayload struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type eventPayload struct {
+	Typename  string              `json:"__typename"`
+	Operation schema.MutationType `json:"operation"`
+	CommitTs  uint64              `json:"commitTs"`
+	Add       *addEvent           `json:"add,omitempty"`
+	Update    *updateEvent        `json:"update,omitempty"`
+	Delete    *deleteEvent        `json:"delete,omitempty"`
+}
+
+type addEvent struct {
+	RootUIDs []string      `json:"rootUIDs"`
+	Input    []interface{} `json:"input"`
+}
+
+type updateEvent struct {
+	RootUIDs    []string    `json:"rootUIDs"`
+	SetPatch    interface{} `json:"setPatch"`
+	RemovePatch interface{} `json:"removePatch"`
+}
+
+type deleteEvent struct {
+	RootUIDs []string `json:"rootUIDs"`
+}
+
+// sendWebhookEvent forms an HTTP payload required for the webhooks configured with @lambdaOnMutate
+// directive, and then sends that payload to the lambda URL configured with Alpha. There is no
+// guarantee that the payload will be delivered successfully to the lambda server.
+func sendWebhookEvent(ctx context.Context, m schema.Mutation, commitTs uint64, rootUIDs []string) {
+	accessJWT, _ := x.ExtractJwt(ctx)
+	var authHeader *authHeaderPayload
+	if m.GetAuthMeta() != nil {
+		authHeader = &authHeaderPayload{
+			Key:   m.GetAuthMeta().GetHeader(),
+			Value: authorization.GetJwtToken(ctx),
+		}
+	}
+
+	payload := webhookPayload{
+		Resolver:   "$webhook",
+		AccessJWT:  accessJWT,
+		AuthHeader: authHeader,
+		Event: eventPayload{
+			Typename:  m.MutatedType().Name(),
+			Operation: m.MutationType(),
+			CommitTs:  commitTs,
+		},
+	}
+
+	switch payload.Event.Operation {
+	case schema.AddMutation:
+		input, _ := m.ArgValue(schema.InputArgName).([]interface{})
+		payload.Event.Add = &addEvent{
+			RootUIDs: rootUIDs,
+			Input:    input,
+		}
+	case schema.UpdateMutation:
+		inp, _ := m.ArgValue(schema.InputArgName).(map[string]interface{})
+		payload.Event.Update = &updateEvent{
+			RootUIDs:    rootUIDs,
+			SetPatch:    inp["set"],
+			RemovePatch: inp["remove"],
+		}
+	case schema.DeleteMutation:
+		payload.Event.Delete = &deleteEvent{RootUIDs: rootUIDs}
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		glog.Error(errors.Wrap(err, "error marshalling webhook payload"))
+		// don't care to send the payload if there are JSON marshalling errors
+		return
+	}
+
+	// send the request
+	ns, _ := x.ExtractNamespace(ctx)
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	resp, err := schema.MakeHttpRequest(nil, http.MethodPost, x.LambdaUrl(ns), headers, b)
+
+	// just log the response errors, if any.
+	if err != nil {
+		glog.V(3).Info(errors.Wrap(err, "unable to send webhook event"))
+	}
+	if resp != nil && (resp.StatusCode < 200 || resp.StatusCode >= 300) {
+		glog.V(3).Info(errors.Errorf("got unsuccessful status from webhook: %s", resp.Status))
+	}
+}

--- a/graphql/schema/dgraph_schemagen_test.yml
+++ b/graphql/schema/dgraph_schemagen_test.yml
@@ -841,3 +841,15 @@ schemas:
       User.username: string .
       User.reviews: [uid] .
 
+  - name: "nothing is added in dgraph schema with lambdaOnMutate"
+    input: |
+      type T @lambdaOnMutate(add: true, update: true, delete: true) {
+        id : ID!
+        value: String
+      }
+    output: |
+      type T {
+        T.value
+      }
+      T.value: string .
+

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -46,6 +46,7 @@ const (
 	remoteDirective         = "remote" // types with this directive are not stored in Dgraph.
 	remoteResponseDirective = "remoteResponse"
 	lambdaDirective         = "lambda"
+	lambdaOnMutateDirective = "lambdaOnMutate"
 
 	generateDirective       = "generate"
 	generateQueryArg        = "query"
@@ -289,6 +290,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,
@@ -311,6 +313,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 `
 	filterInputs = `
 input IntFilter {
@@ -566,6 +569,7 @@ var directiveValidators = map[string]directiveValidator{
 	remoteDirective:         ValidatorNoOp,
 	deprecatedDirective:     ValidatorNoOp,
 	lambdaDirective:         lambdaDirectiveValidation,
+	lambdaOnMutateDirective: ValidatorNoOp,
 	generateDirective:       ValidatorNoOp,
 	apolloKeyDirective:      ValidatorNoOp,
 	apolloExtendsDirective:  ValidatorNoOp,
@@ -588,10 +592,16 @@ var directiveLocationMap = map[string]map[ast.DefinitionKind]bool{
 	customDirective:       nil,
 	remoteDirective: {ast.Object: true, ast.Interface: true, ast.Union: true,
 		ast.InputObject: true, ast.Enum: true},
-	cascadeDirective:        nil,
+	lambdaDirective:         nil,
+	lambdaOnMutateDirective: {ast.Object: true, ast.Interface: true},
 	generateDirective:       {ast.Object: true, ast.Interface: true},
+	apolloKeyDirective:      {ast.Object: true, ast.Interface: true},
+	apolloExtendsDirective:  {ast.Object: true, ast.Interface: true},
+	apolloExternalDirective: nil,
 	apolloRequiresDirective: nil,
 	apolloProvidesDirective: nil,
+	remoteResponseDirective: nil,
+	cascadeDirective:        nil,
 }
 
 // Struct to store parameters of @generate directive

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -2863,6 +2863,34 @@ invalid_schemas:
       { "message": "Type TwitterUser: Field name: @remoteResponse directive can only be defined on fields of @remote type.", "locations": [{"line": 3, "column": 17}]}
     ]
 
+  - name: "@lambdaOnMutate with bad arg values"
+    input: |
+      type TwitterUser @lambdaOnMutate(add: true, update: badValue, delete: "false", badArg: true) {
+        id: ID!
+        name: String
+      }
+    errlist: [
+      { "message": "Type TwitterUser; update argument in @lambdaOnMutate directive can only be true/false, found: `badValue`.", "locations": [{"line": 1, "column": 45}]},
+      { "message": "Type TwitterUser; delete argument in @lambdaOnMutate directive can only be true/false, found: `\"false\"`.", "locations": [{"line": 1, "column": 63}]},
+      { "message": "Type TwitterUser; @lambdaOnMutate directive doesn't support argument named: `badArg`.", "locations": [{"line": 1, "column": 80}]}
+    ]
+
+  - name: "@lambdaOnMutate isn't allowed on @remote types"
+    input: |
+      type TwitterUser @remote @lambdaOnMutate(add: true) {
+        id: ID!
+        name: String
+      }
+      type Query{
+        getCustomTwitterUser(name: String!): TwitterUser @custom(http:{
+            url: "https://api.twitter.com/1.1/users/show.json?screen_name=$name"
+            method: "GET"
+        })
+      }
+    errlist: [
+      { "message": "Type TwitterUser; @lambdaOnMutate directive not allowed along with @remote directive.", "locations": [{"line": 1, "column": 27}]}
+    ]
+
 valid_schemas:
   - name: "Multiple fields with @id directive should be allowed"
     input: |
@@ -3325,5 +3353,19 @@ valid_schemas:
         inStock: Boolean
         shippingEstimate: Int @requires(fields: "price weight") @lambda
         reviews: [Review]
+      }
+
+
+
+  - name: "@lambdaOnMutate is allowed on types and interfaces"
+    input: |
+      interface Post @lambdaOnMutate(add: true, delete: false) {
+        id: ID!
+        title: String
+      }
+
+      type Question implements Post @lambdaOnMutate(add: true, update: true) {
+        id: ID!
+        questionText: String
       }
 

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -51,7 +51,7 @@ type handler struct {
 
 // FromString builds a GraphQL Schema from input string, or returns any parsing
 // or validation errors.
-func FromString(schema string) (Schema, error) {
+func FromString(schema string, ns uint64) (Schema, error) {
 	// validator.Prelude includes a bunch of predefined types which help with schema introspection
 	// queries, hence we include it as part of the schema.
 	doc, gqlErr := parser.ParseSchemas(validator.Prelude, &ast.Source{Input: schema})
@@ -64,7 +64,7 @@ func FromString(schema string) (Schema, error) {
 		return nil, errors.Wrap(gqlErr, "while validating GraphQL schema")
 	}
 
-	return AsSchema(gqlSchema)
+	return AsSchema(gqlSchema, ns)
 }
 
 func (s *handler) MetaInfo() *metaInfo {
@@ -187,7 +187,8 @@ type metaInfo struct {
 	// allowedCorsOrigins stores allowed CORS origins extracted from # Dgraph.Allow-Origin.
 	// They are returned to the client as part of Access-Control-Allow-Origin.
 	allowedCorsOrigins map[string]bool
-	// authMeta stores the authorization meta info extracted from # Dgraph.Authorization
+	// authMeta stores the authorization meta info extracted from `# Dgraph.Authorization` if any,
+	// otherwise it is nil.
 	authMeta *authorization.AuthMeta
 }
 

--- a/graphql/schema/schemagen_test.go
+++ b/graphql/schema/schemagen_test.go
@@ -90,7 +90,7 @@ func TestSchemaString(t *testing.T) {
 
 			newSchemaStr := schHandler.GQLSchema()
 
-			_, err = FromString(newSchemaStr)
+			_, err = FromString(newSchemaStr, x.GalaxyNamespace)
 			require.NoError(t, err)
 			outputFileName := outputDir + testFile.Name()
 			str2, err := ioutil.ReadFile(outputFileName)
@@ -121,7 +121,7 @@ func TestApolloServiceQueryResult(t *testing.T) {
 
 			apolloServiceResult := schHandler.GQLSchemaWithoutApolloExtras()
 
-			_, err = FromString(schHandler.GQLSchema())
+			_, err = FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 			require.NoError(t, err)
 			outputFileName := outputDir + testFile.Name()
 			str2, err := ioutil.ReadFile(outputFileName)
@@ -150,7 +150,7 @@ func TestSchemas(t *testing.T) {
 
 				newSchemaStr := schHandler.GQLSchema()
 
-				_, err = FromString(newSchemaStr)
+				_, err = FromString(newSchemaStr, x.GalaxyNamespace)
 				require.NoError(t, err)
 			})
 		}
@@ -159,7 +159,10 @@ func TestSchemas(t *testing.T) {
 	t.Run("Invalid Schemas", func(t *testing.T) {
 		for _, sch := range tests["invalid_schemas"] {
 			t.Run(sch.Name, func(t *testing.T) {
-				_, errlist := NewHandler(sch.Input, false)
+				schHandler, errlist := NewHandler(sch.Input, false)
+				if errlist == nil {
+					_, errlist = FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
+				}
 				if diff := cmp.Diff(sch.Errlist, errlist, cmpopts.IgnoreUnexported(gqlerror.Error{})); diff != "" {
 					t.Errorf("error mismatch (-want +got):\n%s", diff)
 				}
@@ -188,7 +191,7 @@ func TestAuthSchemas(t *testing.T) {
 				schHandler, errlist := NewHandler(sch.Input, false)
 				require.NoError(t, errlist, sch.Name)
 
-				_, authError := FromString(schHandler.GQLSchema())
+				_, authError := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 				require.NoError(t, authError, sch.Name)
 			})
 		}
@@ -200,7 +203,7 @@ func TestAuthSchemas(t *testing.T) {
 				schHandler, errlist := NewHandler(sch.Input, false)
 				require.NoError(t, errlist, sch.Name)
 
-				_, authError := FromString(schHandler.GQLSchema())
+				_, authError := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 
 				if diff := cmp.Diff(authError, sch.Errlist); diff != "" {
 					t.Errorf("error mismatch (-want +got):\n%s", diff)

--- a/graphql/schema/testdata/apolloservice/output/auth-directive.graphql
+++ b/graphql/schema/testdata/apolloservice/output/auth-directive.graphql
@@ -198,6 +198,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/apolloservice/output/custom-directive.graphql
+++ b/graphql/schema/testdata/apolloservice/output/custom-directive.graphql
@@ -190,6 +190,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/apolloservice/output/extended-types.graphql
+++ b/graphql/schema/testdata/apolloservice/output/extended-types.graphql
@@ -204,6 +204,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/apolloservice/output/generate-directive.graphql
+++ b/graphql/schema/testdata/apolloservice/output/generate-directive.graphql
@@ -200,6 +200,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/apolloservice/output/single-extended-type.graphql
+++ b/graphql/schema/testdata/apolloservice/output/single-extended-type.graphql
@@ -185,6 +185,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 
 input IntFilter {
 	eq: Int

--- a/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
+++ b/graphql/schema/testdata/schemagen/output/apollo-federation.graphql
@@ -228,6 +228,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/auth-on-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/auth-on-interfaces.graphql
@@ -210,6 +210,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/authorization.graphql
+++ b/graphql/schema/testdata/schemagen/output/authorization.graphql
@@ -206,6 +206,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
+++ b/graphql/schema/testdata/schemagen/output/comments-and-descriptions.graphql
@@ -219,6 +219,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-dql-query-with-subscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-dql-query-with-subscription.graphql
@@ -207,6 +207,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-mutation.graphql
@@ -197,6 +197,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-nested-types.graphql
@@ -214,6 +214,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-mixed-types.graphql
@@ -198,6 +198,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-not-dgraph-type.graphql
@@ -197,6 +197,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/custom-query-with-dgraph-type.graphql
@@ -193,6 +193,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/deprecated.graphql
+++ b/graphql/schema/testdata/schemagen/output/deprecated.graphql
@@ -193,6 +193,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-on-concrete-type-with-interfaces.graphql
@@ -210,6 +210,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/dgraph-reverse-directive-with-interfaces.graphql
@@ -210,6 +210,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-id-directive.graphql
@@ -207,6 +207,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/field-with-multiple-@id-fields.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-multiple-@id-fields.graphql
@@ -207,6 +207,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/field-with-reverse-predicate-in-dgraph-directive.graphql
@@ -202,6 +202,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-all-empty.graphql
@@ -205,6 +205,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-circular.graphql
@@ -209,6 +209,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-custom-mutation.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-custom-mutation.graphql
@@ -197,6 +197,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
+++ b/graphql/schema/testdata/schemagen/output/filter-cleanSchema-directLink.graphql
@@ -207,6 +207,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/generate-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/generate-directive.graphql
@@ -208,6 +208,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/geo-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/geo-type.graphql
@@ -199,6 +199,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface-having-directive.graphql
@@ -218,6 +218,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-interface.graphql
@@ -220,6 +220,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse-with-type-having-directive.graphql
@@ -218,6 +218,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasInverse.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse.graphql
@@ -199,6 +199,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasInverse_withSubscription.graphql
@@ -199,6 +199,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/hasfilter.graphql
+++ b/graphql/schema/testdata/schemagen/output/hasfilter.graphql
@@ -201,6 +201,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/ignore-unsupported-directive.graphql
@@ -200,6 +200,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-dgraph-pred.graphql
@@ -209,6 +209,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-id-directive.graphql
@@ -203,6 +203,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
+++ b/graphql/schema/testdata/schemagen/output/interface-with-no-ids.graphql
@@ -203,6 +203,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types-and-password.graphql
@@ -228,6 +228,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
+++ b/graphql/schema/testdata/schemagen/output/interfaces-with-types.graphql
@@ -228,6 +228,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/lambda-directive.graphql
+++ b/graphql/schema/testdata/schemagen/output/lambda-directive.graphql
@@ -195,6 +195,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field-with-searchables.graphql
@@ -192,6 +192,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/no-id-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/no-id-field.graphql
@@ -205,6 +205,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/password-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/password-type.graphql
@@ -193,6 +193,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/random.graphql
+++ b/graphql/schema/testdata/schemagen/output/random.graphql
@@ -203,6 +203,7 @@ directive @secret(field: String!, pred: String) on OBJECT | INTERFACE
 directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 
 input IntFilter {

--- a/graphql/schema/testdata/schemagen/output/searchables-references.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables-references.graphql
@@ -203,6 +203,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/searchables.graphql
+++ b/graphql/schema/testdata/schemagen/output/searchables.graphql
@@ -223,6 +223,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type-with-enum.graphql
@@ -201,6 +201,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/single-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/single-type.graphql
@@ -196,6 +196,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-implements-multiple-interfaces.graphql
@@ -210,6 +210,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-reference.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-reference.graphql
@@ -200,6 +200,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-arguments-on-field.graphql
@@ -201,6 +201,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-field-on-dgraph-type.graphql
@@ -200,6 +200,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-with-custom-fields-on-remote-type.graphql
@@ -200,6 +200,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/type-without-orderables.graphql
+++ b/graphql/schema/testdata/schemagen/output/type-without-orderables.graphql
@@ -195,6 +195,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/testdata/schemagen/output/union.graphql
+++ b/graphql/schema/testdata/schemagen/output/union.graphql
@@ -242,6 +242,7 @@ directive @remote on OBJECT | INTERFACE | UNION | INPUT_OBJECT | ENUM
 directive @remoteResponse(name: String) on FIELD_DEFINITION
 directive @cascade(fields: [String]) on FIELD
 directive @lambda on FIELD_DEFINITION
+directive @lambdaOnMutate(add: Boolean, update: Boolean, delete: Boolean) on OBJECT | INTERFACE
 directive @cacheControl(maxAge: Int!) on QUERY
 directive @generate(
 	query: GenerateQueryParams,

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -211,6 +211,7 @@ type Mutation interface {
 	MutatedType() Type
 	QueryField() Field
 	NumUidsField() Field
+	HasLambdaOnMutate() bool
 }
 
 // A Query is a field (from the schema's Query type) from an Operation
@@ -305,6 +306,10 @@ type schema struct {
 	// lambdaDirectives stores the mapping of typeName->fieldName->true, if the field has @lambda.
 	// It is read-only.
 	lambdaDirectives map[string]map[string]bool
+	// lambdaOnMutate stores the mapping of mutationName -> true, if the config of @lambdaOnMutate
+	// enables lambdas for that mutation.
+	// It is read-only.
+	lambdaOnMutate map[string]bool
 	// requiresDirectives stores the mapping of typeName->fieldName->list of fields given in
 	// @requires. It is read-only.
 	requiresDirectives map[string]map[string][]string
@@ -687,7 +692,7 @@ func typeMappings(s *ast.Schema) map[string][]*ast.Definition {
 //	 })
 //	 So, by constructing an appropriate custom directive for @lambda fields,
 //	 we just reuse logic from @custom.
-func customAndLambdaMappings(s *ast.Schema) (map[string]map[string]*ast.Directive,
+func customAndLambdaMappings(s *ast.Schema, ns uint64) (map[string]map[string]*ast.Directive,
 	map[string]map[string]bool) {
 	customDirectives := make(map[string]map[string]*ast.Directive)
 	lambdaDirectives := make(map[string]map[string]bool)
@@ -724,7 +729,7 @@ func customAndLambdaMappings(s *ast.Schema) (map[string]map[string]*ast.Directiv
 						// then, build a custom directive with correct semantics to be put
 						// into custom directives map at this field
 						customFieldMap[field.Name] = buildCustomDirectiveForLambda(typ, field,
-							dir, func(f *ast.FieldDefinition) bool {
+							dir, ns, func(f *ast.FieldDefinition) bool {
 								// Need to skip the fields which have a @custom/@lambda from
 								// going in body template. The field itself may not have the
 								// directive anymore because the directive may have been removed by
@@ -827,8 +832,8 @@ func (m *mutation) IsExternal() bool {
 	return (*field)(m).IsExternal()
 }
 
-func (f *fieldDefinition) IsExternal() bool {
-	return hasExternal(f.fieldDef)
+func (fd *fieldDefinition) IsExternal() bool {
+	return hasExternal(fd.fieldDef)
 }
 
 func hasCustomOrLambda(f *ast.FieldDefinition) bool {
@@ -877,7 +882,8 @@ func externalAndNonKeyField(fld *ast.FieldDefinition, defn *ast.Definition, prov
 //	   mode: BATCH (set only if @lambda was on a non query/mutation field)
 //	})
 func buildCustomDirectiveForLambda(defn *ast.Definition, field *ast.FieldDefinition,
-	lambdaDir *ast.Directive, skipInBodyTemplate func(f *ast.FieldDefinition) bool) *ast.Directive {
+	lambdaDir *ast.Directive, ns uint64, skipInBodyTemplate func(f *ast.FieldDefinition) bool) *ast.
+	Directive {
 	comma := ""
 	var bodyTemplate strings.Builder
 
@@ -912,7 +918,7 @@ func buildCustomDirectiveForLambda(defn *ast.Definition, field *ast.FieldDefinit
 
 	// build the children for http argument
 	httpArgChildrens := []*ast.ChildValue{
-		getChildValue(httpUrl, x.Config.GraphQL.GetString("lambda-url"), ast.StringValue, lambdaDir.Position),
+		getChildValue(httpUrl, x.LambdaUrl(ns), ast.StringValue, lambdaDir.Position),
 		getChildValue(httpMethod, http.MethodPost, ast.EnumValue, lambdaDir.Position),
 		getChildValue(httpBody, bodyTemplate.String(), ast.StringValue, lambdaDir.Position),
 	}
@@ -945,10 +951,27 @@ func getChildValue(name, raw string, kind ast.ValueKind, position *ast.Position)
 	}
 }
 
+func lambdaOnMutateMappings(s *ast.Schema) map[string]bool {
+	result := make(map[string]bool)
+	for _, typ := range s.Types {
+		dir := typ.Directives.ForName(lambdaOnMutateDirective)
+		if dir == nil {
+			continue
+		}
+
+		for _, arg := range dir.Arguments {
+			value, _ := arg.Value.Value(nil)
+			if val, ok := value.(bool); ok && val {
+				result[arg.Name+typ.Name] = true
+			}
+		}
+	}
+	return result
+}
+
 // AsSchema wraps a github.com/dgraph-io/gqlparser/ast.Schema.
-func AsSchema(s *ast.Schema) (Schema, error) {
-	customDirs, lambdaDirs := customAndLambdaMappings(s)
-	remoteResponseDirs := remoteResponseMapping(s)
+func AsSchema(s *ast.Schema, ns uint64) (Schema, error) {
+	customDirs, lambdaDirs := customAndLambdaMappings(s, ns)
 	dgraphPredicate := dgraphMapping(s)
 	sch := &schema{
 		schema:             s,
@@ -956,8 +979,9 @@ func AsSchema(s *ast.Schema) (Schema, error) {
 		typeNameAst:        typeMappings(s),
 		customDirectives:   customDirs,
 		lambdaDirectives:   lambdaDirs,
+		lambdaOnMutate:     lambdaOnMutateMappings(s),
 		requiresDirectives: requiresMappings(s),
-		remoteResponse:     remoteResponseDirs,
+		remoteResponse:     remoteResponseMapping(s),
 		meta:               &metaInfo{}, // initialize with an empty metaInfo
 	}
 	sch.mutatedType = mutatedTypeMapping(sch, dgraphPredicate)
@@ -2134,6 +2158,10 @@ func (m *mutation) NumUidsField() Field {
 		}
 	}
 	return nil
+}
+
+func (m *mutation) HasLambdaOnMutate() bool {
+	return m.op.inSchema.lambdaOnMutate[m.Name()]
 }
 
 func (m *mutation) Location() x.Location {

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -87,7 +87,7 @@ type Starship {
 
 	schHandler, errs := NewHandler(schemaStr, false)
 	require.NoError(t, errs)
-	sch, err := FromString(schHandler.GQLSchema())
+	sch, err := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 	require.NoError(t, err)
 
 	s, ok := sch.(*schema)
@@ -272,7 +272,7 @@ func TestDgraphMapping_WithDirectives(t *testing.T) {
 
 	schHandler, errs := NewHandler(schemaStr, false)
 	require.NoError(t, errs)
-	sch, err := FromString(schHandler.GQLSchema())
+	sch, err := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 	require.NoError(t, err)
 
 	s, ok := sch.(*schema)
@@ -408,7 +408,7 @@ func TestCheckNonNulls(t *testing.T) {
 		req: String!
 		notReq: String
 		alsoReq: String!
-	}`)
+	}`, x.GalaxyNamespace)
 	require.NoError(t, err)
 
 	tcases := map[string]struct {
@@ -918,7 +918,7 @@ func TestGraphQLQueryInCustomHTTPConfig(t *testing.T) {
 		t.Run(tcase.Name, func(t *testing.T) {
 			schHandler, errs := NewHandler(tcase.GQLSchema, false)
 			require.NoError(t, errs)
-			sch, err := FromString(schHandler.GQLSchema())
+			sch, err := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 			require.NoError(t, err)
 
 			var vars map[string]interface{}
@@ -958,7 +958,7 @@ func TestGraphQLQueryInCustomHTTPConfig(t *testing.T) {
 
 			remoteSchemaHandler, errs := NewHandler(tcase.RemoteSchema, false)
 			require.NoError(t, errs)
-			remoteSchema, err := FromString(remoteSchemaHandler.GQLSchema())
+			remoteSchema, err := FromString(remoteSchemaHandler.GQLSchema(), x.GalaxyNamespace)
 			require.NoError(t, err)
 
 			// Validate the generated query against the remote schema.
@@ -1018,7 +1018,7 @@ func TestAllowedHeadersList(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			schHandler, errs := NewHandler(test.schemaStr, false)
 			require.NoError(t, errs)
-			_, err := FromString(schHandler.GQLSchema())
+			_, err := FromString(schHandler.GQLSchema(), x.GalaxyNamespace)
 			require.NoError(t, err)
 			require.Equal(t, strings.Join([]string{x.AccessControlAllowedHeaders, test.expected},
 				","), schHandler.MetaInfo().AllowedCorsHeaders())

--- a/graphql/test/test.go
+++ b/graphql/test/test.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/parser"
@@ -40,7 +42,7 @@ func LoadSchema(t *testing.T, gqlSchema string) schema.Schema {
 	gql, gqlErr := validator.ValidateSchemaDocument(doc)
 	requireNoGQLErrors(t, gqlErr)
 
-	schema, err := schema.AsSchema(gql)
+	schema, err := schema.AsSchema(gql, x.GalaxyNamespace)
 	requireNoGQLErrors(t, err)
 	return schema
 }

--- a/x/config.go
+++ b/x/config.go
@@ -46,6 +46,15 @@ type Options struct {
 	// extensions bool - Will be set to see extensions in GraphQL results
 	// debug bool - Will enable debug mode in GraphQL.
 	// lambda-url string - Stores the URL of lambda functions for custom GraphQL resolvers
+	// 			The configured lambda-url can have a parameter `$ns`,
+	//			which should be replaced with the correct namespace value at runtime.
+	// 	===========================================================================================
+	// 	|                lambda-url                | $ns |           namespacedLambdaUrl          |
+	// 	|==========================================|=====|========================================|
+	// 	| http://localhost:8686/graphql-worker/$ns |  1  | http://localhost:8686/graphql-worker/1 |
+	// 	| http://localhost:8686/graphql-worker     |  1  | http://localhost:8686/graphql-worker   |
+	// 	|=========================================================================================|
+	//
 	// poll-interval duration - The polling interval for graphql subscription.
 	GraphQL      *z.SuperFlag
 	GraphQLDebug bool

--- a/x/jwt_helper.go
+++ b/x/jwt_helper.go
@@ -61,7 +61,7 @@ func ExtractJWTNamespace(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	claims, err := ParseJWT(jwtString[0])
+	claims, err := ParseJWT(jwtString)
 	if err != nil {
 		return 0, err
 	}

--- a/x/x.go
+++ b/x/x.go
@@ -301,18 +301,18 @@ func GetForceNamespace(ctx context.Context) string {
 	return ns[0]
 }
 
-func ExtractJwt(ctx context.Context) ([]string, error) {
+func ExtractJwt(ctx context.Context) (string, error) {
 	// extract the jwt and unmarshal the jwt to get the list of groups
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {
-		return nil, ErrNoJwt
+		return "", ErrNoJwt
 	}
 	accessJwt := md.Get("accessJwt")
 	if len(accessJwt) == 0 {
-		return nil, ErrNoJwt
+		return "", ErrNoJwt
 	}
 
-	return accessJwt, nil
+	return accessJwt[0], nil
 }
 
 // WithLocations adds a list of locations to a GqlError and returns the same
@@ -1378,4 +1378,10 @@ func PrefixesToMatches(prefixes [][]byte, ignore string) []*pb.Match {
 		})
 	}
 	return matches
+}
+
+// LambdaUrl returns the correct lambda-url for the given namespace
+func LambdaUrl(ns uint64) string {
+	return strings.Replace(Config.GraphQL.GetString("lambda-url"), "$ns", strconv.FormatUint(ns,
+		10), 1)
 }


### PR DESCRIPTION
… (#7494)

Please see the [RFC](https://discuss.dgraph.io/t/webhook-lambda-on-add-update-delete-mutations/12904) for more details.

(cherry picked from commit 348119e497375e46e4847428242f4c3f1d37cc61)

\# Conflicts:
\#	graphql/schema/testdata/schemagen/output/interface-with-id-directive-and-ID-field.graphql

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7616)
<!-- Reviewable:end -->
