### PR TITLE
cloud: fix(restore): reset the kv.StreamId before sending to stream writer (#7833)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -397,6 +397,8 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 					return nil
 				}
 			}
+			// Reset the StreamId to prevent ordering issues while writing to stream writer.
+			kv.StreamId = 0
 			// Schema and type keys are not stored in an intermediate format so their
 			// value can be written as is.
 			kv.Key = restoreKey


### PR DESCRIPTION
Reset the StreamId for the schema key to prevent ordering issues.

(cherry picked from commit 9557e56d03980fa2df2648f35b2d39b68f34b115)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7837)
<!-- Reviewable:end -->
