### PR TITLE
release/v20.11-slash: fix(Raft): Detect network partition when streaming

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -413,6 +413,8 @@ func (n *Node) streamMessages(to uint64, s *stream) {
 
 	var logged int
 	for range ticker.C { // Don't do this in an busy-wait loop, use a ticker.
+		// doSendMessage would block doing a stream. So, time.Now().After is
+		// only there to avoid a busy-wait.
 		if err := n.doSendMessage(to, s.msgCh); err != nil {
 			// Update lastLog so we print error only a few times if we are not able to connect.
 			// Otherwise, the log is polluted with repeated errors.
@@ -464,6 +466,10 @@ func (n *Node) doSendMessage(to uint64, msgCh chan []byte) error {
 	}
 
 	ctx = mc.Context()
+
+	fastTick := time.NewTicker(5 * time.Second)
+	defer fastTick.Stop()
+
 	ticker := time.NewTicker(3 * time.Minute)
 	defer ticker.Stop()
 
@@ -474,12 +480,17 @@ func (n *Node) doSendMessage(to uint64, msgCh chan []byte) error {
 				Context: n.RaftContext,
 				Payload: &api.Payload{Data: data},
 			}
-			packets++
 			slurp(batch) // Pick up more entries from msgCh, if present.
-			span.Annotatef(nil, "[Packets: %d] Sending data of length: %d.",
-				packets, len(batch.Payload.Data))
+			span.Annotatef(nil, "[to: %x] [Packets: %d] Sending data of length: %d.",
+				to, packets, len(batch.Payload.Data))
+			if packets%1000 == 0 {
+				glog.V(2).Infof("[to: %x] [Packets: %d] Sending data of length: %d.",
+					to, packets, len(batch.Payload.Data))
+			}
+			packets++
 			if err := mc.Send(batch); err != nil {
 				span.Annotatef(nil, "Error while mc.Send: %v", err)
+				glog.Errorf("[to: %x] Error while mc.Send: %v", to, err)
 				switch {
 				case strings.Contains(err.Error(), "TransientFailure"):
 					glog.Warningf("Reporting node: %d addr: %s as unreachable.", to, pool.Addr)
@@ -490,6 +501,23 @@ func (n *Node) doSendMessage(to uint64, msgCh chan []byte) error {
 				// We don't need to do anything if we receive any error while sending message.
 				// RAFT would automatically retry.
 				return err
+			}
+		case <-fastTick.C:
+			// We use this ticker, because during network partitions, mc.Send is
+			// unable to actually send packets, and also does not complain about
+			// them. We could have potentially used the separately tracked
+			// heartbeats to check this, but what we have observed is that
+			// incoming traffic might be OK, but outgoing might not be. So, this
+			// is a better way for us to verify whether this particular outbound
+			// connection is valid or not.
+			ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			_, err := c.IsPeer(ctx, n.RaftContext)
+			cancel()
+			if err != nil {
+				glog.Errorf("Error while calling IsPeer %v. Reporting %x as unreachable.", err, to)
+				n.Raft().ReportUnreachable(to)
+				pool.SetUnhealthy()
+				return errors.Wrapf(err, "while calling IsPeer %x", to)
 			}
 		case <-ticker.C:
 			if lastPackets == packets {

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -214,11 +214,6 @@ services:
       --tls_internal_port_enabled=true --tls_cert /dgraph-tls/client.alpha6.crt --tls_key /dgraph-tls/client.alpha6.key
       --logtostderr -v=2 --idx=6 --encryption_key_file /data/keys/enc_key
       --whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
-  ratel:
-    image: dgraph/dgraph:latest
-    ports:
-    - 8000
-    command: dgraph-ratel
   zero1:
     image: dgraph/dgraph:latest
     working_dir: /data/zero1


### PR DESCRIPTION
When streaming raft messages in k8s cluster, we don't seem to get an
error if the send didn't succeed. The packets get queued up, but don't
fail and don't get sent. This causes a long re-election process.

This PR periodically tries to send a message to the destination node via
IsPeer, so it has another way to test the connection. If that fails, the
streaming fails too, and the node is marked as unreachable.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7907)
<!-- Reviewable:end -->
