### PR TITLE
fix(lambda): make lambda active only after successful start

### DIFF
--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -44,7 +44,7 @@ const (
 	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; `
-	LambdaDefaults  = `url=; num=1; port=20000; restart-after=10s; `
+	LambdaDefaults  = `url=; num=1; port=20000; restart-after=30s; `
 	LimitDefaults   = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;` +
 		`max-pending-queries=64;  max-retries=-1; shared-instance=false;`


### PR DESCRIPTION
There is a logical race condition that causes panic. This happens because the node process did not complete its initialization before being killed. This PR fixes that issue.

This PR also increases the default restart timeout from `10s` to `30s` to make it more generous.
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbf5f7b]

goroutine 175 [running]:
os.(*Process).signal(0x0, 0x279b908, 0x32592d8, 0x0, 0x0)
	/usr/local/go/src/os/exec_unix.go:63 +0x3b
os.(*Process).Signal(...)
	/usr/local/go/src/os/exec.go:135
os.(*Process).kill(...)
	/usr/local/go/src/os/exec_posix.go:66
os.(*Process).Kill(...)
	/usr/local/go/src/os/exec.go:120
github.com/dgraph-io/dgraph/dgraph/cmd/alpha.setupLambdaServer.func2(0xc0003be1c0)
	/data/go/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:556 +0x191
github.com/dgraph-io/dgraph/dgraph/cmd/alpha.setupLambdaServer.func3(0xc000118ae0, 0xc0005020a8, 0xc0000df6b0)
	/data/go/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:577 +0x91
created by github.com/dgraph-io/dgraph/dgraph/cmd/alpha.setupLambdaServer
	/data/go/src/github.com/dgraph-io/dgraph/dgraph/cmd/alpha/run.go:568 +0x82b

```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8036)
<!-- Reviewable:end -->
