### PR TITLE
Use rank() API from sroar and some cleanup

### DIFF
--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -17,8 +17,6 @@
 package algo
 
 import (
-	"sort"
-
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/sroar"
@@ -50,12 +48,6 @@ func ApplyFilter(u *pb.List, f func(uint64, int) bool) {
 // IndexOf performs a binary search on the uids slice and returns the index at
 // which it finds the uid, else returns -1
 func IndexOf(u *pb.List, uid uint64) int {
-	bm := codec.FromList(u)
-	// TODO(Ahsan): We might want bm.Rank()
-	uids := bm.ToArray()
-	i := sort.Search(len(uids), func(i int) bool { return uids[i] >= uid })
-	if i < len(uids) && uids[i] == uid {
-		return i
-	}
-	return -1
+	bm := codec.FromListNoCopy(u)
+	return bm.Rank(uid)
 }

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -38,11 +38,6 @@ var (
 	bitMask uint64 = 0xffffffff00000000
 )
 
-//TODO(Ahsan): Need to fix this.
-func ApproxLen(bitmap []byte) int {
-	return 0
-}
-
 func ToList(rm *sroar.Bitmap) *pb.List {
 	return &pb.List{
 		Bitmap: rm.ToBufferWithCopy(),
@@ -79,7 +74,7 @@ func GetUids(l *pb.List) []uint64 {
 	if len(l.SortedUids) > 0 {
 		return l.SortedUids
 	}
-	return FromList(l).ToArray()
+	return FromListNoCopy(l).ToArray()
 }
 
 func SetUids(l *pb.List, uids []uint64) {
@@ -98,11 +93,6 @@ func BitmapToSorted(l *pb.List) {
 	}
 	l.SortedUids = FromList(l).ToArray()
 	l.Bitmap = nil
-}
-
-func And(rm *sroar.Bitmap, l *pb.List) {
-	rl := FromList(l)
-	rm.And(rl)
 }
 
 func MatrixToBitmap(matrix []*pb.List) *sroar.Bitmap {

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67
+	github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a
 	github.com/dgraph-io/simdjson-go v0.3.0
-	github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5
+	github.com/dgraph-io/sroar v0.0.0-20210830053543-c5aff93143f7
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a h1:2+hTlwc5y
 github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67 h1:IVHiU4jfB86QzsbwtSxtP6q/CsB9gOB69i1AFu9TiIk=
-github.com/dgraph-io/sroar v0.0.0-20210816194026-bc614dc5ce67/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5 h1:BHM3GOTJDlADVz9cuNZIH03fuyFtNIgWvReO2+Aw9ds=
+github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a h1:2+hTlwc5y
 github.com/dgraph-io/ristretto v0.1.1-0.20210824115121-89e99415887a/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
-github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5 h1:BHM3GOTJDlADVz9cuNZIH03fuyFtNIgWvReO2+Aw9ds=
-github.com/dgraph-io/sroar v0.0.0-20210826113821-4b7f92928ea5/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
+github.com/dgraph-io/sroar v0.0.0-20210830053543-c5aff93143f7 h1:GUNuYUk6Owo1GIxwDxiIDXSn/T3fgpxWbiXmnKFq5Ig=
+github.com/dgraph-io/sroar v0.0.0-20210830053543-c5aff93143f7/go.mod h1:bdNPtQmcxoIQVkZEWZvX0n0/IDlHFab397xdBlP4OoE=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=

--- a/posting/list.go
+++ b/posting/list.go
@@ -1255,14 +1255,6 @@ func (l *List) rollup(readTs uint64, split bool) (*rollupOutput, error) {
 	return out, nil
 }
 
-// ApproxLen returns an approximate count of the UIDs in the posting list.
-func (l *List) ApproxLen() int {
-	l.RLock()
-	defer l.RUnlock()
-
-	return len(l.mutationMap) + codec.ApproxLen(l.plist.Bitmap)
-}
-
 func abs(a int) int {
 	if a < 0 {
 		return -a

--- a/query/query.go
+++ b/query/query.go
@@ -2140,7 +2140,8 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 				rch <- err
 				return
 			}
-			codec.And(sg.DestMap, sg.SrcUIDs)
+			srcBm := codec.FromListNoCopy(sg.SrcUIDs)
+			sg.DestMap.And(srcBm)
 			rch <- nil
 			return
 		}


### PR DESCRIPTION
IndexOf was converting the bitmap to array and then used binary search to find the rank.
The conversion to array is extremely inefficient. This PR uses newly implemented
Rank API from sroar which finds the rank in an efficient way. This PR also does some
cleanup.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8002)
<!-- Reviewable:end -->
