### PR TITLE
fix(Query): Fix cascade pagination with 0 offset.

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1380,7 +1380,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 		child.updateUidMatrix()
 
 		// Apply pagination after the @cascade.
-		if len(child.Params.Cascade.Fields) > 0 && child.Params.Cascade.First != 0 && child.Params.Cascade.Offset != 0 {
+		if len(child.Params.Cascade.Fields) > 0 && (child.Params.Cascade.First != 0 || child.Params.Cascade.Offset != 0) {
 			for i := 0; i < len(child.uidMatrix); i++ {
 				start, end := x.PageRange(child.Params.Cascade.First, child.Params.Cascade.Offset, len(child.uidMatrix[i].Uids))
 				child.uidMatrix[i].Uids = child.uidMatrix[i].Uids[start:end]
@@ -2864,7 +2864,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			// first time at the root here.
 
 			// Apply pagination at the root after @cascade.
-			if len(sg.Params.Cascade.Fields) > 0 && sg.Params.Cascade.First != 0 && sg.Params.Cascade.Offset != 0 {
+			if len(sg.Params.Cascade.Fields) > 0 && (sg.Params.Cascade.First != 0 || sg.Params.Cascade.Offset != 0) {
 				sg.updateUidMatrix()
 				for i := 0; i < len(sg.uidMatrix); i++ {
 					start, end := x.PageRange(sg.Params.Cascade.First, sg.Params.Cascade.Offset, len(sg.uidMatrix[i].Uids))

--- a/query/query.go
+++ b/query/query.go
@@ -2406,7 +2406,8 @@ func (sg *SubGraph) applyOrderAndPagination(ctx context.Context) error {
 		}
 	}
 
-	if sg.Params.Count == 0 {
+	// if the @cascade directive is used then retrieve all the results.
+	if sg.Params.Count == 0 && len(sg.Params.Cascade.Fields) == 0 {
 		// Only retrieve up to 1000 results by default.
 		sg.Params.Count = 1000
 	}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -520,6 +520,19 @@ func TestCascadeWithPaginationAtRoot(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false}]}}`, js)
 }
 
+func TestCascadeWithPaginationAndOffsetZero(t *testing.T) {
+	query := `
+	{
+		me(func: type(Person), first: 1, offset: 0) @cascade{
+		  name
+		  alive
+		}
+	  }
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false}]}}`, js)
+}
+
 func TestLevelBasedFacetVarAggSum(t *testing.T) {
 	query := `
 		{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -530,7 +530,7 @@ func TestCascadeWithPaginationAndOffsetZero(t *testing.T) {
 	  }
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name":"Rick Grimes","alive":true}]}}`, js)
 }
 
 func TestLevelBasedFacetVarAggSum(t *testing.T) {


### PR DESCRIPTION
Fixes DGRAPH-3211.
This PR fixes 2 bugs related to the @cascade directive.
1- Pagination was not working with `Offset = 0`.
2- @cascade directive not working with sort queries.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7636)
<!-- Reviewable:end -->
