### PR TITLE
Fix(GraphQL): Add filter in DQL query in case of reverse predicate (#…

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -310,6 +310,7 @@ func aggregateQuery(query schema.Query, authRw *authRewriter) []*gql.GraphQuery 
 					// var(func: type(Tweets)) {
 					//        scoreVar as Tweets.score
 					// }
+
 					mainQuery.Children = append(mainQuery.Children, child)
 					isAggregateVarAdded[constructedForField] = true
 				}
@@ -1148,6 +1149,12 @@ func buildAggregateFields(
 	fieldFilter, _ := f.ArgValue("filter").(map[string]interface{})
 	_ = addFilter(mainField, constructedForType, fieldFilter)
 
+	// Add type filter in case the Dgraph predicate for which the aggregate
+	// field belongs to is a reverse edge
+	if strings.HasPrefix(constructedForDgraphPredicate, "~") {
+		addTypeFilter(mainField, f.ConstructedFor())
+	}
+
 	// isAggregateVarAdded is a map from field name to boolean. It is used to
 	// ensure that a field is added to Var query at maximum once.
 	// Eg. Even if scoreMax and scoreMin are queried, the corresponding field will
@@ -1165,6 +1172,13 @@ func buildAggregateFields(
 			}
 			// Add filter to count aggregation field.
 			_ = addFilter(aggregateChild, constructedForType, fieldFilter)
+
+			// Add type filter in case the Dgraph predicate for which the aggregate
+			// field belongs to is a reverse edge
+			if strings.HasPrefix(constructedForDgraphPredicate, "~") {
+				addTypeFilter(aggregateChild, f.ConstructedFor())
+			}
+
 			aggregateChildren = append(aggregateChildren, aggregateChild)
 			continue
 		}
@@ -1363,6 +1377,12 @@ func addSelectionSetFrom(
 		if includeField := addFilter(child, f.Type(), filter); !includeField {
 			continue
 		}
+
+		// Add type filter in case the Dgraph predicate is a reverse edge
+		if strings.HasPrefix(f.DgraphPredicate(), "~") {
+			addTypeFilter(child, f.Type())
+		}
+
 		addOrder(child, f)
 		addPagination(child, f)
 		addCascadeDirective(child, f)

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2527,7 +2527,7 @@
     query {
       queryMovie(func: type(Movie)) {
         Movie.name : Movie.name
-        Movie.director : ~directed.movies {
+        Movie.director : ~directed.movies @filter(type(MovieDirector)) {
           MovieDirector.name : MovieDirector.name
           dgraph.uid : uid
         }
@@ -3381,5 +3381,53 @@
           author.name : author.name
           dgraph.uid : uid
         }
+      }
+    }
+
+-
+  name: "Query fields linked to reverse predicates in Dgraph"
+  gqlquery: |
+    query {
+      queryLinkX(filter:{f9:{eq: "Alice"}}) {
+        f1(filter: {f6: {eq: "Eve"}}) {
+          f6
+        }
+        f2(filter: {f7: {eq: "Bob"}}) {
+          f7
+        }
+        f1Aggregate(filter: {f6: {eq: "Eve"}}) {
+          count
+          f6Max
+        }
+        f2Aggregate(filter: {f7: {eq: "Bob"}}) {
+          count
+          f7Min
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryLinkX(func: type(LinkX)) @filter(eq(LinkX.f9, "Alice")) {
+        LinkX.f1 : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          LinkY.f6 : LinkY.f6
+          dgraph.uid : uid
+        }
+        LinkX.f2 : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          LinkZ.f7 : LinkZ.f7
+          dgraph.uid : uid
+        }
+        LinkX.f1Aggregate : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          LinkX.f1Aggregate_f6Var as LinkY.f6
+          dgraph.uid : uid
+        }
+        LinkYAggregateResult.count_LinkX.f1Aggregate : count(~link) @filter((eq(LinkY.f6, "Eve") AND type(LinkY)))
+        LinkYAggregateResult.f6Max_LinkX.f1Aggregate : max(val(LinkX.f1Aggregate_f6Var))
+        LinkX.f2Aggregate : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          LinkX.f2Aggregate_f7Var as LinkZ.f7
+          dgraph.uid : uid
+        }
+        LinkZAggregateResult.count_LinkX.f2Aggregate : count(~link) @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ)))
+        LinkZAggregateResult.f7Min_LinkX.f2Aggregate : min(val(LinkX.f2Aggregate_f7Var))
+        dgraph.uid : uid
       }
     }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -446,3 +446,17 @@ type Friend1 {
 type Friend {
     id: String! @id
 }
+
+type LinkX {
+    f9: String! @id
+    f1: [LinkY] @dgraph(pred: "~link")
+    f2: [LinkZ] @dgraph(pred: "~link")
+}
+type LinkY {
+    f6: String! @id
+    f3: [LinkX] @dgraph(pred: "link")
+}
+type LinkZ {
+    f7: String! @id
+    f4: [LinkX] @dgraph(pred: "link")
+}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -3367,3 +3367,15 @@ valid_schemas:
         questionText: String
       }
 
+  - name: "Same reverse dgraph predicate can be used by two different GraphQL fields"
+    input: |
+      type X {
+        f1: [Y] @dgraph(pred: "~link")
+        f2: [Z] @dgraph(pred: "~link")
+      }
+      type Y {
+        f3: [X] @dgraph(pred: "link")
+      }
+      type Z {
+        f4: [X] @dgraph(pred: "link")
+      }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -195,6 +195,11 @@ func dgraphDirectivePredicateValidation(gqlSch *ast.Schema, definitions []string
 						isSecret:   false,
 					}
 
+					// Skip the checks related to same Dgraph predicates being used twice with
+					// different types in case it is an inverse edge.
+					if strings.HasPrefix(fname, "~") || strings.HasPrefix(fname, "<~") {
+						continue
+					}
 					if pred, ok := preds[fname]; ok {
 						if pred.isSecret {
 							errs = append(errs, secretError(pred, thisPred))


### PR DESCRIPTION
Adds type filter to DQL queries in case graphql field has been mapped to DQL reverse predicate.

(cherry picked from commit 17435010e7edea02b99d5c2989b2c2712ed2567b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7733)
<!-- Reviewable:end -->
