### PR TITLE
opt(snapshot): optimize snapshot by using sinceTs

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,7 +17,6 @@
 package schema
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -506,18 +505,16 @@ func LoadFromDb() error {
 
 // LoadSchemaFromDb iterates through the DB and loads all the stored schema updates.
 func LoadSchemaFromDb() error {
-	prefix := x.SchemaPrefix()
 	txn := pstore.NewTransactionAt(1, false)
 	defer txn.Discard()
-	itr := txn.NewIterator(badger.DefaultIteratorOptions) // Need values, reversed=false.
+	iopts := badger.DefaultIteratorOptions
+	iopts.Prefix = x.SchemaPrefix()
+	itr := txn.NewIterator(iopts) // Need values, reversed=false.
 	defer itr.Close()
 
-	for itr.Seek(prefix); itr.Valid(); itr.Next() {
+	for itr.Rewind(); itr.Valid(); itr.Next() {
 		item := itr.Item()
 		key := item.Key()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
 		pk, err := x.Parse(key)
 		if err != nil {
 			glog.Errorf("Error while parsing key %s: %v", hex.Dump(key), err)
@@ -542,18 +539,16 @@ func LoadSchemaFromDb() error {
 
 // LoadTypesFromDb iterates through the DB and loads all the stored type updates.
 func LoadTypesFromDb() error {
-	prefix := x.TypePrefix()
 	txn := pstore.NewTransactionAt(1, false)
 	defer txn.Discard()
-	itr := txn.NewIterator(badger.DefaultIteratorOptions) // Need values, reversed=false.
+	iopts := badger.DefaultIteratorOptions
+	iopts.Prefix = x.TypePrefix()
+	itr := txn.NewIterator(iopts) // Need values, reversed=false.
 	defer itr.Close()
 
-	for itr.Seek(prefix); itr.Valid(); itr.Next() {
+	for itr.Rewind(); itr.Valid(); itr.Next() {
 		item := itr.Item()
 		key := item.Key()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
 		pk, err := x.Parse(key)
 		if err != nil {
 			glog.Errorf("Error while parsing key %s: %v", hex.Dump(key), err)

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -28,6 +28,8 @@ import (
 	"go.etcd.io/etcd/raft"
 
 	"github.com/dgraph-io/badger/v3"
+	bpb "github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -211,26 +213,10 @@ func doStreamSnapshot(snap *pb.Snapshot, out pb.Worker_StreamSnapshotServer) err
 	// Use the default implementation. We no longer try to generate a rolled up posting list here.
 	// Instead, we just stream out all the versions as they are.
 	stream.KeyToList = nil
+	stream.SinceTs = snap.SinceTs
 	stream.Send = func(buf *z.Buffer) error {
 		kvs := &pb.KVS{Data: buf.Bytes()}
 		return out.Send(kvs)
-	}
-	stream.ChooseKey = func(item *badger.Item) bool {
-		if item.Version() >= snap.SinceTs {
-			return true
-		}
-
-		if item.Version() != 1 {
-			return false
-		}
-
-		// Type and Schema keys always have a timestamp of 1. They all need to be sent
-		// with the snapshot.
-		pk, err := x.Parse(item.Key())
-		if err != nil {
-			return false
-		}
-		return pk.IsSchema() || pk.IsType()
 	}
 
 	// Get the list of all the predicate and types at the time of the snapshot so that the receiver
@@ -240,6 +226,49 @@ func doStreamSnapshot(snap *pb.Snapshot, out pb.Worker_StreamSnapshotServer) err
 
 	if err := stream.Orchestrate(out.Context()); err != nil {
 		return err
+	}
+
+	// Type and Schema keys always have a timestamp of 1. They all need to be sent
+	// with the snapshot. The stream framework does not send it when streaming at SinceTs > 1.
+	if stream.SinceTs > 0 {
+		buf := z.NewBuffer(10*MB, "DoStreamSnapshot")
+		defer buf.Release()
+		txn := pstore.NewTransactionAt(1, false)
+		defer txn.Discard()
+		copyKvsForPrefix := func(prefix []byte) error {
+			iopts := badger.DefaultIteratorOptions
+			iopts.Prefix = prefix
+			itr := txn.NewIterator(iopts)
+			defer itr.Close()
+
+			kv := bpb.KV{}
+			for itr.Rewind(); itr.Valid(); itr.Next() {
+				kv.Reset()
+				item := itr.Item()
+				if err := item.Value(func(val []byte) error {
+					kv.Value = y.SafeCopy(nil, val)
+					return nil
+				}); err != nil {
+					return err
+				}
+				kv.Key = item.KeyCopy(nil)
+				kv.Version = item.Version()
+				kv.ExpiresAt = item.ExpiresAt()
+				kv.UserMeta = []byte{item.UserMeta()}
+				badger.KVToBuffer(&kv, buf)
+			}
+			return nil
+		}
+		if err := copyKvsForPrefix(x.SchemaPrefix()); err != nil {
+			return errors.Wrap(err, "streamSnapshot: while copying schema")
+		}
+		if err := copyKvsForPrefix(x.TypePrefix()); err != nil {
+			return errors.Wrap(err, "streamSnapshot: while copying types")
+		}
+		kvs := &pb.KVS{Data: buf.Bytes()}
+		if err := out.Send(kvs); err != nil {
+			return err
+		}
 	}
 
 	// Indicate that sending is done.


### PR DESCRIPTION
We were not using `stream.SinceTs` in snapshot transfer. Instead, we were using `ChooseKey` to skip the keys with a lesser version. This can be very slow and memory heavy, because we will have to iterate over the entire DB and skip the keys. Using `SinceTs`, we will be skipping the entire table.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7826)
<!-- Reviewable:end -->
