### PR TITLE
fix(export): don't return an error if there was no GraphQL schema

### DIFF
--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -429,11 +429,47 @@ func TestIntrospection(t *testing.T) {
 	// introspection response or the JSON comparison. Needs deeper looking.
 }
 
+func TestDeleteSchemaAndExport(t *testing.T) {
+	// first apply a schema
+	schema := `
+	type Person {
+		name: String
+	}`
+	schemaResp := updateGQLSchemaReturnSchema(t, schema, groupOneAdminServer)
+
+	// now delete it with S * * delete mutation
+	dg, err := testutil.DgraphClient(groupOnegRPC)
+	require.NoError(t, err)
+	txn := dg.NewTxn()
+	_, err = txn.Mutate(context.Background(), &api.Mutation{
+		DelNquads: []byte(fmt.Sprintf("<%s> * * .", schemaResp.Id)),
+	})
+	require.NoError(t, err)
+	require.NoError(t, txn.Commit(context.Background()))
+
+	// running an export shouldn't give any errors
+	exportReq := &common.GraphQLParams{
+		Query: `mutation {
+		  export(input: {format: "rdf"}) {
+			exportedFiles
+		  }
+		}`,
+	}
+	exportGqlResp := exportReq.ExecuteAsPost(t, groupOneAdminServer)
+	common.RequireNoGQLErrors(t, exportGqlResp)
+
+	// applying a new schema should still work
+	newSchemaResp := updateGQLSchemaReturnSchema(t, schema, groupOneAdminServer)
+	// we can assert that the uid allocated to new schema isn't same as the uid for old schema
+	require.NotEqual(t, schemaResp.Id, newSchemaResp.Id)
+}
+
 func updateGQLSchema(t *testing.T, schema, url string) *common.GraphQLResponse {
 	req := &common.GraphQLParams{
 		Query: `mutation updateGQLSchema($sch: String!) {
 			updateGQLSchema(input: { set: { schema: $sch }}) {
 				gqlSchema {
+					id
 					schema
 				}
 			}
@@ -447,6 +483,19 @@ func updateGQLSchema(t *testing.T, schema, url string) *common.GraphQLResponse {
 
 func updateGQLSchemaRequireNoErrors(t *testing.T, schema, url string) {
 	require.Nil(t, updateGQLSchema(t, schema, url).Errors)
+}
+
+func updateGQLSchemaReturnSchema(t *testing.T, schema, url string) gqlSchema {
+	resp := updateGQLSchema(t, schema, url)
+	require.Nil(t, resp.Errors)
+
+	var updateResp struct {
+		UpdateGQLSchema struct {
+			GqlSchema gqlSchema
+		}
+	}
+	require.NoError(t, json.Unmarshal(resp.Data, &updateResp))
+	return updateResp.UpdateGQLSchema.GqlSchema
 }
 
 func updateGQLSchemaConcurrent(t *testing.T, schema, url string) bool {

--- a/worker/export.go
+++ b/worker/export.go
@@ -548,7 +548,14 @@ func exportInternal(ctx context.Context, in *pb.ExportRequest, db *badger.DB,
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot read value of GraphQL schema")
 			}
-			if len(vals) != 1 {
+			// if the GraphQL schema node was deleted with S * * delete mutation,
+			// then the data key will be overwritten with nil value.
+			// So, just skip exporting it as there will be no value for this data key.
+			if len(vals) == 0 {
+				return nil, nil
+			}
+			// Give an error only if we find more than one value for the schema.
+			if len(vals) > 1 {
 				return nil, errors.Errorf("found multiple values for the GraphQL schema")
 			}
 			val, ok := vals[0].Value.([]byte)


### PR DESCRIPTION
Cherry-pick of #6815.

FIxes GRAPHQL-747
Fixes [Discuss Issue](https://discuss.dgraph.io/t/multiple-values-for-the-graphql-schema/10881)
This PR fixes the issue where you would get an error, if you first add a GraphQL schema, then delete the GraphQL schema using `<uid> * *` delete mutation and try to export the DB.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7660)
<!-- Reviewable:end -->
