### PR TITLE
Fix(GraphQL): Fix returning of error in case of transaction conflict

### DIFF
--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -407,7 +407,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	err = mr.executor.CommitOrAbort(ctx, mutResp.Txn)
 	if err != nil {
 		return emptyResult(
-				schema.GQLWrapf(authErr, "mutation failed, couldn't commit transaction")),
+				schema.GQLWrapf(err, "mutation failed, couldn't commit transaction")),
 			resolverFailed
 	}
 	commit = true


### PR DESCRIPTION
Motivation:
In case there is an error at the time of CommitOrAbort, wrong error ("authErr") was getting returned. This should have been "err" . As "authErr" was empty, the customer interpreted this as a successful mutation. In reality, the mutation had failed.

This PR fixes this and returns proper error message in case of transaction conflict. User can take corrective action on seeing this.

Fixes GRAPHQL-1168

Testing:
Tested locally that returning of this error recreates the issue mentioned in JIRA.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7763)
<!-- Reviewable:end -->
