### PR TITLE
Opt(Backup): Make backups faster

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -181,11 +181,7 @@ func RemoveRange(bm *roaring64.Bitmap, from, to uint64) {
 
 // DecodeToBuffer is the same as Decode but it returns a z.Buffer which is
 // calloc'ed and can be SHOULD be freed up by calling buffer.Release().
-func DecodeToBuffer(bm *roaring64.Bitmap) *z.Buffer {
-	buf, err := z.NewBufferWith(256<<20, 32<<30, z.UseCalloc, "Codec.DecodeToBuffer")
-	x.Check(err)
-	buf.AutoMmapAfter(1 << 30)
-
+func DecodeToBuffer(buf *z.Buffer, bm *roaring64.Bitmap) {
 	var last uint64
 	tmp := make([]byte, 16)
 	itr := bm.ManyIterator()
@@ -201,5 +197,4 @@ func DecodeToBuffer(bm *roaring64.Bitmap) *z.Buffer {
 			last = u
 		}
 	}
-	return buf
 }

--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -199,32 +199,42 @@ func run(conf *viper.Viper) {
 		dg = dgTmp
 	}
 
-	// Run things serially first.
-	for i := 0; i < conc; i++ {
-		_, err := process(dg, conf)
-		x.Check(err)
-		num--
+	addOne := func(i int) error {
+		txnStart := time.Now() // Start time of transaction
+		cnt, err := process(dg, conf)
+		now := time.Now().UTC().Format(format)
+		if err != nil {
+			return err
+		}
+		serverLat := cnt.qLatency + cnt.mLatency
+		clientLat := time.Since(txnStart).Round(time.Millisecond)
+		fmt.Printf(
+			"[w%d] %-17s Counter VAL: %d   [ Ts: %d ] Latency: Q %s M %s S %s C %s D %s\n",
+			i, now, cnt.Val, cnt.startTs, cnt.qLatency, cnt.mLatency,
+			serverLat, clientLat, clientLat-serverLat)
+		return nil
+	}
+
+	// Run things serially first, if conc > 1.
+	if conc > 1 {
+		for i := 0; i < conc; i++ {
+			err := addOne(0)
+			x.Check(err)
+			num--
+		}
 	}
 
 	var wg sync.WaitGroup
-	f := func(i int) {
+	f := func(worker int) {
 		defer wg.Done()
 		count := 0
 		for count < num {
-			txnStart := time.Now() // Start time of transaction
-			cnt, err := process(dg, conf)
-			now := time.Now().UTC().Format(format)
-			if err != nil {
+			if err := addOne(worker); err != nil {
+				now := time.Now().UTC().Format(format)
 				fmt.Printf("%-17s While trying to process counter: %v. Retrying...\n", now, err)
 				time.Sleep(time.Second)
 				continue
 			}
-			serverLat := cnt.qLatency + cnt.mLatency
-			clientLat := time.Since(txnStart).Round(time.Millisecond)
-			fmt.Printf(
-				"[%d] %-17s Counter VAL: %d   [ Ts: %d ] Latency: Q %s M %s S %s C %s D %s\n",
-				i, now, cnt.Val, cnt.startTs, cnt.qLatency, cnt.mLatency,
-				serverLat, clientLat, clientLat-serverLat)
 			time.Sleep(waitDur)
 			count++
 		}
@@ -232,7 +242,7 @@ func run(conf *viper.Viper) {
 
 	for i := 0; i < conc; i++ {
 		wg.Add(1)
-		go f(i)
+		go f(i + 1)
 	}
 	wg.Wait()
 }

--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -57,7 +57,7 @@ func main() {
 		for range ticker.C {
 			// Read Jemalloc stats first. Print if there's a big difference.
 			z.ReadMemStats(&js)
-			if diff := absDiff(uint64(z.NumAllocBytes()), lastAlloc); diff > 256<<20 {
+			if diff := absDiff(uint64(z.NumAllocBytes()), lastAlloc); diff > 1<<30 {
 				glog.V(2).Infof("NumAllocBytes: %s jemalloc: Active %s Allocated: %s"+
 					" Resident: %s Retained: %s\n",
 					humanize.IBytes(uint64(z.NumAllocBytes())),

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/dgraph-io/dgraph
 
 go 1.12
 
-// replace github.com/dgraph-io/badger/v2 => /home/mrjn/go/src/github.com/dgraph-io/badger
+// replace github.com/dgraph-io/badger/v3 => /home/mrjn/go/src/github.com/dgraph-io/badger
 // replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
 // replace github.com/dgraph-io/roaring => /home/mrjn/go/src/github.com/dgraph-io/roaring
 
@@ -18,7 +18,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.0.0-20210309075542-2245c18dfd1f
+	github.com/dgraph-io/badger/v3 v3.0.0-20210401200525-7d7d7908a001
 	github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v3 v3.0.0-20210309075542-2245c18dfd1f h1:dZpGNLp9YUpq4h2DRcWAjW5dWj47SM3W3NK71z6FRa0=
-github.com/dgraph-io/badger/v3 v3.0.0-20210309075542-2245c18dfd1f/go.mod h1:GHMCYxuDWyzbHkh4k3yyg4PM61tJPFfEGSMbE3Vd5QE=
+github.com/dgraph-io/badger/v3 v3.0.0-20210401200525-7d7d7908a001 h1:7OzzBbTJUQDOLyAVMsukbWUluAapUQr/2kW5dr0rgs0=
+github.com/dgraph-io/badger/v3 v3.0.0-20210401200525-7d7d7908a001/go.mod h1:GHMCYxuDWyzbHkh4k3yyg4PM61tJPFfEGSMbE3Vd5QE=
 github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2 h1:3STgJCaLdsBynA0FDLqocwk/OdlnrQ5MGbR74C4NvUs=
 github.com/dgraph-io/dgo/v200 v200.0.0-20210212152539-e0a5bde40ba2/go.mod h1:zCfS4R3E/UC/PhETXJYq/Blia0eCH1EQqKrWDvvimxE=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -937,7 +937,8 @@ func gunzipData(data []byte) ([]byte, error) {
 
 func gzipData(data []byte) ([]byte, error) {
 	var b bytes.Buffer
-	gz := gzip.NewWriter(&b)
+	gz, err := gzip.NewWriterLevel(&b, gzip.BestSpeed)
+	x.Check(err)
 
 	if _, err := gz.Write(data); err != nil {
 		return nil, err

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/dgraph-io/roaring/roaring64"
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
@@ -1436,7 +1437,9 @@ func TestSingleListRollup(t *testing.T) {
 	}
 
 	var bl pb.BackupPostingList
-	kv, err := ol.ToBackupPostingList(&bl, nil)
+	buf := z.NewBuffer(10<<10, "TestSingleListRollup")
+	defer buf.Release()
+	kv, err := ol.ToBackupPostingList(&bl, nil, buf)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(kv.UserMeta))
 	require.Equal(t, BitCompletePosting, kv.UserMeta[0])

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -71,6 +71,8 @@ type Manifest struct {
 	// DropOperations lists the various DROP operations that took place since the last backup.
 	// These are used during restore to redo those operations before applying the backup.
 	DropOperations []*pb.DropOperation `json:"drop_operations"`
+	// Compression keeps track of the compression that was used for the data.
+	Compression string `json:"compression"`
 }
 
 type MasterManifest struct {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -199,9 +199,11 @@ func (n *node) stopAllTasks() {
 	defer n.closer.Done() // CLOSER:1
 	<-n.closer.HasBeenClosed()
 
+	glog.Infof("Stopping all ongoing registered tasks...")
 	n.opsLock.Lock()
 	defer n.opsLock.Unlock()
-	for _, closer := range n.ops {
+	for op, closer := range n.ops {
+		glog.Infof("Stopping op: %s...\n", op)
 		closer.SignalAndWait()
 	}
 	glog.Infof("Stopped all ongoing registered tasks.")

--- a/worker/export.go
+++ b/worker/export.go
@@ -378,7 +378,7 @@ func (writer *ExportWriter) open(fpath string) error {
 	if err != nil {
 		return err
 	}
-	writer.gw, err = gzip.NewWriterLevel(w, gzip.BestCompression)
+	writer.gw, err = gzip.NewWriterLevel(w, gzip.BestSpeed)
 	return err
 }
 


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

- Gzip compression is slow. For backups, I've switched to using snappy for compression. This change is backwards compatible.
- Refactor how backup reader is generated to deal with the compression that's used for creating backup.
- Avoid creating a z.Buffer for every call to marshal uid list. Instead, reuse the same one over and over.

With these changes, we can backup 150GB of data in ~50 mins on my workstation, using 8 goroutines and under 1.5GB of jemalloc memory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7680)
<!-- Reviewable:end -->
