### PR TITLE
fix(lambda): fix race condition in lambda server spin up

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -34,6 +34,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -487,11 +488,13 @@ func setupLambdaServer(closer *z.Closer) {
 	}
 
 	type lambda struct {
+		sync.Mutex
 		cmd        *exec.Cmd
 		active     bool
 		lastActive int64
-		health     string
-		port       int
+
+		health string
+		port   int
 	}
 
 	lambdas := make([]*lambda, 0, num)
@@ -519,9 +522,11 @@ func setupLambdaServer(closer *z.Closer) {
 					cmd.Env = append(cmd.Env, fmt.Sprintf("DGRAPH_URL="+dgraphUrl))
 					cmd.Stdout = os.Stdout
 					cmd.Stderr = os.Stderr
+					lambdas[i].Lock()
 					lambdas[i].cmd = cmd
 					lambdas[i].lastActive = time.Now().UnixNano()
 					lambdas[i].active = true
+					lambdas[i].Unlock()
 					glog.Infof("Running node command: %+v\n", cmd)
 					if err := cmd.Run(); err != nil {
 						glog.Errorf("Lambda server at port: %d stopped with error: %v",
@@ -544,11 +549,15 @@ func setupLambdaServer(closer *z.Closer) {
 			case <-closer.HasBeenClosed():
 				return
 			case <-ticker.C:
-				timestamp := time.Now().UnixNano()
-				for _, l := range lambdas {
+				healthCheck := func(l *lambda) {
+					l.Lock()
+					defer l.Unlock()
+
 					if !l.active {
-						continue
+						return
 					}
+
+					timestamp := time.Now().UnixNano()
 					resp, err := client.Get(l.health)
 					if err != nil || resp.StatusCode != 200 {
 						if time.Duration(timestamp-l.lastActive) > x.Config.Lambda.RestartAfter {
@@ -556,10 +565,15 @@ func setupLambdaServer(closer *z.Closer) {
 								" Killed it with err: %v", l.port, l.cmd.Process.Kill())
 							l.active = false
 						}
-						continue
+						return
 					}
+
 					resp.Body.Close()
 					l.lastActive = timestamp
+				}
+
+				for _, l := range lambdas {
+					healthCheck(l)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes the race condition while spinning up the lambda server.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8013)
<!-- Reviewable:end -->
