### PR TITLE
fix(shutdown): wait for pending queries to process on alpha shutdown

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -985,6 +985,7 @@ func run() {
 	// wait for it after group is closed.
 	updaters.Signal()
 
+	edgraph.Cleanup()
 	worker.BlockingStop()
 	glog.Infoln("worker stopped.")
 

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1355,6 +1355,18 @@ func Init() {
 	maxPendingQueries = x.Config.Limit.GetInt64("max-pending-queries")
 }
 
+func Cleanup() {
+	// Mark the server unhealthy so that no new operations are started and wait for 5 seconds for
+	// the pending queries to finish.
+	x.UpdateHealthStatus(false)
+	for i := 0; i < 10; i++ {
+		if atomic.LoadInt64(&pendingQueries) == 0 {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
 func (s *Server) doQuery(ctx context.Context, req *Request) (resp *api.Response, rerr error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1356,7 +1356,7 @@ func Init() {
 }
 
 func Cleanup() {
-	// Mark the server unhealthy so that no new operations are started and wait for 5 seconds for
+	// Mark the server unhealthy so that no new operations starts and wait for 5 seconds for
 	// the pending queries to finish.
 	x.UpdateHealthStatus(false)
 	for i := 0; i < 10; i++ {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -91,13 +91,21 @@ func Init(ps *badger.DB, cacheSize int64) {
 		},
 	})
 	x.Check(err)
+
+	closer.AddRunning(1)
 	go func() {
+		defer closer.Done()
 		m := lCache.Metrics
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 		for range ticker.C {
-			// Record the posting list cache hit ratio
-			ostats.Record(context.Background(), x.PLCacheHitRatio.M(m.Ratio()))
+			select {
+			case <-closer.HasBeenClosed():
+				return
+			default:
+				// Record the posting list cache hit ratio
+				ostats.Record(context.Background(), x.PLCacheHitRatio.M(m.Ratio()))
+			}
 		}
 	}()
 }


### PR DESCRIPTION
When alpha shuts down, we were earlier not waiting for the pending queries to process. We should wait for some time for those queries to complete processing. This also helps us prevent unpleasant _harmless_ panics caused due to those pending queries as they access the DB in the closed state.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8057)
<!-- Reviewable:end -->
