### PR TITLE
opt(schema): Optimize populateSchema() by avoiding repeated lock acquisition

### DIFF
--- a/worker/schema.go
+++ b/worker/schema.go
@@ -90,28 +90,30 @@ func populateSchema(attr string, fields []string) *pb.SchemaNode {
 	}
 	schemaNode.Predicate = attr
 	ctx := context.Background()
+	pred, _ := schema.State().Get(ctx, attr)
+
 	for _, field := range fields {
 		switch field {
 		case "type":
 			schemaNode.Type = typ.Name()
 		case "index":
-			schemaNode.Index = schema.State().IsIndexed(ctx, attr)
+			schemaNode.Index = len(pred.GetTokenizer()) > 0
 		case "tokenizer":
-			if schema.State().IsIndexed(ctx, attr) {
+			if len(pred.GetTokenizer()) > 0 {
 				schemaNode.Tokenizer = schema.State().TokenizerNames(ctx, attr)
 			}
 		case "reverse":
-			schemaNode.Reverse = schema.State().IsReversed(ctx, attr)
+			schemaNode.Reverse = pred.GetDirective() == pb.SchemaUpdate_REVERSE
 		case "count":
-			schemaNode.Count = schema.State().HasCount(ctx, attr)
+			schemaNode.Count = pred.GetCount()
 		case "list":
-			schemaNode.List = schema.State().IsList(attr)
+			schemaNode.List = pred.GetList()
 		case "upsert":
-			schemaNode.Upsert = schema.State().HasUpsert(attr)
+			schemaNode.Upsert = pred.GetUpsert()
 		case "lang":
-			schemaNode.Lang = schema.State().HasLang(attr)
+			schemaNode.Lang = pred.GetLang()
 		case "noconflict":
-			schemaNode.NoConflict = schema.State().HasNoConflict(attr)
+			schemaNode.NoConflict = pred.GetNoConflict()
 		default:
 			//pass
 		}


### PR DESCRIPTION
Optimize populateSchema() by avoiding repeated lock acquisition,
we can get the schema for the predicate once and then check for
the required field.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8068)
<!-- Reviewable:end -->
