### PR TITLE
fix(lsBackup): Fix profiler conf in lsBackup

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -34,9 +34,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Restore is the sub-command used to restore a backup.
-var Restore x.SubCommand
-
 // LsBackup is the sub-command used to list the backups in a folder.
 var LsBackup x.SubCommand
 
@@ -67,7 +64,7 @@ func initBackupLs() {
 		Short: "List info on backups in a given location",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			defer x.StartProfile(Restore.Conf).Stop()
+			defer x.StartProfile(LsBackup.Conf).Stop()
 			if err := runLsbackupCmd(); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)


### PR DESCRIPTION
Before lsBackup was using wrong conf for starting profiling. This PR fixes it.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7729)
<!-- Reviewable:end -->
