### PR TITLE
fix(endpoints): Move z and jemalloc endpoints to /debug

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -501,7 +501,8 @@ func setupServer(closer *z.Closer) {
 	baseMux.HandleFunc("/alter", alterHandler)
 	baseMux.HandleFunc("/health", healthCheck)
 	baseMux.HandleFunc("/state", stateHandler)
-	baseMux.HandleFunc("/jemalloc", x.JemallocHandler)
+	baseMux.HandleFunc("/debug/jemalloc", x.JemallocHandler)
+	zpages.Handle(baseMux, "/debug/z")
 
 	// TODO: Figure out what this is for?
 	http.HandleFunc("/debug/store", storeStatsHandler)
@@ -556,9 +557,6 @@ func setupServer(closer *z.Closer) {
 	addr := fmt.Sprintf("%s:%d", laddr, httpPort())
 	glog.Infof("Bringing up GraphQL HTTP API at %s/graphql", addr)
 	glog.Infof("Bringing up GraphQL HTTP admin API at %s/admin", addr)
-
-	// Add OpenCensus z-pages.
-	zpages.Handle(baseMux, "/z")
 
 	baseMux.Handle("/", http.HandlerFunc(homeHandler))
 	baseMux.Handle("/ui/keywords", http.HandlerFunc(keywordHandler))

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -42,7 +42,7 @@ var (
 )
 
 var metricMap = map[string]string{
-	"jemalloc":     "/jemalloc",
+	"jemalloc":     "/debug/jemalloc",
 	"state":        "/state",
 	"health":       "/health",
 	"vars":         "/debug/vars",

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -306,8 +306,8 @@ func run() {
 	baseMux.HandleFunc("/moveTablet", st.moveTablet)
 	baseMux.HandleFunc("/assign", st.assign)
 	baseMux.HandleFunc("/enterpriseLicense", st.applyEnterpriseLicense)
-	baseMux.HandleFunc("/jemalloc", x.JemallocHandler)
-	zpages.Handle(baseMux, "/z")
+	baseMux.HandleFunc("/debug/jemalloc", x.JemallocHandler)
+	zpages.Handle(baseMux, "/debug/z")
 
 	// This must be here. It does not work if placed before Grpc init.
 	x.Check(st.node.initAndStartNode())

--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -63,9 +63,8 @@ var skipApis = map[string]bool{
 
 var skipEPs = map[string]bool{
 	// list of endpoints that needs to be skipped
-	"/health":   true,
-	"/jemalloc": true,
-	"/state":    true,
+	"/health": true,
+	"/state":  true,
 }
 
 func AuditRequestGRPC(ctx context.Context, req interface{},


### PR DESCRIPTION
This PR moves the `/z` and `/jemalloc` endpoints in zero and alpha to 
`/debug/z` and `/debug/jemalloc` respectively.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7641)
<!-- Reviewable:end -->
