### PR TITLE
cherry-pick (master): fix(test): Fix test flakiness (GRAPHQL-1125) (#7615)

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -108,7 +108,7 @@ func command(args ...string) *exec.Cmd {
 func startCluster(composeFile, prefix string) error {
 	cmd := command(
 		"docker-compose", "-f", composeFile, "-p", prefix,
-		"up", "--force-recreate", "--remove-orphans", "--detach")
+		"up", "--force-recreate", "--build", "--remove-orphans", "--detach")
 	cmd.Stderr = nil
 
 	fmt.Printf("Bringing up cluster %s for package: %s ...\n", prefix, composeFile)


### PR DESCRIPTION
The `--build` flag was missing from the `docker-compose up` command. That flag is required for tests in `graphql/e2e/custom_logic` package.

(cherry picked from commit 1d6e633a6b85286fc2b173bc11790bc802384b59)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7618)
<!-- Reviewable:end -->
