### PR TITLE
fix(txn): ensure that txn hash is set (#7782)

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1252,6 +1252,18 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (
 			qc.latency.AssignTimestamp = time.Since(start)
 		}
 	}
+	if x.WorkerConfig.AclEnabled {
+		ns, err := x.ExtractNamespace(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if resp != nil && resp.Txn != nil {
+				// attach the hash, user must send this hash when further operating on this startTs.
+				resp.Txn.Hash = getHash(ns, resp.Txn.StartTs)
+			}
+		}()
+	}
 
 	var gqlErrs error
 	if resp, rerr = processQuery(ctx, qc); rerr != nil {
@@ -1284,14 +1296,6 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (
 		ProcessingNs:      uint64(l.Processing.Nanoseconds()),
 		EncodingNs:        uint64(l.Json.Nanoseconds()),
 		TotalNs:           uint64((time.Since(l.Start)).Nanoseconds()),
-	}
-	if x.WorkerConfig.AclEnabled {
-		// attach the hash, user should send this hash when further operating on this startTs.
-		ns, err := x.ExtractNamespace(ctx)
-		if err != nil {
-			return nil, err
-		}
-		resp.Txn.Hash = getHash(ns, resp.Txn.StartTs)
 	}
 	md := metadata.Pairs(x.DgraphCostHeader, fmt.Sprint(resp.Metrics.NumUids["_total"]))
 	grpc.SendHeader(ctx, md)


### PR DESCRIPTION
We were setting the hash after completing the transaction successfully. This leads to the failure of the commit as it won't contain the hash. This PR fixes that issue.

(cherry picked from commit ae029f0e24189fc28c1dbc0e81bfc3078d4370a1)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
