### PR TITLE
opt(recurse): Optimise recurse and bring range iterators from sroar

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -43,7 +43,7 @@ func ApplyFilter(u *pb.List, f func(uint64, int) bool) {
 	} else {
 		b := sroar.NewBitmap()
 		b.SetMany(out)
-		u.Bitmap = codec.ToBytes(b)
+		u.Bitmap = b.ToBuffer()
 	}
 }
 

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -135,8 +135,7 @@ func Merge(matrix []*pb.List) *sroar.Bitmap {
 
 	var bms []*sroar.Bitmap
 	for _, m := range matrix {
-		bmc := FromListNoCopy(m)
-		if bmc != nil {
+		if bmc := FromListNoCopy(m); bmc != nil {
 			bms = append(bms, bmc)
 		}
 	}

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -155,6 +155,13 @@ func ToBytes(bm *sroar.Bitmap) []byte {
 	return bm.ToBufferWithCopy()
 }
 
+func ToBytesNoCopy(bm *sroar.Bitmap) []byte {
+	if bm.IsEmpty() {
+		return nil
+	}
+	return bm.ToBuffer()
+}
+
 func FromList(l *pb.List) *sroar.Bitmap {
 	iw := sroar.NewBitmap()
 	if l == nil {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -174,12 +174,16 @@ func FromListNoCopy(l *pb.List) *sroar.Bitmap {
 	if l == nil {
 		return nil
 	}
+	if len(l.SortedUids) > 0 {
+		bm := sroar.NewBitmap()
+		bm.SetMany(l.SortedUids)
+		return bm
+	}
 	if len(l.Bitmap) > 0 {
 		// Optimize the code for this case. Avoid creating NewBitmap for error
 		// handling.
 		return sroar.FromBuffer(l.Bitmap)
 	}
-	x.AssertTrue(len(l.SortedUids) == 0)
 	return nil
 }
 

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -62,7 +62,11 @@ func ListCardinality(l *pb.List) uint64 {
 	if len(l.SortedUids) > 0 {
 		return uint64(len(l.SortedUids))
 	}
-	b := FromList(l)
+	b := FromListNoCopy(l)
+	if b == nil {
+		return 0
+	}
+	// TODO: Update GetCardinality to handle nil Bitmap.
 	return uint64(b.GetCardinality())
 }
 

--- a/dgraph/cmd/bulk/count_index.go
+++ b/dgraph/cmd/bulk/count_index.go
@@ -24,7 +24,6 @@ import (
 	"sync/atomic"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
@@ -146,7 +145,7 @@ func (c *countIndexer) writeIndex(buf *z.Buffer) {
 			return
 		}
 
-		pl.Bitmap = codec.ToBytes(bm)
+		pl.Bitmap = bm.ToBuffer()
 
 		kv := posting.MarshalPostingList(&pl, nil)
 		kv.Key = append([]byte{}, lastCe.Key()...)

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -38,7 +38,6 @@ import (
 	bo "github.com/dgraph-io/badger/v3/options"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
-	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
@@ -615,7 +614,7 @@ func (r *reducer) toList(req *encodeRequest) {
 
 		// We should not do defer FreePack here, because we might be giving ownership of it away if
 		// we run Rollup.
-		pl.Bitmap = codec.ToBytes(bm)
+		pl.Bitmap = bm.ToBuffer()
 		numUids := bm.GetCardinality()
 
 		atomic.AddInt64(&r.prog.reduceKeyCount, 1)

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2
+	github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
@@ -75,7 +75,7 @@ require (
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210511113859-b0526f3d8744
 	golang.org/x/text v0.3.6
-	golang.org/x/tools v0.1.1
+	golang.org/x/tools v0.1.6-0.20210802203754-9b21a8868e16
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210510173355-fb37daa5cd7a // indirect
 	google.golang.org/grpc v1.37.1
@@ -83,5 +83,6 @@ require (
 	gopkg.in/DataDog/dd-trace-go.v1 v1.13.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.1
 	gopkg.in/yaml.v2 v2.2.8
+	honnef.co/go/tools v0.2.0 // indirect
 	src.techknowlogick.com/xgo v1.4.1-0.20210311222705-d25c33fcd864
 )

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec
+	github.com/dgraph-io/sroar v0.0.0-20210816191646-201f86ca72d6
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2
+	github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec h1:tNXffo6Ede/BZVR/zOkchfLwOx1irhplsP983LXP38I=
-github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210816191646-201f86ca72d6 h1:n7NOldILQ6Dy6Z2uaNWb1ZzSO4dj0DxDvyZ2DwXzKdI=
+github.com/dgraph-io/sroar v0.0.0-20210816191646-201f86ca72d6/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2 h1:QHkxyr51iACbEpvf6/R6/D7XfAqQrj1GvX5OigmNv8Y=
-github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec h1:tNXffo6Ede/BZVR/zOkchfLwOx1irhplsP983LXP38I=
 github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/Lu
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2 h1:r6+OcMwALExXQjyoZPBBKjGHTTioBU39J1aagrxgzN4=
-github.com/dgraph-io/sroar v0.0.0-20210812083743-986f6c1098e2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2 h1:QHkxyr51iACbEpvf6/R6/D7XfAqQrj1GvX5OigmNv8Y=
+github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
@@ -1007,8 +1007,8 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.6-0.20210802203754-9b21a8868e16 h1:ZC/gVBZl8poJyKzWLxxlsmhayVGosF4mohR35szD5Bg=
+golang.org/x/tools v0.1.6-0.20210802203754-9b21a8868e16/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1185,8 +1185,9 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2 h1:QHkxyr51iACbEpvf6/R6/D7XfAqQrj1GvX5OigmNv8Y=
 github.com/dgraph-io/sroar v0.0.0-20210815124606-0dc04a81e2b2/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec h1:tNXffo6Ede/BZVR/zOkchfLwOx1irhplsP983LXP38I=
+github.com/dgraph-io/sroar v0.0.0-20210816152148-de6cc6680eec/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/posting/list.go
+++ b/posting/list.go
@@ -600,7 +600,7 @@ func (l *List) iterateAll(readTs uint64, afterUid uint64, f func(obj *pb.Posting
 
 	p := &pb.Posting{}
 
-	uitr := bm.NewFastIterator()
+	uitr := bm.NewIterator()
 	var next uint64
 
 	advance := func() {
@@ -638,7 +638,7 @@ func (l *List) iterateAll(readTs uint64, afterUid uint64, f func(obj *pb.Posting
 	}
 
 	codec.RemoveRange(bm, 0, maxUid)
-	uitr = bm.NewFastIterator()
+	uitr = bm.NewIterator()
 	for u := uitr.Next(); u > 0; u = uitr.Next() {
 		p.Uid = u
 		f(p)

--- a/posting/list.go
+++ b/posting/list.go
@@ -600,13 +600,13 @@ func (l *List) iterateAll(readTs uint64, afterUid uint64, f func(obj *pb.Posting
 
 	p := &pb.Posting{}
 
-	uitr := bm.NewIterator()
+	uitr := bm.NewFastIterator()
 	var next uint64
 
 	advance := func() {
 		next = math.MaxUint64
-		if uitr.HasNext() {
-			next = uitr.Next()
+		if nx := uitr.Next(); nx > 0 {
+			next = nx
 		}
 	}
 	advance()
@@ -638,9 +638,9 @@ func (l *List) iterateAll(readTs uint64, afterUid uint64, f func(obj *pb.Posting
 	}
 
 	codec.RemoveRange(bm, 0, maxUid)
-	uitr = bm.NewIterator()
-	for uitr.HasNext() {
-		p.Uid = uitr.Next()
+	uitr = bm.NewFastIterator()
+	for u := uitr.Next(); u > 0; u = uitr.Next() {
+		p.Uid = u
 		f(p)
 	}
 	return nil

--- a/posting/list.go
+++ b/posting/list.go
@@ -1107,7 +1107,7 @@ func (ro *rollupOutput) split(startUid uint64) error {
 	// Remove everything from startUid to uid.
 	nr := r.Clone()
 	nr.RemoveRange(0, uid) // Keep all uids >= uid.
-	newpl.Bitmap = codec.ToBytes(nr)
+	newpl.Bitmap = nr.ToBuffer()
 
 	// Take everything from the first posting where posting.Uid >= uid.
 	idx := sort.Search(len(pl.Postings), func(i int) bool {
@@ -1117,7 +1117,7 @@ func (ro *rollupOutput) split(startUid uint64) error {
 
 	// Update pl as well. Keeps the lower UIDs.
 	codec.RemoveRange(r, uid, math.MaxUint64)
-	pl.Bitmap = codec.ToBytes(r)
+	pl.Bitmap = r.ToBuffer()
 	pl.Postings = pl.Postings[:idx]
 
 	return nil
@@ -1169,7 +1169,7 @@ func (l *List) encode(out *rollupOutput, readTs uint64, split bool) error {
 		}
 
 		plist := &pb.PostingList{}
-		plist.Bitmap = codec.ToBytes(r)
+		plist.Bitmap = r.ToBuffer()
 
 		out.parts[startUid] = plist
 	}
@@ -1283,7 +1283,7 @@ func (l *List) Uids(opt ListOptions) (*pb.List, error) {
 	// Before this, we were only picking math.Int32 number of uids.
 	// Now we're picking everything.
 	if opt.First == 0 {
-		out.Bitmap = codec.ToBytes(bm)
+		out.Bitmap = bm.ToBufferWithCopy()
 		// TODO: Not yet ready to use Bitmap for data transfer. We'd have to deal with all the
 		// places where List.Uids is being called.
 		// out.Bitmap = codec.ToBytes(bm)
@@ -1688,7 +1688,7 @@ func FromBackupPostingList(bl *pb.BackupPostingList) *pb.PostingList {
 	} else if len(bl.UidBytes) > 0 {
 		r = codec.FromBackup(bl.UidBytes)
 	}
-	l.Bitmap = codec.ToBytes(r)
+	l.Bitmap = r.ToBuffer()
 	l.Postings = bl.Postings
 	l.CommitTs = bl.CommitTs
 	l.Splits = bl.Splits

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -35,7 +35,6 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -520,26 +519,26 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 		return nil, badger.ErrDBClosed
 	}
 	// TODO: Fix this up later.
-	cachedVal, ok := lCache.Get(key)
-	if ok {
-		l, ok := cachedVal.(*List)
-		if ok && l != nil {
-			// No need to clone the immutable layer or the key since mutations will not modify it.
-			lCopy := &List{
-				minTs: l.minTs,
-				maxTs: l.maxTs,
-				key:   key,
-				plist: l.plist,
-			}
-			if l.mutationMap != nil {
-				lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
-				for ts, pl := range l.mutationMap {
-					lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
-				}
-			}
-			return lCopy, nil
-		}
-	}
+	// cachedVal, ok := lCache.Get(key)
+	// if ok {
+	// 	l, ok := cachedVal.(*List)
+	// 	if ok && l != nil {
+	// 		// No need to clone the immutable layer or the key since mutations will not modify it.
+	// 		lCopy := &List{
+	// 			minTs: l.minTs,
+	// 			maxTs: l.maxTs,
+	// 			key:   key,
+	// 			plist: l.plist,
+	// 		}
+	// 		if l.mutationMap != nil {
+	// 			lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
+	// 			for ts, pl := range l.mutationMap {
+	// 				lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
+	// 			}
+	// 		}
+	// 		return lCopy, nil
+	// 	}
+	// }
 
 	txn := pstore.NewTransactionAt(readTs, false)
 	defer txn.Discard()
@@ -556,6 +555,6 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 	if err != nil {
 		return l, err
 	}
-	lCache.Set(key, l, 0)
+	// lCache.Set(key, l, 0)
 	return l, nil
 }

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -137,7 +137,7 @@ func (d *dedup) addValue(attr string, value types.Val, uid uint64) {
 	}
 	r := codec.FromList(cur.elements[strKey].entities)
 	r.Set(uid)
-	cur.elements[strKey].entities.Bitmap = codec.ToBytes(r)
+	cur.elements[strKey].entities.Bitmap = r.ToBuffer()
 }
 
 func aggregateGroup(grp *groupResult, child *SubGraph) (types.Val, error) {

--- a/query/query.go
+++ b/query/query.go
@@ -804,7 +804,7 @@ func (sg *SubGraph) populate(uids []uint64) error {
 	sort.Slice(uids, func(i, j int) bool { return uids[i] < uids[j] })
 	r := sroar.NewBitmap()
 	r.SetMany(uids)
-	sg.uidMatrix = []*pb.List{{Bitmap: codec.ToBytes(r)}}
+	sg.uidMatrix = []*pb.List{{Bitmap: r.ToBuffer()}}
 	// User specified list may not be sorted.
 	sg.SrcUIDs = &pb.List{SortedUids: uids}
 	return nil
@@ -1275,7 +1275,7 @@ func (sg *SubGraph) valueVarAggregation(doneVars map[string]varValue, path []*Su
 			mp := make(map[uint64]types.Val)
 			rangeOver := sg.SrcUIDs
 			if parent == nil {
-				rangeOver = &pb.List{Bitmap: codec.ToBytes(sg.DestMap)}
+				rangeOver = &pb.List{Bitmap: sg.DestMap.ToBuffer()}
 			}
 			if rangeOver == nil {
 				it := doneVars[sg.Params.Var]
@@ -2469,7 +2469,7 @@ func (sg *SubGraph) applyRandom(ctx context.Context) error {
 
 		r := sroar.NewBitmap()
 		r.SetMany(uidList[:numRandom])
-		sg.uidMatrix[i].Bitmap = codec.ToBytes(r)
+		sg.uidMatrix[i].Bitmap = r.ToBuffer()
 	}
 
 	sg.DestMap = codec.Merge(sg.uidMatrix)
@@ -2490,7 +2490,7 @@ func (sg *SubGraph) applyPagination(ctx context.Context) error {
 		start, end := x.PageRange(sg.Params.Count, sg.Params.Offset, len(uids))
 		r := sroar.NewBitmap()
 		r.SetMany(uids[start:end])
-		sg.uidMatrix[i].Bitmap = codec.ToBytes(r)
+		sg.uidMatrix[i].Bitmap = r.ToBuffer()
 	}
 	// Re-merge the UID matrix.
 	sg.DestMap = codec.Merge(sg.uidMatrix)

--- a/query/query.go
+++ b/query/query.go
@@ -1431,7 +1431,7 @@ func (sg *SubGraph) populateVarMap(doneVars map[string]varValue, sgPath []*SubGr
 	}
 
 	// Filter out UIDs that don't have atleast one UID in every child.
-	itr := sg.DestMap.NewFastIterator()
+	itr := sg.DestMap.NewIterator()
 	out := sg.DestMap.Clone()
 	uid := itr.Next()
 	for i := 0; uid > 0; i++ {
@@ -1775,7 +1775,7 @@ func (sg *SubGraph) fillVars(mp map[string]varValue) error {
 
 		case (v.Typ == gql.UidVar && sg.SrcFunc != nil && sg.SrcFunc.Name == "uid_in"):
 			srcFuncArgs := sg.SrcFunc.Args[:0]
-			itr := l.UidMap.NewFastIterator()
+			itr := l.UidMap.NewIterator()
 			for uid := itr.Next(); uid > 0; uid = itr.Next() {
 				// We use base 10 here because the uid parser expects the uid to be in base 10.
 				arg := gql.Arg{Value: strconv.FormatUint(uid, 10)}

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -18,18 +18,18 @@ package query
 
 import (
 	"context"
-	"fmt"
 	"math"
+	"strconv"
 
-	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/sroar"
 	"github.com/pkg/errors"
 )
 
 func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error {
 	// Note: Key format is - "attr|fromUID|toUID"
-	reachMap := make(map[string]struct{})
+	reachMap := make(map[string]*sroar.Bitmap)
 	allowLoop := start.Params.RecurseArgs.AllowLoop
 	var numEdges uint64
 	var exec []*SubGraph
@@ -121,21 +121,42 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 
 			for mIdx, fromUID := range codec.GetUids(sg.SrcUIDs) {
 				if allowLoop {
+					// TODO: This needs to be optimized.
 					for _, ul := range sg.uidMatrix {
 						numEdges += codec.ListCardinality(ul)
 					}
 				} else {
-					algo.ApplyFilter(sg.uidMatrix[mIdx], func(uid uint64, i int) bool {
-						key := fmt.Sprintf("%s|%d|%d", sg.Attr, fromUID, uid)
-						_, seen := reachMap[key] // Combine fromUID here.
-						if seen {
-							return false
-						}
-						// Mark this edge as taken. We'd disallow this edge later.
-						reachMap[key] = struct{}{}
-						numEdges++
-						return true
-					})
+					ul := sg.uidMatrix[mIdx]
+					ur := codec.FromListNoCopy(ul)
+					if ur == nil {
+						continue
+					}
+
+					key := sg.Attr + "|" + strconv.Itoa(int(fromUID))
+					prev, ok := reachMap[key]
+					if !ok {
+						reachMap[key] = codec.FromList(ul)
+					} else {
+						// Any edges that we have seen before, do not consider
+						// them again.
+						ur.AndNot(prev) // This would only keep the UIDs which are NEW.
+						sg.uidMatrix[mIdx].Bitmap = ur.ToBuffer()
+
+						prev.Or(ur) // Add the new UIDs to our "reach"
+						reachMap[key] = prev
+					}
+
+					// algo.ApplyFilter(sg.uidMatrix[mIdx], func(uid uint64, i int) bool {
+					// 	key := fmt.Sprintf("%s|%d|%d", sg.Attr, fromUID, uid)
+					// 	_, seen := reachMap[key] // Combine fromUID here.
+					// 	if seen {
+					// 		return false
+					// 	}
+					// 	// Mark this edge as taken. We'd disallow this edge later.
+					// 	reachMap[key] = struct{}{}
+					// 	numEdges++
+					// 	return true
+					// })
 				}
 			}
 			if len(sg.Params.Order) > 0 || len(sg.Params.FacetsOrder) > 0 {

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -151,9 +151,9 @@ func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error
 							return true
 						})
 					} else {
-						// TODO: update the numEdges
 						ur.AndNot(prev) // This would only keep the UIDs which are NEW.
 						sg.uidMatrix[mIdx].Bitmap = ur.ToBuffer()
+						numEdges += uint64(ur.GetCardinality())
 
 						prev.Or(ur) // Add the new UIDs to our "reach"
 						reachMap[key] = prev

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -412,7 +412,7 @@ func multiSort(ctx context.Context, r *sortresult, ts *pb.SortMessage) error {
 		result := or.r
 		dsz := int(dest.GetCardinality())
 		x.AssertTrue(len(result.ValueMatrix) == dsz)
-		itr := dest.NewFastIterator()
+		itr := dest.NewIterator()
 		uid := itr.Next()
 		for i := 0; uid > 0; i++ {
 			var sv types.Val

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -412,8 +412,9 @@ func multiSort(ctx context.Context, r *sortresult, ts *pb.SortMessage) error {
 		result := or.r
 		dsz := int(dest.GetCardinality())
 		x.AssertTrue(len(result.ValueMatrix) == dsz)
-		itr := dest.NewIterator()
-		for i := 0; itr.HasNext(); i++ {
+		itr := dest.NewFastIterator()
+		uid := itr.Next()
+		for i := 0; uid > 0; i++ {
 			var sv types.Val
 			if len(result.ValueMatrix[i].Values) == 0 {
 				// Assign nil value which is sorted as greater than all other values.
@@ -428,8 +429,8 @@ func multiSort(ctx context.Context, r *sortresult, ts *pb.SortMessage) error {
 					return err
 				}
 			}
-			uid := itr.Next()
 			sortVals[uid][or.idx] = sv
+			uid = itr.Next()
 		}
 	}
 

--- a/worker/task.go
+++ b/worker/task.go
@@ -381,7 +381,7 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 	outputs := make([]*pb.Result, numGo)
 	listType := schema.State().IsList(q.Attr)
 
-	calculate := func(idx int, itr *sroar.FastIterator) error {
+	calculate := func(idx int, itr *sroar.Iterator) error {
 		out := &pb.Result{}
 		outputs[idx] = out
 
@@ -1174,7 +1174,7 @@ func (qs *queryState) handleRegexFunction(ctx context.Context, arg funcArgs) err
 	span.Annotatef(nil, "Total uids: %d, list: %t lang: %v", uids.GetCardinality(), isList, lang)
 
 	filtered := sroar.NewBitmap()
-	itr := uids.NewFastIterator()
+	itr := uids.NewIterator()
 	for uid := itr.Next(); uid > 0; uid = itr.Next() {
 		select {
 		case <-ctx.Done():
@@ -1421,7 +1421,7 @@ func (qs *queryState) handleMatchFunction(ctx context.Context, arg funcArgs) err
 	matchQuery := strings.Join(arg.srcFn.tokens, "")
 	filtered := sroar.NewBitmap()
 
-	itr := uids.NewFastIterator()
+	itr := uids.NewIterator()
 	for uid := itr.Next(); uid > 0; uid = itr.Next() {
 		select {
 		case <-ctx.Done():
@@ -1496,7 +1496,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 	}
 
 	filtered := make([]*sroar.Bitmap, numGo)
-	filter := func(idx int, it *sroar.FastIterator) error {
+	filter := func(idx int, it *sroar.Iterator) error {
 
 		filtered[idx] = sroar.NewBitmap()
 		out := filtered[idx]
@@ -1526,7 +1526,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 	iters := uids.NewRangeIterators(numGo)
 	errCh := make(chan error, numGo)
 	for i := 0; i < numGo; i++ {
-		go func(idx int, it *sroar.FastIterator) {
+		go func(idx int, it *sroar.Iterator) {
 			errCh <- filter(idx, it)
 		}(i, iters[i])
 	}
@@ -1602,7 +1602,7 @@ func (qs *queryState) filterStringFunction(arg funcArgs) error {
 	// matrix, to check it later.
 	// TODO: This function can be optimized by having a query specific cache, which can be populated
 	// by the handleHasFunction for e.g. for a `has(name)` query.
-	itr := uids.NewFastIterator()
+	itr := uids.NewIterator()
 
 	// We can't directly modify uids bitmap. We need to add them to another bitmap, and then take
 	// the difference.

--- a/worker/task.go
+++ b/worker/task.go
@@ -499,7 +499,7 @@ func (qs *queryState) handleValuePostings(ctx context.Context, args funcArgs) er
 				// Add an empty UID list to make later processing consistent
 				out.UidMatrix = append(out.UidMatrix, &pb.List{})
 			default:
-				out.UidMatrix = append(out.UidMatrix, &pb.List{Bitmap: codec.ToBytesNoCopy(res)})
+				out.UidMatrix = append(out.UidMatrix, &pb.List{Bitmap: res.ToBuffer()})
 			}
 		}
 		return nil
@@ -1216,7 +1216,7 @@ func (qs *queryState) handleRegexFunction(ctx context.Context, arg funcArgs) err
 	}
 
 	list := &pb.List{
-		Bitmap: codec.ToBytes(filtered),
+		Bitmap: filtered.ToBuffer(),
 	}
 	arg.out.UidMatrix = append(arg.out.UidMatrix, list)
 	return nil
@@ -1464,7 +1464,7 @@ func (qs *queryState) handleMatchFunction(ctx context.Context, arg funcArgs) err
 	}
 
 	out := &pb.List{
-		Bitmap: codec.ToBytes(filtered),
+		Bitmap: filtered.ToBuffer(),
 	}
 	arg.out.UidMatrix = append(arg.out.UidMatrix, out)
 	return nil
@@ -1546,7 +1546,7 @@ func (qs *queryState) filterGeoFunction(ctx context.Context, arg funcArgs) error
 	}
 	for i := 0; i < len(matrix); i++ {
 		matrix[i].And(final)
-		arg.out.UidMatrix[i].Bitmap = codec.ToBytes(matrix[i])
+		arg.out.UidMatrix[i].Bitmap = matrix[i].ToBuffer()
 	}
 	return nil
 }
@@ -1633,7 +1633,7 @@ func (qs *queryState) filterStringFunction(arg funcArgs) error {
 	uids.AndNot(remove)
 	for i := 0; i < len(matrix); i++ {
 		matrix[i].And(uids)
-		arg.out.UidMatrix[i].Bitmap = codec.ToBytes(matrix[i])
+		arg.out.UidMatrix[i].Bitmap = matrix[i].ToBuffer()
 	}
 	return nil
 }
@@ -2483,7 +2483,7 @@ loop:
 	if span != nil {
 		span.Annotatef(nil, "handleHasFunction found %d uids", setCnt)
 	}
-	result := &pb.List{Bitmap: codec.ToBytes(res)}
+	result := &pb.List{Bitmap: res.ToBuffer()}
 	out.UidMatrix = append(out.UidMatrix, result)
 	return nil
 }

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -21,7 +21,6 @@ import (
 
 	cindex "github.com/google/codesearch/index"
 
-	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
@@ -43,7 +42,7 @@ func uidsForRegex(attr string, arg funcArgs,
 	// TODO: Unnecessary conversion here. Avoid if possible.
 	if !intersect.IsEmpty() {
 		opts.Intersect = &pb.List{
-			Bitmap: codec.ToBytes(intersect),
+			Bitmap: intersect.ToBuffer(),
 		}
 	} else {
 		intersect = sroar.NewBitmap()


### PR DESCRIPTION
Optimise recurse by using reached map with bitmap as the value, so a direct 
bitmap `AndNot` can be done to get the list of unvisited edges. Also, use
range iterators and the fast iterator.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7989)
<!-- Reviewable:end -->
