### PR TITLE
chore(deps): bump jinja2 from 2.11.2 to 2.11.3

### DIFF
--- a/contrib/config/marketplace/aws/tests/requirements.txt
+++ b/contrib/config/marketplace/aws/tests/requirements.txt
@@ -14,7 +14,7 @@ docker==4.2.0
 docutils==0.15.2
 dulwich==0.19.15
 idna==2.9
-Jinja2==2.11.2
+Jinja2==2.11.3
 jmespath==0.9.5
 jsonpatch==1.25
 jsonpointer==2.0

--- a/contrib/embargo/requirements.txt
+++ b/contrib/embargo/requirements.txt
@@ -11,7 +11,7 @@ greenlet==0.4.15
 httpie==2.1.0
 idna==2.9
 itsdangerous==1.1.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 Pygments==2.6.1
 PyYAML==5.3.1


### PR DESCRIPTION
 Dependabot recommendation to bump Python jinja2 from 2.11.2 to 2.11.3 in:
* /contrib/embargo
* /contrib/config/marketplace/aws/tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7629)
<!-- Reviewable:end -->
