### PR TITLE
perf(compression): Use gzip with BestSpeed in export and backup (#7643)

### DIFF
--- a/worker/backup_processor.go
+++ b/worker/backup_processor.go
@@ -126,9 +126,12 @@ func (pr *BackupProcessor) WriteBackup(ctx context.Context) (*pb.BackupResponse,
 
 	newhandler, err := enc.GetWriter(x.WorkerConfig.EncryptionKey, handler)
 	if err != nil {
-		return &response, err
+		return &response, errors.Wrap(err, "failed to get encWriter")
 	}
-	gzWriter := gzip.NewWriter(newhandler)
+	gzWriter, err := gzip.NewWriterLevel(newhandler, gzip.BestSpeed)
+	if err != nil {
+		return &response, errors.Wrap(err, "failed to create new gzip writer")
+	}
 
 	stream := pr.DB.NewStreamAt(pr.Request.ReadTs)
 	stream.LogPrefix = "Dgraph.Backup"

--- a/worker/export.go
+++ b/worker/export.go
@@ -365,7 +365,7 @@ func (writer *fileWriter) open(fpath string) error {
 	if err != nil {
 		return err
 	}
-	writer.gw, err = gzip.NewWriterLevel(w, gzip.BestCompression)
+	writer.gw, err = gzip.NewWriterLevel(w, gzip.BestSpeed)
 	return err
 }
 


### PR DESCRIPTION
Cherry-pick of #7643.

The export and backup code were using BestCompression and Default
gzip compression levels respectively. We see a 4x speed improvement when
switching from BestCompression to BestSpeed compression level.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7657)
<!-- Reviewable:end -->
