### PR TITLE
fix(Chunker): don't delete node with empty facet in mutation

### DIFF
--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -1072,6 +1072,22 @@ func TestSetNquadNilValue(t *testing.T) {
 	require.Equal(t, 0, len(fastNQ))
 }
 
+func TestNquadsFromJsonEmptyFacet(t *testing.T) {
+	json := `{"uid":1000,"doesnt|exist":null}`
+
+	// fast
+	buf := NewNQuadBuffer(-1)
+	require.Nil(t, buf.FastParseJSON([]byte(json), DeleteNquads))
+	buf.Flush()
+	require.Equal(t, 0, len(<-buf.Ch()))
+
+	// old
+	buf = NewNQuadBuffer(-1)
+	require.Nil(t, buf.ParseJSON([]byte(json), DeleteNquads))
+	buf.Flush()
+	require.Equal(t, 0, len(<-buf.Ch()))
+}
+
 func BenchmarkNoFacets(b *testing.B) {
 	json := []byte(`[
 	{

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -1079,12 +1079,14 @@ func TestNquadsFromJsonEmptyFacet(t *testing.T) {
 	buf := NewNQuadBuffer(-1)
 	require.Nil(t, buf.FastParseJSON([]byte(json), DeleteNquads))
 	buf.Flush()
+	// needs to be empty, otherwise node gets deleted
 	require.Equal(t, 0, len(<-buf.Ch()))
 
 	// old
 	buf = NewNQuadBuffer(-1)
 	require.Nil(t, buf.ParseJSON([]byte(json), DeleteNquads))
 	buf.Flush()
+	// needs to be empty, otherwise node gets deleted
 	require.Equal(t, 0, len(<-buf.Ch()))
 }
 

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -1072,6 +1072,7 @@ func TestSetNquadNilValue(t *testing.T) {
 	require.Equal(t, 0, len(fastNQ))
 }
 
+// See PR #7737 to understand why this test exists.
 func TestNquadsFromJsonEmptyFacet(t *testing.T) {
 	json := `{"uid":1000,"doesnt|exist":null}`
 


### PR DESCRIPTION
This is a fix for [this issue found on Friday](https://discuss.dgraph.io/t/critical-bug-node-gets-deleted-completely-if-a-non-existend-facet-is-removed/13741).

**Postmortem**

* With #7171, we [moved facet keys](https://github.com/dgraph-io/dgraph/blob/master/chunker/json_parser.go#L400-L407) from the main `map[string]interface{}` to a separate map for a performance boost. 
* However, in our `buf.checkForDeletion` function we [don't account for facet keys removed from the main map](https://github.com/dgraph-io/dgraph/blob/master/chunker/json_parser.go#L265-L267). 
* For example, this JSON: `{"uid":1000,"doesnt|exist":null}` essentially gets turned into `{"uid":1000}` before it reaches `buf.checkForDeletion`, and since it's a `DeleteNquads` operation, it deletes the entire node.

**Fix**

* Store the separate [facets map](https://github.com/dgraph-io/dgraph/blob/master/chunker/json_parser.go#L401) in [`mapResponse`](https://github.com/dgraph-io/dgraph/blob/bc0b9b611c7b1fb3211022e90e46050a1f60a3a6/chunker/json_parser.go#L402).
* Verify that [no facet keys exist in the mutation](https://github.com/dgraph-io/dgraph/blob/bc0b9b611c7b1fb3211022e90e46050a1f60a3a6/chunker/json_parser.go#L268) before deleting the node.
* `buf.checkForDeletion` should now behave as it did before #7171.

Let me know if this could introduce any other issues, or anything else I should add to the Chunker tests. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7737)
<!-- Reviewable:end -->
