### PR TITLE
Revert "fix(Query): Fix cascade pagination with 0 offset. (#7636)"

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -1383,7 +1383,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 		child.updateUidMatrix()
 
 		// Apply pagination after the @cascade.
-		if len(child.Params.Cascade.Fields) > 0 && (child.Params.Cascade.First != 0 || child.Params.Cascade.Offset != 0) {
+		if len(child.Params.Cascade.Fields) > 0 && child.Params.Cascade.First != 0 && child.Params.Cascade.Offset != 0 {
 			for i := 0; i < len(child.uidMatrix); i++ {
 				start, end := x.PageRange(child.Params.Cascade.First, child.Params.Cascade.Offset, len(child.uidMatrix[i].Uids))
 				child.uidMatrix[i].Uids = child.uidMatrix[i].Uids[start:end]
@@ -2409,8 +2409,7 @@ func (sg *SubGraph) applyOrderAndPagination(ctx context.Context) error {
 		}
 	}
 
-	// if the @cascade directive is used then retrieve all the results.
-	if sg.Params.Count == 0 && len(sg.Params.Cascade.Fields) == 0 {
+	if sg.Params.Count == 0 {
 		// Only retrieve up to 1000 results by default.
 		sg.Params.Count = 1000
 	}
@@ -2868,7 +2867,7 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 			// first time at the root here.
 
 			// Apply pagination at the root after @cascade.
-			if len(sg.Params.Cascade.Fields) > 0 && (sg.Params.Cascade.First != 0 || sg.Params.Cascade.Offset != 0) {
+			if len(sg.Params.Cascade.Fields) > 0 && sg.Params.Cascade.First != 0 && sg.Params.Cascade.Offset != 0 {
 				sg.updateUidMatrix()
 				for i := 0; i < len(sg.uidMatrix); i++ {
 					start, end := x.PageRange(sg.Params.Cascade.First, sg.Params.Cascade.Offset, len(sg.uidMatrix[i].Uids))

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -520,19 +520,6 @@ func TestCascadeWithPaginationAtRoot(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false}]}}`, js)
 }
 
-func TestCascadeWithPaginationAndOffsetZero(t *testing.T) {
-	query := `
-	{
-		me(func: type(Person), first: 1, offset: 0) @cascade{
-		  name
-		  alive
-		}
-	  }
-	`
-	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Rick Grimes","alive":true}]}}`, js)
-}
-
 func TestLevelBasedFacetVarAggSum(t *testing.T) {
 	query := `
 		{


### PR DESCRIPTION
This reverts commit 95deb0a8fa5f317059b22d7537b89b7fe46785ac.

Reverting this commit fixes Alpha panics when using both ordering and
@cascade in a query:

    2021/06/03 21:27:33 3 0
    github.com/dgraph-io/dgraph/x.AssertTruef
    	/ext-go/1/src/github.com/dgraph-io/dgraph/x/error.go:107
    github.com/dgraph-io/dgraph/worker.intersectBucket
    	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:694
    github.com/dgraph-io/dgraph/worker.sortWithIndex
    	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:286
    github.com/dgraph-io/dgraph/worker.processSort.func2
    	/ext-go/1/src/github.com/dgraph-io/dgraph/worker/sort.go:518
    runtime.goexit
    	/usr/local/go/src/runtime/asm_amd64.s:1371

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7883)
<!-- Reviewable:end -->
