### PR TITLE
fix(testing): parallelism and binary build

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -63,7 +63,8 @@ var (
 		"Run only custom cluster tests.")
 	count = pflag.IntP("count", "c", 0,
 		"If set, would add -count arg to go test.")
-	concurrency = pflag.IntP("concurrency", "j", 3,
+	// formerly 3
+	concurrency = pflag.IntP("concurrency", "j", 1,
 		"Number of clusters to run concurrently.")
 	keepCluster = pflag.BoolP("keep", "k", false,
 		"Keep the clusters running on program end.")
@@ -71,7 +72,8 @@ var (
 		"Clear all the test clusters.")
 	dry = pflag.BoolP("dry", "", false,
 		"Just show how the packages would be executed, without running tests.")
-	rebuildBinary = pflag.BoolP("rebuild-binary", "", true,
+	// earlier default was true, want to use binary we build manually
+	rebuildBinary = pflag.BoolP("rebuild-binary", "", false,
 		"Build Dgraph before running tests.")
 	useExisting = pflag.String("prefix", "",
 		"Don't bring up a cluster, instead use an existing cluster with this prefix.")


### PR DESCRIPTION
## Problem

Changing some default parameters in t.go for testing purposes.  We have had issues with concurrency flag and build.

## Solution

Change j=3 to j=1 and set rebuild-binary to false.