### PR TITLE
fix(restore-test): Use separate map directory for each group in offline restore

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -71,6 +71,7 @@ type flagOptions struct {
 	namespace     uint64
 	key           x.Sensitive
 	onlySummary   bool
+	magic         uint16
 
 	// Options related to the WAL.
 	wdir           string
@@ -108,6 +109,7 @@ func init() {
 		"Show a histogram of the key and value sizes.")
 	flag.BoolVar(&opt.onlySummary, "only-summary", false,
 		"If true, only show the summary of the p directory.")
+	flag.Uint16Var(&opt.magic, "magic", 1, "Magic version of the p directory.")
 
 	// Flags related to WAL.
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
@@ -878,6 +880,7 @@ func run() {
 		WithEncryptionKey(opt.key).
 		WithBlockCacheSize(1 << 30).
 		WithIndexCacheSize(1 << 30).
+		WithExternalMagic(opt.magic).
 		WithNamespaceOffset(x.NamespaceOffset) // We don't want to see the banned data.
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -542,10 +542,6 @@ func RunOfflineRestore(dir, location, backupId string, keyFile string,
 		}
 	}
 
-	mapDir, err := ioutil.TempDir(x.WorkerConfig.TmpDir, "restore-map")
-	x.Check(err)
-	defer os.RemoveAll(mapDir)
-
 	for gid := range manifest.Groups {
 		req := &pb.RestoreRequest{
 			Location:          location,
@@ -554,6 +550,12 @@ func RunOfflineRestore(dir, location, backupId string, keyFile string,
 			EncryptionKeyFile: keyFile,
 			RestoreTs:         1,
 		}
+		mapDir, err := ioutil.TempDir(x.WorkerConfig.TmpDir, "restore-map")
+		if err != nil {
+			return LoadResult{Err: errors.Wrapf(err, "Failed to create temp map directory")}
+		}
+		defer os.RemoveAll(mapDir)
+
 		if _, err := RunMapper(req, mapDir); err != nil {
 			return LoadResult{Err: errors.Wrap(err, "RunRestore failed to map")}
 		}

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -305,11 +305,11 @@ func (p *processor) processKV(buf *z.Buffer, in *loadBackupInput, kv *bpb.KV) er
 	toBuffer := func(kv *bpb.KV, version uint64) error {
 		key := y.KeyWithTs(kv.Key, version)
 		sz := kv.Size()
-		buf := buf.SliceAllocate(2 + len(key) + sz)
+		b := buf.SliceAllocate(2 + len(key) + sz)
 
-		binary.BigEndian.PutUint16(buf[0:2], uint16(len(key)))
-		x.AssertTrue(copy(buf[2:], key) == len(key))
-		_, err := kv.MarshalToSizedBuffer(buf[2+len(key):])
+		binary.BigEndian.PutUint16(b[0:2], uint16(len(key)))
+		x.AssertTrue(copy(b[2:], key) == len(key))
+		_, err := kv.MarshalToSizedBuffer(b[2+len(key):])
 		return err
 	}
 	if len(kv.GetUserMeta()) != 1 {


### PR DESCRIPTION
Offline restore was using the same map directory for all the  groups. This causes the same map files to get reduced in multiple groups. 
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8047)
<!-- Reviewable:end -->
