### PR TITLE
[cherry-pick] CLOUD: Add namespaces field to state

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -151,6 +151,11 @@ const (
 		removed: [Member]
 		cid: String
 		license: License
+		"""
+		Contains list of namespaces. Note that this is not stored in proto's MembershipState and
+		computed at the time of query.
+		"""
+		namespaces: [UInt64]
 	}
 
 	type ClusterGroup {

--- a/x/keys.go
+++ b/x/keys.go
@@ -143,6 +143,19 @@ func IsReverseAttr(attr string) bool {
 	return pred[0] == '~'
 }
 
+func ExtractNamespaceFromPredicate(predicate string) (uint64, error) {
+	splitString := strings.Split(predicate, "-")
+	if len(splitString) <= 1 {
+		return 0, errors.Errorf("predicate does not contain namespace name")
+	}
+	uintVal, err := strconv.ParseUint(splitString[0], 0, 64)
+	if err != nil {
+		return 0, errors.Wrapf(err, "while parsing %s as uint64", splitString[0])
+	}
+	return uintVal, nil
+
+}
+
 func writeAttr(buf []byte, attr string) []byte {
 	AssertTrue(len(attr) < math.MaxUint16)
 	binary.BigEndian.PutUint16(buf[:2], uint16(len(attr)))


### PR DESCRIPTION
Motivation:
Currently, there is no way to query namespaces. This adds namespaces field to state. This field can be used to query list of namespaces.
Note that this will output list of namespace only in case the user is an admin user (guardians of galaxy). In all other cases, it will return an empty list.

(cherry picked from commit d2bd8328e6534dc7c894a4a9727a34674da0fd11)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7937)
<!-- Reviewable:end -->
