### PR TITLE
fix(graphql): Checkpwd func  and val inside eq func now work in custom dql

### DIFF
--- a/gql/parser.go
+++ b/gql/parser.go
@@ -228,6 +228,9 @@ func (f *Function) IsAggregator() bool {
 
 // IsPasswordVerifier returns true if the function name is "checkpwd".
 func (f *Function) IsPasswordVerifier() bool {
+	if f == nil {
+		return false
+	}
 	return f.Name == "checkpwd"
 }
 

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -204,7 +204,7 @@ func writeUIDFunc(b *strings.Builder, uids []uint64, args []gql.Arg, needVar []g
 // writeRoot writes the root function as well as any ordering and paging
 // specified in q.
 //
-// Only uid(0x123, 0x124), type(...) and eq(Type.Predicate, ...) functions are supported at root.
+// Only uid(0x123, 0x124), type(...), eq(Type.Predicate, ...) and eq(val(var), ...) functions are supported at root.
 // Multiple arguments for `eq` filter will be required in case of resolving `entities` query.
 func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	if q.Func == nil {
@@ -232,7 +232,11 @@ func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 // string since we add Attr in the argument itself.
 func writeFilterArguments(b *strings.Builder, q *gql.Function) {
 	if q.Attr != "" {
-		x.Check2(b.WriteString(q.Attr))
+		if q.IsValueVar {
+			x.Check2(b.WriteString(fmt.Sprintf("val(%s)", q.Attr)))
+		} else {
+			x.Check2(b.WriteString(q.Attr))
+		}
 	}
 
 	for i, arg := range q.Args {

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -204,7 +204,8 @@ func writeUIDFunc(b *strings.Builder, uids []uint64, args []gql.Arg, needVar []g
 // writeRoot writes the root function as well as any ordering and paging
 // specified in q.
 //
-// Only uid(0x123, 0x124), type(...), eq(Type.Predicate, ...) and eq(val(var), ...) functions are supported at root.
+// Only uid(0x123, 0x124), type(...), eq(Type.Predicate, ...) and
+// eq(val(var), ...) functions are supported at root.
 // Multiple arguments for `eq` filter will be required in case of resolving `entities` query.
 func writeRoot(b *strings.Builder, q *gql.GraphQuery) {
 	if q.Func == nil {

--- a/graphql/dgraph/graphquery.go
+++ b/graphql/dgraph/graphquery.go
@@ -69,6 +69,9 @@ func writeQuery(b *strings.Builder, query *gql.GraphQuery, prefix string) {
 
 	if query.IsCount {
 		x.Check2(b.WriteString(fmt.Sprintf("count(%s)", query.Attr)))
+	} else if query.Func.IsPasswordVerifier() {
+		val := schema.MaybeQuoteArg(query.Func.Name, query.Func.Args[0].Value)
+		x.Check2(b.WriteString(fmt.Sprintf("checkpwd(%s,%s", query.Attr, val)))
 	} else if query.Attr != "val" {
 		x.Check2(b.WriteString(query.Attr))
 	} else if isAggregateFn(query.Func) {


### PR DESCRIPTION
The checkpwd func does not work in custom dql queries since #7775 . The query rewriter for custom dql did not handle the checkpwd function. Also it did not allow to use val inside of the eq function.

Example:
```
type Query {
    authenticate(username: String, email: String, password: String!): [User] @custom(dql: """
	query q($username: string, $email: string, $password: string) {
          var(func: type(User)) @filter(eq(User.username, $username) OR eq(User.email, $email)) {
              check as checkpwd(User.password, $password)
          }
              
          authenticate(func: eq(val(check), 1)) {
              id: uid
              username: User.username
              email: User.email
          }
      }
    """
    )
}
```
This query uses checkpwd in the first query, which would be rewritten to 
```
check as User.password)
```
and it uses func: eq(val(check), 1) in the second query, which would result in
```
func: eq(check, "1")
``` 

I added handling for both of these issues.
The issue has also been documented in [discuss](https://discuss.dgraph.io/t/checkpwd-in-custom-dql-supported/16200/7)

Please let me know if I missed something. I would be glad if this could make it into the next release, as it is a minor change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8103)
<!-- Reviewable:end -->
