### PR TITLE
fix(acl): filter out the results based on type (#7978)

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -277,7 +277,7 @@ func getRefreshJwt(userId string, namespace uint64) (string, error) {
 
 const queryUser = `
     query search($userid: string, $password: string){
-      user(func: eq(dgraph.xid, $userid)) {
+      user(func: eq(dgraph.xid, $userid)) @filter(type(dgraph.type.User)) {
 	    uid
         dgraph.xid
         password_match: checkpwd(dgraph.password, $password)
@@ -455,7 +455,7 @@ func upsertGuardianAndGroot(closer *z.Closer, ns uint64) {
 func upsertGuardian(ctx context.Context) error {
 	query := fmt.Sprintf(`
 			{
-				guid as guardians(func: eq(dgraph.xid, "%s")){
+				guid as guardians(func: eq(dgraph.xid, "%s")) @filter(type(dgraph.type.Group)) {
 					uid
 				}
 			}
@@ -525,10 +525,10 @@ func upsertGroot(ctx context.Context, passwd string) error {
 	// groot is the default user of guardians group.
 	query := fmt.Sprintf(`
 			{
-				grootid as grootUser(func: eq(dgraph.xid, "%s")){
+				grootid as grootUser(func: eq(dgraph.xid, "%s")) @filter(type(dgraph.type.User)) {
 					uid
 				}
-				guid as var(func: eq(dgraph.xid, "%s"))
+				guid as var(func: eq(dgraph.xid, "%s")) @filter(type(dgraph.type.Group))
 			}
 		`, x.GrootId, x.GuardiansId)
 	userNQuads := acl.CreateUserNQuads(x.GrootId, passwd)


### PR DESCRIPTION
We store the groupId and userId in a predicate named dgraph.xid.There was a subtle bug where if a we create the group with same name as that of a user, then the user is not able to log in. This happens because we were not applying a filter by type.

This PR fixes that.

(cherry picked from commit 355385563636779655a70132eb9662fddd584d27)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7980)
<!-- Reviewable:end -->
