### PR TITLE
opt(predMove): iterate Phase I till there is major data to move

### DIFF
--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -201,6 +201,8 @@ func (s *Server) movePredicate(predicate string, srcGroup, dstGroup uint32) erro
 		}
 		took := time.Since(start)
 		if took < phaseOneThreshold || counter > 3 {
+			// If we already did atleast 3 iterations in Phase I or the last iteration took less
+			// than phaseOneThreshold, then move to Phase II.
 			msg := fmt.Sprintf("Done Phase I: took %s at counter: %d", took, counter)
 			span.Annotate(nil, msg)
 			glog.Infof(msg)

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -245,20 +245,20 @@ func (w *grpcWorker) MovePredicate(ctx context.Context,
 	glog.Info(msg)
 	span.Annotate(nil, msg)
 
-	err = movePredicateHelper(ctx, in)
+	payload, err := movePredicateHelper(ctx, in)
 	if err != nil {
 		span.Annotatef(nil, "Error while movePredicateHelper: %v", err)
 	}
-	return &emptyPayload, err
+	return payload, nil
 }
 
-func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error {
+func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) (*api.Payload, error) {
 	// Note: Manish thinks it *should* be OK for a predicate receiver to not have to stop other
 	// operations like snapshots and rollups. Note that this is the sender. This should stop other
 	// operations.
 	closer, err := groups().Node.startTask(opPredMove)
 	if err != nil {
-		return errors.Wrapf(err, "unable to start task opPredMove")
+		return nil, errors.Wrapf(err, "unable to start task opPredMove")
 	}
 	defer closer.Done()
 
@@ -266,12 +266,12 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 
 	pl := groups().Leader(in.DestGid)
 	if pl == nil {
-		return errors.Errorf("Unable to find a connection for group: %d\n", in.DestGid)
+		return nil, errors.Errorf("Unable to find a connection for group: %d\n", in.DestGid)
 	}
 	c := pb.NewWorkerClient(pl.Get())
 	out, err := c.ReceivePredicate(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "while calling ReceivePredicate")
+		return nil, errors.Wrapf(err, "while calling ReceivePredicate")
 	}
 
 	// This txn is only reading the schema. Doesn't really matter what read timestamp we use,
@@ -287,11 +287,11 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 		// The predicate along with the schema could have been deleted. In that case badger would
 		// return ErrKeyNotFound. We don't want to try and access item.Value() in that case.
 	case err != nil:
-		return err
+		return nil, err
 	default:
 		val, err := item.ValueCopy(nil)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		buf := z.NewBuffer(1024, "PredicateMove.MovePredicateHelper")
 		defer buf.Release()
@@ -311,7 +311,7 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 			Data: buf.Bytes(),
 		}
 		if err := out.Send(kvs); err != nil {
-			return errors.Errorf("while sending: %v", err)
+			return nil, errors.Errorf("while sending: %v", err)
 		}
 	}
 
@@ -362,19 +362,19 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 	}
 	span.Annotatef(nil, "Starting stream list orchestrate")
 	if err := stream.Orchestrate(out.Context()); err != nil {
-		return err
+		return nil, err
 	}
 
 	payload, err := out.CloseAndRecv()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	recvCount, err := strconv.Atoi(string(payload.Data))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	msg := fmt.Sprintf("Receiver %s says it got %d keys.\n", pl.Addr, recvCount)
 	span.Annotate(nil, msg)
 	glog.Infof(msg)
-	return nil
+	return payload, nil
 }


### PR DESCRIPTION
Discuss post: https://discuss.dgraph.io/t/13888
Relates to DGRAPH-3321

This PR adds optimization to predicate move by staying in Phase I, it took more than 20 mins.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7792)
<!-- Reviewable:end -->
