### PR TITLE
Fix(GraphQL): Fix GraphQL encoding in case of empty list

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -862,7 +862,8 @@ func RunAll(t *testing.T) {
 	t.Run("add multiple mutations", testMultipleMutations)
 	t.Run("deep XID mutations", deepXIDMutations)
 	t.Run("three level xid", testThreeLevelXID)
-	t.Run("nested add mutation with @hasInverse", nestedAddMutationWithHasInverse)
+	t.Run("nested add mutation with multiple linked lists and @hasInverse",
+		nestedAddMutationWithMultipleLinkedListsAndHasInverse)
 	t.Run("add mutation with @hasInverse overrides correctly", addMutationWithHasInverseOverridesCorrectly)
 	t.Run("error in multiple mutations", addMultipleMutationWithOneError)
 	t.Run("dgraph directive with reverse edge adds data correctly",

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -4143,7 +4143,7 @@ func intWithList(t *testing.T) {
 
 }
 
-func nestedAddMutationWithHasInverse(t *testing.T) {
+func nestedAddMutationWithMultipleLinkedListsAndHasInverse(t *testing.T) {
 	params := &GraphQLParams{
 		Query: `mutation addPerson1($input: [AddPerson1Input!]!) {
             addPerson1(input: $input) {
@@ -4151,6 +4151,9 @@ func nestedAddMutationWithHasInverse(t *testing.T) {
                     name
                     friends {
                         name
+						closeFriends {
+							name
+						}
                         friends {
                             name
                         }
@@ -4186,6 +4189,7 @@ func nestedAddMutationWithHasInverse(t *testing.T) {
             {
               "friends": [
                 {
+				  "closeFriends": [],
                   "friends": [
                     {
                       "name": "Or"

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -207,6 +207,7 @@ type post1{
 type Person1 {
     id: ID!
     name: String!
+    closeFriends: [Person1] @hasInverse(field: closeFriends)
     friends: [Person1] @hasInverse(field: friends)
 }
 

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -351,6 +351,11 @@
       "list": true
     },
     {
+      "predicate": "Person1.closeFriends",
+      "type": "uid",
+      "list": true
+    },
+    {
       "predicate": "Person1.name",
       "type": "string"
     },
@@ -1086,6 +1091,9 @@
         },
         {
           "name": "Person1.friends"
+        },
+        {
+          "name": "Person1.closeFriends"
         }
       ],
       "name": "Person1"

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -220,6 +220,7 @@ type post1{
 type Person1 {
     id: ID!
     name: String!
+    closeFriends: [Person1] @hasInverse(field: closeFriends)
     friends: [Person1] @hasInverse(field: friends)
 }
 

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -433,6 +433,11 @@
       "list": true
     },
     {
+      "predicate": "Person1.closeFriends",
+      "type": "uid",
+      "list": true
+    },
+    {
       "predicate": "Person1.name",
       "type": "string"
     },
@@ -1119,6 +1124,9 @@
         },
         {
           "name": "Person1.friends"
+        },
+        {
+          "name": "Person1.closeFriends"
         }
       ],
       "name": "Person1"

--- a/query/outputnode_graphql.go
+++ b/query/outputnode_graphql.go
@@ -449,7 +449,8 @@ func (genc *graphQLEncoder) encode(encInp encodeInput) bool {
 		// 2. We are at the end of json encoding process and there is no fastjson node ahead (next == nil)
 		// 3. We are at the end of list writing and the type of next fastJSON node is not equal to
 		//    type of curr fastJSON node.
-		// 4. The current selection set which we are encoding is not equal to the type of current fastJSON node.
+		// 4. The current selection set which we are encoding is not equal to the type of
+		//    current fastJSON node.
 		if !curSelectionIsDgList || next == nil ||
 			genc.getAttr(cur) != genc.getAttr(next) ||
 			curSelection.DgraphAlias() != genc.attrForID(genc.getAttr(cur)) {

--- a/query/outputnode_graphql.go
+++ b/query/outputnode_graphql.go
@@ -444,7 +444,15 @@ func (genc *graphQLEncoder) encode(encInp encodeInput) bool {
 		}
 
 		// Step-3: Update counters and Write closing ] for JSON arrays
-		if !curSelectionIsDgList || next == nil || genc.getAttr(cur) != genc.getAttr(next) {
+		// We perform this step in any of the 4 conditions is satisfied.
+		// 1. The current selection is not a Dgraph List (It's of custom type or a single JSON object)
+		// 2. We are at the end of json encoding process and there is no fastjson node ahead (next == nil)
+		// 3. We are at the end of list writing and the type of next fastJSON node is not equal to
+		//    type of curr fastJSON node.
+		// 4. The current selection set which we are encoding is not equal to the type of current fastJSON node.
+		if !curSelectionIsDgList || next == nil ||
+			genc.getAttr(cur) != genc.getAttr(next) ||
+			curSelection.DgraphAlias() != genc.attrForID(genc.getAttr(cur)) {
 			if curSelectionIsDgList && !nullWritten {
 				x.Check2(genc.buf.WriteRune(']'))
 			}


### PR DESCRIPTION
Motivation:
Current GraphQL encoding had a bug which led to timing out in case there is an empty list in dataset and it is queried before any non-null field. This fixes this behaviour.

Fixes DGRAPH-3257

Testing:
1. The test times out (as expected) without the change to outputnode_graphql.go
2. The test passes with the change to outputnode_graphql.go 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7726)
<!-- Reviewable:end -->
