### PR TITLE
feat(DQL): @groupby on scalar fields and count duplicate 

### DIFF
--- a/query/groupby.go
+++ b/query/groupby.go
@@ -324,6 +324,10 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 			// 			a as count(uid)
 			// 		}
 			// 	}
+			// since `a` is a global variable which stores (uid, val) pair for
+			// all the srcUids (1 & 31 in this case), we can't store distinct
+			// vals for same uid locally. This will eventually lead to incorrect
+			// results.
 			if sg.SrcFunc == nil {
 				return errors.Errorf("Vars can be assigned only at root when grouped by Value")
 			}

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -327,7 +327,9 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 			if sg.SrcFunc == nil {
 				return errors.Errorf("Vars can be assigned only at root when grouped by Value")
 			}
-			valUidMap := make(map[types.Val][]uint64)
+
+			// valUidListMap gathers all the uids corresponding to one value.
+			valUidListMap := make(map[types.Val][]uint64)
 			for i, v := range child.valueMatrix {
 				srcUid := child.SrcUIDs.Uids[i]
 				if len(v.Values) == 0 {
@@ -337,9 +339,13 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 				if err != nil {
 					continue
 				}
-				valUidMap[val] = append(valUidMap[val], srcUid)
+				valUidListMap[val] = append(valUidListMap[val], srcUid)
 			}
-			for _, uidList := range valUidMap {
+			// for each uidList corresponding to one value, for eg:
+			// v1 -> [u1, u2, u3], groups are made in following way:
+			// u1 -> [u1, u2, u3], u2 -> [u1, u2, u3], u3 -> [u1, u2, u3]
+			// Hence, u_i contains all the uids having same value.
+			for _, uidList := range valUidListMap {
 				for _, uid := range uidList {
 					strKey := strconv.FormatUint(uid, 10)
 					cur := dedupMap.getGroup(attr)

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -384,8 +384,18 @@ func (sg *SubGraph) fillGroupedVars(doneVars map[string]varValue, path []*SubGra
 				// if there are more than one predicates or a single scalar
 				// predicate in the @groupby then the variable stores the mapping of
 				// uid -> count of duplicates. for eg if there are two predicates(u & v) and
-				// the groupby uids for (u1, v1) pair are (uid1, uid2, uid3) then the variable
+				// the grouped uids for (u1, v1) pair are (uid1, uid2, uid3) then the variable
 				// stores (uid1, 3), (uid2, 3) & (uid2, 2) map.
+				// For the query given below:-
+				// 	var(func: type(Student)) @groupby(school, age) {
+				// 		c as count(uid)
+				// 	}
+				// if the grouped result is:-
+				// (s1, age1) -> "0x1", "0x2", "0x3"
+				// (s2, age2) -> "0x4"
+				// (s3, ag3) -> "0x5","0x6"
+				// then `c` will store the mapping:-
+				// {"0x1" -> 3, "0x2" -> 3, "0x3" -> 3, "0x4" -> 1, "0x5" -> 2, "0x6"-> 2}
 				for _, uid := range grp.uids {
 					if len(grp.aggregates) > 0 {
 						tempMap[uid] = grp.aggregates[len(grp.aggregates)-1].key

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1487,6 +1487,22 @@ func TestGroupByCountValVar(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"uid": "0x1","val":1},{"uid": "0x17","val": 2},{"uid": "0x18","val": 2},{"uid": "0x19","val": 1},{"uid": "0x1f","val": 1}]}}`, js)
 }
 
+func TestGroupByCountValVarFilter(t *testing.T) {
+	query := `
+	{
+		var(func: uid(1, 23, 24, 25, 31)) @groupby(age) {
+			c as count(uid)
+		}
+		me(func: uid(c)) @filter(ge(val(c),2)) {
+			name
+			val: val(c)
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":"me":[{"name": "Rick Grimes","val": 2},{"name": "Glenn Rhee","val": 2}]}}`, js)
+}
+
 func TestGroupByMultiCountValVar(t *testing.T) {
 	query := `
 	{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1471,6 +1471,38 @@ func TestGroupByRootAlias(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"@groupby":[{"age":17,"Count":1},{"age":19,"Count":1},{"age":38,"Count":1},{"age":15,"Count":2}]}]}}`, js)
 }
 
+func TestGroupByCountValVar(t *testing.T) {
+	query := `
+	{
+		var(func: uid(1, 23, 24, 25, 31)) @groupby(age) {
+			c as count(uid)
+		}
+		me(func: uid(c)) {
+			uid
+			val: val(c)
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"uid": "0x1","val":1},{"uid": "0x17","val": 2},{"uid": "0x18","val": 2},{"uid": "0x19","val": 1},{"uid": "0x1f","val": 1}]}}`, js)
+}
+
+func TestGroupByMultiCountValVar(t *testing.T) {
+	query := `
+	{
+		var(func: uid(1, 23, 24, 25, 31)) @groupby(name,age) {
+			c as count(uid)
+		}
+		me(func: uid(c)) {
+			name
+			val: val(c)
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me": [{"name": "Michonne","val": 1},{"name": "Rick Grimes","val": 1},{"name": "Glenn Rhee","val": 1},{"name": "Daryl Dixon","val": 1},{"name": "Andrea","val": 1}]}}`, js)
+}
+
 func TestGroupByRootAlias2(t *testing.T) {
 	query := `
 	{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1500,7 +1500,7 @@ func TestGroupByCountValVarFilter(t *testing.T) {
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":"me":[{"name": "Rick Grimes","val": 2},{"name": "Glenn Rhee","val": 2}]}}`, js)
+	require.JSONEq(t, `{"data":{"me": [{"name": "Rick Grimes","val": 2},{"name": "Glenn Rhee","val": 2}]}}`, js)
 }
 
 func TestGroupByMultiCountValVar(t *testing.T) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1519,6 +1519,22 @@ func TestGroupByMultiCountValVar(t *testing.T) {
 	require.JSONEq(t, `{"data": {"me": [{"name": "Michonne","val": 1},{"name": "Rick Grimes","val": 1},{"name": "Glenn Rhee","val": 1},{"name": "Daryl Dixon","val": 1},{"name": "Andrea","val": 1}]}}`, js)
 }
 
+func TestGroupByCountUidValVar(t *testing.T) {
+	query := `
+	{
+		var(func: uid(1, 23, 24)) @groupby(school, age) {
+		  c as count(uid)
+		}
+		me(func: uid(c))  {
+		  name
+		  val: val(c)
+		}
+	  }
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data": {"me": [{"name": "Michonne","val": 1},{"name": "Rick Grimes","val": 1},{"name": "Glenn Rhee","val": 1}]}}`, js)
+}
+
 func TestGroupByRootAlias2(t *testing.T) {
 	query := `
 	{


### PR DESCRIPTION
This PR extends support for var inside the @groupby query on a scalar predicate at root.
for example the given query now doesn't result to error:-
```
var(func: ... ) @groupby(age) {
  c as count(uid)
}
```
Now the uid variable `c` contains map of uid to count of uids with the same age.
Suppose for the data :-
```{
        "uid": "0x1",
        "age": 38
      },
      {
        "uid": "0x17",
        "age": 15
      },
      {
        "uid": "0x18",
        "age": 15
      },
      {
        "uid": "0x19",
        "age": 17
      }
```
The following groupby query:-
```
var(func: uid(1, 23, 24, 25)) @groupby(age) {
      c as count(uid)
}
 me(func: uid(c)) {
      uid
      val(c)
}
```
returns the result:-
```
"data": {
    "me": [
      {
        "uid": "0x1",
        "val(c)": 1
      },
      {
        "uid": "0x17",
        "val(c)": 2
      },
      {
        "uid": "0x18",
        "val(c)": 2
      },
      {
        "uid": "0x19",
        "val(c)": 1
      }
    ]
  }
```
The behaviour will be the same if there are multiple predicates and some of them are uid predicates.
However, it is only supported at root currently. Hence the given query will still return error:-
```
var(func: .....) {
   friend @groupby(age) {
       a as count(uid)
   }
}
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7746)
<!-- Reviewable:end -->
