### PR TITLE
fix(query): Prevent multiple entries for same predicate in mutations.

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -285,7 +285,15 @@ func parseSchemaFromAlterOperation(ctx context.Context, op *api.Operation) (*sch
 		return nil, err
 	}
 
+	preds := make(map[string]struct{})
+
 	for _, update := range result.Preds {
+		if _, ok := preds[update.Predicate]; ok {
+			return nil, errors.Errorf("predicate %s defined multiple times",
+				x.ParseAttr(update.Predicate))
+		}
+		preds[update.Predicate] = struct{}{}
+
 		// Pre-defined predicates cannot be altered but let the update go through
 		// if the update is equal to the existing one.
 		if schema.IsPreDefPredChanged(update) {
@@ -308,7 +316,14 @@ func parseSchemaFromAlterOperation(ctx context.Context, op *api.Operation) (*sch
 		}
 	}
 
+	types := make(map[string]struct{})
+
 	for _, typ := range result.Types {
+		if _, ok := types[typ.TypeName]; ok {
+			return nil, errors.Errorf("type %s defined multiple times", x.ParseAttr(typ.TypeName))
+		}
+		types[typ.TypeName] = struct{}{}
+
 		// Pre-defined types cannot be altered but let the update go through
 		// if the update is equal to the existing one.
 		if schema.IsPreDefTypeChanged(typ) {

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -34,28 +34,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-// isValidSchemaChange check if the mutation has valid schema changes. In case the mutation
-// has multiple entries for the same predicate we error out.
-func isValidSchemaChange(m *pb.Mutations) error {
-	if m.Schema == nil || len(m.Schema) == 0 {
-		return nil
-	}
-	preds := make(map[string]struct{})
-	for _, s := range m.Schema {
-		if _, ok := preds[s.Predicate]; ok {
-			return errors.Errorf("Multiple entries for same predicate are not allowed")
-		}
-		preds[s.Predicate] = struct{}{}
-	}
-	return nil
-}
-
 // ApplyMutations performs the required edge expansions and forwards the results to the
 // worker to perform the mutations.
 func ApplyMutations(ctx context.Context, m *pb.Mutations) (*api.TxnContext, error) {
-	if err := isValidSchemaChange(m); err != nil {
-		return nil, err
-	}
 	// In expandEdges, for non * type prredicates, we prepend the namespace directly and for
 	// * type predicates, we fetch the predicates and prepend the namespace.
 	edges, err := expandEdges(ctx, m)

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -34,9 +34,28 @@ import (
 	"github.com/pkg/errors"
 )
 
+// isValidSchemaChange check if the mutation has valid schema changes. In case the mutation
+// has multiple entries for the same predicate we error out.
+func isValidSchemaChange(m *pb.Mutations) error {
+	if m.Schema == nil || len(m.Schema) == 0 {
+		return nil
+	}
+	preds := make(map[string]struct{})
+	for _, s := range m.Schema {
+		if _, ok := preds[s.Predicate]; ok {
+			return errors.Errorf("Multiple entries for same predicate are not allowed")
+		}
+		preds[s.Predicate] = struct{}{}
+	}
+	return nil
+}
+
 // ApplyMutations performs the required edge expansions and forwards the results to the
 // worker to perform the mutations.
 func ApplyMutations(ctx context.Context, m *pb.Mutations) (*api.TxnContext, error) {
+	if err := isValidSchemaChange(m); err != nil {
+		return nil, err
+	}
 	// In expandEdges, for non * type prredicates, we prepend the namespace directly and for
 	// * type predicates, we fetch the predicates and prepend the namespace.
 	edges, err := expandEdges(ctx, m)


### PR DESCRIPTION
Multiple entries for the same predicate can lead to inconsistent state, hence adding an error for it instead.

Fixes DGRAPH-3225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7715)
<!-- Reviewable:end -->
