### PR TITLE
feat(Flags): [Breaking] Add flag for snapshot duration frequency

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -311,7 +311,7 @@ func getAlpha(idx int, raft string) service {
 	}
 
 	if opts.SnapshotAfter != "" {
-		raft = fmt.Sprintf("%s; snapshot-after=%s", raft, opts.SnapshotAfter)
+		raft = fmt.Sprintf("%s; snapshot-after-entries=%s", raft, opts.SnapshotAfter)
 	}
 	svc.Command += fmt.Sprintf(` --raft "%s"`, raft)
 

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -311,7 +311,7 @@ func getAlpha(idx int, raft string) service {
 	}
 
 	if opts.SnapshotAfter != "" {
-		raft = fmt.Sprintf("%s; snapshot-after-entries=%s", raft, opts.SnapshotAfter)
+		raft = fmt.Sprintf("%s; %s", raft, opts.SnapshotAfter)
 	}
 	svc.Command += fmt.Sprintf(` --raft "%s"`, raft)
 

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -160,13 +160,11 @@ they form a Raft group and provide synchronous replication.
 				"in Raft elections. This can be used to achieve a read-only replica.").
 		Flag("snapshot-after-entries",
 			"Create a new Raft snapshot after N number of Raft entries. The lower this number, "+
-				"the more frequent snapshot creation will be. Snapshots are created if either "+
-				"snapshot-after-duration or snapshot-after-entries threshold is crossed.").
+				"the more frequent snapshot creation will be. Snapshots are created only if both "+
+				"snapshot-after-duration and snapshot-after-entries threshold are crossed.").
 		Flag("snapshot-after-duration",
 			"Frequency at which we should create a new raft snapshots. Set "+
-				"to 0 to disable duration based snapshot. Snapshots are "+
-				"created if either snapshot-after-duration or "+
-				"snapshot-after-entries threshold is crossed.").
+				"to 0 to disable duration based snapshot.").
 		Flag("pending-proposals",
 			"Number of pending mutation proposals. Useful for rate limiting.").
 		String())

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -158,9 +158,15 @@ they form a Raft group and provide synchronous replication.
 		Flag("learner",
 			`Make this Alpha a "learner" node. In learner mode, this Alpha will not participate `+
 				"in Raft elections. This can be used to achieve a read-only replica.").
-		Flag("snapshot-after",
+		Flag("snapshot-after-entries",
 			"Create a new Raft snapshot after N number of Raft entries. The lower this number, "+
-				"the more frequent snapshot creation will be.").
+				"the more frequent snapshot creation will be. Snapshots are created if either "+
+				"snapshot-after-duration or snapshot-after-entries threshold is crossed.").
+		Flag("snapshot-after-duration",
+			"Frequency at which we should create a new raft snapshots. Set "+
+				"to 0 to disable duration based snapshot. Snapshots are "+
+				"created if either snapshot-after-duration or "+
+				"snapshot-after-entries threshold is crossed.").
 		Flag("pending-proposals",
 			"Number of pending mutation proposals. Useful for rate limiting.").
 		String())

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -15,11 +15,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha2
@@ -33,11 +31,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha3
@@ -51,11 +47,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha4
@@ -69,11 +63,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha4:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha5
@@ -87,11 +79,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha5:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha6
@@ -105,11 +95,9 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha6:7080
-      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
-      --raft "snapshot-after=100;"
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
+      --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
+      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   jaeger:
     image: jaegertracing/all-in-one:1.18
     working_dir: /working/jaeger
@@ -133,9 +121,8 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080
-      --replicas=3 --logtostderr -v=2 --bindall
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
+      --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
   zero2:
     image: dgraph/dgraph:latest
     working_dir: /data/zero2
@@ -151,9 +138,8 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=2;" --my=zero2:5080
-      --replicas=3 --logtostderr -v=2 --peer=zero1:5080
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
+      --my=zero2:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:latest
     working_dir: /data/zero3
@@ -169,7 +155,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=3;" --my=zero3:5080
-      --replicas=3 --logtostderr -v=2 --peer=zero1:5080
-      --trace "jaeger=http://jaeger:14268;"
+    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
+      --my=zero3:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
 volumes: {}

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -1,4 +1,4 @@
-# Auto-generated with: [./compose -a 6 -z 3 -j -w --port_offset=0 --expose_ports=false -O ../worker/docker-compose.yml --mem= --snapshot_after=100 --names=false]
+# Auto-generated with: [./compose -a 6 -z 3 -j -w --port_offset=0 --expose_ports=false -O ../worker/docker-compose.yml --mem= --snapshot_after=snapshot-after-entries=100; snapshot-after-duration=1m --names=false]
 #
 version: "3.5"
 services:
@@ -17,7 +17,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha2
@@ -33,7 +33,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha3
@@ -49,7 +49,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha4
@@ -65,7 +65,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha5
@@ -81,7 +81,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
     image: dgraph/dgraph:latest
     working_dir: /data/alpha6
@@ -97,7 +97,7 @@ services:
       read_only: true
     command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
-      snapshot-after-entries=100" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   jaeger:
     image: jaegertracing/all-in-one:1.18
     working_dir: /working/jaeger

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1061,8 +1061,9 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 					// or our checkpoint already crossed the SnapshotAfter threshold.
 					if err := n.proposeSnapshot(); err != nil {
 						glog.Errorf("While calculating and proposing snapshot: %v", err)
+					} else {
+						lastSnapshotTime = time.Now()
 					}
-					lastSnapshotTime = time.Now()
 				}
 				go n.abortOldTransactions()
 			}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1003,9 +1003,7 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 	snapshotAfterEntries := x.WorkerConfig.Raft.GetUint64("snapshot-after-entries")
 	x.AssertTruef(snapshotAfterEntries > 10, "raft.snapshot-after must be a number greater than 10")
 
-	snapshotAfterDuration, err := time.ParseDuration(x.WorkerConfig.Raft.GetString("snapshot-after-duration"))
-	x.AssertTruef(err == nil, "raft.snapshot-after-duration must be a duration, recieved: %s",
-		x.WorkerConfig.Raft.GetString("snapshot-after-duration"))
+	snapshotAfterDuration := x.WorkerConfig.Raft.GetDuration("snapshot-after-duration")
 
 	for {
 		select {
@@ -1031,6 +1029,8 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 
 				// If we don't have a snapshot, or if there are too many log files in Raft,
 				// calculate a new snapshot.
+				// For snapshotAfterDuration, 0 is a special value used to
+				// disable time based snapshots.
 				calculate := raft.IsEmptySnap(snap) || n.Store.NumLogFiles() > 4 ||
 					(snapshotAfterDuration != 0 && time.Since(lastSnapshotTime) > snapshotAfterDuration)
 

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -38,10 +38,11 @@ const (
 	//       For easy readability, keep the options without default values (if any) at the end of
 	//       the *Defaults string. Also, since these strings are printed in --help text, avoid line
 	//       breaks.
-	AclDefaults       = `access-ttl=6h; refresh-ttl=30d; secret-file=;`
-	AuditDefaults     = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
-	BadgerDefaults    = `compression=snappy; goroutines=8; max-retries=-1;`
-	RaftDefaults      = `learner=false; snapshot-after=10000; pending-proposals=256; idx=; group=;`
+	AclDefaults    = `access-ttl=6h; refresh-ttl=30d; secret-file=;`
+	AuditDefaults  = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
+	BadgerDefaults = `compression=snappy; goroutines=8; max-retries=-1;`
+	RaftDefaults   = `learner=false; snapshot-after-entries=10000; ` +
+		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
 	SecurityDefaults  = `token=; whitelist=;`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +


### PR DESCRIPTION
Add a new flag snapshot-after-duration, which will take duration as a value. Raft snapshots will now be taken based on time since the last snapshot or the number of new raft entries. Also, rename snapshot-after to snapshot-after-entries for distinction.

Fixes DGRAPH-3213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7675)
<!-- Reviewable:end -->
