### PR TITLE
fix(bulk): quote the schema correctly in bulk loader

### DIFF
--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -377,7 +377,7 @@ func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
 		}
 		gqlBuf := &bytes.Buffer{}
 		sch := x.GQL{
-			Schema: strconv.Quote(schema.Schema),
+			Schema: schema.Schema,
 			Script: schema.Script,
 		}
 		b, err := json.Marshal(sch)
@@ -385,11 +385,12 @@ func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
 			fmt.Printf("Error while marshalling schema for the namespace: %d. err: %v", ns, err)
 			return
 		}
+		quotedSch := strconv.Quote(string(b))
 		switch loadType {
 		case chunker.RdfFormat:
-			x.Check2(gqlBuf.Write([]byte(fmt.Sprintf(rdfSchema, ns, ns, b, ns))))
+			x.Check2(gqlBuf.Write([]byte(fmt.Sprintf(rdfSchema, ns, ns, quotedSch, ns))))
 		case chunker.JsonFormat:
-			x.Check2(gqlBuf.Write([]byte(fmt.Sprintf(jsonSchema, ns, b))))
+			x.Check2(gqlBuf.Write([]byte(fmt.Sprintf(jsonSchema, ns, quotedSch))))
 		}
 		ld.readerChunkCh <- gqlBuf
 	}

--- a/systest/bulk_live/common/bulk_live_cases.go
+++ b/systest/bulk_live/common/bulk_live_cases.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 
@@ -76,6 +77,8 @@ func RunBulkCases(t *testing.T) {
 	suite = deleteEdgeWithStarSetup(t, true)
 	testDeleteEdgeWithStar(t)
 	suite.cleanup(t)
+
+	testGqlSchema(t)
 }
 
 func RunBulkCasesAcl(t *testing.T) {
@@ -706,9 +709,14 @@ func testDeleteEdgeWithStar(t *testing.T) {
 }
 
 func testGqlSchema(t *testing.T) {
-	t.Skipf("Skipping: This is failing for some reason. Please fix this.")
 	s := newBulkOnlySuite(t, "", "", "abc")
 	defer s.cleanup(t)
+
+	var sch x.GQL
+	sch.Schema = "abc"
+	b, err := json.Marshal(sch)
+	require.NoError(t, err)
+	schema := strconv.Quote(string(b))
 
 	t.Run("Get GraphQL schema", testCase(`
 	{
@@ -717,14 +725,14 @@ func testGqlSchema(t *testing.T) {
 			dgraph.graphql.xid
 			dgraph.type
 		}
-	}`, `
+	}`, fmt.Sprintf(`
 		{
 			"schema": [{
-				"dgraph.graphql.schema": "abc",
+				"dgraph.graphql.schema": %s,
 				"dgraph.graphql.xid": "dgraph.graphql.schema",
 				"dgraph.type": ["dgraph.graphql"]
 			}]
-		}`))
+		}`, schema)))
 
 }
 


### PR DESCRIPTION
With the format change of exported schema, the schema needs to be quoted at a later stage while bulk loading.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8019)
<!-- Reviewable:end -->
