### PR TITLE
fix(lambda): shutdown node processes when alpha gets killed (#8027)

### DIFF
--- a/dgraph/cmd/alpha/lambda_linux.go
+++ b/dgraph/cmd/alpha/lambda_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import "syscall"
+
+func childProcessConfig() *syscall.SysProcAttr {
+	// When alpha dies, send the kill signal to child processes. Pdeathsig is a linux only option.
+	// Hence, in case of panics in other operating systems, the alpha would just hang.
+	return &syscall.SysProcAttr{Pdeathsig: syscall.SIGKILL}
+}

--- a/dgraph/cmd/alpha/lambda_others.go
+++ b/dgraph/cmd/alpha/lambda_others.go
@@ -1,0 +1,25 @@
+// +build !linux
+
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package alpha
+
+import "syscall"
+
+func childProcessConfig() *syscall.SysProcAttr {
+	return nil
+}

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -515,6 +515,7 @@ func setupLambdaServer(closer *z.Closer) {
 					return
 				default:
 					cmd := exec.CommandContext(closer.Ctx(), "node", filename)
+					cmd.SysProcAttr = childProcessConfig()
 					cmd.Env = append(cmd.Env, fmt.Sprintf("PORT=%d", lambdas[i].port))
 					cmd.Env = append(cmd.Env, fmt.Sprintf("DGRAPH_URL="+dgraphUrl))
 					cmd.Stdout = os.Stdout


### PR DESCRIPTION
We were already handling the graceful shutdown of node processes when alpha shuts down. We were passing the closer.Ctx() so that node process shuts down when alpha stops. But that is not sufficient when alpha panics.
In case alpha panics, the alpha gets stuck because the node processes. This happens when sentry is also enabled. Sentry waits for all processes (child as well as grandchild to complete).

(cherry picked from commit d3285b8472d5871c6076adfd9dcb4a99873ad0d2)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8030)
<!-- Reviewable:end -->
