### PR TITLE
opt(Alpha): Load schema and types using Stream framework (#7938)

### DIFF
--- a/schema/schema.go
+++ b/schema/schema.go
@@ -17,7 +17,6 @@
 package schema
 
 import (
-	"bytes"
 	"context"
 	"encoding/hex"
 	"fmt"
@@ -30,6 +29,7 @@ import (
 	"golang.org/x/net/trace"
 
 	"github.com/dgraph-io/badger/v3"
+	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
@@ -499,82 +499,72 @@ func Load(predicate string) error {
 
 // LoadFromDb reads schema information from db and stores it in memory
 func LoadFromDb() error {
-	if err := LoadSchemaFromDb(); err != nil {
+	if err := loadFromDB(loadSchema); err != nil {
 		return err
 	}
-	return LoadTypesFromDb()
+	return loadFromDB(loadType)
 }
 
-// LoadSchemaFromDb iterates through the DB and loads all the stored schema updates.
-func LoadSchemaFromDb() error {
-	prefix := x.SchemaPrefix()
-	txn := pstore.NewTransactionAt(math.MaxUint64, false)
-	defer txn.Discard()
-	itr := txn.NewIterator(badger.DefaultIteratorOptions) // Need values, reversed=false.
-	defer itr.Close()
+const (
+	loadSchema int = iota
+	loadType
+)
 
-	for itr.Seek(prefix); itr.Valid(); itr.Next() {
+// loadFromDb iterates through the DB and loads all the stored schema updates.
+func loadFromDB(loadType int) error {
+	stream := pstore.NewStreamAt(math.MaxUint64)
+
+	switch loadType {
+	case loadSchema:
+		stream.Prefix = x.SchemaPrefix()
+		stream.LogPrefix = "LoadFromDb Schema"
+	case loadType:
+		stream.Prefix = x.TypePrefix()
+		stream.LogPrefix = "LoadFromDb Type"
+	default:
+		glog.Fatalf("Invalid load type")
+	}
+
+	stream.KeyToList = func(key []byte, itr *badger.Iterator) (*badgerpb.KVList, error) {
 		item := itr.Item()
-		key := item.Key()
-		if !bytes.HasPrefix(key, prefix) {
-			break
-		}
 		pk, err := x.Parse(key)
 		if err != nil {
 			glog.Errorf("Error while parsing key %s: %v", hex.Dump(key), err)
-			continue
+			return nil, nil
 		}
-		attr := pk.Attr
-		var s pb.SchemaUpdate
-		err = item.Value(func(val []byte) error {
-			if len(val) == 0 {
-				s = pb.SchemaUpdate{Predicate: attr, ValueType: pb.Posting_DEFAULT}
-			}
-			x.Checkf(s.Unmarshal(val), "Error while loading schema from db")
-			State().Set(attr, &s)
-			return nil
-		})
-		if err != nil {
-			return err
+		if len(pk.Attr) == 0 {
+			glog.Warningf("Empty Attribute: %+v for Key: %x\n", pk, key)
+			return nil, nil
 		}
-	}
-	return nil
-}
 
-// LoadTypesFromDb iterates through the DB and loads all the stored type updates.
-func LoadTypesFromDb() error {
-	prefix := x.TypePrefix()
-	txn := pstore.NewTransactionAt(math.MaxUint64, false)
-	defer txn.Discard()
-	itr := txn.NewIterator(badger.DefaultIteratorOptions) // Need values, reversed=false.
-	defer itr.Close()
-
-	for itr.Seek(prefix); itr.Valid(); itr.Next() {
-		item := itr.Item()
-		key := item.Key()
-		if !bytes.HasPrefix(key, prefix) {
-			break
+		switch loadType {
+		case loadSchema:
+			var s pb.SchemaUpdate
+			err := item.Value(func(val []byte) error {
+				if len(val) == 0 {
+					s = pb.SchemaUpdate{Predicate: pk.Attr, ValueType: pb.Posting_DEFAULT}
+				}
+				x.Checkf(s.Unmarshal(val), "Error while loading schema from db")
+				State().Set(pk.Attr, &s)
+				return nil
+			})
+			return nil, err
+		case loadType:
+			var t pb.TypeUpdate
+			err := item.Value(func(val []byte) error {
+				if len(val) == 0 {
+					t = pb.TypeUpdate{TypeName: pk.Attr}
+				}
+				x.Checkf(t.Unmarshal(val), "Error while loading types from db")
+				State().SetType(pk.Attr, t)
+				return nil
+			})
+			return nil, err
 		}
-		pk, err := x.Parse(key)
-		if err != nil {
-			glog.Errorf("Error while parsing key %s: %v", hex.Dump(key), err)
-			continue
-		}
-		attr := pk.Attr
-		var t pb.TypeUpdate
-		err = item.Value(func(val []byte) error {
-			if len(val) == 0 {
-				t = pb.TypeUpdate{TypeName: attr}
-			}
-			x.Checkf(t.Unmarshal(val), "Error while loading types from db")
-			State().SetType(attr, t)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
+		glog.Fatalf("Invalid load type")
+		return nil, errors.New("shouldn't reach here")
 	}
-	return nil
+	return stream.Orchestrate(context.Background())
 }
 
 // InitialTypes returns the type updates to insert at the beginning of

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -150,8 +150,10 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	gr.Node = newNode(walStore, gid, raftIdx, x.WorkerConfig.MyAddr)
 
 	x.Checkf(schema.LoadFromDb(), "Error while initializing schema")
+	glog.Infof("Load schema from DB: OK")
 	raftServer.UpdateNode(gr.Node.Node)
 	gr.Node.InitAndStartNode()
+	glog.Infof("Init and start Raft node: OK")
 
 	gr.closer = z.NewCloser(3) // Match CLOSER:1 in this file.
 	go gr.sendMembershipUpdates()
@@ -159,11 +161,13 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	go gr.processOracleDeltaStream()
 
 	gr.informZeroAboutTablets()
+	glog.Infof("Informed Zero about tablets I have: OK")
 	gr.applyInitialSchema()
 	gr.applyInitialTypes()
+	glog.Infof("Upserted Schema and Types: OK")
 
 	x.UpdateHealthStatus(true)
-	glog.Infof("Server is ready")
+	glog.Infof("Server is ready: OK")
 }
 
 func (g *groupi) Ctx() context.Context {
@@ -186,6 +190,10 @@ func (g *groupi) informZeroAboutTablets() {
 		failed := false
 		preds := schema.State().Predicates()
 		for _, pred := range preds {
+			if len(pred) == 0 {
+				glog.Warningf("Got an empty pred")
+				continue
+			}
 			if tablet, err := g.Tablet(pred); err != nil {
 				failed = true
 				glog.Errorf("Error while getting tablet for pred %q: %v", pred, err)


### PR DESCRIPTION
For big datasets, we're seeing a big slowdown due to loading schema and types serially using a single iterator. Using the Stream framework, makes this metadata loading step much faster, resulting in a much faster Alpha initialization.

(cherry picked from commit d03d5ad14e8ec5044d1e7f16c8be271d890346f1)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7941)
<!-- Reviewable:end -->
