### PR TITLE
Fix(GraphQL): Add filter in DQL query in case of reverse predicate (#…

### DIFF
--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -2395,7 +2395,7 @@
     query {
       queryMovie(func: type(Movie)) {
         name : Movie.name
-        director : ~directed.movies {
+        director : ~directed.movies @filter(type(MovieDirector)) {
           name : MovieDirector.name
           dgraph.uid : uid
         }
@@ -3181,6 +3181,54 @@
     query {
       queryAuthor(func: uid(0x1)) @filter(type(Author)) {
         name : Author.name
+        dgraph.uid : uid
+      }
+    }
+
+-
+  name: "Query fields linked to reverse predicates in Dgraph"
+  gqlquery: |
+    query {
+      queryLinkX(filter:{f9:{eq: "Alice"}}) {
+        f1(filter: {f6: {eq: "Eve"}}) {
+          f6
+        }
+        f2(filter: {f7: {eq: "Bob"}}) {
+          f7
+        }
+        f1Aggregate(filter: {f6: {eq: "Eve"}}) {
+          count
+          f6Max
+        }
+        f2Aggregate(filter: {f7: {eq: "Bob"}}) {
+          count
+          f7Min
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryLinkX(func: type(LinkX)) @filter(eq(LinkX.f9, "Alice")) {
+        f1 : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          f6 : LinkY.f6
+          dgraph.uid : uid
+        }
+        f2 : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          f7 : LinkZ.f7
+          dgraph.uid : uid
+        }
+        f1Aggregate : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
+          f1Aggregate_f6Var as LinkY.f6
+          dgraph.uid : uid
+        }
+        count_f1Aggregate : count(~link) @filter((eq(LinkY.f6, "Eve") AND type(LinkY)))
+        f6Max_f1Aggregate : max(val(f1Aggregate_f6Var))
+        f2Aggregate : ~link @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ))) {
+          f2Aggregate_f7Var as LinkZ.f7
+          dgraph.uid : uid
+        }
+        count_f2Aggregate : count(~link) @filter((eq(LinkZ.f7, "Bob") AND type(LinkZ)))
+        f7Min_f2Aggregate : min(val(f2Aggregate_f7Var))
         dgraph.uid : uid
       }
     }

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -379,3 +379,17 @@ type Workflow {
 type Node {
     name: String!
 }
+
+type LinkX {
+    f9: String! @id
+    f1: [LinkY] @dgraph(pred: "~link")
+    f2: [LinkZ] @dgraph(pred: "~link")
+}
+type LinkY {
+    f6: String! @id
+    f3: [LinkX] @dgraph(pred: "link")
+}
+type LinkZ {
+    f7: String! @id
+    f4: [LinkX] @dgraph(pred: "link")
+}

--- a/graphql/schema/gqlschema_test.yml
+++ b/graphql/schema/gqlschema_test.yml
@@ -3121,3 +3121,16 @@ valid_schemas:
       type Z {
         f4: [X] @dgraph(pred: "link")
       }
+
+  - name: "Same reverse dgraph predicate can be used by two different GraphQL fields"
+    input: |
+      type X {
+        f1: [Y] @dgraph(pred: "~link")
+        f2: [Z] @dgraph(pred: "~link")
+      }
+      type Y {
+        f3: [X] @dgraph(pred: "link")
+      }
+      type Z {
+        f4: [X] @dgraph(pred: "link")
+      }


### PR DESCRIPTION
Add type filter to DQL filters for GraphQL fields mapped to DQL reverse predicates.

(cherry picked from commit 17435010e7edea02b99d5c2989b2c2712ed2567b)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7734)
<!-- Reviewable:end -->
