### PR TITLE
fix(state): fix hex to uint64 response of list of namespaces

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -380,6 +380,8 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 			})
 		}
 	}
+
+	var tablets []*pb.Tablet
 	for key, dstTablet := range dst.Tablets {
 		group, has := s.state.Groups[dstTablet.GroupId]
 		if !has {
@@ -395,11 +397,12 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 		d := float64(dstTablet.OnDiskBytes)
 		if dstTablet.Remove || (s == 0 && d > 0) || (s > 0 && math.Abs(d/s-1) > 0.1) {
 			dstTablet.Force = false
-			proposal := &pb.ZeroProposal{
-				Tablet: dstTablet,
-			}
-			res = append(res, proposal)
+			tablets = append(tablets, dstTablet)
 		}
+	}
+
+	if len(tablets) > 0 {
+		res = append(res, &pb.ZeroProposal{Tablets: tablets})
 	}
 	return res, nil
 }

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -91,10 +91,7 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 		var tablets = make([]*pb.Tablet, 0, len(v.Tablets))
 		for name, v1 := range v.Tablets {
 			tablets = append(tablets, v1)
-			val, err := x.ExtractNamespaceFromPredicate(name)
-			if err == nil {
-				namespaces[val] = struct{}{}
-			}
+			namespaces[x.ParseNamespace(name)] = struct{}{}
 		}
 		state.Groups = append(state.Groups, clusterGroup{
 			Id:         k,

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -46,13 +46,13 @@ func resolveState(ctx context.Context, q schema.Query) *resolve.Resolved {
 	u := jsonpb.Unmarshaler{}
 	var ms pb.MembershipState
 	err = u.Unmarshal(bytes.NewReader(resp.GetJson()), &ms)
-
 	if err != nil {
 		return resolve.EmptyResult(q, err)
 	}
 
-	// map to graphql response structure
-	state := convertToGraphQLResp(ms)
+	ns, _ := x.ExtractNamespace(ctx)
+	// map to graphql response structure. Only guardian of galaxy can list the namespaces.
+	state := convertToGraphQLResp(ms, ns == x.GalaxyNamespace)
 	b, err := json.Marshal(state)
 	if err != nil {
 		return resolve.EmptyResult(q, err)
@@ -76,7 +76,7 @@ func resolveState(ctx context.Context, q schema.Query) *resolve.Resolved {
 // values and not the keys. For pb.MembershipState.Group, the keys are the group IDs
 // and pb.Group didn't contain this ID, so we are creating a custom clusterGroup type,
 // which is same as pb.Group and also contains the ID for the group.
-func convertToGraphQLResp(ms pb.MembershipState) membershipState {
+func convertToGraphQLResp(ms pb.MembershipState, listNs bool) membershipState {
 	var state membershipState
 
 	// namespaces stores set of namespaces
@@ -91,7 +91,9 @@ func convertToGraphQLResp(ms pb.MembershipState) membershipState {
 		var tablets = make([]*pb.Tablet, 0, len(v.Tablets))
 		for name, v1 := range v.Tablets {
 			tablets = append(tablets, v1)
-			namespaces[x.ParseNamespace(name)] = struct{}{}
+			if listNs {
+				namespaces[x.ParseNamespace(name)] = struct{}{}
+			}
 		}
 		state.Groups = append(state.Groups, clusterGroup{
 			Id:         k,

--- a/x/keys.go
+++ b/x/keys.go
@@ -143,19 +143,6 @@ func IsReverseAttr(attr string) bool {
 	return pred[0] == '~'
 }
 
-func ExtractNamespaceFromPredicate(predicate string) (uint64, error) {
-	splitString := strings.Split(predicate, "-")
-	if len(splitString) <= 1 {
-		return 0, errors.Errorf("predicate does not contain namespace name")
-	}
-	uintVal, err := strconv.ParseUint(splitString[0], 0, 64)
-	if err != nil {
-		return 0, errors.Wrapf(err, "while parsing %s as uint64", splitString[0])
-	}
-	return uintVal, nil
-
-}
-
 func writeAttr(buf []byte, attr string) []byte {
 	AssertTrue(len(attr) < math.MaxUint16)
 	binary.BigEndian.PutUint16(buf[:2], uint16(len(attr)))


### PR DESCRIPTION
There is an issue in `ExtractNamespaceFromPredicate`. The issue is the parsing was done assuming `ns` in `<ns>-<attr>` to be decimal (actually it is hexadecimal). This leads to the following issues. 
- A predicate `a-name`, it was skipped.
- A predicate `11-name` was parsed as namespace 11, actually it is namespace 17 (0x11).

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8091)
<!-- Reviewable:end -->
