### PR TITLE
feat(multi-tenancy): make drop data namespace aware (#7789)

### DIFF
--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -46,6 +46,10 @@ func ResetAcl(closer *z.Closer) {
 	// do nothing
 }
 
+func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
+	// do nothing
+}
+
 // ResetAcls is an empty method since ACL is only supported in the enterprise version.
 func RefreshAcls(closer *z.Closer) {
 	// do nothing

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -426,14 +426,6 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 	}
 
 	if op.DropOp == api.Operation_DATA {
-		if x.Config.BlockClusterWideDrop {
-			glog.V(2).Info("Blocked drop-data because it is not permitted.")
-			return empty, errors.New("Drop data operation is not permitted.")
-		}
-		if err := AuthGuardianOfTheGalaxy(ctx); err != nil {
-			return empty, errors.Wrapf(err, "Drop data can only be called by the guardian of the"+
-				" galaxy")
-		}
 		if len(op.DropValue) > 0 {
 			return empty, errors.Errorf("If DropOp is set to DATA, DropValue must be empty")
 		}
@@ -445,13 +437,14 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		}
 
 		m.DropOp = pb.Mutations_DATA
+		m.DropValue = fmt.Sprintf("%#x", namespace)
 		_, err = query.ApplyMutations(ctx, m)
 		if err != nil {
 			return empty, err
 		}
 
 		// insert a helper record for backup & restore, indicating that drop_data was done
-		err = InsertDropRecord(ctx, "DROP_DATA;")
+		err = InsertDropRecord(ctx, fmt.Sprintf("DROP_DATA;%#x", namespace))
 		if err != nil {
 			return empty, err
 		}
@@ -459,7 +452,7 @@ func (s *Server) Alter(ctx context.Context, op *api.Operation) (*api.Payload, er
 		// just reinsert the GraphQL schema, no need to alter dgraph schema as this was drop_data
 		_, err = UpdateGQLSchema(ctx, graphQLSchema, "")
 		// recreate the admin account after a drop data operation
-		ResetAcl(nil)
+		upsertGuardianAndGroot(nil, namespace)
 		return empty, err
 	}
 

--- a/posting/index.go
+++ b/posting/index.go
@@ -19,6 +19,7 @@ package posting
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -1222,9 +1223,12 @@ func DeleteAll() error {
 	return pstore.DropAll()
 }
 
-// DeleteData deletes all data but leaves types and schema intact.
-func DeleteData() error {
-	return pstore.DropPrefix([]byte{x.DefaultPrefix})
+// DeleteData deletes all data for the namespace but leaves types and schema intact.
+func DeleteData(ns uint64) error {
+	prefix := make([]byte, 9)
+	prefix[0] = x.DefaultPrefix
+	binary.BigEndian.PutUint64(prefix[1:], ns)
+	return pstore.DropPrefix(prefix)
 }
 
 // DeletePredicate deletes all entries and indices for a given predicate. The delete may be logical

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -682,8 +682,9 @@ func checkAndGetDropOp(key []byte, l *posting.List, readTs uint64) (*pb.DropOper
 		}
 		// A dgraph.drop.op record can have values in only one of the following formats:
 		// * DROP_ALL;
-		// * DROP_DATA;
+		// * DROP_DATA;ns
 		// * DROP_ATTR;attrName
+		// * DROP_NS;ns
 		// So, accordingly construct the *pb.DropOperation.
 		dropOp := &pb.DropOperation{}
 		dropInfo := strings.Split(string(val), ";")
@@ -695,6 +696,7 @@ func checkAndGetDropOp(key []byte, l *posting.List, readTs uint64) (*pb.DropOper
 			dropOp.DropOp = pb.DropOperation_ALL
 		case "DROP_DATA":
 			dropOp.DropOp = pb.DropOperation_DATA
+			dropOp.DropValue = dropInfo[1] // contains namespace.
 		case "DROP_ATTR":
 			dropOp.DropOp = pb.DropOperation_ATTR
 			dropOp.DropValue = dropInfo[1]

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -504,6 +505,10 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 	span := otrace.FromContext(ctx)
 
 	if proposal.Mutations.DropOp == pb.Mutations_DATA {
+		ns, err := strconv.ParseUint(proposal.Mutations.DropValue, 0, 64)
+		if err != nil {
+			return err
+		}
 		// Ensures nothing get written to disk due to commit proposals.
 		n.keysWritten.rejectBeforeIndex = proposal.Index
 
@@ -511,13 +516,14 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 		n.stopTask(opRollup)
 		defer n.startTask(opRollup)
 
-		posting.Oracle().ResetTxns()
-		if err := posting.DeleteData(); err != nil {
+		posting.Oracle().ResetTxnsForNs(ns)
+		if err := posting.DeleteData(ns); err != nil {
 			return err
 		}
 
-		// Clear entire cache.
-		posting.ResetCache()
+		// TODO: Revisit this when we work on posting cache. Clear entire cache.
+		// We don't want to drop entire cache, just due to one namespace.
+		// posting.ResetCache()
 		return nil
 	}
 

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -103,11 +103,12 @@ func (br *backupReader) WithCompression(comp string) *backupReader {
 }
 
 type loadBackupInput struct {
-	restoreTs      uint64
-	preds          predicateSet
-	dropOperations []*pb.DropOperation
-	isOld          bool
-	keepSchema     bool
+	restoreTs   uint64
+	preds       predicateSet
+	dropNs      map[uint64]struct{}
+	isOld       bool
+	keepSchema  bool
+	compression string
 }
 
 type listReq struct {
@@ -296,7 +297,7 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 				"Unexpected meta: %v for key: %s", kv.UserMeta, hex.Dump(kv.Key))
 		}
 
-		restoreKey, _, err := fromBackupKey(kv.Key)
+		restoreKey, ns, err := fromBackupKey(kv.Key)
 		if err != nil {
 			return errors.Wrap(err, "fromBackupKey")
 		}
@@ -317,6 +318,9 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 
 		switch kv.GetUserMeta()[0] {
 		case posting.BitEmptyPosting, posting.BitCompletePosting, posting.BitDeltaPosting:
+			if _, ok := in.dropNs[ns]; ok {
+				return nil
+			}
 			backupPl := &pb.BackupPostingList{}
 			if err := backupPl.Unmarshal(kv.Value); err != nil {
 				return errors.Wrapf(err, "while reading backup posting list")
@@ -577,6 +581,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 
 	dropAll := false
 	dropAttr := make(map[string]struct{})
+	dropNs := make(map[uint64]struct{})
 
 	// manifests are ordered as: latest..full
 	for i, manifest := range manifests {
@@ -610,11 +615,15 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 					delete(predSet, p)
 				}
 			}
+			localDropNs := make(map[uint64]struct{})
+			for ns := range dropNs {
+				localDropNs[ns] = struct{}{}
+			}
 			in := &loadBackupInput{
-				preds:          predSet,
-				dropOperations: manifest.DropOperations,
-				isOld:          manifest.Version == 0,
-				restoreTs:      req.RestoreTs,
+				preds:     predSet,
+				dropNs:    localDropNs,
+				isOld:     manifest.Version == 0,
+				restoreTs: req.RestoreTs,
 				// Only map the schema keys corresponding to the latest backup.
 				keepSchema: i == 0,
 			}
@@ -633,12 +642,15 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) error {
 			case pb.DropOperation_ALL:
 				dropAll = true
 			case pb.DropOperation_DATA:
-				dropAll = true
+				ns, err := strconv.ParseUint(op.DropValue, 0, 64)
+				if err != nil {
+					return errors.Wrap(err, "Map phase failed to parse namespace")
+				}
+				dropNs[ns] = struct{}{}
 			case pb.DropOperation_ATTR:
 				dropAttr[op.DropValue] = struct{}{}
 			case pb.DropOperation_NS:
 				// If there is a drop namespace, we just ban the namespace in the pstore.
-				// TODO: We probably need to propose ban request.
 				ns, err := strconv.ParseUint(op.DropValue, 0, 64)
 				if err != nil {
 					return errors.Wrapf(err, "Map phase failed to parse namespace")


### PR DESCRIPTION
This PR makes DropData namespace-aware in a multi-tenant system. Now, guardians of a namespace can call drop data on their namespace. Earlier only the guardian of the galaxy was allowed to do cluster-wide drop operation.

(cherry picked from commit 260a7896ef07f0c110f34075de2c615a312352a3)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
