### PR TITLE
fix(bug): use copy of loop variable in Go routines

### DIFF
--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1204,6 +1204,7 @@ func TestQueryRemoveUnauthorizedPred(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc // capture range variable
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)
@@ -1889,6 +1890,7 @@ func TestNewACLPredicates(t *testing.T) {
 	}
 
 	for _, tc := range queryTests {
+		tc := tc // capture range variable
 		t.Run(tc.description, func(t *testing.T) {
 			t.Parallel()
 			resp, err := userClient.NewTxn().Query(ctx, tc.input)

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -358,6 +358,7 @@ func (g *groupi) applyState(myId uint64, state *pb.MembershipState) {
 		for _, member := range g.state.GetRemoved() {
 			// TODO: This leader check can be done once instead of repeatedly.
 			if member.GetGroupId() == g.Node.gid && g.Node.AmLeader() {
+				member := member // capture range variable
 				go func() {
 					// Don't try to remove a member if it's already marked as removed in
 					// the membership state and is not a current peer of the node.


### PR DESCRIPTION
This fixes cases where loop variables are incorrectly captured in
asynchronous code (parallel tests or Go routines). In the case of a
parallel test, the most likely scenario is that only the last test
case will be executed. In the case of Go routines that directly
access loop variables without any synchronization, the value stored in
the loop variable will likely not be the same as what it was when the
Go routine is created.
