### PR TITLE
[BREAKING] chore(flags): move encryption_key_file and 2 other flags under superflag

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -347,7 +347,7 @@ func getAlpha(idx int, raft string) service {
 		}
 	}
 	if opts.Encryption {
-		svc.Command += " --encryption_key_file=/secret/enc_key"
+		svc.Command += ` --encryption "key-file=/secret/enc_key;"`
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
 			Source:   "./enc-secret",

--- a/contrib/config/backups/client/compose-setup.sh
+++ b/contrib/config/backups/client/compose-setup.sh
@@ -220,7 +220,7 @@ config_compose() {
   [[ $TOKEN_ENABLED == "true" ]] && \
     echo "auth_token = '$(cat ./data/token/auth_token_file)'" >> "$CFGPATH/config.toml"
   [[ $ENC_ENABLED == "true" ]] && \
-    echo "encryption_key_file = '/dgraph/enc/enc_key_file'" >> "$CFGPATH/config.toml"
+    echo "--encryption \"key-file=/dgraph/enc/enc_key_file;\"" >> "$CFGPATH/config.toml"
   [[ $TLS_ENABLED == "true" ]] &&
     cat <<-TLS_CONFIG >> $CFGPATH/config.toml
 tls_client_auth = '$TLS_CLIENT_AUTH'

--- a/contrib/manual_tests/test.sh
+++ b/contrib/manual_tests/test.sh
@@ -267,7 +267,7 @@ function test::manual_start_encryption() {
   local -r n_alphas=3
 
   dgraph::start_zeros "$n_zeros"
-  dgraph::start_alphas "$n_alphas" --encryption_key_file "$ENCRYPTION_KEY_PATH"
+  dgraph::start_alphas "$n_alphas" --encryption "key-file=$ENCRYPTION_KEY_PATH;"
 
   for i in $(seq "$n_zeros"); do
     dgraph::healthcheck_zero "$i"
@@ -398,7 +398,7 @@ function test::manual_start_encryption_acl_tls() {
   dgraph::start_zeros "$n_zeros"
   dgraph::start_alphas "$n_alphas" \
     --acl "secret-file=$ACL_SECRET_PATH;" \
-    --encryption_key_file "$ENCRYPTION_KEY_PATH" \
+    --encryption "key-file=$ENCRYPTION_KEY_PATH" \
     --tls "ca-cert=$TLS_PATH/ca.crt; server-cert=$TLS_PATH/node.crt; server-key=$TLS_PATH/node.key;"
 
   for i in $(seq "$n_zeros"); do

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -105,16 +105,11 @@ they form a Raft group and provide synchronous replication.
 	x.FillCommonFlags(flag)
 	// --tls SuperFlag
 	x.RegisterServerTLSFlags(flag)
-	// --encryption_key_file
+	// --encryption and --vault Superflag
 	enc.RegisterFlags(flag)
 
 	flag.StringP("postings", "p", "p", "Directory to store posting lists.")
 	flag.String("tmp", "t", "Directory to store temporary buffers.")
-
-	// Snapshot and Transactions.
-	flag.String("abort_older_than", "5m",
-		"Abort any pending transactions older than this duration. The liveness of a"+
-			" transaction is determined by its last mutation.")
 
 	flag.StringP("wal", "w", "w", "Directory to store raft write-ahead logs.")
 	flag.String("export", "export", "Folder in which to store exports.")
@@ -217,6 +212,8 @@ they form a Raft group and provide synchronous replication.
 		Flag("query-timeout",
 			"Maximum time after which a query execution will fail. If set to"+
 				" 0, the timeout is infinite.").
+		Flag("txn-abort-after", "Abort any pending transactions older than this duration."+
+			" The liveness of a transaction is determined by its last mutation.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
@@ -672,6 +669,7 @@ func run() {
 
 	x.Config.Limit = z.NewSuperFlag(Alpha.Conf.GetString("limit")).MergeAndCheckDefault(
 		worker.LimitDefaults)
+	abortDur := x.Config.Limit.GetDuration("txn-abort-after")
 	switch strings.ToLower(x.Config.Limit.GetString("mutations")) {
 	case "allow":
 		opts.MutationsMode = worker.AllowMutations
@@ -687,9 +685,6 @@ func run() {
 	worker.SetConfiguration(&opts)
 
 	ips, err := getIPsFromString(security.GetString("whitelist"))
-	x.Check(err)
-
-	abortDur, err := time.ParseDuration(Alpha.Conf.GetString("abort_older_than"))
 	x.Check(err)
 
 	tlsClientConf, err := x.LoadClientTLSConfigForInternalPort(Alpha.Conf)

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -73,10 +73,10 @@ func init() {
 		"Specify file format (rdf or json) instead of getting it from filename.")
 	flag.Bool("encrypted", false,
 		"Flag to indicate whether schema and data files are encrypted. "+
-			"Must be specified with --encryption_key_file or vault option(s).")
+			"Must be specified with --encryption or vault option(s).")
 	flag.Bool("encrypted_out", false,
 		"Flag to indicate whether to encrypt the output. "+
-			"Must be specified with --encryption_key_file or vault option(s).")
+			"Must be specified with --encryption or vault option(s).")
 	flag.String("out", defaultOutDir,
 		"Location to write the final dgraph data directories.")
 	flag.Bool("replace_out", false,
@@ -194,7 +194,7 @@ func run() {
 	_, opt.EncryptionKey = ee.GetKeys(Bulk.Conf)
 	if len(opt.EncryptionKey) == 0 {
 		if opt.Encrypted || opt.EncryptedOut {
-			fmt.Fprint(os.Stderr, "Must use --encryption_key_file or vault option(s).\n")
+			fmt.Fprint(os.Stderr, "Must use --encryption or vault option(s).\n")
 			os.Exit(1)
 		}
 	} else {

--- a/dgraph/cmd/decrypt/decrypt.go
+++ b/dgraph/cmd/decrypt/decrypt.go
@@ -31,7 +31,7 @@ import (
 )
 
 type options struct {
-	// keyfile comes from the encryption_key_file or Vault flags
+	// keyfile comes from the encryption or Vault flags
 	keyfile x.SensitiveByteSlice
 	file    string
 	output  string

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 )
@@ -284,7 +285,8 @@ func TestLiveLoadExportedSchema(t *testing.T) {
 		{testutil.DgraphBinaryPath(), "live",
 			"--schema", localExportPath + "/" + exportId + "/" + groupId + ".schema.gz",
 			"--files", localExportPath + "/" + exportId + "/" + groupId + ".rdf.gz",
-			"--encryption_key_file", testDataDir + "/../../../../ee/enc/test-fixtures/enc-key",
+			"--encryption",
+			enc.BuildEncFlag(testDataDir + "/../../../../ee/enc/test-fixtures/enc-key"),
 			"--alpha", alphaService, "--zero", zeroService,
 			"--creds", "user=groot;password=password;"},
 	}

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -101,8 +101,6 @@ instances to achieve high-availability.
 	flag.StringP("wal", "w", "zw", "Directory storing WAL.")
 	flag.Duration("rebalance_interval", 8*time.Minute, "Interval for trying a predicate move.")
 	flag.String("enterprise_license", "", "Path to the enterprise license file.")
-	flag.Bool("disable_admin_http", false,
-		"Turn on/off the administrative endpoints exposed over Zero's HTTP port.")
 
 	flag.String("limit", worker.ZeroLimitsDefaults, z.NewSuperFlagHelp(worker.ZeroLimitsDefaults).
 		Head("Limit options").
@@ -111,6 +109,8 @@ instances to achieve high-availability.
 			in an interval specified by refill-interval. Set it to 0 to remove limiting.`).
 		Flag("refill-interval",
 			"The interval after which the tokens for UID lease are replenished.").
+		Flag("disable-admin-http",
+			"Turn on/off the administrative endpoints exposed over Zero's HTTP port.").
 		String())
 
 	flag.String("raft", raftDefaults, z.NewSuperFlagHelp(raftDefaults).
@@ -328,7 +328,7 @@ func run() {
 
 	baseMux.HandleFunc("/health", st.pingResponse)
 	// the following endpoints are disabled only if the flag is explicitly set to true
-	if !Zero.Conf.GetBool("disable_admin_http") {
+	if !limit.GetBool("disable-admin-http") {
 		baseMux.HandleFunc("/state", st.getState)
 		baseMux.HandleFunc("/removeNode", st.removeNode)
 		baseMux.HandleFunc("/moveTablet", st.moveTablet)

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -102,7 +102,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -130,7 +130,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -158,7 +158,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -186,7 +186,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -214,7 +214,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption_key_file "/dgraph-enc/enc-key" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1129,7 +1129,7 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, er
 	}
 	// Add a timeout for queries which don't have a deadline set. We don't want to
 	// apply a timeout if it's a mutation, that's currently handled by flag
-	// "abort_older_than".
+	// "txn-abort-after".
 	if req.GetMutations() == nil && x.Config.QueryTimeout != 0 {
 		if d, _ := ctx.Deadline(); d.IsZero() {
 			var cancel context.CancelFunc

--- a/ee/enc/flags.go
+++ b/ee/enc/flags.go
@@ -17,16 +17,27 @@ package enc
  */
 
 import (
+	"fmt"
+
 	"github.com/dgraph-io/dgraph/ee/vault"
+	"github.com/dgraph-io/ristretto/z"
 	"github.com/spf13/pflag"
 )
 
+const EncryptionDefaults = `key-file=;`
+
+func BuildEncFlag(filename string) string {
+	return fmt.Sprintf("key-file=%s;", filename)
+}
+
 // RegisterFlags registers the required encryption flags.
 func RegisterFlags(flag *pflag.FlagSet) {
-	flag.String("encryption_key_file", "",
-		"[Enterprise Feature] Encryption At Rest: The file that stores the symmetric key of "+
-			"length 16, 24, or 32 bytes. The key size determines the chosen AES cipher "+
-			"(AES-128, AES-192, and AES-256 respectively).")
+	flag.String("encryption", EncryptionDefaults, z.NewSuperFlagHelp(EncryptionDefaults).
+		Head("[Enterprise Feature] Encryption At Rest options").
+		Flag("key-file",
+			"The file that stores the symmetric key of length 16, 24, or 32 bytes. The key size"+
+				" determines the chosen AES cipher (AES-128, AES-192, and AES-256 respectively).").
+		String())
 
 	vault.RegisterFlags(flag)
 }

--- a/ee/utils.go
+++ b/ee/utils.go
@@ -25,7 +25,7 @@ import (
 )
 
 // GetKeys returns the ACL and encryption keys as configured by the user
-// through the --acl, --encryption_key_file, and --vault flags. On OSS builds,
+// through the --acl, --encryption, and --vault flags. On OSS builds,
 // this function exits with an error.
 func GetKeys(config *viper.Viper) (x.SensitiveByteSlice, x.SensitiveByteSlice) {
 	glog.Exit("flags: acl / encryption is an enterprise-only feature")

--- a/ee/utils_ee.go
+++ b/ee/utils_ee.go
@@ -15,6 +15,7 @@ package ee
 import (
 	"io/ioutil"
 
+	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/ee/vault"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
@@ -23,7 +24,7 @@ import (
 )
 
 // GetKeys returns the ACL and encryption keys as configured by the user
-// through the --acl, --encryption_key_file, and --vault flags. On OSS builds,
+// through the --acl, --encryption, and --vault flags. On OSS builds,
 // this function exits with an error.
 func GetKeys(config *viper.Viper) (x.SensitiveByteSlice, x.SensitiveByteSlice) {
 	aclSuperFlag := z.NewSuperFlag(config.GetString("acl"))
@@ -43,10 +44,11 @@ func GetKeys(config *viper.Viper) (x.SensitiveByteSlice, x.SensitiveByteSlice) {
 		glog.Exitf("ACL secret key must have length of at least 32 bytes, got %d bytes instead", l)
 	}
 
-	encKeyFile := config.GetString("encryption_key_file")
+	encSuperFlag := z.NewSuperFlag(config.GetString("encryption")).MergeAndCheckDefault(enc.EncryptionDefaults)
+	encKeyFile := encSuperFlag.GetPath("key-file")
 	if encKeyFile != "" {
 		if encKey != nil {
-			glog.Exit("flags: Encryption key set in both vault and encryption_key_file")
+			glog.Exit("flags: Encryption key set in both vault and encryption")
 		}
 		if encKey, err = ioutil.ReadFile(encKeyFile); err != nil {
 			glog.Exitf("error reading encryption key from file: %s: %s", encKeyFile, err)

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -333,7 +333,7 @@ func runFailingRestore(t *testing.T, backupLocation, lastDir string, commitTs ui
 
 	// Get key.
 	config := getEncConfig()
-	config.Set("encryption_key_file", "../../../ee/enc/test-fixtures/enc-key")
+	config.Set("encryption", enc.BuildEncFlag("../../../ee/enc/test-fixtures/enc-key"))
 	_, encKey := ee.GetKeys(config)
 	require.NotNil(t, encKey)
 

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -1,5 +1,3 @@
-# Auto-generated with: [./compose -a 3 -z 1 -r 1 --minio_port=9001 --minio_env_file=../../backup.env --alpha_volume=../../../ee/enc/test-fixtures/enc-key:/dgraph-enc/enc-key:ro --extra_alpha_flags=--encryption_key_file="/dgraph-enc/enc-key" --alpha_env_file=../../backup.env -w --port_offset=0 --expose_ports=false --mem= --names=false -O ../systest/backup/encryption/docker-compose.yml]
-#
 version: "3.5"
 services:
   alpha1:
@@ -25,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption_key_file="/dgraph-enc/enc-key"
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -51,7 +49,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption_key_file="/dgraph-enc/enc-key"
+    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -77,8 +75,8 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption_key_file="/dgraph-enc/enc-key"
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" --encryption_key_file="/dgraph-enc/enc-key"
+    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
     image: dgraph/dgraph:latest

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=1;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=1;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -65,7 +65,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=2;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=2;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -100,7 +100,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=3;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=3;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   alpha4:
@@ -135,7 +135,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha4:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=4;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=4;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha4.crt; client-key=/dgraph-tls/client.alpha4.key;"
   alpha5:
@@ -170,7 +170,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha5:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=5;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=5;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha5.crt; client-key=/dgraph-tls/client.alpha5.key;"
   alpha6:
@@ -205,7 +205,7 @@ services:
       target: /dgraph-tls
       read_only: true
     command: /gobin/dgraph alpha --my=alpha6:7080 --zero=zero1:5080
-      --logtostderr -v=2 --raft "idx=6;" --encryption_key_file /data/keys/enc_key
+      --logtostderr -v=2 --raft "idx=6;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha6.crt; client-key=/dgraph-tls/client.alpha6.key;"
   ratel:

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -52,7 +52,7 @@ func openDgraph(pdir string) (*badger.DB, error) {
 	if err := config.BindPFlags(flags); err != nil {
 		return nil, err
 	}
-	config.Set("encryption_key_file", KeyFile)
+	config.Set("encryption", enc.BuildEncFlag(KeyFile))
 	_, encKey := ee.GetKeys(config)
 
 	opt := badger.DefaultOptions(pdir).

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -293,7 +293,7 @@ func getEncConfig(req *pb.RestoreRequest) (*viper.Viper, error) {
 	}
 
 	// Copy from the request.
-	config.Set("encryption_key_file", req.EncryptionKeyFile)
+	config.Set("encryption", enc.BuildEncFlag(req.EncryptionKeyFile))
 
 	vaultBuilder := new(strings.Builder)
 	if req.VaultRoleidFile != "" {

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -48,8 +48,8 @@ const (
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
-		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms;`
-	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s`
+		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;`
+	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
 	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 	CacheDefaults = `size-mb=1024; percentage=0,65,35;`


### PR DESCRIPTION
- Moves `encryption_key_file` under NEW `encryption` super flag.
- Moves `abort_older_than` flag in alpha as `txn-abort-after` under `--limit` flag.
- Moves `disable_admin_http` flag in zero as `disable-admin-http` under `--limit` flag.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7681)
<!-- Reviewable:end -->
