### PR TITLE
fix(magic): fix the magic version in bulk loader etc

### DIFF
--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -133,7 +133,8 @@ func (r *reducer) createBadgerInternal(dir string, compression bool) *badger.DB 
 	opt := r.state.opt.Badger.
 		WithDir(dir).WithValueDir(dir).
 		WithSyncWrites(false).
-		WithEncryptionKey(key)
+		WithEncryptionKey(key).
+		WithExternalMagic(x.MagicVersion)
 
 	opt.Compression = bo.None
 	opt.ZSTDCompressionLevel = 0

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -71,7 +71,6 @@ type flagOptions struct {
 	namespace     uint64
 	key           x.Sensitive
 	onlySummary   bool
-	magic         uint16
 
 	// Options related to the WAL.
 	wdir           string
@@ -109,7 +108,6 @@ func init() {
 		"Show a histogram of the key and value sizes.")
 	flag.BoolVar(&opt.onlySummary, "only-summary", false,
 		"If true, only show the summary of the p directory.")
-	flag.Uint16Var(&opt.magic, "magic", 1, "Magic version of the p directory.")
 
 	// Flags related to WAL.
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
@@ -880,7 +878,7 @@ func run() {
 		WithEncryptionKey(opt.key).
 		WithBlockCacheSize(1 << 30).
 		WithIndexCacheSize(1 << 30).
-		WithExternalMagic(opt.magic).
+		WithExternalMagic(x.MagicVersion).
 		WithNamespaceOffset(x.NamespaceOffset) // We don't want to see the banned data.
 
 	x.AssertTruef(len(bopts.Dir) > 0, "No posting or wal dir specified.")

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -60,7 +60,8 @@ func openDgraph(pdir string) (*badger.DB, error) {
 		WithBlockCacheSize(10 * (1 << 20)).
 		WithIndexCacheSize(10 * (1 << 20)).
 		WithEncryptionKey(keys.EncKey).
-		WithNamespaceOffset(x.NamespaceOffset)
+		WithNamespaceOffset(x.NamespaceOffset).
+		WithExternalMagic(x.MagicVersion)
 	return badger.OpenManaged(opt)
 }
 

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -128,7 +128,8 @@ func StoreExport(request *pb.ExportRequest, dir string, key x.Sensitive) error {
 		WithSyncWrites(false).
 		WithValueThreshold(1 << 10).
 		WithNumVersionsToKeep(math.MaxInt32).
-		WithEncryptionKey(key))
+		WithEncryptionKey(key).
+		WithExternalMagic(x.MagicVersion))
 
 	if err != nil {
 		return err

--- a/worker/config.go
+++ b/worker/config.go
@@ -24,9 +24,6 @@ import (
 )
 
 const (
-	// magicVersion is a unique uint16 number. Badger won't start if this magic number doesn't match
-	// with the one present in the manifest. It prevents starting up dgraph with new data format
-	// (eg. the change in 21.09 by using roaring bitmap) on older p directory.
 	magicVersion = 1
 
 	// AllowMutations is the mode allowing all mutations.

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -540,7 +540,8 @@ func RunOfflineRestore(dir, location, backupId string, keyFile string,
 			WithIndexCacheSize(100 * (1 << 20)).
 			WithNumVersionsToKeep(math.MaxInt32).
 			WithEncryptionKey(key).
-			WithNamespaceOffset(x.NamespaceOffset))
+			WithNamespaceOffset(x.NamespaceOffset).
+			WithExternalMagic(x.MagicVersion))
 		if err != nil {
 			return LoadResult{Err: errors.Wrap(err, "RunRestore failed to open DB")}
 		}

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -130,7 +130,7 @@ func (s *ServerState) initStorage() {
 			WithDir(Config.PostingDir).WithValueDir(Config.PostingDir).
 			WithNumVersionsToKeep(math.MaxInt32).
 			WithNamespaceOffset(x.NamespaceOffset).
-			WithExternalMagic(magicVersion)
+			WithExternalMagic(x.MagicVersion)
 		opt = setBadgerOptions(opt)
 
 		// Print the options w/o exposing key.

--- a/x/x.go
+++ b/x/x.go
@@ -141,6 +141,11 @@ const (
 	DgraphCostHeader = "Dgraph-TouchedUids"
 
 	ManifestVersion = 2105
+
+	// MagicVersion is a unique uint16 number. Badger won't start if this magic number doesn't match
+	// with the one present in the manifest. It prevents starting up dgraph with new data format
+	// (eg. the change in 21.09 by using roaring bitmap) on older p directory.
+	MagicVersion = 1
 )
 
 var (


### PR DESCRIPTION
The bulk loader creates the p directory and hence should have the correct external magic version. With the change that introduced the magic version, somehow bulk loader got missed out. 
This PR fixes that.
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8070)
<!-- Reviewable:end -->
