### PR TITLE
fix(DQL): revert changes related to cascade pagination with sort (#7885)

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -2409,8 +2409,8 @@ func (sg *SubGraph) applyOrderAndPagination(ctx context.Context) error {
 		}
 	}
 
-	// if the @cascade directive is used then retrieve all the results.
-	if sg.Params.Count == 0 && len(sg.Params.Cascade.Fields) == 0 {
+	// Todo: fix offset for cascade queries.
+	if sg.Params.Count == 0 {
 		// Only retrieve up to 1000 results by default.
 		sg.Params.Count = 1000
 	}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -533,6 +533,19 @@ func TestCascadeWithPaginationAndOffsetZero(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"name":"Rick Grimes","alive":true}]}}`, js)
 }
 
+func TestCascadeWithSort(t *testing.T) {
+	query := `
+	{
+		me(func: type(Person), first: 2, offset: 1, orderasc: name) @cascade{
+			name
+			alive
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"name": "Daryl Dixon","alive": false},{"name": "Rick Grimes","alive": true}]}}`, js)
+}
+
 func TestLevelBasedFacetVarAggSum(t *testing.T) {
 	query := `
 		{


### PR DESCRIPTION
Fixes DGRAPH-3370.
This PR reverts the change related to `cascade with sort` which is currently causing panic on the master.

(cherry picked from commit 5ae487fd4c7a9c7e7ce2263bec750eb33e386aec)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7888)
<!-- Reviewable:end -->
