### PR TITLE
build: Fix Dgraph version string for master branch.

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -23,12 +23,7 @@ BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 
 # Use the next build version on master branch
 # NOTE: this needs to be updated with each new release
-ifeq ($(BUILD_BRANCH),master)
-# Version on master is of the format <next-release-version>-g<commit-id>
-BUILD_VERSION ?= 'v21.07.0-g'$(BUILD)
-else
 BUILD_VERSION ?= $(shell git describe --always --tags)
-endif
 
 GOOS          ?= $(shell go env GOOS)
 # Only build with jemalloc on Linux, mac

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -20,9 +20,6 @@ BUILD          ?= $(shell git rev-parse --short HEAD)
 BUILD_CODENAME  = zion
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
-
-# Use the next build version on master branch
-# NOTE: this needs to be updated with each new release
 BUILD_VERSION ?= $(shell git describe --always --tags)
 
 GOOS          ?= $(shell go env GOOS)


### PR DESCRIPTION
`Dgraph version` should now be based on v21.12.

```
Dgraph version   : v21.12.0
Dgraph codename  : zion-mod
Dgraph SHA-256   : c94def6f0958000c005ec7ec0b06b9c569dcf225615d5316305ccb14a40846c8
Commit SHA-1     : d62ed5f15
Commit timestamp : 2021-12-02 21:20:09 +0530
Branch           : master
Go version       : go1.17.3
jemalloc enabled : true
```

The previous logic is only needed if the tagged version is not reachable from the master branch. For Dgraph v21.12, this isn't needed.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8108)
<!-- Reviewable:end -->
