### PR TITLE
Fix(GraphQL): Fix __typename result along with aggregate fields

### DIFF
--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -19,7 +19,6 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cast"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cast"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 
@@ -2952,6 +2953,7 @@ func queryAggregateWithRepeatedFields(t *testing.T) {
 }
 
 func queryAggregateAtChildLevel(t *testing.T) {
+	// Also checks if __typename is properly returned.
 	queryNumberOfStates := &GraphQLParams{
 		Query: `query
 		{
@@ -2960,7 +2962,9 @@ func queryAggregateAtChildLevel(t *testing.T) {
 				ag : statesAggregate {
 					count
 					nameMin
+					__typename
 				}
+				__typename
 			}
 		}`,
 	}
@@ -2973,8 +2977,10 @@ func queryAggregateAtChildLevel(t *testing.T) {
 				"name": "India",
 				"ag": { 
 					"count" : 3,
-					"nameMin": "Gujarat"
-				}
+					"nameMin": "Gujarat",
+					"__typename": "StateAggregateResult"
+				},
+				"__typename": "Country"
 			}]
 		}`,
 		string(gqlResponse.Data))

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -1461,7 +1461,8 @@ func completeObject(
 				// case
 				val = nil
 			} else {
-				if count, ok = countVal.(json.Number); !ok {
+				var okCount bool
+				if count, okCount = countVal.(json.Number); !okCount {
 					// This is to handle case in which countVal is of any other type than
 					// json.Number. This should never happen. We return an error.
 					return nil, x.GqlErrorList{&x.GqlError{


### PR DESCRIPTION
Motivation:
Related Discuss Post: https://discuss.dgraph.io/t/dgraph-returns-empty-string-for-typename-when-coupled-with-aggregate-edge/13548 

The PR uses different name for ok variable. The bug occurred because the same variable was used twice. At the time of getting dgraph type from result and getting count result. 

Fixes GRAPHQL-1142

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7687)
<!-- Reviewable:end -->
