### PR TITLE
opt(rdf-output): Make RDF output generation concurrent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2
+	github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2 h1:r6+OcMwALExXQjyoZPBBKjGHTTioBU39J1aagrxgzN4=
-github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67 h1:IVHiU4jfB86QzsbwtSxtP6q/CsB9gOB69i1AFu9TiIk=
+github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"sync"
 
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -28,53 +29,82 @@ import (
 	"github.com/pkg/errors"
 )
 
+const numGo = 32
+
 // rdfBuilder is used to generate RDF from subgraph.
 type rdfBuilder struct {
-	buf *bytes.Buffer
+	buf   []byte
+	sgCh  chan *SubGraph
+	outCh chan *bytes.Buffer
 }
 
 // ToRDF converts the given subgraph list into rdf format.
 func ToRDF(l *Latency, sgl []*SubGraph) ([]byte, error) {
+	var fwg, wg sync.WaitGroup
 	b := &rdfBuilder{
-		buf: &bytes.Buffer{},
+		sgCh:  make(chan *SubGraph, 1000),
+		outCh: make(chan *bytes.Buffer, 1000),
 	}
+
+	fwg.Add(1)
+	go b.finalize(&fwg)
+
+	for i := 0; i < numGo; i++ {
+		wg.Add(1)
+		go b.worker(&wg)
+	}
+
 	for _, sg := range sgl {
 		if err := validateSubGraphForRDF(sg); err != nil {
 			return nil, err
 		}
-		// Skip parent graph. we don't want parent values.
 		for _, child := range sg.Children {
-			if err := b.castToRDF(child); err != nil {
+			if err := b.send(child); err != nil {
 				return nil, err
 			}
 		}
 	}
-	return b.buf.Bytes(), nil
+	// close the subgraph channel and wait for workers to finish
+	close(b.sgCh)
+	wg.Wait()
+
+	// close the out channel and wait for finalize to finish
+	close(b.outCh)
+	fwg.Wait()
+	return b.buf, nil
 }
 
-// castToRDF converts the given subgraph to RDF and appends to the
-// output string.
-func (b *rdfBuilder) castToRDF(sg *SubGraph) error {
-	if err := validateSubGraphForRDF(sg); err != nil {
-		return err
-	}
+func (b *rdfBuilder) send(sg *SubGraph) error {
 	if sg.SrcUIDs != nil {
-		// Get RDF for the given subgraph.
-		if err := b.rdfForSubgraph(sg); err != nil {
+		if err := validateSubGraphForRDF(sg); err != nil {
 			return err
 		}
+		b.sgCh <- sg
 	}
-	// Recursively cnvert RDF for the children graph.
 	for _, child := range sg.Children {
-		if err := b.castToRDF(child); err != nil {
+		if err := b.send(child); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
+func (b *rdfBuilder) worker(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for sg := range b.sgCh {
+		b.rdfForSubgraph(sg)
+	}
+}
+
+func (b *rdfBuilder) finalize(wg *sync.WaitGroup) {
+	defer wg.Done()
+	for buf := range b.outCh {
+		b.buf = append(b.buf, buf.Bytes()...)
+	}
+}
+
 // rdfForSubgraph generates RDF and appends to the output parameter.
-func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
+func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) {
 	// handle the case of recurse queries
 	// Do not generate RDF if all the children of sg null uidMatrix
 	nonNullChild := false
@@ -85,9 +115,10 @@ func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
 	}
 
 	if len(sg.Children) > 0 && !nonNullChild {
-		return nil
+		return
 	}
 
+	buf := &bytes.Buffer{}
 	for i, uid := range codec.GetUids(sg.SrcUIDs) {
 		if sg.Params.IgnoreResult {
 			// Skip ignored values.
@@ -107,69 +138,71 @@ func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) error {
 			if err != nil {
 				continue
 			}
-			b.writeRDF(uid, []byte(sg.aggWithVarFieldName()), outputval)
+			b.writeRDF(buf, uid, []byte(sg.aggWithVarFieldName()), outputval)
 			continue
 		}
 		switch {
 		case len(sg.counts) > 0:
 			// Add count rdf.
-			b.rdfForCount(uid, sg.counts[i], sg)
+			b.rdfForCount(buf, uid, sg.counts[i], sg)
 		case i < len(sg.uidMatrix) && codec.ListCardinality(sg.uidMatrix[i]) != 0 &&
 			len(sg.Children) > 0:
 			// Add posting list relation.
-			b.rdfForUIDList(uid, sg.uidMatrix[i], sg)
+			b.rdfForUIDList(buf, uid, sg.uidMatrix[i], sg)
 		case i < len(sg.valueMatrix):
-			b.rdfForValueList(uid, sg.valueMatrix[i], sg.fieldName())
+			b.rdfForValueList(buf, uid, sg.valueMatrix[i], sg.fieldName())
 		}
 	}
-	return nil
+	b.outCh <- buf
+	return
 }
 
-func (b *rdfBuilder) writeRDF(subject uint64, predicate []byte, object []byte) {
+func (b *rdfBuilder) writeRDF(buf *bytes.Buffer, subject uint64, predicate []byte, object []byte) {
 	// add subject
-	x.Check2(b.buf.Write(x.ToHex(subject, true)))
-	x.Check(b.buf.WriteByte(' '))
+	x.Check2(buf.Write(x.ToHex(subject, true)))
+	x.Check(buf.WriteByte(' '))
 	// add predicate
-	b.writeTriple(predicate)
-	x.Check(b.buf.WriteByte(' '))
+	b.writeTriple(buf, predicate)
+	x.Check(buf.WriteByte(' '))
 	// add object
-	x.Check2(b.buf.Write(object))
-	x.Check(b.buf.WriteByte(' '))
-	x.Check(b.buf.WriteByte('.'))
-	x.Check(b.buf.WriteByte('\n'))
+	x.Check2(buf.Write(object))
+	x.Check(buf.WriteByte(' '))
+	x.Check(buf.WriteByte('.'))
+	x.Check(buf.WriteByte('\n'))
 }
 
-func (b *rdfBuilder) writeTriple(val []byte) {
-	x.Check(b.buf.WriteByte('<'))
-	x.Check2(b.buf.Write(val))
-	x.Check(b.buf.WriteByte('>'))
+func (b *rdfBuilder) writeTriple(buf *bytes.Buffer, val []byte) {
+	x.Check(buf.WriteByte('<'))
+	x.Check2(buf.Write(val))
+	x.Check(buf.WriteByte('>'))
 }
 
 // rdfForCount returns rdf for count fucntion.
-func (b *rdfBuilder) rdfForCount(subject uint64, count uint32, sg *SubGraph) {
+func (b *rdfBuilder) rdfForCount(buf *bytes.Buffer, subject uint64, count uint32, sg *SubGraph) {
 	fieldName := sg.Params.Alias
 	if fieldName == "" {
 		fieldName = fmt.Sprintf("count(%s)", sg.Attr)
 	}
-	b.writeRDF(subject, []byte(fieldName),
+	b.writeRDF(buf, subject, []byte(fieldName),
 		quotedNumber([]byte(strconv.FormatUint(uint64(count), 10))))
 }
 
 // rdfForUIDList returns rdf for uid list.
-func (b *rdfBuilder) rdfForUIDList(subject uint64, list *pb.List, sg *SubGraph) {
+func (b *rdfBuilder) rdfForUIDList(buf *bytes.Buffer, subject uint64, list *pb.List, sg *SubGraph) {
 	for _, destUID := range codec.GetUids(list) {
 		if !sg.DestMap.Contains(destUID) {
 			// This uid is filtered.
 			continue
 		}
 		// Build object.
-		b.writeRDF(subject, []byte(sg.fieldName()), x.ToHex(destUID, true))
+		b.writeRDF(buf, subject, []byte(sg.fieldName()), x.ToHex(destUID, true))
 	}
 }
 
 // rdfForValueList returns rdf for the value list.
 // Ignore RDF's for the attirbute `uid`.
-func (b *rdfBuilder) rdfForValueList(subject uint64, valueList *pb.ValueList, attr string) {
+func (b *rdfBuilder) rdfForValueList(buf *bytes.Buffer, subject uint64, valueList *pb.ValueList,
+	attr string) {
 	for _, destValue := range valueList.Values {
 		val, err := convertWithBestEffort(destValue, attr)
 		if err != nil {
@@ -179,7 +212,7 @@ func (b *rdfBuilder) rdfForValueList(subject uint64, valueList *pb.ValueList, at
 		if err != nil {
 			continue
 		}
-		b.writeRDF(subject, []byte(attr), outputval)
+		b.writeRDF(buf, subject, []byte(attr), outputval)
 	}
 }
 

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -145,8 +145,8 @@ func (b *rdfBuilder) rdfForSubgraph(sg *SubGraph) {
 
 func (b *rdfBuilder) write(buf *bytes.Buffer) {
 	b.Lock()
-	defer b.Unlock()
 	b.buf = append(b.buf, buf.Bytes()...)
+	b.Unlock()
 }
 
 func writeRDF(buf *bytes.Buffer, subject uint64, predicate []byte, object []byte) {

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -47,6 +47,7 @@ func TestRDFResult(t *testing.T) {
 		`<0x18> <age> "15" .`,
 		`<0x19> <age> "17" .`,
 	}
+	// TODO: We should do both size equality check.
 	for _, rdf := range rdfs {
 		require.Contains(t, output, rdf)
 	}
@@ -173,26 +174,30 @@ func TestRDFPredicateCount(t *testing.T) {
     }
 	`
 
-	rdf, err := processQueryRDF(context.Background(), t, query)
+	output, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
-	require.Equal(t, `<0x1> <name> "Michonne" .
-<0x17> <name> "Rick Grimes" .
-<0x19> <name> "Daryl Dixon" .
-<0x1> <count(friend)> "5" .
-<0x17> <count(friend)> "1" .
-<0x19> <count(friend)> "0" .
-<0x1> <friend> <0x17> .
-<0x1> <friend> <0x18> .
-<0x1> <friend> <0x19> .
-<0x1> <friend> <0x1f> .
-<0x1> <friend> <0x65> .
-<0x17> <friend> <0x1> .
-<0x1> <name> "Michonne" .
-<0x17> <name> "Rick Grimes" .
-<0x18> <name> "Glenn Rhee" .
-<0x19> <name> "Daryl Dixon" .
-<0x1f> <name> "Andrea" .
-`, rdf)
+	rdfs := []string{
+		`<0x1> <name> "Michonne" .`,
+		`<0x17> <name> "Rick Grimes" .`,
+		`<0x19> <name> "Daryl Dixon" .`,
+		`<0x1> <count(friend)> "5" .`,
+		`<0x17> <count(friend)> "1" .`,
+		`<0x19> <count(friend)> "0" .`,
+		`<0x1> <friend> <0x17> .`,
+		`<0x1> <friend> <0x18> .`,
+		`<0x1> <friend> <0x19> .`,
+		`<0x1> <friend> <0x1f> .`,
+		`<0x1> <friend> <0x65> .`,
+		`<0x17> <friend> <0x1> .`,
+		`<0x1> <name> "Michonne" .`,
+		`<0x17> <name> "Rick Grimes" .`,
+		`<0x18> <name> "Glenn Rhee" .`,
+		`<0x19> <name> "Daryl Dixon" .`,
+		`<0x1f> <name> "Andrea" .`,
+	}
+	for _, rdf := range rdfs {
+		require.Contains(t, output, rdf)
+	}
 }
 
 func TestRDFFacets(t *testing.T) {
@@ -220,23 +225,26 @@ func TestDateRDF(t *testing.T) {
 			}
 		}
 	`
-	rdf, err := processQueryRDF(context.Background(), t, query)
+	output, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
-	expected := `<0x1> <name> "Michonne" .
-<0x1> <gender> "female" .
-<0x1> <friend> <0x19> .
-<0x1> <friend> <0x18> .
-<0x1> <friend> <0x17> .
-<0x1> <friend> <0x1f> .
-<0x1> <friend> <0x65> .
-<0x17> <name> "Rick Grimes" .
-<0x18> <name> "Glenn Rhee" .
-<0x19> <name> "Daryl Dixon" .
-<0x1f> <name> "Andrea" .
-<0x17> <film.film.initial_release_date> "1900-01-02T00:00:00Z" .
-<0x18> <film.film.initial_release_date> "1909-05-05T00:00:00Z" .
-<0x19> <film.film.initial_release_date> "1929-01-10T00:00:00Z" .
-<0x1f> <film.film.initial_release_date> "1801-01-15T00:00:00Z" .
-`
-	require.Equal(t, expected, rdf)
+	rdfs := []string{
+		`<0x1> <name> "Michonne" .`,
+		`<0x1> <gender> "female" .`,
+		`<0x1> <friend> <0x19> .`,
+		`<0x1> <friend> <0x18> .`,
+		`<0x1> <friend> <0x17> .`,
+		`<0x1> <friend> <0x1f> .`,
+		`<0x1> <friend> <0x65> .`,
+		`<0x17> <name> "Rick Grimes" .`,
+		`<0x18> <name> "Glenn Rhee" .`,
+		`<0x19> <name> "Daryl Dixon" .`,
+		`<0x1f> <name> "Andrea" .`,
+		`<0x17> <film.film.initial_release_date> "1900-01-02T00:00:00Z" .`,
+		`<0x18> <film.film.initial_release_date> "1909-05-05T00:00:00Z" .`,
+		`<0x19> <film.film.initial_release_date> "1929-01-10T00:00:00Z" .`,
+		`<0x1f> <film.film.initial_release_date> "1801-01-15T00:00:00Z" .`,
+	}
+	for _, rdf := range rdfs {
+		require.Contains(t, output, rdf)
+	}
 }

--- a/query/rdf_result_test.go
+++ b/query/rdf_result_test.go
@@ -34,19 +34,22 @@ func TestRDFResult(t *testing.T) {
 		}
 	  }`
 
-	rdf, err := processQueryRDF(context.Background(), t, query)
+	output, err := processQueryRDF(context.Background(), t, query)
 	require.NoError(t, err)
-	require.Equal(t, rdf, `<0x1> <name> "Michonne" .
-<0x1> <friend> <0x17> .
-<0x1> <friend> <0x18> .
-<0x1> <friend> <0x19> .
-<0x17> <name> "Rick Grimes" .
-<0x18> <name> "Glenn Rhee" .
-<0x19> <name> "Daryl Dixon" .
-<0x17> <age> "15" .
-<0x18> <age> "15" .
-<0x19> <age> "17" .
-`)
+	rdfs := []string{`<0x1> <name> "Michonne" .`,
+		`<0x1> <friend> <0x17> .`,
+		`<0x1> <friend> <0x18> .`,
+		`<0x1> <friend> <0x19> .`,
+		`<0x17> <name> "Rick Grimes" .`,
+		`<0x18> <name> "Glenn Rhee" .`,
+		`<0x19> <name> "Daryl Dixon" .`,
+		`<0x17> <age> "15" .`,
+		`<0x18> <age> "15" .`,
+		`<0x19> <age> "17" .`,
+	}
+	for _, rdf := range rdfs {
+		require.Contains(t, output, rdf)
+	}
 }
 
 func TestRDFNormalize(t *testing.T) {


### PR DESCRIPTION
For RDF format output, the order of rdf's doesn't matter, so we can make them concurrent. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7988)
<!-- Reviewable:end -->
