### PR TITLE
chore(contrib/systemd): Add file descriptors limit.

### DIFF
--- a/contrib/systemd/centos/dgraph-alpha.service
+++ b/contrib/systemd/centos/dgraph-alpha.service
@@ -8,6 +8,7 @@ Requires=dgraph-zero.service
 Type=simple
 WorkingDirectory=/var/lib/dgraph
 ExecStart=/usr/bin/bash -c 'dgraph alpha -p /var/lib/dgraph/p -w /var/lib/dgraph/w'
+LimitNOFILE=65536
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal

--- a/contrib/systemd/centos/dgraph-zero.service
+++ b/contrib/systemd/centos/dgraph-zero.service
@@ -7,6 +7,7 @@ After=network.target
 Type=simple
 WorkingDirectory=/var/lib/dgraph
 ExecStart=/usr/bin/bash -c 'dgraph zero --wal /var/lib/dgraph/zw'
+LimitNOFILE=65536
 Restart=on-failure
 StandardOutput=journal
 StandardError=journal


### PR DESCRIPTION
Specify the open file descriptors limit to higher than typical default
settings in Linux (1024). This covers cases for larger databases where
there's a sizeable amount of data loaded into Dgraph.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7831)
<!-- Reviewable:end -->
