### PR TITLE
fix(pagination): Fix after for regexp, match functions

### DIFF
--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -2545,3 +2545,31 @@ func TestExpandAll_empty_panic(t *testing.T) {
 	js := processQueryNoErr(t, query)
 	require.JSONEq(t, `{"data":{"me":[]}}`, js)
 }
+
+func TestMatchFuncWithAfter(t *testing.T) {
+	query := `
+		{
+			q(func: match(name, Ali, 5), after: 0x2710) {
+				uid
+				name
+			}
+		}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"q": [{"name": "Alice", "uid": "0x2712"}, {"name": "Alice", "uid": "0x2714"}]}}`, js)
+}
+
+func TestCompareFuncWithAfter(t *testing.T) {
+	query := `
+		{
+			q(func: eq(name, Alice), after: 0x2710) {
+				uid
+				name
+			}
+		}
+	`
+
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"q": [{"name": "Alice", "uid": "0x2712"}, {"name": "Alice", "uid": "0x2714"}]}}`, js)
+}

--- a/query/query2_test.go
+++ b/query/query2_test.go
@@ -3133,3 +3133,16 @@ func TestLangDotInFunction(t *testing.T) {
 		`{"data": {"me":[{"name@pl":"Borsuk europejski","name@en":"European badger"},{"name@en":"Honey badger"},{"name@en":"Honey bee"}]}}`,
 		js)
 }
+
+func TestGeoFuncWithAfter(t *testing.T) {
+
+	query := `{
+		me(func: near(geometry, [-122.082506, 37.4249518], 1000), after: 0x13ee) {
+			name
+		}
+	}`
+
+	js := processQueryNoErr(t, query)
+	expected := `{"data": {"me":[{"name": "SF Bay area"}, {"name": "Mountain View"}]}}`
+	require.JSONEq(t, expected, js)
+}

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -3216,3 +3216,17 @@ func TestMultiRegexInFilter2(t *testing.T) {
 		require.JSONEq(t, `{"data": {"q": [{"firstName": "Han", "lastName":"Solo"}]}}`, res)
 	}
 }
+
+func TestRegexFuncWithAfter(t *testing.T) {
+	query := `
+		{
+			q(func: regexp(name, /^Ali/i), after: 0x2710) {
+				uid
+				name
+			}
+		}
+	`
+
+	res := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"q": [{"name": "Alice", "uid": "0x2712"}, {"name": "Alice", "uid": "0x2714"}]}}`, res)
+}

--- a/worker/match.go
+++ b/worker/match.go
@@ -83,6 +83,7 @@ func uidsForMatch(attr string, arg funcArgs) (*roaring64.Bitmap, error) {
 	opts := posting.ListOptions{
 		ReadTs: arg.q.ReadTs,
 		First:  int(arg.q.First),
+		AfterUid: arg.q.AfterUid,
 	}
 	uidsForNgram := func(ngram string) (*roaring64.Bitmap, error) {
 		key := x.IndexKey(attr, ngram)

--- a/worker/task.go
+++ b/worker/task.go
@@ -1545,9 +1545,6 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 			}
 			var tv pb.TaskValue
 			err = pl.Iterate(arg.q.ReadTs, 0, func(p *pb.Posting) error {
-				if uid < arg.q.AfterUid {
-					return nil
-				}
 				tv.ValType = p.ValType
 				tv.Val = p.Value
 				if types.MatchGeo(&tv, arg.srcFn.geoQuery) {

--- a/worker/task.go
+++ b/worker/task.go
@@ -1545,6 +1545,9 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 			}
 			var tv pb.TaskValue
 			err = pl.Iterate(arg.q.ReadTs, 0, func(p *pb.Posting) error {
+				if uid < arg.q.AfterUid {
+					return nil
+				}
 				tv.ValType = p.ValType
 				tv.Val = p.Value
 				if types.MatchGeo(&tv, arg.srcFn.geoQuery) {

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -37,6 +37,7 @@ func uidsForRegex(attr string, arg funcArgs,
 	opts := posting.ListOptions{
 		ReadTs: arg.q.ReadTs,
 		First:  int(arg.q.First),
+		AfterUid: arg.q.AfterUid,
 	}
 	// TODO: Unnecessary conversion here. Avoid if possible.
 	if !intersect.IsEmpty() {


### PR DESCRIPTION
This change fixes the pagination functioning that used "after" to specify a UID as offset.

Fixes DGRAPH-3222

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7700)
<!-- Reviewable:end -->
