### PR TITLE
fix: fixing graphql schema update when the data is restored + skipping /probe/graphql from audit

### DIFF
--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -63,8 +63,9 @@ var skipApis = map[string]bool{
 
 var skipEPs = map[string]bool{
 	// list of endpoints that needs to be skipped
-	"/health": true,
-	"/state":  true,
+	"/health":        true,
+	"/state":         true,
+	"/probe/graphql": true,
 }
 
 func AuditRequestGRPC(ctx context.Context, req interface{},

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -651,7 +651,9 @@ func newAdminResolver(
 	}
 	adminServerVar = server // store the admin server in package variable
 
-	prefix := x.PredicatePrefix(x.GalaxyAttr(worker.GqlSchemaPred))
+	prefix := x.DataKey(x.GalaxyAttr(worker.GqlSchemaPred), 0)
+	// Remove uid from the key, to get the correct prefix
+	prefix = prefix[:len(prefix)-8]
 	// Listen for graphql schema changes in group 1.
 	go worker.SubscribeForUpdates([][]byte{prefix}, x.IgnoreBytes, func(kvs *badgerpb.KVList) {
 

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -659,9 +659,7 @@ func newAdminResolver(
 	}
 	adminServerVar = server // store the admin server in package variable
 
-	prefix := x.DataKey(x.GalaxyAttr(worker.GqlSchemaPred), 0)
-	// Remove uid from the key, to get the correct prefix
-	prefix = prefix[:len(prefix)-8]
+	prefix := x.PredicatePrefix(x.GalaxyAttr(worker.GqlSchemaPred))
 	// Listen for graphql schema changes in group 1.
 	go worker.SubscribeForUpdates([][]byte{prefix}, x.IgnoreBytes, func(kvs *badgerpb.KVList) {
 
@@ -1064,8 +1062,21 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 	return nil
 }
 
+func (as *adminServer) resetGQLSchema() error {
+	as.mux.Lock()
+	defer as.mux.Unlock()
+
+	as.schema = make(map[uint64]*gqlSchema)
+	return nil
+}
+
+
 func LazyLoadSchema(namespace uint64) error {
 	return adminServerVar.lazyLoadSchema(namespace)
+}
+
+func ResetGQLSchema() error {
+	return adminServerVar.resetGQLSchema()
 }
 
 func inputArgError(err error) error {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -18,6 +18,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -577,14 +578,6 @@ func (g *GraphQLHealthStore) updatingSchema() {
 	g.v.Store(GraphQLHealth{Healthy: true, StatusMsg: "updating schema"})
 }
 
-type gqlSchema struct {
-	ID              string `json:"id,omitempty"`
-	Schema          string `json:"schema,omitempty"`
-	Version         uint64
-	GeneratedSchema string
-	loaded          bool // This indicate whether the schema has been loaded into graphql server or not
-}
-
 type adminServer struct {
 	rf       resolve.ResolverFactory
 	resolver *resolve.RequestResolver
@@ -595,8 +588,7 @@ type adminServer struct {
 	// The GraphQL server that's being admin'd
 	gqlServer IServeGraphQL
 
-	schema map[uint64]*gqlSchema
-
+	gqlSchemas *worker.GQLSchemaStorage
 	// When the schema changes, we use these to create a new RequestResolver for
 	// the main graphql endpoint (gqlServer) and thus refresh the API.
 	fns               *resolve.ResolverFns
@@ -654,7 +646,7 @@ func newAdminResolver(
 		fns:               fns,
 		withIntrospection: withIntrospection,
 		globalEpoch:       epoch,
-		schema:            make(map[uint64]*gqlSchema),
+		gqlSchemas:        worker.NewGQLSchemaStorage(),
 		gqlServer:         defaultGqlServer,
 	}
 	adminServerVar = server // store the admin server in package variable
@@ -688,14 +680,14 @@ func newAdminResolver(
 		}
 		ns, _ := x.ParseNamespaceAttr(pk.Attr)
 
-		newSchema := &gqlSchema{
+		newSchema := &worker.GqlSchema{
 			ID:      query.UidToHex(pk.Uid),
 			Version: kv.GetVersion(),
 			Schema:  string(pl.Postings[0].Value),
 		}
 
 		server.mux.RLock()
-		currentSchema, ok := server.schema[ns]
+		currentSchema, ok := server.gqlSchemas.GetCurrent(ns)
 		if ok {
 			schemaChanged := newSchema.Schema == currentSchema.Schema
 			if newSchema.Version <= currentSchema.Version || schemaChanged {
@@ -723,18 +715,18 @@ func newAdminResolver(
 
 		server.incrementSchemaUpdateCounter(ns)
 		// if the schema hasn't been loaded yet, then we don't need to load it here
-		currentSchema, ok = server.schema[ns]
-		if !(ok && currentSchema.loaded) {
+		currentSchema, ok = server.gqlSchemas.GetCurrent(ns)
+		if !(ok && currentSchema.Loaded) {
 			// this just set schema in admin server, so that next invalid badger subscription update gets rejected upfront
-			server.schema[ns] = newSchema
+			server.gqlSchemas.Set(ns, newSchema)
 			glog.Infof("namespace: %d. Skipping in-memory GraphQL schema update, "+
 				"it will be lazy-loaded later.", ns)
 			return
 		}
 
 		// update this schema in both admin and graphql server
-		newSchema.loaded = true
-		server.schema[ns] = newSchema
+		newSchema.Loaded = true
+		server.gqlSchemas.Set(ns, newSchema)
 		server.resetSchema(ns, gqlSchema)
 
 		glog.Infof("namespace: %d. Successfully updated GraphQL schema. "+
@@ -808,16 +800,16 @@ func newAdminResolverFactory() resolve.ResolverFactory {
 	return rf.WithSchemaIntrospection()
 }
 
-func getCurrentGraphQLSchema(namespace uint64) (*gqlSchema, error) {
+func getCurrentGraphQLSchema(namespace uint64) (*worker.GqlSchema, error) {
 	uid, graphQLSchema, err := edgraph.GetGQLSchema(namespace)
 	if err != nil {
 		return nil, err
 	}
 
-	return &gqlSchema{ID: uid, Schema: graphQLSchema}, nil
+	return &worker.GqlSchema{ID: uid, Schema: graphQLSchema}, nil
 }
 
-func generateGQLSchema(sch *gqlSchema, ns uint64) (schema.Schema, error) {
+func generateGQLSchema(sch *worker.GqlSchema, ns uint64) (schema.Schema, error) {
 	schHandler, err := schema.NewHandler(sch.Schema, false)
 	if err != nil {
 		return nil, err
@@ -855,8 +847,8 @@ func (as *adminServer) initServer() {
 			glog.Errorf("namespace: %d. Error reading GraphQL schema: %s.", x.GalaxyNamespace, err)
 			continue
 		}
-		sch.loaded = true
-		as.schema[x.GalaxyNamespace] = sch
+		sch.Loaded = true
+		as.gqlSchemas.Set(x.GalaxyNamespace, sch)
 		// adding the actual resolvers for updateGQLSchema and getGQLSchema only after server has
 		// current GraphQL schema, if there was any.
 		as.addConnectedAdminResolvers()
@@ -996,8 +988,12 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 				return resolve.QueryResolverFunc(func(ctx context.Context, query schema.Query) *resolve.Resolved {
 					as.mux.RLock()
 					defer as.mux.RUnlock()
-					sch := as.schema[ns].Schema
-					handler, err := schema.NewHandler(sch, true)
+					sch, ok := as.gqlSchemas.GetCurrent(ns)
+					if !ok {
+						return resolve.EmptyResult(query,
+							fmt.Errorf("error while getting the schema for ns %d", ns))
+					}
+					handler, err := schema.NewHandler(sch.Schema, true)
 					if err != nil {
 						return resolve.EmptyResult(query, err)
 					}
@@ -1024,7 +1020,7 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 	// if the schema is already in memory, no need to fetch it from disk
 	as.mux.RLock()
-	if currentSchema, ok := as.schema[namespace]; ok && currentSchema.loaded {
+	if currentSchema, ok := as.gqlSchemas.GetCurrent(namespace); ok && currentSchema.Loaded {
 		as.mux.RUnlock()
 		return nil
 	}
@@ -1054,29 +1050,16 @@ func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 
 	as.mux.Lock()
 	defer as.mux.Unlock()
-	sch.loaded = true
-	as.schema[namespace] = sch
+	sch.Loaded = true
+	as.gqlSchemas.Set(namespace, sch)
 	as.resetSchema(namespace, generatedSchema)
 
 	glog.Infof("namespace: %d. Successfully lazy-loaded GraphQL schema.", namespace)
 	return nil
 }
 
-func (as *adminServer) resetGQLSchema() error {
-	as.mux.Lock()
-	defer as.mux.Unlock()
-
-	as.schema = make(map[uint64]*gqlSchema)
-	return nil
-}
-
-
 func LazyLoadSchema(namespace uint64) error {
 	return adminServerVar.lazyLoadSchema(namespace)
-}
-
-func ResetGQLSchema() error {
-	return adminServerVar.resetGQLSchema()
 }
 
 func inputArgError(err error) error {

--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -588,7 +588,7 @@ type adminServer struct {
 	// The GraphQL server that's being admin'd
 	gqlServer IServeGraphQL
 
-	gqlSchemas *worker.GQLSchemaStorage
+	gqlSchemas *worker.GQLSchemaStore
 	// When the schema changes, we use these to create a new RequestResolver for
 	// the main graphql endpoint (gqlServer) and thus refresh the API.
 	fns               *resolve.ResolverFns
@@ -646,7 +646,7 @@ func newAdminResolver(
 		fns:               fns,
 		withIntrospection: withIntrospection,
 		globalEpoch:       epoch,
-		gqlSchemas:        worker.NewGQLSchemaStorage(),
+		gqlSchemas:        worker.NewGQLSchemaStore(),
 		gqlServer:         defaultGqlServer,
 	}
 	adminServerVar = server // store the admin server in package variable

--- a/graphql/admin/restore.go
+++ b/graphql/admin/restore.go
@@ -19,7 +19,6 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"github.com/golang/glog"
 	"sync"
 
 	"github.com/dgraph-io/dgraph/edgraph"
@@ -86,9 +85,6 @@ func resolveRestore(ctx context.Context, m schema.Mutation) (*resolve.Resolved, 
 	go func() {
 		wg.Wait()
 		edgraph.ResetAcl(nil)
-		if err := ResetGQLSchema(); err != nil {
-			glog.Errorf("error while refreshing graphql schema %+v", err)
-		}
 	}()
 
 	return resolve.DataResult(

--- a/graphql/admin/restore.go
+++ b/graphql/admin/restore.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"github.com/golang/glog"
 	"sync"
 
 	"github.com/dgraph-io/dgraph/edgraph"
@@ -85,6 +86,9 @@ func resolveRestore(ctx context.Context, m schema.Mutation) (*resolve.Resolved, 
 	go func() {
 		wg.Wait()
 		edgraph.ResetAcl(nil)
+		if err := ResetGQLSchema(); err != nil {
+			glog.Errorf("error while refreshing graphql schema %+v", err)
+		}
 	}()
 
 	return resolve.DataResult(

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -89,7 +89,7 @@ func (gsr *getSchemaResolver) Resolve(ctx context.Context, q schema.Query) *reso
 		return resolve.EmptyResult(q, err)
 	}
 
-	cs, _:= gsr.admin.gqlSchemas.GetCurrent(ns)
+	cs, _ := gsr.admin.gqlSchemas.GetCurrent(ns)
 	if cs == nil || cs.ID == "" {
 		data = map[string]interface{}{q.Name(): nil}
 	} else {

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"github.com/dgraph-io/dgraph/worker"
 
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -33,7 +34,7 @@ type getSchemaResolver struct {
 }
 
 type updateGQLSchemaInput struct {
-	Set gqlSchema `json:"set,omitempty"`
+	Set worker.GqlSchema `json:"set,omitempty"`
 }
 
 type updateSchemaResolver struct {
@@ -88,7 +89,7 @@ func (gsr *getSchemaResolver) Resolve(ctx context.Context, q schema.Query) *reso
 		return resolve.EmptyResult(q, err)
 	}
 
-	cs := gsr.admin.schema[ns]
+	cs, _:= gsr.admin.gqlSchemas.GetCurrent(ns)
 	if cs == nil || cs.ID == "" {
 		data = map[string]interface{}{q.Name(): nil}
 	} else {

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -48,7 +48,7 @@ var (
 	errUpdatingGraphQLSchemaOnNonGroupOneLeader = errors.New(
 		"while updating GraphQL schema: this server isn't group-1 leader, please retry")
 	ErrMultipleGraphQLSchemaNodes = errors.New("found multiple nodes for GraphQL schema")
-	gqlSchemaStorage              *GQLSchemaStorage
+	gqlSchemaStore                *GQLSchemaStore
 )
 
 type GqlSchema struct {
@@ -60,41 +60,41 @@ type GqlSchema struct {
 	// or not
 }
 
-type GQLSchemaStorage struct {
+type GQLSchemaStore struct {
 	mux    sync.RWMutex
 	schema map[uint64]*GqlSchema
 }
 
-func NewGQLSchemaStorage() *GQLSchemaStorage {
-	gqlSchemaStorage = &GQLSchemaStorage{
+func NewGQLSchemaStore() *GQLSchemaStore {
+	gqlSchemaStore = &GQLSchemaStore{
 		mux:    sync.RWMutex{},
 		schema: make(map[uint64]*GqlSchema),
 	}
-	return gqlSchemaStorage
+	return gqlSchemaStore
 }
 
-func (gs *GQLSchemaStorage) Set(ns uint64, sch *GqlSchema) {
+func (gs *GQLSchemaStore) Set(ns uint64, sch *GqlSchema) {
 	gs.mux.Lock()
 	defer gs.mux.Unlock()
 	gs.schema[ns] = sch
 }
 
-func (gs *GQLSchemaStorage) GetCurrent(ns uint64) (*GqlSchema, bool) {
+func (gs *GQLSchemaStore) GetCurrent(ns uint64) (*GqlSchema, bool) {
 	gs.mux.RLock()
 	defer gs.mux.RUnlock()
 	sch, ok := gs.schema[ns]
 	return sch, ok
 }
 
-func (gs *GQLSchemaStorage) resetGQLSchema() {
+func (gs *GQLSchemaStore) resetGQLSchema() {
 	gs.mux.Lock()
 	defer gs.mux.Unlock()
 
 	gs.schema = make(map[uint64]*GqlSchema)
 }
 
-func ResetGQLSchema() {
-	gqlSchemaStorage.resetGQLSchema()
+func ResetGQLSchemaStore() {
+	gqlSchemaStore.resetGQLSchema()
 }
 
 // UpdateGQLSchemaOverNetwork sends the request to the group one leader for execution.

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -48,7 +48,7 @@ var (
 	errUpdatingGraphQLSchemaOnNonGroupOneLeader = errors.New(
 		"while updating GraphQL schema: this server isn't group-1 leader, please retry")
 	ErrMultipleGraphQLSchemaNodes = errors.New("found multiple nodes for GraphQL schema")
-	gqlSchemaStorage *GQLSchemaStorage
+	gqlSchemaStorage              *GQLSchemaStorage
 )
 
 type GqlSchema struct {
@@ -61,14 +61,14 @@ type GqlSchema struct {
 }
 
 type GQLSchemaStorage struct {
-	mux sync.RWMutex
+	mux    sync.RWMutex
 	schema map[uint64]*GqlSchema
 }
 
 func NewGQLSchemaStorage() *GQLSchemaStorage {
 	gqlSchemaStorage = &GQLSchemaStorage{
-		mux:               sync.RWMutex{},
-		schema:            make(map[uint64]*GqlSchema),
+		mux:    sync.RWMutex{},
+		schema: make(map[uint64]*GqlSchema),
 	}
 	return gqlSchemaStorage
 }
@@ -100,7 +100,7 @@ func RefreshGQLSchema() error {
 
 // UpdateGQLSchemaOverNetwork sends the request to the group one leader for execution.
 func UpdateGQLSchemaOverNetwork(ctx context.Context, req *pb.UpdateGraphQLSchemaRequest) (*pb.
-UpdateGraphQLSchemaResponse, error) {
+	UpdateGraphQLSchemaResponse, error) {
 	if isGroupOneLeader() {
 		return (&grpcWorker{}).UpdateGraphQLSchema(ctx, req)
 	}

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -86,16 +86,15 @@ func (gs *GQLSchemaStorage) GetCurrent(ns uint64) (*GqlSchema, bool) {
 	return sch, ok
 }
 
-func (gs *GQLSchemaStorage) refreshGQLSchema() error {
+func (gs *GQLSchemaStorage) resetGQLSchema() {
 	gs.mux.Lock()
 	defer gs.mux.Unlock()
 
 	gs.schema = make(map[uint64]*GqlSchema)
-	return nil
 }
 
-func RefreshGQLSchema() error {
-	return gqlSchemaStorage.refreshGQLSchema()
+func ResetGQLSchema() {
+	gqlSchemaStorage.resetGQLSchema()
 }
 
 // UpdateGQLSchemaOverNetwork sends the request to the group one leader for execution.

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -336,10 +336,8 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 		return errors.Wrapf(err, "cannot load schema after restore")
 	}
 
-	// refreshing gql schema
-	if err := RefreshGQLSchema(); err != nil {
-		glog.Errorf("error while refreshing graphql schema %+v", err)
-	}
+	// reset gql schema
+	RefreshGQLSchema()
 
 	// Propose a snapshot immediately after all the work is done to prevent the restore
 	// from being replayed.

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -336,6 +336,11 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 		return errors.Wrapf(err, "cannot load schema after restore")
 	}
 
+	// refreshing gql schema
+	if err := RefreshGQLSchema(); err != nil {
+		glog.Errorf("error while refreshing graphql schema %+v", err)
+	}
+
 	// Propose a snapshot immediately after all the work is done to prevent the restore
 	// from being replayed.
 	if err := groups().Node.proposeSnapshot(); err != nil {

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -337,7 +337,8 @@ func handleRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
 	}
 
 	// reset gql schema
-	RefreshGQLSchema()
+	glog.Info("reseting local gql schema store")
+	ResetGQLSchemaStore()
 
 	// Propose a snapshot immediately after all the work is done to prevent the restore
 	// from being replayed.


### PR DESCRIPTION
1. The issue is graphql layer relies upon the badger subscribe events to update the inmemory schema. But with new restore changes, where stream is used to backups, there were no subscribed updated events for the graphql layer. 

Hence after restores, gql schema was not getting updated. This PR refreshed the gql schema if there is a successful restore operation. One thing is dgraph stores schema in memory. This PR only makes the current node to refresh the inmemory state of schema. Now restore operation runs on every node. Therefore in the end each node will refresh its schema and thus returns to the stable state.

2. Skipping /probe/graphql from audit as this is used by cloud to check pods health status
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7925)
<!-- Reviewable:end -->
