### PR TITLE
fix(lease): prevent ID lease overflow

### DIFF
--- a/dgraph/cmd/zero/assign.go
+++ b/dgraph/cmd/zero/assign.go
@@ -107,37 +107,38 @@ func (s *Server) lease(ctx context.Context, num *pb.Num) (*pb.AssignedIds, error
 		// readonly transactions, if needed.
 	}
 
-	// If we're asking for more ids than the standard lease bandwidth, then we
-	// should set howMany generously, so we can service future requests from
-	// memory, without asking for another lease. Only used if we need to renew
-	// our lease.
-	howMany := leaseBandwidth
-	if num.Val > leaseBandwidth {
-		howMany = num.Val + leaseBandwidth
-	}
-
 	if s.nextLease[pb.Num_UID] == 0 || s.nextLease[pb.Num_TXN_TS] == 0 ||
 		s.nextLease[pb.Num_NS_ID] == 0 {
 		return nil, errors.New("Server not initialized")
 	}
 
-	var proposal pb.ZeroProposal
-
 	// Calculate how many ids do we have available in memory, before we need to
 	// renew our lease.
 	maxLease := s.maxLease(typ)
 	available := maxLease - s.nextLease[typ] + 1
-	switch typ {
-	case pb.Num_TXN_TS:
-		proposal.MaxTxnTs = maxLease + howMany
-	case pb.Num_UID:
-		proposal.MaxUID = maxLease + howMany
-	case pb.Num_NS_ID:
-		proposal.MaxNsID = maxLease + howMany
-	}
 
 	// If we have less available than what we need, we need to renew our lease.
 	if available < num.Val+1 { // +1 for a potential readonly ts.
+		// If we're asking for more ids than the standard lease bandwidth, then we
+		// should set howMany generously, so we can service future requests from
+		// memory, without asking for another lease. Only used if we need to renew
+		// our lease.
+		howMany := leaseBandwidth
+		if num.Val > leaseBandwidth {
+			howMany = num.Val + leaseBandwidth
+		}
+		var proposal pb.ZeroProposal
+		switch typ {
+		case pb.Num_TXN_TS:
+			proposal.MaxTxnTs = maxLease + howMany
+		case pb.Num_UID:
+			proposal.MaxUID = maxLease + howMany
+		case pb.Num_NS_ID:
+			proposal.MaxNsID = maxLease + howMany
+		}
+		if maxLease+howMany < maxLease { // check for overflow.
+			return &emptyAssignedIds, errors.Errorf("Cannot lease %s as the limit has reached", typ)
+		}
 		// Blocking propose to get more ids or timestamps.
 		if err := s.Node.proposeAndWait(ctx, &proposal); err != nil {
 			return nil, err

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -18,9 +18,11 @@ package zero
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +36,11 @@ func TestRemoveNode(t *testing.T) {
 	require.Error(t, err)
 	_, err = server.RemoveNode(context.TODO(), &pb.RemoveNodeRequest{NodeId: 1, GroupId: 2})
 	require.Error(t, err)
+}
+
+func TestIdLeaseOverflow(t *testing.T) {
+	require.NoError(t, testutil.AssignUids(100))
+	err := testutil.AssignUids(math.MaxUint64 - 10)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "limit has reached")
 }

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -290,14 +290,12 @@ func (m *XidMap) updateMaxSeen(max uint64) {
 // BumpTo can be used to make Zero allocate UIDs up to this given number. Attempts are made to
 // ensure all future allocations of UIDs be higher than this one, but results are not guaranteed.
 func (m *XidMap) BumpTo(uid uint64) {
-	curMax := atomic.LoadUint64(&m.maxUidSeen)
-	if uid <= curMax {
-		return
-	}
-
-	for {
-		glog.V(1).Infof("Bumping up to %v", uid)
-		num := x.Max(uid-curMax, 1e4)
+	var curMax uint64
+	bump := func(num uint64) bool {
+		curMax = atomic.LoadUint64(&m.maxUidSeen)
+		if uid <= curMax {
+			return true
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		ctx = m.attachNamespace(ctx)
 		assigned, err := m.zc.AssignIds(ctx, &pb.Num{Val: num, Type: pb.Num_UID})
@@ -305,13 +303,27 @@ func (m *XidMap) BumpTo(uid uint64) {
 		if err == nil {
 			glog.V(1).Infof("Requested bump: %d. Got assigned: %v", uid, assigned)
 			m.updateMaxSeen(assigned.EndId)
-			return
+			return true
 		}
 		glog.Errorf("While requesting AssignUids(%d): %v", num, err)
 		if x.IsJwtExpired(err) {
 			if err := m.relogin(); err != nil {
 				glog.Errorf("While trying to relogin: %v", err)
 			}
+		}
+		return false
+	}
+
+	for {
+		glog.V(1).Infof("Bumping up to %v", uid)
+		if ok := bump(1); !ok {
+			// Before bumping the uids to a large number, update the maxSeenUid by leasing a
+			// single uid to check if cluster is already above the required level.
+			continue
+		}
+		num := x.Max(uid-curMax, 1e4)
+		if ok := bump(num); ok {
+			return
 		}
 	}
 }


### PR DESCRIPTION
Fixes DGRAPH-3262

This PR adds checks to prevent integer overflow in ID lease.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7724)
<!-- Reviewable:end -->
