### PR TITLE
fix(test): lint lll fix

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -60,7 +60,8 @@ const (
 
 	"""
 	The DateTime scalar type represents date and time as a string in RFC3339 format.
-	For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+	For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of 
+				 April 12th, 1985 in UTC.
 	"""
 	scalar DateTime
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -464,7 +464,17 @@ func (arw *AddRewriter) Rewrite(
 
 	for _, i := range val {
 		obj := i.(map[string]interface{})
-		fragment, upsertVar, errs := rewriteObject(ctx, mutatedType, nil, "", varGen, obj, xidMetadata, idExistence, mutationType)
+		fragment, upsertVar, errs := rewriteObject(
+			ctx,
+			mutatedType,
+			nil,
+			"",
+			varGen,
+			obj,
+			xidMetadata,
+			idExistence,
+			mutationType,
+		)
 		if len(errs) > 0 {
 			var gqlErrors x.GqlErrorList
 			for _, err := range errs {
@@ -626,7 +636,17 @@ func (urw *UpdateRewriter) Rewrite(
 
 	if setArg != nil {
 		if len(objSet) != 0 {
-			fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, objSet, xidMetadata, idExistence, UpdateWithSet)
+			fragment, _, errs := rewriteObject(
+				ctx,
+				mutatedType,
+				nil,
+				srcUID,
+				varGen,
+				objSet,
+				xidMetadata,
+				idExistence,
+				UpdateWithSet,
+			)
 			if len(errs) > 0 {
 				var gqlErrors x.GqlErrorList
 				for _, err := range errs {
@@ -644,7 +664,17 @@ func (urw *UpdateRewriter) Rewrite(
 	if delArg != nil {
 		if len(objDel) != 0 {
 			// Set additional deletes to false
-			fragment, _, errs := rewriteObject(ctx, mutatedType, nil, srcUID, varGen, objDel, xidMetadata, idExistence, UpdateWithRemove)
+			fragment, _, errs := rewriteObject(
+				ctx,
+				mutatedType,
+				nil,
+				srcUID,
+				varGen,
+				objDel,
+				xidMetadata,
+				idExistence,
+				UpdateWithRemove,
+			)
 			if len(errs) > 0 {
 				var gqlErrors x.GqlErrorList
 				for _, err := range errs {

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1428,10 +1428,12 @@ func rewriteObject(
 							// tries to add duplicate data to the field with @id.
 							var err error
 							if queryAuthSelector(typ) == nil {
-								err = x.GqlErrorf("id %s already exists for field %s inside type %s", xidString, xid.Name(), typ.Name())
+								err = x.GqlErrorf("id %s already exists "+
+									"for field %s inside type %s", xidString, xid.Name(), typ.Name())
 							} else {
 								// This error will only be reported in debug mode.
-								err = x.GqlErrorf("GraphQL debug: id %s already exists for field %s inside type %s", xidString, xid.Name(), typ.Name())
+								err = x.GqlErrorf("GraphQL debug: id %s already exists for "+
+									"field %s inside type %s", xidString, xid.Name(), typ.Name())
 							}
 							retErrors = append(retErrors, err)
 							return nil, upsertVar, retErrors

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1974,7 +1974,8 @@ func rewritePolygon(val map[string]interface{}) []interface{} {
 // For MultiPolygon type, the mutation json is as follows:
 //	{
 //		"type": "MultiPolygon",
-//		"coordinates": [[[[22.22,11.11],[16.16,15.15],[21.21,20.2]],[[22.28,11.18],[16.18,15.18],[21.28,20.28]]],[[[92.22,91.11],[16.16,15.15],[21.21,20.2]],[[22.28,11.18],[16.18,15.18],[21.28,20.28]]]]
+//		"coordinates": [[[[22.22,11.11],[16.16,15.15],[21.21,20.2]],[[22.28,11.18],[16.18,15.18],[21.28,20.28]]],
+//	 	[[[92.22,91.11],[16.16,15.15],[21.21,20.2]],[[22.28,11.18],[16.18,15.18],[21.28,20.28]]]]
 //	}
 func rewriteMultiPolygon(val map[string]interface{}) []interface{} {
 	// type casting this is safe, because of strict GraphQL schema

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -1613,7 +1613,15 @@ func rewriteObject(
 		switch val := val.(type) {
 		case map[string]interface{}:
 			if fieldDef.Type().IsUnion() {
-				fieldMutationFragment, _, err := rewriteUnionField(ctx, fieldDef, myUID, varGen, val, xidMetadata, idExistence, mutationType)
+				fieldMutationFragment, _, err := rewriteUnionField(
+					ctx,
+					fieldDef,
+					myUID,
+					varGen,
+					val,
+					xidMetadata,
+					idExistence,
+					mutationType)
 				if fieldMutationFragment != nil {
 					newObj[fieldName] = fieldMutationFragment.fragment
 					updateFromChildren(frag, fieldMutationFragment)
@@ -1626,7 +1634,16 @@ func rewriteObject(
 						"coordinates": rewriteGeoObject(val, fieldDef.Type()),
 					}
 			} else {
-				fieldMutationFragment, _, err := rewriteObject(ctx, fieldDef.Type(), fieldDef, myUID, varGen, val, xidMetadata, idExistence, mutationType)
+				fieldMutationFragment, _, err := rewriteObject(
+					ctx,
+					fieldDef.Type(),
+					fieldDef,
+					myUID,
+					varGen,
+					val,
+					xidMetadata,
+					idExistence,
+					mutationType)
 				if fieldMutationFragment != nil {
 					newObj[fieldName] = fieldMutationFragment.fragment
 					updateFromChildren(frag, fieldMutationFragment)
@@ -1641,7 +1658,15 @@ func rewriteObject(
 				switch object := object.(type) {
 				case map[string]interface{}:
 					if fieldDef.Type().IsUnion() {
-						fieldMutationFragment, _, err = rewriteUnionField(ctx, fieldDef, myUID, varGen, object, xidMetadata, idExistence, mutationType)
+						fieldMutationFragment, _, err = rewriteUnionField(
+							ctx,
+							fieldDef,
+							myUID,
+							varGen,
+							object,
+							xidMetadata,
+							idExistence,
+							mutationType)
 					} else if fieldDef.Type().IsGeo() {
 						fieldMutationFragment = newFragment(
 							map[string]interface{}{
@@ -1650,7 +1675,16 @@ func rewriteObject(
 							},
 						)
 					} else {
-						fieldMutationFragment, _, err = rewriteObject(ctx, fieldDef.Type(), fieldDef, myUID, varGen, object, xidMetadata, idExistence, mutationType)
+						fieldMutationFragment, _, err = rewriteObject(
+							ctx,
+							fieldDef.Type(),
+							fieldDef,
+							myUID,
+							varGen,
+							object,
+							xidMetadata,
+							idExistence,
+							mutationType)
 					}
 					if fieldMutationFragment != nil {
 						mutationFragments = append(mutationFragments, fieldMutationFragment.fragment)

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -627,7 +627,8 @@ func addCommonRules(
 		return []*gql.GraphQuery{dgQuery}, rbac
 	}
 
-	if authRw != nil && (authRw.isWritingAuth || authRw.filterByUid) && (authRw.varName != "" || authRw.parentVarName != "") {
+	if authRw != nil && (authRw.isWritingAuth || authRw.filterByUid) &&
+		(authRw.varName != "" || authRw.parentVarName != "") {
 		// When rewriting auth rules, they always start like
 		// Todo2 as var(func: uid(Todo1)) @cascade {
 		// Where Todo1 is the variable generated from the filter of the field
@@ -1211,7 +1212,9 @@ func buildAggregateFields(
 				}
 				aggregateChild := &gql.GraphQuery{
 					Alias: aggregateField.DgraphAlias() + "_" + f.DgraphAlias(),
-					Attr:  strings.ToLower(function) + "(val(" + "" + f.DgraphAlias() + "_" + constructedForField + "Var))",
+					Attr: strings.ToLower(
+						function,
+					) + "(val(" + "" + f.DgraphAlias() + "_" + constructedForField + "Var))",
 				}
 				// This adds the following DQL query
 				// PostAggregateResult.nameMin_Author.postsAggregate : min(val(Author.postsAggregate_nameVar))

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -1285,7 +1285,8 @@ func buildAggregateFields(
 }
 
 // Generate Unique Dgraph Alias for the field based on number of time it has been
-// seen till now in the given query at current level. If it is seen first time then simply returns the field's DgraphAlias,
+// seen till now in the given query at current level.
+// If it is seen first time then simply returns the field's DgraphAlias,
 // and if  it is seen let's say 3rd time  then return "fieldAlias.3" where "fieldAlias"
 // is the  DgraphAlias of the field.
 func generateUniqueDgraphAlias(f schema.Field, fieldSeenCount map[string]int) string {
@@ -1768,16 +1769,21 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 						gql.Arg{Value: fmt.Sprintf("%v", near["distance"])})
 				case "within":
 					// For Geo type we have `within` filter which is written as follows:
-					// { within: { polygon: { coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}] } } }
+					// { within: { polygon: { coordinates: [ { points: [
+					// { latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} ,
+					// { latitude: 20.20, longitude: 21.21} ]}] } } }
 					within := val.(map[string]interface{})
 					polygon := within["polygon"].(map[string]interface{})
 					var buf bytes.Buffer
 					buildPolygon(polygon, &buf)
 					args = append(args, gql.Arg{Value: buf.String()})
 				case "contains":
-					// For Geo type we have `contains` filter which is either point or polygon and is written as follows:
+					// For Geo type we have `contains` filter which is either point or polygon and is written
+					// as follows:
 					// For point: { contains: { point: { latitude: 11.11, longitude: 22.22 }}}
-					// For polygon: { contains: { polygon: { coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}] } } }
+					// For polygon: { contains: { polygon: { coordinates: [ { points: [
+					// { latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} ,
+					// { latitude: 20.20, longitude: 21.21} ]}] } } }
 					contains := val.(map[string]interface{})
 					var buf bytes.Buffer
 					if polygon, ok := contains["polygon"].(map[string]interface{}); ok {
@@ -1793,9 +1799,14 @@ func buildFilter(typ schema.Type, filter map[string]interface{}) *gql.FilterTree
 					// and "point" are given, we only use polygon. If none of them are given,
 					// an incorrect DQL query will be formed and will error out from Dgraph.
 				case "intersects":
-					// For Geo type we have `intersects` filter which is either multi-polygon or polygon and is written as follows:
-					// For polygon: { intersect: { polygon: { coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}] } } }
-					// For multi-polygon : { intersect: { multiPolygon: { polygons: [{ coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}] }] } } }
+					// For Geo type we have `intersects` filter which is either multi-polygon or polygon and is written
+					// as follows:
+					// For polygon: { intersect: { polygon: { coordinates: [ { points: [
+					// { latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} ,
+					// { latitude: 20.20, longitude: 21.21} ]}] } } }
+					// For multi-polygon : { intersect: { multiPolygon: { polygons: [{ coordinates: [ { points: [
+					// { latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} ,
+					// { latitude: 20.20, longitude: 21.21} ]}] }] } } }
 					intersects := val.(map[string]interface{})
 					var buf bytes.Buffer
 					if polygon, ok := intersects["polygon"].(map[string]interface{}); ok {

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -926,7 +926,12 @@ func applyFieldValidations(typ *ast.Definition, field *ast.FieldDefinition) gqle
 // query/mutation/update for all the types mentioned in the schema.
 // In case of Apollo service Query, input types from queries and mutations
 // are excluded due to the limited support currently.
-func completeSchema(sch *ast.Schema, definitions []string, providesFieldsMap map[string]map[string]bool, apolloServiceQuery bool) {
+func completeSchema(
+	sch *ast.Schema,
+	definitions []string,
+	providesFieldsMap map[string]map[string]bool,
+	apolloServiceQuery bool,
+) {
 	query := sch.Types["Query"]
 	if query != nil {
 		query.Kind = ast.Object
@@ -1315,7 +1320,12 @@ func addPatchType(schema *ast.Schema, defn *ast.Definition, providesTypeMap map[
 //     ...
 //   }
 // }
-func addFieldFilters(schema *ast.Schema, defn *ast.Definition, providesTypeMap map[string]bool, apolloServiceQuery bool) {
+func addFieldFilters(
+	schema *ast.Schema,
+	defn *ast.Definition,
+	providesTypeMap map[string]bool,
+	apolloServiceQuery bool,
+) {
 	for _, fld := range defn.Fields {
 		// Filtering and ordering for fields with @custom/@lambda directive is handled by the remote
 		// endpoint.
@@ -1985,7 +1995,12 @@ func addGetQuery(schema *ast.Schema, defn *ast.Definition, providesTypeMap map[s
 	}
 }
 
-func addFilterQuery(schema *ast.Schema, defn *ast.Definition, providesTypeMap map[string]bool, generateSubscription bool) {
+func addFilterQuery(
+	schema *ast.Schema,
+	defn *ast.Definition,
+	providesTypeMap map[string]bool,
+	generateSubscription bool,
+) {
 	qry := &ast.FieldDefinition{
 		Name: "query" + defn.Name,
 		Type: &ast.Type{
@@ -2061,7 +2076,12 @@ func addPasswordQuery(schema *ast.Schema, defn *ast.Definition, providesTypeMap 
 	schema.Query.Fields = append(schema.Query.Fields, qry)
 }
 
-func addQueries(schema *ast.Schema, defn *ast.Definition, providesTypeMap map[string]bool, params *GenerateDirectiveParams) {
+func addQueries(
+	schema *ast.Schema,
+	defn *ast.Definition,
+	providesTypeMap map[string]bool,
+	params *GenerateDirectiveParams,
+) {
 	if params.generateGetQuery {
 		addGetQuery(schema, defn, providesTypeMap, params.generateSubscription)
 	}

--- a/graphql/schema/gqlschema.go
+++ b/graphql/schema/gqlschema.go
@@ -115,7 +115,8 @@ scalar Int64
 
 """
 The DateTime scalar type represents date and time as a string in RFC3339 format.
-For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of April 12th, 1985 in UTC.
+For example: "1985-04-12T23:20:50.52Z" represents 20 minutes and 50.52 seconds after the 23rd hour of 
+			 April 12th, 1985 in UTC.
 """
 scalar DateTime
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1951,10 +1951,14 @@ func customDirectiveValidation(sch *ast.Schema,
 			for _, h := range forwardHeaders.Children {
 				key := strings.Split(h.Value.Raw, ":")
 				if len(key) > 2 {
-					return append(errs, gqlerror.ErrorPosf(errPos,
+					return append(errs, gqlerror.ErrorPosf(
+						errPos,
 						"Type %s; Field %s; forwardHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw))
+						typ.Name,
+						field.Name,
+						h.Value.Raw,
+					))
 				}
 				fHeaders[key[0]] = true
 			}
@@ -1965,17 +1969,25 @@ func customDirectiveValidation(sch *ast.Schema,
 			for _, h := range secretHeaders.Children {
 				secretKey := strings.Split(h.Value.Raw, ":")
 				if len(secretKey) > 2 {
-					return append(errs, gqlerror.ErrorPosf(errPos,
+					return append(errs, gqlerror.ErrorPosf(
+						errPos,
 						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw))
+						typ.Name,
+						field.Name,
+						h.Value.Raw,
+					))
 				}
 				if fHeaders != nil {
 					if fHeaders[secretKey[0]] {
-						return append(errs, gqlerror.ErrorPosf(errPos,
+						return append(errs, gqlerror.ErrorPosf(
+							errPos,
 							"Type %s; Field %s; secretHeaders and forwardHeaders in @custom directive cannot have overlapping headers"+
 								", found: `%s`.",
-							typ.Name, field.Name, h.Value.Raw))
+							typ.Name,
+							field.Name,
+							h.Value.Raw,
+						))
 					}
 				}
 			}
@@ -1989,10 +2001,14 @@ func customDirectiveValidation(sch *ast.Schema,
 					key = []string{h.Value.Raw, h.Value.Raw}
 				}
 				if len(key) > 2 {
-					return append(errs, gqlerror.ErrorPosf(errPos,
+					return append(errs, gqlerror.ErrorPosf(
+						errPos,
 						"Type %s; Field %s; introspectionHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
-						typ.Name, field.Name, h.Value.Raw))
+						typ.Name,
+						field.Name,
+						h.Value.Raw,
+					))
 				}
 				iHeaders[key[0]] = key[1]
 			}
@@ -2009,9 +2025,13 @@ func customDirectiveValidation(sch *ast.Schema,
 			// We try and fetch the value from the stored secrets.
 			value, ok := secrets[val]
 			if !ok {
-				return append(errs, gqlerror.ErrorPosf(graphql.Position,
+				return append(errs, gqlerror.ErrorPosf(
+					graphql.Position,
 					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file.",
-					typ.Name, field.Name, val))
+					typ.Name,
+					field.Name,
+					val,
+				))
 			}
 			headers.Add(key, string(value))
 		}
@@ -2078,7 +2098,10 @@ func apolloKeyValidation(sch *ast.Schema, typ *ast.Definition) gqlerror.List {
 	if !(isID(fld) || hasIDDirective(fld)) {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			arg.Position,
-			"Type %s: Field %s: used inside @key directive should be of type ID or have @id directive.", typ.Name, fld.Name)}
+			"Type %s: Field %s: used inside @key directive should be of type ID or have @id directive.",
+			typ.Name,
+			fld.Name,
+		)}
 	}
 
 	remoteDirective := typ.Directives.ForName(remoteDirective)
@@ -2120,7 +2143,10 @@ func apolloRequiresValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", typ.Name, field.Name)}
+			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+			typ.Name,
+			field.Name,
+		)}
 	}
 
 	arg := dir.Arguments.ForName(apolloKeyArg)
@@ -2174,7 +2200,12 @@ func apolloProvidesValidation(sch *ast.Schema,
 		if fldDefn == nil {
 			return []*gqlerror.Error{gqlerror.ErrorPosf(
 				dir.Position,
-				"Type %s; Field %s: @provides field %s doesn't exist for type %s.", typ.Name, field.Name, fld, fldTypeDefn.Name)}
+				"Type %s; Field %s: @provides field %s doesn't exist for type %s.",
+				typ.Name,
+				field.Name,
+				fld,
+				fldTypeDefn.Name,
+			)}
 		}
 	}
 	return nil
@@ -2190,13 +2221,19 @@ func apolloExternalValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.", typ.Name, field.Name)}
+			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+			typ.Name,
+			field.Name,
+		)}
 	}
 
 	if hasCustomOrLambda(field) {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @external directive can not be defined on  fields with @custom or @lambda directive.", typ.Name, field.Name)}
+			"Type %s: Field %s: @external directive can not be defined on  fields with @custom or @lambda directive.",
+			typ.Name,
+			field.Name,
+		)}
 	}
 
 	if !isKeyField(field, typ) {
@@ -2206,7 +2243,11 @@ func apolloExternalValidation(sch *ast.Schema,
 			if dirDefn != nil {
 				return []*gqlerror.Error{gqlerror.ErrorPosf(
 					dirDefn.Position,
-					"Type %s: Field %s: @%s directive can not be defined on @external fields that are not @key.", typ.Name, field.Name, directive)}
+					"Type %s: Field %s: @%s directive can not be defined on @external fields that are not @key.",
+					typ.Name,
+					field.Name,
+					directive,
+				)}
 			}
 		}
 	}
@@ -2223,14 +2264,21 @@ func remoteResponseValidation(sch *ast.Schema,
 	if remoteDirectiveDefn == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @remoteResponse directive can only be defined on fields of @remote type.", typ.Name, field.Name)}
+			"Type %s: Field %s: @remoteResponse directive can only be defined on fields of @remote type.",
+			typ.Name,
+			field.Name,
+		)}
 	}
 
 	arg := dir.Arguments.ForName("name")
 	if arg == nil || arg.Value.Raw == "" {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: Argument %s inside @remoteResponse directive must be defined.", typ.Name, field.Name, "name")}
+			"Type %s: Field %s: Argument %s inside @remoteResponse directive must be defined.",
+			typ.Name,
+			field.Name,
+			"name",
+		)}
 	}
 	return nil
 }
@@ -2282,7 +2330,8 @@ func isReservedKeyWord(name string) bool {
 		"as": true, // this is reserved keyword because DQL uses this for variables
 	}
 
-	if isScalar(name) || isQueryOrMutation(name) || reservedTypeNames[name] || caseInsensitiveKeywords[strings.ToLower(name)] {
+	if isScalar(name) || isQueryOrMutation(name) || reservedTypeNames[name] ||
+		caseInsensitiveKeywords[strings.ToLower(name)] {
 		return true
 	}
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1953,8 +1953,12 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(key) > 2 {
 					return append(errs, gqlerror.ErrorPosf(
 						errPos,
+<<<<<<< HEAD
 						"Type %s; Field %s; forwardHeaders in @custom directive should be of the form "+
 							"'remote_headername:local_headername' or just 'headername'"+
+=======
+						"Type %s; Field %s; forwardHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+>>>>>>> 9efa04ba9 (line length fixes (automatic) using golines)
 							", found: `%s`.",
 						typ.Name,
 						field.Name,
@@ -1972,8 +1976,12 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(secretKey) > 2 {
 					return append(errs, gqlerror.ErrorPosf(
 						errPos,
+<<<<<<< HEAD
 						"Type %s; Field %s; secretHeaders in @custom directive should be of the form "+
 							"'remote_headername:local_headername' or just 'headername'"+
+=======
+						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+>>>>>>> 9efa04ba9 (line length fixes (automatic) using golines)
 							", found: `%s`.",
 						typ.Name,
 						field.Name,
@@ -2030,9 +2038,13 @@ func customDirectiveValidation(sch *ast.Schema,
 			if !ok {
 				return append(errs, gqlerror.ErrorPosf(
 					graphql.Position,
+<<<<<<< HEAD
 					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to "+
 						"store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' "+
 						"at the bottom of your schema file.",
+=======
+					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file.",
+>>>>>>> 9efa04ba9 (line length fixes (automatic) using golines)
 					typ.Name,
 					field.Name,
 					val,
@@ -2148,8 +2160,12 @@ func apolloRequiresValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
+<<<<<<< HEAD
 			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. "+
 				"i.e., the type must have `@extends` or use `extend` keyword.",
+=======
+			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+>>>>>>> 9efa04ba9 (line length fixes (automatic) using golines)
 			typ.Name,
 			field.Name,
 		)}
@@ -2227,8 +2243,12 @@ func apolloExternalValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
+<<<<<<< HEAD
 			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. "+
 				"i.e., the type must have `@extends` or use `extend` keyword.",
+=======
+			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+>>>>>>> 9efa04ba9 (line length fixes (automatic) using golines)
 			typ.Name,
 			field.Name,
 		)}

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -1953,7 +1953,8 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(key) > 2 {
 					return append(errs, gqlerror.ErrorPosf(
 						errPos,
-						"Type %s; Field %s; forwardHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+						"Type %s; Field %s; forwardHeaders in @custom directive should be of the form "+
+							"'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
 						typ.Name,
 						field.Name,
@@ -1971,7 +1972,8 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(secretKey) > 2 {
 					return append(errs, gqlerror.ErrorPosf(
 						errPos,
-						"Type %s; Field %s; secretHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+						"Type %s; Field %s; secretHeaders in @custom directive should be of the form "+
+							"'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
 						typ.Name,
 						field.Name,
@@ -2003,7 +2005,8 @@ func customDirectiveValidation(sch *ast.Schema,
 				if len(key) > 2 {
 					return append(errs, gqlerror.ErrorPosf(
 						errPos,
-						"Type %s; Field %s; introspectionHeaders in @custom directive should be of the form 'remote_headername:local_headername' or just 'headername'"+
+						"Type %s; Field %s; introspectionHeaders in @custom directive should be of the form "+
+							"'remote_headername:local_headername' or just 'headername'"+
 							", found: `%s`.",
 						typ.Name,
 						field.Name,
@@ -2027,7 +2030,9 @@ func customDirectiveValidation(sch *ast.Schema,
 			if !ok {
 				return append(errs, gqlerror.ErrorPosf(
 					graphql.Position,
-					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' at the bottom of your schema file.",
+					"Type %s; Field %s; introspectionHeaders in @custom directive should use secrets to "+
+						"store the header value. To do that specify `%s` in this format '#Dgraph.Secret name value' "+
+						"at the bottom of your schema file.",
 					typ.Name,
 					field.Name,
 					val,
@@ -2143,7 +2148,8 @@ func apolloRequiresValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+			"Type %s: Field %s: @requires directive can only be defined on fields in type extensions. "+
+				"i.e., the type must have `@extends` or use `extend` keyword.",
 			typ.Name,
 			field.Name,
 		)}
@@ -2221,7 +2227,8 @@ func apolloExternalValidation(sch *ast.Schema,
 	if extendsDirective == nil {
 		return []*gqlerror.Error{gqlerror.ErrorPosf(
 			dir.Position,
-			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. i.e., the type must have `@extends` or use `extend` keyword.",
+			"Type %s: Field %s: @external directive can only be defined on fields in type extensions. "+
+				"i.e., the type must have `@extends` or use `extend` keyword.",
 			typ.Name,
 			field.Name,
 		)}

--- a/graphql/schema/validation_rules.go
+++ b/graphql/schema/validation_rules.go
@@ -28,8 +28,8 @@ import (
 )
 
 var allowedFilters = []string{"StringHashFilter", "StringExactFilter", "StringFullTextFilter",
-	"StringRegExpFilter", "StringTermFilter", "DateTimeFilter", "FloatFilter", "Int64Filter", "IntFilter", "PointGeoFilter",
-	"ContainsFilter", "IntersectsFilter", "PolygonGeoFilter"}
+	"StringRegExpFilter", "StringTermFilter", "DateTimeFilter", "FloatFilter", "Int64Filter",
+	"IntFilter", "PointGeoFilter", "ContainsFilter", "IntersectsFilter", "PolygonGeoFilter"}
 
 func listInputCoercion(observers *validator.Events, addError validator.AddErrFunc) {
 	observers.OnValue(func(walker *validator.Walker, value *ast.Value) {

--- a/graphql/schema/validation_rules.go
+++ b/graphql/schema/validation_rules.go
@@ -53,7 +53,12 @@ func listInputCoercion(observers *validator.Events, addError validator.AddErrFun
 		}
 		val := *value
 		child := &ast.ChildValue{Value: &val}
-		valueNew := ast.Value{Children: []*ast.ChildValue{child}, Kind: ast.ListValue, Position: val.Position, Definition: val.Definition}
+		valueNew := ast.Value{
+			Children:   []*ast.ChildValue{child},
+			Kind:       ast.ListValue,
+			Position:   val.Position,
+			Definition: val.Definition,
+		}
 		*value = valueNew
 	})
 }
@@ -65,7 +70,14 @@ func filterCheck(observers *validator.Events, addError validator.AddErrFunc) {
 		}
 
 		if x.HasString(allowedFilters, value.Definition.Name) && len(value.Children) > 1 {
-			addError(validator.Message("%s filter expects only one filter function, got: %d", value.Definition.Name, len(value.Children)), validator.At(value.Position))
+			addError(
+				validator.Message(
+					"%s filter expects only one filter function, got: %d",
+					value.Definition.Name,
+					len(value.Children),
+				),
+				validator.At(value.Position),
+			)
 		}
 	})
 }
@@ -141,7 +153,8 @@ func directiveArgumentsCheck(observers *validator.Events, addError validator.Add
 
 func intRangeCheck(observers *validator.Events, addError validator.AddErrFunc) {
 	observers.OnValue(func(walker *validator.Walker, value *ast.Value) {
-		if value.Definition == nil || value.ExpectedType == nil || value.Kind == ast.Variable || value.Kind == ast.ListValue {
+		if value.Definition == nil || value.ExpectedType == nil || value.Kind == ast.Variable ||
+			value.Kind == ast.ListValue {
 			return
 		}
 

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -2144,7 +2144,10 @@ func (m *mutation) QueryField() Field {
 		// gets executed to fetch the results of that mutation, so propagating it to the QueryField.
 		if len(m.Cascade()) != 0 && len(f.Cascade()) == 0 {
 			field := f.(*field).field
-			field.Directives = append(field.Directives, &ast.Directive{Name: cascadeDirective, Definition: m.op.inSchema.schema.Directives[cascadeDirective]})
+			field.Directives = append(
+				field.Directives,
+				&ast.Directive{Name: cascadeDirective, Definition: m.op.inSchema.schema.Directives[cascadeDirective]},
+			)
 		}
 		return f
 	}
@@ -2699,7 +2702,8 @@ func (t *astType) ImplementingTypes() []Type {
 // satisfy a valid post.
 func (t *astType) EnsureNonNulls(obj map[string]interface{}, exclusion string) error {
 	for _, fld := range t.inSchema.schema.Types[t.Name()].Fields {
-		if fld.Type.NonNull && !isID(fld) && fld.Name != exclusion && t.inSchema.customDirectives[t.Name()][fld.Name] == nil {
+		if fld.Type.NonNull && !isID(fld) && fld.Name != exclusion &&
+			t.inSchema.customDirectives[t.Name()][fld.Name] == nil {
 			if val, ok := obj[fld.Name]; !ok || val == nil {
 				return errors.Errorf(
 					"type %s requires a value for field %s, but no value present",

--- a/query/outputnode_graphql.go
+++ b/query/outputnode_graphql.go
@@ -1258,7 +1258,10 @@ func completePoint(field gqlSchema.Field, coordinate []interface{}, buf *bytes.B
 
 // completePolygon converts the Dgraph result to GraphQL Polygon type.
 // Dgraph output: coordinate: [[[22.22,11.11],[16.16,15.15],[21.21,20.2]],[[22.28,11.18],[16.18,15.18],[21.28,20.28]]]
-// Graphql output: { coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22}, { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}, { points: [{ latitude: 11.18, longitude: 22.28}, { latitude: 15.18, longitude: 16.18} , { latitude: 20.28, longitude: 21.28}]} ] }
+// Graphql output: { coordinates: [ { points: [{ latitude: 11.11, longitude: 22.22},
+// { latitude: 15.15, longitude: 16.16} , { latitude: 20.20, longitude: 21.21} ]}, { points: [
+// { latitude: 11.18, longitude: 22.28}, { latitude: 15.18, longitude: 16.18} ,
+// { latitude: 20.28, longitude: 21.28}]} ] }
 func completePolygon(field gqlSchema.Field, polygon []interface{}, buf *bytes.Buffer) {
 	comma1 := ""
 

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -180,7 +181,14 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 		}
 	}
 
-	glog.Infof("Created backup request: read_ts:%d since_ts:%d unix_ts:\"%s\" destination:\"%s\" . Groups=%v\n", req.ReadTs, req.SinceTs, req.UnixTs, req.Destination, groups)
+	glog.Infof(
+		"Created backup request: read_ts:%d since_ts:%d unix_ts:\"%s\" destination:\"%s\" . Groups=%v\n",
+		req.ReadTs,
+		req.SinceTs,
+		req.UnixTs,
+		req.Destination,
+		groups,
+	)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/worker/zero_proxy.go
+++ b/worker/zero_proxy.go
@@ -39,7 +39,11 @@ func RegisterZeroProxyServer(s *grpc.Server) {
 		Methods: []grpc.MethodDesc{
 			{
 				MethodName: "AssignIds",
-				Handler: func(srv interface{}, ctx context.Context, dec func(interface{}) error, _ grpc.UnaryServerInterceptor) (interface{}, error) {
+				Handler: func(
+					srv interface{},
+					ctx context.Context,
+					dec func(interface{}) error,
+					_ grpc.UnaryServerInterceptor) (interface{}, error) {
 					in := new(pb.Num)
 					if err := dec(in); err != nil {
 						return nil, err

--- a/x/x.go
+++ b/x/x.go
@@ -898,7 +898,12 @@ func DivideAndRule(num int) (numGo, width int) {
 }
 
 // SetupConnection starts a secure gRPC connection to the given host.
-func SetupConnection(host string, tlsCfg *tls.Config, useGz bool, dialOpts ...grpc.DialOption) (*grpc.ClientConn, error) {
+func SetupConnection(
+	host string,
+	tlsCfg *tls.Config,
+	useGz bool,
+	dialOpts ...grpc.DialOption,
+) (*grpc.ClientConn, error) {
 	callOpts := append([]grpc.CallOption{},
 		grpc.MaxCallRecvMsgSize(GrpcMaxSize),
 		grpc.MaxCallSendMsgSize(GrpcMaxSize))


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 `golangci-lint` tests are failing. The `lll` linter which addresses our `line-length` is reporting issues on a few files. 

## Solution
- fix up lll issues using `golines -m 120 -w <GO_FILE>`
- `golangci-lint run | grep lll` <- this will show where the tests are failing

#### Results 

`lint` error count reduces by ~50+ with this change. This only fixes `lll` issues

- ##### before
  ```
   > golangci-lint run | wc -l
  WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
       291
  ```
- ##### after
  ```
   > golangci-lint run | wc -l
  WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive. 
       239
  ```
