### PR TITLE
fix(lambda): make lambda active only after successful start (#8036)

### DIFF
--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -44,7 +44,7 @@ const (
 	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
 	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; `
-	LambdaDefaults  = `url=; num=1; port=20000; restart-after=10s; `
+	LambdaDefaults  = `url=; num=1; port=20000; restart-after=30s; `
 	LimitDefaults   = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;` +
 		`max-pending-queries=64;  max-retries=-1; shared-instance=false;`


### PR DESCRIPTION
There is a logical race condition that causes panic. This happens because the node process did not complete its initialization before being killed. This PR fixes that issue.

This PR also increases the default restart timeout from 10s to 30s to make it more generous.

(cherry picked from commit eaee2db257b623b1d7711b36f43b9beb13aa3029)

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
