### PR TITLE
feat(schema): do schema versioning and make backup non-blocking for indexing

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -561,7 +561,6 @@ func (r *rebuilder) Run(ctx context.Context) error {
 		WithNumVersionsToKeep(math.MaxInt32).
 		WithLogger(&x.ToGlog{}).
 		WithCompression(options.None).
-		WithEncryptionKey(x.WorkerConfig.EncryptionKey).
 		WithLoggingLevel(badger.WARNING).
 		WithMetricsEnabled(false)
 
@@ -1233,24 +1232,24 @@ func DeleteData(ns uint64) error {
 
 // DeletePredicate deletes all entries and indices for a given predicate. The delete may be logical
 // based on DB options set.
-func DeletePredicate(ctx context.Context, attr string) error {
+func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefix(prefix); err != nil {
 		return err
 	}
-	return schema.State().Delete(attr)
+	return schema.State().Delete(attr, ts)
 }
 
 // DeletePredicateBlocking deletes all entries and indices for a given predicate. It also blocks the
 // writes.
-func DeletePredicateBlocking(ctx context.Context, attr string) error {
+func DeletePredicateBlocking(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefixBlocking(prefix); err != nil {
 		return err
 	}
-	return schema.State().Delete(attr)
+	return schema.State().Delete(attr, ts)
 }
 
 // DeleteNamespace bans the namespace and deletes its predicates/types from the schema.

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -104,13 +104,13 @@ func TestBackupMinioE(t *testing.T) {
 	t.Log("Pausing to let zero move tablet...")
 	moveOk := false
 	for retry := 5; retry > 0; retry-- {
-		time.Sleep(3 * time.Second)
 		state, err := testutil.GetStateHttps(testutil.GetAlphaClientConfig(t))
 		require.NoError(t, err)
 		if _, ok := state.Groups["1"].Tablets[tabletName]; ok {
 			moveOk = true
 			break
 		}
+		time.Sleep(1 * time.Second)
 	}
 	require.True(t, moveOk)
 

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -98,7 +98,6 @@ func TestBackupOfOldRestore(t *testing.T) {
 	require.NoError(t, err)
 
 	testutil.DropAll(t, dg)
-	time.Sleep(2 * time.Second)
 
 	_ = runBackup(t, 3, 1)
 
@@ -113,7 +112,6 @@ func TestBackupOfOldRestore(t *testing.T) {
 
 	// Clean the cluster and try restoring the backups created above.
 	testutil.DropAll(t, dg)
-	time.Sleep(2 * time.Second)
 	sendRestoreRequest(t, alphaBackupDir)
 	testutil.WaitForRestore(t, dg)
 
@@ -171,13 +169,13 @@ func TestBackupFilesystem(t *testing.T) {
 	t.Log("Pausing to let zero move tablet...")
 	moveOk := false
 	for retry := 5; retry > 0; retry-- {
-		time.Sleep(3 * time.Second)
 		state, err := testutil.GetStateHttps(testutil.GetAlphaClientConfig(t))
 		require.NoError(t, err)
 		if _, ok := state.Groups["1"].Tablets[x.NamespaceAttr(x.GalaxyNamespace, "movie")]; ok {
 			moveOk = true
 			break
 		}
+		time.Sleep(1 * time.Second)
 	}
 
 	require.True(t, moveOk)

--- a/systest/backup/minio-large/backup_test.go
+++ b/systest/backup/minio-large/backup_test.go
@@ -110,7 +110,6 @@ func setupTablets(t *testing.T, dg *dgo.Dgraph) {
 	t.Log("Pausing to let zero move tablets...")
 	moveOk := false
 	for retry := 5; retry > 0; retry-- {
-		time.Sleep(3 * time.Second)
 		state, err := testutil.GetStateHttps(testutil.GetAlphaClientConfig(t))
 		require.NoError(t, err)
 		_, ok1 := state.Groups["1"].Tablets[x.GalaxyAttr("name1")]
@@ -120,6 +119,7 @@ func setupTablets(t *testing.T, dg *dgo.Dgraph) {
 			moveOk = true
 			break
 		}
+		time.Sleep(1 * time.Second)
 	}
 	require.True(t, moveOk)
 }

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -99,13 +99,13 @@ func TestBackupMinio(t *testing.T) {
 	t.Log("Pausing to let zero move tablet...")
 	moveOk := false
 	for retry := 5; retry > 0; retry-- {
-		time.Sleep(3 * time.Second)
 		state, err := testutil.GetStateHttps(testutil.GetAlphaClientConfig(t))
 		require.NoError(t, err)
 		if _, ok := state.Groups["1"].Tablets[x.NamespaceAttr(x.GalaxyNamespace, "movie")]; ok {
 			moveOk = true
 			break
 		}
+		time.Sleep(1 * time.Second)
 	}
 	require.True(t, moveOk)
 

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"strings"
 	"testing"
@@ -178,8 +179,7 @@ func readSchema(pdir string, dType dataType) ([]string, error) {
 	defer db.Close()
 	values := make([]string, 0)
 
-	// Predicates and types in the schema are written with timestamp 1.
-	txn := db.NewTransactionAt(1, false)
+	txn := db.NewTransactionAt(math.MaxUint64, false)
 	defer txn.Discard()
 	itr := txn.NewIterator(badger.DefaultIteratorOptions)
 	defer itr.Close()

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -479,8 +479,7 @@ func (pr *BackupProcessor) WriteBackup(ctx context.Context) (*pb.BackupResponse,
 		}
 		defer tl.alloc.Release()
 
-		// Schema and types are written at Ts=1.
-		txn := pr.DB.NewTransactionAt(1, false)
+		txn := pr.DB.NewTransactionAt(pr.Request.ReadTs, false)
 		defer txn.Discard()
 		// We don't need to iterate over all versions.
 		iopts := badger.DefaultIteratorOptions

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -64,7 +64,7 @@ func backupCurrentGroup(ctx context.Context, req *pb.BackupRequest) (*pb.BackupR
 		return nil, err
 	}
 
-	closer, err := g.Node.startTask(opBackup)
+	closer, err := g.Node.startTaskAtTs(opBackup, req.ReadTs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot start backup operation")
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -566,13 +566,13 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 		// Clear entire cache.
 		posting.ResetCache()
 
-		// TODO: Check if this assumption is correct. We removed the special handling for schema
-		// from snapshot transfer.
 		// It should be okay to set the schema at timestamp 1 after drop all operation.
 		if groups().groupId() == 1 {
 			initialSchema := schema.InitialSchema(x.GalaxyNamespace)
 			for _, s := range initialSchema {
-				applySchema(s, 1)
+				if err := applySchema(s, 1); err != nil {
+					return err
+				}
 			}
 		}
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -206,7 +206,8 @@ func (g *groupi) applyInitialTypes() {
 		if _, ok := schema.State().GetType(t.TypeName); ok {
 			continue
 		}
-		if err := updateType(t.GetTypeName(), *t); err != nil {
+		// TODO: What should be the correct timestamp here?
+		if err := updateType(t.GetTypeName(), *t, 1); err != nil {
 			glog.Errorf("Error while applying initial type: %s", err)
 		}
 	}
@@ -220,7 +221,8 @@ func (g *groupi) applyInitialSchema() {
 	ctx := g.Ctx()
 
 	apply := func(s *pb.SchemaUpdate) {
-		if err := applySchema(s); err != nil {
+		// TODO: What should be the correct timestamp here?
+		if err := applySchema(s, 1); err != nil {
 			glog.Errorf("Error while applying initial schema: %s", err)
 		}
 	}
@@ -246,8 +248,8 @@ func (g *groupi) applyInitialSchema() {
 	}
 }
 
-func applySchema(s *pb.SchemaUpdate) error {
-	if err := updateSchema(s); err != nil {
+func applySchema(s *pb.SchemaUpdate, ts uint64) error {
+	if err := updateSchema(s, ts); err != nil {
 		return err
 	}
 	if servesTablet, err := groups().ServesTablet(s.Predicate); err != nil {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -206,7 +206,7 @@ func (g *groupi) applyInitialTypes() {
 		if _, ok := schema.State().GetType(t.TypeName); ok {
 			continue
 		}
-		// TODO: What should be the correct timestamp here?
+		// It is okay to write initial types at ts=1.
 		if err := updateType(t.GetTypeName(), *t, 1); err != nil {
 			glog.Errorf("Error while applying initial type: %s", err)
 		}
@@ -221,7 +221,9 @@ func (g *groupi) applyInitialSchema() {
 	ctx := g.Ctx()
 
 	apply := func(s *pb.SchemaUpdate) {
-		// TODO: What should be the correct timestamp here?
+		// There are 2 cases: either the alpha is fresh or it restarted. If it is fresh cluster
+		// then we can write the schema at ts=1. If alpha restarted, then we will already have the
+		// schema at higher version and this operation will be a no-op.
 		if err := applySchema(s, 1); err != nil {
 			glog.Errorf("Error while applying initial schema: %s", err)
 		}

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -181,7 +181,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 		if err := rebuild.BuildIndexes(wrtCtx); err != nil {
 			return err
 		}
-		if err := updateSchema(update); err != nil {
+		if err := updateSchema(update, rebuild.StartTs); err != nil {
 			return err
 		}
 
@@ -280,7 +280,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 
 		if shouldRebuild {
 			go buildIndexes(su, rebuild, closer)
-		} else if err := updateSchema(su); err != nil {
+		} else if err := updateSchema(su, rebuild.StartTs); err != nil {
 			return err
 		}
 	}
@@ -290,25 +290,25 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 
 // updateSchema commits the schema to disk in blocking way, should be ok because this happens
 // only during schema mutations or we see a new predicate.
-func updateSchema(s *pb.SchemaUpdate) error {
+func updateSchema(s *pb.SchemaUpdate, ts uint64) error {
 	schema.State().Set(s.Predicate, s)
 	schema.State().DeleteMutSchema(s.Predicate)
-	txn := pstore.NewTransactionAt(1, true)
+	txn := pstore.NewTransactionAt(ts, true)
 	defer txn.Discard()
 	data, err := s.Marshal()
 	x.Check(err)
-	err = txn.SetEntry(&badger.Entry{
+	e := &badger.Entry{
 		Key:      x.SchemaKey(s.Predicate),
 		Value:    data,
 		UserMeta: posting.BitSchemaPosting,
-	})
-	if err != nil {
+	}
+	if err = txn.SetEntry(e.WithDiscard()); err != nil {
 		return err
 	}
-	return txn.CommitAt(1, nil)
+	return txn.CommitAt(ts, nil)
 }
 
-func createSchema(attr string, typ types.TypeID, hint pb.Metadata_HintType) error {
+func createSchema(attr string, typ types.TypeID, hint pb.Metadata_HintType, ts uint64) error {
 	ctx := schema.GetWriteContext(context.Background())
 
 	// Don't overwrite schema blindly, acl's might have been set even though
@@ -335,32 +335,32 @@ func createSchema(attr string, typ types.TypeID, hint pb.Metadata_HintType) erro
 	if err := checkSchema(&s); err != nil {
 		return err
 	}
-	return updateSchema(&s)
+	return updateSchema(&s, ts)
 }
 
-func runTypeMutation(ctx context.Context, update *pb.TypeUpdate) error {
+func runTypeMutation(ctx context.Context, update *pb.TypeUpdate, ts uint64) error {
 	current := *update
 	schema.State().SetType(update.TypeName, current)
-	return updateType(update.TypeName, *update)
+	return updateType(update.TypeName, *update, ts)
 }
 
 // We commit schema to disk in blocking way, should be ok because this happens
 // only during schema mutations or we see a new predicate.
-func updateType(typeName string, t pb.TypeUpdate) error {
+func updateType(typeName string, t pb.TypeUpdate, ts uint64) error {
 	schema.State().SetType(typeName, t)
-	txn := pstore.NewTransactionAt(1, true)
+	txn := pstore.NewTransactionAt(ts, true)
 	defer txn.Discard()
 	data, err := t.Marshal()
 	x.Check(err)
-	err = txn.SetEntry(&badger.Entry{
+	e := &badger.Entry{
 		Key:      x.TypeKey(typeName),
 		Value:    data,
 		UserMeta: posting.BitSchemaPosting,
-	})
-	if err != nil {
+	}
+	if err := txn.SetEntry(e.WithDiscard()); err != nil {
 		return err
 	}
-	return txn.CommitAt(1, nil)
+	return txn.CommitAt(ts, nil)
 }
 
 func hasEdges(attr string, startTs uint64) bool {

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -249,7 +249,7 @@ func runSchemaMutation(ctx context.Context, updates []*pb.SchemaUpdate, startTs 
 
 		// Start opIndexing task only if schema update needs to build the indexes.
 		if shouldRebuild && !gr.Node.isRunningTask(opIndexing) {
-			closer, err = gr.Node.startTask(opIndexing)
+			closer, err = gr.Node.startTaskAtTs(opIndexing, startTs)
 			if err != nil {
 				return err
 			}

--- a/worker/predicate_move.go
+++ b/worker/predicate_move.go
@@ -98,7 +98,7 @@ func batchAndProposeKeyValues(ctx context.Context, kvs chan *pb.KVS) error {
 				glog.Infof("Predicate being received: %v", pk.Attr)
 				if kv.StreamId == CleanPredicate {
 					// Delete on all nodes.
-					p := &pb.Proposal{CleanPredicate: pk.Attr}
+					p := &pb.Proposal{CleanPredicate: pk.Attr, StartTs: kv.Version}
 					if err := n.proposeAndWait(ctx, p); err != nil {
 						glog.Errorf("Error while cleaning predicate %v %v\n", pk.Attr, err)
 						return err
@@ -223,7 +223,11 @@ func (w *grpcWorker) MovePredicate(ctx context.Context,
 		// know that they are no longer serving this predicate, before they delete it from their
 		// state. Without this checksum, the members could end up deleting the predicate and then
 		// serve a request asking for that predicate, causing Jepsen failures.
-		p := &pb.Proposal{CleanPredicate: in.Predicate, ExpectedChecksum: in.ExpectedChecksum}
+		p := &pb.Proposal{
+			CleanPredicate:   in.Predicate,
+			ExpectedChecksum: in.ExpectedChecksum,
+			StartTs:          in.ReadTs,
+		}
 		return &emptyPayload, groups().Node.proposeAndWait(ctx, p)
 	}
 	if err := posting.Oracle().WaitForTs(ctx, in.ReadTs); err != nil {
@@ -274,8 +278,6 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 		return errors.Wrapf(err, "while calling ReceivePredicate")
 	}
 
-	// This txn is only reading the schema. Doesn't really matter what read timestamp we use,
-	// because schema keys are always set at ts=1.
 	txn := pstore.NewTransactionAt(in.ReadTs, false)
 	defer txn.Discard()
 
@@ -299,7 +301,7 @@ func movePredicateHelper(ctx context.Context, in *pb.MovePredicatePayload) error
 		kv := &bpb.KV{}
 		kv.Key = schemaKey
 		kv.Value = val
-		kv.Version = 1
+		kv.Version = item.Version()
 		kv.UserMeta = []byte{item.UserMeta()}
 		if in.SinceTs == 0 {
 			// When doing Phase I of predicate move, receiver should clean the predicate.


### PR DESCRIPTION
**Issue:**
We used to write schema/types at `timestamp=1`. That single bit violates the Snapshot Isolation. Hence, we couldn't run schema updates and other operations like backup concurrently. This is an issue in a multi-tenant cluster because if the backup is running we couldn't update the schema. 
**Fix:**
This PR writes the schema/types at the `startTs` of the transaction and enables the schema updates to be made even if the backup is running.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7852)
<!-- Reviewable:end -->
