### PR TITLE
fix(restore): consider the banned namespaces while bumping

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -663,6 +663,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 	dropAll := false
 	dropAttr := make(map[string]struct{})
 	dropNs := make(map[uint64]struct{})
+	var maxBannedNs uint64
 
 	// manifests are ordered as: latest..full
 	for i, manifest := range manifests {
@@ -745,6 +746,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 				if err := pstore.BanNamespace(ns); err != nil {
 					return nil, errors.Wrapf(err, "Map phase failed to ban namespace: %d", ns)
 				}
+				maxBannedNs = x.Max(maxBannedNs, ns)
 			}
 		}
 	} // done with all the manifests.
@@ -761,5 +763,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 		maxUid: mapper.maxUid,
 		maxNs:  mapper.maxNs,
 	}
+	// update the maxNsId considering banned namespaces.
+	mapRes.maxNs = x.Max(mapRes.maxNs, maxBannedNs)
 	return mapRes, nil
 }


### PR DESCRIPTION
We were not considering the banned namespaces while bumping the lease. So, if we restore a backup with namespace 0,1,2 not-banned and 3,4 banned. We will bump only up to 2. This would error out when creating a namespace.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7839)
<!-- Reviewable:end -->
