### PR TITLE
fix(cdc): Show namespace info in event meta

### DIFF
--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -360,7 +360,7 @@ type CDCEvent struct {
 
 type EventMeta struct {
 	RaftIndex uint64 `json:"-"`
-	Namespace []byte `json:"-"`
+	Namespace []byte `json:"namespace"`
 	CommitTs  uint64 `json:"commit_ts"`
 }
 

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -14,7 +14,6 @@ package worker
 
 import (
 	"bytes"
-	"encoding/binary"
 	"encoding/json"
 	"math"
 	"strings"
@@ -191,13 +190,11 @@ func (cdc *CDC) processCDCEvents() {
 			e.Meta.CommitTs = commitTs
 			b, err := json.Marshal(e)
 			x.Check(err)
-			key := make([]byte, 8)
-			binary.BigEndian.PutUint64(key, e.Meta.Namespace)
 			batch[i] = SinkMessage{
 				Meta: SinkMeta{
 					Topic: defaultEventTopic,
 				},
-				Key:   key,
+				Key:   e.Meta.Namespace,
 				Value: b,
 			}
 		}

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -191,11 +191,13 @@ func (cdc *CDC) processCDCEvents() {
 			e.Meta.CommitTs = commitTs
 			b, err := json.Marshal(e)
 			x.Check(err)
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, e.Meta.Namespace)
 			batch[i] = SinkMessage{
 				Meta: SinkMeta{
 					Topic: defaultEventTopic,
 				},
-				Key:   e.Meta.Namespace,
+				Key:   key,
 				Value: b,
 			}
 		}
@@ -360,7 +362,7 @@ type CDCEvent struct {
 
 type EventMeta struct {
 	RaftIndex uint64 `json:"-"`
-	Namespace []byte `json:"namespace"`
+	Namespace uint64 `json:"namespace"`
 	CommitTs  uint64 `json:"commit_ts"`
 }
 
@@ -394,12 +396,11 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 	// todo (aman): right now drop all and data operations are still cluster wide.
 	// Fix these once we have namespace specific operations.
 	if mutation.DropOp != pb.Mutations_NONE {
-		ns := make([]byte, 8)
-		binary.BigEndian.PutUint64(ns, x.GalaxyNamespace)
+		ns := x.GalaxyNamespace
 		var t string
 		if mutation.DropOp == pb.Mutations_TYPE {
 			// drop type are namespace specific.
-			ns, t = x.ParseNamespaceBytes(mutation.DropValue)
+			ns, t = x.ParseNamespaceAttr(mutation.DropValue)
 		}
 
 		return []CDCEvent{
@@ -422,7 +423,7 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 		if x.IsReservedPredicate(edge.Attr) {
 			continue
 		}
-		ns, attr := x.ParseNamespaceBytes(edge.Attr)
+		ns, attr := x.ParseNamespaceAttr(edge.Attr)
 		// Handle drop attr event.
 		if edge.Entity == 0 && bytes.Equal(edge.Value, []byte(x.Star)) {
 			return []CDCEvent{


### PR DESCRIPTION
This PR sets the namespace in the cdc event metadata.

I've also changed the type of key from `[]byte` to `uint64` because it didn't need to be a `[]byte`
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7721)
<!-- Reviewable:end -->
