### PR TITLE
fix(restore): update the schema and type from 2103

### DIFF
--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -13,7 +13,6 @@
 package worker
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -160,18 +159,6 @@ func getConsolidatedManifest(h UriHandler, uri *url.URL) (*MasterManifest, error
 	return &MasterManifest{Manifests: mlist}, nil
 }
 
-// Invalid bytes are replaced with the Unicode replacement rune.
-// See https://golang.org/pkg/encoding/json/#Marshal
-const replacementRune = rune('\ufffd')
-
-func parseNsAttr(attr string) (uint64, string, error) {
-	if strings.ContainsRune(attr, replacementRune) {
-		return 0, "", errors.Errorf("replacement rune found while parsing attr: %s (%+v)",
-			attr, []byte(attr))
-	}
-	return binary.BigEndian.Uint64([]byte(attr[:8])), attr[8:], nil
-}
-
 // upgradeManifest updates the in-memory manifest from various versions to the latest version.
 // If the manifest version is 0 (dgraph version < v21.03), attach namespace to the predicates and
 // the drop data/attr operation.
@@ -203,23 +190,23 @@ func upgradeManifest(m *Manifest) error {
 		for gid, preds := range m.Groups {
 			parsedPreds := preds[:0]
 			for _, pred := range preds {
-				ns, attr, err := parseNsAttr(pred)
+				attr, err := x.AttrFrom2103(pred)
 				if err != nil {
 					return errors.Errorf("while parsing predicate got: %q", err)
 				}
-				parsedPreds = append(parsedPreds, x.NamespaceAttr(ns, attr))
+				parsedPreds = append(parsedPreds, attr)
 			}
 			m.Groups[gid] = parsedPreds
 		}
 		for _, op := range m.DropOperations {
 			// We have a cluster wide drop data in v21.03.
 			if op.DropOp == pb.DropOperation_ATTR {
-				ns, attr, err := parseNsAttr(op.DropValue)
+				attr, err := x.AttrFrom2103(op.DropValue)
 				if err != nil {
 					return errors.Errorf("while parsing the drop operation %+v got: %q",
 						op, err)
 				}
-				op.DropValue = x.NamespaceAttr(ns, attr)
+				op.DropValue = attr
 			}
 		}
 	case 2105:

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -392,6 +392,9 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 				return err
 			}
 			changeFormat := func() error {
+				// In the backup taken on 2103, we have the schemaUpdate.Predicate in format
+				// <namespace 8 bytes>|<attribute>. That had issues with JSON marshalling.
+				// So, we switched over to the format <namespace hex string>-<attribute>.
 				var err error
 				if parsedKey.IsSchema() {
 					var update pb.SchemaUpdate
@@ -422,6 +425,8 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 				}
 				return nil
 			}
+			// We changed the format of predicate in 2103 and 2105. SchemaUpdate and TypeUpdate have
+			// predicate stored within them, so they also need to be updated accordingly.
 			switch in.version {
 			case 0:
 				if parsedKey.IsType() {

--- a/x/keys.go
+++ b/x/keys.go
@@ -61,6 +61,19 @@ const (
 	NsSeparator = "-"
 )
 
+// Invalid bytes are replaced with the Unicode replacement rune.
+// See https://golang.org/pkg/encoding/json/#Marshal
+const replacementRune = rune('\ufffd')
+
+func AttrFrom2103(attr string) (string, error) {
+	if strings.ContainsRune(attr, replacementRune) {
+		return "", errors.Errorf("replacement rune found while parsing attr: %s (%+v)",
+			attr, []byte(attr))
+	}
+	ns, pred := binary.BigEndian.Uint64([]byte(attr[:8])), attr[8:]
+	return NamespaceAttr(ns, pred), nil
+}
+
 func NamespaceToBytes(ns uint64) []byte {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, ns)


### PR DESCRIPTION
With https://github.com/dgraph-io/dgraph/pull/7810 change, we changed the format of the predicate. We missed updating the schema and predicate. This PR fixes it.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7838)
<!-- Reviewable:end -->
