### PR TITLE
fix: fixing audit logs for websocket connections

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -715,7 +715,7 @@ func setupServer(closer *z.Closer) {
 	baseMux.Handle("/ui/keywords", http.HandlerFunc(keywordHandler))
 
 	// Initialize the lambda server
-	setupLambdaServer(x.ServerCloser)
+	//setupLambdaServer(x.ServerCloser)
 	// Initialize the servers.
 	x.ServerCloser.AddRunning(3)
 	go serveGRPC(grpcListener, tlsCfg, x.ServerCloser)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -715,7 +715,7 @@ func setupServer(closer *z.Closer) {
 	baseMux.Handle("/ui/keywords", http.HandlerFunc(keywordHandler))
 
 	// Initialize the lambda server
-	//setupLambdaServer(x.ServerCloser)
+	setupLambdaServer(x.ServerCloser)
 	// Initialize the servers.
 	x.ServerCloser.AddRunning(3)
 	go serveGRPC(grpcListener, tlsCfg, x.ServerCloser)

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -1,4 +1,3 @@
-//go:build !oss
 // +build !oss
 
 /*

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -53,6 +54,7 @@ const (
 	PoorManAuth      = "PoorManAuth"
 	Grpc             = "Grpc"
 	Http             = "Http"
+	WebSocket        = "Websocket"
 )
 
 var auditor = &auditLogger{}

--- a/ee/audit/interceptor.go
+++ b/ee/audit/interceptor.go
@@ -23,6 +23,8 @@ import (
 	"net/http"
 
 	"google.golang.org/grpc"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
 )
 
 func AuditRequestGRPC(ctx context.Context, req interface{},
@@ -34,4 +36,8 @@ func AuditRequestHttp(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r)
 	})
+}
+
+func AuditWebSockets(ctx context.Context, req *schema.Request) {
+	return
 }

--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -145,7 +145,7 @@ func AuditWebSockets(ctx context.Context, req *schema.Request) {
 		ClientHost:  ip,
 		Endpoint:    "/graphql",
 		ReqType:     WebSocket,
-		Req:         req.Query,
+		Req:         truncate(req.Query, maxReqLength),
 		Status:      http.StatusText(http.StatusOK),
 		QueryParams: nil,
 	})

--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -95,7 +95,7 @@ func AuditRequestHttp(next http.Handler) http.Handler {
 			return
 		}
 
-		// Websocket connection in graphQl happens differently. We don't get access tokens and
+		// Websocket connection in graphQl happens differently. We only get access tokens and
 		// metadata in payload later once the connection is upgraded to correct protocol.
 		// Doc: https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md
 		//

--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -1,4 +1,3 @@
-//go:build !oss
 // +build !oss
 
 /*
@@ -96,11 +95,11 @@ func AuditRequestHttp(next http.Handler) http.Handler {
 			return
 		}
 
-		// Websocket connection in graphQl happens differently. We don't get access tokens and other things in
-		// payload later once the connection is upgraded to correct protocol.
-		// Related Doc: https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md
+		// Websocket connection in graphQl happens differently. We don't get access tokens and
+		// metadata in payload later once the connection is upgraded to correct protocol.
+		// Doc: https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md
 		//
-		// Therefore, Auditing for websocket connections will be handled by graphql/admin/http.go:154#Subscribe
+		// Auditing for websocket connections will be handled by graphql/admin/http.go:154#Subscribe
 		for _, subprotocol := range websocket.Subprotocols(r) {
 			if subprotocol == "graphql-ws" {
 				next.ServeHTTP(w, r)

--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -196,7 +196,7 @@ func (gs *graphqlSubscription) Subscribe(
 		Header:        reqHeader,
 	}
 
-	audit.AuditWebSockets(req)
+	audit.AuditWebSockets(ctx, req)
 	namespace := x.ExtractNamespaceHTTP(&http.Request{Header: reqHeader})
 	glog.Infof("namespace: %d. Got GraphQL request over websocket.", namespace)
 	// first load the schema, then do anything else

--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"github.com/dgraph-io/dgraph/ee/audit"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -194,6 +195,8 @@ func (gs *graphqlSubscription) Subscribe(
 		Variables:     variableValues,
 		Header:        reqHeader,
 	}
+
+	audit.AuditWebSockets(req)
 	namespace := x.ExtractNamespaceHTTP(&http.Request{Header: reqHeader})
 	glog.Infof("namespace: %d. Got GraphQL request over websocket.", namespace)
 	// first load the schema, then do anything else

--- a/x/jwt_helper.go
+++ b/x/jwt_helper.go
@@ -73,14 +73,5 @@ func ExtractJWTNamespace(ctx context.Context) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	claims, err := ParseJWT(jwtString)
-	if err != nil {
-		return 0, err
-	}
-
-	namespace, ok := claims["namespace"].(float64)
-	if !ok {
-		return 0, errors.Errorf("namespace in claims is not valid:%v", namespace)
-	}
-	return uint64(namespace), nil
+	return ExtractNamespaceFromJwt(jwtString)
 }

--- a/x/jwt_helper.go
+++ b/x/jwt_helper.go
@@ -56,6 +56,18 @@ func ExtractUserName(jwtToken string) (string, error) {
 	return userId, nil
 }
 
+func ExtractNamespaceFromJwt(jwtToken string) (uint64, error) {
+	claims, err := ParseJWT(jwtToken)
+	if err != nil {
+		return 0, err
+	}
+	namespace, ok := claims["namespace"].(float64)
+	if !ok {
+		return 0, errors.Errorf("namespace in claims is not valid:%v", namespace)
+	}
+	return uint64(namespace), nil
+}
+
 func ExtractJWTNamespace(ctx context.Context) (uint64, error) {
 	jwtString, err := ExtractJwt(ctx)
 	if err != nil {


### PR DESCRIPTION
Audits were made to operate as a middleware for all the requests over the 8080 port of Dgraph alpha. This works great for grpc and http requests but not for graphQL subscriptions over websockets. websocket connections works in different way. They start as normal Http connection and then gets upgraded to the websocket connection. Till the upgrade is over, there is no transfer of metadata and headers across the network. This makes auditing impossible at the middleware layer for websocket connections.

This PR separates out the audit for websockets connection to the http.go#subscriber which will handle the auditing in the right manner.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8048)
<!-- Reviewable:end -->
