### PR TITLE
chore(tracing): Add ns attribute to doQuery

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1331,6 +1331,11 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (
 
 	var measurements []ostats.Measurement
 	ctx, span := otrace.StartSpan(ctx, methodRequest)
+	ns, err := x.ExtractNamespace(ctx)
+	if err == nil {
+		span.AddAttributes(otrace.Int64Attribute("ns", int64(ns)))
+	}
+
 	ctx = x.WithMethod(ctx, methodRequest)
 	defer func() {
 		span.End()


### PR DESCRIPTION
Adds a `ns` attribute to traces for `doQuery` and `Server.CommitOrAbort`.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7850)
<!-- Reviewable:end -->
