### PR TITLE
cherry: fix(dropdata): use galaxynamespace when restore from old backup (#7809)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -673,9 +673,15 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 			case pb.DropOperation_ALL:
 				dropAll = true
 			case pb.DropOperation_DATA:
-				ns, err := strconv.ParseUint(op.DropValue, 0, 64)
-				if err != nil {
-					return nil, errors.Wrap(err, "Map phase failed to parse namespace")
+				var ns uint64
+				if manifest.Version == 0 {
+					ns = x.GalaxyNamespace
+				} else {
+					var err error
+					ns, err = strconv.ParseUint(op.DropValue, 0, 64)
+					if err != nil {
+						return nil, errors.Wrap(err, "Map phase failed to parse namespace")
+					}
 				}
 				dropNs[ns] = struct{}{}
 			case pb.DropOperation_ATTR:


### PR DESCRIPTION
For the backups taken on version < 21.03, we don't have a namespace appended with the drop namespace entry. This PR fix that.

(cherry picked from commit 7981a4d098af69f6f67ee32cba50f677a9f4d985)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7816)
<!-- Reviewable:end -->
