### PR TITLE
fix(query): Fix pagination with match functions

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -328,6 +328,9 @@ gender                         : string .
 indexpred                      : string @index(exact) .
 pred                           : string .
 pname                          : string .
+tweet-a                        : string @index(trigram) .
+tweet-b                        : string @index(term) .
+tweet-c                        : string @index(fulltext) .
 `
 
 func populateCluster() {
@@ -828,6 +831,21 @@ func populateCluster() {
 		<67> <index-pred2> "I" .
 		<68> <index-pred2> "J" .
 		<69> <index-pred2> "K" .
+
+		<61> <tweet-a> "aaa" .
+		<62> <tweet-a> "aaaa" .
+		<63> <tweet-a> "aaaab" .
+		<64> <tweet-a> "aaaabb" .
+
+		<61> <tweet-b> "indiana" .
+		<62> <tweet-b> "indiana" .
+		<63> <tweet-b> "indiana jones" .
+		<64> <tweet-b> "indiana pop" .
+
+		<61> <tweet-c> "I am a citizen" .
+		<62> <tweet-c> "I am a citizen" .
+		<63> <tweet-c> "I am a citizen" .
+		<64> <tweet-c> "I am a citizen of Paradis Island" .
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -331,6 +331,7 @@ pname                          : string .
 tweet-a                        : string @index(trigram) .
 tweet-b                        : string @index(term) .
 tweet-c                        : string @index(fulltext) .
+tweet-d                        : string @index(trigram) .
 `
 
 func populateCluster() {
@@ -846,6 +847,10 @@ func populateCluster() {
 		<62> <tweet-c> "I am a citizen" .
 		<63> <tweet-c> "I am a citizen" .
 		<64> <tweet-c> "I am a citizen of Paradis Island" .
+
+		<61> <tweet-d> "aaabxxx" .
+		<62> <tweet-d> "aaacdxx" .
+		<63> <tweet-d> "aaabcd" .
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/query.go
+++ b/query/query.go
@@ -983,7 +983,7 @@ func calculateFirstN(sg *SubGraph) int32 {
 	shouldExclude := false
 	if sg.SrcFunc != nil {
 		switch sg.SrcFunc.Name {
-		case "regexp", "alloftext", "anyoftext", "anyofterms", "allofterms", "match":
+		case "regexp", "alloftext", "allofterms", "match":
 			shouldExclude = true
 		default:
 			shouldExclude = false

--- a/query/query.go
+++ b/query/query.go
@@ -975,19 +975,22 @@ func calculateFirstN(sg *SubGraph) int32 {
 	//     name
 	//   }
 	// }
-	// - should be has function (Right now, I'm doing it for has, later it can be extended)
-	// {
-	//   q(func: has(name), first:1) {
-	//     name
-	//   }
-	// }
-	// isSupportedFunction := sg.SrcFunc != nil && sg.SrcFunc.Name == "has"
+	// - should not be one of those function which fetches some results and then do further
+	// processing to narrow down the result. For example: allofterm will fetch the index postings
+	// for each term and then do an intersection.
+	// TODO: Look into how we can optimize queries involving these functions.
 
-	// Manish: Shouldn't all functions allow this? If we don't have a order and we don't have a
-	// filter, then we can respect the first N, offset Y arguments when retrieving data.
-	isSupportedFunction := true
-	if len(sg.Filters) == 0 && len(sg.Params.Order) == 0 &&
-		isSupportedFunction {
+	shouldExclude := false
+	if sg.SrcFunc != nil {
+		switch sg.SrcFunc.Name {
+		case "regexp", "alloftext", "anyoftext", "anyofterms", "allofterms", "match":
+			shouldExclude = true
+		default:
+			shouldExclude = false
+		}
+	}
+
+	if len(sg.Filters) == 0 && len(sg.Params.Order) == 0 && !shouldExclude {
 		// Offset also added because, we need n results to trim the offset.
 		if sg.Params.Count != 0 {
 			count = sg.Params.Count + sg.Params.Offset

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3432,6 +3432,52 @@ func TestEqFilterWithoutIndex(t *testing.T) {
 
 }
 
+func TestMatchingWithPagination(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		expected string
+	}{
+		{
+			`Test regexp matching with pagination`,
+			`{
+				me(func: regexp(tweet-a, /aaa.b/), first:1){
+					tweet-a
+				}
+			 }`,
+
+			`{"data":{"me":[{"tweet-a":"aaaab"}]}}`,
+		},
+		{
+			`Test term matching with pagination`,
+			`{
+				me(func: allofterms(tweet-b, "indiana jones"), first:1){
+					tweet-b
+				}
+			 }`,
+
+			`{"data":{"me":[{"tweet-b":"indiana jones"}]}}`,
+		},
+		{
+			`Test full-text matching with pagination`,
+			`{
+				me(func: alloftext(tweet-c, "I am a citizen of Paradis Island"), first:1){
+					tweet-c
+				}
+			 }`,
+
+			`{"data":{"me":[{"tweet-c":"I am a citizen of Paradis Island"}]}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := processQueryNoErr(t, tc.query)
+			require.JSONEq(t, tc.expected, result)
+		})
+	}
+}
+
 var client *dgo.Dgraph
 
 func TestMain(m *testing.M) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3445,7 +3445,6 @@ func TestMatchingWithPagination(t *testing.T) {
 					tweet-a
 				}
 			 }`,
-
 			`{"data":{"me":[{"tweet-a":"aaaab"}]}}`,
 		},
 		{
@@ -3455,7 +3454,6 @@ func TestMatchingWithPagination(t *testing.T) {
 					tweet-b
 				}
 			 }`,
-
 			`{"data":{"me":[{"tweet-b":"indiana jones"}]}}`,
 		},
 		{
@@ -3465,7 +3463,6 @@ func TestMatchingWithPagination(t *testing.T) {
 					tweet-c
 				}
 			 }`,
-
 			`{"data":{"me":[{"tweet-c":"I am a citizen of Paradis Island"}]}}`,
 		},
 	}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3465,6 +3465,15 @@ func TestMatchingWithPagination(t *testing.T) {
 			 }`,
 			`{"data":{"me":[{"tweet-c":"I am a citizen of Paradis Island"}]}}`,
 		},
+		{
+			`Test match function with pagination`,
+			`{
+				me(func: match(tweet-d, "aaaaaa", 3), first:1) {
+					tweet-d
+				}
+			 }`,
+			`{"data":{"me":[{"tweet-d":"aaabcd"}]}}`,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Due to narrowing down the query to only fetch N results from the
postings, some of the queries got broken. Some queries like 
`allofterms` requires fetching all the uids/postings from the posting list 
corresponding to each term relevant to the queries. And then do an
intersection of the results corresponding to each token. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7668)
<!-- Reviewable:end -->
