### PR TITLE
chore(debug): add summary to show LSM tree and namespace size

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/dustin/go-humanize"
 
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee"
@@ -68,6 +69,7 @@ type flagOptions struct {
 	sizeHistogram bool
 	noKeys        bool
 	key           x.Sensitive
+	onlySummary   bool
 
 	// Options related to the WAL.
 	wdir           string
@@ -102,6 +104,10 @@ func init() {
 	flag.StringVarP(&opt.pdir, "postings", "p", "", "Directory where posting lists are stored.")
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
+	flag.BoolVar(&opt.onlySummary, "only-summary", false,
+		"If true, only show the summary of the p directory.")
+
+	// Flags related to WAL.
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
 		"Remove data from Raft entries until but not including this index.")
@@ -874,6 +880,51 @@ func printZeroProposal(buf *bytes.Buffer, zpr *pb.ZeroProposal) {
 	}
 }
 
+func printSummary(db *badger.DB) {
+	nsFromKey := func(key []byte) uint64 {
+		pk, err := x.Parse(key)
+		if err != nil {
+			// Some of the keys are badger's internal and couldn't be parsed.
+			// Hence, the error is expected in that case.
+			fmt.Printf("Unable to parse key: %#x\n", key)
+			return x.GalaxyNamespace
+		}
+		return x.ParseNamespace(pk.Attr)
+	}
+	banned := db.BannedNamespaces()
+	bannedNs := make(map[uint64]struct{})
+	for _, ns := range banned {
+		bannedNs[ns] = struct{}{}
+	}
+
+	tables := db.Tables()
+	levelSizes := make([]uint64, len(db.Levels()))
+	nsSize := make(map[uint64]uint64)
+	for _, tab := range tables {
+		levelSizes[tab.Level] += uint64(tab.OnDiskSize)
+		if nsFromKey(tab.Left) == nsFromKey(tab.Right) {
+			nsSize[nsFromKey(tab.Left)] += uint64(tab.OnDiskSize)
+		}
+	}
+
+	fmt.Println("[SUMMARY]")
+	totalSize := uint64(0)
+	for i, sz := range levelSizes {
+		fmt.Printf("Level %d size: %12s\n", i, humanize.IBytes(sz))
+		totalSize += sz
+	}
+	fmt.Printf("Total SST size: %12s\n", humanize.IBytes(totalSize))
+	fmt.Println()
+	for ns, sz := range nsSize {
+		fmt.Printf("Namespace %#x size: %12s", ns, humanize.IBytes(sz))
+		if _, ok := bannedNs[ns]; !ok {
+			fmt.Printf(" (banned)")
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+}
+
 func run() {
 	go func() {
 		for i := 8080; i < 9080; i++ {
@@ -919,6 +970,11 @@ func run() {
 	// Not using posting list cache
 	posting.Init(db, 0)
 	defer db.Close()
+
+	printSummary(db)
+	if opt.onlySummary {
+		return
+	}
 
 	// Commenting the following out because on large Badger DBs, this can take a LONG time.
 	// min, max := getMinMax(db, opt.readTs)


### PR DESCRIPTION
Add `--only-summary` flag in `dgraph debug` to show LSM tree and namespace sizes.
Sample:
```
[SUMMARY]
Level 0 size:       31 KiB
Level 1 size:          0 B
Level 2 size:          0 B
Level 3 size:          0 B
Level 4 size:          0 B
Level 5 size:      710 MiB
Level 6 size:      7.0 GiB
Total SST size:      7.6 GiB

Namespace 0x95 size:      1.6 GiB
Namespace 0x27 size:      1.3 GiB
Namespace 0x28 size:       16 MiB (banned)
Namespace 0x18 size:       46 MiB (banned)
Namespace 0x76 size:       32 MiB (banned)
Namespace 0x93 size:      1.6 GiB
Namespace 0x90 size:      291 MiB (banned)
Namespace 0x91 size:      2.2 GiB (banned)
Namespace 0x4a size:      222 MiB (banned)
Namespace 0x5d size:       15 MiB (banned)
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7891)
<!-- Reviewable:end -->
