### PR TITLE
perf: Speed up parsing of a huge query with a lot of conditional mutations

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -829,7 +829,7 @@ func buildUpsertQuery(qc *queryContext) string {
 	qc.condVars = make([]string, len(qc.req.Mutations))
 
 	var b strings.Builder
-	b.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
+	x.Check2(b.WriteString(strings.TrimSuffix(qc.req.Query, "}")))
 
 	for i, gmu := range qc.gmuList {
 		isCondUpsert := strings.TrimSpace(gmu.Cond) != ""
@@ -855,11 +855,11 @@ func buildUpsertQuery(qc *queryContext) string {
 			// The variable __dgraph_0__ will -
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
-			b.WriteString(qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
-			 `)
+			x.Check2(b.WriteString(qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
+			 `))
 		}
 	}
-	b.WriteString(`}`)
+	x.Check2(b.WriteString(`}`))
 
 	return b.String()
 }

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -828,8 +828,8 @@ func buildUpsertQuery(qc *queryContext) string {
 
 	qc.condVars = make([]string, len(qc.req.Mutations))
 
-        var b strings.Builder
-        b.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
+	var b strings.Builder
+	b.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
 
 	for i, gmu := range qc.gmuList {
 		isCondUpsert := strings.TrimSpace(gmu.Cond) != ""

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -828,9 +828,8 @@ func buildUpsertQuery(qc *queryContext) string {
 
 	qc.condVars = make([]string, len(qc.req.Mutations))
 
-        // We use String Builder for effective string concatenation
-        var upsertQueryBuilder strings.Builder
-        upsertQueryBuilder.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
+        var b strings.Builder
+        b.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
 
 	for i, gmu := range qc.gmuList {
 		isCondUpsert := strings.TrimSpace(gmu.Cond) != ""
@@ -856,13 +855,13 @@ func buildUpsertQuery(qc *queryContext) string {
 			// The variable __dgraph_0__ will -
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
-			upsertQueryBuilder.WriteString(qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
+			b.WriteString(qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
 			 `)
 		}
 	}
-	upsertQueryBuilder.WriteString(`}`)
+	b.WriteString(`}`)
 
-	return upsertQueryBuilder.String()
+	return b.String()
 }
 
 // updateMutations updates the mutation and replaces uid(var) and val(var) with

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -827,7 +827,11 @@ func buildUpsertQuery(qc *queryContext) string {
 	}
 
 	qc.condVars = make([]string, len(qc.req.Mutations))
-	upsertQuery := strings.TrimSuffix(qc.req.Query, "}")
+
+        // We use String Builder for effective string concatenation
+        var upsertQueryBuilder strings.Builder
+        upsertQueryBuilder.WriteString(strings.TrimSuffix(qc.req.Query, "}"))
+
 	for i, gmu := range qc.gmuList {
 		isCondUpsert := strings.TrimSpace(gmu.Cond) != ""
 		if isCondUpsert {
@@ -852,13 +856,13 @@ func buildUpsertQuery(qc *queryContext) string {
 			// The variable __dgraph_0__ will -
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
-			upsertQuery += qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
-			 `
+			upsertQueryBuilder.WriteString(qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
+			 `)
 		}
 	}
-	upsertQuery += `}`
+	upsertQueryBuilder.WriteString(`}`)
 
-	return upsertQuery
+	return upsertQueryBuilder.String()
 }
 
 // updateMutations updates the mutation and replaces uid(var) and val(var) with


### PR DESCRIPTION
Recently I faced a situation when my queries containing a lot of conditional mutations (+5000) took a long time to process. According to the servers reply the slowest part of the query handling was parsing. For example:
parsing_ns:835833349 processing_ns:157596840 encoding_ns:5105536 assign_timestamp_ns:454011 total_ns:1033841289 
So the parsing took several times longer that the processing itself!
The reason of the issue is in the ineffective implementation of buildUpsertQuery method. I suggest using String Builder instead of just simple string concatenation. After these changes the parsing speed increased significantly:
parsing_ns:134053025 processing_ns:114263143 encoding_ns:4992320 assign_timestamp_ns:495987 total_ns:286159717 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7871)
<!-- Reviewable:end -->
