### PR TITLE
fix(admin): make config changes to pass through gog middlewares

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -531,7 +531,7 @@ var (
 	adminQueryMWConfig = map[string]resolve.QueryMiddlewares{
 		"health":          minimalAdminQryMWs, // dgraph checks Guardian auth for health
 		"state":           minimalAdminQryMWs, // dgraph checks Guardian auth for state
-		"config":          stdAdminQryMWs,
+		"config":          gogQryMWs,
 		"listBackups":     gogQryMWs,
 		"getGQLSchema":    stdAdminQryMWs,
 		"getLambdaScript": stdAdminQryMWs,


### PR DESCRIPTION
Currently, guardians of any namespace can enable/disable query logging, update the cache parameters, etc.
This operation should only be allowed to the guardian of the galaxy.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8014)
<!-- Reviewable:end -->
