### PR TITLE
protobuf: upgrade golang/protobuf library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,10 +32,10 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/geo v0.0.0-20170810003146-31fb0106dc4a
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
-	github.com/golang/protobuf v1.4.1
+	github.com/golang/protobuf v1.5.2
 	github.com/golang/snappy v0.0.3
 	github.com/google/codesearch v1.0.0
-	github.com/google/go-cmp v0.5.4
+	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.0.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/graph-gophers/graphql-go v0.0.0-20200309224638-dae41bde9ef9

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,10 @@ github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:x
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
-github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
@@ -247,8 +249,9 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
@@ -821,8 +824,10 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.22.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
-google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/DataDog/dd-trace-go.v1 v1.13.1 h1:oTzOClfuudNhW9Skkp2jxjqYO92uDKXqKLbiuPA13Rk=
 gopkg.in/DataDog/dd-trace-go.v1 v1.13.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=


### PR DESCRIPTION
Protobuf 1.4.x is not compatible with gogo-generated protos.
There were some improvements in 1.5.1 protobuf runtime that enabled some basic compatibility. Upgrading the protobuf version should fix some of the compatibility issues.
It fixes this crash.
```
panic: field raftpb.Entry.Type has invalid type: got raftpb.EntryType, want pointer
goroutine 294 [running]:
google.golang.org/protobuf/internal/impl.fieldInfoForScalar(0x23a3c38, 0xc006734000, 0x1e17763, 0x4, 0x0, 0x0, 0x23a3d48, 0x1e8c900, 0x1e17769, 0x43, ...)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message_reflect_field.go:228 +0x7f7
google.golang.org/protobuf/internal/impl.(*MessageInfo).makeKnownFieldsFunc(0xc000152000, 0xffffffffffffffff, 0xffffffffffffffff, 0x30, 0xffffffffffffffff, 0xc0061f9c80, 0xc0061f9cb0, 0xc0061f9ce0, 0xc0061f9d10)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message_reflect.go:67 +0x99d
google.golang.org/protobuf/internal/impl.(*MessageInfo).makeReflectFuncs(0xc000152000, 0x23a3d48, 0x1f823e0, 0xffffffffffffffff, 0xffffffffffffffff, 0x30, 0xffffffffffffffff, 0xc0061f9c80, 0xc0061f9cb0, 0xc0061f9ce0, ...)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message_reflect.go:36 +0x65
google.golang.org/protobuf/internal/impl.(*MessageInfo).initOnce(0xc000152000)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message.go:90 +0x195
google.golang.org/protobuf/internal/impl.(*MessageInfo).init(...)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message.go:72
google.golang.org/protobuf/internal/impl.(*messageReflectWrapper).Has(0xc00638ba70, 0x23a3c38, 0xc006734000, 0xc006734000)
    /home/dmai/go/pkg/mod/google.golang.org/protobuf@v1.25.0/internal/impl/message_reflect_gen.go:185 +0xf9
github.com/golang/protobuf/proto.(*textWriter).writeMessage(0xc0061f9c50, 0x239bb10, 0xc00638ba70, 0x0, 0x0)
    /home/dmai/go/pkg/mod/github.com/golang/protobuf@v1.4.1/proto/text_encode.go:278 +0x131e
github.com/golang/protobuf/proto.(*TextMarshaler).marshal(0x2d19ede, 0x237b4e8, 0xc0005deff0, 0xc0064e8048, 0x1, 0x2be5398, 0x2d37f80, 0xd)
    /home/dmai/go/pkg/mod/github.com/golang/protobuf@v1.4.1/proto/text_encode.go:86 +0x193
github.com/golang/protobuf/proto.(*TextMarshaler).Text(...)
    /home/dmai/go/pkg/mod/github.com/golang/protobuf@v1.4.1/proto/text_encode.go:44
github.com/golang/protobuf/proto.CompactTextString(...)
    /home/dmai/go/pkg/mod/github.com/golang/protobuf@v1.4.1/proto/text_encode.go:106
go.etcd.io/etcd/raft/raftpb.(*Entry).String(...)
    /home/dmai/go/pkg/mod/go.etcd.io/etcd@v0.0.0-20190228193606-a943ad0ee4c9/raft/raftpb/raft.pb.go:212
go.etcd.io/etcd/raft.stepLeader(0xc0001a03c0, 0x2, 0x0, 0x1, 0x0, 0x0, 0x0, 0xc0005defa0, 0x1, 0x1, ...)
    /home/dmai/go/pkg/mod/go.etcd.io/etcd@v0.0.0-20190228193606-a943ad0ee4c9/raft/raft.go:1012 +0x230
go.etcd.io/etcd/raft.(*raft).Step(0xc0001a03c0, 0x2, 0x0, 0x1, 0x0, 0x0, 0x0, 0xc0005defa0, 0x1, 0x1, ...)
    /home/dmai/go/pkg/mod/go.etcd.io/etcd@v0.0.0-20190228193606-a943ad0ee4c9/raft/raft.go:971 +0x1235
go.etcd.io/etcd/raft.(*node).run(0xc0003cc2a0, 0xc0001a03c0)
    /home/dmai/go/pkg/mod/go.etcd.io/etcd@v0.0.0-20190228193606-a943ad0ee4c9/raft/node.go:349 +0xb98
created by go.etcd.io/etcd/raft.StartNode
    /home/dmai/go/pkg/mod/go.etcd.io/etcd@v0.0.0-20190228193606-a943ad0ee4c9/raft/node.go:233 +0x409
W0714 02:38:15.596380       1 sentry_integration.go:140] unable to read CID from file /tmp/dgraph-alpha-cid-sentry open /tmp/dgraph-alpha-cid-sentry: no such file or directory. Skip
[Sentry] 2021/07/14 02:38:15 Sending fatal event [8c415c6848ca4f298c09962ec81e760b] to o318308.ingest.sentry.io project: 5208688
[Sentry] 2021/07/14 02:38:15 Buffer flushed successfully.
```

Fixes DGRAPH-3252
Related to https://github.com/dgraph-io/dgraph/pull/7688

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7947)
<!-- Reviewable:end -->
