### PR TITLE
Fix(rollups): Fix splits in roll-up (#7609)

### DIFF
--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/ristretto/z"
@@ -971,6 +970,53 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 	require.Equal(t, 0, len(ol.plist.Splits))
 
 	return ol, commits
+}
+
+func TestLargePlistSplit(t *testing.T) {
+	key := x.DataKey(uuid.New().String(), 1331)
+	ol, err := getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	b := make([]byte, 30<<20)
+	rand.Read(b)
+	for i := 1; i <= 2; i++ {
+		edge := &pb.DirectedEdge{
+			ValueId: uint64(i),
+			Facets:  []*api.Facet{{Key: strconv.Itoa(i)}},
+			Value:   b,
+		}
+		txn := Txn{StartTs: uint64(i)}
+		addMutationHelper(t, ol, edge, Set, &txn)
+		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+	}
+	_, err = ol.Rollup(nil)
+	require.NoError(t, err)
+
+	ol, err = getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	b = make([]byte, 10<<20)
+	rand.Read(b)
+	for i := 0; i < 63; i++ {
+		edge := &pb.DirectedEdge{
+			Entity:  uint64(1 << uint32(i)),
+			ValueId: uint64(i),
+			Facets:  []*api.Facet{{Key: strconv.Itoa(i)}},
+			Value:   b,
+		}
+		txn := Txn{StartTs: uint64(i)}
+		addMutationHelper(t, ol, edge, Set, &txn)
+		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+	}
+
+	kvs, err := ol.Rollup(nil)
+	require.NoError(t, err)
+	require.NoError(t, writePostingListToDisk(kvs))
+	ol, err = getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	require.Nil(t, ol.plist.Bitmap)
+	require.Equal(t, 0, len(ol.plist.Postings))
+	t.Logf("Num splits: %d\n", len(ol.plist.Splits))
+	require.True(t, len(ol.plist.Splits) > 0)
+	verifySplits(t, ol.plist.Splits)
 }
 
 func TestDeleteStarMultiPartList(t *testing.T) {


### PR DESCRIPTION
Fix roll-up split generation by fixing the range of UIDs
to keep in the first and second part of the split.

<!--
Your title must be in the following format: topic(Area): Feature
Topic must be one of build|ci|docs|feat|fix|perf|refactor|chore|test

Sample Titles:
feat(Enterprise): Backups can now get credentials from IAM
fix(Query): Skipping floats that cannot be Marshalled in JSON
perf: [Breaking] json encoding is now 35% faster if SIMD is present
chore: all chores/tests will be excluded from the CHANGELOG

Please add a description with these things:
1. A good description explaining the problem and what you changed.
2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
4. If this is a breaking change, please put "[Breaking]" in the title. In the description, please put a note with exactly who these changes are breaking for.
-->
