### PR TITLE
Fix(GraphQL): Make mutation rewriting tests more robust

### DIFF
--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -169,7 +169,7 @@
     }
   queryjson: |
     {
-      "Project_1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123", "dgraph.type": ["Project"] } ]
     }
   uids: |
     {
@@ -464,8 +464,8 @@
     }
   queryjson: |
     {
-      "Project_1": [ { "uid": "0x123" } ],
-      "Ticket_2": [ { "uid": "0x789" } ]
+      "Project_1": [ { "uid": "0x123", "dgraph.type": ["Project"] } ],
+      "Ticket_2": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {
@@ -627,7 +627,7 @@
     }
   queryjson: |
     {
-      "Ticket_1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -783,13 +783,17 @@ func checkAddUpdateCase(
 	resolver := NewDgraphResolver(rewriter(), ex)
 
 	// -- Act --
-	resolved, _ := resolver.Resolve(ctx, mut)
+	resolved, success := resolver.Resolve(ctx, mut)
 
 	// -- Assert --
 	// most cases are built into the authExecutor
 	if tcase.Error != nil {
+		require.False(t, success, "Mutation should have failed as it throws an error")
 		require.NotNil(t, resolved.Err)
 		require.Equal(t, tcase.Error.Error(), resolved.Err.Error())
+	} else {
+		require.True(t, success, "Mutation should have not failed as it did not"+
+			" throw an error")
 	}
 }
 

--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -184,7 +184,7 @@
     }
   queryjson: |
     {
-      "Ticket_1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -489,7 +489,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	dgQuery, err = mr.mutationRewriter.FromMutationResult(ctx, mutation, mutResp.GetUids(), result)
 	queryErrs = schema.AppendGQLErrs(queryErrs, schema.GQLWrapf(err,
 		"couldn't rewrite query for mutation %s", mutation.Name()))
-	if dgQuery == nil && err != nil {
+	if err != nil {
 		return emptyResult(queryErrs), resolverFailed
 	}
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -775,10 +775,9 @@ func (arw *AddRewriter) FromMutationResult(
 
 	if errs != nil {
 		return nil, errs
-	} else {
-		// No errors are thrown while rewriting queries by Ids.
-		return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), nil
 	}
+	// No errors are thrown while rewriting queries by Ids.
+	return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), nil
 }
 
 // FromMutationResult rewrites the query part of a GraphQL update mutation into a Dgraph query.

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -773,7 +773,12 @@ func (arw *AddRewriter) FromMutationResult(
 	}
 	authRw.hasAuthRules = hasAuthRules(mutation.QueryField(), authRw)
 
-	return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), errs
+	if errs != nil {
+		return nil, errs
+	} else {
+		// No errors are thrown while rewriting queries by Ids.
+		return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), nil
+	}
 }
 
 // FromMutationResult rewrites the query part of a GraphQL update mutation into a Dgraph query.


### PR DESCRIPTION
Motivation:
Auth Mutation rewriting tests now also ensure that the mutation returned a false for success in case of error. This PR fixes related tests.
This PR also fixes a potential bug where in in spite of failing on auth, the mutation would have succeeded without throwing an error.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7768)
<!-- Reviewable:end -->
