### PR TITLE
fix(build): for standalone image, add zero server's admin REST API endpoint to list of EXPOSEd ports

### DIFF
--- a/contrib/standalone/Dockerfile
+++ b/contrib/standalone/Dockerfile
@@ -2,10 +2,12 @@ ARG DGRAPH_VERSION=latest
 FROM dgraph/dgraph:${DGRAPH_VERSION}
 LABEL MAINTAINER="Dgraph Labs <contact@dgraph.io>"
 
-# REST API port
+# alpha REST API port
 EXPOSE 8080
-# gRPC API port
+# alpha gRPC API port
 EXPOSE 9080
+# zero admin REST API port
+EXPOSE 6080
 
 ADD run.sh /run.sh
 RUN chmod +x /run.sh


### PR DESCRIPTION
The Docker SDK will not allow mapping a port that it not explicitly exposed in the image's Dockerfile (the docker cli does not have the same restrictions, any port can be mapped with the -P command line parameter).  For more background: https://discuss.dgraph.io/t/docker-compose-dgraph-standalone/14635