### PR TITLE
fix(schema-update): Start opIndexing only when index creation is required.

### DIFF
--- a/edgraph/multi_tenancy_ee.go
+++ b/edgraph/multi_tenancy_ee.go
@@ -110,9 +110,6 @@ func (s *Server) CreateNamespace(ctx context.Context, passwd string) (uint64, er
 		return 0, err
 	}
 
-	if err = worker.WaitForIndexing(ctx, true); err != nil {
-		return 0, errors.Wrap(err, "Creating namespace, got error: ")
-	}
 	err = x.RetryUntilSuccess(10, 100*time.Millisecond, func() error {
 		return createGuardianAndGroot(ctx, ids.StartId, passwd)
 	})

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -269,6 +269,13 @@ func (n *node) waitForTask(id op) {
 	closer.Wait()
 }
 
+func (n *node) isRunningTask(id op) bool {
+	n.opsLock.Lock()
+	_, ok := n.ops[id]
+	n.opsLock.Unlock()
+	return ok
+}
+
 func (n *node) stopAllTasks() {
 	defer n.closer.Done() // CLOSER:1
 	<-n.closer.HasBeenClosed()

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -245,8 +245,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 		}
 
 		// Start opIndexing task only if schema update needs to build the indexes.
-		if ok && rebuild.NeedIndexRebuild() {
-			gr.Node.waitForTask(opIndexing)
+		if ok && rebuild.NeedIndexRebuild() && !gr.Node.isRunningTask(opIndexing) {
 			closer, err := gr.Node.startTask(opIndexing)
 			if err != nil {
 				return err

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -208,8 +208,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 	throttle := y.NewThrottle(maxOpenFileLimit / 8)
 
 	buildIndexes := func(update *pb.SchemaUpdate, rebuild posting.IndexRebuild, c *z.Closer) {
-		// In case background indexing is running, we should call it here again. stopIndexing will
-		// stop opIndexing only if indexing is no more in progress.
+		// In case background indexing is running, we should call it here again.
 		defer stopIndexing(c)
 
 		// We should only start building indexes once this function has returned.

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -245,9 +245,10 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 			OldSchema:     &old,
 			CurrentSchema: su,
 		}
+		shouldRebuild := ok && rebuild.NeedIndexRebuild()
 
 		// Start opIndexing task only if schema update needs to build the indexes.
-		if ok && rebuild.NeedIndexRebuild() && !gr.Node.isRunningTask(opIndexing) {
+		if shouldRebuild && !gr.Node.isRunningTask(opIndexing) {
 			closer, err = gr.Node.startTask(opIndexing)
 			if err != nil {
 				return err
@@ -277,7 +278,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 			return err
 		}
 
-		if ok && rebuild.NeedIndexRebuild() {
+		if shouldRebuild {
 			go buildIndexes(su, rebuild, closer)
 		} else if err := updateSchema(su); err != nil {
 			return err


### PR DESCRIPTION
We were starting `opIndexing` while schema update irrespective of whether index building is required or not. 
This caused Dgraph to be unable to create namespace while backup (or in fact any other conflicting task with opIndexing) is running.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7845)
<!-- Reviewable:end -->
