### PR TITLE
fix(query): return empty result if nothing found for geo queries

### DIFF
--- a/worker/task.go
+++ b/worker/task.go
@@ -1514,6 +1514,9 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 		uids.Or(bm)
 	}
 	numUids := int(uids.GetCardinality())
+	if numUids == 0 {
+		return nil
+	}
 
 	numGo, width := x.DivideAndRule(numUids)
 	if span != nil && numGo > 1 {


### PR DESCRIPTION
This PR fixes an error returned if there are no uids for geo query.
Query:
```
{
  tourist(func: near(loc, [-122.469829, 37.771935], 1000) ) {
    name
  }
}
```
Expected result:
```json
"data": {
    "tourist": []
  },
```
Actual result:
```json
"errors": [
    {
      "message": ": can't find 0th integer in a bitmap with only 0 items",
      "extensions": {
        "code": "ErrorInvalidRequest"
      }
    }
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7651)
<!-- Reviewable:end -->
