### PR TITLE
fix(debug): Check length of wal entry before parsing

### DIFF
--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -36,8 +36,13 @@ func printEntry(es raftpb.Entry, pending map[uint64]bool, isZero bool) {
 	defer func() {
 		fmt.Printf("%s\n", buf.Bytes())
 	}()
+
+	var key uint64
+	if len(es.Data) >= 8 {
+		key = binary.BigEndian.Uint64(es.Data[:8])
+	}
 	fmt.Fprintf(&buf, "%d . %d . %v . %-6s . %8d .", es.Term, es.Index, es.Type,
-		humanize.Bytes(uint64(es.Size())), binary.BigEndian.Uint64(es.Data[:8]))
+		humanize.Bytes(uint64(es.Size())), key)
 	if es.Type == raftpb.EntryConfChange {
 		return
 	}


### PR DESCRIPTION
Check for the length of wal entry's data before parsing it for key
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7898)
<!-- Reviewable:end -->
