### PR TITLE
cloud: fix(schema-update): Start opIndexing only when index creation is requ…

### DIFF
--- a/edgraph/multi_tenancy_ee.go
+++ b/edgraph/multi_tenancy_ee.go
@@ -110,9 +110,6 @@ func (s *Server) CreateNamespace(ctx context.Context, passwd string) (uint64, er
 		return 0, err
 	}
 
-	if err = worker.WaitForIndexing(ctx, true); err != nil {
-		return 0, errors.Wrap(err, "Creating namespace, got error: ")
-	}
 	err = x.RetryUntilSuccess(10, 100*time.Millisecond, func() error {
 		return createGuardianAndGroot(ctx, ids.StartId, passwd)
 	})

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -196,6 +196,13 @@ func (n *node) waitForTask(id op) {
 	closer.Wait()
 }
 
+func (n *node) isRunningTask(id op) bool {
+	n.opsLock.Lock()
+	_, ok := n.ops[id]
+	n.opsLock.Unlock()
+	return ok
+}
+
 func (n *node) stopAllTasks() {
 	defer n.closer.Done() // CLOSER:1
 	<-n.closer.HasBeenClosed()


### PR DESCRIPTION
…ired. (#7845)

We were starting opIndexing while schema update irrespective of whether index
building is required or not. This caused Dgraph to be unable to create namespaces
while backup is running, despite the fact that namespace creation doesn't need
any indexing. This PR fixes this issue.

(cherry picked from commit 5595f9cdbe1223a37a8a337f976ea95dcc8594ae)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7846)
<!-- Reviewable:end -->
