### PR TITLE
feat(GraphQL): Support auth with custom DQL

### DIFF
--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -212,18 +212,18 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 		x.Check2(b.WriteString(fmt.Sprintf("(func: type(%s)", q.Func.Args[0].Value)))
 	case q.Func.Name == "eq":
 		x.Check2(b.WriteString("(func: eq("))
-		writeFilterArguments(b, q.Func.Args)
+		writeFilterArguments(b, q.Func.Args, q.Func.Attr)
 		x.Check2(b.WriteRune(')'))
 	}
 	writeOrderAndPage(b, q, true)
 }
 
-func writeFilterArguments(b *strings.Builder, args []gql.Arg) {
+func writeFilterArguments(b *strings.Builder, args []gql.Arg, attr string) {
 	for i, arg := range args {
 		if i != 0 {
 			x.Check2(b.WriteString(", "))
 		}
-		if arg.IsValueVar && string(arg.Value[0]) != "\"" {
+		if attr != "" && string(arg.Value[0]) != "\"" {
 			arg.Value = fmt.Sprintf("\"%v\"", arg.Value)
 		}
 		x.Check2(b.WriteString(arg.Value))
@@ -244,7 +244,7 @@ func writeFilterFunction(b *strings.Builder, f *gql.Function) {
 			x.Check2(b.WriteString(f.Attr))
 			x.Check2(b.WriteRune(','))
 		}
-		writeFilterArguments(b, f.Args)
+		writeFilterArguments(b, f.Args, f.Attr)
 		x.Check2(b.WriteRune(')'))
 	}
 }

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -237,7 +237,9 @@ func maybeQuoteArg(fn string, arg interface{}) string {
 func writeFilterArguments(b *strings.Builder, args []gql.Arg, attr, fn string) {
 	if attr != "" {
 		x.Check2(b.WriteString(attr))
-		x.Check2(b.WriteString(", "))
+		if len(args) != 0 {
+			x.Check2(b.WriteString(", "))
+		}
 	}
 	for i, arg := range args {
 		if i != 0 {

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -242,6 +242,9 @@ func writeFilterArguments(b *strings.Builder, args []gql.Arg) {
 		if i != 0 {
 			x.Check2(b.WriteString(", "))
 		}
+		if arg.IsValueVar && string(arg.Value[0]) != "\"" {
+			arg.Value = fmt.Sprintf("\"%v\"", arg.Value)
+		}
 		x.Check2(b.WriteString(arg.Value))
 	}
 }

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -218,25 +218,6 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	writeOrderAndPage(b, q, true)
 }
 
-func writeAggregate(b *strings.Builder, args []gql.Arg, needVar []gql.VarContext) {
-	if len(args) > 0 {
-		// uid function with a Dgraph query variable - uid(Post1)
-		for i, arg := range args {
-			if i != 0 {
-				x.Check2(b.WriteString(", "))
-			}
-			x.Check2(b.WriteString(arg.Value))
-		}
-	} else {
-		for i, v := range needVar {
-			if i != 0 {
-				x.Check2(b.WriteString(", "))
-			}
-			x.Check2(b.WriteString(v.Name))
-		}
-	}
-}
-
 func writeFilterArguments(b *strings.Builder, args []gql.Arg) {
 	for i, arg := range args {
 		if i != 0 {

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -205,6 +205,8 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	}
 
 	switch {
+	case q.Func.Name == "has":
+		x.Check2(b.WriteString(fmt.Sprintf("(func: has(%s)", q.Func.Attr)))
 	case q.Func.Name == "uid":
 		x.Check2(b.WriteString("(func: "))
 		writeUIDFunc(b, q.Func.UID, q.Func.Args, q.Func.NeedsVar)

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -65,7 +65,12 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 		x.Check2(b.WriteString(query.Alias))
 		x.Check2(b.WriteString(" : "))
 	}
-	x.Check2(b.WriteString(query.Attr))
+
+	if query.IsCount {
+		x.Check2(b.WriteString(fmt.Sprintf("count(%s)", query.Attr)))
+	} else {
+		x.Check2(b.WriteString(query.Attr))
+	}
 
 	if query.Func != nil {
 		writeRoot(b, query)
@@ -93,6 +98,12 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 		}
 	}
 
+	if query.IsGroupby {
+		x.Check2(b.WriteString(" @groupby("))
+		writeGroupByAttributes(b, query.GroupbyAttrs)
+		x.Check2(b.WriteRune(')'))
+	}
+
 	switch {
 	case len(query.Children) > 0:
 		prefixAdd := ""
@@ -109,6 +120,19 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 		}
 	case query.Var != "" || query.Alias != "" || query.Attr != "":
 		x.Check2(b.WriteString("\n"))
+	}
+}
+
+func writeGroupByAttributes(b *strings.Builder, attrList []gql.GroupByAttr) {
+	for i, attr := range attrList {
+		if i != 0 {
+			x.Check2(b.WriteString(", "))
+		}
+		if attr.Alias != "" {
+			x.Check2(b.WriteString(attr.Alias))
+			x.Check2(b.WriteString(" : "))
+		}
+		x.Check2(b.WriteString(attr.Attr))
 	}
 }
 

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -133,6 +133,9 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 	}
 }
 
+// writeNeedVar writes the NeedsVar of the query. For eg :-
+// `userFollowerCount as sum(val(followers))` has `followers`
+// as NeedsVar.
 func writeNeedVar(b *strings.Builder, query *gql.GraphQuery) {
 	for i, v := range query.NeedsVar {
 		if i != 0 {
@@ -221,18 +224,21 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	writeOrderAndPage(b, q, true)
 }
 
+// writeFilterArguments writes the filter arguments. If the filter
+// is constructed in graphql query rewriting then `Attr` is an empty
+// string since we add Attr in the argument itself.
 func writeFilterArguments(b *strings.Builder, q *gql.Function) {
 	if q.Attr != "" {
 		x.Check2(b.WriteString(q.Attr))
-		if len(q.Args) != 0 {
-			x.Check2(b.WriteString(", "))
-		}
 	}
+
 	for i, arg := range q.Args {
-		if i != 0 {
+		if i != 0 || q.Attr != "" {
 			x.Check2(b.WriteString(", "))
 		}
 		if q.Attr != "" {
+			// quote the arguments since this is the case of
+			// @custom DQL string.
 			arg.Value = schema.MaybeQuoteArg(q.Name, arg.Value)
 		}
 		x.Check2(b.WriteString(arg.Value))

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -178,6 +178,10 @@ func writeFilterFunction(b *strings.Builder, f *gql.Function) {
 		writeUIDFunc(b, f.UID, f.Args)
 	default:
 		x.Check2(b.WriteString(fmt.Sprintf("%s(", f.Name)))
+		if f.Attr != "" {
+			x.Check2(b.WriteString(f.Attr))
+			x.Check2(b.WriteRune(','))
+		}
 		writeFilterArguments(b, f.Args)
 		x.Check2(b.WriteRune(')'))
 	}

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -327,23 +327,23 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "RBAC OR filter query; RBAC Pass",
 			query: `
-		query{
-			queryProjectsOrderByName{
-				name
+			query{
+				queryProjectsOrderByName{
+					name
+				}
 			}
-		}
 		`,
 			role:   "ADMIN",
 			result: `{"queryProjectsOrderByName":[{"name": "Project1"},{"name": "Project2"}]}`,
 		},
 		{
-			name: "RBAC OR filter query; RBAC fail",
+			name: "RBAC OR filter query; RBAC false OR `user1` projects",
 			query: `
-		query{
-			queryProjectsOrderByName{
-				name
+			query{
+				queryProjectsOrderByName{
+					name
+				}
 			}
-		}
 		`,
 			role:   "USER",
 			user:   "user1",
@@ -352,22 +352,22 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "RBAC OR filter query; missing jwt",
 			query: `
-		query{
-			queryProjectsOrderByName{
-				name
+			query{
+				queryProjectsOrderByName{
+					name
+				}
 			}
-		}
 		`,
 			result: `{"queryProjectsOrderByName":[]}`,
 		},
 		{
 			name: "var query; RBAC AND filter query; RBAC pass",
 			query: `
-		query{
-			queryIssueSortedByOwnerAge{
-				msg
+			query{
+				queryIssueSortedByOwnerAge{
+					msg
+				}
 			}
-		}
 		`,
 			role:   "ADMIN",
 			user:   "user2",
@@ -376,11 +376,11 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "var query; RBAC AND filter query; RBAC fail",
 			query: `
-		query{
-			queryIssueSortedByOwnerAge{
-				msg
+			query{
+				queryIssueSortedByOwnerAge{
+					msg
+				}
 			}
-		}
 		`,
 			role:   "USER",
 			user:   "user2",
@@ -389,15 +389,15 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "DQL query with @cascade and pagination",
 			query: `
-		query{
-			queryFirstTwoMovieWithNonNullRegion{
-				content
-				code
-				regionsAvailable{
-					name
+			query{
+				queryFirstTwoMovieWithNonNullRegion{
+					content
+					code
+					regionsAvailable{
+						name
+					}
 				}
 			}
-		}
 		`,
 			role: "ADMIN",
 			user: "user1",
@@ -426,11 +426,11 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "query interface; auth rules pass for all the implementing types",
 			query: `
-		query{
-			queryQuestionAndAnswer{
-				text
+			query{
+				queryQuestionAndAnswer{
+					text
+				}
 			}
-		}
 		`,
 			ans:    true,
 			user:   "user1@dgraph.io",
@@ -439,11 +439,11 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "query interface; auth rules fail for some implementing types",
 			query: `
-		query{
-			queryQuestionAndAnswer{
-				text
+			query{
+				queryQuestionAndAnswer{
+					text
+				}
 			}
-		}
 		`,
 			user:   "user2@dgraph.io",
 			result: `{"queryQuestionAndAnswer": [{"text": "B Answer"}]}`,
@@ -451,11 +451,11 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		{
 			name: "query interface; auth rules fail for the interface",
 			query: `
-		query{
-			queryQuestionAndAnswer{
-				text
+			query{
+				queryQuestionAndAnswer{
+					text
+				}
 			}
-		}
 		`,
 			ans:    true,
 			result: `{"queryQuestionAndAnswer": []}`,

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -358,35 +358,33 @@ func TestAuthWithCustomDQL(t *testing.T) {
 			}
 		}
 		`,
-			role:   "USER",
-			user:   "user1",
 			result: `{"queryProjectsOrderByName":[]}`,
 		},
 		{
 			name: "var query; RBAC AND filter query; RBAC pass",
 			query: `
 		query{
-			queryIssueOrderByOwnerAge{
+			queryIssueSortedByOwnerAge{
 				msg
 			}
 		}
 		`,
 			role:   "ADMIN",
 			user:   "user2",
-			result: `{"queryIssueSortedByOwnerAge": [{"msg": "Issue2"}]}}`,
+			result: `{"queryIssueSortedByOwnerAge": [{"msg": "Issue2"}]}`,
 		},
 		{
 			name: "var query; RBAC AND filter query; RBAC fail",
 			query: `
 		query{
-			queryIssueOrderByOwnerAge{
+			queryIssueSortedByOwnerAge{
 				msg
 			}
 		}
 		`,
 			role:   "USER",
 			user:   "user2",
-			result: `{"queryIssueSortedByOwnerAge": []}}`,
+			result: `{"queryIssueSortedByOwnerAge": []}`,
 		},
 		{
 			name: "DQL query with @cascade and pagination",

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -423,6 +423,43 @@ func TestAuthWithCustomDQL(t *testing.T) {
 			  ]
 			}`,
 		},
+		{
+			name: "query interface; auth rules pass for all the implementing types",
+			query: `
+		query{
+			queryQuestionAndAnswer{
+				text
+			}
+		}
+		`,
+			ans:    true,
+			user:   "user1@dgraph.io",
+			result: `{"queryQuestionAndAnswer": [{"text": "A Answer"},{"text": "A Question"}]}`,
+		},
+		{
+			name: "query interface; auth rules fail for some implementing types",
+			query: `
+		query{
+			queryQuestionAndAnswer{
+				text
+			}
+		}
+		`,
+			user:   "user2@dgraph.io",
+			result: `{"queryQuestionAndAnswer": [{"text": "B Answer"}]}`,
+		},
+		{
+			name: "query interface; auth rules fail for the interface",
+			query: `
+		query{
+			queryQuestionAndAnswer{
+				text
+			}
+		}
+		`,
+			ans:    true,
+			result: `{"queryQuestionAndAnswer": []}`,
+		},
 	}
 
 	for _, tcase := range TestCases {

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -401,13 +401,13 @@ func TestAuthWithCustomDQL(t *testing.T) {
 		`,
 			role: "ADMIN",
 			user: "user1",
-			result: `"queryFirstTwoMovieWithNonNullRegion": [
+			result: `{"queryFirstTwoMovieWithNonNullRegion": [
 				{
 				  "content": "Movie3",
 				  "code": "m3",
 				  "regionsAvailable": [
 					{
-					  "name": "Region6"
+					  "name": "Region1"
 					}
 				  ]
 				},

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -332,7 +332,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					name
 				}
 			}
-		`,
+			`,
 			role:   "ADMIN",
 			result: `{"queryProjectsOrderByName":[{"name": "Project1"},{"name": "Project2"}]}`,
 		},
@@ -344,7 +344,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					name
 				}
 			}
-		`,
+			`,
 			role:   "USER",
 			user:   "user1",
 			result: `{"queryProjectsOrderByName":[{"name": "Project1"}]}`,
@@ -357,7 +357,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					name
 				}
 			}
-		`,
+			`,
 			result: `{"queryProjectsOrderByName":[]}`,
 		},
 		{
@@ -368,7 +368,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					msg
 				}
 			}
-		`,
+			`,
 			role:   "ADMIN",
 			user:   "user2",
 			result: `{"queryIssueSortedByOwnerAge": [{"msg": "Issue2"}]}`,
@@ -381,7 +381,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					msg
 				}
 			}
-		`,
+			`,
 			role:   "USER",
 			user:   "user2",
 			result: `{"queryIssueSortedByOwnerAge": []}`,
@@ -398,7 +398,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					}
 				}
 			}
-		`,
+			`,
 			role: "ADMIN",
 			user: "user1",
 			result: `{"queryFirstTwoMovieWithNonNullRegion": [
@@ -431,7 +431,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					text
 				}
 			}
-		`,
+			`,
 			ans:    true,
 			user:   "user1@dgraph.io",
 			result: `{"queryQuestionAndAnswer": [{"text": "A Answer"},{"text": "A Question"}]}`,
@@ -444,7 +444,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					text
 				}
 			}
-		`,
+			`,
 			user:   "user2@dgraph.io",
 			result: `{"queryQuestionAndAnswer": [{"text": "B Answer"}]}`,
 		},
@@ -456,7 +456,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 					text
 				}
 			}
-		`,
+			`,
 			ans:    true,
 			result: `{"queryQuestionAndAnswer": []}`,
 		},

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -465,7 +465,7 @@ func TestAuthWithCustomDQL(t *testing.T) {
 	for _, tcase := range TestCases {
 		t.Run(tcase.name, func(t *testing.T) {
 			getUserParams := &common.GraphQLParams{
-				Headers: common.GetJWT(t, tcase.user, tcase.role, metaInfo),
+				Headers: common.GetJWTForInterfaceAuth(t, tcase.user, tcase.role, tcase.ans, metaInfo),
 				Query:   tcase.query,
 			}
 			gqlResponse := getUserParams.ExecuteAsPost(t, common.GraphqlURL)

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -988,61 +988,61 @@ type IssueMap {
 type Query {
 
     queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
-	query {
-		iss as var(func: type(Issue)) @filter(has(Issue.owner)) {
-			Issue.owner {
-				age as User.age
-			}
-            ownerAge as max(val(age))
-		}
-		queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
-			id : uid
-            msg : Issue.msg
-            random : Issue.random
-		}
-	}"""
+        query {
+            iss as var(func: type(Issue)) @filter(has(Issue.owner)) {
+                Issue.owner {
+                    age as User.age
+                }
+                ownerAge as max(val(age))
+            }
+            queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
+                id : uid
+                msg : Issue.msg
+                random : Issue.random
+            }
+        }"""
     )
 
-	queryIssueGroupedByOwner: [GroupedIssueMapQ] @custom(dql: """
-    query{
-        queryIssueGroupedByOwner(func: type(Issue)) @groupby(owner: Issue.owner) {
-            count(uid)
-        }
-    }"""
+    queryIssueGroupedByOwner: [GroupedIssueMapQ] @custom(dql: """
+        query{
+            queryIssueGroupedByOwner(func: type(Issue)) @groupby(owner: Issue.owner) {
+                count(uid)
+            }
+        }"""
     )
 
     queryContacts: [Contact] @custom(dql: """
-    query {
-      queryContacts(func: type(Contact)) @cascade {
-        id : uid
-        nickName : Contact.nickName
-        adminTasks : Contact.adminTasks {
-          id : uid
-          name : AdminTask.name
-          occurrences : AdminTask.occurrences {
-            due : TaskOccurrence.due
-            comp : TaskOccurrence.comp
-          }
-        }
-      }
-    }"""
+        query {
+            queryContacts(func: type(Contact)) @cascade {
+                id : uid
+                nickName : Contact.nickName
+                adminTasks : Contact.adminTasks {
+                id : uid
+                name : AdminTask.name
+                occurrences : AdminTask.occurrences {
+                    due : TaskOccurrence.due
+                    comp : TaskOccurrence.comp
+                }
+                }
+            }
+        }"""
     )
 
-   queryUsers: [User] @custom(dql: """
-    query {
-      queryUsers(func: uid("0x1", "0x2")) @filter(eq(User.username, "minhaj")) {
-        username: User.username
-        tickets: User.tickets {
-          id: uid
-          title: Ticket.title
-        }
-        tweets: User.tweets {
-            id: uid
-            text: Tweets.text
-            score: Tweets.score
-        }
-      }
-    }"""
+    queryUsers: [User] @custom(dql: """
+        query {
+            queryUsers(func: uid("0x1", "0x2")) @filter(eq(User.username, "minhaj")) {
+                username: User.username
+                tickets: User.tickets {
+                id: uid
+                title: Ticket.title
+                }
+                tweets: User.tweets {
+                    id: uid
+                    text: Tweets.text
+                    score: Tweets.score
+                }
+            }
+        }"""
     )
 
     queryProjectsOrderByName: [Project] @custom(dql: """

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -986,23 +986,6 @@ type IssueMap {
 }
 
 type Query {
-    queryUserSortedByTweetScore: [User] @custom(dql: """
-	query q($search: string) {
-		var(func: type(User)) {
-			User.tweets {
-				score as Tweets.score
-			}
-		}
-		queryUserSortedByTweetScore(func: uid(score), orderdesc: val(score)) {
-			username : User.username
-            age : User.age
-			tweets: User.tweets {
-			    text : Tweets.text
-			    score : Tweets.score
-			}
-		}
-	}"""
-    )
 
     queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
 	query q($search: string) {
@@ -1046,11 +1029,16 @@ type Query {
 
    queryUsers: [User] @custom(dql: """
     query {
-      queryUsers(func: uid("0x1")) @filter(eq(User.username, "minhaj")) {
+      queryUsers(func: uid("0x1", "0x2")) @filter(eq(User.username, "minhaj")) {
         username: User.username
         tickets: User.tickets {
           id: uid
           title: Ticket.title
+        }
+        tweets: User.tweets {
+            id: uid
+            text: Tweets.text
+            score: Tweets.score
         }
       }
     }"""

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -986,6 +986,24 @@ type IssueMap {
 }
 
 type Query {
+    queryUserSortedByTweetScore: [User] @custom(dql: """
+	query q($search: string) {
+		var(func: type(User)) {
+			User.tweets {
+				score as Tweets.score
+			}
+		}
+		queryUserSortedByTweetScore(func: uid(score), orderdesc: val(score)) {
+			username : User.username
+            age : User.age
+			tweets: User.tweets {
+			    text : Tweets.text
+			    score : Tweets.score
+			}
+		}
+	}"""
+    )
+
 	queryIssueGroupedByOwner: [GroupedIssueMapQ] @custom(dql: """
     query{
         queryIssueGroupedByOwner(func: type(Issue)) @groupby(owner: Issue.owner) {

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -1027,9 +1027,26 @@ type Query {
     }"""
     )
 
+    queryContacts: [Contact] @custom(dql: """
+    query {
+      queryContacts(func: type(Contact)) @cascade {
+        id : uid
+        nickName : Contact.nickName
+        adminTasks : Contact.adminTasks {
+          id : uid
+          name : AdminTask.name
+          occurrences : AdminTask.occurrences {
+            due : TaskOccurrence.due
+            comp : TaskOccurrence.comp
+          }
+        }
+      }
+    }"""
+    )
+
    queryUsers: [User] @custom(dql: """
     query {
-      queryUsers(func: type(User)) {
+      queryUsers(func: uid("0x1")) @filter(eq(User.username, "minhaj")) {
         username: User.username
         tickets: User.tickets {
           id: uid

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -988,11 +988,12 @@ type IssueMap {
 type Query {
 
     queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
-	query q($search: string) {
+	query {
 		iss as var(func: type(Issue)) @filter(has(Issue.owner)) {
 			Issue.owner {
 				age as User.age
 			}
+            ownerAge as max(val(age))
 		}
 		queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
 			id : uid
@@ -1058,6 +1059,21 @@ type Query {
                 code: Movie.code
                 regionsAvailable: Movie.regionsAvailable(first: 1, orderasc: Region.name) {
                     name: Region.name
+                }
+            }
+        }"""
+    )
+    queryQuestionAndAnswer: [Post] @custom(dql: """
+        query {
+            ques as var(func: type(Question))
+            ans as var(func: type(Answer))
+            queryQuestionAndAnswer(func: uid(ques, ans)) {
+                id : uid
+                text : Post.text
+                topic : Post.topic
+                author : Post.author {
+                    id : Author.id
+                    name : Author.name
                 }
             }
         }"""

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -995,7 +995,7 @@ type Query {
 			}
             ownerAge as max(val(age))
 		}
-		queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
+		queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
 			id : uid
             msg : Issue.msg
             random : Issue.random

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -989,7 +989,7 @@ type Query {
 
     queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
 	query q($search: string) {
-		iss as var(func: type(Issue)) {
+		iss as var(func: type(Issue)) @filter(has(Issue.owner)) {
 			Issue.owner {
 				age as User.age
 			}

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -977,21 +977,22 @@ type Home @auth(
 ## custom DQL testing start
 
 type GroupedIssueMapQ @remote {
-    groupby: [FriendMap] @remoteResponse(name: "@groupby")
+    groupby: [IssueMap] @remoteResponse(name: "@groupby")
 }
 
 type IssueMap {
-	author: ID!
+	owner: ID!
 	count: Int
 }
 
 type Query {
-	queryIssueGroupedByAuthor: [GroupedIssueMapQ] @custom(dql: "
+	queryIssueGroupedByOwner: [GroupedIssueMapQ] @custom(dql: """
     query{
-        queryIssueGroupedByAuthor(func: type(Issue)) @groupby(author: Issue.Author) {
+        queryIssueGroupedByOwner(func: type(Issue)) @groupby(owner: Issue.owner) {
             count(uid)
         }
-    }")
+    }"""
+    )
 }
 
 ## custom DQL testing end

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -972,3 +972,26 @@ type Home @auth(
     favouriteMember: HomeMember
 }
 # union testing - end
+
+
+## custom DQL testing start
+
+type GroupedIssueMapQ @remote {
+    groupby: [FriendMap] @remoteResponse(name: "@groupby")
+}
+
+type IssueMap {
+	author: ID!
+	count: Int
+}
+
+type Query {
+	queryIssueGroupedByAuthor: [GroupedIssueMapQ] @custom(dql: "
+    query{
+        queryIssueGroupedByAuthor(func: type(Issue)) @groupby(author: Issue.Author) {
+            count(uid)
+        }
+    }")
+}
+
+## custom DQL testing end

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -1026,6 +1026,18 @@ type Query {
         }
     }"""
     )
+
+   queryUsers: [User] @custom(dql: """
+    query {
+      queryUsers(func: type(User)) {
+        username: User.username
+        tickets: User.tickets {
+          id: uid
+          title: Ticket.title
+        }
+      }
+    }"""
+    )
 }
 
 ## custom DQL testing end

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -989,12 +989,12 @@ type Query {
 
     queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
 	query q($search: string) {
-		var(func: type(Issue)) {
+		iss as var(func: type(Issue)) {
 			Issue.owner {
 				age as User.age
 			}
 		}
-		queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+		queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
 			id : uid
             msg : Issue.msg
             random : Issue.random
@@ -1042,6 +1042,25 @@ type Query {
         }
       }
     }"""
+    )
+
+    queryProjectsOrderByName: [Project] @custom(dql: """
+        query {
+            queryProjectsOrderByName(func: eq(Project.name, "Project1", "Project2"), orderasc: Project.name) {
+                name: Project.name
+            }
+        }"""
+    )
+    queryFirstTwoMovieWithNonNullRegion: [Movie] @ custom(dql: """
+        query {
+            queryFirstTwoMovieWithNonNullRegion(func: has(Movie.content), first: 2, offset: 0, orderasc: Movie.content) @cascade {
+                content: Movie.content
+                code: Movie.code
+                regionsAvailable: Movie.regionsAvailable(first: 1, orderasc: Region.name) {
+                    name: Region.name
+                }
+            }
+        }"""
     )
 }
 

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -1067,7 +1067,7 @@ type Query {
         query {
             ques as var(func: type(Question))
             ans as var(func: type(Answer))
-            queryQuestionAndAnswer(func: uid(ques, ans)) {
+            queryQuestionAndAnswer(func: uid(ques, ans), orderasc: Post.text) {
                 id : uid
                 text : Post.text
                 topic : Post.topic

--- a/graphql/e2e/auth/schema.graphql
+++ b/graphql/e2e/auth/schema.graphql
@@ -1004,6 +1004,21 @@ type Query {
 	}"""
     )
 
+    queryIssueSortedByOwnerAge: [Issue] @custom(dql: """
+	query q($search: string) {
+		var(func: type(Issue)) {
+			Issue.owner {
+				age as User.age
+			}
+		}
+		queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+			id : uid
+            msg : Issue.msg
+            random : Issue.random
+		}
+	}"""
+    )
+
 	queryIssueGroupedByOwner: [GroupedIssueMapQ] @custom(dql: """
     query{
         queryIssueGroupedByOwner(func: type(Issue)) @groupby(owner: Issue.owner) {

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -823,6 +823,11 @@ func TestAuthQueryRewriting(t *testing.T) {
 			mutationQueryRewriting(t, strSchema, metaInfo)
 		})
 
+		b = read(t, "custom_auth_query_test.yaml")
+		t.Run("Custom DQL Query Rewriting"+algo, func(t *testing.T) {
+			queryRewriting(t, strSchema, metaInfo, b)
+		})
+
 		b = read(t, "auth_add_test.yaml")
 		t.Run("Add Mutation "+algo, func(t *testing.T) {
 			mutationAdd(t, strSchema, metaInfo, b)

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -1,21 +1,24 @@
-- name : "Simple DQL query"
+- name : "custom DQL query with @groupby"
   gqlquery: |
     query{
-      queryIssueGroupedByAuthor {
+      queryIssueGroupedByOwner {
         groupby {
-        author
-        count
+          owner
+          count
         } 
       }
     }
   jwtvar:
-    ROLE: "USER"
+    ROLE: "ADMIN"
     USER: "user1"
   dgquery: |-
-    queryIssueGroupedByAuthor(func: type(Person)) @groupby(friend: Person.friends) @filter(uid(Issue_Auth2)) {
-      count(uid)
-    }
-    Issue_1 as var(func: type(Issue))
-    Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
-      Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
+    query {
+      queryIssueGroupedByOwner(func: uid(GroupedIssueMapQRoot)) @groupby(owner : Issue.owner) {
+        count(uid)
+      }
+      GroupedIssueMapQRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      Issue_1 as var(func: type(Issue))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
+        Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
+      }
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -58,7 +58,7 @@
       }
     }
 
-- name : "f custom DQL query with var block failing RBAC @auth rules"
+- name : "custom DQL query with var block failing RBAC @auth rules"
   gqlquery: |
     query{
       queryIssueSortedByOwnerAge {
@@ -122,7 +122,7 @@
       }
     }
 
-- name : "Auth rules with deep filter failed"
+- name : "Auth rules with deep filter missing JWT"
   gqlquery: |
     query{
       queryUsers{

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -41,6 +41,7 @@
         Issue.owner @filter(uid(User_1)) {
           age as User.age
         }
+        ownerAge as sum(val(age))
       }
       IssueRoot as var(func: uid(Issue_3)) @filter(uid(Issue_Auth4))
       Issue_3 as var(func: type(Issue)) @filter(has(Issue.owner))
@@ -51,7 +52,7 @@
         User_2 as Issue.owner
       }
       User_1 as var(func: uid(User_2))
-      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -76,8 +77,9 @@
         Issue.owner {
           age as User.age
         }
+        ownerAge as sum(val(age))
       }
-      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -101,8 +103,9 @@
         Issue.owner {
           age as User.age
         }
+        ownerAge as sum(val(age))
       }
-      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(ownerAge)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -297,4 +300,25 @@
         Region_2 as Movie.regionsAvailable
       }
       Region_1 as var(func: uid(Region_2))
+    }
+
+- name: "Query interface with @auth rules true for interface and implementing types"
+  gqlquery: |-
+    query {
+      queryQuestionAndAnswer{
+        id
+        text
+        topic
+        author {
+          id
+          name
+        }
+      }
+    }
+  jwtVar:
+    USER: "user1"
+    ANS: "true"
+  dgquery: |-
+    query {
+
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -1,4 +1,4 @@
--name : "Simple DQL query"
+- name : "Simple DQL query"
   gqlquery: |
     query{
       queryIssueGroupedByAuthor {

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -23,7 +23,7 @@
       }
     }
 
-- name : "custom DQL query with var block satisfying RBAC @auth rules"
+- name : "custom DQL query with var block RBAC rules true"
   gqlquery: |
     query{
       queryIssueSortedByOwnerAge {
@@ -58,7 +58,7 @@
       }
     }
 
-- name : "custom DQL query with var block failing RBAC @auth rules"
+- name : "custom DQL query with var block RBAC rules false"
   gqlquery: |
     query{
       queryIssueSortedByOwnerAge {
@@ -83,6 +83,32 @@
         random : Issue.random
       }
     }
+
+- name : "custom DQL query with var block missing partial jwt"
+  gqlquery: |
+    query{
+      queryIssueSortedByOwnerAge {
+        id
+        msg
+        random
+      }
+    }
+  jwtvar:
+    ROLE: "ADMIN"
+  dgquery: |-
+    query {
+      var(func: uid(0x0)) {
+        Issue.owner {
+          age as User.age
+        }
+      }
+      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+        id : uid
+        msg : Issue.msg
+        random : Issue.random
+      }
+    }
+
 - name : "Auth Rules with deep filter"
   gqlquery: |
     query {
@@ -105,8 +131,8 @@
           title : Ticket.title
         }
       }
-      UserRoot as var(func: uid(User_4))
-      User_4 as var(func: uid(0x1)) @filter(eq(User.username, "minhaj"))
+      UserRoot as var(func: uid(User_6))
+      User_6 as var(func: uid(0x1, 0x2)) @filter(eq(User.username, "minhaj"))
       var(func: uid(UserRoot)) {
         Ticket_2 as User.tickets
       }
@@ -131,6 +157,10 @@
           id
           title
         }
+        tweets {
+          id
+          score
+        }
       }
     }
   dgquery: |-
@@ -138,8 +168,52 @@
       queryUsers(func: uid(UserRoot)) {
         username : User.username
       }
-      UserRoot as var(func: uid(User_3))
-      User_3 as var(func: uid(0x1)) @filter(eq(User.username, "minhaj"))
+      UserRoot as var(func: uid(User_5))
+      User_5 as var(func: uid(0x1, 0x2)) @filter(eq(User.username, "minhaj"))
+    }
+
+- name : "Auth rules with deep filter and level 1 RBAC false"
+  gqlquery: |
+    query {
+      queryUsers{
+        username
+        tickets {
+          id
+          title
+        }
+        tweets {
+          id
+          score
+        }
+      }
+    }
+  jwtvar:
+    ROLE: "user"
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUsers(func: uid(UserRoot)) {
+        username : User.username
+        tickets : User.tickets @filter(uid(Ticket_1)) {
+          id : uid
+          title : Ticket.title
+        }
+      }
+      UserRoot as var(func: uid(User_6))
+      User_6 as var(func: uid(0x1, 0x2)) @filter(eq(User.username, "minhaj"))
+      var(func: uid(UserRoot)) {
+        Ticket_2 as User.tickets
+      }
+      Ticket_1 as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
+        Ticket.onColumn : Ticket.onColumn {
+          Column.inProject : Column.inProject {
+            Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            }
+          }
+        }
+      }
     }
 
 - name: "Deep RBAC rule with cascade - Level 1 false"

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -51,7 +51,7 @@
         User_2 as Issue.owner
       }
       User_1 as var(func: uid(User_2))
-      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
+      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -77,7 +77,7 @@
           age as User.age
         }
       }
-      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
+      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -106,7 +106,7 @@
         }
       }
       UserRoot as var(func: uid(User_4))
-      User_4 as var(func: uid(0x1)) @filter(eq(User.username,minhaj))
+      User_4 as var(func: uid(0x1)) @filter(eq(User.username, "minhaj"))
       var(func: uid(UserRoot)) {
         Ticket_2 as User.tickets
       }
@@ -139,7 +139,7 @@
         username : User.username
       }
       UserRoot as var(func: uid(User_3))
-      User_3 as var(func: uid(0x1)) @filter(eq(User.username,minhaj))
+      User_3 as var(func: uid(0x1)) @filter(eq(User.username, "minhaj"))
     }
 
 - name: "Deep RBAC rule with cascade - Level 1 false"

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -341,13 +341,32 @@
           Author.name : Author.name
         }
       }
-      queryQuestionAndAnswer(func: uid(ques, ans)) {
+      queryQuestionAndAnswer(func: uid(PostRoot), orderasc: Post.text) {
         id : uid
         text : Post.text
         topic : Post.topic
         author : Post.author {
           id : Author.id
           name : Author.name
+        }
+      }
+      PostRoot as var(func: uid(Post_6), orderasc: Post.text) @filter(((uid(Question_Auth8) AND uid(Question_Auth9)) OR uid(Answer_Auth11)))
+      Post_6 as var(func: uid(ques, ans))
+      Question_7 as var(func: type(Question))
+      Question_Auth8 as var(func: uid(Question_7)) @filter(eq(Question.answered, true)) @cascade {
+        Question.id : uid
+      }
+      Question_Auth9 as var(func: uid(Question_7)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
+        }
+      }
+      Answer_10 as var(func: type(Answer))
+      Answer_Auth11 as var(func: uid(Answer_10)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
         }
       }
     }
@@ -379,13 +398,22 @@
           Author.name : Author.name
         }
       }
-      queryQuestionAndAnswer(func: uid(ques, ans)) {
+      queryQuestionAndAnswer(func: uid(PostRoot), orderasc: Post.text) {
         id : uid
         text : Post.text
         topic : Post.topic
         author : Post.author {
           id : Author.id
           name : Author.name
+        }
+      }
+      PostRoot as var(func: uid(Post_3), orderasc: Post.text) @filter((uid(Answer_Auth5)))
+      Post_3 as var(func: uid(ques, ans))
+      Answer_4 as var(func: type(Answer))
+      Answer_Auth5 as var(func: uid(Answer_4)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
         }
       }
     }
@@ -407,15 +435,5 @@
     ANS: "true"
   dgquery: |-
     query {
-      ques as var(func: uid(0x1)) @filter(uid(0x2))
-      ans as var(func: uid(0x1)) @filter(uid(0x2))
-      queryQuestionAndAnswer(func: uid(ques, ans)) {
-        id : uid
-        text : Post.text
-        topic : Post.topic
-        author : Post.author {
-          id : Author.id
-          name : Author.name
-        }
-      }
+      queryQuestionAndAnswer()
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -13,10 +13,10 @@
     USER: "user1"
   dgquery: |-
     query {
-      queryIssueGroupedByOwner(func: uid(GroupedIssueMapQRoot)) @groupby(owner : Issue.owner) {
+      queryIssueGroupedByOwner(func: uid(IssueRoot)) @groupby(owner : Issue.owner) {
         count(uid)
       }
-      GroupedIssueMapQRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
       Issue_1 as var(func: type(Issue))
       Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
@@ -302,10 +302,10 @@
       Region_1 as var(func: uid(Region_2))
     }
 
-- name: "Query interface with @auth rules true for interface and implementing types"
-  gqlquery: |-
+- name : "Query interface with @auth rules true for interface and implementing types"
+  gqlquery: |
     query {
-      queryQuestionAndAnswer{
+      queryQuestionAndAnswer {
         id
         text
         topic
@@ -315,10 +315,107 @@
         }
       }
     }
-  jwtVar:
+  jwtvar:
+    ANS: "true"
     USER: "user1"
+  dgquery: |-
+    query {
+      ques as var(func: uid(QuestionRoot))
+      QuestionRoot as var(func: uid(Question_1)) @filter((uid(Question_Auth2) AND uid(Question_Auth3)))
+      Question_1 as var(func: type(Question))
+      Question_Auth2 as var(func: uid(Question_1)) @filter(eq(Question.answered, true)) @cascade {
+        Question.id : uid
+      }
+      Question_Auth3 as var(func: uid(Question_1)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
+        }
+      }
+      ans as var(func: uid(AnswerRoot))
+      AnswerRoot as var(func: uid(Answer_4)) @filter(uid(Answer_Auth5))
+      Answer_4 as var(func: type(Answer))
+      Answer_Auth5 as var(func: uid(Answer_4)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
+        }
+      }
+      queryQuestionAndAnswer(func: uid(ques, ans)) {
+        id : uid
+        text : Post.text
+        topic : Post.topic
+        author : Post.author {
+          id : Author.id
+          name : Author.name
+        }
+      }
+    }
+
+- name : "Query interface with @auth rules true for some of the implementing types"
+  gqlquery: |
+    query {
+      queryQuestionAndAnswer {
+        id
+        text
+        topic
+        author {
+          id
+          name
+        }
+      }
+    }
+  jwtvar:
+    USER: "user1"
+  dgquery: |-
+    query {
+      ques as var(func: uid(0x1)) @filter(uid(0x2))
+      ans as var(func: uid(AnswerRoot))
+      AnswerRoot as var(func: uid(Answer_1)) @filter(uid(Answer_Auth2))
+      Answer_1 as var(func: type(Answer))
+      Answer_Auth2 as var(func: uid(Answer_1)) @cascade {
+        dgraph.type
+        Post.author : Post.author @filter(eq(Author.name, "user1")) {
+          Author.name : Author.name
+        }
+      }
+      queryQuestionAndAnswer(func: uid(ques, ans)) {
+        id : uid
+        text : Post.text
+        topic : Post.topic
+        author : Post.author {
+          id : Author.id
+          name : Author.name
+        }
+      }
+    }
+
+- name : "Query interface with @auth rules false for interface"
+  gqlquery: |
+    query {
+      queryQuestionAndAnswer {
+        id
+        text
+        topic
+        author {
+          id
+          name
+        }
+      }
+    }
+  jwtvar:
     ANS: "true"
   dgquery: |-
     query {
-
+      ques as var(func: uid(0x1)) @filter(uid(0x2))
+      ans as var(func: uid(0x1)) @filter(uid(0x2))
+      queryQuestionAndAnswer(func: uid(ques, ans)) {
+        id : uid
+        text : Post.text
+        topic : Post.topic
+        author : Post.author {
+          id : Author.id
+          name : Author.name
+        }
+      }
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -79,3 +79,61 @@
         random : Issue.random
       }
     }
+- name : "Auth Rules with deep filter"
+  gqlquery: |
+    query {
+      queryUsers {
+        username
+        tickets {
+          id
+          title
+        }
+      }
+    }
+  jwtvar:
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryUsers(func: uid(UserRoot)) {
+        username : User.username
+        tickets : User.tickets @filter(uid(Ticket_1)) {
+          id : uid
+          title : Ticket.title
+        }
+      }
+      UserRoot as var(func: uid(User_4))
+      User_4 as var(func: type(User))
+      var(func: uid(UserRoot)) {
+        Ticket_2 as User.tickets
+      }
+      Ticket_1 as var(func: uid(Ticket_2)) @filter(uid(Ticket_Auth3))
+      Ticket_Auth3 as var(func: uid(Ticket_2)) @cascade {
+        Ticket.onColumn : Ticket.onColumn {
+          Column.inProject : Column.inProject {
+            Project.roles : Project.roles @filter(eq(Role.permission, "VIEW")) {
+              Role.assignedTo : Role.assignedTo @filter(eq(User.username, "user1"))
+            }
+          }
+        }
+      }
+    }
+
+- name : "Auth rules with deep filter failed"
+  gqlquery: |
+    query{
+      queryUsers{
+        username
+        tickets {
+          id
+          title
+        }
+      }
+    }
+  dgquery: |-
+    query {
+      queryUsers(func: uid(UserRoot)) {
+        username : User.username
+      }
+      UserRoot as var(func: uid(User_3))
+      User_3 as var(func: type(User))
+    }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -22,3 +22,31 @@
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
     }
+
+- name : "custom DQL query with var block"
+  gqlquery: |
+    query{
+      queryUserSortedByTweetScore {
+        username
+        age
+      }
+    }
+  jwtvar:
+    ROLE: "ADMIN"
+    USER: "user1"
+  dgquery: |-
+    query {
+      var(func: type(User)) {
+        User.tweets {
+          score as Tweets.score
+        }
+      }
+      queryUserSortedByTweetScore(func: uid(score), orderdesc: score) {
+        username : User.username
+        age : User.age
+        tweets : User.tweets {
+          text : Tweets.text
+          score : Tweets.score
+        }
+      }
+    }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -43,7 +43,7 @@
         }
       }
       IssueRoot as var(func: uid(Issue_3)) @filter(uid(Issue_Auth4))
-      Issue_3 as var(func: type(Issue))
+      Issue_3 as var(func: type(Issue)) @filter(has(Issue.owner))
       Issue_Auth4 as var(func: uid(Issue_3)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
@@ -72,7 +72,7 @@
     USER: "user1"
   dgquery: |-
     query {
-      iss as var(func: uid(0x0)) {
+      iss as var(func: uid(0x1)) @filter((uid(0x2) AND has(Issue.owner))) {
         Issue.owner {
           age as User.age
         }
@@ -97,7 +97,7 @@
     ROLE: "ADMIN"
   dgquery: |-
     query {
-      iss as var(func: uid(0x0)) {
+      iss as var(func: uid(0x1)) @filter((uid(0x2) AND has(Issue.owner))) {
         Issue.owner {
           age as User.age
         }
@@ -288,7 +288,7 @@
         }
       }
       MovieRoot as var(func: uid(Movie_3)) @filter((NOT (uid(Movie_Auth4)) AND uid(Movie_Auth5)))
-      Movie_3 as var)
+      Movie_3 as var(func: has(Movie.content))
       Movie_Auth4 as var(func: uid(Movie_3)) @filter(eq(Movie.hidden, true)) @cascade
       Movie_Auth5 as var(func: uid(Movie_3)) @cascade {
         Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -38,15 +38,19 @@
   dgquery: |-
     query {
       var(func: uid(IssueRoot)) {
-        Issue.owner {
+        Issue.owner @filter(uid(User_1)) {
           age as User.age
         }
       }
-      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
-      Issue_1 as var(func: type(Issue))
-      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
+      IssueRoot as var(func: uid(Issue_3)) @filter(uid(Issue_Auth4))
+      Issue_3 as var(func: type(Issue))
+      Issue_Auth4 as var(func: uid(Issue_3)) @cascade {
         Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
       }
+      var(func: uid(IssueRoot)) {
+        User_2 as Issue.owner
+      }
+      User_1 as var(func: uid(User_2))
       queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
         id : uid
         msg : Issue.msg
@@ -54,7 +58,7 @@
       }
     }
 
-- name : "custom DQL query with var block failing RBAC @auth rules"
+- name : "f custom DQL query with var block failing RBAC @auth rules"
   gqlquery: |
     query{
       queryIssueSortedByOwnerAge {
@@ -68,7 +72,7 @@
     USER: "user1"
   dgquery: |-
     query {
-      var() {
+      var(func: uid(0x0)) {
         Issue.owner {
           age as User.age
         }
@@ -102,7 +106,7 @@
         }
       }
       UserRoot as var(func: uid(User_4))
-      User_4 as var(func: type(User))
+      User_4 as var(func: uid(0x1)) @filter(eq(User.username,minhaj))
       var(func: uid(UserRoot)) {
         Ticket_2 as User.tickets
       }
@@ -135,5 +139,53 @@
         username : User.username
       }
       UserRoot as var(func: uid(User_3))
-      User_3 as var(func: type(User))
+      User_3 as var(func: uid(0x1)) @filter(eq(User.username,minhaj))
+    }
+
+- name: "Deep RBAC rule with cascade - Level 1 false"
+  gqlquery: |
+    query {
+      queryContacts {
+        id
+        nickName
+        adminTasks {
+          id
+          name
+          occurrences {
+            due
+            comp
+          }
+        }
+      }
+    }
+  jwtvar:
+    ContactRole: ADMINISTRATOR
+    TaskRole: User
+    TaskOccuranceRole: ADMINISTRATOR
+  dgquery: |-
+    query {
+      queryContacts(func: uid(ContactRoot)) @cascade {
+        id : uid
+        nickName : Contact.nickName
+        adminTasks : Contact.adminTasks @filter(uid(AdminTask_1)) {
+          id : uid
+          name : AdminTask.name
+          occurrences : AdminTask.occurrences @filter(uid(TaskOccurrence_3)) {
+            due : TaskOccurrence.due
+            comp : TaskOccurrence.comp
+          }
+        }
+      }
+      ContactRoot as var(func: uid(Contact_7))
+      Contact_7 as var(func: type(Contact))
+      var(func: uid(ContactRoot)) {
+        AdminTask_2 as Contact.adminTasks
+      }
+      AdminTask_1 as var(func: uid(AdminTask_2)) @filter(uid(AdminTask_6))
+      var(func: uid(AdminTask_1)) {
+        TaskOccurrence_4 as AdminTask.occurrences
+      }
+      TaskOccurrence_3 as var(func: uid(TaskOccurrence_4)) @filter(uid(TaskOccurrence_Auth5))
+      TaskOccurrence_Auth5 as var(func: uid(TaskOccurrence_4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
+      AdminTask_6 as var(func: uid())
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -1,0 +1,21 @@
+-name : "Simple DQL query"
+  gqlquery: |
+    query{
+      queryIssueGroupedByAuthor {
+        groupby {
+        author
+        count
+        } 
+      }
+    }
+  jwtvar:
+    ROLE: "USER"
+    USER: "user1"
+  dgquery: |-
+    queryIssueGroupedByAuthor(func: type(Person)) @groupby(friend: Person.friends) @filter(uid(Issue_Auth2)) {
+      count(uid)
+    }
+    Issue_1 as var(func: type(Issue))
+    Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
+      Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
+    }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -68,7 +68,11 @@
     USER: "user1"
   dgquery: |-
     query {
-      var()
+      var() {
+        Issue.owner {
+          age as User.age
+        }
+      }
       queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
         id : uid
         msg : Issue.msg

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -37,7 +37,7 @@
     USER: "user1"
   dgquery: |-
     query {
-      var(func: uid(IssueRoot)) {
+      iss as var(func: uid(IssueRoot)) {
         Issue.owner @filter(uid(User_1)) {
           age as User.age
         }
@@ -51,7 +51,7 @@
         User_2 as Issue.owner
       }
       User_1 as var(func: uid(User_2))
-      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -72,12 +72,12 @@
     USER: "user1"
   dgquery: |-
     query {
-      var(func: uid(0x0)) {
+      iss as var(func: uid(0x0)) {
         Issue.owner {
           age as User.age
         }
       }
-      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -97,12 +97,12 @@
     ROLE: "ADMIN"
   dgquery: |-
     query {
-      var(func: uid(0x0)) {
+      iss as var(func: uid(0x0)) {
         Issue.owner {
           age as User.age
         }
       }
-      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: val(age)) {
+      queryIssueSortedByOwnerAge(func: uid(iss), orderdesc: val(age)) {
         id : uid
         msg : Issue.msg
         random : Issue.random
@@ -262,4 +262,39 @@
       TaskOccurrence_3 as var(func: uid(TaskOccurrence_4)) @filter(uid(TaskOccurrence_Auth5))
       TaskOccurrence_Auth5 as var(func: uid(TaskOccurrence_4)) @filter(eq(TaskOccurrence.role, "ADMINISTRATOR")) @cascade
       AdminTask_6 as var(func: uid())
+    }
+
+- name: "DQL query with @cascade and pagination"
+  gqlquery: |
+    query{
+      queryFirstTwoMovieWithNonNullRegion{
+        content
+        code
+        regionsAvailable{
+          name
+        }
+      }
+    }
+  jwtVar:
+    ROLE: "ADMIN"
+    USER: "user1"
+  dgquery: |-
+    query {
+      queryFirstTwoMovieWithNonNullRegion(func: uid(MovieRoot), orderasc: Movie.content, first: 2, offset: 0) @cascade {
+        content : Movie.content
+        code : Movie.code
+        regionsAvailable : Movie.regionsAvailable @filter(uid(Region_1)) (orderasc: Region.name, first: 1) {
+          name : Region.name
+        }
+      }
+      MovieRoot as var(func: uid(Movie_3)) @filter((NOT (uid(Movie_Auth4)) AND uid(Movie_Auth5)))
+      Movie_3 as var)
+      Movie_Auth4 as var(func: uid(Movie_3)) @filter(eq(Movie.hidden, true)) @cascade
+      Movie_Auth5 as var(func: uid(Movie_3)) @cascade {
+        Movie.regionsAvailable : Movie.regionsAvailable @filter(eq(Region.global, true))
+      }
+      var(func: uid(MovieRoot)) {
+        Region_2 as Movie.regionsAvailable
+      }
+      Region_1 as var(func: uid(Region_2))
     }

--- a/graphql/resolve/custom_auth_query_test.yaml
+++ b/graphql/resolve/custom_auth_query_test.yaml
@@ -23,12 +23,13 @@
       }
     }
 
-- name : "custom DQL query with var block"
+- name : "custom DQL query with var block satisfying RBAC @auth rules"
   gqlquery: |
     query{
-      queryUserSortedByTweetScore {
-        username
-        age
+      queryIssueSortedByOwnerAge {
+        id
+        msg
+        random
       }
     }
   jwtvar:
@@ -36,17 +37,41 @@
     USER: "user1"
   dgquery: |-
     query {
-      var(func: type(User)) {
-        User.tweets {
-          score as Tweets.score
+      var(func: uid(IssueRoot)) {
+        Issue.owner {
+          age as User.age
         }
       }
-      queryUserSortedByTweetScore(func: uid(score), orderdesc: score) {
-        username : User.username
-        age : User.age
-        tweets : User.tweets {
-          text : Tweets.text
-          score : Tweets.score
-        }
+      IssueRoot as var(func: uid(Issue_1)) @filter(uid(Issue_Auth2))
+      Issue_1 as var(func: type(Issue))
+      Issue_Auth2 as var(func: uid(Issue_1)) @cascade {
+        Issue.owner : Issue.owner @filter(eq(User.username, "user1"))
+      }
+      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
+        id : uid
+        msg : Issue.msg
+        random : Issue.random
+      }
+    }
+
+- name : "custom DQL query with var block failing RBAC @auth rules"
+  gqlquery: |
+    query{
+      queryIssueSortedByOwnerAge {
+        id
+        msg
+        random
+      }
+    }
+  jwtvar:
+    ROLE: "USER"
+    USER: "user1"
+  dgquery: |-
+    query {
+      var()
+      queryIssueSortedByOwnerAge(func: uid(age), orderdesc: age) {
+        id : uid
+        msg : Issue.msg
+        random : Issue.random
       }
     }

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1221,7 +1221,7 @@ func checkXIDExistsQuery(
 			Name: "eq",
 			Args: []gql.Arg{
 				{Value: typ.DgraphPredicate(xidPredicate)},
-				{Value: maybeQuoteArg("eq", xidString)},
+				{Value: schema.MaybeQuoteArg("eq", xidString)},
 			},
 		},
 		Children: []*gql.GraphQuery{{Attr: "uid"}, {Attr: "dgraph.type"}},

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -198,6 +198,7 @@ func (qr *customDQLQueryResolver) rewriteAndExecute(ctx context.Context,
 		return resolved
 	}
 
+	dgQuery := query.DQLQuery()
 	args := query.Arguments()
 	vars := make(map[string]string)
 	for k, v := range args {

--- a/graphql/resolve/query.go
+++ b/graphql/resolve/query.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strconv"
+	"strings"
 
 	"github.com/golang/glog"
 	otrace "go.opencensus.io/trace"
@@ -197,7 +198,6 @@ func (qr *customDQLQueryResolver) rewriteAndExecute(ctx context.Context,
 		return resolved
 	}
 
-	dgQuery := query.DQLQuery()
 	args := query.Arguments()
 	vars := make(map[string]string)
 	for k, v := range args {
@@ -211,9 +211,37 @@ func (qr *customDQLQueryResolver) rewriteAndExecute(ctx context.Context,
 		vars["$"+k] = vStr
 	}
 
+	dqlReq := gql.Request{
+		Str:       dgQuery,
+		Variables: vars,
+	}
+	parsedResult, err := gql.Parse(dqlReq)
+	parsedResult.Query[0].Attr = parsedResult.Query[0].Alias
+	parsedResult.Query[0].Alias = ""
+	if err != nil {
+		return emptyResult(schema.GQLWrapf(err, "Could not parse DQL query"))
+	}
+
+	customClaims, _ := query.GetAuthMeta().ExtractCustomClaims(ctx)
+	authRw := &authRewriter{
+		authVariables: customClaims.AuthVariables,
+		varGen:        NewVariableGenerator(),
+		selector:      getAuthSelector(query.QueryType()),
+		parentVarName: query.ConstructedFor().Name() + "Root",
+	}
+	authRw.hasAuthRules = hasAuthRules(query, authRw)
+	authRw.hasCascade = hasCascadeDirective(query)
+
+	dgGraph, err := rewriteWithAuth(parsedResult.Query, query.Schema(), authRw)
+	if err != nil {
+		return emptyResult(schema.GQLWrapf(err, "rewriting failed"))
+	}
+
+	qry := dgraph.AsString(dgGraph)
+
 	queryTimer := newtimer(ctx, &dgraphQueryDuration.OffsetDuration)
 	queryTimer.Start()
-	resp, err := qr.executor.Execute(ctx, &dgoapi.Request{Query: dgQuery, Vars: vars,
+	resp, err := qr.executor.Execute(ctx, &dgoapi.Request{Query: qry, Vars: vars,
 		ReadOnly: true}, nil)
 	queryTimer.Stop()
 
@@ -230,6 +258,49 @@ func (qr *customDQLQueryResolver) rewriteAndExecute(ctx context.Context,
 	resolved := DataResult(query, respJson, nil)
 	resolved.Extensions = ext
 	return resolved
+}
+
+func extractType(dgQuery *gql.GraphQuery) string {
+	typeName := extractTypeFromFunc(dgQuery.Func)
+	if typeName != "" {
+		return typeName
+	}
+
+	typeName = extractTypeFromFilter(dgQuery.Filter)
+	return typeName
+}
+
+func extractTypeFromFilter(f *gql.FilterTree) string {
+	for _, fltr := range f.Child {
+		typeName := extractTypeFromFilter(fltr)
+		if typeName != "" {
+			return typeName
+		}
+	}
+	return extractTypeFromFunc(f.Func)
+}
+
+func extractTypeFromFunc(f *gql.Function) string {
+	switch f.Name {
+	case "type":
+		return f.Args[0].Value
+	case "eq", "allofterms", "anyofterms", "gt", "le":
+		return strings.Split(f.Attr, ".")[0]
+	}
+	return ""
+}
+
+func rewriteWithAuth(dgQuery []*gql.GraphQuery, sch schema.Schema, authRw *authRewriter) ([]*gql.GraphQuery, error) {
+	qry := dgQuery[0]
+	typeName := extractType(qry)
+	if typeName == "" {
+		return dgQuery, nil
+	}
+
+	typ := sch.Type(typeName)
+	rbac := authRw.evaluateStaticRules(typ)
+	dgQuery = authRw.addAuthQueries(typ, dgQuery, rbac)
+	return dgQuery, nil
 }
 
 func resolveIntrospection(ctx context.Context, q schema.Query) *Resolved {

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -752,7 +752,7 @@ func rewriteDQLQueryWithAuth(
 
 		// parentVarName needs to be calculated separately for
 		// each query block.
-		//authRw.parentVarName = typeName + "Root"
+		authRw.parentVarName = typeName + "Root"
 
 		// authRw.hasAuthRules & auth.hasCascade needs to be calculated
 		// separately for each query block in case of DQL queries.

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -672,7 +672,10 @@ func extractTypeFromFunc(f *gql.Function) string {
 	return ""
 }
 
-func rewriteWithAuth(dgQuery []*gql.GraphQuery, sch schema.Schema, authRw *authRewriter) ([]*gql.GraphQuery, error) {
+func rewriteWithAuth(
+	dgQuery []*gql.GraphQuery,
+	sch schema.Schema,
+	authRw *authRewriter) ([]*gql.GraphQuery, error) {
 	qry := dgQuery[0]
 	typeName := extractType(qry)
 	if typeName == "" {

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -780,7 +780,7 @@ func rewriteDQLQueryWithAuth(
 			} else {
 				// if it is main Query then just return this empty query only as there might
 				// be some unused variables. We do the similar thing for interface also.
-				return []*gql.GraphQuery{&gql.GraphQuery{Attr: qry.Attr + "()"}}, nil
+				return []*gql.GraphQuery{{Attr: qry.Attr + "()"}}, nil
 			}
 			continue
 		}

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -851,13 +851,6 @@ func (authRw *authRewriter) addAuthQueries(
 		},
 		Filter: filter,
 	}
-	// if @auth rules are applied on DQL query and the root function is of
-	// uid(0x1, 0x2,...) then the root query will be written as:-
-	// typeRoot as var(func: uid(0x1, 0x2, 0x3), ....) @filter
-	if len(dgQuery[0].UID) != 0 {
-		rootQry.Func.UID = dgQuery[0].UID
-		rootQry.Func.Args = nil
-	}
 
 	// The user query doesn't need the filter parameter anymore,
 	// as it has been taken care of by the var and root queries generated above.

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1725,6 +1725,9 @@ func dqlHasAuthRules(q *gql.GraphQuery, typ schema.Type, authRw *authRewriter) b
 	return false
 }
 
+// Todo: Currently it doesn't work for fields with
+// @dgraph predicate in the GraphQL schema because
+// it doesn't enforce the Type.FieldName syntax.
 func getFieldName(attr string) string {
 	fldSplit := strings.Split(attr, ".")
 	if len(fldSplit) == 1 || attr == "dgraph.type" {

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1659,7 +1659,7 @@ func addSelectionSetFrom(
 // the corresponding child is ignored during calculation. for eg: predicates like
 // `uid`,`name@en` will be ignored.
 func dqlHasAuthRules(q *gql.GraphQuery, typ schema.Type, authRw *authRewriter) bool {
-	if q == nil {
+	if q == nil || typ == nil {
 		return false
 	}
 	rn := authRw.selector(typ)
@@ -1680,7 +1680,7 @@ func dqlHasAuthRules(q *gql.GraphQuery, typ schema.Type, authRw *authRewriter) b
 
 func getFieldName(attr string) string {
 	fldSplit := strings.Split(attr, ".")
-	if len(fldSplit) == 1 {
+	if len(fldSplit) == 1 || attr == "dgraph.type" {
 		return ""
 	}
 	return fldSplit[1]

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -699,7 +699,14 @@ func rewriteWithAuth(
 		}
 		rbac := authRw.evaluateStaticRules(typ)
 		if rbac == schema.Negative {
-			dgQueries = append(dgQueries, &gql.GraphQuery{Attr: qry.Attr + "()"})
+			if qry.Attr == "var" {
+				qry.Attr = qry.Attr + "()"
+				qry.Func = nil
+				dgQueries = append(dgQueries, qry)
+			} else {
+				dgQueries = append(dgQueries, &gql.GraphQuery{Attr: qry.Attr + "()"})
+			}
+			continue
 		}
 		dgQueries = append(dgQueries, authRw.addAuthQueries(typ, []*gql.GraphQuery{qry}, rbac)...)
 	}

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -669,8 +669,10 @@ func extractType(dgQuery *gql.GraphQuery) string {
 		return typeName
 	}
 	typeName = extractTypeFromOrder(dgQuery.Order)
-	typeName = extractTypeFromFilter(dgQuery.Filter)
-	return typeName
+	if typeName != "" {
+		return typeName
+	}
+	return extractTypeFromFilter(dgQuery.Filter)
 }
 
 func getTypeNameFromAttr(Attr string) string {

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -704,7 +704,7 @@ func extractTypeFromFunc(f *gql.Function) string {
 	switch f.Name {
 	case "type":
 		return f.Args[0].Value
-	case "eq", "allofterms", "anyofterms", "gt", "le":
+	case "eq", "allofterms", "anyofterms", "gt", "le", "has":
 		split := strings.Split(f.Attr, ".")
 		if len(split) == 1 {
 			return ""

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -259,7 +259,7 @@ func (rf *resolverFactory) WithConventionResolvers(
 	for _, q := range s.Queries(schema.DQLQuery) {
 		rf.WithQueryResolver(q, func(q schema.Query) QueryResolver {
 			// DQL queries don't need any QueryRewriter
-			return NewCustomDQLQueryResolver(fns.Ex)
+			return NewCustomDQLQueryResolver(fns.Qrw, fns.Ex)
 		})
 	}
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -2378,6 +2378,9 @@ func isID(fd *ast.FieldDefinition) bool {
 }
 
 func (fd *fieldDefinition) Type() Type {
+	if fd.fieldDef == nil {
+		return nil
+	}
 	return &astType{
 		typ:             fd.fieldDef.Type,
 		inSchema:        fd.inSchema,

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -3155,3 +3155,18 @@ func parseRequiredArgsFromGQLRequest(req string) (map[string]bool, error) {
 	_, rf, err := parseBodyTemplate("{"+args+"}", false)
 	return rf, err
 }
+
+// MaybeQuoteArg puts a quote on the function arguments.
+func MaybeQuoteArg(fn string, arg interface{}) string {
+	switch arg := arg.(type) {
+	case string: // dateTime also parsed as string
+		if fn == "regexp" {
+			return arg
+		}
+		return fmt.Sprintf("%q", arg)
+	case float64, float32:
+		return fmt.Sprintf("\"%v\"", arg)
+	default:
+		return fmt.Sprintf("%v", arg)
+	}
+}


### PR DESCRIPTION
Fixes GRAPHQL-1171.
This PR adds support for @auth on custom DQL queries.
This PR also adds the parsing step to the DQL query.
The Algorithm tries to figure out the `queried type` at the root of the query either from the `root func` or `filters`.
Suppose if the root func is `func: type(Person)` or `func: has(Person.name)` or `func: eq(Person.age, 10)` then 
it infers that the queried type is `Person`. 
However, there are certain DQL queries on which @auth rules are not added currently since the queried type is not clear. 
for eg: 
```
me(func: uid(0x1, 0x2)) {
 ...
}
```
or the query:
```
me(func: has(name@en) {
 ...
}
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7775)
<!-- Reviewable:end -->
