### PR TITLE
Chore(GraphQL): Minor refactoring of mutation_rewriter.go

### DIFF
--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -433,7 +433,8 @@ func (arw *AddRewriter) Rewrite(
 	// The above query is used to find old Author of the Post. The edge between the Post and
 	// Author is then deleted using the accompanied mutation.
 	var queries []*gql.GraphQuery
-	// newNodes is map from variable name to node type. This is used for applying auth on newly added nodes.
+	// newNodes is map from variable name to node type.
+	// This is used for applying auth on newly added nodes.
 	// This is collated from newNodes of each fragment.
 	// Example
 	// newNodes["Project3"] = schema.Type(Project)
@@ -441,7 +442,8 @@ func (arw *AddRewriter) Rewrite(
 	// mutationsAll stores mutations computed from fragment. These are returned as Mutation parameter
 	// of UpsertMutation
 	var mutationsAll []*dgoapi.Mutation
-	// retErrors stores errors found out during rewriting mutations. These are returned by this function.
+	// retErrors stores errors found out during rewriting mutations.
+	// These are returned by this function.
 	var retErrors error
 
 	// Parse upsert parameter from addMutation input.
@@ -491,7 +493,8 @@ func (arw *AddRewriter) Rewrite(
 			// }
 			// These are formed while doing Upserts with Add Mutations. These also contain
 			// any related auth queries.
-			queries = append(queries, RewriteUpsertQueryFromMutation(m, authRw, upsertVar, upsertVar, idExistence[upsertVar])...)
+			queries = append(queries, RewriteUpsertQueryFromMutation(
+				m, authRw, upsertVar, upsertVar, idExistence[upsertVar])...)
 			// Add upsert condition to ensure that the upsert takes place only when the node
 			// exists and has proper auth permission.
 			// Example condition:  cond: "@if(gt(len(State1), 0))"
@@ -579,7 +582,8 @@ func (urw *UpdateRewriter) Rewrite(
 	// The above query is used to find old Author of the Post. The edge between the Post and
 	// Author is then deleted using the accompanied mutation.
 	var queries []*gql.GraphQuery
-	// newNodes is map from variable name to node type. This is used for applying auth on newly added nodes.
+	// newNodes is map from variable name to node type.
+	// This is used for applying auth on newly added nodes.
 	// This is collated from newNodes of each fragment.
 	// Example
 	// newNodes["Project3"] = schema.Type(Project)
@@ -587,7 +591,8 @@ func (urw *UpdateRewriter) Rewrite(
 	// mutations stores mutations computed from fragment. These are returned as Mutation parameter
 	// of UpsertMutation
 	var mutations []*dgoapi.Mutation
-	// retErrors stores errors found out during rewriting mutations. These are returned by this function.
+	// retErrors stores errors found out during rewriting mutations.
+	// These are returned by this function.
 	var retErrors error
 
 	customClaims, err := m.GetAuthMeta().ExtractCustomClaims(ctx)
@@ -603,7 +608,8 @@ func (urw *UpdateRewriter) Rewrite(
 	}
 	authRw.hasAuthRules = hasAuthRules(m.QueryField(), authRw)
 
-	queries = append(queries, RewriteUpsertQueryFromMutation(m, authRw, MutationQueryVar, m.Name(), "")...)
+	queries = append(queries, RewriteUpsertQueryFromMutation(
+		m, authRw, MutationQueryVar, m.Name(), "")...)
 	srcUID := MutationQueryVarUID
 	objDel, okDelArg := delArg.(map[string]interface{})
 	objSet, okSetArg := setArg.(map[string]interface{})


### PR DESCRIPTION
Motivation:
After the large refactor of mutation_rewriter.go carried out as part of https://github.com/dgraph-io/dgraph/pull/7409, this PR does some more minor refactoring to Add and Update mutations.
1. Some small functions have been removed.
2. At a few places, arrays were unnecessarily used. They have been replaced with a single element.
3. Added comments.
4. Some repetitive variables have been removed.

This is meant to make code more readable and maintainable.

Testing:
Existing unit tests, e2e tests.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7653)
<!-- Reviewable:end -->
