### PR TITLE
fix(auth): preserve the status code while returning error

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1110,27 +1110,33 @@ func authorizeSchemaQuery(ctx context.Context, er *query.ExecutionResult) error 
 // AuthGuardianOfTheGalaxy authorizes the operations for the users who belong to the guardians
 // group in the galaxy namespace. This authorization is used for admin usages like creation and
 // deletion of a namespace, resetting passwords across namespaces etc.
+// NOTE: The caller should not wrap the error returned. If needed, propagate the GRPC error code.
 func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	if !x.WorkerConfig.AclEnabled {
 		return nil
 	}
 	ns, err := x.ExtractJWTNamespace(ctx)
 	if err != nil {
-		return errors.Wrap(err, "Authorize guardian of the galaxy, extracting jwt token, error:")
+		return status.Error(codes.Unauthenticated,
+			"AuthGuardianOfTheGalaxy: extracting jwt token, error:"+err.Error())
 	}
 	if ns != 0 {
-		return errors.New("Only guardian of galaxy is allowed to do this operation")
+		return status.Error(
+			codes.PermissionDenied, "Only guardian of galaxy is allowed to do this operation")
 	}
 	// AuthorizeGuardians will extract (user, []groups) from the JWT claims and will check if
 	// any of the group to which the user belongs is "guardians" or not.
 	if err := AuthorizeGuardians(ctx); err != nil {
-		return errors.Wrap(err, "AuthGuardianOfTheGalaxy, failed to authorize guardians")
+		s := status.Convert(err)
+		return status.Error(
+			s.Code(), "AuthGuardianOfTheGalaxy: failed to authorize guardians"+s.Message())
 	}
 	glog.V(3).Info("Successfully authorised guardian of the galaxy")
 	return nil
 }
 
 // AuthorizeGuardians authorizes the operation for users which belong to Guardians group.
+// NOTE: The caller should not wrap the error returned. If needed, propagate the GRPC error code.
 func AuthorizeGuardians(ctx context.Context) error {
 	if len(worker.Config.HmacSecret) == 0 {
 		// the user has not turned on the acl feature

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -2601,9 +2601,10 @@ func assertNonGuardianFailure(t *testing.T, queryName string, respIsNull bool,
 	resp := makeRequestAndRefreshTokenIfNecessary(t, token, params)
 
 	require.Len(t, resp.Errors, 1)
-	require.Contains(t, resp.Errors[0].Message,
-		fmt.Sprintf("rpc error: code = PermissionDenied desc = Only guardians are allowed access."+
-			" User '%s' is not a member of guardians group.", commonUserId))
+	require.Contains(t, resp.Errors[0].Message, "rpc error: code = PermissionDenied")
+	require.Contains(t, resp.Errors[0].Message, fmt.Sprintf(
+		"Only guardians are allowed access. User '%s' is not a member of guardians group.",
+		commonUserId))
 	if len(resp.Data) != 0 {
 		queryVal := "null"
 		if !respIsNull {


### PR DESCRIPTION
Clients like `dgo` rely on GRPC status code for operations in scenarios like relogin if JWT expired. We must preserve the status code while returning and not just wrap it.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7832)
<!-- Reviewable:end -->
