### PR TITLE
release/21.03: make exports synchronous again

### DIFF
--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -189,7 +189,7 @@ func exportHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		  }
 		}`,
-		Variables: map[string]interface{}{},
+		Variables: map[string]interface{}{"format": format},
 	}
 
 	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -83,6 +83,8 @@ func getAdminMux() *http.ServeMux {
 		http.MethodPut:  true,
 		http.MethodPost: true,
 	}, adminAuthHandler(http.HandlerFunc(drainingHandler))))
+	adminMux.Handle("/admin/export", allowedMethodsHandler(allowedMethods{http.MethodGet: true},
+		adminAuthHandler(http.HandlerFunc(exportHandler))))
 	adminMux.Handle("/admin/config/cache_mb", allowedMethodsHandler(allowedMethods{
 		http.MethodGet: true,
 		http.MethodPut: true,
@@ -156,6 +158,46 @@ func shutDownHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	x.Check2(w.Write([]byte(`{"code": "Success", "message": "Server is shutting down"}`)))
+}
+
+func exportHandler(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		x.SetHttpStatus(w, http.StatusBadRequest, "Parse of export request failed.")
+		return
+	}
+
+	format := worker.DefaultExportFormat
+	if vals, ok := r.Form["format"]; ok {
+		if len(vals) > 1 {
+			x.SetHttpStatus(w, http.StatusBadRequest,
+				"Only one export format may be specified.")
+			return
+		}
+		format = worker.NormalizeExportFormat(vals[0])
+		if format == "" {
+			x.SetHttpStatus(w, http.StatusBadRequest, "Invalid export format.")
+			return
+		}
+	}
+
+	gqlReq := &schema.Request{
+		Query: `
+		mutation export($format: String) {
+		  export(input: {format: $format}) {
+			response {
+			  code
+			}
+		  }
+		}`,
+		Variables: map[string]interface{}{},
+	}
+
+	if resp := resolveWithAdminServer(gqlReq, r, adminServer); len(resp.Errors) != 0 {
+		x.SetStatus(w, resp.Errors[0].Message, "Export failed.")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	x.Check2(w.Write([]byte(`{"code": "Success", "message": "Export completed."}`)))
 }
 
 func memoryLimitHandler(w http.ResponseWriter, r *http.Request) {

--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -1,0 +1,68 @@
+// +build !oss
+
+/*
+ * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import (
+	"net/http"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
+)
+
+func init() {
+	http.Handle("/admin/backup", allowedMethodsHandler(allowedMethods{http.MethodPost: true},
+		adminAuthHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			backupHandler(w, r)
+		}))))
+}
+
+// backupHandler handles backup requests coming from the HTTP endpoint.
+func backupHandler(w http.ResponseWriter, r *http.Request) {
+	gqlReq := &schema.Request{
+		Query: `
+		 mutation backup($input: BackupInput!) {
+		   backup(input: $input) {
+			 response {
+			   code
+			 }
+		   }
+		 }`,
+		Variables: map[string]interface{}{"input": map[string]interface{}{
+			"destination":  r.FormValue("destination"),
+			"accessKey":    r.FormValue("access_key"),
+			"secretKey":    r.FormValue("secret_key"),
+			"sessionToken": r.FormValue("session_token"),
+			"anonymous":    r.FormValue("anonymous") == "true",
+			"forceFull":    r.FormValue("force_full") == "true",
+		}},
+	}
+	glog.Infof("gqlReq %+v, r %+v adminServer %+v", gqlReq, r, adminServer)
+	resp := resolveWithAdminServer(gqlReq, r, adminServer)
+	if resp.Errors != nil {
+		x.SetStatus(w, resp.Errors.Error(), "Backup failed.")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	x.Check2(w.Write([]byte(`{` +
+		`"code": "Success", ` +
+		`"message": "Backup queued successfully."}`)))
+}

--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -1,7 +1,7 @@
 // +build !oss
 
 /*
- * Copyright 2018 Dgraph Labs, Inc. and Contributors
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -253,8 +253,8 @@ const (
 	}
 
 	type ExportPayload {
+		exportedFiles: [String]
 		response: Response
-		taskId: String
 	}
 
 	type DrainingPayload {

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -673,7 +673,6 @@ func TestDeleteSchemaAndExport(t *testing.T) {
 		Query: `mutation {
 		  export(input: {format: "rdf"}) {
 			response { code }
-			taskId
 		  }
 		}`,
 	}
@@ -682,10 +681,7 @@ func TestDeleteSchemaAndExport(t *testing.T) {
 
 	var data interface{}
 	require.NoError(t, json.Unmarshal(exportGqlResp.Data, &data))
-
 	require.Equal(t, "Success", testutil.JsonGet(data, "export", "response", "code").(string))
-	taskId := testutil.JsonGet(data, "export", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false)
 
 	// applying a new schema should still work
 	newSchemaResp := common.AssertUpdateGQLSchemaSuccess(t, groupOneHTTP, schema, nil)

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -54,8 +53,6 @@ func TestExportSchemaToMinio(t *testing.T) {
 
 	setupDgraph(t, moviesData, movieSchema)
 	result := requestExport(t, minioDest, "rdf")
-
-	log.Printf("ajeet %+v", result)
 	require.Equal(t, "Success", testutil.JsonGet(result, "data", "export", "response", "code").(string))
 	require.Equal(
 		t, "Export completed.", testutil.JsonGet(result, "data", "export", "response", "message").(string))

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -21,10 +21,10 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/dgraph-io/dgo/v210"
@@ -53,17 +53,21 @@ func TestExportSchemaToMinio(t *testing.T) {
 	mc.MakeBucket(bucketName, "")
 
 	setupDgraph(t, moviesData, movieSchema)
-	requestExport(t, minioDest, "rdf")
+	result := requestExport(t, minioDest, "rdf")
 
-	schemaFile := ""
-	doneCh := make(chan struct{})
-	defer close(doneCh)
-	for obj := range mc.ListObjectsV2(bucketName, "dgraph.", true, doneCh) {
-		if strings.Contains(obj.Key, ".schema.gz") {
-			schemaFile = obj.Key
-		}
+	log.Printf("ajeet %+v", result)
+	require.Equal(t, "Success", testutil.JsonGet(result, "data", "export", "response", "code").(string))
+	require.Equal(
+		t, "Export completed.", testutil.JsonGet(result, "data", "export", "response", "message").(string))
+
+	var files []string
+	for _, f := range testutil.JsonGet(result, "data", "export", "exportedFiles").([]interface{}) {
+		files = append(files, f.(string))
 	}
-	require.NotEmpty(t, schemaFile)
+	require.Equal(t, 3, len(files))
+
+	schemaFile := files[1]
+	require.Contains(t, schemaFile, ".schema.gz")
 
 	object, err := mc.GetObject(bucketName, schemaFile, minio.GetObjectOptions{})
 	require.NoError(t, err)
@@ -287,11 +291,11 @@ func setupDgraph(t *testing.T, nquads, schema string) {
 	require.NoError(t, err)
 }
 
-func requestExport(t *testing.T, dest string, format string) {
+func requestExport(t *testing.T, dest string, format string) map[string]interface{} {
 	exportRequest := `mutation export($dst: String!, $f: String!) {
 		export(input: {destination: $dst, format: $f}) {
-			response { code }
-			taskId
+			response { code message }
+			exportedFiles
 		}
 	}`
 
@@ -309,9 +313,11 @@ func requestExport(t *testing.T, dest string, format string) {
 	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
 	require.NoError(t, err)
 
-	var data interface{}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
-	require.Equal(t, "Success", testutil.JsonGet(data, "data", "export", "response", "code").(string))
-	taskId := testutil.JsonGet(data, "data", "export", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false)
+	buf, err := ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(buf, &result))
+
+	return result
 }

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -403,7 +403,6 @@ func TestExportJson(t *testing.T) {
 const exportRequest = `mutation export($format: String!) {
 	export(input: {format: $format}) {
 		response { code }
-		taskId
 	}
 }`
 
@@ -429,8 +428,6 @@ func TestExportFormat(t *testing.T) {
 	var data interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
 	require.Equal(t, "Success", testutil.JsonGet(data, "data", "export", "response", "code").(string))
-	taskId := testutil.JsonGet(data, "data", "export", "taskId").(string)
-	testutil.WaitForTask(t, taskId, false)
 
 	params.Variables["format"] = "rdf"
 	b, err = json.Marshal(params)


### PR DESCRIPTION
21.03.0 has async backups, but not exports. An earlier cherry-pick moved the async backups onto the async Task framework, but also made exports async, which breaks backwards compatibility.

This PR is a temporary fix to make exports sync just for 21.03.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7877)
<!-- Reviewable:end -->
