### PR TITLE
fix(postingList): Acquire lock before reading the cached posting list (#7632)

### DIFF
--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -437,12 +437,14 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 				key:   key,
 				plist: l.plist,
 			}
+			l.RLock()
 			if l.mutationMap != nil {
 				lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
 				for ts, pl := range l.mutationMap {
 					lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
 				}
 			}
+			l.RUnlock()
 			return lCopy, nil
 		}
 	}


### PR DESCRIPTION
The GetNew function may fetch the posting list from the cache. This
cached copy of the posting list might be still in use at other places
and so we need to acquire a lock on it before we read it.

Co-authored-by: NamanJain8 <jnaman806@gmail.com>
(cherry picked from commit 3f9effa96a8faff0d78cacc5b323138585727d0b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7671)
<!-- Reviewable:end -->
