### PR TITLE
Fix(GraphQL): Fix duplicate XID error in case of interface XIDs

### DIFF
--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -900,6 +900,8 @@ func RunAll(t *testing.T) {
 	t.Run("Update language tag fields", updateLangTagFields)
 	t.Run("mutation with @id field and interface arg", mutationWithIDFieldHavingInterfaceArg)
 	t.Run("xid update and nullable tests", xidUpdateAndNullableTests)
+	t.Run("Referencing same node containing multiple XIDs",
+		referencingSameNodeWithMultipleXIds)
 
 	// error tests
 	t.Run("graphql completion on", graphQLCompletionOn)

--- a/graphql/e2e/directives/schema.graphql
+++ b/graphql/e2e/directives/schema.graphql
@@ -206,7 +206,9 @@ type post1{
 
 type Person1 {
     id: ID!
-    name: String!
+    name: String! @id
+    name1: String @id
+    regId: String @id
     closeFriends: [Person1] @hasInverse(field: closeFriends)
     friends: [Person1] @hasInverse(field: friends)
 }

--- a/graphql/e2e/directives/schema_response.json
+++ b/graphql/e2e/directives/schema_response.json
@@ -469,7 +469,30 @@
     },
     {
       "predicate": "Person1.name",
-      "type": "string"
+      "type": "string",
+      "upsert": true,
+      "tokenizer": [
+        "hash"
+      ],
+      "index": true
+    },
+    {
+      "predicate": "Person1.regId",
+      "type": "string",
+      "upsert": true,
+      "tokenizer": [
+        "hash"
+      ],
+      "index": true
+    },
+    {
+      "predicate": "Person1.name1",
+      "type": "string",
+      "upsert": true,
+      "tokenizer": [
+        "hash"
+      ],
+      "index": true
     },
     {
       "predicate": "Plant.breed",
@@ -1209,6 +1232,12 @@
         },
         {
           "name": "Person1.closeFriends"
+        },
+        {
+          "name": "Person1.name1"
+        },
+        {
+          "name": "Person1.regId"
         }
       ],
       "name": "Person1"

--- a/graphql/e2e/normal/schema.graphql
+++ b/graphql/e2e/normal/schema.graphql
@@ -219,7 +219,9 @@ type post1{
 
 type Person1 {
     id: ID!
-    name: String!
+    name: String! @id
+    name1: String @id
+    regId: String @id
     closeFriends: [Person1] @hasInverse(field: closeFriends)
     friends: [Person1] @hasInverse(field: friends)
 }

--- a/graphql/e2e/normal/schema_response.json
+++ b/graphql/e2e/normal/schema_response.json
@@ -523,7 +523,30 @@
     },
     {
       "predicate": "Person1.name",
-      "type": "string"
+      "index": true,
+      "type": "string",
+      "tokenizer": [
+        "hash"
+      ],
+      "upsert": true
+    },
+    {
+      "predicate": "Person1.name1",
+      "index": true,
+      "type": "string",
+      "tokenizer": [
+        "hash"
+      ],
+      "upsert": true
+    },
+    {
+      "predicate": "Person1.regId",
+      "index": true,
+      "type": "string",
+      "tokenizer": [
+        "hash"
+      ],
+      "upsert": true
     },
     {
       "predicate": "Plant.breed",
@@ -1236,6 +1259,12 @@
       "fields": [
         {
           "name": "Person1.name"
+        },
+        {
+          "name": "Person1.name1"
+        },
+        {
+          "name": "Person1.regId"
         },
         {
           "name": "Person1.friends"

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -661,8 +661,10 @@
     }
   explanation: "A reference must be a valid UID"
   error:
-    { "message":
-        "failed to rewrite mutation payload because ID argument (HI!) was not able to be parsed" }
+    {
+      "message":
+        "failed to rewrite mutation payload because ID argument (HI!) was not able to be parsed"
+    }
 
 -
   name: "Add mutation with inverse reference"
@@ -2740,43 +2742,6 @@
   error:
     message: |-
       failed to rewrite mutation payload because duplicate XID found: S1
-
-#- name: "Duplicate XIDs in single mutation for Interface"
-#  gqlmutation: |
-#    mutation addStudent($input: [AddStudentInput!]!) {
-#      addStudent(input: $input) {
-#        student {
-#          xid
-#          name
-#          taughtBy {
-#            xid
-#            name
-#            subject
-#          }
-#        }
-#      }
-#    }
-#  gqlvariables: |
-#    {
-#      "input": [
-#        {
-#          "xid": "S1",
-#          "name": "Stud1"
-#        },
-#        {
-#          "xid": "S2",
-#          "name": "Stud2",
-#          "taughtBy": [
-#            {"xid": "S1", "name": "Teacher1", "subject": "Sub1"}
-#          ]
-#        }
-#      ]
-#    }
-#  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
-#  should return error."
-#  error:
-#    message: |-
-#      failed to rewrite mutation payload because duplicate XID found: S1
 
 # Additional Deletes
 #
@@ -5500,3 +5465,42 @@
     {
       "message": "failed to rewrite mutation payload because field id cannot be empty"
     }
+
+-
+  name: "Add Mutation referencing same XID in different types"
+  gqlmutation: |
+    mutation($input: [AddT1Input!]!) {
+      addT1(input: $input) {
+        t1 {
+          name
+          name1
+          name2
+          link {
+            name
+            name1
+            name3
+          }
+        }
+      }
+    }
+  gqlvariables: |
+    {
+      "input": [
+        {
+          "name": "Bob",
+          "name1": "Bob11",
+          "name2": "Bob2",
+          "link": {
+            "name": "Bob"
+          }
+        }
+      ]
+    }
+  explanation: "As the link and top level object contain the same XID, Bob, this should throw an error"
+  error:
+    {
+      "message":
+        "failed to rewrite mutation payload because using duplicate XID value: Bob for XID: name for two different
+         implementing types of same interfaces: T1 and T2"
+    }
+

--- a/graphql/resolve/add_mutation_test.yaml
+++ b/graphql/resolve/add_mutation_test.yaml
@@ -2741,42 +2741,42 @@
     message: |-
       failed to rewrite mutation payload because duplicate XID found: S1
 
-- name: "Duplicate XIDs in single mutation for Interface"
-  gqlmutation: |
-    mutation addStudent($input: [AddStudentInput!]!) {
-      addStudent(input: $input) {
-        student {
-          xid
-          name
-          taughtBy {
-            xid
-            name
-            subject
-          }
-        }
-      }
-    }
-  gqlvariables: |
-    {
-      "input": [
-        {
-          "xid": "S1",
-          "name": "Stud1"
-        },
-        {
-          "xid": "S2",
-          "name": "Stud2",
-          "taughtBy": [
-            {"xid": "S1", "name": "Teacher1", "subject": "Sub1"}
-          ]
-        }
-      ]
-    }
-  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
-  should return error."
-  error:
-    message: |-
-      failed to rewrite mutation payload because duplicate XID found: S1
+#- name: "Duplicate XIDs in single mutation for Interface"
+#  gqlmutation: |
+#    mutation addStudent($input: [AddStudentInput!]!) {
+#      addStudent(input: $input) {
+#        student {
+#          xid
+#          name
+#          taughtBy {
+#            xid
+#            name
+#            subject
+#          }
+#        }
+#      }
+#    }
+#  gqlvariables: |
+#    {
+#      "input": [
+#        {
+#          "xid": "S1",
+#          "name": "Stud1"
+#        },
+#        {
+#          "xid": "S2",
+#          "name": "Stud2",
+#          "taughtBy": [
+#            {"xid": "S1", "name": "Teacher1", "subject": "Sub1"}
+#          ]
+#        }
+#      ]
+#    }
+#  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
+#  should return error."
+#  error:
+#    message: |-
+#      failed to rewrite mutation payload because duplicate XID found: S1
 
 # Additional Deletes
 #

--- a/graphql/resolve/schema.graphql
+++ b/graphql/resolve/schema.graphql
@@ -500,3 +500,20 @@ type LibraryManager  {
     name: String! @id
     manages: [LibraryMember]
 }
+
+interface T {
+    name: String! @id(interface:true)
+    name1: String
+
+}
+
+type T1 implements T {
+    name2:String
+    link:T2
+
+}
+
+type T2 implements T {
+    name3:String
+
+}

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -1457,47 +1457,46 @@
     message: |-
       failed to rewrite mutation payload because duplicate XID found: T1
 
-- name: "Duplicate XIDs in single mutation for Interface"
-  gqlmutation: |
-    mutation updateStudent($input: UpdateStudentInput!) {
-      updateStudent(input: $input) {
-        student {
-          xid
-          name
-          taughtBy {
-            xid
-            name
-            subject
-          }
-        }
-      }
-    }
-  gqlvariables: |
-    {
-      "input": {
-        "filter": {
-          "xid": {"eq": "S1"}
-        },
-        "set": {
-          "taughtBy": [
-            {
-              "xid": "T1",
-              "name": "Teacher1",
-              "subject": "Sub1",
-              "teaches": [
-                {"xid": "T1", "name": "Stud2"}
-              ]
-            }
-          ]
-        }
-      }
-    }
-  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
-  should return error."
-  error:
-    message: |-
-      failed to rewrite mutation payload because duplicate XID found: T1
-
+#- name: "Duplicate XIDs in single mutation for Interface"
+#  gqlmutation: |
+#    mutation updateStudent($input: UpdateStudentInput!) {
+#      updateStudent(input: $input) {
+#        student {
+#          xid
+#          name
+#          taughtBy {
+#            xid
+#            name
+#            subject
+#          }
+#        }
+#      }
+#    }
+#  gqlvariables: |
+#    {
+#      "input": {
+#        "filter": {
+#          "xid": {"eq": "S1"}
+#        },
+#        "set": {
+#          "taughtBy": [
+#            {
+#              "xid": "T1",
+#              "name": "Teacher1",
+#              "subject": "Sub1",
+#              "teaches": [
+#                {"xid": "T1", "name": "Stud2"}
+#              ]
+#            }
+#          ]
+#        }
+#      }
+#    }
+#  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
+#  should return error."
+#  error:
+#    message: |-
+#      failed to rewrite mutation payload because duplicate XID found: T1
 
 # Additional Deletes
 #

--- a/graphql/resolve/update_mutation_test.yaml
+++ b/graphql/resolve/update_mutation_test.yaml
@@ -1457,47 +1457,6 @@
     message: |-
       failed to rewrite mutation payload because duplicate XID found: T1
 
-#- name: "Duplicate XIDs in single mutation for Interface"
-#  gqlmutation: |
-#    mutation updateStudent($input: UpdateStudentInput!) {
-#      updateStudent(input: $input) {
-#        student {
-#          xid
-#          name
-#          taughtBy {
-#            xid
-#            name
-#            subject
-#          }
-#        }
-#      }
-#    }
-#  gqlvariables: |
-#    {
-#      "input": {
-#        "filter": {
-#          "xid": {"eq": "S1"}
-#        },
-#        "set": {
-#          "taughtBy": [
-#            {
-#              "xid": "T1",
-#              "name": "Teacher1",
-#              "subject": "Sub1",
-#              "teaches": [
-#                {"xid": "T1", "name": "Stud2"}
-#              ]
-#            }
-#          ]
-#        }
-#      }
-#    }
-#  explanation: "When duplicate XIDs are given as input for an Interface in a single mutation, it
-#  should return error."
-#  error:
-#    message: |-
-#      failed to rewrite mutation payload because duplicate XID found: T1
-
 # Additional Deletes
 #
 # If we have


### PR DESCRIPTION
Implementation:
This PR adds the implementing type name to the key. This ensures that different variable names are generated for different implementing types of the same interface with same XID (name and value). It also adds an error condition to give error in case two nodes of different types with same XID(with interface=true) flag are added.

It also fixes other bug related to referencing same node with multiple IDs in same mutation.

Testing:
Added yaml and e2e tests.
Note that two tests from yaml tests have been removed as they were wrong.

Fixes GRAPHQL-1164
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7776)
<!-- Reviewable:end -->
