### PR TITLE
cherry-pick v21.03: chore(GraphQL): Improvise error logging (#7791) (GRAPHQL-1208)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -536,7 +536,10 @@ func setupServer(closer *z.Closer) {
 	baseMux.HandleFunc("/graphql", func(w http.ResponseWriter, r *http.Request) {
 		namespace := x.ExtractNamespaceHTTP(r)
 		r.Header.Set("resolver", strconv.FormatUint(namespace, 10))
-		admin.LazyLoadSchema(namespace)
+		if err := admin.LazyLoadSchema(namespace); err != nil {
+			admin.WriteErrorResponse(w, r, err)
+			return
+		}
 		mainServer.HTTPHandler().ServeHTTP(w, r)
 	})
 
@@ -546,7 +549,10 @@ func setupServer(closer *z.Closer) {
 		r.Header.Set("resolver", "0")
 		// We don't need to load the schema for all the admin operations.
 		// Only a few like getUser, queryGroup require this. So, this can be optimized.
-		admin.LazyLoadSchema(x.ExtractNamespaceHTTP(r))
+		if err := admin.LazyLoadSchema(x.ExtractNamespaceHTTP(r)); err != nil {
+			admin.WriteErrorResponse(w, r, err)
+			return
+		}
 		allowedMethodsHandler(allowedMethods{
 			http.MethodGet:     true,
 			http.MethodPost:    true,

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -185,7 +185,7 @@ func GetGQLSchema(namespace uint64) (uid, graphQLSchema string, err error) {
 	sort.Slice(res, func(i, j int) bool {
 		return res[i].UidInt < res[j].UidInt
 	})
-	glog.Errorf("Multiple schema node found, using the last one")
+	glog.Errorf("namespace: %d. Multiple schema nodes found, using the last one", namespace)
 	resLast := res[len(res)-1]
 	return resLast.Uid, resLast.Schema, nil
 }

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -673,11 +673,15 @@ func newAdminResolver(
 
 		server.mux.RLock()
 		currentSchema, ok := server.schema[ns]
-		if ok && (newSchema.Version <= currentSchema.Version || newSchema.Schema == currentSchema.Schema) {
-			glog.Infof("Skipping GraphQL schema update, new badger key version is %d, the old version was %d.",
-				newSchema.Version, currentSchema.Version)
-			server.mux.RUnlock()
-			return
+		if ok {
+			schemaChanged := newSchema.Schema == currentSchema.Schema
+			if newSchema.Version <= currentSchema.Version || schemaChanged {
+				glog.Infof("namespace: %d. Skipping GraphQL schema update. "+
+					"newSchema.Version: %d, oldSchema.Version: %d, schemaChanged: %v.",
+					ns, newSchema.Version, currentSchema.Version, schemaChanged)
+				server.mux.RUnlock()
+				return
+			}
 		}
 		server.mux.RUnlock()
 
@@ -686,7 +690,7 @@ func newAdminResolver(
 		if newSchema.Schema != "" {
 			gqlSchema, err = generateGQLSchema(newSchema, ns)
 			if err != nil {
-				glog.Errorf("Error processing GraphQL schema: %s.  ", err)
+				glog.Errorf("namespace: %d. Error processing GraphQL schema: %s.", ns, err)
 				return
 			}
 		}
@@ -700,7 +704,8 @@ func newAdminResolver(
 		if !(ok && currentSchema.loaded) {
 			// this just set schema in admin server, so that next invalid badger subscription update gets rejected upfront
 			server.schema[ns] = newSchema
-			glog.Infof("Skipping in-memory GraphQL schema update, it will be lazy-loaded later.")
+			glog.Infof("namespace: %d. Skipping in-memory GraphQL schema update, "+
+				"it will be lazy-loaded later.", ns)
 			return
 		}
 
@@ -709,7 +714,8 @@ func newAdminResolver(
 		server.schema[ns] = newSchema
 		server.resetSchema(ns, gqlSchema)
 
-		glog.Infof("Successfully updated GraphQL schema. Serving New GraphQL API.")
+		glog.Infof("namespace: %d. Successfully updated GraphQL schema. "+
+			"Serving New GraphQL API.", ns)
 	}, 1, closer)
 
 	go server.initServer()
@@ -821,7 +827,7 @@ func (as *adminServer) initServer() {
 
 		sch, err := getCurrentGraphQLSchema(x.GalaxyNamespace)
 		if err != nil {
-			glog.Infof("Error reading GraphQL schema: %s.", err)
+			glog.Errorf("namespace: %d. Error reading GraphQL schema: %s.", x.GalaxyNamespace, err)
 			continue
 		}
 		sch.loaded = true
@@ -832,19 +838,22 @@ func (as *adminServer) initServer() {
 		mainHealthStore.up()
 
 		if sch.Schema == "" {
-			glog.Infof("No GraphQL schema in Dgraph; serving empty GraphQL API")
+			glog.Infof("namespace: %d. No GraphQL schema in Dgraph; serving empty GraphQL API",
+				x.GalaxyNamespace)
 			break
 		}
 
 		generatedSchema, err := generateGQLSchema(sch, x.GalaxyNamespace)
 		if err != nil {
-			glog.Infof("Error processing GraphQL schema: %s.", err)
+			glog.Errorf("namespace: %d. Error processing GraphQL schema: %s.",
+				x.GalaxyNamespace, err)
 			break
 		}
 		as.incrementSchemaUpdateCounter(x.GalaxyNamespace)
 		as.resetSchema(x.GalaxyNamespace, generatedSchema)
 
-		glog.Infof("Successfully loaded GraphQL schema.  Serving GraphQL API.")
+		glog.Infof("namespace: %d. Successfully loaded GraphQL schema.  Serving GraphQL API.",
+			x.GalaxyNamespace)
 
 		break
 	}
@@ -987,20 +996,20 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 	mainHealthStore.up()
 }
 
-func (as *adminServer) lazyLoadSchema(namespace uint64) {
+func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 	// if the schema is already in memory, no need to fetch it from disk
 	as.mux.RLock()
 	if currentSchema, ok := as.schema[namespace]; ok && currentSchema.loaded {
 		as.mux.RUnlock()
-		return
+		return nil
 	}
 	as.mux.RUnlock()
 
 	// otherwise, fetch the schema from disk
 	sch, err := getCurrentGraphQLSchema(namespace)
 	if err != nil {
-		glog.Infof("Error reading GraphQL schema: %s.", err)
-		return
+		glog.Errorf("namespace: %d. Error reading GraphQL schema: %s.", namespace, err)
+		return errors.Wrap(err, "failed to lazy-load GraphQL schema")
 	}
 
 	var generatedSchema schema.Schema
@@ -1008,12 +1017,13 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) {
 		// if there was no schema stored in Dgraph, we still need to attach resolvers to the main
 		// graphql server which should just return errors for any incoming request.
 		// generatedSchema will be nil in this case
-		glog.Infof("No GraphQL schema in Dgraph; serving empty GraphQL API")
+		glog.Infof("namespace: %d. No GraphQL schema in Dgraph; serving empty GraphQL API",
+			namespace)
 	} else {
 		generatedSchema, err = generateGQLSchema(sch, namespace)
 		if err != nil {
-			glog.Infof("Error processing GraphQL schema: %s.", err)
-			return
+			glog.Errorf("namespace: %d. Error processing GraphQL schema: %s.", namespace, err)
+			return errors.Wrap(err, "failed to lazy-load GraphQL schema")
 		}
 	}
 
@@ -1023,11 +1033,12 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) {
 	as.schema[namespace] = sch
 	as.resetSchema(namespace, generatedSchema)
 
-	glog.Infof("Successfully lazy-loaded GraphQL schema.")
+	glog.Infof("namespace: %d. Successfully lazy-loaded GraphQL schema.", namespace)
+	return nil
 }
 
-func LazyLoadSchema(namespace uint64) {
-	adminServerVar.lazyLoadSchema(namespace)
+func LazyLoadSchema(namespace uint64) error {
+	return adminServerVar.lazyLoadSchema(namespace)
 }
 
 func inputArgError(err error) error {

--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -124,15 +124,31 @@ func write(w http.ResponseWriter, rr *schema.Response, acceptGzip bool) {
 	}
 }
 
+// WriteErrorResponse writes the error to the HTTP response writer in GraphQL format.
+func WriteErrorResponse(w http.ResponseWriter, r *http.Request, err error) {
+	write(w, schema.ErrorResponse(err), strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
+}
+
 type graphqlSubscription struct {
 	graphqlHandler *graphqlHandler
 }
 
-func (gs *graphqlSubscription) isValid(namespace uint64) bool {
+func (gs *graphqlSubscription) isValid(namespace uint64) error {
 	gs.graphqlHandler.pollerMux.RLock()
 	defer gs.graphqlHandler.pollerMux.RUnlock()
-	return !(gs == nil || !gs.graphqlHandler.isValid(namespace) || gs.graphqlHandler.
-		poller == nil || gs.graphqlHandler.poller[namespace] == nil)
+	if gs == nil {
+		return errors.New("gs is nil")
+	}
+	if err := gs.graphqlHandler.isValid(namespace); err != nil {
+		return err
+	}
+	if gs.graphqlHandler.poller == nil {
+		return errors.New("poller is nil")
+	}
+	if gs.graphqlHandler.poller[namespace] == nil {
+		return errors.New("poller not found")
+	}
+	return nil
 }
 
 func (gs *graphqlSubscription) Subscribe(
@@ -167,7 +183,8 @@ func (gs *graphqlSubscription) Subscribe(
 	}
 	namespace := x.ExtractNamespaceHTTP(&http.Request{Header: reqHeader})
 	LazyLoadSchema(namespace) // first load the schema, then do anything else
-	if !gs.isValid(namespace) {
+	if err = gs.isValid(namespace); err != nil {
+		glog.Errorf("namespace: %d. graphqlSubscription not initialized: %s", namespace, err)
 		return nil, errors.New(resolve.ErrInternal)
 	}
 
@@ -203,8 +220,10 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	ns, _ := strconv.ParseUint(r.Header.Get("resolver"), 10, 64)
-	if !gh.isValid(ns) {
-		x.Panic(errors.New("graphqlHandler not initialised"))
+	if err := gh.isValid(ns); err != nil {
+		glog.Errorf("namespace: %d. graphqlHandler not initialised: %s", ns, err)
+		WriteErrorResponse(w, r, errors.New(resolve.ErrInternal))
+		return
 	}
 
 	gh.resolverMux.RLock()
@@ -227,12 +246,12 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	gqlReq, err := getRequest(r)
 
 	if err != nil {
-		write(w, schema.ErrorResponse(err), strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
+		WriteErrorResponse(w, r, err)
 		return
 	}
 
 	if err = edgraph.ProcessPersistedQuery(ctx, gqlReq); err != nil {
-		write(w, schema.ErrorResponse(err), strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
+		WriteErrorResponse(w, r, err)
 		return
 	}
 
@@ -240,11 +259,22 @@ func (gh *graphqlHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	write(w, res, strings.Contains(r.Header.Get("Accept-Encoding"), "gzip"))
 }
 
-func (gh *graphqlHandler) isValid(namespace uint64) bool {
+func (gh *graphqlHandler) isValid(namespace uint64) error {
 	gh.resolverMux.RLock()
 	defer gh.resolverMux.RUnlock()
-	return !(gh == nil || gh.resolver == nil || gh.resolver[namespace] == nil || gh.
-		resolver[namespace].Schema() == nil || gh.resolver[namespace].Schema().Meta() == nil)
+	switch {
+	case gh == nil:
+		return errors.New("gh is nil")
+	case gh.resolver == nil:
+		return errors.New("resolver is nil")
+	case gh.resolver[namespace] == nil:
+		return errors.New("resolver not found")
+	case gh.resolver[namespace].Schema() == nil:
+		return errors.New("schema is nil")
+	case gh.resolver[namespace].Schema().Meta() == nil:
+		return errors.New("schema meta is nil")
+	}
+	return nil
 }
 
 type gzreadCloser struct {


### PR DESCRIPTION
This PR replaces a panic with a user-facing error. In addition, it also adds the current namespace in logs where possible. That enables better error debugging.

(cherry picked from commit d2f1d81e46339fe8b87d16284add6a1b92c1f2fc)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7793)
<!-- Reviewable:end -->
