### PR TITLE
fix(raftwal): take snapshot after restore

### DIFF
--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -362,12 +362,6 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 		return errors.Wrapf(err, "cannot load schema after restore")
 	}
 
-	// Propose a snapshot immediately after all the work is done to prevent the restore
-	// from being replayed.
-	if err := groups().Node.proposeSnapshot(); err != nil {
-		return errors.Wrapf(err, "cannot propose snapshot after processing restore proposal")
-	}
-
 	// Update the membership state to re-compute the group checksums.
 	if err := UpdateMembershipState(ctx); err != nil {
 		return errors.Wrapf(err, "cannot update membership state after restore")

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -266,7 +266,7 @@ func (w *grpcWorker) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.S
 }
 
 // TODO(DGRAPH-1232): Ensure all groups receive the restore proposal.
-func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
+func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uint64) error {
 	if req == nil {
 		return errors.Errorf("nil restore request")
 	}
@@ -361,6 +361,22 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 	if err := schema.LoadFromDb(); err != nil {
 		return errors.Wrapf(err, "cannot load schema after restore")
 	}
+
+	// Propose a snapshot immediately after all the work is done to prevent the restore
+	// from being replayed.
+	go func(idx uint64) {
+		n := groups().Node
+		if !n.AmLeader() {
+			return
+		}
+		if err := n.Applied.WaitForMark(context.Background(), idx); err != nil {
+			glog.Errorf("Error waiting for mark for index %d: %+v", idx, err)
+			return
+		}
+		if err := n.proposeSnapshot(); err != nil {
+			glog.Errorf("cannot propose snapshot after processing restore proposal %+v", err)
+		}
+	}(pidx)
 
 	// Update the membership state to re-compute the group checksums.
 	if err := UpdateMembershipState(ctx); err != nil {

--- a/worker/online_restore_oss.go
+++ b/worker/online_restore_oss.go
@@ -38,6 +38,6 @@ func (w *grpcWorker) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.S
 	return &pb.Status{}, x.ErrNotSupported
 }
 
-func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
+func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uint64) error {
 	return nil
 }


### PR DESCRIPTION
Fixes DGRAPH-3202

We should propose a snapshot immediately after the restore to prevent the restore from being replayed.
Earlier we were trying to that too. Snapshot happens after the restore but that does not actually include the restore proposal as it has not been applied yet (`n.Applied.Done()` is not yet called for that proposal). 
Now, we will first wait for the raft entries to be marked as done and then try to propose the snapshot.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7719)
<!-- Reviewable:end -->
