### PR TITLE
feat(flags): [Breaking] Add cache superflag for alpha

### DIFF
--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -222,7 +222,7 @@ func memoryLimitPutHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	gqlReq := &schema.Request{
 		Query: `
-		mutation config($cacheMb: Int) {
+		mutation config($cacheMb: Float) {
 		  config(input: {cacheMb: $cacheMb}) {
 			response {
 			  code

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -152,7 +152,7 @@ they form a Raft group and provide synchronous replication.
 			"Total size of cache (in MB) to be used in Dgraph.").
 		Flag("percentage",
 			"Cache percentages summing up to 100 for various caches (FORMAT: PostingListCache,"+
-				"PstoreBlockCache,PstoreIndexCache,WAL)").
+				"PstoreBlockCache,PstoreIndexCache)").
 		String())
 
 	flag.String("raft", worker.RaftDefaults, z.NewSuperFlagHelp(worker.RaftDefaults).
@@ -626,12 +626,11 @@ func run() {
 	x.AssertTruef(totalCache >= 0, "ERROR: Cache size must be non-negative")
 
 	cachePercentage := cache.GetString("percentage")
-	cachePercent, err := x.GetCachePercentages(cachePercentage, 4)
+	cachePercent, err := x.GetCachePercentages(cachePercentage, 3)
 	x.Check(err)
 	postingListCacheSize := (cachePercent[0] * (totalCache << 20)) / 100
 	pstoreBlockCacheSize := (cachePercent[1] * (totalCache << 20)) / 100
 	pstoreIndexCacheSize := (cachePercent[2] * (totalCache << 20)) / 100
-	walCache := (cachePercent[3] * (totalCache << 20)) / 100
 
 	badger := z.NewSuperFlag(Alpha.Conf.GetString("badger")).MergeAndCheckDefault(
 		worker.BadgerDefaults)
@@ -649,7 +648,6 @@ func run() {
 		CachePercentage:            cachePercentage,
 		PBlockCacheSize:            pstoreBlockCacheSize,
 		PIndexCacheSize:            pstoreIndexCacheSize,
-		WalCache:                   walCache,
 
 		MutationsMode:  worker.AllowMutations,
 		AuthToken:      security.GetString("token"),

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -108,10 +108,6 @@ they form a Raft group and provide synchronous replication.
 	// --encryption_key_file
 	enc.RegisterFlags(flag)
 
-	flag.String("cache_percentage", "0,65,35,0",
-		`Cache percentages summing up to 100 for various caches (FORMAT: PostingListCache,`+
-			`PstoreBlockCache,PstoreIndexCache,WAL).`)
-
 	flag.StringP("postings", "p", "p", "Directory to store posting lists.")
 	flag.String("tmp", "t", "Directory to store temporary buffers.")
 
@@ -147,6 +143,16 @@ they form a Raft group and provide synchronous replication.
 		Flag("max-retries",
 			"Commits to disk will give up after these number of retries to prevent locking the "+
 				"worker in a failed state. Use -1 to retry infinitely.").
+		String())
+
+	// Cache flags.
+	flag.String("cache", worker.CacheDefaults, z.NewSuperFlagHelp(worker.CacheDefaults).
+		Head("Cache options").
+		Flag("size-mb",
+			"Total size of cache (in MB) to be used in Dgraph.").
+		Flag("percentage",
+			"Cache percentages summing up to 100 for various caches (FORMAT: PostingListCache,"+
+				"PstoreBlockCache,PstoreIndexCache,WAL)").
 		String())
 
 	flag.String("raft", worker.RaftDefaults, z.NewSuperFlagHelp(worker.RaftDefaults).
@@ -614,17 +620,12 @@ func run() {
 	}
 
 	bindall = Alpha.Conf.GetBool("bindall")
-
-	totalCache := int64(Alpha.Conf.GetInt("cache_mb"))
+	cache := z.NewSuperFlag(Alpha.Conf.GetString("cache")).MergeAndCheckDefault(
+		worker.CacheDefaults)
+	totalCache := cache.GetInt64("size-mb")
 	x.AssertTruef(totalCache >= 0, "ERROR: Cache size must be non-negative")
-	if Alpha.Conf.IsSet("lru_mb") {
-		glog.Warningln("--lru_mb is deprecated, use --cache_mb instead")
-		if !Alpha.Conf.IsSet("cache_mb") {
-			totalCache = int64(Alpha.Conf.GetFloat64("lru_mb"))
-		}
-	}
 
-	cachePercentage := Alpha.Conf.GetString("cache_percentage")
+	cachePercentage := cache.GetString("percentage")
 	cachePercent, err := x.GetCachePercentages(cachePercentage, 4)
 	x.Check(err)
 	postingListCacheSize := (cachePercent[0] * (totalCache << 20)) / 100

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -645,6 +645,7 @@ func run() {
 		WALDir:                     Alpha.Conf.GetString("wal"),
 		PostingDirCompression:      ctype,
 		PostingDirCompressionLevel: clevel,
+		CacheMb:                    totalCache,
 		CachePercentage:            cachePercentage,
 		PBlockCacheSize:            pstoreBlockCacheSize,
 		PIndexCacheSize:            pstoreIndexCacheSize,

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -90,9 +90,6 @@ instances to achieve high-availability.
 	// --tls SuperFlag
 	x.RegisterServerTLSFlags(flag)
 
-	// Cache flags.
-	flag.Int64("cache_mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
-
 	flag.IntP("port_offset", "o", 0,
 		"Value added to all listening port numbers. [Grpc=5080, HTTP=6080]")
 	flag.Int("replicas", 1, "How many Dgraph Alpha replicas to run per data shard group."+

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -90,6 +90,9 @@ instances to achieve high-availability.
 	// --tls SuperFlag
 	x.RegisterServerTLSFlags(flag)
 
+	// Cache flags.
+	flag.Int64("cache_mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
+
 	flag.IntP("port_offset", "o", 0,
 		"Value added to all listening port numbers. [Grpc=5080, HTTP=6080]")
 	flag.Int("replicas", 1, "How many Dgraph Alpha replicas to run per data shard group."+

--- a/worker/config.go
+++ b/worker/config.go
@@ -54,8 +54,6 @@ type Options struct {
 	PBlockCacheSize int64
 	// PIndexCacheSize is the size of index cache for pstore
 	PIndexCacheSize int64
-	// WalCache is the size of block cache for wstore
-	WalCache int64
 
 	// HmacSecret stores the secret used to sign JSON Web Tokens (JWT).
 	HmacSecret x.SensitiveByteSlice

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -50,7 +50,7 @@ const (
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
-	CacheDefaults = `size-mb=1024; percentage=0,65,35,0;`
+	CacheDefaults = `size-mb=1024; percentage=0,65,35;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -50,6 +50,7 @@ const (
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
+	CacheDefaults = `size-mb=1024; percentage=0,65,35,0;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -164,6 +164,8 @@ func UpdateCacheMb(memoryMB int64) error {
 	if _, err := pstore.CacheMaxCost(badger.IndexCache, indexCacheSize); err != nil {
 		return errors.Wrapf(err, "cannot update index cache size")
 	}
+
+	Config.CacheMb = memoryMB
 	return nil
 }
 

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -149,7 +149,7 @@ func UpdateCacheMb(memoryMB int64) error {
 		return errors.Errorf("cache_mb must be non-negative")
 	}
 
-	cachePercent, err := x.GetCachePercentages(Config.CachePercentage, 4)
+	cachePercent, err := x.GetCachePercentages(Config.CachePercentage, 3)
 	if err != nil {
 		return err
 	}

--- a/x/flags.go
+++ b/x/flags.go
@@ -54,9 +54,6 @@ func FillCommonFlags(flag *pflag.FlagSet) {
 			`guaranteeing no data loss in case of hard reboot.`+"\n    "+
 			`Most users should be OK with choosing "process".`)
 
-	// Cache flags.
-	flag.Int64("cache_mb", 1024, "Total size of cache (in MB) to be used in Dgraph.")
-
 	flag.String("telemetry", TelemetryDefaults, z.NewSuperFlagHelp(TelemetryDefaults).
 		Head("Telemetry (diagnostic) options").
 		Flag("reports",


### PR DESCRIPTION
This change introduces **cache** as a superflag, with **size-mb** and **percentage** as subflags for dgraph alphas.

Fixes DGRAPH-3212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7652)
<!-- Reviewable:end -->
