### PR TITLE
release/v21.03: fix(raftwal): take snapshot after restore (#7719)

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -627,7 +627,9 @@ func (n *node) applyCommitted(proposal *pb.Proposal, key uint64) error {
 		}
 		defer closer.Done()
 
-		if err := handleRestoreProposal(ctx, proposal.Restore); err != nil {
+		glog.Infof("Got restore proposal at Index:%d, ReadTs:%d",
+			proposal.Index, proposal.Restore.RestoreTs)
+		if err := handleRestoreProposal(ctx, proposal.Restore, proposal.Index); err != nil {
 			return err
 		}
 

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -38,6 +38,6 @@ func (w *grpcWorker) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.S
 	return &pb.Status{}, x.ErrNotSupported
 }
 
-func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
+func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uint64) error {
 	return nil
 }

--- a/worker/online_restore_ee.go
+++ b/worker/online_restore_ee.go
@@ -188,7 +188,7 @@ func (w *grpcWorker) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.S
 }
 
 // TODO(DGRAPH-1232): Ensure all groups receive the restore proposal.
-func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
+func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest, pidx uint64) error {
 	if req == nil {
 		return errors.Errorf("nil restore request")
 	}
@@ -270,9 +270,19 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 
 	// Propose a snapshot immediately after all the work is done to prevent the restore
 	// from being replayed.
-	if err := groups().Node.proposeSnapshot(); err != nil {
-		return errors.Wrapf(err, "cannot propose snapshot after processing restore proposal")
-	}
+	go func(idx uint64) {
+		n := groups().Node
+		if !n.AmLeader() {
+			return
+		}
+		if err := n.Applied.WaitForMark(context.Background(), idx); err != nil {
+			glog.Errorf("Error waiting for mark for index %d: %+v", idx, err)
+			return
+		}
+		if err := n.proposeSnapshot(); err != nil {
+			glog.Errorf("cannot propose snapshot after processing restore proposal %+v", err)
+		}
+	}(pidx)
 
 	// Update the membership state to re-compute the group checksums.
 	if err := UpdateMembershipState(ctx); err != nil {


### PR DESCRIPTION
We should propose a snapshot immediately after the restore to prevent the restore from being replayed.
Earlier we were trying to do that too. Snapshot happens after the restore but that does not actually include the restore proposal as it has not been applied yet (n.Applied.Done() is not yet called for that proposal).
Now, we will first wait for the raft entry to be marked as done and then try to propose the snapshot.

(cherry picked from commit 72cebd1349e21f48e756c9ba9df4cbe98017ae9a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7750)
<!-- Reviewable:end -->
