### PR TITLE
fix(rollups): Write rollup keys at ts+1

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -827,7 +827,7 @@ func (l *List) Rollup(alloc *z.Allocator) ([]*bpb.KV, error) {
 
 	var kvs []*bpb.KV
 	kv := MarshalPostingList(out.plist, alloc)
-	kv.Version = out.newMinTs
+	kv.Version = out.newMinTs + 1
 	kv.Key = alloc.Copy(l.key)
 	kvs = append(kvs, kv)
 
@@ -906,7 +906,7 @@ func (out *rollupOutput) marshalPostingListPart(alloc *z.Allocator,
 			hex.EncodeToString(baseKey), startUid)
 	}
 	kv := MarshalPostingList(plist, alloc)
-	kv.Version = out.newMinTs
+	kv.Version = out.newMinTs + 1
 	kv.Key = alloc.Copy(key)
 	return kv, nil
 }

--- a/posting/list.go
+++ b/posting/list.go
@@ -830,6 +830,12 @@ func (l *List) Rollup(alloc *z.Allocator) ([]*bpb.KV, error) {
 	// We set kv.Version to newMinTs + 1 because if we write the rolled up keys at the same ts as
 	// that of the delta, then in case of wal replay the rolled up key would get over-written by the
 	// delta which can bring db to an invalid state.
+	// It would be fine to write rolled up key at ts+1 and this key won't be overwritten by any
+	// other delta because there cannot be commit at ts as well as ts+1 on the same key. The reason
+	// is as follows:
+	// Suppose there are two inter-leaved txns [s1 s2 c1 c2] where si, ci is the start and commit
+	// of the i'th txn. In this case c2 would not have happened because of conflict.
+	// Suppose there are two disjoint txns [s1 c1 s2 c2], then c1 and c2 cannot be consecutive.
 	kv.Version = out.newMinTs + 1
 	kv.Key = alloc.Copy(l.key)
 	kvs = append(kvs, kv)

--- a/posting/list.go
+++ b/posting/list.go
@@ -827,6 +827,9 @@ func (l *List) Rollup(alloc *z.Allocator) ([]*bpb.KV, error) {
 
 	var kvs []*bpb.KV
 	kv := MarshalPostingList(out.plist, alloc)
+	// We set kv.Version to newMinTs + 1 because if we write the rolled up keys at the same ts as
+	// that of the delta, then in case of wal replay the rolled up key would get over-written by the
+	// delta which can bring db to an invalid state.
 	kv.Version = out.newMinTs + 1
 	kv.Key = alloc.Copy(l.key)
 	kvs = append(kvs, kv)

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -469,7 +469,7 @@ func TestMillion(t *testing.T) {
 	}
 
 	t.Logf("Completed a million writes.\n")
-	opt := ListOptions{ReadTs: uint64(N) + 1}
+	opt := ListOptions{ReadTs: math.MaxUint64}
 	l, err := ol.Uids(opt)
 	require.NoError(t, err)
 	require.Equal(t, commits, len(l.Uids), "List of Uids received: %+v", l.Uids)
@@ -882,6 +882,7 @@ func createMultiPartList(t *testing.T, size int, addFacet bool) (*List, int) {
 	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	commits := 0
+	curTs := 1
 	for i := 1; i <= size; i++ {
 		edge := &pb.DirectedEdge{
 			ValueId: uint64(i),
@@ -892,10 +893,11 @@ func createMultiPartList(t *testing.T, size int, addFacet bool) (*List, int) {
 			edge.Facets = []*api.Facet{{Key: strconv.Itoa(i)}}
 		}
 
-		txn := Txn{StartTs: uint64(i)}
+		txn := Txn{StartTs: uint64(curTs)}
 		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+		require.NoError(t, ol.commitMutation(uint64(curTs), uint64(curTs)+1))
 		if i%2000 == 0 {
+			curTs++
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
@@ -903,12 +905,13 @@ func createMultiPartList(t *testing.T, size int, addFacet bool) (*List, int) {
 			require.NoError(t, err)
 		}
 		commits++
+		curTs++
 	}
 
 	kvs, err := ol.Rollup(nil)
 	require.NoError(t, err)
 	for _, kv := range kvs {
-		require.Equal(t, uint64(size+1), kv.Version)
+		require.Equal(t, uint64(curTs+1), kv.Version)
 	}
 	require.NoError(t, writePostingListToDisk(kvs))
 	ol, err = getNew(key, ps, math.MaxUint64)
@@ -1022,7 +1025,7 @@ func writePostingListToDisk(kvs []*bpb.KV) error {
 func TestMultiPartListBasic(t *testing.T) {
 	size := int(1e5)
 	ol, commits := createMultiPartList(t, size, false)
-	opt := ListOptions{ReadTs: uint64(size) + 1}
+	opt := ListOptions{ReadTs: math.MaxUint64}
 	l, err := ol.Uids(opt)
 	require.NoError(t, err)
 	require.Equal(t, commits, len(l.Uids), "List of Uids received: %+v", l.Uids)
@@ -1056,7 +1059,7 @@ func TestBinSplit(t *testing.T) {
 		kvs, err := ol.Rollup(nil)
 		require.NoError(t, err)
 		for _, kv := range kvs {
-			require.Equal(t, uint64(size+1), kv.Version)
+			require.Equal(t, uint64(size+2), kv.Version)
 		}
 		require.NoError(t, writePostingListToDisk(kvs))
 		ol, err = getNew(key, ps, math.MaxUint64)
@@ -1106,7 +1109,7 @@ func TestMultiPartListIterAfterUid(t *testing.T) {
 	ol, _ := createMultiPartList(t, size, false)
 
 	var visitedUids []uint64
-	ol.Iterate(uint64(size+1), 50000, func(p *pb.Posting) error {
+	ol.Iterate(math.MaxUint64, 50000, func(p *pb.Posting) error {
 		visitedUids = append(visitedUids, p.Uid)
 		return nil
 	})
@@ -1122,7 +1125,7 @@ func TestMultiPartListWithPostings(t *testing.T) {
 	ol, commits := createMultiPartList(t, size, true)
 
 	var facets []string
-	err := ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
+	err := ol.Iterate(math.MaxUint64, 0, func(p *pb.Posting) error {
 		if len(p.Facets) > 0 {
 			facets = append(facets, p.Facets[0].Key)
 		}
@@ -1159,7 +1162,7 @@ func TestMultiPartListMarshal(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, data, kvs[i+1].Value)
 		require.Equal(t, []byte{BitCompletePosting}, kvs[i+1].UserMeta)
-		require.Equal(t, ol.minTs, kvs[i+1].Version)
+		require.Equal(t, ol.minTs+1, kvs[i+1].Version)
 	}
 }
 
@@ -1176,7 +1179,7 @@ func TestMultiPartListWriteToDisk(t *testing.T) {
 	newList, err := getNew(kvs[0].Key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
-	opt := ListOptions{ReadTs: uint64(size) + 1}
+	opt := ListOptions{ReadTs: math.MaxUint64}
 	originalUids, err := originalList.Uids(opt)
 	require.NoError(t, err)
 	newUids, err := newList.Uids(opt)
@@ -1207,7 +1210,7 @@ func TestMultiPartListDelete(t *testing.T) {
 
 	for _, kv := range kvs {
 		require.Equal(t, []byte{BitEmptyPosting}, kv.UserMeta)
-		require.Equal(t, ol.minTs, kv.Version)
+		require.Equal(t, ol.minTs+1, kv.Version)
 	}
 }
 
@@ -1224,21 +1227,24 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	key := x.DataKey(x.GalaxyAttr(uuid.New().String()), 1331)
 	ol, err := getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
+	var curTs uint64
 	for i := 1; i <= size; i++ {
 		edge := &pb.DirectedEdge{
 			ValueId: uint64(i),
 		}
 
-		txn := Txn{StartTs: uint64(i)}
+		txn := Txn{StartTs: uint64(curTs)}
 		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+		require.NoError(t, ol.commitMutation(curTs, curTs+1))
 		if i%2000 == 0 {
+			curTs++
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
 			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
+		curTs++
 	}
 
 	// Verify all entries are in the list.
@@ -1251,31 +1257,33 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	}
 
 	// Delete the first half of the previously inserted entries from the list.
-	baseStartTs := uint64(size) + 1
 	for i := 1; i <= size/2; i++ {
 		edge := &pb.DirectedEdge{
 			ValueId: uint64(i),
 		}
-		txn := Txn{StartTs: baseStartTs + uint64(i)}
+		txn := Txn{StartTs: curTs}
 		addMutationHelper(t, ol, edge, Del, &txn)
-		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
+		require.NoError(t, ol.commitMutation(curTs, curTs+1))
 		if i%2000 == 0 {
+			curTs++
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
 			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
+		curTs++
 	}
 
 	// Rollup list at the end of all the deletions.
+	curTs++
 	kvs, err := ol.Rollup(nil)
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
 	ol, err = getNew(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	for _, kv := range kvs {
-		require.Equal(t, baseStartTs+uint64(1+size/2), kv.Version)
+		require.Equal(t, curTs, kv.Version)
 	}
 	// Verify that the entries were actually deleted.
 	opt = ListOptions{ReadTs: math.MaxUint64}
@@ -1287,22 +1295,23 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	}
 
 	// Re-add the entries that were just deleted.
-	baseStartTs = uint64(2*size) + 1
 	for i := 1; i <= 50000; i++ {
 		edge := &pb.DirectedEdge{
 			ValueId: uint64(i),
 		}
-		txn := Txn{StartTs: baseStartTs + uint64(i)}
+		txn := Txn{StartTs: curTs}
 		addMutationHelper(t, ol, edge, Set, &txn)
-		require.NoError(t, ol.commitMutation(baseStartTs+uint64(i), baseStartTs+uint64(i)+1))
+		require.NoError(t, ol.commitMutation(curTs, curTs+1))
 
 		if i%2000 == 0 {
+			curTs++
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
 			ol, err = getNew(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
+		curTs++
 	}
 
 	// Rollup list at the end of all the additions
@@ -1328,7 +1337,7 @@ func TestSingleListRollup(t *testing.T) {
 	ol, commits := createMultiPartList(t, size, true)
 
 	var facets []string
-	err := ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
+	err := ol.Iterate(math.MaxUint64, 0, func(p *pb.Posting) error {
 		if len(p.Facets) > 0 {
 			facets = append(facets, p.Facets[0].Key)
 		}
@@ -1389,7 +1398,7 @@ func TestRecursiveSplits(t *testing.T) {
 
 	// Read back the list and verify the data is correct.
 	var facets []string
-	err = ol.Iterate(uint64(size)+1, 0, func(p *pb.Posting) error {
+	err = ol.Iterate(math.MaxUint64, 0, func(p *pb.Posting) error {
 		if len(p.Facets) > 0 {
 			facets = append(facets, p.Facets[0].Key)
 		}

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -59,7 +59,7 @@ func TestRollupTimestamp(t *testing.T) {
 	// delete marker being the most recent update.
 	kvs, err := nl.Rollup(nil)
 	require.NoError(t, err)
-	require.Equal(t, uint64(10), kvs[0].Version)
+	require.Equal(t, uint64(11), kvs[0].Version)
 }
 
 func TestPostingListRead(t *testing.T) {


### PR DESCRIPTION
We should write rolled up keys at (maxTs of the deltas + 1) because if we write the rolled up keys at the same ts as
that of the delta, then in case of WAL replay the rolled-up key would get over-written by the
delta which can bring DB to an invalid state.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7957)
<!-- Reviewable:end -->
