### PR TITLE
fix(export): use UriHandler for exports

### DIFF
--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -91,7 +91,7 @@ func getManifestsToRestore(
 	h x.UriHandler, uri *url.URL, req *pb.RestoreRequest) ([]*Manifest, error) {
 
 	if !h.DirExists("") {
-		return nil, errors.Errorf("getManifestsToRestore: The uri path: %q doesn't exists",
+		return nil, errors.Errorf("getManifestsToRestore: The uri path: %q doesn't exist",
 			uri.Path)
 	}
 	manifest, err := getConsolidatedManifest(h, uri)
@@ -212,7 +212,7 @@ func readManifest(h x.UriHandler, path string) (*Manifest, error) {
 func GetLatestManifest(h x.UriHandler, uri *url.URL) (*Manifest, error) {
 	manifest, err := GetManifest(h, uri)
 	if err != nil {
-		return &Manifest{}, errors.Wrap(err, "Fialed to get the manifest")
+		return &Manifest{}, errors.Wrap(err, "Failed to get manifest")
 	}
 	if len(manifest.Manifests) == 0 {
 		return &Manifest{}, nil
@@ -234,7 +234,7 @@ func readMasterManifest(h x.UriHandler, path string) (*MasterManifest, error) {
 
 func GetManifest(h x.UriHandler, uri *url.URL) (*MasterManifest, error) {
 	if !h.DirExists("") {
-		return &MasterManifest{}, errors.Errorf("getManifest: The uri path: %q doesn't exists",
+		return &MasterManifest{}, errors.Errorf("getManifest: The uri path: %q doesn't exist",
 			uri.Path)
 	}
 	manifest, err := getConsolidatedManifest(h, uri)

--- a/worker/export.go
+++ b/worker/export.go
@@ -771,7 +771,11 @@ func exportInternal(ctx context.Context, in *pb.ExportRequest, db *badger.DB,
 	skipZero bool) (ExportedFiles, error) {
 
 	// Create a UriHandler for the given destination.
-	uri, err := url.Parse(in.GetDestination())
+	destination := in.GetDestination()
+	if destination == "" {
+		destination = x.WorkerConfig.ExportPath
+	}
+	uri, err := url.Parse(destination)
 	if err != nil {
 		return nil, err
 	}

--- a/worker/export.go
+++ b/worker/export.go
@@ -27,7 +27,6 @@ import (
 	"io"
 	"math"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -383,21 +382,6 @@ func newExportWriter(handler x.UriHandler, fileName string) (*ExportWriter, erro
 		return nil, err
 	}
 	return writer, nil
-}
-
-func (writer *ExportWriter) open(fpath string) error {
-	var err error
-	writer.w, err = os.Create(fpath)
-	if err != nil {
-		return err
-	}
-	writer.bw = bufio.NewWriterSize(writer.w, 1e6)
-	w, err := enc.GetWriter(x.WorkerConfig.EncryptionKey, writer.bw)
-	if err != nil {
-		return err
-	}
-	writer.gw, err = gzip.NewWriterLevel(w, gzip.BestSpeed)
-	return err
 }
 
 func (writer *ExportWriter) Close() error {

--- a/x/error.go
+++ b/x/error.go
@@ -119,3 +119,13 @@ func AssertTruefNoTrace(b bool, format string, args ...interface{}) {
 func Fatalf(format string, args ...interface{}) {
 	log.Fatalf("%+v", errors.Errorf(format, args...))
 }
+
+// MultiError returns the first error in a list of errors.
+func MultiError(errs ...error) error {
+	for _, err := range errs {
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION

Use UriHandler for Export and ExportBackup. This way, we can have unified logic for handling local filesystems, Minio, etc. across backups and exports.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7690)
<!-- Reviewable:end -->
