### PR TITLE
opening up whitelist for local setup with docker-compose 

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
+        env:
+          # prevent OOM
+          GOGC: 20
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.36
           only-new-issues: true
-          args: --timeout=5m
+          args: --timeout=2m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,4 +19,4 @@ jobs:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.36
           only-new-issues: true
-          args: --timeout=2m
+          args: --timeout=5m

--- a/contrib/config/docker/docker-compose-ha.yml
+++ b/contrib/config/docker/docker-compose-ha.yml
@@ -8,6 +8,9 @@
 # Data would be persisted to a docker volume called data-volume on the virtual machines which are
 # part of the swarm.
 # Run `docker stack deploy -c docker-compose-ha.yml` on the Swarm leader to start the cluster.
+# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+#       please change it accordingly for your production setup
+#       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
 version: "3.2"
 networks:
@@ -70,7 +73,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws01
-    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5081,zero3:5082
+    command: dgraph alpha --my=alpha1:7080 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082
   alpha2:
     image: dgraph/dgraph:latest
     hostname: "alpha2"
@@ -86,7 +89,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws02
-    command: dgraph alpha --my=alpha2:7081 --zero=zero1:5080,zero2:5081,zero3:5082 -o 1
+    command: dgraph alpha --my=alpha2:7081 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 1
   alpha3:
     image: dgraph/dgraph:latest
     hostname: "alpha3"
@@ -102,7 +105,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws03
-    command: dgraph alpha --my=alpha3:7082 --zero=zero1:5080,zero2:5081,zero3:5082 -o 2
+    command: dgraph alpha --my=alpha3:7082 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 2
   alpha4:
     image: dgraph/dgraph:latest
     hostname: "alpha4"
@@ -117,7 +120,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws04
-    command: dgraph alpha --my=alpha4:7083 --zero=zero1:5080,zero2:5081,zero3:5082 -o 3
+    command: dgraph alpha --my=alpha4:7083 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 3
   alpha5:
     image: dgraph/dgraph:latest
     hostname: "alpha5"
@@ -132,7 +135,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws05
-    command: dgraph alpha --my=alpha5:7084 --zero=zero1:5080,zero2:5081,zero3:5082 -o 4
+    command: dgraph alpha --my=alpha5:7084 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 4
   alpha6:
     image: dgraph/dgraph:latest
     hostname: "alpha6"
@@ -147,6 +150,6 @@ services:
       placement:
         constraints:
           - node.hostname == aws06
-    command: dgraph alpha --my=alpha6:7085 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
+    command: dgraph alpha --my=alpha6:7085 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose-ha.yml
+++ b/contrib/config/docker/docker-compose-ha.yml
@@ -8,7 +8,7 @@
 # Data would be persisted to a docker volume called data-volume on the virtual machines which are
 # part of the swarm.
 # Run `docker stack deploy -c docker-compose-ha.yml` on the Swarm leader to start the cluster.
-# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+# NOTE: whitelisting is set to private address ranges, this is ONLY for a local setup
 #       please change it accordingly for your production setup
 #       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
@@ -73,7 +73,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws01
-    command: dgraph alpha --my=alpha1:7080 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082
+    command: dgraph alpha --my=alpha1:7080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082
   alpha2:
     image: dgraph/dgraph:latest
     hostname: "alpha2"
@@ -89,7 +89,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws02
-    command: dgraph alpha --my=alpha2:7081 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 1
+    command: dgraph alpha --my=alpha2:7081 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082 -o 1
   alpha3:
     image: dgraph/dgraph:latest
     hostname: "alpha3"
@@ -105,7 +105,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws03
-    command: dgraph alpha --my=alpha3:7082 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 2
+    command: dgraph alpha --my=alpha3:7082 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082 -o 2
   alpha4:
     image: dgraph/dgraph:latest
     hostname: "alpha4"
@@ -120,7 +120,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws04
-    command: dgraph alpha --my=alpha4:7083 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 3
+    command: dgraph alpha --my=alpha4:7083 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082 -o 3
   alpha5:
     image: dgraph/dgraph:latest
     hostname: "alpha5"
@@ -135,7 +135,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws05
-    command: dgraph alpha --my=alpha5:7084 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 4
+    command: dgraph alpha --my=alpha5:7084 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082 -o 4
   alpha6:
     image: dgraph/dgraph:latest
     hostname: "alpha6"
@@ -150,6 +150,6 @@ services:
       placement:
         constraints:
           - node.hostname == aws06
-    command: dgraph alpha --my=alpha6:7085 --security whitelist=0.0.0.0/0 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
+    command: dgraph alpha --my=alpha6:7085 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose-multi.yml
+++ b/contrib/config/docker/docker-compose-multi.yml
@@ -6,6 +6,9 @@
 # Data would be persisted to a Docker volume called data-volume on the virtual machines which are
 # part of the swarm.
 # Run `docker stack deploy -c docker-compose-multi.yml` on the Swarm leader to start the cluster.
+# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+#       please change it accordingly for your production setup
+#       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
 version: "3.2"
 networks:
@@ -39,7 +42,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws01
-    command: dgraph alpha --my=alpha1:7080 --zero=zero:5080
+    command: dgraph alpha --my=alpha1:7080 --security whitelist=0.0.0.0/0 --zero=zero:5080
   alpha2:
     image: dgraph/dgraph:latest
     hostname: "alpha2"
@@ -55,7 +58,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws02
-    command: dgraph alpha --my=alpha2:7081 --zero=zero:5080 -o 1
+    command: dgraph alpha --my=alpha2:7081 --security whitelist=0.0.0.0/0 --zero=zero:5080 -o 1
   alpha3:
     image: dgraph/dgraph:latest
     hostname: "alpha3"
@@ -71,6 +74,6 @@ services:
       placement:
         constraints:
           - node.hostname == aws03
-    command: dgraph alpha --my=alpha3:7082 --zero=zero:5080 -o 2
+    command: dgraph alpha --my=alpha3:7082 --security whitelist=0.0.0.0/0 --zero=zero:5080 -o 2
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose-multi.yml
+++ b/contrib/config/docker/docker-compose-multi.yml
@@ -6,7 +6,7 @@
 # Data would be persisted to a Docker volume called data-volume on the virtual machines which are
 # part of the swarm.
 # Run `docker stack deploy -c docker-compose-multi.yml` on the Swarm leader to start the cluster.
-# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+# NOTE: whitelisting is set to private address ranges, this is ONLY for a local setup
 #       please change it accordingly for your production setup
 #       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
@@ -42,7 +42,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws01
-    command: dgraph alpha --my=alpha1:7080 --security whitelist=0.0.0.0/0 --zero=zero:5080
+    command: dgraph alpha --my=alpha1:7080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero:5080
   alpha2:
     image: dgraph/dgraph:latest
     hostname: "alpha2"
@@ -58,7 +58,7 @@ services:
       placement:
         constraints:
           - node.hostname == aws02
-    command: dgraph alpha --my=alpha2:7081 --security whitelist=0.0.0.0/0 --zero=zero:5080 -o 1
+    command: dgraph alpha --my=alpha2:7081 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero:5080 -o 1
   alpha3:
     image: dgraph/dgraph:latest
     hostname: "alpha3"
@@ -74,6 +74,6 @@ services:
       placement:
         constraints:
           - node.hostname == aws03
-    command: dgraph alpha --my=alpha3:7082 --security whitelist=0.0.0.0/0 --zero=zero:5080 -o 2
+    command: dgraph alpha --my=alpha3:7082 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1 --zero=zero:5080 -o 2
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -4,7 +4,7 @@
 # It mounts /tmp/data on the host machine to /dgraph within the
 # container. You can change /tmp/data to a more appropriate location.
 # Run `docker-compose up` to start Dgraph.
-# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+# NOTE: whitelisting is set to private address ranges, this is ONLY for a local setup
 #       please change it accordingly for your production setup
 #       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
@@ -27,4 +27,4 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=0.0.0.0/0
+    command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1

--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -4,6 +4,9 @@
 # It mounts /tmp/data on the host machine to /dgraph within the
 # container. You can change /tmp/data to a more appropriate location.
 # Run `docker-compose up` to start Dgraph.
+# NOTE: whitelisting is set to 0.0.0.0/0, this is ONLY for a local setup
+#       please change it accordingly for your production setup
+#       more here https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations
 
 version: "3.2"
 services:
@@ -24,4 +27,4 @@ services:
       - 8080:8080
       - 9080:9080
     restart: on-failure
-    command: dgraph alpha --my=alpha:7080 --zero=zero:5080
+    command: dgraph alpha --my=alpha:7080 --zero=zero:5080 --security whitelist=0.0.0.0/0


### PR DESCRIPTION
<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
### Issue & Fix (in PR)
The existing docker-compose files cause the following errors when trying to interact with `dgraphDB`:
```
Sudhishs-MacBook-Pro:Desktop sudhishkr$ curl -X POST localhost:8080/admin/schema --data-binary '@schema.graphql'
{"errors":[{"message":"resolving updateGQLSchema failed because unauthorized ip address: 172.18.0.1 (Locations: [{Line: 3, Column: 4}])","extensions":{"code":"Error"}}]}
```

The issue here is `unauthorized ip address`, caused because of [`whitelist settings`](https://dgraph.io/docs/deploy/dgraph-administration/#whitelisting-admin-operations). The fix is listed in the article [here](https://discuss.dgraph.io/t/update-schema-fails-unauthorized-ip-address/9250/4). The default dgraphDB setting to `127.0.0.1` creates the above problem - and this fix should help ease spinning up the setup locally.

### Why is this needed?
- to Test local execution <b>without</b> `minikube` or `k8s` by directly running on top of `docker-compose`
- this helps local testing

