### PR TITLE
fix(login): fix login based on refresh token logic

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -81,7 +81,7 @@ func (s *Server) Login(ctx context.Context,
 	glog.Infof("%s logged in successfully", user.UserID)
 
 	resp := &api.Response{}
-	accessJwt, err := getAccessJwt(user.UserID, user.Groups, request.Namespace)
+	accessJwt, err := getAccessJwt(user.UserID, user.Groups, user.Namespace)
 	if err != nil {
 		errMsg := fmt.Sprintf("unable to get access jwt (userid=%s,addr=%s):%v",
 			user.UserID, addr, err)
@@ -89,7 +89,7 @@ func (s *Server) Login(ctx context.Context,
 		return nil, errors.Errorf(errMsg)
 	}
 
-	refreshJwt, err := getRefreshJwt(user.UserID, request.Namespace)
+	refreshJwt, err := getRefreshJwt(user.UserID, user.Namespace)
 	if err != nil {
 		errMsg := fmt.Sprintf("unable to get refresh jwt (userid=%s,addr=%s):%v",
 			user.UserID, addr, err)
@@ -122,9 +122,6 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 		return nil, errors.Wrapf(err, "invalid login request")
 	}
 
-	// In case of login, we can't extract namespace from JWT because we have not yet given JWT
-	// to the user, so the login request should contain the namespace, which is then set to ctx.
-	ctx = x.AttachNamespace(ctx, request.Namespace)
 	var user *acl.User
 	if len(request.RefreshToken) > 0 {
 		userData, err := validateToken(request.RefreshToken)
@@ -133,7 +130,8 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 				request.RefreshToken)
 		}
 
-		userId := userData[0]
+		userId := userData.userId
+		ctx = x.AttachNamespace(ctx, userData.namespace)
 		user, err = authorizeUser(ctx, userId, "")
 		if err != nil {
 			return nil, errors.Wrapf(err, "while querying user with id %v", userId)
@@ -143,9 +141,14 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 			return nil, errors.Errorf("unable to authenticate: invalid credentials")
 		}
 
+		user.Namespace = userData.namespace
 		glog.Infof("Authenticated user %s through refresh token", userId)
 		return user, nil
 	}
+
+	// In case of login, we can't extract namespace from JWT because we have not yet given JWT
+	// to the user, so the login request should contain the namespace, which is then set to ctx.
+	ctx = x.AttachNamespace(ctx, request.Namespace)
 
 	// authorize the user using password
 	var err error
@@ -161,13 +164,20 @@ func (s *Server) authenticateLogin(ctx context.Context, request *api.LoginReques
 	if !user.PasswordMatch {
 		return nil, x.ErrorInvalidLogin
 	}
+	user.Namespace = request.Namespace
 	return user, nil
+}
+
+type userData struct {
+	namespace uint64
+	userId    string
+	groupIds  []string
 }
 
 // validateToken verifies the signature and expiration of the jwt, and if validation passes,
 // returns a slice of strings, where the first element is the extracted userId
 // and the rest are groupIds encoded in the jwt.
-func validateToken(jwtStr string) ([]string, error) {
+func validateToken(jwtStr string) (*userData, error) {
 	claims, err := x.ParseJWT(jwtStr)
 	if err != nil {
 		return nil, err
@@ -203,7 +213,7 @@ func validateToken(jwtStr string) ([]string, error) {
 			groupIds = append(groupIds, groupId)
 		}
 	}
-	return append([]string{userId}, groupIds...), nil
+	return &userData{namespace: uint64(namespace), userId: userId, groupIds: groupIds}, nil
 }
 
 // validateLoginRequest validates that the login request has either the refresh token or the
@@ -579,7 +589,11 @@ func extractUserAndGroups(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return validateToken(accessJwt[0])
+	userData, err := validateToken(accessJwt[0])
+	if err != nil {
+		return nil, err
+	}
+	return append([]string{userData.userId}, userData.groupIds...), nil
 }
 
 type authPredResult struct {

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -73,6 +73,7 @@ type User struct {
 	Uid           string  `json:"uid"`
 	UserID        string  `json:"dgraph.xid"`
 	Password      string  `json:"dgraph.password"`
+	Namespace     uint64  `json:"namespace"`
 	PasswordMatch bool    `json:"password_match"`
 	Groups        []Group `json:"dgraph.user.group"`
 }


### PR DESCRIPTION
We were fetching the namespace from the `api.LoginRequest.Namespace` even if the user has sent the refresh token. We should not do that and extract the namespace from the refresh token itself.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7637)
<!-- Reviewable:end -->
