### PR TITLE
Improve DirExists and FileExists functions

### DIFF
--- a/x/handlers.go
+++ b/x/handlers.go
@@ -107,9 +107,27 @@ func NewFileHandler(uri *url.URL) *fileHandler {
 	return h
 }
 
-func (h *fileHandler) DirExists(path string) bool       { return pathExist(h.JoinPath(path)) }
-func (h *fileHandler) FileExists(path string) bool      { return pathExist(h.JoinPath(path)) }
-func (h *fileHandler) Read(path string) ([]byte, error) { return ioutil.ReadFile(h.JoinPath(path)) }
+func (h *fileHandler) DirExists(path string) bool {
+	path = h.JoinPath(path)
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return stat.IsDir()
+}
+
+func (h *fileHandler) FileExists(path string) bool {
+	path = h.JoinPath(path)
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return stat.Mode().IsRegular()
+}
+
+func (h *fileHandler) Read(path string) ([]byte, error) {
+	return ioutil.ReadFile(h.JoinPath(path))
+}
 
 func (h *fileHandler) JoinPath(path string) string {
 	return filepath.Join(h.rootDir, h.prefix, path)
@@ -154,16 +172,6 @@ func (h *fileHandler) Rename(src, dst string) error {
 	src = h.JoinPath(src)
 	dst = h.JoinPath(dst)
 	return os.Rename(src, dst)
-}
-
-// pathExist checks if a path (file or dir) is found at target.
-// Returns true if found, false otherwise.
-func pathExist(path string) bool {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true
-	}
-	return !os.IsNotExist(err) && !os.IsPermission(err)
 }
 
 // S3 Handler.


### PR DESCRIPTION
Our current behaviour of checking if `DirExists` and `FileExists` is inaccurate. This PR fixes this.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7704)
<!-- Reviewable:end -->
