### PR TITLE
perf(dgraph): Avoid redundant sorting

### DIFF
--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -426,7 +426,7 @@ func mutationHandler(w http.ResponseWriter, r *http.Request) {
 		Latency: resp.Latency,
 	}
 	sort.Strings(e.Txn.Keys)
-	sort.Strings(e.Txn.Preds)
+	e.Txn.Preds = x.Unique(e.Txn.Preds)
 
 	// Don't send keys array which is part of txn context if its commit immediately.
 	if req.CommitNow {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -249,5 +249,5 @@ func (lc *LocalCache) fillPreds(ctx *api.TxnContext, gid uint32) {
 		predKey := fmt.Sprintf("%d-%s", gid, pk.Attr)
 		ctx.Preds = append(ctx.Preds, predKey)
 	}
-	ctx.Preds = x.Unique(ctx.Preds)
+	// ctx.Preds = x.Unique(ctx.Preds)
 }

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -266,7 +266,7 @@ func (txn *Txn) FillContext(ctx *api.TxnContext, gid uint32) {
 		fps := strconv.FormatUint(key, 36)
 		ctx.Keys = append(ctx.Keys, fps)
 	}
-	ctx.Keys = x.Unique(ctx.Keys)
+	// ctx.Keys = x.Unique(ctx.Keys)
 
 	txn.Unlock()
 	txn.cache.fillPreds(ctx, gid)

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -832,7 +832,7 @@ func CommitOverNetwork(ctx context.Context, tc *api.TxnContext) (uint64, error) 
 
 	// Do de-duplication before sending the request to zero.
 	tc.Keys = x.Unique(tc.Keys)
-	tc.Preds = x.Unique(tc.Preds)
+	// tc.Preds = x.Unique(tc.Preds)
 
 	zc := pb.NewZeroClient(pl.Get())
 	tctx, err := zc.CommitOrAbort(ctx, tc)


### PR DESCRIPTION
Repeatedly sending mutations under a single transaction in Dgraph are slow. The reason for this is:

- We sort Preds upon every mutation to remove duplicates.
- We sort Preds again upon committing.
- This is slow and redundant, since the Zero only needs to iterate over Preds once, and the duplicates won't matter.

Downsides of removing these sorts are:
- Any client using Dgraph will now get duplicates in their `response.Txn.Preds` field.
- The `/mutate` endpoint returns duplicate Preds too. I added logic here to do deduplication in the `mutationHandler`.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7788)
<!-- Reviewable:end -->
