### PR TITLE
 feat(query): cherry-pick Add mechanism to have a limit on number of pending queries 

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -129,6 +129,8 @@ they form a Raft group and provide synchronous replication.
 	flag.String("export", "export", "Folder in which to store exports.")
 	flag.Int("pending_proposals", 256,
 		"Number of pending mutation proposals. Useful for rate limiting.")
+	flag.Int64("max_pending_queries", 10000,
+		"Number of maximum pending queries before we reject them as too many requests.")
 	flag.StringP("zero", "z", fmt.Sprintf("localhost:%d", x.PortZeroGrpc),
 		"Comma separated list of Dgraph zero addresses of the form IP_ADDRESS:PORT.")
 	flag.Uint64("idx", 0,
@@ -645,6 +647,7 @@ func run() {
 		TmpDir:               Alpha.Conf.GetString("tmp"),
 		ExportPath:           Alpha.Conf.GetString("export"),
 		NumPendingProposals:  Alpha.Conf.GetInt("pending_proposals"),
+		MaxPendingQueries:    Alpha.Conf.GetInt64("max_pending_queries"),
 		ZeroAddr:             strings.Split(Alpha.Conf.GetString("zero"), ","),
 		RaftId:               cast.ToUint64(Alpha.Conf.GetString("idx")),
 		WhiteListedIPRanges:  ips,

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -691,6 +691,7 @@ func run() {
 			return
 		}
 	}
+	edgraph.Init()
 
 	x.PrintVersion()
 	glog.Infof("x.Config: %+v", x.Config)

--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/dgraph-io/dgo/v200"
@@ -49,11 +50,12 @@ func init() {
 
 	flag := Increment.Cmd.Flags()
 	flag.String("alpha", "localhost:9080", "Address of Dgraph Alpha.")
-	flag.Int("num", 1, "How many times to run.")
+	flag.Int("num", 1, "How many times to run per goroutine.")
 	flag.Int("retries", 10, "How many times to retry setting up the connection.")
 	flag.Duration("wait", 0*time.Second, "How long to wait.")
 	flag.String("user", "", "Username if login is required.")
 	flag.String("password", "", "Password of the user.")
+	flag.Int("conc", 1, "How many goroutines to run.")
 	flag.String("pred", "counter.val",
 		"Predicate to use for storing the counter.")
 	flag.Bool("ro", false,
@@ -167,25 +169,46 @@ func run(conf *viper.Viper) {
 
 	waitDur := conf.GetDuration("wait")
 	num := conf.GetInt("num")
+	conc := int(conf.GetInt("conc"))
 	format := "0102 03:04:05.999"
 
 	dg, closeFunc := x.GetDgraphClient(Increment.Conf, true)
 	defer closeFunc()
 
-	for num > 0 {
-		txnStart := time.Now() // Start time of transaction
-		cnt, err := process(dg, conf)
-		now := time.Now().UTC().Format(format)
-		if err != nil {
-			fmt.Printf("%-17s While trying to process counter: %v. Retrying...\n", now, err)
-			time.Sleep(time.Second)
-			continue
-		}
-		serverLat := cnt.qLatency + cnt.mLatency
-		clientLat := time.Since(txnStart).Round(time.Millisecond)
-		fmt.Printf("%-17s Counter VAL: %d   [ Ts: %d ] Latency: Q %s M %s S %s C %s D %s\n", now, cnt.Val,
-			cnt.startTs, cnt.qLatency, cnt.mLatency, serverLat, clientLat, clientLat-serverLat)
+	// Run things serially first.
+	for i := 0; i < conc; i++ {
+		_, err := process(dg, conf)
+		x.Check(err)
 		num--
-		time.Sleep(waitDur)
 	}
+
+	var wg sync.WaitGroup
+	f := func(i int) {
+		defer wg.Done()
+		count := 0
+		for count < num {
+			txnStart := time.Now() // Start time of transaction
+			cnt, err := process(dg, conf)
+			now := time.Now().UTC().Format(format)
+			if err != nil {
+				fmt.Printf("%-17s While trying to process counter: %v. Retrying...\n", now, err)
+				time.Sleep(time.Second)
+				continue
+			}
+			serverLat := cnt.qLatency + cnt.mLatency
+			clientLat := time.Since(txnStart).Round(time.Millisecond)
+			fmt.Printf(
+				"[%d] %-17s Counter VAL: %d   [ Ts: %d ] Latency: Q %s M %s S %s C %s D %s\n",
+				i, now, cnt.Val, cnt.startTs, cnt.qLatency, cnt.mLatency,
+				serverLat, clientLat, clientLat-serverLat)
+			time.Sleep(waitDur)
+			count++
+		}
+	}
+
+	for i := 0; i < conc; i++ {
+		wg.Add(1)
+		go f(i)
+	}
+	wg.Wait()
 }

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1009,19 +1009,15 @@ func (s *Server) Query(ctx context.Context, req *api.Request) (*api.Response, er
 	return s.doQuery(ctx, req, NoAuthorize)
 }
 
-<<<<<<< HEAD
-func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode) (
-=======
 var pendingQueries int64
 var maxPendingQueries int64
 var serverOverloadErr = errors.New("429 Too Many Requests. Please throttle your requests")
 
 func Init() {
-	maxPendingQueries = x.Config.Limit.GetInt64("max-pending-queries")
+	maxPendingQueries = x.WorkerConfig.MaxPendingQueries
 }
 
-func (s *Server) doQuery(ctx context.Context, req *Request) (
->>>>>>> 1450f8100... feat(query): Add mechanism to have a limit on number of pending queries (#7603)
+func (s *Server) doQuery(ctx context.Context, req *api.Request, doAuth AuthMode) (
 	resp *api.Response, rerr error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/x/config.go
+++ b/x/config.go
@@ -63,6 +63,8 @@ type WorkerOptions struct {
 	ExportPath string
 	// NumPendingProposals indicates the maximum number of pending mutation proposals.
 	NumPendingProposals int
+	// MaxPendingQueries indicates the maximum number of pending queries.
+	MaxPendingQueries int64
 	// Tracing tells Dgraph to only sample a percentage of the traces equal to its value.
 	// The value of this option must be between 0 and 1.
 	// TODO: Get rid of this here.


### PR DESCRIPTION
  This is useful to avoid blowing up the number of goroutines handling queries, if the user bombards Dgraph with lots of concurrent / asynchronous requests.

Cherry pick from #7603

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7990)
<!-- Reviewable:end -->
