### PR TITLE
fix(xidmap): Avoid computing hash repeatedly

### DIFF
--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -243,7 +243,8 @@ func (m *XidMap) AssignUid(xid string) (uint64, bool) {
 	sh := m.shardFor(xid)
 	sh.RLock()
 
-	uid := sh.tree.Get(farm.Fingerprint64([]byte(xid)))
+	key := farm.Fingerprint64([]byte(xid))
+	uid := sh.tree.Get(key)
 	sh.RUnlock()
 	if uid > 0 {
 		return uid, false
@@ -252,13 +253,13 @@ func (m *XidMap) AssignUid(xid string) (uint64, bool) {
 	sh.Lock()
 	defer sh.Unlock()
 
-	uid = sh.tree.Get(farm.Fingerprint64([]byte(xid)))
+	uid = sh.tree.Get(key)
 	if uid > 0 {
 		return uid, false
 	}
 
 	newUid := sh.assign(m.newRanges)
-	sh.tree.Set(farm.Fingerprint64([]byte(xid)), newUid)
+	sh.tree.Set(key, newUid)
 
 	if m.writer != nil {
 		var uidBuf [8]byte


### PR DESCRIPTION
Avoid unnecessary hash computation of the same key.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7772)
<!-- Reviewable:end -->
