### PR TITLE
fix(restore): reset the kv.StreamId before sending to stream writer

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -285,6 +285,8 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 	maxUid := uint64(0)
 
 	toBuffer := func(kv *bpb.KV, version uint64) error {
+		// Reset the StreamId to prevent ordering issues.
+		kv.StreamId = 0
 		key := y.KeyWithTs(kv.Key, version)
 		sz := kv.Size()
 		buf := buf.SliceAllocate(2 + len(key) + sz)


### PR DESCRIPTION
Fixes DGRAPH-3356

Reset the StreamId for the schema key.
We get the following error in the master while restoring a backup:
```
E0518 15:43:03.303267 2849821 draft.go:728] Applying proposal. Error: while stream writer flush: Levels Controller err: Inter: Biggest(j-1)[2]                                                                                                
00000000  04 00 00 00 00 00 00 00  00 00 0b 64 67 72 61 70  |...........dgrap|                                                                                                                                                                
00000010  68 2e 74 79 70 65 02 02  50 65 72 73 6f 6e bf 98  |h.type..Person..|                                                                                                                                                                
00000020  d8 ed cd 5a f3 dd ff ff  ff ff ff ff f8 e1        |...Z..........|                                                                                                                                                                  

vs Smallest(j)[1]:                                                                                                                                                                                                                           
00000000  01 00 00 00 00 00 00 00  00 00 03 6c 6f 63 ff ff  |...........loc..|                                                                                                                                                                
00000010  ff ff ff ff ff fe                                 |......|                                                                                                                                                                          

: level=6 j=1 numTables=2                                                                                                                                                                                                                     
github.com/dgraph-io/badger/v3.(*levelHandler).validate                                                                                                                                                                                       
/home/dg/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210504192519-da5f789ecb38/util.go:55                                                                                                                                      
github.com/dgraph-io/badger/v3.(*levelsController).validate                                                                                                                                                                                   
/home/dg/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210504192519-da5f789ecb38/util.go:33                                                                                                                                      
github.com/dgraph-io/badger/v3.(*StreamWriter).Flush                                                                                                                                                                                          
/home/dg/go/pkg/mod/github.com/dgraph-io/badger/v3@v3.0.0-20210504192519-da5f789ecb38/stream_writer.go:249                                                                                                                            
github.com/dgraph-io/dgraph/worker.handleRestoreProposal                                                                                                                                                                                      
/home/dg/testing/dgraph/worker/online_restore.go:325                                                                                                                                                                                  
github.com/dgraph-io/dgraph/worker.(*node).applyCommitted                                                                                                                                                                                     
/home/dg/testing/dgraph/worker/draft.go:636                                                                                                                                                                                           
github.com/dgraph-io/dgraph/worker.(*node).processApplyCh.func1                                                                                                                                                                               
/home/dg/testing/dgraph/worker/draft.go:722                                                                                                                                                                                           
github.com/dgraph-io/dgraph/worker.(*node).processApplyCh                                                                                                                                                                                     
/home/dg/testing/dgraph/worker/draft.go:763    
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7833)
<!-- Reviewable:end -->
