### PR TITLE
feat(multi-tenancy): make drop data namespace aware

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -46,6 +46,9 @@ func ResetAcl(closer *z.Closer) {
 	// do nothing
 }
 
+func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
+}
+
 // ResetAcls is an empty method since ACL is only supported in the enterprise version.
 func RefreshAcls(closer *z.Closer) {
 	// do nothing

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -47,6 +47,7 @@ func ResetAcl(closer *z.Closer) {
 }
 
 func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
+	// do nothing
 }
 
 // ResetAcls is an empty method since ACL is only supported in the enterprise version.

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -411,14 +411,6 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	}
 
 	if op.DropOp == api.Operation_DATA {
-		if x.Config.BlockClusterWideDrop {
-			glog.V(2).Info("Blocked drop-data because it is not permitted.")
-			return empty, errors.New("Drop data operation is not permitted.")
-		}
-		if err := AuthGuardianOfTheGalaxy(ctx); err != nil {
-			return empty, errors.Wrapf(err, "Drop data can only be called by the guardian of the"+
-				" galaxy")
-		}
 		if len(op.DropValue) > 0 {
 			return empty, errors.Errorf("If DropOp is set to DATA, DropValue must be empty")
 		}
@@ -430,13 +422,14 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		}
 
 		m.DropOp = pb.Mutations_DATA
+		m.DropValue = fmt.Sprintf("%#x", namespace)
 		_, err = query.ApplyMutations(ctx, m)
 		if err != nil {
 			return empty, err
 		}
 
 		// insert a helper record for backup & restore, indicating that drop_data was done
-		err = InsertDropRecord(ctx, "DROP_DATA;")
+		err = InsertDropRecord(ctx, fmt.Sprintf("DROP_DATA;%#x", namespace))
 		if err != nil {
 			return empty, err
 		}
@@ -444,7 +437,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		// just reinsert the GraphQL schema, no need to alter dgraph schema as this was drop_data
 		_, err = UpdateGQLSchema(ctx, graphQLSchema, "")
 		// recreate the admin account after a drop data operation
-		ResetAcl(nil)
+		upsertGuardianAndGroot(nil, namespace)
 		return empty, err
 	}
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -19,6 +19,7 @@ package posting
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -1236,9 +1237,12 @@ func DeleteAll() error {
 	return pstore.DropAll()
 }
 
-// DeleteData deletes all data but leaves types and schema intact.
-func DeleteData() error {
-	return pstore.DropPrefix([]byte{x.DefaultPrefix})
+// DeleteData deletes all data for the namespace but leaves types and schema intact.
+func DeleteData(ns uint64) error {
+	prefix := make([]byte, 9)
+	prefix[0] = x.DefaultPrefix
+	binary.BigEndian.PutUint64(prefix[1:], ns)
+	return pstore.DropPrefix(prefix)
 }
 
 // DeletePredicate deletes all entries and indices for a given predicate. The delete may be logical

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -18,6 +18,7 @@ package posting
 
 import (
 	"context"
+	"encoding/hex"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -246,6 +247,23 @@ func (o *oracle) ResetTxns() {
 	o.Lock()
 	defer o.Unlock()
 	o.pendingTxns = make(map[uint64]*Txn)
+}
+
+// ResetTxnForNs deletes all the pending transactions for a given namespace.
+func (o *oracle) ResetTxnsForNs(ns uint64) {
+	txns := o.IterateTxns(func(key []byte) bool {
+		pk, err := x.Parse(key)
+		if err != nil {
+			glog.Errorf("error %v while parsing key %v", err, hex.EncodeToString(key))
+			return false
+		}
+		return x.ParseNamespace(pk.Attr) == ns
+	})
+	o.Lock()
+	defer o.Unlock()
+	for _, txn := range txns {
+		delete(o.pendingTxns, txn)
+	}
 }
 
 func (o *oracle) GetTxn(startTs uint64) *Txn {

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -663,8 +663,9 @@ func checkAndGetDropOp(key []byte, l *posting.List, readTs uint64) (*pb.DropOper
 		}
 		// A dgraph.drop.op record can have values in only one of the following formats:
 		// * DROP_ALL;
-		// * DROP_DATA;
+		// * DROP_DATA;ns
 		// * DROP_ATTR;attrName
+		// * DROP_NS;ns
 		// So, accordingly construct the *pb.DropOperation.
 		dropOp := &pb.DropOperation{}
 		dropInfo := strings.Split(string(val), ";")
@@ -676,6 +677,7 @@ func checkAndGetDropOp(key []byte, l *posting.List, readTs uint64) (*pb.DropOper
 			dropOp.DropOp = pb.DropOperation_ALL
 		case "DROP_DATA":
 			dropOp.DropOp = pb.DropOperation_DATA
+			dropOp.DropValue = dropInfo[1] // contains namespace.
 		case "DROP_ATTR":
 			dropOp.DropOp = pb.DropOperation_ATTR
 			dropOp.DropValue = dropInfo[1]

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -430,7 +430,7 @@ func toCDCEvent(index uint64, mutation *pb.Mutations) []CDCEvent {
 		case pb.Mutations_TYPE:
 			namespace, t = x.ParseNamespaceBytes(mutation.DropValue)
 		default:
-			panic("unhandled drop operation")
+			glog.Error("CDC: got unhandled drop operation")
 		}
 
 		return []CDCEvent{

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -325,9 +325,9 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 			return err
 		}
 
-		// Clear entire cache.
-		// TODO(Naman): Would it be okay for now to reset cluster wide cache on drop data.
-		posting.ResetCache()
+		// TODO: Revisit this when we work on posting cache. Clear entire cache.
+		// We don't want to drop entire cache, just due to one namespace.
+		// posting.ResetCache()
 		return nil
 	}
 

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -611,9 +611,13 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 					delete(predSet, p)
 				}
 			}
+			localDropNs := make(map[uint64]struct{})
+			for ns := range dropNs {
+				localDropNs[ns] = struct{}{}
+			}
 			in := &loadBackupInput{
 				preds:     predSet,
-				dropNs:    dropNs,
+				dropNs:    localDropNs,
 				isOld:     manifest.Version == 0,
 				restoreTs: req.RestoreTs,
 				// Only map the schema keys corresponding to the latest backup.


### PR DESCRIPTION
This PR makes DropData namespace-aware in a multi-tenant system. Now, guardians of a namespace can call drop data on their namespace. Earlier only the guardian of the galaxy was allowed to do cluster-wide drop operation.  
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7789)
<!-- Reviewable:end -->
