### PR TITLE
fix(rollups): Write rolled-up keys at ts+1 (#7957)

### DIFF
--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -60,7 +60,7 @@ func TestRollupTimestamp(t *testing.T) {
 	// delete marker being the most recent update.
 	kvs, err := nl.Rollup(nil)
 	require.NoError(t, err)
-	require.Equal(t, uint64(10), kvs[0].Version)
+	require.Equal(t, uint64(11), kvs[0].Version)
 }
 
 func TestPostingListRead(t *testing.T) {


### PR DESCRIPTION
Write rolled up keys at (max ts of the deltas + 1) because if we write
the rolled-up keys at the same ts as that of the delta, then in case of
WAL replay the rolled-up key would get over-written by the delta which
can bring DB to an invalid state.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7959)
<!-- Reviewable:end -->
