### PR TITLE
test(acl): Test reverse edge access with dgraph.all.

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1727,7 +1727,7 @@ func TestAllPredsPermission(t *testing.T) {
 			_:a <age> "23" .
 			_:a <nickname> "RG" .
 			_:a <dgraph.type> "TypeName" .
-            _:a <connects> _:b .
+			_:a <connects> _:b .
 			_:b <name> "RandomGuy2" .
 			_:b <age> "25" .
 			_:b <nickname> "RG2" .
@@ -1741,18 +1741,18 @@ func TestAllPredsPermission(t *testing.T) {
 	query := `{q1(func: has(name)){
 		v as name
 		a as age
-    }
-    q2(func: eq(val(v), "RandomGuy")) {
+	}
+	q2(func: eq(val(v), "RandomGuy")) {
 		val(v)
 		val(a)
-        connects {
-          name
-          age
-          ~connects {
-            name
-            age
-          }
-        }
+		connects {
+			name
+			age
+			~connects {
+				name
+				age
+			}
+		}
 	}}`
 
 	// Test that groot has access to all the predicates
@@ -1781,6 +1781,14 @@ func TestAllPredsPermission(t *testing.T) {
 				q2(func: eq(val(n), "RandomGuy")) {
 					val(n)
 					val(a)
+					connects {
+						name
+						age
+						~connects {
+							name
+							age
+						}
+					}
 				}
 			}
 			`,
@@ -1790,7 +1798,7 @@ func TestAllPredsPermission(t *testing.T) {
 			`alice has access to name`,
 			`{"q1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],"q2":[{"val(n)":"RandomGuy"}]}`,
 
-			"alice has access to name, age, connects, and ~connects",
+			"alice has access to all predicates",
 			`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],"q2":[{"val(v)":"RandomGuy","val(a)":23,"connects":[{"name":"RandomGuy2","age":25,"~connects":[{"name":"RandomGuy","age":23}]}]}]}`,
 		},
 	}

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1799,7 +1799,7 @@ func TestAllPredsPermission(t *testing.T) {
 			`{"q1":[{"name":"RandomGuy"},{"name":"RandomGuy2"}],"q2":[{"val(n)":"RandomGuy"}]}`,
 
 			"alice has access to all predicates",
-			`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],"q2":[{"val(v)":"RandomGuy","val(a)":23,"connects":[{"name":"RandomGuy2","age":25,"~connects":[{"name":"RandomGuy","age":23}]}]}]}`,
+			`{"q1":[{"name":"RandomGuy","age":23},{"name":"RandomGuy2","age":25}],"q2":[{"val(n)":"RandomGuy","val(a)":23,"connects":[{"name":"RandomGuy2","age":25,"~connects":[{"name":"RandomGuy","age":23}]}]}]}`,
 		},
 	}
 


### PR DESCRIPTION
Update ACL tests to cover the behavior for `dgraph.all` permissions with reverse edges. When the `dgraph.all` permission is set, it also applies to reverse edges.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8093)
<!-- Reviewable:end -->
