### PR TITLE
fix(chore): resurrecting git templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @manishrjain @vvbalaji-dgraph
-/posting/ @manishrjain @martinmr
-/ee/acl/ @manishrjain @gitlw
-/wiki/ @danielmai @MichaelJCompton
-/contrib/config/ @danielmai
-/query/ @pawanrawal
-/graphql/ @pawanrawal @MichaelJCompton
+* @akon-dey
+/posting/ @akon-dey
+/ee/acl/ @akon-dey
+/wiki/ @akon-dey
+/contrib/config/ @akon-dey
+/query/ @akon-dey
+/graphql/ @akon-dey

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,4 @@
 /contrib/config/ @akon-dey
 /query/ @akon-dey
 /graphql/ @akon-dey
+

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,1 +1,0 @@
-**GitHub Issues are deprecated. Use [Discuss Issues](https://discuss.dgraph.io/c/issues/dgraph/38) for reporting issues about this repository.**

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report
+
+about: File a bug report.
+
+---
+
+<!-- If you suspect this could be a bug, follow the template. -->
+
+### What version of Dgraph are you using?
+
+### Have you tried reproducing the issue with the latest release?
+
+
+### What is the hardware spec (RAM, CPU, OS)?
+
+
+### Steps to reproduce the issue (command/config used to run Dgraph).
+
+
+### Expected behaviour and actual result.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,7 @@ about: File a bug report.
 
 ### What version of Dgraph are you using?
 
+
 ### Have you tried reproducing the issue with the latest release?
 
 
@@ -19,3 +20,4 @@ about: File a bug report.
 
 
 ### Expected behaviour and actual result.
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,9 @@ about: File a bug report.
 ### What version of Dgraph are you using?
 
 
+### Tell us a little more about your go-environment?
+
+
 ### Have you tried reproducing the issue with the latest release?
 
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -5,7 +5,7 @@ about: Suggest improvements, additions, or revisions to Dgraph documentation.
 
 ---
 
+<!-- If you think Dgraph's documentation at https://dgraph.io/docs/ is lacking, please explain it here. -->
+
 ## Documentation
 
-<!-- If you think Dgraph's documentation at https://dgraph.io/docs/ is lacking, please -->
-<!-- explain it here. -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: Documentation
+
+about: Suggest improvements, additions, or revisions to Dgraph documentation.
+
+---
+
+## Documentation
+
+<!-- If you think Dgraph's documentation at https://dgraph.io/docs/ is lacking, please -->
+<!-- explain it here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+
+about: Suggest a new feature
+
+---
+
+## Experience Report
+
+Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions.
+
+### What you wanted to do
+
+### What you actually did
+
+### Why that wasn't it great, with examples
+
+### Any external references to support your case

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,18 +1,24 @@
 ---
-name: Feature request
+name: Feature Request
 
 about: Suggest a new feature
 
 ---
 
-## Experience Report
+<!-- If you think we can make Dgraph better, describe your feature request here. -->
 
+## Experience Report
 Note: Feature requests are judged based on user experience and modeled on [Go Experience Reports](https://github.com/golang/go/wiki/ExperienceReports). These reports should focus on the problems: they should not focus on and need not propose solutions.
+
 
 ### What you wanted to do
 
+
 ### What you actually did
+
 
 ### Why that wasn't it great, with examples
 
+
 ### Any external references to support your case
+

--- a/.github/ISSUE_TEMPLATE/issue_question.md
+++ b/.github/ISSUE_TEMPLATE/issue_question.md
@@ -1,0 +1,13 @@
+---
+name: 'Issue: Question'
+
+about: The issue tracker is not for questions. Please ask questions on https://discuss.dgraph.io
+or our Slack Channel.
+
+---
+
+The issue tracker is not for questions.
+
+- If you have a question, please ask it on https://discuss.dgraph.io
+- Our Docs: https://dgraph.io/docs/
+- Slack Channel: https://slack.dgraph.io/

--- a/.github/ISSUE_TEMPLATE/issue_question.md
+++ b/.github/ISSUE_TEMPLATE/issue_question.md
@@ -1,5 +1,5 @@
 ---
-name: 'Issue: Question'
+name: Issue/Question
 
 about: The issue tracker is not for questions. Please ask questions on https://discuss.dgraph.io
 or our Slack Channel.

--- a/.github/ISSUE_TEMPLATE/issue_question.md
+++ b/.github/ISSUE_TEMPLATE/issue_question.md
@@ -1,5 +1,5 @@
 ---
-name: Issue/Question
+name: Issue / Question
 
 about: The issue tracker is not for questions. Please ask questions on https://discuss.dgraph.io
 or our Slack Channel.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,28 @@
 <!--
-Your title must be in the following format: topic(Area): Feature
-Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test
+Change Github PR Title 
+
+Your title must be in the following format: 
+- `topic(Area): Feature`
+- `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`
 
 Sample Titles:
-feat(Enterprise): Backups can now get credentials from IAM
-fix(Query): Skipping floats that cannot be Marshalled in JSON
-perf: [Breaking] json encoding is now 35% faster if SIMD is present
-chore: all chores/tests will be excluded from the CHANGELOG
+- `feat(Enterprise)`: Backups can now get credentials from IAM
+- `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
+- `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
+- `chore`: all chores/tests will be excluded from the CHANGELOG
+-->
 
+## Problem 
+<!--
 Please add a description with these things:
-1. A good description explaining the problem and what you changed.
+1. Explain the problem.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
-4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
+4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
+-->
+
+## Solution 
+<!--
+Please add a description with these things:
+1. Explain the solution to make it easier to review the PR.
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,4 +25,5 @@ Please add a description with these things:
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
+2. Make it easier for the reviewer by describing complex sections with comments.
 -->


### PR DESCRIPTION
resurrecting the `git` tracking for `bugs` / `features` / `documentation` issues & templating `PR` description.