### PR TITLE
cloud: fix(groot): do not upsert groot for all namespaces on restart (#7917)

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -118,7 +118,9 @@ func init() {
 	flag.Bool("new_uids", false,
 		"Ignore UIDs in load files and assign new ones.")
 	flag.Uint64("force-namespace", math.MaxUint64,
-		"Namespace onto which to load the data. If not set, will preserve the namespace.")
+		"Namespace onto which to load the data. If not set, will preserve the namespace."+
+			" When using this flag to load data into specific namespace, make sure that the "+
+			"load data do not have ACL data.")
 
 	flag.String("badger", BulkBadgerDefaults, z.NewSuperFlagHelp(BulkBadgerDefaults).
 		Head("Badger options (Refer to badger documentation for all possible options)").

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -417,10 +417,7 @@ func ResetAcl(closer *z.Closer) {
 		// The acl feature is not turned on.
 		return
 	}
-
-	for ns := range schema.State().Namespaces() {
-		upsertGuardianAndGroot(closer, ns)
-	}
+	upsertGuardianAndGroot(closer, x.GalaxyNamespace)
 }
 
 // Note: The handling of closer should be done by caller.

--- a/ee/acl/run.go
+++ b/ee/acl/run.go
@@ -19,6 +19,7 @@
 package acl
 
 import (
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
 )
@@ -30,6 +31,44 @@ func init() {
 		Use:         "acl",
 		Short:       "Enterprise feature. Not supported in oss version",
 		Annotations: map[string]string{"group": "security"},
-	},
-		Acl.Cmd.SetHelpTemplate(x.NonRootTemplate)
+	}
+	CmdAcl.Cmd.SetHelpTemplate(x.NonRootTemplate)
+}
+
+// CreateUserNQuads creates the NQuads needed to store a user with the given ID and
+// password in the ACL system.
+func CreateUserNQuads(userId, password string) []*api.NQuad {
+	return []*api.NQuad{
+		{
+			Subject:     "_:newuser",
+			Predicate:   "dgraph.xid",
+			ObjectValue: &api.Value{Val: &api.Value_StrVal{StrVal: userId}},
+		},
+		{
+			Subject:     "_:newuser",
+			Predicate:   "dgraph.password",
+			ObjectValue: &api.Value{Val: &api.Value_StrVal{StrVal: password}},
+		},
+		{
+			Subject:     "_:newuser",
+			Predicate:   "dgraph.type",
+			ObjectValue: &api.Value{Val: &api.Value_StrVal{StrVal: "dgraph.type.User"}},
+		},
+	}
+}
+
+// CreateGroupNQuads cretes NQuads needed to store a group with the give ID.
+func CreateGroupNQuads(groupId string) []*api.NQuad {
+	return []*api.NQuad{
+		{
+			Subject:     "_:newgroup",
+			Predicate:   "dgraph.xid",
+			ObjectValue: &api.Value{Val: &api.Value_StrVal{StrVal: groupId}},
+		},
+		{
+			Subject:     "_:newgroup",
+			Predicate:   "dgraph.type",
+			ObjectValue: &api.Value{Val: &api.Value_StrVal{StrVal: "dgraph.type.Group"}},
+		},
+	}
 }


### PR DESCRIPTION
Earlier, whenever the alpha starts(or restarts), we were upserting guardian and groot for all the namespaces. This is not actually needed.
The change was made in the PR #7759 to fix a bulk loader edge case.
This PR fixes that by generating the required RDFs in the bulk loader itself. Essentially, it inserts the ACL RDFs when force loading into non-Galaxy namespace.

(cherry picked from commit 6730f10b62da7c7dc3bf5985ef957f08d3c733b4)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7924)
<!-- Reviewable:end -->
