### PR TITLE
fix(restore): Set kv version to restoreTs for rolled up keys and schema keys

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -450,8 +450,10 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 			kv.StreamId = 0
 			// Schema and type keys are not stored in an intermediate format so their
 			// value can be written as is.
+			version := kv.Version
+			kv.Version = m.restoreTs
 			kv.Key = restoreKey
-			if err := toBuffer(kv, kv.Version); err != nil {
+			if err := toBuffer(kv, version); err != nil {
 				return err
 			}
 

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -371,7 +371,9 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 					return err
 				}
 				for _, kv := range kvs {
-					if err := toBuffer(kv, kv.Version); err != nil {
+					version := kv.Version
+					kv.Version = m.restoreTs
+					if err := toBuffer(kv, version); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
The kv version should be set to restore timestamp for rolled-up keys and schema keys as well.

NOTE: I need to double-check if writing schema to restoreTs is right thing to do.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7930)
<!-- Reviewable:end -->
