### PR TITLE
fix(Processing Empty Schemas)

### DIFF
--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -762,6 +762,10 @@ func verifyTypes(ctx context.Context, m *pb.Mutations) error {
 
 	// Retrieve the schema for those predicates.
 	schemas, err := GetSchemaOverNetwork(ctx, &pb.SchemaRequest{Predicates: fields})
+	if len(schemas) == 0 {
+		return errors.Errorf("No schemas found. No need to proceed")
+			}
+	}
 	if err != nil {
 		return errors.Wrapf(err, "cannot retrieve predicate information")
 	}


### PR DESCRIPTION
Issue:
I spent several hours wondering why I was getting the following error: 
       "Schema does not contain a matching predicate for field %s in type %s".
Only to realize that the schema was empty.

Fix:
Users should be informed when schemas are empty, and no need to process empty schemas. This helps with debugging

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8086)
<!-- Reviewable:end -->
