### PR TITLE
fix(test): bug fix for test driver skip functionality to use fully qualified package name

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -38,8 +38,9 @@ jobs:
           cp ~/work/dgraph/dgraph/dgraph/dgraph ~/go/bin 
           # build the test binary
           cd t; go build .
-          # run the tests
+          # clean up docker containers before test execution
           ./t -r
+          # run the tests
           ./t --skip algo,chunker,codec,conn,contrib,dgraph,edgraph,ee,filestore,gql,graphql,lex,licenses,ocagent,paper,posting,present,protos,query,raftwal,schema,static,systest,t,task,telemetry,testutil,tlstest,tok,types,upgrade,worker,x,xidmap 
           # clean up docker containers after test execution
           ./t -r

--- a/t/t.go
+++ b/t/t.go
@@ -457,7 +457,7 @@ func composeFileFor(pkg string) string {
 func getPackages() []task {
 	has := func(list []string, in string) bool {
 		for _, l := range list {
-			if len(l) > 0 && strings.Contains(in, l) {
+			if len(l) > 0 && strings.Contains(in, "github.com/dgraph-io/dgraph/"+l) {
 				return true
 			}
 		}

--- a/t/t.go
+++ b/t/t.go
@@ -457,7 +457,7 @@ func composeFileFor(pkg string) string {
 func getPackages() []task {
 	has := func(list []string, in string) bool {
 		for _, l := range list {
-			if len(l) > 0 && strings.Contains(in, "github.com/dgraph-io/dgraph/"+l) {
+			if len(l) > 0 && strings.Contains(in+"/", "github.com/dgraph-io/dgraph/"+l+"/") {
 				return true
 			}
 		}


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
- current problem with `--skip` list is because the comparison is NOT happening on `fully qualified package name` but just the `folder name`
- when we try to `--skip` with a bunch of entries (with `dgraph` folder for tests), the conditional returns `true` and exits the loop as its comparing against `fully qualified package name` when it hits `dgraph` (this is an ordering problem in some sorts). If we move `dgraph` folder to the end of this list, we can bypass this problem.
- this causes the remaining skip list items to get ignored and breaks the `--skip` functionality, there by making it difficult & non-intuitive.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
- the correct fix is to compare with `fully qualified package name` vs. just the `folder name` like before
- with this fix the ordering inside the `--skip` doesn't matter