### PR TITLE
fix(Chunker): don't delete node with empty facet in mutation (#7737)

### DIFF
--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -1072,6 +1072,25 @@ func TestSetNquadNilValue(t *testing.T) {
 	require.Equal(t, 0, len(fastNQ))
 }
 
+// See PR #7737 to understand why this test exists.
+func TestNquadsFromJsonEmptyFacet(t *testing.T) {
+	json := `{"uid":1000,"doesnt|exist":null}`
+
+	// fast
+	buf := NewNQuadBuffer(-1)
+	require.Nil(t, buf.FastParseJSON([]byte(json), DeleteNquads))
+	buf.Flush()
+	// needs to be empty, otherwise node gets deleted
+	require.Equal(t, 0, len(<-buf.Ch()))
+
+	// old
+	buf = NewNQuadBuffer(-1)
+	require.Nil(t, buf.ParseJSON([]byte(json), DeleteNquads))
+	buf.Flush()
+	// needs to be empty, otherwise node gets deleted
+	require.Equal(t, 0, len(<-buf.Ch()))
+}
+
 func BenchmarkNoFacets(b *testing.B) {
 	json := []byte(`[
 	{


### PR DESCRIPTION
#7737 cherry pick

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7745)
<!-- Reviewable:end -->
