### PR TITLE
fix(logging): do error handling upfront if JWT is not found

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -668,7 +668,10 @@ func resolveWithAdminServer(gqlReq *schema.Request, r *http.Request,
 	ctx = x.AttachAccessJwt(ctx, r)
 	ctx = x.AttachRemoteIP(ctx, r)
 	ctx = x.AttachAuthToken(ctx, r)
-	ctx = x.AttachJWTNamespace(ctx)
+	ctx, err := x.AttachJWTNamespace(ctx)
+	if err != nil {
+		return schema.ErrorResponse(err)
+	}
 
 	return adminServer.ResolveWithNs(ctx, x.GalaxyNamespace, gqlReq)
 }

--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -221,7 +221,8 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx = x.AttachAccessJwt(ctx, r)
 	ctx = x.AttachRemoteIP(ctx, r)
 	ctx = x.AttachAuthToken(ctx, r)
-	ctx = x.AttachJWTNamespace(ctx)
+	// Ignore the error here, it will be handled accordingly in downstream functions.
+	ctx, _ = x.AttachJWTNamespace(ctx)
 
 	var res *schema.Response
 	gqlReq, err := getRequest(r)

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -502,7 +502,6 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) (
 		return
 	}
 
-	ctx = x.AttachJWTNamespace(ctx)
 	op, err := r.schema.Operation(gqlReq)
 	if err != nil {
 		resp.Errors = schema.AsGQLErrors(err)
@@ -521,6 +520,13 @@ func (r *RequestResolver) Resolve(ctx context.Context, gqlReq *schema.Request) (
 			glog.Infof("Resolving GQL request: \n%s\nWith Variables: \n%s\n",
 				gqlReq.Query, string(b))
 		}
+	}
+
+	ctx, err = x.AttachJWTNamespace(ctx)
+	if err != nil && !(op.IsMutation() && op.Mutations()[0].Name() == "login") {
+		// For login request, JWT is not required.
+		resp.Errors = schema.AsGQLErrors(err)
+		return
 	}
 
 	// resolveQueries will resolve user's queries.

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -80,7 +80,10 @@ func (w *grpcWorker) UpdateGraphQLSchema(ctx context.Context,
 		return nil, errUpdatingGraphQLSchemaOnNonGroupOneLeader
 	}
 
-	ctx = x.AttachJWTNamespace(ctx)
+	ctx, err := x.AttachJWTNamespace(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "While updating gql schema")
+	}
 	namespace, err := x.ExtractNamespace(ctx)
 	if err != nil {
 		return nil, errors.Wrapf(err, "While updating gql schema")

--- a/x/x.go
+++ b/x/x.go
@@ -436,22 +436,17 @@ func ParseRequest(w http.ResponseWriter, r *http.Request, data interface{}) bool
 
 // AttachJWTNamespace attaches the namespace in the JWT claims to the context if present, otherwise
 // it attaches the galaxy namespace.
-func AttachJWTNamespace(ctx context.Context) context.Context {
+func AttachJWTNamespace(ctx context.Context) (context.Context, error) {
 	if !WorkerConfig.AclEnabled {
-		return AttachNamespace(ctx, GalaxyNamespace)
+		return AttachNamespace(ctx, GalaxyNamespace), nil
 	}
 
 	ns, err := ExtractJWTNamespace(ctx)
 	if err != nil {
-		glog.Errorf("Failed to get namespace from the accessJWT token: Error: %s", err)
-	} else {
-		// Attach the namespace only if we got one from JWT.
-		// This preserves any namespace directly present in the context which is needed for
-		// requests originating from dgraph internal code like server.go::GetGQLSchema() where
-		// context is created by hand.
-		ctx = AttachNamespace(ctx, ns)
+		return ctx, err
 	}
-	return ctx
+	ctx = AttachNamespace(ctx, ns)
+	return ctx, nil
 }
 
 // AttachNamespace adds given namespace to the metadata of the context.


### PR DESCRIPTION
There was some noise in logs due to errors printed when JWT was not found in context. This creates a bad user experience and creates confusion for users. 
We used to handle such errors in downstream code. This PR handles that error upfront.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
