### PR TITLE
cherry-pick: chore(graphql): fixing query timeouts for graphql queries too (#7796)

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -207,7 +207,7 @@ they form a Raft group and provide synchronous replication.
 		Flag("txn-abort-after", "Abort any pending transactions older than this duration."+
 			" The liveness of a transaction is determined by its last mutation.").
 		Flag("shared-instance", "When set to true, it disables ACLs for non-galaxy users. "+
-			"It expects the access JWT to be contructed outside dgraph for those users as even "+
+			"It expects the access JWT to be constructed outside dgraph for those users as even "+
 			"login is denied to them. Additionally, this disables access to environment variables"+
 			"for minio, aws, etc.").
 		String())


### PR DESCRIPTION
* fixing query timeouts for graphql queries too

* fixing online restore test

(cherry picked from commit bb0358e6db5e0731023af4d7a1163d1227959133)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7874)
<!-- Reviewable:end -->
