### PR TITLE
fix(export-backup): Fix double free in export backup

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -215,11 +215,7 @@ func (bw *bufWriter) Write(buf *z.Buffer) error {
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-	buf.Release()
-	return nil
+	return errors.Wrap(err, "bufWriter failed to write")
 }
 
 func runExportBackup() error {


### PR DESCRIPTION
In case of export backup, in the reduce phase the `kvBuf` is freed by the `(*reducer) Process()` function as a defer. 
`(*bufWriter) Write()` is called  from the `(*reducer) process()` so `(*bufWriter) Write()` doesn't need to free the `kvBuf`.

This PR fixes the issue of double free. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7780)
<!-- Reviewable:end -->
