### PR TITLE
fix(DGRAPH): fix @normalize response when multiple fields at different levels with same alias are selected. (#7639)

### DIFF
--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -1841,6 +1841,70 @@ func TestNormalizeDirective(t *testing.T) {
 		}`, js)
 }
 
+func TestNormalizeDirectiveWithRecurseDirective(t *testing.T) {
+	query := `
+		{
+			me(func: uid(0x01)) @recurse @normalize {
+				n: name
+				d: dob
+				friend
+			}
+		}`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `
+		{
+          "data": {
+              "me": [
+                  {
+                      "n": [
+                          "Michonne",
+                          "Rick Grimes",
+                          "Michonne"
+                      ],
+                      "d": [
+                          "1910-01-01T00:00:00Z",
+                          "1910-01-02T00:00:00Z",
+                          "1910-01-01T00:00:00Z"
+                      ]
+                  },
+                  {
+                      "n": [
+                          "Michonne",
+                          "Glenn Rhee"
+                      ],
+                      "d": [
+                          "1910-01-01T00:00:00Z",
+                          "1909-05-05T00:00:00Z"
+                      ]
+                  },
+                  {
+                      "n": [
+                          "Michonne",
+                          "Daryl Dixon"
+                      ],
+                      "d": [
+                          "1910-01-01T00:00:00Z",
+                          "1909-01-10T00:00:00Z"
+                      ]
+                  },
+                  {
+                      "n": [
+                          "Michonne",
+                          "Andrea",
+                          "Glenn Rhee"
+                      ],
+                      "d": [
+                          "1910-01-01T00:00:00Z",
+                          "1901-01-15T00:00:00Z",
+                          "1909-05-05T00:00:00Z"
+                      ]
+                  }
+              ]
+          }
+      }`, js)
+}
+
 func TestNormalizeDirectiveSubQueryLevel1(t *testing.T) {
 	query := `
 		{


### PR DESCRIPTION
We are generating incorrect order of the fields in a result of the @normalize directive when there are multiple fields with same Alias at nested levels. As a result of that in resulting JSON, the nodes with the same Alias were not converted to list.
For example, if we have below data in dgraph .
```
{
      "_id": "Process",
      "Name": "Process",
      "Extends": {
        "_id": "Core/Namespace",
        "Name": "Namespace"        
      }
}

```
And if we do below query with @recurse and @normalize directive
```
{
  item as var(func:eq(_id,"Process"))
  b2(func:uid(item))@normalize@recurse {
    Name:Name id:_id  Extends
  }
}
```
We will get this response from Dgraph where fields with same alias are not together and while converting response to JSON  , we are not able to combine fields with same Alias in a list.
```
"b2": [
      {
        "Name": "Process",
        "id": "Process",
        "Name":"Namespace",
        "id": "Core/Namespace"
      }
    ]
```
In this PR we fix this in normalize, by putting all fields with the same Alias together. So now response of above query will be 
```
"b2": [
      {
        "Name": [
          "Process",
          "Namespace"
        ],
        "id": [
          "Process",
          "Core/Namespace"
        ]
      }
]
```
This behaviour is broken by PR https://github.com/dgraph-io/dgraph/pull/6362. Prior to this , we used sorting on fields which guarantee that fields with same name or Alias comes together.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7639)
<!-- Reviewable:end -->


(cherry picked from commit 711e955010ed8fd870af46f746cc23a9178cc004)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7691)
<!-- Reviewable:end -->
