### PR TITLE
chore(release) - update release.sh with GOVERSION=1.15.5 (#7621)

### DIFF
--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -6,13 +6,73 @@
 # binaries and prepare them such that any human or script can then pick these up
 # and use them as they deem fit.
 
+# Path to this script
+scriptdir="$(cd "$(dirname $0)">/dev/null; pwd)"
+# Path to the root repo directory
+repodir="$(cd "$scriptdir/..">/dev/null; pwd)"
+
 # Output colors
 RED='\033[91;1m'
 RESET='\033[0m'
 
+## Toggle Builds
+## TODO: update to use command line flags
+DGRAPH_BUILD_WINDOWS=${DGRAPH_BUILD_WINDOWS:-1}
+DGRAPH_BUILD_MAC=${DGRAPH_BUILD_MAC:-1}
+DGRAPH_BUILD_RATEL=${DGRAPH_BUILD_RATEL:-1}
+DGRAPH_BUILD_AMD64=${DGRAPH_BUILD_AMD64:-1}
+DGRAPH_BUILD_ARM64=${DGRAPH_BUILD_ARM64:-0}
+
+print_error() {
+    printf "$RED$1$RESET\n"
+}
+
+exit_error() {
+    print_error "$@"
+    exit 1
+}
+check_command_exists() {
+    if ! command -v "$1" > /dev/null; then
+        exit_error "$1: command not found"
+    fi
+}
+
+if [ "$#" -lt 1 ]; then
+    exit_error "Usage: $0 commitish [docker_tag]
+
+Examples:
+Build v1.2.3 release binaries
+  $0 v1.2.3
+Build dev/feature-branch branch and tag as dev-abc123 for the Docker image
+  $0 dev/feature-branch dev-abc123"
+fi
+
+
+if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+  check_command_exists nvm
+  check_command_exists npm
+fi
+
+# TODO Check if ports 8000, 9080, or 6080 are bound already and error out early.
+
+check_command_exists strip
+check_command_exists make
+check_command_exists gcc
+check_command_exists go
+check_command_exists docker
+check_command_exists docker-compose
+check_command_exists protoc
+check_command_exists shasum
+check_command_exists tar
+check_command_exists zip
+
 # Don't use standard GOPATH. Create a new one.
 unset GOBIN
-GOPATH="/tmp/go"
+export GOPATH="/tmp/go"
 if [ -d $GOPATH ]; then
    chmod -R 755 $GOPATH
 fi
@@ -23,15 +83,14 @@ mkdir $GOPATH
 PATH="$GOPATH/bin:$PATH"
 
 # The Go version used for release builds must match this version.
-GOVERSION="1.14.1"
-
-# Turn off go modules by default. Only enable go modules when needed.
-export GO111MODULE=off
+GOVERSION=${GOVERSION:-"1.15.5"}
 
 TAG=$1
-# The Docker tag should not contain a slash e.g. feature/issue1234
-# The initial slash is taken from the repository name dgraph/dgraph:tag
-DTAG=$(echo "$TAG" | tr '/' '-')
+
+(
+    cd "$repodir"
+    git cat-file -e "$TAG"
+) || exit_error "Ref $TAG does not exist"
 
 # DO NOT change the /tmp/build directory, because Dockerfile also picks up binaries from there.
 TMP="/tmp/build"
@@ -48,55 +107,53 @@ echo "Building Dgraph for tag: $TAG"
 set -e
 set -o xtrace
 
-# Check for existence of strip tool.
-type strip
-type shasum
-
 ratel_release="github.com/dgraph-io/ratel/server.ratelVersion"
 release="github.com/dgraph-io/dgraph/x.dgraphVersion"
+codenameKey="github.com/dgraph-io/dgraph/x.dgraphCodename"
 branch="github.com/dgraph-io/dgraph/x.gitBranch"
 commitSHA1="github.com/dgraph-io/dgraph/x.lastCommitSHA"
 commitTime="github.com/dgraph-io/dgraph/x.lastCommitTime"
+jemallocXgoFlags=
 
-echo "Using Go version"
-go version
-if [[ ! "$(go version)" =~ $GOVERSION ]]; then
-   echo -e "${RED}Go version is NOT expected. Should be $GOVERSION.${RESET}"
-   exit 1
+# Get xgo and docker image
+if [[ $GOVERSION =~ ^1\.16.* ]]; then
+  # Build xgo docker image with 'go env -w GO111MODULE=auto' to support 1.16.x
+  docker build -f release/xgo.Dockerfile -t dgraph/xgo:go-${GOVERSION} --build-arg GOVERSION=${GOVERSION} .
+  # Instruct xgo to use alternative image
+  export DGRAPH_BUILD_XGO_IMAGE="-image dgraph/xgo:go-${GOVERSION}"
 fi
+go install src.techknowlogick.com/xgo
+mkdir -p ~/.xgo-cache
 
-go get -u github.com/jteeuwen/go-bindata/...
-go get -d google.golang.org/grpc
-go get -u github.com/prometheus/client_golang/prometheus
-go get -u github.com/dgraph-io/dgo
-# go get github.com/stretchr/testify/require
-go get -u github.com/dgraph-io/badger
-go get -u github.com/golang/protobuf/protoc-gen-go
-go get -u github.com/gogo/protobuf/protoc-gen-gofast
-go get -u src.techknowlogick.com/xgo
-
-pushd $GOPATH/src/google.golang.org/grpc
-  git checkout v1.13.0
-popd
 
 basedir=$GOPATH/src/github.com/dgraph-io
+mkdir -p "$basedir"
+
 # Clone Dgraph repo.
 pushd $basedir
-  git clone https://github.com/dgraph-io/dgraph.git
+  git clone "$repodir"
 popd
 
 pushd $basedir/dgraph
-  git pull
   git checkout $TAG
   # HEAD here points to whatever is checked out.
   lastCommitSHA1=$(git rev-parse --short HEAD)
+  codename="$(awk '/^BUILD_CODENAME/ { print $NF }' ./dgraph/Makefile)"
   gitBranch=$(git rev-parse --abbrev-ref HEAD)
   lastCommitTime=$(git log -1 --format=%ci)
   release_version=$(git describe --always --tags)
 popd
 
+# The Docker tag should not contain a slash e.g. feature/issue1234
+# The initial slash is taken from the repository name dgraph/dgraph:tag
+DOCKER_TAG=${2:-$release_version}
+
 # Regenerate protos. Should not be different from what's checked in.
 pushd $basedir/dgraph/protos
+  # We need to fetch the modules to get the correct proto files. e.g., for
+  # badger and dgo
+  go get -d -v ../dgraph
+
   make regenerate
   if [[ "$(git status --porcelain)" ]]; then
       echo >&2 "Generated protos different in release."
@@ -104,111 +161,215 @@ pushd $basedir/dgraph/protos
   fi
 popd
 
-# Clone ratel repo.
+# Clone Badger repo.
 pushd $basedir
-  git clone https://github.com/dgraph-io/ratel.git
+  git clone https://github.com/dgraph-io/badger.git
+  # Check out badger version specific to the Dgraph release.
+  cd ./badger
+  ref="$(grep github.com/dgraph-io/badger/v3 $basedir/dgraph/go.mod | grep -v replace |  awk '{ print $2 }')"
+  commitish="$(echo "$ref" | awk -F- '{ print $NF }')"
+  git checkout "$commitish"
 popd
 
-pushd $basedir/ratel
-  git pull
-  source ~/.nvm/nvm.sh
-  nvm install --lts
-  ./scripts/build.prod.sh
-  ./scripts/test.sh
-popd
+if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+  # Clone ratel repo.
+  pushd $basedir
+    git clone https://github.com/dgraph-io/ratel.git
+  popd
 
-# Build Windows.
-pushd $basedir/dgraph/dgraph
-  xgo -go="go-$GOVERSION" --targets=windows/amd64 -ldflags \
-      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-  mkdir $TMP/windows
-  mv dgraph-windows-4.0-amd64.exe $TMP/windows/dgraph.exe
-popd
+  # build ratel client
+  pushd $basedir/ratel
+    nvm install --lts
+    (export GO111MODULE=off; ./scripts/build.prod.sh)
+    ./scripts/test.sh
+  popd
+fi
 
-pushd $basedir/badger/badger
-  xgo -go="go-$GOVERSION" --targets=windows/amd64 .
-  mv badger-windows-4.0-amd64.exe $TMP/windows/badger.exe
-popd
+build_windows() {
+  # Build Windows.
+  pushd $basedir/dgraph/dgraph
+    xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe -ldflags \
+        "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+    mkdir -p $TMP/$GOARCH/windows
+    mv dgraph-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph.exe
+  popd
 
-pushd $basedir/ratel
-  xgo -go="go-$GOVERSION" --targets=windows/amd64 -ldflags "-X $ratel_release=$release_version" .
-  mv ratel-windows-4.0-amd64.exe $TMP/windows/dgraph-ratel.exe
-popd
+  pushd $basedir/badger/badger
+    xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -buildmode=exe .
+    mv badger-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/badger.exe
+  popd
 
-# Build Darwin.
-pushd $basedir/dgraph/dgraph
-  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 -ldflags \
-  "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-  mkdir $TMP/darwin
-  mv dgraph-darwin-10.9-amd64 $TMP/darwin/dgraph
-popd
+  if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+    pushd $basedir/ratel
+      xgo -x -go="go-$GOVERSION" --targets=windows/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version"  -buildmode=exe .
+      mv ratel-windows-4.0-$GOARCH.exe $TMP/windows/$GOARCH/dgraph-ratel.exe
+    popd
+  fi
+}
 
-pushd $basedir/badger/badger
-  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 .
-  mv badger-darwin-10.9-amd64 $TMP/darwin/badger
-popd
+build_darwin() {
+  # Build Darwin.
+  pushd $basedir/dgraph/dgraph
+    xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags \
+    "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
+    mkdir -p $TMP/darwin/$GOARCH
+    mv dgraph-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph
+  popd
 
-pushd $basedir/ratel
-  xgo -go="go-$GOVERSION" --targets=darwin-10.9/amd64 -ldflags "-X $ratel_release=$release_version" .
-  mv ratel-darwin-10.9-amd64 $TMP/darwin/dgraph-ratel
-popd
+  pushd $basedir/badger/badger
+    xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE .
+    mv badger-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/badger
+  popd
 
-# Build Linux.
-pushd $basedir/dgraph/dgraph
-  xgo -go="go-$GOVERSION" --targets=linux/amd64 -ldflags \
-      "-X $release=$release_version -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" .
-  strip -x dgraph-linux-amd64
-  mkdir $TMP/linux
-  mv dgraph-linux-amd64 $TMP/linux/dgraph
-popd
+  if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+    pushd $basedir/ratel
+      xgo -x -go="go-$GOVERSION" --targets=darwin-10.9/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version" .
+      mv ratel-darwin-10.9-$GOARCH $TMP/darwin/$GOARCH/dgraph-ratel
+    popd
+  fi
+}
 
-pushd $basedir/badger/badger
-  xgo -go="go-$GOVERSION" --targets=linux/amd64 .
-  strip -x badger-linux-amd64
-  mv badger-linux-amd64 $TMP/linux/badger
-popd
+build_linux() {
+  # Build Linux.
+  pushd $basedir/dgraph/dgraph
+    xgo -x -v -go="go-$GOVERSION" --targets=linux/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags \
+       "-X $release=$release_version -X $codenameKey=$codename -X $branch=$gitBranch -X $commitSHA1=$lastCommitSHA1 -X '$commitTime=$lastCommitTime'" --tags=jemalloc -deps=https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2  --depsargs='--with-jemalloc-prefix=je_ --with-malloc-conf=background_thread:true,metadata_thp:auto --enable-prof' .
+    strip -x dgraph-linux-$GOARCH
+    mkdir -p $TMP/linux/$GOARCH
+    mv dgraph-linux-$GOARCH $TMP/linux/$GOARCH/dgraph
+  popd
 
-pushd $basedir/ratel
-  xgo -go="go-$GOVERSION" --targets=linux/amd64 -ldflags "-X $ratel_release=$release_version" .
-  strip -x ratel-linux-amd64
-  mv ratel-linux-amd64 $TMP/linux/dgraph-ratel
-popd
+  pushd $basedir/badger/badger
+    xgo -x -v -go="go-$GOVERSION" --targets=linux/$GOARCH $DGRAPH_BUILD_XGO_IMAGE --tags=jemalloc -deps=https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2  --depsargs='--with-jemalloc-prefix=je_ --with-malloc-conf=background_thread:true,metadata_thp:auto --enable-prof' .
+    strip -x badger-linux-$GOARCH
+    mv badger-linux-$GOARCH $TMP/linux/$GOARCH/badger
+  popd
+
+  if [[ $DGRAPH_BUILD_RATEL =~ 1|true ]]; then
+    pushd $basedir/ratel
+      xgo -x -v -go="go-$GOVERSION" --targets=linux/$GOARCH $DGRAPH_BUILD_XGO_IMAGE -ldflags "-X $ratel_release=$release_version"  .
+      strip -x ratel-linux-$GOARCH
+      mv ratel-linux-$GOARCH $TMP/linux/dgraph-ratel
+    popd
+  fi
+}
 
 createSum () {
   os=$1
   echo "Creating checksum for $os"
-  pushd $TMP/$os
-    csum=$(shasum -a 256 dgraph | awk '{print $1}')
-    echo $csum /usr/local/bin/dgraph >> ../dgraph-checksum-$os-amd64.sha256
-    csum=$(shasum -a 256 dgraph-ratel | awk '{print $1}')
-    echo $csum /usr/local/bin/dgraph-ratel >> ../dgraph-checksum-$os-amd64.sha256
-  popd
+  if [[ "$os" != "windows" ]]; then
+    pushd $TMP/$os/$GOARCH
+      csum=$(shasum -a 256 dgraph | awk '{print $1}')
+      echo $csum /usr/local/bin/dgraph >> ../dgraph-checksum-$os-$GOARCH.sha256
+      csum=$(shasum -a 256 dgraph-ratel | awk '{print $1}')
+      echo $csum /usr/local/bin/dgraph-ratel >> ../dgraph-checksum-$os-$GOARCH.sha256
+    popd
+  else
+    pushd $TMP/$os/$GOARCH
+      csum=$(shasum -a 256 dgraph.exe | awk '{print $1}')
+      echo $csum dgraph.exe >> ../dgraph-checksum-$os-$GOARCH.sha256
+      csum=$(shasum -a 256 dgraph-ratel.exe | awk '{print $1}')
+      echo $csum dgraph-ratel.exe >> ../dgraph-checksum-$os-$GOARCH.sha256
+    popd
+  fi
 }
 
-createSum darwin
-createSum linux
+## TODO: Add arm64 buildkit support once xgo works for arm64
+build_docker_image() {
+  if [[ "$GOARCH" == "amd64" ]]; then
+    # Create Dgraph Docker image.
+    # edit Dockerfile to point to binaries 
+    sed "s/^ADD linux/ADD linux\/$GOARCH/" $basedir/dgraph/contrib/Dockerfile > $TMP/Dockerfile
+    pushd $TMP
+      # Get a fresh ubuntu:latest image each time
+      # Don't rely on whatever "latest" version
+      # happens to be on the machine.
+      docker pull ubuntu:latest
 
-# Create Docker image.
-cp $basedir/dgraph/contrib/Dockerfile $TMP
-pushd $TMP
-  docker build -t dgraph/dgraph:$DTAG .
-popd
-rm $TMP/Dockerfile
+      docker build -t dgraph/dgraph:$DOCKER_TAG .
+    popd
+    rm $TMP/Dockerfile
 
-# Create the tars and delete the binaries.
+    # Create Dgraph standalone Docker image.
+    pushd $basedir/dgraph/contrib/standalone
+      make DGRAPH_VERSION=$DOCKER_TAG
+    popd
+  fi
+}
+
+# Create the tar and delete the binaries.
 createTar () {
   os=$1
   echo "Creating tar for $os"
-  pushd $TMP/$os
-    tar -zcvf ../dgraph-$os-amd64.tar.gz *
+  pushd $TMP/$os/$GOARCH
+    tar -zcvf ../dgraph-$os-$GOARCH.tar.gz *
   popd
-  rm -Rf $TMP/$os
+  rm -Rf $TMP/$os/$GOARCH
 }
 
-createTar windows
-createTar darwin
-createTar linux
+# Create the zip and delete the binaries.
+createZip () {
+  os=$1
+  echo "Creating zip for $os"
+  pushd $TMP/$os/$GOARCH
+    zip -r ../dgraph-$os-$GOARCH.zip *
+  popd
+  rm -Rf $TMP/$os/$GOARCH
+}
 
-echo "Release $TAG is ready."
-docker run -it dgraph/dgraph:$DTAG dgraph
-ls -alh $TMP
+build_artifacts() {
+  # Build Binaries
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && build_windows
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && build_darwin
+  build_linux
+
+  # Build Checksums
+  createSum linux
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createSum darwin
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createSum windows
+
+  # Build Docker images
+  build_docker_image
+
+  # Build Archives
+  createTar linux
+  [[ $DGRAPH_BUILD_WINDOWS =~ 1|true ]] && createZip windows
+  [[ $DGRAPH_BUILD_MAC =~ 1|true ]] && createTar darwin
+
+  if [[ "$GOARCH" == "amd64" ]]; then
+    echo "Release $TAG is ready."
+    docker run dgraph/dgraph:$DOCKER_TAG dgraph
+  fi
+  ls -alh $TMP
+}
+
+if [[ $DGRAPH_BUILD_AMD64 =~ 1|true ]]; then
+  export GOARCH=amd64
+  build_artifacts
+fi
+
+## Currently arm64 xgo fails for dgraph and badger
+## * https://github.com/techknowlogick/xgo/issues/105
+if [[ $DGRAPH_BUILD_ARM64 =~ 1|true ]]; then
+  export GOARCH=arm64
+  build_artifacts
+fi
+
+set +o xtrace
+echo "To release:"
+if git show-ref -q --verify "refs/tags/$TAG"; then
+    echo
+    echo "Push the git tag"
+    echo "  git push origin $TAG"
+fi
+echo
+echo "Push the Docker tag:"
+echo "  docker push dgraph/dgraph:$DOCKER_TAG"
+echo "  docker push dgraph/standalone:$DOCKER_TAG"
+echo
+echo "If this should be the latest release, then tag"
+echo "the image as latest too."
+echo "  docker tag dgraph/dgraph:$DOCKER_TAG dgraph/dgraph:latest"
+echo "  docker tag dgraph/standalone:$DOCKER_TAG dgraph/standalone:latest"
+echo "  docker push dgraph/dgraph:latest"
+echo "  docker push dgraph/standalone:latest"

--- a/contrib/release/xgo.Dockerfile
+++ b/contrib/release/xgo.Dockerfile
@@ -1,0 +1,4 @@
+ARG GOVERSION=1.16.0
+FROM techknowlogick/xgo:go-${GOVERSION}
+# https://github.com/techknowlogick/xgo/issues/104
+RUN go env -w GO111MODULE=auto

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,5 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.13.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.4
+	src.techknowlogick.com/xgo v1.4.1-0.20210311222705-d25c33fcd864
 )

--- a/go.sum
+++ b/go.sum
@@ -814,3 +814,5 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20180110180208-2cc67fd64755/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
 sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=
+src.techknowlogick.com/xgo v1.4.1-0.20210311222705-d25c33fcd864 h1:wBdOhmwnc6zZZzlGdhZLxBk2yDzKcQoqB5C9fePlORM=
+src.techknowlogick.com/xgo v1.4.1-0.20210311222705-d25c33fcd864/go.mod h1:31CE1YKtDOrKTk9PSnjTpe6YbO6W/0LTYZ1VskL09oU=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// +build tools
+package tools
+
+import (
+	_ "src.techknowlogick.com/xgo"
+)


### PR DESCRIPTION
Cherry-pick of #7621 to release/v20.11-slash.

Release Script Update:
  * Update to release.sh script to include modularized version with support for go1.16.x and arm64 builds.
  * GOVERSION set to 1.15.5 as this is version supported with dgraph v20.11.x
  * add xgo.Dockerfile to support GOVERSION build arg
  * add tools.go so that xgo can be installed with go install

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7819)
<!-- Reviewable:end -->
