### PR TITLE
fix(zero): fix update membership to make bulk tablet proposal instead…

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -380,6 +380,8 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 			})
 		}
 	}
+
+	var tablets []*pb.Tablet
 	for key, dstTablet := range dst.Tablets {
 		group, has := s.state.Groups[dstTablet.GroupId]
 		if !has {
@@ -395,11 +397,12 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 		d := float64(dstTablet.OnDiskBytes)
 		if dstTablet.Remove || (s == 0 && d > 0) || (s > 0 && math.Abs(d/s-1) > 0.1) {
 			dstTablet.Force = false
-			proposal := &pb.ZeroProposal{
-				Tablet: dstTablet,
-			}
-			res = append(res, proposal)
+			tablets = append(tablets, dstTablet)
 		}
+	}
+
+	if len(tablets) > 0 {
+		res = append(res, &pb.ZeroProposal{Tablets: tablets})
 	}
 	return res, nil
 }


### PR DESCRIPTION
… of multiple small

Converting the smaller tablet proposals into a single bulk call makes the execution faster. Else, this update becomes of the order of `O(n^2)`, where `n` is the number of tablet updates.  

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8090)
<!-- Reviewable:end -->
