### PR TITLE
compose.go changes

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -743,7 +743,7 @@ func main() {
 		"minio service port")
 	cmd.PersistentFlags().StringArrayVar(&opts.MinioEnvFile, "minio_env_file", nil,
 		"minio service env_file")
-	cmd.PersistentFlags().StringVar(&opts.ContainerPrefix, "alias", "",
+	cmd.PersistentFlags().StringVar(&opts.ContainerPrefix, "prefix", "",
 		"prefix for the container name")
 	cmd.PersistentFlags().StringArrayVar(&opts.CustomAlphaOptions, "custom_alpha_flags", nil,
 		"Custom alpha flags for specific alphas, following {\"1:custom_flags\", \"2:custom_flags\"}, eg: {\"2: -p <bulk_path>")

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -745,7 +745,7 @@ func main() {
 		"minio service env_file")
 	cmd.PersistentFlags().StringVar(&opts.ContainerPrefix, "prefix", "",
 		"prefix for the container name")
-	cmd.PersistentFlags().StringArrayVar(&opts.CustomAlphaOptions, "custom_alpha_flags", nil,
+	cmd.PersistentFlags().StringArrayVar(&opts.CustomAlphaOptions, "custom_alpha_options", nil,
 		"Custom alpha flags for specific alphas, following {\"1:custom_flags\", \"2:custom_flags\"}, eg: {\"2: -p <bulk_path>")
 	cmd.PersistentFlags().StringVar(&opts.Hostname, "hostname", "",
 		"hostname for the alpha and zero servers")

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -744,7 +744,7 @@ func main() {
 	cmd.PersistentFlags().StringArrayVar(&opts.MinioEnvFile, "minio_env_file", nil,
 		"minio service env_file")
 	cmd.PersistentFlags().StringVar(&opts.ContainerPrefix, "alias", "",
-		"alias for the containers")
+		"prefix for the container name")
 	cmd.PersistentFlags().StringArrayVar(&opts.CustomAlphaOptions, "custom_alpha_flags", nil,
 		"Custom alpha flags for specific alphas, following {\"1:custom_flags\", \"2:custom_flags\"}, eg: {\"2: -p <bulk_path>")
 	cmd.PersistentFlags().StringVar(&opts.Hostname, "hostname", "",

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -321,11 +321,11 @@ func getAlpha(idx int, raft string, customFlags string) service {
 		zeroName = opts.ContainerPrefix + "_" + zeroName
 	}
 
-	zeroHostAddr := fmt.Sprintf("%s%d:%d", zeroName, 1, zeroBasePort+opts.PortOffset)
+	zeroHostAddr := fmt.Sprintf("%s:%d", getHost(zeroName+"1"), zeroBasePort+opts.PortOffset)
 	zeros := []string{zeroHostAddr}
 	for i := 2; i <= maxZeros; i++ {
 		port := zeroBasePort + opts.PortOffset + getOffset(i)
-		zeroHost := fmt.Sprintf("zero%d", i)
+		zeroHost := fmt.Sprintf("%s%d", zeroName, i)
 		zeroHostAddr = fmt.Sprintf("%s:%d", getHost(zeroHost), port)
 		zeros = append(zeros, zeroHostAddr)
 	}
@@ -746,7 +746,8 @@ func main() {
 	cmd.PersistentFlags().StringVar(&opts.ContainerPrefix, "prefix", "",
 		"prefix for the container name")
 	cmd.PersistentFlags().StringArrayVar(&opts.CustomAlphaOptions, "custom_alpha_options", nil,
-		"Custom alpha flags for specific alphas, following {\"1:custom_flags\", \"2:custom_flags\"}, eg: {\"2: -p <bulk_path>")
+		"Custom alpha flags for specific alphas,"+
+			" following {\"1:custom_flags\", \"2:custom_flags\"}, eg: {\"2: -p <bulk_path>\"")
 	cmd.PersistentFlags().StringVar(&opts.Hostname, "hostname", "",
 		"hostname for the alpha and zero servers")
 	cmd.PersistentFlags().BoolVar(&opts.Cdc, "cdc", false,
@@ -800,13 +801,13 @@ func main() {
 	for _, flag := range opts.CustomAlphaOptions {
 		splits := strings.SplitN(flag, ":", 2)
 		if len(splits) != 2 {
-			fatal(errors.Errorf(" --custom_alpha_flags option requires string in index:options format."))
+			fatal(errors.Errorf("custom_alpha_options, requires string in index:options format."))
 		}
-		custIdx, err := strconv.Atoi(splits[0])
+		idx, err := strconv.Atoi(splits[0])
 		if err != nil {
-			fatal(errors.Errorf(" --custom_alpha_flags captured erros while parsing index value %v", err))
+			fatal(errors.Errorf(" custom_alpha_options, captured erros while parsing index value %v", err))
 		}
-		customAlphas[custIdx] = splits[1]
+		customAlphas[idx] = splits[1]
 	}
 
 	for i := 1; i <= opts.NumAlphas; i++ {


### PR DESCRIPTION
Modified compose.go file to accept alias and custom alpha flags:
1. `--alias` - alias for the containers
2. `--custom_alpha_flags` Custom alpha flags for specific alphas, following {"1:custom_flags", "2:custom_flags"},
eg: {"2: -p <bulk_path>"}
`go run compose.go -a=2 -z=1 --alias=test --custom_alpha_flags={"2:-p <bulk_path>"}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7872)
<!-- Reviewable:end -->
