### PR TITLE
perf: Multiple `append` combined into a single call

### DIFF
--- a/dgraph/cmd/alpha/http_test.go
+++ b/dgraph/cmd/alpha/http_test.go
@@ -187,8 +187,7 @@ func queryWithTsForResp(inp queryInp) (string, *tsInfo, *http.Response, error) {
 		params = append(params, "debug="+inp.debug)
 	}
 	if inp.ts != 0 {
-		params = append(params, fmt.Sprintf("startTs=%v", strconv.FormatUint(inp.ts, 10)))
-		params = append(params, fmt.Sprintf("hash=%s", inp.hash))
+		params = append(params, fmt.Sprintf("startTs=%v", strconv.FormatUint(inp.ts, 10)), fmt.Sprintf("hash=%s", inp.hash))
 	}
 	url := addr + "/query?" + strings.Join(params, "&")
 
@@ -234,8 +233,7 @@ type mutationInp struct {
 func mutationWithTs(inp mutationInp) (mutationResponse, error) {
 	params := make([]string, 0, 3)
 	if inp.ts != 0 {
-		params = append(params, "startTs="+strconv.FormatUint(inp.ts, 10))
-		params = append(params, "hash="+inp.hash)
+		params = append(params, "startTs="+strconv.FormatUint(inp.ts, 10), "hash="+inp.hash)
 	}
 
 	var mr mutationResponse

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -52,9 +52,7 @@ func LiveLoad(opts LiveOpts) error {
 		if opts.Creds.Namespace == x.GalaxyNamespace || opts.ForceNs != 0 {
 			args = append(args, "--force-namespace", strconv.FormatInt(opts.ForceNs, 10))
 		}
-		args = append(args, "--creds")
-		args = append(args, fmt.Sprintf("user=%s;password=%s;namespace=%d",
-			opts.Creds.UserID, opts.Creds.Passwd, opts.Creds.Namespace))
+		args = append(args, "--creds", fmt.Sprintf("user=%s;password=%s;namespace=%d", opts.Creds.UserID, opts.Creds.Passwd, opts.Creds.Namespace))
 	}
 	liveCmd := exec.Command(DgraphBinaryPath(), args...)
 

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -1081,8 +1081,7 @@ func GetEEFeaturesList() []string {
 	}
 	var ee []string
 	if len(Config.HmacSecret) > 0 {
-		ee = append(ee, "acl")
-		ee = append(ee, "multi_tenancy")
+		ee = append(ee, "acl", "multi_tenancy")
 	}
 	if x.WorkerConfig.EncryptionKey != nil {
 		ee = append(ee, "encryption_at_rest", "encrypted_backup_restore", "encrypted_export")


### PR DESCRIPTION
## Description

The `append` built-in function appends elements to the end of a slice. If it has sufficient capacity, the destination is resliced to accommodate the new elements, but if capacity is not enough, then `append` will allocate a new underlying array and return the updated slice. Therefore, it is necessary to store the result of append, often in the variable holding the slice itself. Appending calls in a single call of `append` allocates memory just once to accommodate all the elements to be appended. Whereas multiple calls to `append` introduce many overheads, most notably being the possibility of more calls for memory allocation because the total number of elements to be appended over multiple calls of `append` is unknown beforehand, resulting in inaccurate preallocation.

## <!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7944)

<!-- Reviewable:end -->
