### PR TITLE
fix(docs): Update readme to point to 21.03 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Dgraph supports [GraphQL query syntax](https://dgraph.io/docs/master/query-langu
 
 ## Status
 
-Dgraph is [at version v20.11.0][rel] and is production-ready. Apart from the vast open source community, it is being used in
+Dgraph is [at version v21.03.0][rel] and is production-ready. Apart from the vast open source community, it is being used in
 production at multiple Fortune 500 companies, and by
 [Intuit Katlas](https://github.com/intuit/katlas) and [VMware Purser](https://github.com/vmware/purser).
 
-[rel]: https://github.com/dgraph-io/dgraph/releases/tag/v20.11.0
+[rel]: https://github.com/dgraph-io/dgraph/releases/tag/v21.03.0
 
 ## Quick Install
 


### PR DESCRIPTION
Dgraph is production ready at version 21.03.0.  This PR updates this information in the README.
