### PR TITLE
opt(restore): Sort the buffer before spinning the writeToDisk goroutine (#7984)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -165,11 +165,6 @@ func (m *mapper) writeToDisk(buf *z.Buffer) error {
 	if buf.IsEmpty() {
 		return nil
 	}
-	buf.SortSlice(func(ls, rs []byte) bool {
-		lme := mapEntry(ls)
-		rme := mapEntry(rs)
-		return y.CompareKeys(lme.Key(), rme.Key()) < 0
-	})
 
 	f, err := m.newMapFile()
 	if err != nil {
@@ -242,6 +237,11 @@ func (mw *mapper) sendForWriting() error {
 	if mw.buf.IsEmpty() {
 		return nil
 	}
+	mw.buf.SortSlice(func(ls, rs []byte) bool {
+		lme := mapEntry(ls)
+		rme := mapEntry(rs)
+		return y.CompareKeys(lme.Key(), rme.Key()) < 0
+	})
 
 	if err := mw.thr.Do(); err != nil {
 		return err


### PR DESCRIPTION
Cherry-pick of #7984.

Sort the buffer beforehand instead of sorting it in the goroutine used for
writing the buffer to disk. The writeToDisk goroutines are throttled and
making it expensive causes other goroutines to block.

This change significantly improves the restore map phase.

(cherry picked from commit 196624562acdb611cf724927c280c9e812a05d0f)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7996)
<!-- Reviewable:end -->
