### PR TITLE
feat(GraphQL): Disallow DQL schema changes for predicates used in GraphQL schema (DGRAPH-3245)

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -551,7 +551,8 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	return empty, nil
 }
 
-func validateDQLSchemaForGraphQL(ctx context.Context, dqlSch *schema.ParsedSchema, ns uint64) error {
+func validateDQLSchemaForGraphQL(ctx context.Context,
+	dqlSch *schema.ParsedSchema, ns uint64) error {
 	// fetch the GraphQL schema for this namespace from disk
 	_, existingGQLSch, err := GetGQLSchema(ns)
 	if err != nil || existingGQLSch == "" {
@@ -613,7 +614,8 @@ func validateDQLSchemaForGraphQL(ctx context.Context, dqlSch *schema.ParsedSchem
 			}
 			for _, t := range gqlPred.Tokenizer {
 				if !x.HasString(dqlPred.Tokenizer, t) {
-					return errors.Errorf("missing %s index for GraphQL predicate %s", t, x.ParseAttr(gqlPred.Predicate))
+					return errors.Errorf("missing %s index for GraphQL predicate %s", t,
+						x.ParseAttr(gqlPred.Predicate))
 				}
 			}
 		}

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -736,7 +736,9 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "type mismatch for GraphQL predicate Person.age. want: int, got: float")
+	}).Error(), "can't alter predicate Person.age as it is used by the GraphQL API, "+
+		"and type definition is incompatible with what is expected by the GraphQL API. "+
+		"want: int, got: float")
 
 	// 2. int -> [int] should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -754,7 +756,9 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "type mismatch for GraphQL predicate Person.age. want: int, got: [int]")
+	}).Error(), "can't alter predicate Person.age as it is used by the GraphQL API, "+
+		"and type definition is incompatible with what is expected by the GraphQL API. "+
+		"want: int, got: [int]")
 
 	// 3. [uid] -> uid should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -772,7 +776,9 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: uid @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "type mismatch for GraphQL predicate Person.follows. want: [uid], got: uid")
+	}).Error(), "can't alter predicate Person.follows as it is used by the GraphQL API, "+
+		"and type definition is incompatible with what is expected by the GraphQL API. "+
+		"want: [uid], got: uid")
 
 	// 4. removing @index should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -790,7 +796,8 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing @index for GraphQL predicate Person.name")
+	}).Error(), "can't alter predicate Person.name as it is used by the GraphQL API, "+
+		"and is missing index definition that is expected by the GraphQL API. want: @index(hash)")
 
 	// 5. @index(hash) -> @index(term) should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -808,7 +815,9 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing hash index for GraphQL predicate Person.name")
+	}).Error(), "can't alter predicate Person.name as it is used by the GraphQL API, "+
+		"and is missing index definition that is expected by the GraphQL API. "+
+		"want: @index(term, hash), got: @index(term)")
 
 	// 6. removing @reverse should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -826,7 +835,8 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing @reverse for GraphQL predicate Person.follows")
+	}).Error(), "can't alter predicate Person.follows as it is used by the GraphQL API, "+
+		"and is missing @reverse that is expected by the GraphQL API.")
 
 	// 7. removing @upsert should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -844,7 +854,8 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing @upsert for GraphQL predicate Person.name")
+	}).Error(), "can't alter predicate Person.name as it is used by the GraphQL API, "+
+		"and is missing @upsert that is expected by the GraphQL API.")
 
 	// 8. removing @lang should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -862,7 +873,8 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing @lang for GraphQL predicate Person.bio")
+	}).Error(), "can't alter predicate Person.bio as it is used by the GraphQL API, "+
+		"and is missing @lang that is expected by the GraphQL API.")
 
 	// 9. removing a GraphQL field from Person type should fail
 	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
@@ -879,7 +891,8 @@ func TestAlterWithGraphQLSchema(t *testing.T) {
 		Person.follows: [uid] @reverse .
 		Person.relative: uid .
 		`,
-	}).Error(), "missing field Person.name in GraphQL type Person")
+	}).Error(), "can't alter type Person as it is used by the GraphQL API, "+
+		"and is missing fields: [Person.name] that are expected by the GraphQL API.")
 
 	/******************
 		SUCCESS CASES

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -685,6 +685,231 @@ func TestDeleteSchemaAndExport(t *testing.T) {
 	require.NotEqual(t, schemaResp.Id, newSchemaResp.Id)
 }
 
+// TestAlterWithGraphQLSchema ensures that the predicates used by GraphQL schema can't be
+// modified using Alter directly.
+func TestAlterWithGraphQLSchema(t *testing.T) {
+	common.SafelyDropAll(t)
+
+	// initially alter should succeed
+	dg, err := testutil.DgraphClient(groupOnegRPC)
+	require.NoError(t, err)
+	require.NoError(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+		}
+		Person.name: string @index(exact) .
+		dqlPred: int .
+		`,
+	}))
+
+	// now apply a GraphQL schema
+	common.SafelyUpdateGQLSchema(t, groupOneHTTP, `
+	type Person {
+		id: ID!
+		name: String! @id
+		age: Int
+		bio: String @search(by: [term,fulltext])
+		bioHi: String @dgraph(pred: "Person.bio@hi")
+		follows: [Person] @dgraph(pred: "Person.follows")
+		followedBy: [Person] @dgraph(pred: "~Person.follows")
+		relative: Person
+	}`, nil)
+
+	/******************
+		FAILURE CASES
+	******************/
+
+	// 1. int -> float should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: float .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "type mismatch for GraphQL predicate Person.age. want: int, got: float")
+
+	// 2. int -> [int] should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: [int] .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "type mismatch for GraphQL predicate Person.age. want: int, got: [int]")
+
+	// 3. [uid] -> uid should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: uid @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "type mismatch for GraphQL predicate Person.follows. want: [uid], got: uid")
+
+	// 4. removing @index should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing @index for GraphQL predicate Person.name")
+
+	// 5. @index(hash) -> @index(term) should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(term) @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing hash index for GraphQL predicate Person.name")
+
+	// 6. removing @reverse should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing @reverse for GraphQL predicate Person.follows")
+
+	// 7. removing @upsert should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing @upsert for GraphQL predicate Person.name")
+
+	// 8. removing @lang should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing @lang for GraphQL predicate Person.bio")
+
+	// 9. removing a GraphQL field from Person type should fail
+	require.Contains(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+		}
+		Person.name: string @index(hash) @upsert .
+		Person.age: int .
+		Person.bio: string @index(term, fulltext) @lang .
+		Person.follows: [uid] @reverse .
+		Person.relative: uid .
+		`,
+	}).Error(), "missing field Person.name in GraphQL type Person")
+
+	/******************
+		SUCCESS CASES
+	******************/
+	// 1. adding/updating a non-GraphQL predicate, as well as adding/removing them from a type
+	// 2. @index(term, fulltext) -> @index(exact, term, fulltext) for a GraphQL predicate
+	// 3. adding @count to a GraphQL predicate
+	// 4. adding @reverse to a GraphQL predicate
+	// 5. adding @upsert to a GraphQL predicate
+	// 6. adding @lang to a GraphQL predicate
+	require.NoError(t, dg.Alter(context.Background(), &api.Operation{
+		Schema: `
+		type Person {
+			Person.name
+			Person.age
+			Person.bio
+			Person.follows
+			Person.relative
+			dqlPred
+		}
+		Person.name: string @index(hash) @upsert @lang .
+		Person.age: int @index(int) @upsert .
+		Person.bio: string @index(exact, term, fulltext) @lang .
+		Person.follows: [uid] @reverse @count .
+		Person.relative: uid @reverse .
+		dqlPred: float @index(float) .
+		`,
+	}))
+}
+
 func updateGQLSchemaConcurrent(t *testing.T, schema, authority string) bool {
 	res := common.RetryUpdateGQLSchema(t, authority, schema, nil)
 	err := res.Errors.Error()


### PR DESCRIPTION
See [Discuss Issue](https://discuss.dgraph.io/t/disallow-dql-schema-changes-for-predicates-used-in-graphql-schema/13570) for more details.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7742)
<!-- Reviewable:end -->
