### PR TITLE
fix(flags): Convert numbers correctly in SuperFlags

### DIFF
--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -306,6 +307,13 @@ func convertJSON(old string) io.Reader {
 	// condense superflags
 	for f, options := range super {
 		for k, v := range options {
+			// JSON does not have distinct types for integers and floats.
+			// Go will always give us a float64 value. So, an exceptionally
+			// large integer like 1_000_000 will be printed as 1e06 unless
+			// we format it carefully.
+			if vFloat, ok := v.(float64); ok {
+				v = strconv.FormatFloat(vFloat, 'f', -1, 64)
+			}
 			good[f] += fmt.Sprintf("%s=%v; ", k, v)
 		}
 		good[f] = good[f][:len(good[f])-1]


### PR DESCRIPTION
Large JSON integers are not being printed correctly (since JSON doesn't have an actual integer type). This PR provides a best-effort way to convert from JSON floats to SuperFlag integers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7712)
<!-- Reviewable:end -->
