### PR TITLE
cherry-pick release/v21.03: Fix(graphql): Fix error message of lambdaOnMutate directive  (#7751)

### DIFF
--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1264,7 +1264,7 @@ func lambdaOnMutateValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.Lis
 	if x.LambdaUrl(x.GalaxyNamespace) == "" {
 		errs = append(errs, gqlerror.ErrorPosf(dir.Position,
 			"Type %s: has the @lambdaOnMutate directive, but the "+
-				"`--graphql_lambda_url` flag wasn't specified during alpha startup.", typ.Name))
+				"`--graphql lambda-url` flag wasn't specified during alpha startup.", typ.Name))
 	}
 
 	if typ.Directives.ForName(remoteDirective) != nil {


### PR DESCRIPTION
The error message used to contain `--graphql_lambda_url" flag.
This flags has been deprecated. This change fixes the error
message of lambdaOnMutate directive to contain superflag.

(cherry picked from commit eb7dc76b29bba08680c646f80e0609ab92b8b906)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7754)
<!-- Reviewable:end -->
