### PR TITLE
fix: add validation of null values with correct order of graphql rule validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.0.0-20210707084205-c40b2e9af902
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
-	github.com/dgraph-io/gqlparser/v2 v2.2.0
+	github.com/dgraph-io/gqlparser/v2 v2.2.1
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCz
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/gqlparser/v2 v2.2.0 h1:fKSCW8OxoMogjDwUhO9OrFvrgIA0UZspTDbcm0QGk9M=
-github.com/dgraph-io/gqlparser/v2 v2.2.0/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
+github.com/dgraph-io/gqlparser/v2 v2.2.1 h1:15msK9XEHOSrRqQO48UU+2ZTf1R1U8+tfL9H5D5/eQQ=
+github.com/dgraph-io/gqlparser/v2 v2.2.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15 h1:X2NRsgAtVUAp2nmTPCq+x+wTcRRrj74CEpy7E0Unsl4=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -47,7 +47,7 @@ func init() {
 	validator.AddRule("Check variable type is correct", variableTypeCheck)
 	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
 	validator.AddRule("Check range for Int type", intRangeCheck)
-	validator.AddRule("Input Coercion to List", listInputCoercion)
+	validator.AddRuleWithOrder("Input Coercion to List", 100, listInputCoercion)
 	validator.AddRule("Check filter functions", filterCheck)
 
 }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -47,6 +47,10 @@ func init() {
 	validator.AddRule("Check variable type is correct", variableTypeCheck)
 	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
 	validator.AddRule("Check range for Int type", intRangeCheck)
+	// Graphql accept both single object and array of objects as value when the schema is defined
+	// as an array. listInputCoercion changes the value to array if the single object is provided.
+	// Changing the value can mess up with the other data validation rules hence we are setting
+	// up the order to a high value so that it will be executed last.
 	validator.AddRuleWithOrder("Input Coercion to List", 100, listInputCoercion)
 	validator.AddRule("Check filter functions", filterCheck)
 


### PR DESCRIPTION
This PR fixes the bug mentioned in https://discuss.dgraph.io/t/no-input-field-null-validation-on-non-nullable-fields/14085.
 Issue is suppose a schema is defined type Task { name: String! }.
Now dgraph generates the mutation schema as follows:
```
type mutation {
 addTask(input: [AddTaskInput]!): Result!
}
```

Now while executing mutation, graphql accept both arrays and single object as input. This means:
```
M1: 

mutation {
 addTask(input: {name: string})
}

m2:
mutation {
 addTask(input: [{name: string}])
}

```
both the above mutation are valid. But dgraph after the validation assumes that it will always be an list. This leads to some panics in the past and hence to make it compliant we added listInputCoercion which will change the value to List if needed so that there wont be any issue afterwards. But this leads to other bugs where few of the validations were getting skipped. For example this mutation will fail
```
mutation MyMutation {
  addTask(input: {}) {
    numUids
    test {
      name
    }
  }
}
```
because listInputCoercion changes the {} to [{}] and this will be skipped by the data type validation because of arrays. Hence
an empty data object will be inserted leading to a corrupted database.

This PR adds the order to the execution of rule validations and listInputCoercion is placed in the end so that when the rules are getting executed, all validations are executed first and value change is executed last so that it wont mess up the queries again 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8007)
<!-- Reviewable:end -->
