### PR TITLE
Chore(GraphQL): Fix query logging for mutations in case of panic

### DIFF
--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -480,15 +480,15 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) (
 			},
 		},
 	}
-	defer func() {
-		// Panic Handler for mutation. This ensures that the mutation which causes panic
-		// gets logged in Alpha logs. This panic handler overrides the default Panic Handler
-		// used in recoveryHandler in admin/http.go
-		api.PanicHandler(
-			func(err error) {
-				resp.Errors = schema.AsGQLErrors(schema.AppendGQLErrs(resp.Errors, err))
-			}, gqlReq.Query)
+	// Panic Handler for mutation. This ensures that the mutation which causes panic
+	// gets logged in Alpha logs. This panic handler overrides the default Panic Handler
+	// used in recoveryHandler in admin/http.go
+	defer api.PanicHandler(
+		func(err error) {
+			resp.Errors = schema.AsGQLErrors(schema.AppendGQLErrs(resp.Errors, err))
+		}, gqlReq.Query)
 
+	defer func() {
 		endTime := time.Now()
 		resp.Extensions.Tracing.EndTime = endTime.Format(time.RFC3339Nano)
 		resp.Extensions.Tracing.Duration = endTime.Sub(startTime).Nanoseconds()


### PR DESCRIPTION
This adds logging for mutations in case of panic.

Testing:
Tested Locally

```
=== RUN   TestRunAll_Normal/panic_catcher/mutation
E0324 18:20:07.423360  955317 panics.go:34] panic: 
****
this test should trap this panic.
It's working as expected if this message is logged with a stack trace
****.
 query: mutation {
						addCountry(input: [{ name: "A Country" }]) { country { id } }
					}
 trace: goroutine 5272 [running]:
```

Fixes GRAPHQL-1062
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7646)
<!-- Reviewable:end -->
