### PR TITLE
feat(auth): Allow none signing for development environments

### DIFF
--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -323,3 +323,9 @@ func AppendJWKAndVerificationKey(schema []byte) ([]byte, error) {
 	authInfo := `#Dgraph.Authorization{"VerificationKey":"some-key","Header":"X-Test-Auth","jwkurl":"some-url", "Namespace":"https://xyz.io/jwt/claims","Algo":"algo","Audience":["fir-project1-259e7"]}`
 	return append(schema, []byte(authInfo)...), nil
 }
+
+func AppendAuthInfoWithAlgoAndVerificationkey(schema []byte, algo, verificationKey string) ([]byte, error) {
+	authInfo := `# Dgraph.Authorization {"VerificationKey":"%s","Header":"X-Test-Auth","Namespace":"https://xyz.io/jwt/claims","Algo":"%s"}`
+	authInfo = fmt.Sprintf(authInfo, verificationKey, algo)
+	return append(schema, []byte(authInfo)...), nil
+}


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

"TL;DR"
> Enable the "none" signing algorithm in the supported algorithms list in dgraph to allow the usage of unsigned tokens during development.
(https://discuss.dgraph.io/t/accepting-the-none-algorithm-in-dgraph-graphql-auth/15813)

I was developing dgraph locally and using the firebase emulator as an auth provider.
But I had to disable the authentication layer on my local environment because dgraph doesn't support the JWT none signing method.

This method is being used in the firebase emulator to generate unsigned tokens to use during development and is only able to generate these using the emulator and cannot be adjusted to created actual signed tokens.

But I would love to actually test authentication in dgraph locally as well using the emulated firebase authentication flow. So to solve this I am making this pull request to enable the "none" signing algorithm in the supported algorithm list in dgraph auth.

I haven't tested the implementation yet will do that later this week. But feel free to review and let me know if this is worth pursuing or requires a totally different approach.|

Thanks in advance for the review

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8066)
<!-- Reviewable:end -->
