### PR TITLE
fix(GraphQL): optimize eq filter queries

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -866,6 +866,16 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) []*gql.GraphQuery 
 		return append(dgQuery, selectionAuth...)
 	}
 
+	dgQuery = rootQueryOptimization(dgQuery)
+	return dgQuery
+}
+
+func rootQueryOptimization(dgQuery []*gql.GraphQuery) []*gql.GraphQuery {
+	if dgQuery[0].Filter != nil && dgQuery[0].Filter.Func != nil && dgQuery[0].Filter.Func.Name == "eq" && dgQuery[0].Func.Name == "type" {
+		rootFunc := dgQuery[0].Func
+		dgQuery[0].Func = dgQuery[0].Filter.Func
+		dgQuery[0].Filter.Func = rootFunc
+	}
 	return dgQuery
 }
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -871,7 +871,8 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) []*gql.GraphQuery 
 }
 
 func rootQueryOptimization(dgQuery []*gql.GraphQuery) []*gql.GraphQuery {
-	if dgQuery[0].Filter != nil && dgQuery[0].Filter.Func != nil && dgQuery[0].Filter.Func.Name == "eq" && dgQuery[0].Func.Name == "type" {
+	if dgQuery[0].Filter != nil && dgQuery[0].Filter.Func != nil &&
+		dgQuery[0].Filter.Func.Name == "eq" && dgQuery[0].Func.Name == "type" {
 		rootFunc := dgQuery[0].Func
 		dgQuery[0].Func = dgQuery[0].Filter.Func
 		dgQuery[0].Filter.Func = rootFunc

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -40,7 +40,7 @@
     }
   dgquery: |-
     query {
-      queryState(func: type(State)) @filter(eq(State.code, "abc", "def", "ghi")) {
+      queryState(func: eq(State.code, "abc", "def", "ghi")) @filter(type(State)) {
         State.code : State.code
         State.name : State.name
         dgraph.uid : uid
@@ -57,7 +57,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.reputation, "10.3", "12.6", "13.6")) {
+      queryAuthor(func: eq(Author.reputation, "10.3", "12.6", "13.6")) @filter(type(Author)) {
         Author.name : Author.name
         Author.dob : Author.dob
         dgraph.uid : uid
@@ -74,7 +74,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.dob, "2001-01-01", "2002-02-01")) {
+      queryAuthor(func: eq(Author.dob, "2001-01-01", "2002-02-01")) @filter(type(Author)) {
         Author.name : Author.name
         Author.reputation : Author.reputation
         dgraph.uid : uid
@@ -90,7 +90,7 @@
     }
   dgquery: |-
     query {
-      queryPost(func: type(Post)) @filter(eq(Post.numLikes, 10, 15, 100)) {
+      queryPost(func: eq(Post.numLikes, 10, 15, 100)) @filter(type(Post)) {
         Post.title : Post.title
         dgraph.uid : uid
       }
@@ -105,7 +105,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.prevStatus, "ACTIVE", "DEACTIVATED")) {
+      queryVerification(func: eq(Verification.prevStatus, "ACTIVE", "DEACTIVATED")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.prevStatus : Verification.prevStatus
         dgraph.uid : uid
@@ -122,7 +122,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.status, "ACTIVE", "DEACTIVATED")) {
+      queryVerification(func: eq(Verification.status, "ACTIVE", "DEACTIVATED")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.status : Verification.status
         dgraph.uid : uid
@@ -139,7 +139,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.status, "ACTIVE")) {
+      queryVerification(func: eq(Verification.status, "ACTIVE")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.status : Verification.status
         dgraph.uid : uid
@@ -820,7 +820,7 @@
       }
     }
 
-- name: "Filter gets rewritten as @filter"
+- name: "eq Filter gets rewritten as root func"
   gqlquery: |
     query {
       queryAuthor(filter: { name: { eq: "A. N. Author" } }) {
@@ -829,7 +829,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -844,7 +844,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1083,7 +1083,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), first: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), first: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1098,7 +1098,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), first: 10, offset: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1113,7 +1113,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderasc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderasc: Author.reputation) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1128,7 +1128,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1144,7 +1144,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation, orderasc: Author.dob) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation, orderasc: Author.dob) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1159,7 +1159,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation, first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation, first: 10, offset: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1387,7 +1387,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -3302,7 +3302,7 @@
     }
   dgquery: |-
     query {
-      queryLinkX(func: type(LinkX)) @filter(eq(LinkX.f9, "Alice")) {
+      queryLinkX(func: eq(LinkX.f9, "Alice")) @filter(type(LinkX)) {
         LinkX.f1 : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
           LinkY.f6 : LinkY.f6
           dgraph.uid : uid


### PR DESCRIPTION
Fixes GQLSAAS-1236.
This PR optimizes `eq` filter GraphQL queries.
For ex:
The below DQL query:
```
query {
  queryPerson(filter: {nick: {eq: "Dgraph"}}){
    id
    name
    nick
  }
}
```
will now be written into:
```
query {
  queryPerson(func: eq(Person.nick, "Dgraph")) @filter(type(Person)) {
    Person.id : uid
    Person.name : Person.name
    Person.nick : Person.nick
  }
}
```
which was earlier written into:-
```
query {
  queryPerson(func: type(Person)) @filter(eq(Person.nick, "Dgraph")){
    Person.id : uid
    Person.name : Person.name
    Person.nick : Person.nick
  }
}
```
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7895)
<!-- Reviewable:end -->
