### PR TITLE
fix(cmd/debug): Print banned namespaces correctly.

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -835,7 +835,7 @@ func printSummary(db *badger.DB) {
 	fmt.Println()
 	for ns, sz := range nsSize {
 		fmt.Printf("Namespace %#x size: %12s", ns, humanize.IBytes(sz))
-		if _, ok := bannedNs[ns]; !ok {
+		if _, ok := bannedNs[ns]; ok {
 			fmt.Printf(" (banned)")
 		}
 		fmt.Println()


### PR DESCRIPTION
Earlier we were showing the opposite status: unbanned namespaces were shown as
banned. This change fixes that.

(cherry picked from commit 43a1bd0b09f157144a075ab872c7faae4b28abb4)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7929)
<!-- Reviewable:end -->
