### PR TITLE
Fix example for --cloud command for dgraph increment

### DIFF
--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -55,7 +55,7 @@ func init() {
 	// --tls SuperFlag
 	x.RegisterClientTLSFlags(flag)
 
-	flag.String("cloud", "", "addr: xxx; jwt: xxx")
+	flag.String("cloud", "", "addr=xxx; jwt=yyy")
 	flag.String("alpha", "localhost:9080", "Address of Dgraph Alpha.")
 	flag.Int("num", 1, "How many times to run per goroutine.")
 	flag.Int("retries", 10, "How many times to retry setting up the connection.")


### PR DESCRIPTION
This PR fixes the example for `--cloud` command for `dgraph increment` by replacing the `:` with the `=` sign

Current syntax:
```
--cloud "addr: <endpoint>; jwt: <JWT>
```
Correct syntax:
```
--cloud "addr=<endpoint>; jwt=<JWT>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7903)
<!-- Reviewable:end -->
