### PR TITLE
Fix(graphql): Fix error message of lambdaOnMutate directive

### DIFF
--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1299,7 +1299,7 @@ func lambdaOnMutateValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.Lis
 	if x.LambdaUrl(x.GalaxyNamespace) == "" {
 		errs = append(errs, gqlerror.ErrorPosf(dir.Position,
 			"Type %s: has the @lambdaOnMutate directive, but the "+
-				"`--graphql_lambda_url` flag wasn't specified during alpha startup.", typ.Name))
+				"`--graphql lambda-url` flag wasn't specified during alpha startup.", typ.Name))
 	}
 
 	if typ.Directives.ForName(remoteDirective) != nil {


### PR DESCRIPTION
When posting a schema that uses the @lambdaOnMutate directive, this error comes up:
```
{"errors":[{"message":"resolving updateGQLSchema failed because input:1: Type Author: has the @lambdaOnMutate directive, but the –graphql_lambda_url flag wasn't specified during alpha startup.\n (Locations: [{Line: 3, Column: 4}])","extensions":{"code":"Error"}}]}(base)
```
But when we start alpha with the suggested flag, we get:
```
./dgraph alpha --graphql_lambda_url http://127.0.0.1:8686
Error: unknown flag: --graphql_lambda_url
```

This PR fixes the error message.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7751)
<!-- Reviewable:end -->
