### PR TITLE
fix(upgrade): make upgrade tool to work with non-acl cluster

### DIFF
--- a/upgrade/change_v21.03.0.go
+++ b/upgrade/change_v21.03.0.go
@@ -152,7 +152,8 @@ func dropDeprecated(dg *dgo.Dgraph) error {
 }
 
 func upgradePersitentQuery() error {
-	dg, cb := x.GetDgraphClient(Upgrade.Conf, true)
+	login := len(Upgrade.Conf.GetString(user)) > 0
+	dg, cb := x.GetDgraphClient(Upgrade.Conf, login)
 	defer cb()
 
 	jwt, err := getAccessJwt()
@@ -205,7 +206,8 @@ func upgradePersitentQuery() error {
 }
 
 func upgradeCORS() error {
-	dg, cb := x.GetDgraphClient(Upgrade.Conf, true)
+	login := len(Upgrade.Conf.GetString(user)) > 0
+	dg, cb := x.GetDgraphClient(Upgrade.Conf, login)
 	defer cb()
 
 	jwt, err := getAccessJwt()
@@ -215,7 +217,7 @@ func upgradeCORS() error {
 
 	// Get CORS.
 	corsData := make(map[string][]cors)
-	if err = getQueryResult(dg, queryCORS_v21_03_0, &corsData); err != nil {
+	if err := getQueryResult(dg, queryCORS_v21_03_0, &corsData); err != nil {
 		return errors.Wrap(err, "error querying cors")
 	}
 
@@ -239,7 +241,7 @@ func upgradeCORS() error {
 
 	// Get GraphQL schema.
 	schemaData := make(map[string][]sch)
-	if err = getQueryResult(dg, querySchema_v21_03_0, &schemaData); err != nil {
+	if err := getQueryResult(dg, querySchema_v21_03_0, &schemaData); err != nil {
 		return errors.Wrap(err, "error querying graphql schema")
 	}
 

--- a/upgrade/change_v21.03.0.go
+++ b/upgrade/change_v21.03.0.go
@@ -152,8 +152,7 @@ func dropDeprecated(dg *dgo.Dgraph) error {
 }
 
 func upgradePersitentQuery() error {
-	login := len(Upgrade.Conf.GetString(user)) > 0
-	dg, cb := x.GetDgraphClient(Upgrade.Conf, login)
+	dg, cb := x.GetDgraphClient(Upgrade.Conf, hasAclCreds())
 	defer cb()
 
 	jwt, err := getAccessJwt()
@@ -206,8 +205,7 @@ func upgradePersitentQuery() error {
 }
 
 func upgradeCORS() error {
-	login := len(Upgrade.Conf.GetString(user)) > 0
-	dg, cb := x.GetDgraphClient(Upgrade.Conf, login)
+	dg, cb := x.GetDgraphClient(Upgrade.Conf, hasAclCreds())
 	defer cb()
 
 	jwt, err := getAccessJwt()

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -41,7 +41,6 @@ var (
 type versionComparisonResult uint8
 
 const (
-	acl       = "acl"
 	dryRun    = "dry-run"
 	alpha     = "alpha"
 	slashGrpc = "slash_grpc_endpoint"
@@ -151,9 +150,9 @@ func init() {
 		},
 		Annotations: map[string]string{"group": "tool"},
 	}
+	Upgrade.EnvPrefix = "DGRAPH_UPGRADE"
 	Upgrade.Cmd.SetHelpTemplate(x.NonRootTemplate)
 	flag := Upgrade.Cmd.Flags()
-	flag.Bool(acl, false, "upgrade ACL from v1.2.2 to >=v20.03.0")
 	flag.Bool(dryRun, false, "dry-run the upgrade")
 	flag.StringP(alpha, "a", "127.0.0.1:9080",
 		"Comma separated list of Dgraph Alpha gRPC server address")
@@ -188,22 +187,9 @@ func run() {
 }
 
 func validateAndParseInput() (*commandInput, error) {
-	if !Upgrade.Conf.GetBool(acl) {
-		return nil, formatAsFlagParsingError(acl,
-			fmt.Errorf("we only support acl upgrade as of now"))
-	}
-
 	_, _, err := net.SplitHostPort(strings.TrimSpace(Upgrade.Conf.GetString(alpha)))
 	if err != nil {
 		return nil, formatAsFlagParsingError(alpha, err)
-	}
-
-	if strings.TrimSpace(Upgrade.Conf.GetString(user)) == "" {
-		return nil, formatAsFlagRequiredError(user)
-	}
-
-	if strings.TrimSpace(Upgrade.Conf.GetString(password)) == "" {
-		return nil, formatAsFlagRequiredError(password)
 	}
 
 	fromVersionParsed, err := parseVersionFromString(Upgrade.Conf.GetString(from))

--- a/upgrade/utils.go
+++ b/upgrade/utils.go
@@ -35,6 +35,9 @@ import (
 
 // getAccessJwt gets the access jwt token from by logging into the cluster.
 func getAccessJwt() (*api.Jwt, error) {
+	if len(Upgrade.Conf.GetString(user)) == 0 {
+		return &api.Jwt{}, nil
+	}
 	user := Upgrade.Conf.GetString(user)
 	password := Upgrade.Conf.GetString(password)
 	header := http.Header{}

--- a/upgrade/utils.go
+++ b/upgrade/utils.go
@@ -33,9 +33,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+func hasAclCreds() bool {
+	return len(Upgrade.Conf.GetString(user)) > 0
+}
+
 // getAccessJwt gets the access jwt token from by logging into the cluster.
 func getAccessJwt() (*api.Jwt, error) {
-	if len(Upgrade.Conf.GetString(user)) == 0 {
+	if !hasAclCreds() {
 		return &api.Jwt{}, nil
 	}
 	user := Upgrade.Conf.GetString(user)


### PR DESCRIPTION
For the upgrade in versions <= 20.07, `dgraph upgrade` tool updates the acl relates data. Hence, it had `--acl` flag. With the update of the upgrade tool for 21.03, it should work without ACL as well. This PR adds that support.
  
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7674)
<!-- Reviewable:end -->
