### PR TITLE
fix(GraphQL): Fix panic when no schema exists for a new namespace

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -39,7 +39,7 @@ import (
 const (
 	errMsgServerNotReady = "Unavailable: Server not ready."
 
-	errNoGraphQLSchema = "Not resolving %s. There's no GraphQL schema in Dgraph.  " +
+	errNoGraphQLSchema = "Not resolving %s. There's no GraphQL schema in Dgraph. " +
 		"Use the /admin API to add a GraphQL schema"
 	errResolverNotFound = "%s was not executed because no suitable resolver could be found - " +
 		"this indicates a resolver or validation bug. Please let us know by filing an issue."

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -814,15 +814,19 @@ func resolverFactoryWithErrorMsg(msg string) resolve.ResolverFactory {
 	return resolve.NewResolverFactory(qErr, mErr)
 }
 
-func (as *adminServer) incrementSchemaUpdateCounter(ns uint64) {
-	// Increment the Epoch when you get a new schema. So, that subscription's local epoch
-	// will match against global epoch to terminate the current subscriptions.
+func (as *adminServer) getGlobalEpoch(ns uint64) *uint64 {
 	e := as.globalEpoch[ns]
 	if e == nil {
 		e = new(uint64)
 		as.globalEpoch[ns] = e
 	}
-	atomic.AddUint64(e, 1)
+	return e
+}
+
+func (as *adminServer) incrementSchemaUpdateCounter(ns uint64) {
+	// Increment the Epoch when you get a new schema. So, that subscription's local epoch
+	// will match against global epoch to terminate the current subscriptions.
+	atomic.AddUint64(as.getGlobalEpoch(ns), 1)
 }
 
 func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
@@ -830,7 +834,10 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 	mainHealthStore.updatingSchema()
 
 	var resolverFactory resolve.ResolverFactory
-	// If schema is nil (which becomes after drop_all) then do not attach Resolver for
+	// gqlSchema can be nil in following cases:
+	// * after DROP_ALL
+	// * if the schema hasn't yet been set even once for a non-Galaxy namespace
+	// If schema is nil then do not attach Resolver for
 	// introspection operations, and set GQL schema to empty.
 	if gqlSchema == nil {
 		resolverFactory = resolverFactoryWithErrorMsg(errNoGraphQLSchema)
@@ -863,7 +870,7 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 	}
 
 	resolvers := resolve.New(gqlSchema, resolverFactory)
-	as.gqlServer.Set(ns, as.globalEpoch[ns], resolvers)
+	as.gqlServer.Set(ns, as.getGlobalEpoch(ns), resolvers)
 
 	// reset status to up, as now we are serving the new schema
 	mainHealthStore.up()
@@ -885,15 +892,18 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) {
 		return
 	}
 
+	var generatedSchema schema.Schema
 	if sch.Schema == "" {
+		// if there was no schema stored in Dgraph, we still need to attach resolvers to the main
+		// graphql server which should just return errors for any incoming request.
+		// generatedSchema will be nil in this case
 		glog.Infof("No GraphQL schema in Dgraph; serving empty GraphQL API")
-		return
-	}
-
-	generatedSchema, err := generateGQLSchema(sch, namespace)
-	if err != nil {
-		glog.Infof("Error processing GraphQL schema: %s.", err)
-		return
+	} else {
+		generatedSchema, err = generateGQLSchema(sch, namespace)
+		if err != nil {
+			glog.Infof("Error processing GraphQL schema: %s.", err)
+			return
+		}
 	}
 
 	as.mux.Lock()
@@ -902,7 +912,7 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) {
 	as.schema[namespace] = sch
 	as.resetSchema(namespace, generatedSchema)
 
-	glog.Infof("Successfully lazy-loaded GraphQL schema. Serving GraphQL API.")
+	glog.Infof("Successfully lazy-loaded GraphQL schema.")
 }
 
 func LazyLoadSchema(namespace uint64) {

--- a/graphql/e2e/multi_tenancy/schema_test.go
+++ b/graphql/e2e/multi_tenancy/schema_test.go
@@ -175,17 +175,37 @@ func TestGraphQLResponse(t *testing.T) {
 
 	header := http.Header{}
 	header.Set(accessJwtHeader, testutil.GrootHttpLogin(groupOneAdminServer).AccessJwt)
+
+	ns := common.CreateNamespace(t, header)
+	header1 := http.Header{}
+	header1.Set(accessJwtHeader, testutil.GrootHttpLoginNamespace(groupOneAdminServer,
+		ns).AccessJwt)
+
+	// initially, when no schema is set, we should get error: `there is no GraphQL schema in Dgraph`
+	// for both the namespaces
+	query := `
+	query {
+		queryAuthor {
+			name
+		}
+	}`
+	resp0 := (&common.GraphQLParams{Query: query, Headers: header}).ExecuteAsPost(t,
+		groupOneGraphQLServer)
+	resp1 := (&common.GraphQLParams{Query: query, Headers: header1}).ExecuteAsPost(t,
+		groupOneGraphQLServer)
+	expectedErrs := x.GqlErrorList{{Message: "Not resolving queryAuthor. " +
+		"There's no GraphQL schema in Dgraph.  Use the /admin API to add a GraphQL schema"}}
+	require.Equal(t, expectedErrs, resp0.Errors)
+	require.Equal(t, expectedErrs, resp1.Errors)
+	require.Nil(t, resp0.Data)
+	require.Nil(t, resp1.Data)
+
 	schema := `
 	type Author {
 		id: ID!
 		name: String!
 	}`
 	common.SafelyUpdateGQLSchema(t, common.Alpha1HTTP, schema, header)
-
-	ns := common.CreateNamespace(t, header)
-	header1 := http.Header{}
-	header1.Set(accessJwtHeader, testutil.GrootHttpLoginNamespace(groupOneAdminServer,
-		ns).AccessJwt)
 	common.SafelyUpdateGQLSchema(t, common.Alpha1HTTP, schema, header1)
 
 	require.Equal(t, schema, common.AssertGetGQLSchema(t, common.Alpha1HTTP, header).Schema)
@@ -207,12 +227,6 @@ func TestGraphQLResponse(t *testing.T) {
 			}
 		}`)
 
-	query := `
-	query {
-		queryAuthor {
-			name
-		}
-	}`
 	graphqlHelper(t, query, header,
 		`{
 			"queryAuthor": [

--- a/graphql/e2e/multi_tenancy/schema_test.go
+++ b/graphql/e2e/multi_tenancy/schema_test.go
@@ -194,7 +194,7 @@ func TestGraphQLResponse(t *testing.T) {
 	resp1 := (&common.GraphQLParams{Query: query, Headers: header1}).ExecuteAsPost(t,
 		groupOneGraphQLServer)
 	expectedErrs := x.GqlErrorList{{Message: "Not resolving queryAuthor. " +
-		"There's no GraphQL schema in Dgraph.  Use the /admin API to add a GraphQL schema"}}
+		"There's no GraphQL schema in Dgraph. Use the /admin API to add a GraphQL schema"}}
 	require.Equal(t, expectedErrs, resp0.Errors)
 	require.Equal(t, expectedErrs, resp1.Errors)
 	require.Nil(t, resp0.Data)

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -319,7 +319,7 @@ func TestIntrospectionQueryAfterDropAll(t *testing.T) {
 	introspectionResult := introspect.ExecuteAsPost(t, groupOneGraphQLServer)
 	require.Len(t, introspectionResult.Errors, 1)
 	gotErrorMessage := introspectionResult.Errors[0].Message
-	expectedErrorMessage := "Not resolving __schema. There's no GraphQL schema in Dgraph.  Use the /admin API to add a GraphQL schema"
+	expectedErrorMessage := "Not resolving __schema. There's no GraphQL schema in Dgraph. Use the /admin API to add a GraphQL schema"
 	require.Equal(t, expectedErrorMessage, gotErrorMessage)
 }
 


### PR DESCRIPTION
This PR fixes the issue where if you create a new namespace and run a GraphQL query for the newly created namespace without first applying any GraphQL schema, then you would get a `panic` in alpha.
Now, such a query will not result in `panic`, but instead will give back a similar response:
```
{
  "errors": [
    {
      "message": "Not resolving getAuthor. There's no GraphQL schema in Dgraph.  Use the /admin API to add a GraphQL schema"
    }
  ]
}
``` 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7630)
<!-- Reviewable:end -->
