### PR TITLE
fix(proposals): Incremental proposal key for zero proposals

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -87,12 +87,11 @@ func (n *node) AmLeader() bool {
 // {2 bytes Node ID} {4 bytes for random} {2 bytes zero}
 func (n *node) initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
-	randBytes := make([]byte, 8)
-	if _, err := rand.Read(randBytes); err != nil {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
 		return err
 	}
-	randNum := binary.BigEndian.Uint64(randBytes)
-	proposalKey = uint64(n.Id)<<48 | uint64(randNum)<<16
+	proposalKey = n.Id<<48 | binary.BigEndian.Uint64(b)<<16
 	return nil
 }
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -2120,7 +2120,7 @@ func (n *node) retryUntilSuccess(fn func() error, pause time.Duration) {
 
 // InitAndStartNode gets called after having at least one membership sync with the cluster.
 func (n *node) InitAndStartNode() {
-	initProposalKey(n.Id)
+	x.Check(initProposalKey(n.Id))
 	_, restart, err := n.PastLife()
 	x.Check(err)
 

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -18,6 +18,7 @@ package worker
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"sync"
 	"sync/atomic"
@@ -27,7 +28,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 
 	ostats "go.opencensus.io/stats"
 	"go.opencensus.io/tag"
@@ -112,9 +112,15 @@ func (rl *rateLimiter) decr(retry int) {
 var proposalKey uint64
 
 // {2 bytes Node ID} {4 bytes for random} {2 bytes zero}
-func initProposalKey(id uint64) {
+func initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
-	proposalKey = uint64(groups().Node.Id)<<48 | uint64(z.FastRand())<<16
+	randBytes := make([]byte, 8)
+	if _, err := rand.Read(randBytes); err != nil {
+		return err
+	}
+	randNum := binary.BigEndian.Uint64(randBytes)
+	proposalKey = uint64(groups().Node.Id)<<48 | uint64(randNum)<<16
+	return nil
 }
 
 // uniqueKey is meant to be unique across all the replicas.

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -114,12 +114,11 @@ var proposalKey uint64
 // {2 bytes Node ID} {4 bytes for random} {2 bytes zero}
 func initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
-	randBytes := make([]byte, 8)
-	if _, err := rand.Read(randBytes); err != nil {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
 		return err
 	}
-	randNum := binary.BigEndian.Uint64(randBytes)
-	proposalKey = uint64(groups().Node.Id)<<48 | uint64(randNum)<<16
+	proposalKey = groups().Node.Id<<48 | binary.BigEndian.Uint64(b)<<16
 	return nil
 }
 


### PR DESCRIPTION
Change proposal's unique key to an atomic counter instead of using randomly generated key. For a randomly generated key of 32bits, there is a considerable probability of getting the same key used again. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8005)
<!-- Reviewable:end -->
