### PR TITLE
Chore(release): fix for xgo version to use

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -117,8 +117,8 @@ jemallocXgoFlags=
 
 # Get xgo and docker image
 if [[ $GOVERSION =~ ^1\.16.* ]]; then
-  docker build -f release/xgo.Dockerfile -t dgraph/xgo:go-1.16.0 .
-  export DGRAPH_BUILD_XGO_IMAGE="-image dgraph/xgo:go-1.16.0"
+  docker build -f release/xgo.Dockerfile -t dgraph/xgo:go-${GOVERSION} .
+  export DGRAPH_BUILD_XGO_IMAGE="-image dgraph/xgo:go-${GOVERSION}"
 fi
 go install src.techknowlogick.com/xgo
 mkdir -p ~/.xgo-cache


### PR DESCRIPTION
Fix:

* xgo docker image for 1.16.x now uses GOVERSION (before it was statically setting this to 1.16.0)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7620)
<!-- Reviewable:end -->
