### PR TITLE
[cherry-pick] Fix returning of error in case of transaction conflict (#7763)

### DIFF
--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -400,7 +400,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	err = mr.executor.CommitOrAbort(ctx, mutResp.Txn)
 	if err != nil {
 		return emptyResult(
-				schema.GQLWrapf(authErr, "mutation failed, couldn't commit transaction")),
+				schema.GQLWrapf(err, "mutation failed, couldn't commit transaction")),
 			resolverFailed
 	}
 	commit = true


### PR DESCRIPTION
(cherry picked from commit b0aa7973da734e16c38f369a19f7023a51ae7776)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7894)
<!-- Reviewable:end -->
