### PR TITLE
fix(snapshot): Fix snapshot calculation after restore

### DIFF
--- a/worker/draft.go
+++ b/worker/draft.go
@@ -2043,15 +2043,15 @@ func (n *node) calculateSnapshot(startIdx, lastIdx, minPendingStart uint64) (*pb
 			// a snapshot. This is to avoid the restore happening again if the server restarts.
 			if proposal.Restore != nil {
 				restoreTs := proposal.Restore.GetRestoreTs()
-				glog.Infof("Found restore proposal with restoreTs: %d", restoreTs)
-				span.Annotatef(nil, "Found restore proposal with restoreTs: %d", restoreTs)
-
-				return &pb.Snapshot{
+				s := &pb.Snapshot{
 					Context:     n.RaftContext,
 					Index:       entry.Index,
 					ReadTs:      restoreTs,
 					MaxAssigned: restoreTs,
-				}, nil
+				}
+				span.Annotatef(nil, "Found restore proposal with restoreTs: %d", restoreTs)
+				glog.Infof("calculated snapshot from restore proposal: %+v", s)
+				return s, nil
 			}
 		}
 	}

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -2038,6 +2038,15 @@ func (n *node) calculateSnapshot(startIdx, lastIdx, minPendingStart uint64) (*pb
 					maxCommitTs = x.Max(maxCommitTs, txn.CommitTs)
 				}
 			}
+
+			// If there is a restore proposal then consider the restoreTs as commitTs for the
+			// purpose of snapshot calculation.
+			if proposal.Restore != nil {
+				restoreTs := proposal.Restore.GetRestoreTs()
+				maxCommitTs = x.Max(maxCommitTs, restoreTs)
+				glog.Infof("Found restore proposal with restoreTs: %d", restoreTs)
+				span.Annotatef(nil, "Found restore proposal with restoreTs: %d", restoreTs)
+			}
 		}
 	}
 


### PR DESCRIPTION
If there is no delta proposal with a valid commit then the snapshot was
skipped. For the purpose of snapshot calculation, we should also
consider the restore timestamp. 

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8024)
<!-- Reviewable:end -->
