### PR TITLE
fix(pool): use write lock when getting health info

### DIFF
--- a/conn/pool.go
+++ b/conn/pool.go
@@ -344,10 +344,11 @@ func (p *Pool) IsHealthy() bool {
 
 // HealthInfo returns the healthinfo.
 func (p *Pool) HealthInfo() pb.HealthInfo {
-	p.RLock()
-	defer p.RUnlock()
+	ok := p.IsHealthy()
+	p.Lock()
+	defer p.Unlock()
 	p.healthInfo.Status = "healthy"
-	if !p.IsHealthy() {
+	if !ok {
 		p.healthInfo.Status = "unhealthy"
 	}
 	p.healthInfo.LastEcho = p.lastEcho.Unix()

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -58,6 +58,7 @@ type groupi struct {
 var gr = &groupi{
 	blockDeletes: new(sync.Mutex),
 	tablets:      make(map[string]*pb.Tablet),
+	closer:       z.NewCloser(3), // Match CLOSER:1 in this file.
 }
 
 func groups() *groupi {
@@ -155,7 +156,6 @@ func StartRaftNodes(walStore *raftwal.DiskStorage, bindall bool) {
 	gr.Node.InitAndStartNode()
 	glog.Infof("Init and start Raft node: OK")
 
-	gr.closer = z.NewCloser(3) // Match CLOSER:1 in this file.
 	go gr.sendMembershipUpdates()
 	go gr.receiveMembershipUpdates()
 	go gr.processOracleDeltaStream()


### PR DESCRIPTION
Fixes: https://discuss.dgraph.io/t/bug-mutex-lock-while-health-checking/14940

There was a race condition when accessing HealthInfo. This PR fixes that.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7963)
<!-- Reviewable:end -->
