### PR TITLE
fix(probe): do not contend for lock in lazy load (#8037)

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -1026,12 +1026,9 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 
 func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 	// if the schema is already in memory, no need to fetch it from disk
-	as.mux.RLock()
 	if currentSchema, ok := as.gqlSchemas.GetCurrent(namespace); ok && currentSchema.Loaded {
-		as.mux.RUnlock()
 		return nil
 	}
-	as.mux.RUnlock()
 
 	// otherwise, fetch the schema from disk
 	sch, err := getCurrentGraphQLSchema(namespace)


### PR DESCRIPTION
Earlier the admin server mutex lock was used to protect the graphql schema map. But now we store that in schema store that internally handles the concurrency. Hence, we don't need to take the admin server's read lock to access schema.

/probe/graphql is used as health check and is called very frequently. This rlock on adminserver mutex makes the /probe/graphql requests block while lazy loading when restore operation gets triggered at the startup. That leads to so many go routines being spun up.

(cherry picked from commit 5ad40d8479163697049612f28ba40429652b765a)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8041)
<!-- Reviewable:end -->
