### PR TITLE
fix(metrics): Expose dgraph_num_backups_failed_total metric view.

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -223,6 +223,13 @@ var (
 			TagKeys:     nil,
 		},
 		{
+			Name:        NumBackupsFailed.Name(),
+			Measure:     NumBackupsFailed,
+			Description: NumBackupsFailed.Description(),
+			Aggregation: view.Count(),
+			TagKeys:     nil,
+		},
+		{
 			Name:        TxnCommits.Name(),
 			Measure:     TxnCommits,
 			Description: TxnCommits.Description(),


### PR DESCRIPTION
We've been tracking this metric but didn't actually expose it in the metrics
view, so Prometheus metrics in /metrics never showed it.

This change updates sets the view properly so it shows up in /metrics.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7900)
<!-- Reviewable:end -->
