### PR TITLE
cloud: fix(backup): Fix full backup request (#7932)

### DIFF
--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -56,6 +56,7 @@ func resolveBackup(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 		SecretKey:    input.SecretKey,
 		SessionToken: input.SessionToken,
 		Anonymous:    input.Anonymous,
+		ForceFull:    input.ForceFull,
 	}
 	taskId, err := worker.Tasks.Enqueue(req)
 	if err != nil {


### PR DESCRIPTION
The ForceFull parameter was not being passed in the backup request queue,
causing all the backups to be incremental despite the request with `forceFull=True`.
This commit fixes this issue.

(cherry picked from commit 8d08cc3368e0aa0113080923772c32593073efbc)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7933)
<!-- Reviewable:end -->
