### PR TITLE
fix(txn): Fix data races in transaction code

### DIFF
--- a/posting/lists.go
+++ b/posting/lists.go
@@ -171,6 +171,14 @@ func (lc *LocalCache) getNoStore(key string) *List {
 	return nil
 }
 
+func (lc *LocalCache) ReadKeys() map[uint64]struct{} {
+	return lc.readKeys
+}
+
+func (lc *LocalCache) Deltas() map[string][]byte {
+	return lc.deltas
+}
+
 // SetIfAbsent adds the list for the specified key to the cache. If a list for the same
 // key already exists, the cache will not be modified and the existing list
 // will be returned instead. This behavior is meant to prevent the goroutines

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -247,16 +247,8 @@ func (txn *Txn) addConflictKey(conflictKey uint64) {
 	}
 }
 
-func (txn *Txn) ReadKeys() map[uint64]struct{} {
-	txn.Lock()
-	defer txn.Unlock()
-	return txn.cache.readKeys
-}
-
-func (txn *Txn) Deltas() map[string][]byte {
-	txn.Lock()
-	defer txn.Unlock()
-	return txn.cache.deltas
+func (txn *Txn) Cache() *LocalCache {
+	return txn.cache
 }
 
 // FillContext updates the given transaction context with data from this transaction.

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -275,9 +275,12 @@ func (o *oracle) DeleteTxnsAndRollupKeys(delta *pb.OracleDelta) {
 	for _, status := range delta.Txns {
 		txn := o.pendingTxns[status.StartTs]
 		if txn != nil && status.CommitTs > 0 {
-			for k := range txn.Deltas() {
+			c := txn.Cache()
+			c.RLock()
+			for k := range c.Deltas() {
 				IncrRollup.addKeyToBatch([]byte(k), 0)
 			}
+			c.RUnlock()
 		}
 		delete(o.pendingTxns, status.StartTs)
 	}


### PR DESCRIPTION
There was a data race in the transaction code. The `ReadKey()` function used to take lock and return a map, now the map is unprotected and any other write on it will cause data race. Same is the case with the `txn.cache.deltas`. This PR makes sure that the locks are properly acquired on them.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8060)
<!-- Reviewable:end -->
