### PR TITLE
fix(Query): [Breaking] Return error for illegal math operations.

### DIFF
--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -207,6 +207,10 @@ func applyPow(a, b, c *types.Val) error {
 		c.Tid = types.FloatID
 
 	case FLOAT:
+		if a.Value.(float64) < 0 && b.Value.(float64) > 0 && b.Value.(float64) < 1 {
+			return errors.Errorf("Illegal operands for pow: %v, %v",
+				a.Value.(float64), b.Value.(float64))
+		}
 		c.Value = math.Pow(a.Value.(float64), b.Value.(float64))
 
 	case DEFAULT:
@@ -219,10 +223,18 @@ func applyLog(a, b, c *types.Val) error {
 	vBase := getValType(a)
 	switch vBase {
 	case INT:
+		if a.Value.(int64) < 0 || b.Value.(int64) <= 0 {
+			return errors.Errorf("Illegal operands for logbase: %v, %v",
+				a.Value.(int64), b.Value.(int64))
+		}
 		c.Value = math.Log(float64(a.Value.(int64))) / math.Log(float64(b.Value.(int64)))
 		c.Tid = types.FloatID
 
 	case FLOAT:
+		if a.Value.(float64) < 0 || b.Value.(float64) <= 0 {
+			return errors.Errorf("Illegal operands for logbase: %v, %v",
+				a.Value.(float64), b.Value.(float64))
+		}
 		c.Value = math.Log(a.Value.(float64)) / math.Log(b.Value.(float64))
 
 	case DEFAULT:
@@ -261,10 +273,16 @@ func applyLn(a, res *types.Val) error {
 	vBase := getValType(a)
 	switch vBase {
 	case INT:
+		if a.Value.(int64) < 0 {
+			return errors.Errorf("Illegal operand for ln: %v", a.Value.(int64))
+		}
 		res.Value = math.Log(float64(a.Value.(int64)))
 		res.Tid = types.FloatID
 
 	case FLOAT:
+		if a.Value.(float64) < 0 {
+			return errors.Errorf("Illegal operand for ln: %v", a.Value.(float64))
+		}
 		res.Value = math.Log(a.Value.(float64))
 
 	case DEFAULT:
@@ -308,10 +326,16 @@ func applySqrt(a, res *types.Val) error {
 	vBase := getValType(a)
 	switch vBase {
 	case INT:
+		if a.Value.(int64) < 0 {
+			return errors.Errorf("Illegal operand for sqrt: %v", a.Value.(int64))
+		}
 		res.Value = math.Sqrt(float64(a.Value.(int64)))
 		res.Tid = types.FloatID
 
 	case FLOAT:
+		if a.Value.(float64) < 0 {
+			return errors.Errorf("Illegal operand for sqrt: %v", a.Value.(float64))
+		}
 		res.Value = math.Sqrt(a.Value.(float64))
 
 	case DEFAULT:

--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -247,6 +247,8 @@ func applyLog(a, b, c *types.Val) error {
 	case INT:
 		if a.Value.(int64) < 0 || b.Value.(int64) < 0 {
 			return ErrorNegativeLog
+		} else if b.Value.(int64) == 1 {
+			return ErrorDivisionByZero
 		}
 		c.Value = math.Log(float64(a.Value.(int64))) / math.Log(float64(b.Value.(int64)))
 		c.Tid = types.FloatID
@@ -254,6 +256,8 @@ func applyLog(a, b, c *types.Val) error {
 	case FLOAT:
 		if a.Value.(float64) < 0 || b.Value.(float64) < 0 {
 			return ErrorNegativeLog
+		} else if b.Value.(float64) == 1 {
+			return ErrorDivisionByZero
 		}
 		c.Value = math.Log(a.Value.(float64)) / math.Log(b.Value.(float64))
 

--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -163,9 +163,9 @@ func applyMul(a, b, c *types.Val) error {
 		aVal, bVal := a.Value.(int64), b.Value.(int64)
 		c.Value = aVal * bVal
 
-		if aVal == 0 || bVal == 0 || aVal == 1 || bVal == 1 {
+		if aVal == 0 || bVal == 0 {
 			return nil
-		} else if aVal == math.MinInt64 || bVal == math.MinInt64 || c.Value.(int64)/bVal != aVal {
+		} else if c.Value.(int64)/bVal != aVal {
 			return ErrorIntOverflow
 		}
 

--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -230,7 +230,7 @@ func applyPow(a, b, c *types.Val) error {
 	case FLOAT:
 		// Fractional power of -ve numbers should not be returned.
 		if a.Value.(float64) < 0 &&
-			math.Ceil(b.Value.(float64))-b.Value.(float64) > 0 {
+			math.Abs(math.Ceil(b.Value.(float64))-b.Value.(float64)) > 0 {
 			return ErrorFractionalPower
 		}
 		c.Value = math.Pow(a.Value.(float64), b.Value.(float64))

--- a/query/math.go
+++ b/query/math.go
@@ -30,6 +30,16 @@ type mathTree struct {
 	Child []*mathTree
 }
 
+var (
+	ErrorIntOverflow     = errors.New("Integer overflow")
+	ErrorFloatOverflow   = errors.New("Float overflow")
+	ErrorDivisionByZero  = errors.New("Division by zero")
+	ErrorModuloByZero    = errors.New("Modulo by zero")
+	ErrorFractionalPower = errors.New("Fractional power of negative number")
+	ErrorNegativeLog     = errors.New("Log of negative number")
+	ErrorNegativeRoot    = errors.New("Root of negative number")
+)
+
 // processBinary handles the binary operands like
 // +, -, *, /, %, max, min, logbase
 func processBinary(mNode *mathTree) error {

--- a/query/math.go
+++ b/query/math.go
@@ -38,12 +38,6 @@ var (
 	ErrorNegativeRoot    = errors.New("Root of negative number")
 )
 
-const (
-	NotANumber       = "NaN"
-	PositiveInfinity = "+Inf"
-	NegativeInfinity = "-Int"
-)
-
 // processBinary handles the binary operands like
 // +, -, *, /, %, max, min, logbase
 func processBinary(mNode *mathTree) error {

--- a/query/math.go
+++ b/query/math.go
@@ -32,12 +32,16 @@ type mathTree struct {
 
 var (
 	ErrorIntOverflow     = errors.New("Integer overflow")
-	ErrorFloatOverflow   = errors.New("Float overflow")
 	ErrorDivisionByZero  = errors.New("Division by zero")
-	ErrorModuloByZero    = errors.New("Modulo by zero")
 	ErrorFractionalPower = errors.New("Fractional power of negative number")
 	ErrorNegativeLog     = errors.New("Log of negative number")
 	ErrorNegativeRoot    = errors.New("Root of negative number")
+)
+
+const (
+	NotANumber       = "NaN"
+	PositiveInfinity = "+Inf"
+	NegativeInfinity = "-Int"
 )
 
 // processBinary handles the binary operands like

--- a/query/math_test.go
+++ b/query/math_test.go
@@ -253,24 +253,6 @@ func TestProcessBinary(t *testing.T) {
 			name: "Addition integer underflow",
 		},
 		{in: &mathTree{
-			Fn: "+",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: float64(math.MaxFloat64)}},
-				{Const: types.Val{Tid: types.FloatID, Value: float64(math.MaxFloat64)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Addition float overflow",
-		},
-		{in: &mathTree{
-			Fn: "+",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: float64(-math.MaxFloat64)}},
-				{Const: types.Val{Tid: types.FloatID, Value: float64(-math.MaxFloat64)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Addition float underflow",
-		},
-		{in: &mathTree{
 			Fn: "-",
 			Child: []*mathTree{
 				{Const: types.Val{Tid: types.IntID, Value: int64(9223372036854775800)}},
@@ -289,24 +271,6 @@ func TestProcessBinary(t *testing.T) {
 			name: "Subtraction integer underflow",
 		},
 		{in: &mathTree{
-			Fn: "-",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: math.MaxFloat64}},
-				{Const: types.Val{Tid: types.FloatID, Value: -math.MaxFloat64}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Subtraction float overflow",
-		},
-		{in: &mathTree{
-			Fn: "-",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: -math.MaxFloat64}},
-				{Const: types.Val{Tid: types.FloatID, Value: math.MaxFloat64}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Subtraction float underflow",
-		},
-		{in: &mathTree{
 			Fn: "*",
 			Child: []*mathTree{
 				{Const: types.Val{Tid: types.IntID, Value: int64(9223372036854775)}},
@@ -323,24 +287,6 @@ func TestProcessBinary(t *testing.T) {
 			}},
 			err:  ErrorIntOverflow,
 			name: "Multiplication integer underflow",
-		},
-		{in: &mathTree{
-			Fn: "*",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: math.MaxFloat64}},
-				{Const: types.Val{Tid: types.FloatID, Value: float64(10.2)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Multiplication float overflow",
-		},
-		{in: &mathTree{
-			Fn: "*",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: -math.MaxFloat64}},
-				{Const: types.Val{Tid: types.FloatID, Value: float64(10.23)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Multiplication float underflow",
 		},
 		{in: &mathTree{
 			Fn: "/",
@@ -366,7 +312,7 @@ func TestProcessBinary(t *testing.T) {
 				{Const: types.Val{Tid: types.IntID, Value: int64(23)}},
 				{Const: types.Val{Tid: types.IntID, Value: int64(0)}},
 			}},
-			err:  ErrorModuloByZero,
+			err:  ErrorDivisionByZero,
 			name: "Modulo int zero",
 		},
 		{in: &mathTree{
@@ -375,7 +321,7 @@ func TestProcessBinary(t *testing.T) {
 				{Const: types.Val{Tid: types.FloatID, Value: float64(23)}},
 				{Const: types.Val{Tid: types.FloatID, Value: float64(0)}},
 			}},
-			err:  ErrorModuloByZero,
+			err:  ErrorDivisionByZero,
 			name: "Modulo float zero",
 		},
 		{in: &mathTree{
@@ -386,24 +332,6 @@ func TestProcessBinary(t *testing.T) {
 			}},
 			err:  ErrorFractionalPower,
 			name: "Fractional negative power",
-		},
-		{in: &mathTree{
-			Fn: "pow",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.IntID, Value: int64(200)}},
-				{Const: types.Val{Tid: types.IntID, Value: int64(1231424123)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Power overflow",
-		},
-		{in: &mathTree{
-			Fn: "pow",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: float64(200)}},
-				{Const: types.Val{Tid: types.FloatID, Value: float64(1231424123)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Power overflow float",
 		},
 		{in: &mathTree{
 			Fn: "logbase",
@@ -525,38 +453,6 @@ func TestProcessUnary(t *testing.T) {
 			}},
 			err:  ErrorNegativeLog,
 			name: "Negative float ln",
-		},
-		{in: &mathTree{
-			Fn: "exp",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.IntID, Value: int64(800)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Exp int overflow",
-		},
-		{in: &mathTree{
-			Fn: "exp",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.IntID, Value: int64(-800)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Exp int underflow",
-		},
-		{in: &mathTree{
-			Fn: "exp",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: float64(800)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Exp float overflow",
-		},
-		{in: &mathTree{
-			Fn: "exp",
-			Child: []*mathTree{
-				{Const: types.Val{Tid: types.FloatID, Value: float64(-800)}},
-			}},
-			err:  ErrorFloatOverflow,
-			name: "Exp float underflow",
 		},
 		{in: &mathTree{
 			Fn: "u-",


### PR DESCRIPTION
If an operand is passed to math operations like log (ln, logbase), sqrt, pow  which might result in illegal operation (resulting in NaN) we return 0 instead of an error. This PR fixes that.

Fixes DGRAPH-3150

Operation | Data type | Current behavior | New behavior
-- | -- | -- | -- 
Add | Int64 | Overflow/Underflow | Return error
Sub | Int64 | Overflow/Underflow | Return error
Multiply | Int64 | Overflow/Underflow | Return error | Return error
Pow | Float64 | Fractional power of -ve number returns 0 | Return error
Logbase | Int64 | -ve number returns 0 | Return error
Logbase | Int64 | Log with base 1 returns large float | Return error
Logbase | Float64 | -ve number return 0 | Return error
Logbase | Float64 | Log with base 1 returns large float | Return error
Ln | Int64 | -ve number returns 0 | Return error
Ln | Float64 | -ve number returns 0 | Return error
Negative | Int64 | -ve of MinInt64 remains same | Return error
Sqrt | Int64 | -ve number return 0 | Return error
Sqrt | Float64 | -ve number return 0 | Return error


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7631)
<!-- Reviewable:end -->
