### PR TITLE
fix(restore): append galaxy namespace to type name

### DIFF
--- a/worker/restore.go
+++ b/worker/restore.go
@@ -250,6 +250,7 @@ func loadFromBackup(db *badger.DB, in *loadBackupInput) (uint64, uint64, error) 
 					if err := update.Unmarshal(kv.Value); err != nil {
 						return err
 					}
+					update.TypeName = x.GalaxyAttr(update.TypeName)
 					for _, sch := range update.Fields {
 						sch.Predicate = x.GalaxyAttr(sch.Predicate)
 					}


### PR DESCRIPTION
When restoring from backup taken on version <v21.03, we should append the galaxy namespace to the typename.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7881)
<!-- Reviewable:end -->
