### PR TITLE
fix(ee): GetKeys should return an error

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -646,9 +646,8 @@ func run() {
 	}
 
 	keys, err := ee.GetKeys(Alpha.Conf)
-	if err != nil {
-		glog.Fatal(err)
-	}
+	x.Check(err)
+
 	if keys.AclKey != nil {
 		opts.HmacSecret = keys.AclKey
 		opts.AccessJwtTtl = keys.AclAccessTtl

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -36,7 +36,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/x"
@@ -143,9 +142,15 @@ func run() {
 
 	bopts := badger.DefaultOptions("").FromSuperFlag(BulkBadgerDefaults + cacheDefaults).
 		FromSuperFlag(Bulk.Conf.GetString("badger"))
+	keys, err := ee.GetKeys(Bulk.Conf)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	opt := options{
 		DataFiles:        Bulk.Conf.GetString("files"),
 		DataFormat:       Bulk.Conf.GetString("format"),
+		EncryptionKey:    keys.EncKey,
 		SchemaFile:       Bulk.Conf.GetString("schema"),
 		GqlSchemaFile:    Bulk.Conf.GetString("graphql_schema"),
 		Encrypted:        Bulk.Conf.GetBool("encrypted"),
@@ -178,11 +183,6 @@ func run() {
 		os.Exit(0)
 	}
 
-	keys, err := ee.GetKeys(Bulk.Conf)
-	if err != nil {
-		glog.Fatal(err)
-	}
-	opt.EncryptionKey = keys.EncKey
 	if len(opt.EncryptionKey) == 0 {
 		if opt.Encrypted || opt.EncryptedOut {
 			fmt.Fprint(os.Stderr, "Must use --encryption or vault option(s).\n")
@@ -192,11 +192,13 @@ func run() {
 		requiredFlags := Bulk.Cmd.Flags().Changed("encrypted") &&
 			Bulk.Cmd.Flags().Changed("encrypted_out")
 		if !requiredFlags {
-			fmt.Fprint(os.Stderr, "Must specify --encrypted and --encrypted_out when providing encryption key.\n")
+			fmt.Fprint(os.Stderr,
+				"Must specify --encrypted and --encrypted_out when providing encryption key.\n")
 			os.Exit(1)
 		}
 		if !opt.Encrypted && !opt.EncryptedOut {
-			fmt.Fprint(os.Stderr, "Must set --encrypted and/or --encrypted_out to true when providing encryption key.\n")
+			fmt.Fprint(os.Stderr,
+				"Must set --encrypted and/or --encrypted_out to true when providing encryption key.\n")
 			os.Exit(1)
 		}
 

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -143,9 +143,7 @@ func run() {
 	bopts := badger.DefaultOptions("").FromSuperFlag(BulkBadgerDefaults + cacheDefaults).
 		FromSuperFlag(Bulk.Conf.GetString("badger"))
 	keys, err := ee.GetKeys(Bulk.Conf)
-	if err != nil {
-		log.Fatal(err)
-	}
+	x.Check(err)
 
 	opt := options{
 		DataFiles:        Bulk.Conf.GetString("files"),

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/x"
@@ -177,7 +178,11 @@ func run() {
 		os.Exit(0)
 	}
 
-	_, opt.EncryptionKey = ee.GetKeys(Bulk.Conf)
+	keys, err := ee.GetKeys(Bulk.Conf)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	opt.EncryptionKey = keys.EncKey
 	if len(opt.EncryptionKey) == 0 {
 		if opt.Encrypted || opt.EncryptedOut {
 			fmt.Fprint(os.Stderr, "Must use --encryption or vault option(s).\n")

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee"
@@ -891,14 +892,17 @@ func run() {
 		}
 	}()
 
-	var err error
 	dir := opt.pdir
 	isWal := false
 	if len(dir) == 0 {
 		dir = opt.wdir
 		isWal = true
 	}
-	_, opt.key = ee.GetKeys(Debug.Conf)
+	keys, err := ee.GetKeys(Debug.Conf)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	opt.key = keys.EncKey
 
 	if isWal {
 		store, err := raftwal.InitEncrypted(dir, opt.key)

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -36,7 +36,6 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee"
@@ -899,9 +898,7 @@ func run() {
 		isWal = true
 	}
 	keys, err := ee.GetKeys(Debug.Conf)
-	if err != nil {
-		glog.Fatal(err)
-	}
+	x.Check(err)
 	opt.key = keys.EncKey
 
 	if isWal {

--- a/dgraph/cmd/decrypt/decrypt.go
+++ b/dgraph/cmd/decrypt/decrypt.go
@@ -57,9 +57,7 @@ func init() {
 }
 func run() {
 	keys, err := ee.GetKeys(Decrypt.Conf)
-	if err != nil {
-		glog.Fatal(err)
-	}
+	x.Check(err)
 	if len(keys.EncKey) == 0 {
 		glog.Fatal("Error while reading encryption key: Key is empty")
 	}

--- a/dgraph/cmd/decrypt/decrypt.go
+++ b/dgraph/cmd/decrypt/decrypt.go
@@ -18,15 +18,14 @@ package decrypt
 
 import (
 	"compress/gzip"
-	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 )
 
@@ -57,17 +56,23 @@ func init() {
 	ee.RegisterEncFlag(flag)
 }
 func run() {
+	keys, err := ee.GetKeys(Decrypt.Conf)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	if len(keys.EncKey) == 0 {
+		glog.Fatal("Error while reading encryption key: Key is empty")
+	}
+
 	opts := options{
-		file:   Decrypt.Conf.GetString("file"),
-		output: Decrypt.Conf.GetString("out"),
+		file:    Decrypt.Conf.GetString("file"),
+		output:  Decrypt.Conf.GetString("out"),
+		keyfile: keys.EncKey,
 	}
-	_, opts.keyfile = ee.GetKeys(Decrypt.Conf)
-	if len(opts.keyfile) == 0 {
-		log.Fatal("Error while reading encryption key: Key is empty")
-	}
+
 	f, err := os.Open(opts.file)
 	if err != nil {
-		log.Fatalf("Error opening file: %v\n", err)
+		glog.Fatalf("Error opening file: %v\n", err)
 	}
 	defer f.Close()
 	reader, err := enc.GetReader(opts.keyfile, f)
@@ -78,14 +83,14 @@ func run() {
 	}
 	outf, err := os.OpenFile(opts.output, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
-		log.Fatalf("Error while opening output file: %v\n", err)
+		glog.Fatalf("Error while opening output file: %v\n", err)
 	}
 	w := gzip.NewWriter(outf)
-	fmt.Printf("Decrypting %s\n", opts.file)
-	fmt.Printf("Writing to %v\n", opts.output)
+	glog.Infof("Decrypting %s\n", opts.file)
+	glog.Infof("Writing to %v\n", opts.output)
 	_, err = io.Copy(w, reader)
 	if err != nil {
-		log.Fatalf("Error while writing: %v\n", err)
+		glog.Fatalf("Error while writing: %v\n", err)
 	}
 	err = w.Flush()
 	x.Check(err)
@@ -93,5 +98,5 @@ func run() {
 	x.Check(err)
 	err = outf.Close()
 	x.Check(err)
-	fmt.Println("Done.")
+	glog.Infof("Done.")
 }

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -738,7 +738,12 @@ func run() error {
 
 	z.SetTmpDir(opt.tmpDir)
 
-	_, opt.key = ee.GetKeys(Live.Conf)
+	keys, err := ee.GetKeys(Live.Conf)
+	if err != nil {
+		return err
+	}
+	opt.key = keys.EncKey
+
 	go func() {
 		if err := http.ListenAndServe(opt.httpAddr, nil); err != nil {
 			glog.Errorf("Error while starting HTTP server: %+v", err)

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -697,8 +697,11 @@ func run() error {
 	}
 
 	creds := z.NewSuperFlag(Live.Conf.GetString("creds")).MergeAndCheckDefault(x.DefaultCreds)
+	keys, err := ee.GetKeys(Live.Conf)
+	if err != nil {
+		return err
+	}
 
-	var err error
 	x.PrintVersion()
 	opt = options{
 		dataFiles:       Live.Conf.GetString("files"),
@@ -717,6 +720,7 @@ func run() error {
 		ludicrousMode:   Live.Conf.GetBool("ludicrous"),
 		upsertPredicate: Live.Conf.GetString("upsertPredicate"),
 		tmpDir:          Live.Conf.GetString("tmp"),
+		key:             keys.EncKey,
 	}
 
 	forceNs := Live.Conf.GetInt64("force-namespace")
@@ -737,12 +741,6 @@ func run() error {
 	}
 
 	z.SetTmpDir(opt.tmpDir)
-
-	keys, err := ee.GetKeys(Live.Conf)
-	if err != nil {
-		return err
-	}
-	opt.key = keys.EncKey
 
 	go func() {
 		if err := http.ListenAndServe(opt.httpAddr, nil); err != nil {

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -226,7 +226,11 @@ func (bw *bufWriter) Write(buf *z.Buffer) error {
 }
 
 func runExportBackup() error {
-	_, opt.key = ee.GetKeys(ExportBackup.Conf)
+	keys, err := ee.GetKeys(ExportBackup.Conf)
+	if err != nil {
+		return err
+	}
+	opt.key = keys.EncKey
 	if opt.format != "json" && opt.format != "rdf" {
 		return errors.Errorf("invalid format %s", opt.format)
 	}

--- a/ee/flags.go
+++ b/ee/flags.go
@@ -19,10 +19,20 @@ package ee
 import (
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/spf13/pflag"
 )
+
+// Keys holds the configuration for ACL and encryption.
+type Keys struct {
+	AclKey        x.Sensitive
+	AclAccessTtl  time.Duration
+	AclRefreshTtl time.Duration
+	EncKey        x.Sensitive
+}
 
 const (
 	flagAcl           = "acl"

--- a/ee/keys.go
+++ b/ee/keys.go
@@ -19,6 +19,8 @@
 package ee
 
 import (
+	"fmt"
+
 	"github.com/spf13/viper"
 )
 

--- a/ee/keys.go
+++ b/ee/keys.go
@@ -19,15 +19,13 @@
 package ee
 
 import (
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 	"github.com/spf13/viper"
 )
 
 // GetKeys returns the ACL and encryption keys as configured by the user
 // through the --acl, --encryption, and --vault flags. On OSS builds,
-// this function exits with an error.
-func GetKeys(config *viper.Viper) (x.Sensitive, x.Sensitive) {
-	glog.Exit("flags: acl / encryption is an enterprise-only feature")
-	return nil, nil
+// this function always returns an error.
+func GetKeys(config *viper.Viper) (Keys, error) {
+	return nil, fmt.Errorf(
+		"flags: acl / encryption is an enterprise-only feature")
 }

--- a/ee/keys.go
+++ b/ee/keys.go
@@ -25,7 +25,7 @@ import (
 // GetKeys returns the ACL and encryption keys as configured by the user
 // through the --acl, --encryption, and --vault flags. On OSS builds,
 // this function always returns an error.
-func GetKeys(config *viper.Viper) (Keys, error) {
+func GetKeys(config *viper.Viper) (*Keys, error) {
 	return nil, fmt.Errorf(
 		"flags: acl / encryption is an enterprise-only feature")
 }

--- a/ee/keys_ee.go
+++ b/ee/keys_ee.go
@@ -15,23 +15,14 @@ package ee
 import (
 	"fmt"
 	"io/ioutil"
-	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/spf13/viper"
 )
 
-type Keys struct {
-	AclKey        x.Sensitive
-	AclAccessTtl  time.Duration
-	AclRefreshTtl time.Duration
-	EncKey        x.Sensitive
-}
-
 // GetKeys returns the ACL and encryption keys as configured by the user
 // through the --acl, --encryption, and --vault flags. On OSS builds,
-// this function exits with an error.
+// this function always returns an error.
 func GetKeys(config *viper.Viper) (*Keys, error) {
 	keys := &Keys{}
 	var err error

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -50,12 +50,15 @@ func openDgraph(pdir string) (*badger.DB, error) {
 		return nil, err
 	}
 	config.Set("encryption", ee.BuildEncFlag(KeyFile))
-	_, encKey := ee.GetKeys(config)
+	keys, err := ee.GetKeys(config)
+	if err != nil {
+		return nil, err
+	}
 
 	opt := badger.DefaultOptions(pdir).
 		WithBlockCacheSize(10 * (1 << 20)).
 		WithIndexCacheSize(10 * (1 << 20)).
-		WithEncryptionKey(encKey).
+		WithEncryptionKey(keys.EncKey).
 		WithNamespaceOffset(x.NamespaceOffset)
 	return badger.OpenManaged(opt)
 }

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -546,7 +546,10 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to get encryption config")
 	}
-	_, encKey := ee.GetKeys(cfg)
+	keys, err := ee.GetKeys(cfg)
+	if err != nil {
+		return err
+	}
 
 	mapper := &mapper{
 		buf:       newBuffer(),
@@ -594,7 +597,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 			// Only restore the predicates that were assigned to this group at the time
 			// of the last backup.
 			file := filepath.Join(manifest.Path, backupName(manifest.Since, gid))
-			br := readerFrom(h, file).WithEncryption(encKey).WithCompression(manifest.Compression)
+			br := readerFrom(h, file).WithEncryption(keys.EncKey).WithCompression(manifest.Compression)
 			if br.err != nil {
 				return errors.Wrap(br.err, "newBackupReader")
 			}


### PR DESCRIPTION
Currently, `GetKeys` exits immediately upon error. While this works for most uses, it ends up shutting down the Alpha when a restore request is made with bad input. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7713)
<!-- Reviewable:end -->
