### PR TITLE
fix(txn): ensure that txn hash is set

### DIFF
--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -222,7 +222,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	commit := false
 
 	defer func() {
-		if !commit && mutResp != nil && mutResp.Txn != nil {
+		if !commit && mutResp != nil && mutResp.Txn != nil && mutResp.Txn.StartTs > 0 {
 			mutResp.Txn.Aborted = true
 			_, err := mr.executor.CommitOrAbort(ctx, mutResp.Txn)
 			if err != nil {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -222,7 +222,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	commit := false
 
 	defer func() {
-		if !commit && mutResp != nil && mutResp.Txn != nil && mutResp.Txn.StartTs > 0 {
+		if !commit && mutResp != nil && mutResp.Txn != nil {
 			mutResp.Txn.Aborted = true
 			_, err := mr.executor.CommitOrAbort(ctx, mutResp.Txn)
 			if err != nil {

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -43,7 +43,6 @@ const (
 	CacheDefaults  = `size-mb=1024; percentage=0,65,35;`
 	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
-	CloudDefaults   = `disable-non-galaxy=false;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +


### PR DESCRIPTION
Fixes GQLSAAS-1290

We were setting the hash after completing the transaction successfully. This leads to the failure of the commit as it won't contain the hash. This PR fixes that issue.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7782)
<!-- Reviewable:end -->
