### PR TITLE
opt(cache): Use Ristretto to store posting lists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dgraph-io/dgraph
 go 1.12
 
 // replace github.com/dgraph-io/badger/v3 => /home/mrjn/go/src/github.com/dgraph-io/badger
-replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
+// replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
 // replace github.com/dgraph-io/sroar => /home/ash/go/src/github.com/dgraph-io/sroar
 
 require (
@@ -24,7 +24,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.0
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
-	github.com/dgraph-io/ristretto v0.1.0
+	github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a
+	github.com/dgraph-io/badger/v3 v3.0.0-20210825061050-c2b23c471f5e
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.0.0-20210707084205-c40b2e9af902
+	github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dgraph-io/dgraph
 go 1.12
 
 // replace github.com/dgraph-io/badger/v3 => /home/mrjn/go/src/github.com/dgraph-io/badger
-// replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
+replace github.com/dgraph-io/ristretto => /home/mrjn/go/src/github.com/dgraph-io/ristretto
 // replace github.com/dgraph-io/sroar => /home/ash/go/src/github.com/dgraph-io/sroar
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.0
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
-	github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5
+	github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a h1:4NUj7KVFGNicAKXilmihCeaSr1VNEZzn+/fN4B6hZ4s=
-github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
+github.com/dgraph-io/badger/v3 v3.0.0-20210825061050-c2b23c471f5e h1:lugmhvI1tMal0wKW0g5uxIRHUqXpE5y1lgq/vm/UP/8=
+github.com/dgraph-io/badger/v3 v3.0.0-20210825061050-c2b23c471f5e/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987 h1:5aN6H88a2q3HkO8vSZxDlgjEpJf4Fz8rfy+/Wzx2uAc=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/dgraph-io/gqlparser/v2 v2.2.0/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15 h1:X2NRsgAtVUAp2nmTPCq+x+wTcRRrj74CEpy7E0Unsl4=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
-github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5 h1:eZaLpk24fjkUDiuKZQ2zLEM2H8S9KkBpXusEP3DQWRc=
-github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a h1:2+hTlwc5yG4WAUXCoKWT/JJ11g8J1Q70in9abzFW7EQ=
+github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67 h1:IVHiU4jfB86QzsbwtSxtP6q/CsB9gOB69i1AFu9TiIk=

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,9 @@ github.com/dgraph-io/gqlparser/v2 v2.2.0 h1:fKSCW8OxoMogjDwUhO9OrFvrgIA0UZspTDbc
 github.com/dgraph-io/gqlparser/v2 v2.2.0/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15 h1:X2NRsgAtVUAp2nmTPCq+x+wTcRRrj74CEpy7E0Unsl4=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
-github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5 h1:eZaLpk24fjkUDiuKZQ2zLEM2H8S9KkBpXusEP3DQWRc=
+github.com/dgraph-io/ristretto v0.1.1-0.20210824005722-c10871b265e5/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67 h1:IVHiU4jfB86QzsbwtSxtP6q/CsB9gOB69i1AFu9TiIk=

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v3 v3.0.0-20210707084205-c40b2e9af902 h1:Hk1GPDKdIAZD4TC8tiqjvwmYsicKI8URu0RIb/uFwDU=
-github.com/dgraph-io/badger/v3 v3.0.0-20210707084205-c40b2e9af902/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
+github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a h1:4NUj7KVFGNicAKXilmihCeaSr1VNEZzn+/fN4B6hZ4s=
+github.com/dgraph-io/badger/v3 v3.0.0-20210823122703-53031e64915a/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987 h1:5aN6H88a2q3HkO8vSZxDlgjEpJf4Fz8rfy+/Wzx2uAc=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/posting/index.go
+++ b/posting/index.go
@@ -1232,6 +1232,7 @@ func DeleteData(ns uint64) error {
 // based on DB options set.
 func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
+	// TODO: We should only delete cache for certain keys, not all the keys.
 	ResetCache()
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefix(prefix); err != nil {
@@ -1244,6 +1245,7 @@ func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
 // writes.
 func DeletePredicateBlocking(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
+	// TODO: We should only delete cache for certain keys, not all the keys.
 	ResetCache()
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefixBlocking(prefix); err != nil {
@@ -1254,6 +1256,7 @@ func DeletePredicateBlocking(ctx context.Context, attr string, ts uint64) error 
 
 // DeleteNamespace bans the namespace and deletes its predicates/types from the schema.
 func DeleteNamespace(ns uint64) error {
+	// TODO: We should only delete cache for certain keys, not all the keys.
 	ResetCache()
 	schema.State().DeletePredsForNs(ns)
 	return pstore.BanNamespace(ns)

--- a/posting/index.go
+++ b/posting/index.go
@@ -1215,11 +1215,13 @@ func rebuildListType(ctx context.Context, rb *IndexRebuild) error {
 
 // DeleteAll deletes all entries in the posting list.
 func DeleteAll() error {
+	ResetCache()
 	return pstore.DropAll()
 }
 
 // DeleteData deletes all data for the namespace but leaves types and schema intact.
 func DeleteData(ns uint64) error {
+	ResetCache()
 	prefix := make([]byte, 9)
 	prefix[0] = x.DefaultPrefix
 	binary.BigEndian.PutUint64(prefix[1:], ns)
@@ -1230,6 +1232,7 @@ func DeleteData(ns uint64) error {
 // based on DB options set.
 func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
+	ResetCache()
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefix(prefix); err != nil {
 		return err
@@ -1241,6 +1244,7 @@ func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
 // writes.
 func DeletePredicateBlocking(ctx context.Context, attr string, ts uint64) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
+	ResetCache()
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefixBlocking(prefix); err != nil {
 		return err
@@ -1250,6 +1254,7 @@ func DeletePredicateBlocking(ctx context.Context, attr string, ts uint64) error 
 
 // DeleteNamespace bans the namespace and deletes its predicates/types from the schema.
 func DeleteNamespace(ns uint64) error {
+	ResetCache()
 	schema.State().DeletePredsForNs(ns)
 	return pstore.BanNamespace(ns)
 }

--- a/posting/list.go
+++ b/posting/list.go
@@ -1215,6 +1215,8 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	}
 
 	if len(out.plist.Splits) > 0 || len(l.mutationMap) > 0 {
+		// In case there were splits, this would read all the splits from
+		// Badger.
 		if err := l.encode(out, readTs, split); err != nil {
 			return nil, errors.Wrapf(err, "while encoding")
 		}

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -464,7 +464,7 @@ func TestMillion(t *testing.T) {
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps, math.MaxUint64)
+			ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		commits++
@@ -1001,7 +1001,7 @@ func TestLargePlistSplit(t *testing.T) {
 	_, err = ol.Rollup(nil)
 	require.NoError(t, err)
 
-	ol, err = getNew(key, ps, math.MaxUint64)
+	ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	b = make([]byte, 5<<20)
 	rand.Read(b)
@@ -1020,7 +1020,7 @@ func TestLargePlistSplit(t *testing.T) {
 	kvs, err := ol.Rollup(nil)
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps, math.MaxUint64)
+	ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	require.Nil(t, ol.plist.Bitmap)
 	require.Equal(t, 0, len(ol.plist.Postings))
@@ -1300,7 +1300,7 @@ func TestMultiPartListWriteToDisk(t *testing.T) {
 	require.Equal(t, len(kvs), len(originalList.plist.Splits)+1)
 
 	require.NoError(t, writePostingListToDisk(kvs))
-	newList, err := getNew(kvs[0].Key, ps, math.MaxUint64)
+	newList, err := readPostingListFromDisk(kvs[0].Key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	opt := ListOptions{ReadTs: math.MaxUint64}
@@ -1369,7 +1369,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps, math.MaxUint64)
+			ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		curTs++
@@ -1398,7 +1398,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps, math.MaxUint64)
+			ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		curTs++
@@ -1409,7 +1409,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	kvs, err := ol.Rollup(nil)
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps, math.MaxUint64)
+	ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 	for _, kv := range kvs {
 		require.Equal(t, curTs, kv.Version)
@@ -1438,7 +1438,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 			kvs, err := ol.Rollup(nil)
 			require.NoError(t, err)
 			require.NoError(t, writePostingListToDisk(kvs))
-			ol, err = getNew(key, ps, math.MaxUint64)
+			ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 			require.NoError(t, err)
 		}
 		curTs++
@@ -1448,7 +1448,7 @@ func TestMultiPartListDeleteAndAdd(t *testing.T) {
 	kvs, err = ol.Rollup(nil)
 	require.NoError(t, err)
 	require.NoError(t, writePostingListToDisk(kvs))
-	ol, err = getNew(key, ps, math.MaxUint64)
+	ol, err = readPostingListFromDisk(key, ps, math.MaxUint64)
 	require.NoError(t, err)
 
 	// Verify all entries are once again in the list.

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -109,7 +109,7 @@ func Init(ps *badger.DB, cacheSize int64) {
 }
 
 func UpdateMaxCost(maxCost int64) {
-	// lCache.UpdateMaxCost(maxCost)
+	lCache.UpdateMaxCost(maxCost)
 }
 
 // Cleanup waits until the closer has finished processing.

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -44,9 +44,17 @@ type GoCache struct {
 	mp map[string]interface{}
 }
 
-func (c *GoCache) Set(key []byte, l interface{}, v uint64) {
+func (c *GoCache) Set(key []byte, l interface{}, _ uint64) {
 	c.Lock()
 	c.mp[string(key)] = l
+	c.Unlock()
+}
+
+func (c *GoCache) SetIfAbsent(key []byte, l interface{}, _ uint64) {
+	c.Lock()
+	if _, has := c.mp[string(key)]; !has {
+		c.mp[string(key)] = l
+	}
 	c.Unlock()
 }
 

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -40,7 +40,6 @@ var (
 	pstore *badger.DB
 	closer *z.Closer
 	lCache *ristretto.Cache
-	// lCache *GoCache
 )
 
 // Init initializes the posting lists package, the in memory and dirty list hash.

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/z"
@@ -55,15 +54,14 @@ func Init(ps *badger.DB, cacheSize int64) {
 	// keys which are already cached. Not introduce new keys.
 	go func(closer *z.Closer) {
 		defer closer.Done()
-		err := pstore.Subscribe(closer.Ctx(), func(kvs *bpb.KVList) error {
+		err := pstore.Subscribe(context.Background(), func(kvs *bpb.KVList) error {
 			for _, kv := range kvs.Kv {
-				key := y.ParseKey(kv.Key)
-				if _, ok := lCache.Get(key); ok {
-					lCache.Set(key, nil, 0)
+				if _, ok := lCache.Get(kv.Key); ok {
+					lCache.Set(kv.Key, nil, 0)
 				}
 			}
 			return nil
-		}, nil)
+		}, []bpb.Match{{}})
 		x.Check(err)
 	}(closer)
 

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -50,6 +50,13 @@ func (c *GoCache) Set(key []byte, l interface{}, _ uint64) {
 	c.Unlock()
 }
 
+func (c *GoCache) UpdateIfPresent(key []byte, l interface{}, _ uint64) {
+	c.Lock()
+	if _, has := c.mp[string(key)]; has {
+		c.mp[string(key)] = l
+	}
+	c.Unlock()
+}
 func (c *GoCache) SetIfAbsent(key []byte, l interface{}, _ uint64) {
 	c.Lock()
 	if _, has := c.mp[string(key)]; !has {

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -497,8 +497,8 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 	}
 
 	// We use badger subscription to invalidate the cache. For every write we make the value
-	// of the cache nil. So, if we get some non-nil value from the cache then it means that no
-	// writes have happened after the last set of this key in the cache.
+	// corresponding to the key in the cache to nil. So, if we get some non-nil value from the cache
+	// then it means that no  writes have happened after the last set of this key in the cache.
 	cachedVal, ok := lCache.Get(key)
 	if ok {
 		l, ok := cachedVal.(*List)
@@ -537,7 +537,7 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 		return l, err
 	}
 
-	// Only set this posting list to the cache if readTs >= latestTs, which implies that this is
+	// Only set l to the cache if readTs >= latestTs, which implies that l is
 	// the latest version of the PL.
 	if readTs >= latestTs && l.maxTs > 0 {
 		lCache.Set(key, l, 0)

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -35,6 +35,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 
@@ -91,8 +92,6 @@ func (ir *incrRollupi) rollUpKey(sl *skl.Skiplist, key []byte) error {
 	if err != nil {
 		return err
 	}
-	// Clear the list from the cache after a rollup.
-	RemoveCacheFor(key)
 
 	const N = uint64(1000)
 	if glog.V(2) {
@@ -372,32 +371,6 @@ func (txn *Txn) ToSkiplist() error {
 	return nil
 }
 
-// ResetCache will clear all the cached list.
-func ResetCache() {
-	lCache.Clear()
-}
-
-// RemoveCacheFor will delete the list corresponding to the given key.
-func RemoveCacheFor(key []byte) {
-	// TODO: investigate if this can be done by calling Set with a nil value.
-	lCache.Del(key)
-}
-
-// RemoveCachedKeys will delete the cached list by this txn.
-func (txn *Txn) RemoveCachedKeys() {
-	if txn == nil || txn.cache == nil {
-		return
-	}
-	for key := range txn.cache.deltas {
-		lCache.Del(key)
-	}
-}
-
-func WaitForCache() {
-	// TODO Investigate if this is needed and why Jepsen tests fail with the cache enabled.
-	// lCache.Wait()
-}
-
 func unmarshalOrCopy(plist *pb.PostingList, item *badger.Item) error {
 	if plist == nil {
 		return errors.Errorf("cannot unmarshal value to a nil posting list of key %s",
@@ -518,27 +491,31 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 	if pstore.IsClosed() {
 		return nil, badger.ErrDBClosed
 	}
-	// TODO: Fix this up later.
-	// cachedVal, ok := lCache.Get(key)
-	// if ok {
-	// 	l, ok := cachedVal.(*List)
-	// 	if ok && l != nil {
-	// 		// No need to clone the immutable layer or the key since mutations will not modify it.
-	// 		lCopy := &List{
-	// 			minTs: l.minTs,
-	// 			maxTs: l.maxTs,
-	// 			key:   key,
-	// 			plist: l.plist,
-	// 		}
-	// 		if l.mutationMap != nil {
-	// 			lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
-	// 			for ts, pl := range l.mutationMap {
-	// 				lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
-	// 			}
-	// 		}
-	// 		return lCopy, nil
-	// 	}
-	// }
+
+	// We use badger subscription to invalidate the cache. For every write we make the value
+	// of the cache nil. So, if we get some non-nil value from the cache then it means that no
+	// writes have happened after the last set of this key in the cache.
+	cachedVal, ok := lCache.Get(key)
+	if ok {
+		l, ok := cachedVal.(*List)
+		if ok && l != nil {
+			x.AssertTrue(l.maxTs <= readTs)
+			// No need to clone the immutable layer or the key since mutations will not modify it.
+			lCopy := &List{
+				minTs: l.minTs,
+				maxTs: l.maxTs,
+				key:   l.key,
+				plist: l.plist,
+			}
+			if l.mutationMap != nil {
+				lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
+				for ts, pl := range l.mutationMap {
+					lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
+				}
+			}
+			return lCopy, nil
+		}
+	}
 
 	txn := pstore.NewTransactionAt(readTs, false)
 	defer txn.Discard()
@@ -550,11 +527,16 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 	iterOpts.PrefetchValues = false
 	itr := txn.NewKeyIterator(key, iterOpts)
 	defer itr.Close()
-	itr.Seek(key)
+	latestTs := itr.Seek(key)
 	l, err := ReadPostingList(key, itr)
 	if err != nil {
 		return l, err
 	}
-	// lCache.Set(key, l, 0)
+
+	// Only set this posting list to the cache if readTs >= latestTs, which implies that this is
+	// the latest version of the PL.
+	if readTs >= latestTs {
+		lCache.Set(key, l, 0)
+	}
 	return l, nil
 }

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -371,6 +371,10 @@ func (txn *Txn) ToSkiplist() error {
 	return nil
 }
 
+func ResetCache() {
+	lCache.Clear()
+}
+
 func unmarshalOrCopy(plist *pb.PostingList, item *badger.Item) error {
 	if plist == nil {
 		return errors.Errorf("cannot unmarshal value to a nil posting list of key %s",

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -521,11 +521,10 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 	}
 
 	// We could consider writing this to Badger here, as we already have a
-	// rolled up version. But, doing the write here to Badger wouldn't be
-	// ideal. We write to Badger using Skiplists, instead of writing one entry
-	// at a time. Secondly, sending it over to IncrRollup would require us to
-	// deal with the race between the write from here against the key being
-	// registered for a rollup. Ignore this optimization to maintain simplicity.
+	// rolled up version. But, doing the write here to Badger wouldn't be ideal.
+	// We write to Badger using Skiplists, instead of writing one entry at a
+	// time. In fact, rollups use getNew. So our cache here would get used by
+	// the roll up, hence achieving this optimization.
 
 	newList := func() *List {
 		return &List{

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -508,7 +508,7 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 				plist: l.plist,
 			}
 			if l.mutationMap != nil {
-				lCopy.mutationMap = make(map[uint64]*pb.PostingList, len(l.mutationMap))
+				lCopy.mutationMap = make(map[uint64]*pb.PostingList)
 				for ts, pl := range l.mutationMap {
 					lCopy.mutationMap[ts] = proto.Clone(pl).(*pb.PostingList)
 				}
@@ -535,7 +535,7 @@ func getNew(key []byte, pstore *badger.DB, readTs uint64) (*List, error) {
 
 	// Only set this posting list to the cache if readTs >= latestTs, which implies that this is
 	// the latest version of the PL.
-	if readTs >= latestTs {
+	if readTs >= latestTs && l.maxTs > 0 {
 		lCache.Set(key, l, 0)
 	}
 	return l, nil

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -293,11 +293,10 @@ func (txn *Txn) ToSkiplist() error {
 	sort.Strings(keys)
 
 	// Add these keys to be rolled up after we're done writing them to Badger.
-	// TODO: We are no longer rolling up the keys on write. A simple way to achieve
-	// that would be to subscribe to Badger writes, and just push those to
-	// IncrRollup. Some full text indices could easily gain hundreds of
-	// thousands of mutations, while never being read. We do want to capture
-	// those cases.
+	// Some full text indices could easily gain hundreds of thousands of
+	// mutations, while never being read. We do want to capture those cases.
+	// Update: We roll up the keys in oracle.DeleteTxnsAndRollupKeys, which is a
+	// callback that happens after skip list gets handed over to Badger.
 
 	b := skl.NewBuilder(1 << 10)
 	for _, key := range keys {

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -268,10 +268,18 @@ func (o *oracle) WaitForTs(ctx context.Context, startTs uint64) error {
 	}
 }
 
-func (o *oracle) DeleteTxns(delta *pb.OracleDelta) {
+// DeleteTxnsAndRollupKeys is called via a callback when Skiplist is handled
+// over to Badger with latest commits in it.
+func (o *oracle) DeleteTxnsAndRollupKeys(delta *pb.OracleDelta) {
 	o.Lock()
-	for _, txn := range delta.Txns {
-		delete(o.pendingTxns, txn.StartTs)
+	for _, status := range delta.Txns {
+		if status.CommitTs > 0 {
+			txn := o.pendingTxns[status.StartTs]
+			for k := range txn.Deltas() {
+				IncrRollup.addKeyToBatch([]byte(k), 0)
+			}
+		}
+		delete(o.pendingTxns, status.StartTs)
 	}
 	o.Unlock()
 }

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -273,8 +273,8 @@ func (o *oracle) WaitForTs(ctx context.Context, startTs uint64) error {
 func (o *oracle) DeleteTxnsAndRollupKeys(delta *pb.OracleDelta) {
 	o.Lock()
 	for _, status := range delta.Txns {
-		if status.CommitTs > 0 {
-			txn := o.pendingTxns[status.StartTs]
+		txn := o.pendingTxns[status.StartTs]
+		if txn != nil && status.CommitTs > 0 {
 			for k := range txn.Deltas() {
 				IncrRollup.addKeyToBatch([]byte(k), 0)
 			}

--- a/posting/size.go
+++ b/posting/size.go
@@ -36,13 +36,12 @@ func (l *List) DeepSize() uint64 {
 	l.RLock()
 	defer l.RUnlock()
 
-	var size uint64 = uint64(unsafe.Sizeof(&List{}))
-	// var size uint64 = 4*8 + // safe mutex consists of 4 words.
-	// 	1*8 + // plist pointer consists of 1 word.
-	// 	1*8 + // mutation map pointer  consists of 1 word.
-	// 	2*8 + // minTs and maxTs take 1 word each.
-	// 	3*8 + // array take 3 words. so key array is 3 words.
-	// 	1*8 // So far 11 words, in order to round the slab we're adding one more word.
+	var size uint64 = 4*8 + // safe mutex consists of 4 words.
+		1*8 + // plist pointer consists of 1 word.
+		1*8 + // mutation map pointer  consists of 1 word.
+		2*8 + // minTs and maxTs take 1 word each.
+		3*8 + // array take 3 words. so key array is 3 words.
+		1*8 // So far 11 words, in order to round the slab we're adding one more word.
 	// // so far basic struct layout has been calculated.
 
 	// Add each entry size of key array.

--- a/posting/size.go
+++ b/posting/size.go
@@ -42,7 +42,7 @@ func (l *List) DeepSize() uint64 {
 		2*8 + // minTs and maxTs take 1 word each.
 		3*8 + // array take 3 words. so key array is 3 words.
 		1*8 // So far 11 words, in order to round the slab we're adding one more word.
-	// // so far basic struct layout has been calculated.
+	// so far basic struct layout has been calculated.
 
 	// Add each entry size of key array.
 	size += uint64(cap(l.key))

--- a/posting/size.go
+++ b/posting/size.go
@@ -36,13 +36,14 @@ func (l *List) DeepSize() uint64 {
 	l.RLock()
 	defer l.RUnlock()
 
-	var size uint64 = 4*8 + // safe mutex consists of 4 words.
-		1*8 + // plist pointer consists of 1 word.
-		1*8 + // mutation map pointer  consists of 1 word.
-		2*8 + // minTs and maxTs take 1 word each.
-		3*8 + // array take 3 words. so key array is 3 words.
-		1*8 // So far 11 words, in order to round the slab we're adding one more word.
-	// so far basic struct layout has been calculated.
+	var size uint64 = uint64(unsafe.Sizeof(&List{}))
+	// var size uint64 = 4*8 + // safe mutex consists of 4 words.
+	// 	1*8 + // plist pointer consists of 1 word.
+	// 	1*8 + // mutation map pointer  consists of 1 word.
+	// 	2*8 + // minTs and maxTs take 1 word each.
+	// 	3*8 + // array take 3 words. so key array is 3 words.
+	// 	1*8 // So far 11 words, in order to round the slab we're adding one more word.
+	// // so far basic struct layout has been calculated.
 
 	// Add each entry size of key array.
 	size += uint64(cap(l.key))

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1161,7 +1161,6 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 			txn.UpdateCachedKeys(status.CommitTs)
 		}
 	}
-	posting.WaitForCache()
 	span.Annotate(nil, "cache keys removed")
 
 	// Now advance Oracle(), so we can service waiting reads.

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1109,7 +1109,7 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 	// This would be used for callback via Badger when skiplist is pushed to
 	// disk.
 	deleteTxns := func() {
-		posting.Oracle().DeleteTxns(delta)
+		posting.Oracle().DeleteTxnsAndRollupKeys(delta)
 	}
 
 	if len(itrs) == 0 {

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1076,7 +1076,7 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 	var sz int64
 	for _, status := range delta.Txns {
 		txn := posting.Oracle().GetTxn(status.StartTs)
-		if txn == nil {
+		if txn == nil || status.CommitTs == 0 {
 			continue
 		}
 		for k := range txn.Deltas() {
@@ -1157,7 +1157,9 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 	// Clear all the cached lists that were touched by this transaction.
 	for _, status := range delta.Txns {
 		txn := posting.Oracle().GetTxn(status.StartTs)
-		txn.UpdateCachedKeys(status.CommitTs)
+		if status.CommitTs > 0 {
+			txn.UpdateCachedKeys(status.CommitTs)
+		}
 	}
 	posting.WaitForCache()
 	span.Annotate(nil, "cache keys removed")

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1157,7 +1157,7 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 	// Clear all the cached lists that were touched by this transaction.
 	for _, status := range delta.Txns {
 		txn := posting.Oracle().GetTxn(status.StartTs)
-		txn.RemoveCachedKeys()
+		txn.UpdateCachedKeys(status.CommitTs)
 	}
 	posting.WaitForCache()
 	span.Annotate(nil, "cache keys removed")

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -559,9 +559,6 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 			return err
 		}
 
-		// TODO: Revisit this when we work on posting cache. Clear entire cache.
-		// We don't want to drop entire cache, just due to one namespace.
-		// posting.ResetCache()
 		return nil
 	}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -1120,11 +1120,21 @@ func (n *node) commitOrAbort(_ uint64, delta *pb.OracleDelta) error {
 		var keys int
 		b := skl.NewBuilder(int64(float64(sz) * 1.1))
 		for mi.Valid() {
+			posting.RemoveCacheFor(y.ParseKey(mi.Key()))
 			b.Add(mi.Key(), mi.Value())
 			keys++
 			mi.Next()
 		}
 		span.Annotatef(nil, "Iterating and skiplist over %d keys took: %s", keys, time.Since(sn))
+
+		// // Clear all the cached lists that were touched by this transaction.
+		// for _, status := range delta.Txns {
+		// 	txn := posting.Oracle().GetTxn(status.StartTs)
+		// 	txn.RemoveCachedKeys()
+		// }
+		// posting.WaitForCache()
+		span.Annotate(nil, "cache keys removed")
+
 		err := x.RetryUntilSuccess(3600, time.Second, func() error {
 			if numKeys == 0 {
 				return nil

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -580,6 +580,9 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 			return err
 		}
 
+		// Clear entire cache.
+		posting.ResetCache()
+
 		// It should be okay to set the schema at timestamp 1 after drop all operation.
 		if groups().groupId() == 1 {
 			initialSchema := schema.InitialSchema(x.GalaxyNamespace)
@@ -628,6 +631,12 @@ func (n *node) applyMutations(ctx context.Context, proposal *pb.Proposal) (rerr 
 
 		if err := runSchemaMutation(ctx, proposal.Mutations.Schema, startTs); err != nil {
 			return err
+		}
+
+		// Clear the entire cache if there is a schema update because the index rebuild
+		// will invalidate the state.
+		if len(proposal.Mutations.Schema) > 0 {
+			posting.ResetCache()
 		}
 
 		for _, tupdate := range proposal.Mutations.Types {

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -40,7 +40,7 @@ const (
 	//       breaks.
 	AuditDefaults  = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
 	BadgerDefaults = `compression=snappy; numgoroutines=8;`
-	CacheDefaults  = `size-mb=1024; percentage=0,65,35;`
+	CacheDefaults  = `size-mb=1024; percentage=50,30,20;`
 	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -47,7 +47,7 @@ const (
 		`lambda-url=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;` +
-		`max-pending-queries=10000;  max-retries=-1; shared-instance=false;`
+		`max-pending-queries=64;  max-retries=-1; shared-instance=false;`
 	RaftDefaults = `learner=false; snapshot-after-entries=10000; ` +
 		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
 	SecurityDefaults   = `token=; whitelist=;`

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -114,6 +114,8 @@ func (n *node) populateSnapshot(snap pb.Snapshot, pl *conn.Pool) error {
 	if err := deleteStalePreds(ctx, done, snap.ReadTs); err != nil {
 		return err
 	}
+	// Reset the cache after having received a snapshot.
+	posting.ResetCache()
 
 	glog.Infof("Snapshot writes DONE. Sending ACK")
 	// Send an acknowledgement back to the leader.


### PR DESCRIPTION
- Use some nifty techniques to make Ristretto caching work with MVCC posting lists.
- Use posting list cache by default.
- Set max pending to 64 by default.

This PR significantly improves query performance. This coupled with Roaring Bitmaps has shown to improve query latency by 20x for 50% of user queries, and 100x for 25% of them.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7995)
<!-- Reviewable:end -->