### PR TITLE
fix(restore): append the object path prefix while reading backup

### DIFF
--- a/worker/s3_handler.go
+++ b/worker/s3_handler.go
@@ -222,7 +222,7 @@ func (h *s3Handler) Load(uri *url.URL, backupId string, backupNum uint64, fn loa
 			continue
 		}
 
-		path := manifests[i].Path
+		path := filepath.Join(h.objectPrefix, manifests[i].Path)
 		for gid := range manifest.Groups {
 			object := filepath.Join(path, backupName(manifest.Since, gid))
 			reader, err := h.mc.GetObject(h.bucketName, object, minio.GetObjectOptions{})


### PR DESCRIPTION
The restore fails on S3 when the object is nested (`s3://s3.us-east-1.amazonaws.com/dgraphbucket/abc/xyz`). This PR fixes it.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7686)
<!-- Reviewable:end -->
