### PR TITLE
perf(sroar): Use latest sroar and add histogram in the sbs tool

### DIFF
--- a/contrib/sbs/go.mod
+++ b/contrib/sbs/go.mod
@@ -4,7 +4,8 @@ go 1.16
 
 require (
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210421093152-78a2fece3ebd
-	github.com/pkg/errors v0.8.1
+	github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99 // indirect
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
 	google.golang.org/grpc v1.38.0

--- a/contrib/sbs/go.sum
+++ b/contrib/sbs/go.sum
@@ -143,8 +143,9 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99 h1:twflg0XRTjwKpxb/jFExr4HGq6on2dEOmnL6FV+fgPw=
+github.com/gopherjs/gopherjs v0.0.0-20190910122728-9d188e94fb99/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -204,8 +205,9 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/contrib/sbs/sbs.go
+++ b/contrib/sbs/sbs.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"reflect"
 	"regexp"
 	"strconv"
 	"sync"
@@ -153,6 +152,8 @@ func processLog(dcLeft, dcRight *dgo.Dgraph) {
 	defer f.Close()
 
 	var failed, total uint64
+	hist := newHistogram([]float64{0, 0.5, 1, 1.5, 2})
+
 	reqCh := make(chan *api.Request, opts.numGo*5)
 
 	var wg sync.WaitGroup
@@ -172,6 +173,10 @@ func processLog(dcLeft, dcRight *dgo.Dgraph) {
 				klog.Infof("Failed Query: %s \nVars: %v\nLeft: %v\nRight: %v\n",
 					r.Query, r.Vars, respL, respR)
 			}
+
+			lt, rt := respL.Latency.ProcessingNs, respR.Latency.ProcessingNs
+			ratio := float64(rt) / float64(lt)
+			hist.add(ratio)
 			atomic.AddUint64(&total, 1)
 		}
 	}
@@ -199,6 +204,7 @@ func processLog(dcLeft, dcRight *dgo.Dgraph) {
 		for range ticker.C {
 			klog.Infof("Total: %d Failed: %d\n", atomic.LoadUint64(&total),
 				atomic.LoadUint64(&failed))
+			hist.print()
 		}
 	}()
 	wg.Wait()
@@ -315,24 +321,4 @@ func runQuery(r *api.Request, client *dgo.Dgraph) (*api.Response, error) {
 			r.Query, r.Vars, err)
 	}
 	return resp, nil
-}
-
-func areEqualJSON(s1, s2 string) bool {
-	var o1, o2 interface{}
-
-	err := json.Unmarshal([]byte(s1), &o1)
-	if err != nil {
-		return false
-	}
-	err = json.Unmarshal([]byte(s2), &o2)
-	if err != nil {
-		return false
-	}
-	return reflect.DeepEqual(o1, o2)
-}
-
-func check(err error) {
-	if err != nil {
-		panic(err)
-	}
 }

--- a/contrib/sbs/utils.go
+++ b/contrib/sbs/utils.go
@@ -36,8 +36,9 @@ func (h *histogram) add(v float64) {
 	atomic.AddUint64(&h.total, 1)
 }
 
-func (h *histogram) print() {
-	fmt.Printf("-------------- Histogram --------------\n")
+func (h *histogram) show() {
+	fmt.Printf("-------------- Histogram --------------\nTotal samples: %d\n",
+		atomic.LoadUint64(&h.total))
 	for i := 0; i < len(h.bins); i++ {
 		pert := float64(atomic.LoadUint64(&h.count[i])) / float64(atomic.LoadUint64(&h.total))
 		if i+1 >= len(h.bins) {

--- a/contrib/sbs/utils.go
+++ b/contrib/sbs/utils.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sync/atomic"
+)
+
+type histogram struct {
+	bins  []float64
+	count []uint64
+	total uint64
+}
+
+func newHistogram(bins []float64) *histogram {
+	return &histogram{
+		bins:  bins,
+		count: make([]uint64, len(bins)),
+	}
+}
+
+func (h *histogram) add(v float64) {
+	idx := 0
+	for i := 0; i < len(h.bins); i++ {
+		if i+1 >= len(h.bins) {
+			idx = i
+			break
+		}
+		if h.bins[i] <= v && h.bins[i+1] > v {
+			idx = i
+			break
+		}
+	}
+	atomic.AddUint64(&h.count[idx], 1)
+	atomic.AddUint64(&h.total, 1)
+}
+
+func (h *histogram) print() {
+	fmt.Printf("-------------- Histogram --------------\n")
+	for i := 0; i < len(h.bins); i++ {
+		pert := float64(atomic.LoadUint64(&h.count[i])) / float64(atomic.LoadUint64(&h.total))
+		if i+1 >= len(h.bins) {
+			fmt.Printf("%.2f - infi  --> %.2f\n", h.bins[i], pert)
+			continue
+		}
+		fmt.Printf("%.2f - %.2f  --> %.2f\n", h.bins[i], h.bins[i+1], pert)
+	}
+}
+
+func areEqualJSON(s1, s2 string) bool {
+	var o1, o2 interface{}
+
+	err := json.Unmarshal([]byte(s1), &o1)
+	if err != nil {
+		return false
+	}
+	err = json.Unmarshal([]byte(s2), &o2)
+	if err != nil {
+		return false
+	}
+	return reflect.DeepEqual(o1, o2)
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210810060359-2dcd866b0b1f
+	github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61
+	github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e
+	github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f
+	github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210810060359-2dcd866b0b1f h1:t0+mRMDoMgWykf89mPKW9RaeFb3ujM7HoISogMXsaDo=
-github.com/dgraph-io/sroar v0.0.0-20210810060359-2dcd866b0b1f/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61 h1:6WzuZQqHG2uxrQ5byjPK6J7GF9yJfpWafaLEveRYXbg=
+github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e h1:ik2LeOq8BN7at9jXpptZehOnAxRkCADTdvPsveU9jgg=
-github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2 h1:r6+OcMwALExXQjyoZPBBKjGHTTioBU39J1aagrxgzN4=
+github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61 h1:6WzuZQqHG2uxrQ5byjPK6J7GF9yJfpWafaLEveRYXbg=
 github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f h1:HnDmpINXs9ZwWlfGAXePRAg3LXZh9S77/yTlRHTcAi8=
+github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/go.sum
+++ b/go.sum
@@ -182,10 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61 h1:6WzuZQqHG2uxrQ5byjPK6J7GF9yJfpWafaLEveRYXbg=
-github.com/dgraph-io/sroar v0.0.0-20210810163422-f75b2800dd61/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
-github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f h1:HnDmpINXs9ZwWlfGAXePRAg3LXZh9S77/yTlRHTcAi8=
-github.com/dgraph-io/sroar v0.0.0-20210811173337-718279667a8f/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e h1:ik2LeOq8BN7at9jXpptZehOnAxRkCADTdvPsveU9jgg=
+github.com/dgraph-io/sroar v0.0.0-20210811202423-d560c5ba143e/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=


### PR DESCRIPTION
This commit brings in sroar with some more optimizations like 
cleanup of the bitmap, it also implements histogram in the sbs
tool, which will help in better comparison.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7982)
<!-- Reviewable:end -->
