### PR TITLE
fix(federation): sort hex number ID type correctly

### DIFF
--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -374,7 +374,19 @@ func entitiesQueryCompletion(ctx context.Context, resolved *Resolved) {
 	sort.Slice(uniqueKeyList, func(i, j int) bool {
 		switch val := uniqueKeyList[i].(type) {
 		case string:
-			return val < uniqueKeyList[j].(string)
+			val2 := uniqueKeyList[j].(string)
+			switch keyFieldType {
+			case "ID":
+				// If the type is ID, we actually have a hex number as a string, so we can't sort by string
+				// naively or we end up with the wrong sort example: (0x1, 0x10, 0x2, 0x3, 0x4)
+				if len(val) != len(val2) {
+					return len(val) < len(val2)
+				}
+
+				return val < val2
+			default:
+				return val < val2
+			}
 		case json.Number:
 			switch keyFieldType {
 			case "Int", "Int64":

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -378,7 +378,7 @@ func entitiesQueryCompletion(ctx context.Context, resolved *Resolved) {
 			switch keyFieldType {
 			case "ID":
 				// If the type is ID, we actually have a hex number as a string, so we can't sort by string
-				// naively or we end up with the wrong sort example: (0x1, 0x10, 0x2, 0x3, 0x4)
+				// naively or we end up with the wrong sort. Example: (0x1, 0x10, 0x2, 0x3, 0x4)
 				if len(val) != len(val2) {
 					return len(val) < len(val2)
 				}


### PR DESCRIPTION
Fixes issue: https://github.com/dgraph-io/dgraph/issues/8120

The short of it is that when the key is of type ID, dgraph uses a string to represent a hex value. The results from dgraph used in this function come back sorted by the hex value. The function, however, was sorting the expected key strings as if they were strings. So if you ever hit a boundary such as: 0x1, 0x10, 0x2, 0x3, your results would be out of order and the Apollo gateway would mismatch the data and key.

This was a pretty critical bug in my application as it destroyed any sorting I had done in a different subgraph and also cached data to the wrong ID.

Certainly would like some input as to whether this change is safe. Specifically:
1. Is it safe to check keyFieldType and assume we have a hex string?
2. Is it safe to use `len(string)` or should I use `len([]rune(string))`?
3. Would it be better to parse the ID as a u64 and sort based on that? I thought this might be risky in the case where the u64 max is hit (though this seemed unlikely?)

Additionally, would it be beneficial to write a test which caught this error case?

There are also a few other concerns I have, perhaps founded or unfounded, which I figured I would ask:
1. Is it truly safe to expect there will only ever be a single type passed into representations? https://github.com/dgraph-io/dgraph/blob/master/graphql/schema/wrappers.go#L1781-L1782
2. Is it safe to expect dgraph will always return results sorted by key when used in the function?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgraph/8123)
<!-- Reviewable:end -->
