### PR TITLE
fix(export_backup): Do not try banning namespace in export_backup

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -739,6 +739,10 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 			case pb.DropOperation_ATTR:
 				dropAttr[op.DropValue] = struct{}{}
 			case pb.DropOperation_NS:
+				// pstore will be nil for export_backup tool. In that case we don't need to ban ns.
+				if pstore == nil {
+					continue
+				}
 				// If there is a drop namespace, we just ban the namespace in the pstore.
 				ns, err := strconv.ParseUint(op.DropValue, 0, 64)
 				if err != nil {


### PR DESCRIPTION
We should not try to ban the namespace while doing export_backup.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7896)
<!-- Reviewable:end -->
