### PR TITLE
chore(compose): Add a flag to specify hostname

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -160,11 +160,11 @@ func getOffset(idx int) int {
 	return idx
 }
 
-func getHost(basename string) string {
+func getHost(host string) string {
 	if opts.Hostname != "" {
 		return opts.Hostname
 	}
-	return basename
+	return host
 }
 
 func initService(basename string, idx, grpcPort int) service {

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -175,6 +175,10 @@ func initService(basename string, idx, grpcPort int) service {
 		toPort(grpcPort + 1000), // http port
 	}
 
+	if basename == "alpha" {
+		svc.Ports = append(svc.Ports, toPort(grpcPort-1000))
+	}
+
 	if opts.LocalBin {
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",


### PR DESCRIPTION
Add a flag `--hostname` in the compose tool to make the tool generate compose file
with alpha and zero's host using the given hostname. This will allow us to use compose
tool to run a cluster which uses public IP addresses. If `--hostname` is set then the 
internal grpc port (7080) is also exposed.

For example, to connect a learner node running on a different machine:
Step-1: Run a cluster on a public IP with ports exposed.
`go run compose.go -a 1 -z 1 -w --hostname=dgin-foxtrot.corp.dgraph.io`
`docker-compose up`

Step-2: Connect a learner node running on other machine:
`dgraph alpha --raft "learner=true; idx=4; group=1" --my=publicHostname:7080 --zero=dgin-foxtrot.corp.dgraph.io:5080`
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7723)
<!-- Reviewable:end -->
