### PR TITLE
opt(Restore): Make restore map phase faster

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -655,7 +655,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 	glog.Infof("Setting numGo = %d\n", numGo)
 	mapper := &mapper{
 		closer:    z.NewCloser(1),
-		reqCh:     make(chan listReq, 2*numGo),
+		reqCh:     make(chan listReq, numGo+numGo/4),
 		writeCh:   make(chan *z.Buffer, numGo),
 		writers:   make(chan struct{}, numGo/2), // Only half the writers should be writing at the same time.
 		restoreTs: req.RestoreTs,

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -648,7 +648,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 	numGo := runtime.NumCPU()
 	mapper := &mapper{
 		buf:       newBuffer(),
-		thr:       y.NewThrottle(3),
+		thr:       y.NewThrottle(numGo),
 		bufLock:   &sync.Mutex{},
 		closer:    z.NewCloser(1),
 		reqCh:     make(chan listReq, 2*numGo),

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -493,7 +493,7 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 				if err := processKV(req.in, kv); err != nil {
 					return err
 				}
-				if buf.LenNoPadding() > 16<<20 {
+				if buf.LenNoPadding() > 256<<20 {
 					if err := mergeBuffer(); err != nil {
 						return err
 					}

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -646,7 +646,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 		return nil, err
 	}
 
-	numGo := runtime.NumCPU() / 2
+	numGo := int(float64(runtime.NumCPU()) * 0.75)
 	glog.Infof("Setting numGo = %d\n", numGo)
 	mapper := &mapper{
 		thr:       y.NewThrottle(numGo),

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -653,7 +653,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 		closer:    z.NewCloser(1),
 		reqCh:     make(chan listReq, 2*numGo),
 		writeCh:   make(chan *z.Buffer, numGo),
-		writers:   make(chan struct{}, 3),
+		writers:   make(chan struct{}, numGo/2), // Only half the writers should be writing at the same time.
 		restoreTs: req.RestoreTs,
 		mapDir:    mapDir,
 		szHist:    z.NewHistogramData(z.HistogramBounds(10, 32)),

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -273,7 +273,7 @@ func (m *mapper) mergeAndSend(closer *z.Closer) error {
 			writeNow = true
 			m.writers <- struct{}{}
 
-		} else if mbuf.LenNoPadding() >= mapFileSz/8 {
+		} else if mbuf.LenNoPadding() >= mapFileSz/4 {
 			select {
 			case m.writers <- struct{}{}:
 				writeNow = true

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -551,8 +551,9 @@ func (m *mapper) Progress() {
 		proc := atomic.LoadUint64(&m.bytesProcessed)
 		since := time.Since(start)
 		rate := uint64(float64(proc) / since.Seconds())
-		glog.Infof("Restore MAP %s reqCh: %d read: %s. output: %s. rate: %s/sec. jemalloc: %s.\n",
-			x.FixedDuration(since), len(m.reqCh), humanize.IBytes(read), humanize.IBytes(proc),
+		glog.Infof("Restore MAP %s len(reqCh): %d len(writeCh): %d read: %s. output: %s."+
+			" rate: %s/sec. jemalloc: %s.\n", x.FixedDuration(since), len(m.reqCh),
+			len(m.writeCh), humanize.IBytes(read), humanize.IBytes(proc),
 			humanize.IBytes(rate), humanize.IBytes(uint64(z.NumAllocBytes())))
 	}
 	for {


### PR DESCRIPTION
With this change, this is what we got on a 48 core AWS machine.

```
alpha1    | I0917 08:03:27.921912      17 restore_map.go:547] Restore MAP 01h04m30s len(reqCh): 0 len(writeCh): 0 read: 472 GiB. output: 1.6 TiB. rate: 437 MiB/sec. nextFileId: 2474 writers: 0 jemalloc: 0 B.
alpha1    | I0917 08:03:27.921934      17 restore_map.go:559] Restore MAP Done in 01h04m30s.
```

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8038)
<!-- Reviewable:end -->
