### PR TITLE
fix(live): make live loader progress on a cluster with very high maxUid 

### DIFF
--- a/dgraph/cmd/zero/assign.go
+++ b/dgraph/cmd/zero/assign.go
@@ -127,7 +127,8 @@ func (s *Server) lease(ctx context.Context, num *pb.Num) (*pb.AssignedIds, error
 			howMany = num.Val + leaseBandwidth
 		}
 		if howMany < num.Val || maxLease+howMany < maxLease { // check for overflow.
-			return &emptyAssignedIds, errors.Errorf("Cannot lease %s as the limit has reached", typ)
+			return &emptyAssignedIds, errors.Errorf("Cannot lease %s as the limit has reached."+
+				" currMax:%d", typ, s.nextLease[typ]-1)
 		}
 
 		var proposal pb.ZeroProposal

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"encoding/binary"
 	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +38,8 @@ import (
 	"github.com/dgryski/go-farm"
 	"github.com/golang/glog"
 )
+
+var maxLeaseRegex = regexp.MustCompile(`currMax:([0-9]+)`)
 
 // XidMapOptions specifies the options for creating a new xidmap.
 type XidMapOptions struct {
@@ -290,12 +295,27 @@ func (m *XidMap) updateMaxSeen(max uint64) {
 // BumpTo can be used to make Zero allocate UIDs up to this given number. Attempts are made to
 // ensure all future allocations of UIDs be higher than this one, but results are not guaranteed.
 func (m *XidMap) BumpTo(uid uint64) {
-	curMax := atomic.LoadUint64(&m.maxUidSeen)
-	if uid <= curMax {
-		return
+	updateLease := func(msg string) {
+		if !strings.Contains(msg, "limit has reached. currMax:") {
+			return
+		}
+		matches := maxLeaseRegex.FindAllStringSubmatch(msg, 1)
+		if len(matches) == 0 {
+			return
+		}
+		maxUidLeased, err := strconv.ParseUint(matches[0][1], 10, 64)
+		if err != nil {
+			glog.Error("While parsing currMax %+v", err)
+			return
+		}
+		m.updateMaxSeen(maxUidLeased)
 	}
 
 	for {
+		curMax := atomic.LoadUint64(&m.maxUidSeen)
+		if uid <= curMax {
+			return
+		}
 		glog.V(1).Infof("Bumping up to %v", uid)
 		num := x.Max(uid-curMax, 1e4)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -307,6 +327,7 @@ func (m *XidMap) BumpTo(uid uint64) {
 			m.updateMaxSeen(assigned.EndId)
 			return
 		}
+		updateLease(err.Error())
 		glog.Errorf("While requesting AssignUids(%d): %v", num, err)
 		if x.IsJwtExpired(err) {
 			if err := m.relogin(); err != nil {


### PR DESCRIPTION
Relates to https://github.com/dgraph-io/dgraph/pull/7724
This PR fixes the following case:
If we have a cluster that cannot lease out new UIDs because it has already leased upto its 
max limit. Now, we try to live load the data with the given UIDs and the AssignIds complains
that the limit has reached. Hence, update the xidmap's maxSeenUid and make progress.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7743)
<!-- Reviewable:end -->
