### PR TITLE
fix(restore): Do not retry restore proposal

### DIFF
--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -176,7 +176,7 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync
 		reqCopy.GroupId = gid
 		wg.Add(1)
 		go func() {
-			errCh <- proposeRestoreOrSend(ctx, req)
+			errCh <- proposeRestoreOrSend(ctx, reqCopy)
 		}()
 	}
 

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/minio/minio-go/v6/pkg/credentials"
@@ -177,7 +176,7 @@ func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync
 		reqCopy.GroupId = gid
 		wg.Add(1)
 		go func() {
-			errCh <- tryRestoreProposal(ctx, reqCopy)
+			errCh <- proposeRestoreOrSend(ctx, req)
 		}()
 	}
 
@@ -206,41 +205,6 @@ func proposeRestoreOrSend(ctx context.Context, req *pb.RestoreRequest) error {
 	c := pb.NewWorkerClient(pl.Get())
 
 	_, err := c.Restore(ctx, req)
-	return err
-}
-
-func retriableRestoreError(err error) bool {
-	switch {
-	case err == conn.ErrNoConnection:
-		// Try to recover from temporary connection issues.
-		return true
-	case strings.Contains(err.Error(), "Raft isn't initialized yet"):
-		// Try to recover if raft has not been initialized.
-		return true
-	case strings.Contains(err.Error(), errRestoreProposal):
-		// Do not try to recover from other errors when sending the proposal.
-		return false
-	default:
-		// Try to recover from other errors (e.g wrong group, waiting for timestamp, etc).
-		return true
-	}
-}
-
-func tryRestoreProposal(ctx context.Context, req *pb.RestoreRequest) error {
-	var err error
-	for i := 0; i < 10; i++ {
-		err = proposeRestoreOrSend(ctx, req)
-		if err == nil {
-			glog.Info("proposeRestoreOrSend done.")
-			return nil
-		}
-		glog.Errorf("Got error while proposeRestoreOrSend: %v, will retry...\n", err)
-		if retriableRestoreError(err) {
-			time.Sleep(time.Second)
-			continue
-		}
-		return err
-	}
 	return err
 }
 


### PR DESCRIPTION
There is an issue caused due to retry of restore proposal, consider the following scenario:
```
1. alpha-2 gets the restore request (leader is alpha-0)
2. alpha-2 sends the request to alpha-0 (leader).
3. alpha-0 called proposeAndWait which proposed the req (index 24) at time=15:56:10
4. alpha-0 was still waiting for the proposal to be applied and rpc call for `Restore` by alpha-2 got "transport closing error" at time=15:59:08
5. transport closing is a retriable error, so alpha-2 again tried to proposeoOrSend, this time leader was alpha-1, so it sent it to alpha-1
6. alpha-1 proposed the restore request (index 28) at time=15:59:09
```
This PR removes the retry logic. If the restore fails, it should be re-triggered manually.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8058)
<!-- Reviewable:end -->
