### PR TITLE
fix(test): adding lint ignore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ run:
 
 linters-settings:
   lll:
-    line-length: 100
+    line-length: 120
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,16 @@
 run:
   tests: false
+  skip-dirs:
+    - contrib
+    - compose
+    - graphql/bench
+    - graphql/e2e
+    - graphql/test
+    - graphql/testdata
+    - systest
+    - t
+  skip-files:
+    - ".*test.go$"
 
 linters-settings:
   lll:
@@ -13,7 +24,7 @@ linters:
     - gas
     - gofmt
     - golint
-    - gosimple
+    #- gosimple
     - govet
     - lll
     - varcheck


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
- `lint` runs on certain test-folders 
- `lint` doesn't exclude certain test-files
- `lint` `gosimple` is a good to have vs. a necessity

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
- introduce skip-dirs (for folder skipping)
- introduce skip-files (for file skipping)
- comment out `gosimple` 
- introduce line limits for `lll` to `120`

#### Results 

`lint` error count reduces by 210+ with this change

- ##### before
  ```
   > golangci-lint run | wc -l
  WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
       507
  ```
- ##### after
  ```
   > golangci-lint run | wc -l
  WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
       291
  ```
