### PR TITLE
feat(compose): Add setup for CDC with Kafka.

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -117,6 +117,8 @@ type options struct {
 	MinioDataDir   string
 	MinioPort      uint16
 	MinioEnvFile   []string
+	Cdc            bool
+	CdcConsumer    bool
 
 	// Extra flags
 	AlphaFlags string
@@ -357,6 +359,9 @@ func getAlpha(idx int, raft string) service {
 			ReadOnly: true,
 		})
 	}
+	if opts.Cdc {
+		svc.Command += " --cdc='kafka=kafka:9092'"
+	}
 	if len(opts.AlphaVolumes) > 0 {
 		for _, vol := range opts.AlphaVolumes {
 			svc.Volumes = append(svc.Volumes, getVolume(vol))
@@ -503,6 +508,32 @@ func addMetrics(cfg *composeConfig) {
 	}
 }
 
+func addCdc(cfg *composeConfig) {
+	cfg.Services["zookeeper"] = service{
+		Image:         "bitnami/zookeeper:3.7.0",
+		ContainerName: containerName("zookeeper"),
+		Environment: []string{
+			"ALLOW_ANONYMOUS_LOGIN=yes",
+		},
+	}
+	cfg.Services["kafka"] = service{
+		Image:         "bitnami/kafka:2.7.0",
+		ContainerName: containerName("kafka"),
+		Environment: []string{
+			"ALLOW_PLAINTEXT_LISTENER=yes",
+			"KAFKA_BROKER_ID=1",
+			"KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181",
+		},
+	}
+	if opts.CdcConsumer {
+		cfg.Services["kafka-consumer"] = service{
+			Image:         "bitnami/kafka:2.7.0",
+			ContainerName: containerName("kafka-consumer"),
+			Command:       "kafka-console-consumer.sh --bootstrap-server kafka:9092 --topic dgraph-cdc",
+		}
+	}
+}
+
 func semverCompare(constraint, version string) (bool, error) {
 	c, err := sv.NewConstraint(constraint)
 	if err != nil {
@@ -612,6 +643,10 @@ func main() {
 		"minio service port")
 	cmd.PersistentFlags().StringArrayVar(&opts.MinioEnvFile, "minio_env_file", nil,
 		"minio service env_file")
+	cmd.PersistentFlags().BoolVar(&opts.Cdc, "cdc", false,
+		"run Kafka and push CDC data to it")
+	cmd.PersistentFlags().BoolVar(&opts.CdcConsumer, "cdc_consumer", false,
+		"run Kafka consumer that prints out CDC events")
 	err := cmd.ParseFlags(os.Args)
 	if err != nil {
 		if err == pflag.ErrHelp {
@@ -640,7 +675,9 @@ func main() {
 	if cmd.Flags().Changed("ratel_port") && !opts.Ratel {
 		fatal(errors.Errorf("--ratel_port option requires --ratel"))
 	}
-
+	if cmd.Flags().Changed("cdc-consumer") && !opts.Cdc {
+		fatal(errors.Errorf("--cdc_consumer requires --cdc"))
+	}
 	services := make(map[string]service)
 
 	for i := 1; i <= opts.NumZeros; i++ {
@@ -733,6 +770,10 @@ func main() {
 		if err != nil {
 			fatal(errors.Errorf("unable to write file: %v", err))
 		}
+	}
+
+	if opts.Cdc {
+		addCdc(&cfg)
 	}
 
 	yml, err := yaml.Marshal(cfg)


### PR DESCRIPTION
The compose tool now has flags for `--cdc` and `--cdc_consumer`.

* `--cdc` runs Zookeeper and Kafka containers and configures every Alpha to push
  CDC events to Kafka
* `--cdc_consumer` runs `kafka-console-consumer.sh` to print out the CDC
  events of the dgraph-cdc topic in Kafka. You can skip setting this
  flag if you don't need to print out the CDC events.

Example:

    cd compose && ./run.sh --cdc --cdc_consumer

    dgraph increment --alpha localhost:9180 --num=3

    docker logs kafka-consumer
    ...
    {"meta":{"commit_ts":4},"type":"mutation","event":{"operation":"set","uid":1,"attr":"counter.val","value":1,"value_type":"int"}}
    {"meta":{"commit_ts":6},"type":"mutation","event":{"operation":"set","uid":1,"attr":"counter.val","value":2,"value_type":"int"}}
    {"meta":{"commit_ts":8},"type":"mutation","event":{"operation":"set","uid":1,"attr":"counter.val","value":3,"value_type":"int"}}

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7720)
<!-- Reviewable:end -->
