### PR TITLE
fix(GraphQL): handle extend keyword for Queries and Mutations

### DIFF
--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -326,9 +326,13 @@ func NewHandler(input string, apolloServiceQuery bool) (Handler, error) {
 	}
 
 	// Convert All the Type Extensions into the Type Definitions with @external directive
-	// to maintain uniformity in the output schema
+	// to maintain uniformity in the output schema.
+	// No need to add `@extends` directive to type `Query` and `Mutation` since
+	// `extend type Query` is same as declaring `type Query`.
 	for _, ext := range doc.Extensions {
-		ext.Directives = append(ext.Directives, &ast.Directive{Name: "extends"})
+		if ext.Name != "Query" && ext.Name != "Mutation" {
+			ext.Directives = append(ext.Directives, &ast.Directive{Name: "extends"})
+		}
 	}
 	doc.Definitions = append(doc.Definitions, doc.Extensions...)
 	doc.Extensions = nil


### PR DESCRIPTION
Fixes DO-13.
This PR fixes validation for `extend type Query` or `extend type Mutation` defined in the schema for the custom queries and mutation mentioned which was earlier resulting in error.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7916)
<!-- Reviewable:end -->
