### PR TITLE
release/v21.03-slash: fix(export-backup): Fix double free in export backup (#7780)

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -217,11 +217,7 @@ func (bw *bufWriter) Write(buf *z.Buffer) error {
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-	buf.Release()
-	return nil
+	return errors.Wrap(err, "bufWriter failed to write")
 }
 
 func runExportBackup() error {


### PR DESCRIPTION
Fix issue of double-free in export-backup. kvBuf is released by
the reducer so the Writer shouldn't free it.

(cherry picked from commit 00a67d55536b5d49b79b9e9824d308953ef0fecd)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7783)
<!-- Reviewable:end -->
