### PR TITLE
Fix(GraphQL): Log query along with the panic

### DIFF
--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -344,7 +344,7 @@ func recoveryHandler(next http.Handler) http.Handler {
 			func(err error) {
 				rr := schema.ErrorResponse(err)
 				write(w, rr, strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
-			})
+			}, "")
 
 		next.ServeHTTP(w, r)
 	})

--- a/graphql/api/panics.go
+++ b/graphql/api/panics.go
@@ -28,9 +28,10 @@ import (
 //
 // If PanicHandler recovers from a panic, it logs a stack trace, creates an error
 // and applies fn to the error.
-func PanicHandler(fn func(error)) {
+func PanicHandler(fn func(error), query string) {
 	if err := recover(); err != nil {
-		glog.Errorf("panic: %s.\n trace: %s", err, string(debug.Stack()))
+		// Log the panic along with query which caused it.
+		glog.Errorf("panic: %s.\n query: %s\n trace: %s", err, query, string(debug.Stack()))
 
 		fn(errors.Errorf("Internal Server Error - a panic was trapped.  " +
 			"This indicates a bug in the GraphQL server.  A stack trace was logged.  " +

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -533,7 +533,7 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) *
 							Field: q,
 							Err:   err,
 						}
-					})
+					}, gqlReq.Query)
 				allResolved[storeAt] = r.resolvers.queryResolverFor(q).Resolve(ctx, q)
 			}(q, i)
 		}


### PR DESCRIPTION
This PR adds functionality to log the query and mutations which cause panic in PanicHandler.


Testing:
Tested locally. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7638)
<!-- Reviewable:end -->
