### PR TITLE
fix(codec): Return nil instead of a new bitmap

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -155,6 +155,7 @@ func FromList(l *pb.List) *sroar.Bitmap {
 		bm.SetMany(l.SortedUids)
 		return bm
 	}
+	// TODO: Return nil here and handle nil for all the APIs in sroar itself.
 	return sroar.NewBitmap()
 }
 
@@ -171,7 +172,7 @@ func FromListNoCopy(l *pb.List) *sroar.Bitmap {
 		bm.SetMany(l.SortedUids)
 		return bm
 	}
-	return sroar.NewBitmap()
+	return nil
 }
 
 func FromBytes(buf []byte) *sroar.Bitmap {


### PR DESCRIPTION
Return `nil` in from FromListWithCopy instead of a new bitmap.
We should also do the same for FromList.

NOTE: we'll soon make sroar to better handle the nils so that we can return nil and don't
worry about it in dgraph. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/7997)
<!-- Reviewable:end -->
