### PR TITLE
cloud: fix(restore): append galaxy namespace to type name (#7880)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -385,6 +385,7 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 				if err := update.Unmarshal(kv.Value); err != nil {
 					return err
 				}
+				update.TypeName = x.GalaxyAttr(update.TypeName)
 				for _, sch := range update.Fields {
 					sch.Predicate = x.GalaxyAttr(sch.Predicate)
 				}


### PR DESCRIPTION
When restoring from backup taken on version <v21.03, we should append the galaxy namespace to the typename.

(cherry picked from commit 624202e13e1ef9c11511d7fe6db0cac06c3d8ed9)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7882)
<!-- Reviewable:end -->
