### PR TITLE
Feat(Multi-tenancy): Add namespaces field to state

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -150,6 +150,10 @@ const (
 		removed: [Member]
 		cid: String
 		license: License
+		"""
+		Contains list of namespaces. Note that this is not stored in proto's MembershipState and
+		computed at the time of query.
+		"""
 		namespaces: [UInt64]
 	}
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -150,6 +150,7 @@ const (
 		removed: [Member]
 		cid: String
 		license: License
+		namespaces: [UInt64]
 	}
 
 	type ClusterGroup {

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -117,7 +117,7 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 	state.License = ms.License
 
 	state.Namespaces = []uint64{}
-	for ns, _ := range namespaces {
+	for ns := range namespaces {
 		state.Namespaces = append(state.Namespaces, ns)
 	}
 

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -15,16 +15,17 @@ import (
 )
 
 type membershipState struct {
-	Counter   uint64         `json:"counter,omitempty"`
-	Groups    []clusterGroup `json:"groups,omitempty"`
-	Zeros     []*pb.Member   `json:"zeros,omitempty"`
-	MaxUID    uint64         `json:"maxUID,omitempty"`
-	MaxNsID   uint64         `json:"maxNsID,omitempty"`
-	MaxTxnTs  uint64         `json:"maxTxnTs,omitempty"`
-	MaxRaftId uint64         `json:"maxRaftId,omitempty"`
-	Removed   []*pb.Member   `json:"removed,omitempty"`
-	Cid       string         `json:"cid,omitempty"`
-	License   *pb.License    `json:"license,omitempty"`
+	Counter    uint64         `json:"counter,omitempty"`
+	Groups     []clusterGroup `json:"groups,omitempty"`
+	Zeros      []*pb.Member   `json:"zeros,omitempty"`
+	MaxUID     uint64         `json:"maxUID,omitempty"`
+	MaxNsID    uint64         `json:"maxNsID,omitempty"`
+	MaxTxnTs   uint64         `json:"maxTxnTs,omitempty"`
+	MaxRaftId  uint64         `json:"maxRaftId,omitempty"`
+	Removed    []*pb.Member   `json:"removed,omitempty"`
+	Cid        string         `json:"cid,omitempty"`
+	License    *pb.License    `json:"license,omitempty"`
+	Namespaces []uint64       `json:"namespaces,omitempty"`
 }
 
 type clusterGroup struct {
@@ -78,6 +79,9 @@ func resolveState(ctx context.Context, q schema.Query) *resolve.Resolved {
 func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 	var state membershipState
 
+	// namespaces stores set of namespaces
+	namespaces := make(map[uint64]bool)
+
 	state.Counter = ms.Counter
 	for k, v := range ms.Groups {
 		var members = make([]*pb.Member, 0, len(v.Members))
@@ -85,8 +89,12 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 			members = append(members, v1)
 		}
 		var tablets = make([]*pb.Tablet, 0, len(v.Tablets))
-		for _, v1 := range v.Tablets {
+		for name, v1 := range v.Tablets {
 			tablets = append(tablets, v1)
+			val, err := x.ExtractNamespaceFromPredicate(name)
+			if err == nil {
+				namespaces[val] = true
+			}
 		}
 		state.Groups = append(state.Groups, clusterGroup{
 			Id:         k,
@@ -107,6 +115,11 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 	state.Removed = ms.Removed
 	state.Cid = ms.Cid
 	state.License = ms.License
+
+	state.Namespaces = []uint64{}
+	for ns, _ := range namespaces {
+		state.Namespaces = append(state.Namespaces, ns)
+	}
 
 	return state
 }

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -80,7 +80,7 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 	var state membershipState
 
 	// namespaces stores set of namespaces
-	namespaces := make(map[uint64]bool)
+	namespaces := make(map[uint64]struct{})
 
 	state.Counter = ms.Counter
 	for k, v := range ms.Groups {
@@ -93,7 +93,7 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 			tablets = append(tablets, v1)
 			val, err := x.ExtractNamespaceFromPredicate(name)
 			if err == nil {
-				namespaces[val] = true
+				namespaces[val] = struct{}{}
 			}
 		}
 		state.Groups = append(state.Groups, clusterGroup{

--- a/x/keys.go
+++ b/x/keys.go
@@ -122,13 +122,13 @@ func ExtractNamespaceFromPredicate(predicate string) (uint64, error) {
 	splitString := strings.Split(predicate, "-")
 	if len(splitString) <= 1 {
 		return 0, errors.Errorf("predicate does not contain namespace name")
-	} else {
-		uintVal, err := strconv.ParseUint(splitString[0], 0, 64)
-		if err != nil {
-			return 0, errors.Wrapf(err, "while parsing %s as uint64", splitString[0])
-		}
-		return uintVal, nil
 	}
+	uintVal, err := strconv.ParseUint(splitString[0], 0, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "while parsing %s as uint64", splitString[0])
+	}
+	return uintVal, nil
+
 }
 
 func writeAttr(buf []byte, attr string) []byte {

--- a/x/keys.go
+++ b/x/keys.go
@@ -118,6 +118,19 @@ func FormatNsAttr(attr string) string {
 	return strconv.FormatUint(ns, 10) + "-" + attr
 }
 
+func ExtractNamespaceFromPredicate(predicate string) (uint64, error) {
+	splitString := strings.Split(predicate, "-")
+	if len(splitString) <= 1 {
+		return 0, errors.Errorf("predicate does not contain namespace name")
+	} else {
+		uintVal, err := strconv.ParseUint(splitString[0], 0, 64)
+		if err != nil {
+			return 0, errors.Wrapf(err, "while parsing %s as uint64", splitString[0])
+		}
+		return uintVal, nil
+	}
+}
+
 func writeAttr(buf []byte, attr string) []byte {
 	AssertTrue(len(attr) < math.MaxUint16)
 	binary.BigEndian.PutUint16(buf[:2], uint16(len(attr)))


### PR DESCRIPTION
Motivation:
Currently, there is no way to query namespaces. This adds namespaces field to state. This field can be used to query list of namespaces.
Note that this will output list of namespace only in case the user is an admin user (guardians of galaxy). In all other cases, it will return an empty list. 

Testing:
1. Added e2e test to ensure that namespaces is returned in case user is guardian of galaxy and not returned in case it is not.

Fixes DGRAPH-3310
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7808)
<!-- Reviewable:end -->
