### PR TITLE
fix(conn): JoinCluster loop should use latest conn (#7950)

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -632,10 +632,9 @@ func (n *node) initAndStartNode() error {
 			return errors.Errorf("Unhealthy connection to %v", opts.peer)
 		}
 
-		gconn := p.Get()
-		c := pb.NewRaftClient(gconn)
 		timeout := 8 * time.Second
 		for {
+			c := pb.NewRaftClient(p.Get())
 			ctx, cancel := context.WithTimeout(n.ctx, timeout)
 			// JoinCluster can block indefinitely, raft ignores conf change proposal
 			// if it has pending configuration.

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1768,8 +1768,7 @@ func (n *node) joinPeers() error {
 		return err
 	}
 
-	gconn := pl.Get()
-	c := pb.NewRaftClient(gconn)
+	c := pb.NewRaftClient(pl.Get())
 	glog.Infof("Calling JoinCluster via leader: %s", pl.Addr)
 	if _, err := c.JoinCluster(n.ctx, n.RaftContext); err != nil {
 		return errors.Wrapf(err, "error while joining cluster")

--- a/worker/multi_tenancy_ee.go
+++ b/worker/multi_tenancy_ee.go
@@ -88,9 +88,7 @@ func proposeDeleteOrSend(ctx context.Context, req *pb.DeleteNsRequest) error {
 	if pl == nil {
 		return conn.ErrNoConnection
 	}
-	con := pl.Get()
-	c := pb.NewWorkerClient(con)
-
+	c := pb.NewWorkerClient(pl.Get())
 	_, err := c.DeleteNamespace(ctx, req)
 	return err
 }

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -598,10 +598,9 @@ func proposeOrSend(ctx context.Context, gid uint32, m *pb.Mutations, chr chan re
 		chr <- res
 		return
 	}
-	con := pl.Get()
 
 	var tc *api.TxnContext
-	c := pb.NewWorkerClient(con)
+	c := pb.NewWorkerClient(pl.Get())
 
 	ch := make(chan error, 1)
 	go func() {

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -178,8 +178,7 @@ func proposeRestoreOrSend(ctx context.Context, req *pb.RestoreRequest) error {
 	if pl == nil {
 		return conn.ErrNoConnection
 	}
-	con := pl.Get()
-	c := pb.NewWorkerClient(con)
+	c := pb.NewWorkerClient(pl.Get())
 
 	_, err := c.Restore(ctx, req)
 	return err

--- a/worker/schema.go
+++ b/worker/schema.go
@@ -174,8 +174,7 @@ func getSchemaOverNetwork(ctx context.Context, gid uint32, s *pb.SchemaRequest, 
 		ch <- resultErr{err: conn.ErrNoConnection}
 		return
 	}
-	conn := pl.Get()
-	c := pb.NewWorkerClient(conn)
+	c := pb.NewWorkerClient(pl.Get())
 	schema, e := c.Schema(ctx, s)
 	ch <- resultErr{result: schema, err: e}
 }

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -47,8 +47,7 @@ type badgerWriter interface {
 
 // populateSnapshot gets data for a shard from the leader and writes it to BadgerDB on the follower.
 func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) error {
-	con := pl.Get()
-	c := pb.NewWorkerClient(con)
+	c := pb.NewWorkerClient(pl.Get())
 
 	// We should absolutely cancel the context when we return from this function, that way, the
 	// leader who is sending the snapshot would stop sending.

--- a/worker/task.go
+++ b/worker/task.go
@@ -53,11 +53,10 @@ func invokeNetworkRequest(ctx context.Context, addr string,
 		return nil, errors.Wrapf(err, "dispatchTaskOverNetwork: while retrieving connection.")
 	}
 
-	con := pl.Get()
 	if span := otrace.FromContext(ctx); span != nil {
 		span.Annotatef(nil, "invokeNetworkRequest: Sending request to %v", addr)
 	}
-	c := pb.NewWorkerClient(con)
+	c := pb.NewWorkerClient(pl.Get())
 	return f(ctx, c)
 }
 

--- a/worker/zero.go
+++ b/worker/zero.go
@@ -31,8 +31,7 @@ func RemoveNodeOverNetwork(ctx context.Context, req *pb.RemoveNodeRequest) (*pb.
 		return nil, conn.ErrNoConnection
 	}
 
-	con := pl.Get()
-	c := pb.NewZeroClient(con)
+	c := pb.NewZeroClient(pl.Get())
 	return c.RemoveNode(ctx, req)
 }
 
@@ -44,8 +43,7 @@ func MoveTabletOverNetwork(ctx context.Context, req *pb.MoveTabletRequest) (*pb.
 		return nil, conn.ErrNoConnection
 	}
 
-	con := pl.Get()
-	c := pb.NewZeroClient(con)
+	c := pb.NewZeroClient(pl.Get())
 	return c.MoveTablet(ctx, req)
 }
 
@@ -57,7 +55,6 @@ func ApplyLicenseOverNetwork(ctx context.Context, req *pb.ApplyLicenseRequest) (
 		return nil, conn.ErrNoConnection
 	}
 
-	con := pl.Get()
-	c := pb.NewZeroClient(con)
+	c := pb.NewZeroClient(pl.Get())
 	return c.ApplyLicense(ctx, req)
 }


### PR DESCRIPTION
> JoinCluster loop was getting the connection from pool upfront, and then looping over it. This opened up a bug because in https://github.com/dgraph-io/dgraph/pull/7918 , we close the connection in case it becomes unhealthy.
>
> This PR gets the latest connection available in the loop. This was the only place in the codebase where I found this issue.

(cherry picked from commit 7531e95f9854f9f2315e5400a78cf43c080680d6)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7951)
<!-- Reviewable:end -->
