### PR TITLE
Fix(GraphQL): Add filter in DQL query in case of reverse predicate

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -311,12 +311,6 @@ func aggregateQuery(query schema.Query, authRw *authRewriter) []*gql.GraphQuery 
 					//        scoreVar as Tweets.score
 					// }
 
-					// Add type filter in case the Dgraph predicate for which the aggregate
-					// field belongs is a reverse edge
-					if strings.HasPrefix(constructedForDgraphPredicate, "~") {
-						addTypeFilter(child, f.ConstructedFor())
-					}
-
 					mainQuery.Children = append(mainQuery.Children, child)
 					isAggregateVarAdded[constructedForField] = true
 				}
@@ -1182,7 +1176,7 @@ func buildAggregateFields(
 			// Add type filter in case the Dgraph predicate for which the aggregate
 			// field belongs to is a reverse edge
 			if strings.HasPrefix(constructedForDgraphPredicate, "~") {
-				addTypeFilter(mainField, f.ConstructedFor())
+				addTypeFilter(aggregateChild, f.ConstructedFor())
 			}
 
 			aggregateChildren = append(aggregateChildren, aggregateChild)

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2527,7 +2527,7 @@
     query {
       queryMovie(func: type(Movie)) {
         Movie.name : Movie.name
-        Movie.director : ~directed.movies {
+        Movie.director : ~directed.movies @filter(type(MovieDirector)) {
           MovieDirector.name : MovieDirector.name
           dgraph.uid : uid
         }
@@ -3407,6 +3407,54 @@
         Person.nameHiZh : Person.name@hi:zh
         Person.nameHi_Zh_Untag : Person.name@hi:zh:.
         Person.name_Untag_AnyLang : Person.name@.
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Query fields linked to reverse predicates in Dgraph"
+  gqlquery: |
+    query {
+      queryLinkX(filter:{f9:{eq: "Alice"}}) {
+        f1(filter: {f6: {eq: "Eve"}}) {
+          f6
+        }
+        f2(filter: {f7: {eq: "Bob"}}) {
+          f7
+        }
+        f1Aggregate(filter: {f6: {eq: "Eve"}}) {
+          count
+          f6Max
+        }
+        f2Aggregate(filter: {f7: {eq: "Bob"}}) {
+          count
+          f7Min
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryLinkX(func: type(LinkX)) @filter(eq(LinkX.f9, "Alice")) {
+        LinkX.f1 : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          LinkY.f6 : LinkY.f6
+          dgraph.uid : uid
+        }
+        LinkX.f2 : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          LinkZ.f7 : LinkZ.f7
+          dgraph.uid : uid
+        }
+        LinkX.f1Aggregate : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          LinkX.f1Aggregate_f6Var as LinkY.f6
+          dgraph.uid : uid
+        }
+        LinkYAggregateResult.count_LinkX.f1Aggregate : count(~link) @filter((eq(LinkY.f6, "Eve") AND type(LinkY)))
+        LinkYAggregateResult.f6Max_LinkX.f1Aggregate : max(val(LinkX.f1Aggregate_f6Var))
+        LinkX.f2Aggregate : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          LinkX.f2Aggregate_f7Var as LinkZ.f7
+          dgraph.uid : uid
+        }
+        LinkZAggregateResult.count_LinkX.f2Aggregate : count(~link) @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ)))
+        LinkZAggregateResult.f7Min_LinkX.f2Aggregate : min(val(LinkX.f2Aggregate_f7Var))
         dgraph.uid : uid
       }
     }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -451,3 +451,17 @@ type Friend1 {
 type Friend {
     id: String! @id
 }
+
+type LinkX {
+    f9: String! @id
+    f1: [LinkY] @dgraph(pred: "~link")
+    f2: [LinkZ] @dgraph(pred: "~link")
+}
+type LinkY {
+    f6: String! @id
+    f3: [LinkX] @dgraph(pred: "link")
+}
+type LinkZ {
+    f7: String! @id
+    f4: [LinkX] @dgraph(pred: "link")
+}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -3375,6 +3375,7 @@ valid_schemas:
         name: String
       }
 
+<<<<<<< HEAD
   - name: "A valid federation schema"
     input: |
       type Review {
@@ -3430,4 +3431,17 @@ valid_schemas:
         address: String @search(by: [fulltext])
         addressHi: String @dgraph(pred: "Person.address@hi")
         professionEn: String @dgraph(pred: "Person.profession@en")
+      }
+
+  - name: "Same reverse dgraph predicate can be used by two different GraphQL fields"
+    input: |
+      type X {
+        f1: [Y] @dgraph(pred: "~link")
+        f2: [Z] @dgraph(pred: "~link")
+      }
+      type Y {
+        f3: [X] @dgraph(pred: "link")
+      }
+      type Z {
+        f4: [X] @dgraph(pred: "link")
       }

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -3375,7 +3375,6 @@ valid_schemas:
         name: String
       }
 
-<<<<<<< HEAD
   - name: "A valid federation schema"
     input: |
       type Review {

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -195,6 +195,11 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 						isSecret:   false,
 					}
 
+					// Skip the checks related to same Dgraph predicates being used twice with
+					// different types in case it is an inverse edge.
+					if strings.HasPrefix(fname, "~") || strings.HasPrefix(fname, "<~") {
+						continue
+					}
 					if pred, ok := preds[fname]; ok {
 						if pred.isSecret {
 							errs = append(errs, secretError(pred, thisPred))


### PR DESCRIPTION
Motivation:
This adds support for having two GraphQL fields linking to the same reverse edge. This also adds corresponding changes to query_rewriter to filter out only the wanted nodes.

Testing:
1. Add yaml test in query_test.yaml

Fixes GRAPHQL-1140

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7728)
<!-- Reviewable:end -->
