### PR TITLE
fix(sroar): Fix TestAuthWithCustomDQL failure because of roaring bitmaps

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -82,6 +82,19 @@ func GetUids(l *pb.List) []uint64 {
 	return FromList(l).ToArray()
 }
 
+func SetUids(l *pb.List, uids []uint64) {
+	if l == nil {
+		return
+	}
+	if len(l.SortedUids) > 0 {
+		l.SortedUids = uids
+	} else {
+		r := sroar.NewBitmap()
+		r.SetMany(uids)
+		l.Bitmap = ToBytes(r)
+	}
+}
+
 func BitmapToSorted(l *pb.List) {
 	if l == nil {
 		return

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -83,9 +83,6 @@ func GetUids(l *pb.List) []uint64 {
 }
 
 func SetUids(l *pb.List, uids []uint64) {
-	if l == nil {
-		return
-	}
 	if len(l.SortedUids) > 0 {
 		l.SortedUids = uids
 	} else {

--- a/query/query.go
+++ b/query/query.go
@@ -1415,14 +1415,13 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 		child.updateUidMatrix()
 
 		// Apply pagination after the @cascade.
-		if len(child.Params.Cascade.Fields) > 0 && (child.Params.Cascade.First != 0 || child.Params.Cascade.Offset != 0) {
+		if len(child.Params.Cascade.Fields) > 0 && (child.Params.Cascade.First != 0 ||
+			child.Params.Cascade.Offset != 0) {
 			for i := 0; i < len(child.uidMatrix); i++ {
 				uids := codec.GetUids(child.uidMatrix[i])
 				start, end := x.PageRange(child.Params.Cascade.First, child.Params.Cascade.Offset,
 					len(uids))
-				r := sroar.NewBitmap()
-				r.SetMany(uids[start:end])
-				child.uidMatrix[i].Bitmap = codec.ToBytes(r)
+				codec.SetUids(child.uidMatrix[i], uids[start:end])
 			}
 		}
 	}


### PR DESCRIPTION
We should consider the state of UIdMatrix (whether it was in the form of SortedUids or bitmap) in order to set the result after pagination. Pagination with cascade is handled separately, where it is possible to have no order.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7902)
<!-- Reviewable:end -->
