### PR TITLE
cherrypick release/v21.09: feat(magicNumber): Introduce magic number (#8032)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.0.0-20210914152503-560e319d7ceb
+	github.com/dgraph-io/badger/v3 v3.0.0-20210916095630-2a9a524b649b
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210421093152-78a2fece3ebd
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v3 v3.0.0-20210914152503-560e319d7ceb h1:FlJGJO+ebnP7GeDe8K77tRuLwCJSVoMgOsTFCgcbFtg=
-github.com/dgraph-io/badger/v3 v3.0.0-20210914152503-560e319d7ceb/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
+github.com/dgraph-io/badger/v3 v3.0.0-20210916095630-2a9a524b649b h1:t7Em1/gcmd4THIGLYDHhkxwLE/gbNLe08QFVM0dKxaQ=
+github.com/dgraph-io/badger/v3 v3.0.0-20210916095630-2a9a524b649b/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210421093152-78a2fece3ebd h1:bKck5FnruuJxL1oCmrDSYWRl634IxBwL/IwwWx4UgEM=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210421093152-78a2fece3ebd/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/worker/config.go
+++ b/worker/config.go
@@ -24,6 +24,11 @@ import (
 )
 
 const (
+	// magicVersion is a unique uint16 number. Badger won't start if this magic number doesn't match
+	// with the one present in the manifest. It prevents starting up dgraph with new data format
+	// (eg. the change in 21.09 by using roaring bitmap) on older p directory.
+	magicVersion = 1
+
 	// AllowMutations is the mode allowing all mutations.
 	AllowMutations int = iota
 	// DisallowMutations is the mode that disallows all mutations.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -129,7 +129,8 @@ func (s *ServerState) initStorage() {
 		opt := x.WorkerConfig.Badger.
 			WithDir(Config.PostingDir).WithValueDir(Config.PostingDir).
 			WithNumVersionsToKeep(math.MaxInt32).
-			WithNamespaceOffset(x.NamespaceOffset)
+			WithNamespaceOffset(x.NamespaceOffset).
+			WithExternalMagic(magicVersion)
 		opt = setBadgerOptions(opt)
 
 		// Print the options w/o exposing key.


### PR DESCRIPTION
Magic number is a unique identifier for the data format of dgraph. In 21.09 we
have changed the data format of posting lists by bringing in sroar. Running
Dgraph with sroar change on older p directory can cause data corruption.
This magic number prevents DB to start up if the version is not compatible.

(cherry picked from commit 59f6e7a775df6297dda0ae32e9304e2215065b7c)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8033)
<!-- Reviewable:end -->
