### PR TITLE
cloud: fix(snapshot): update last snapshot time across members

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -636,6 +636,7 @@ func (n *node) applyCommitted(proposal *pb.Proposal, key uint64) error {
 			}
 			glog.Warningf("Error while calling CreateSnapshot: %v. Retrying...", err)
 		}
+		atomic.StoreInt64(&lastSnapshotTime, time.Now().Unix())
 		// We can now discard all invalid versions of keys below this ts.
 		pstore.SetDiscardTs(snap.ReadTs)
 		return nil
@@ -1037,9 +1038,10 @@ func (n *node) updateRaftProgress() error {
 	return nil
 }
 
+var lastSnapshotTime int64 = time.Now().Unix()
+
 func (n *node) checkpointAndClose(done chan struct{}) {
 	slowTicker := time.NewTicker(time.Minute)
-	lastSnapshotTime := time.Now()
 	defer slowTicker.Stop()
 
 	snapshotAfterEntries := x.WorkerConfig.Raft.GetUint64("snapshot-after-entries")
@@ -1076,7 +1078,8 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 				// Only take snapshot if both snapshotFrequency and
 				// snapshotAfterEntries requirements are met. If set to 0,
 				// we consider duration condition to be disabled.
-				if snapshotFrequency == 0 || time.Since(lastSnapshotTime) > snapshotFrequency {
+				lastSnapTime := time.Unix(atomic.LoadInt64(&lastSnapshotTime), 0)
+				if snapshotFrequency == 0 || time.Since(lastSnapTime) > snapshotFrequency {
 					if chk, err := n.Store.Checkpoint(); err == nil {
 						if first, err := n.Store.FirstIndex(); err == nil {
 							// Save some cycles by only calculating snapshot if the checkpoint
@@ -1107,7 +1110,7 @@ func (n *node) checkpointAndClose(done chan struct{}) {
 					if err := n.proposeSnapshot(); err != nil {
 						glog.Errorf("While calculating and proposing snapshot: %v", err)
 					} else {
-						lastSnapshotTime = time.Now()
+						atomic.StoreInt64(&lastSnapshotTime, time.Now().Unix())
 					}
 				}
 				go n.abortOldTransactions()


### PR DESCRIPTION
Addresses DO-79.
We see frequent snapshots in an HA cluster because of the leadership re-election because of leader crash/shutdown. The local variable that we use for snapshot frequency is not synchronized across alphas. So each alpha thinks differently about the time the last snapshot was taken.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7965)
<!-- Reviewable:end -->
