### PR TITLE
fix: Prevent proposal from being dropped accidentally (#7741)

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1745,6 +1745,7 @@ func (n *node) retryUntilSuccess(fn func() error, pause time.Duration) {
 
 // InitAndStartNode gets called after having at least one membership sync with the cluster.
 func (n *node) InitAndStartNode() {
+	initProposalKey(n.Id)
 	_, restart, err := n.PastLife()
 	x.Check(err)
 

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 
 	ostats "go.opencensus.io/stats"
 	tag "go.opencensus.io/tag"
@@ -108,9 +109,18 @@ func (rl *rateLimiter) decr(retry int) {
 	rl.c.Broadcast()
 }
 
+var proposalKey uint64
+
+// {2 bytes Node ID} {4 bytes for random} {2 bytes zero}
+func initProposalKey(id uint64) {
+	x.AssertTrue(id != 0)
+	proposalKey = uint64(groups().Node.Id)<<48 | uint64(z.FastRand())<<16
+}
+
 // uniqueKey is meant to be unique across all the replicas.
+// initProposalKey should be called before calling uniqueKey.
 func uniqueKey() uint64 {
-	return uint64(groups().Node.Id)<<32 | uint64(groups().Node.Rand.Uint32())
+	return atomic.AddUint64(&proposalKey, 1)
 }
 
 var errInternalRetry = errors.New("Retry Raft proposal internally")


### PR DESCRIPTION
Cherry-pick of #7741 for release/v21.03-slash.

Each proposal in alpha has a unique key but this unique key is not
guaranteed to be unique. We could end up creating duplicate keys and
these duplicate keys would get ignored in the raft loop.

This PR proposes a different way of creating the proposal keys so that
they are always unique.

Fixes - DGRAPH-3012, CLOUD-376

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7814)
<!-- Reviewable:end -->
