### PR TITLE
possible fix for t pkg flag

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -100,9 +100,12 @@ func commandWithContext(ctx context.Context, args ...string) *exec.Cmd {
 
 // command takes a list of args and executes them as a program.
 // Example:
-//   docker-compose up -f "./my docker compose.yml"
+//
+//	docker-compose up -f "./my docker compose.yml"
+//
 // would become:
-//   command("docker-compose", "up", "-f", "./my docker compose.yml")
+//
+//	command("docker-compose", "up", "-f", "./my docker compose.yml")
 func command(args ...string) *exec.Cmd {
 	return commandWithContext(ctxb, args...)
 }
@@ -503,7 +506,7 @@ func getPackages() []task {
 
 	var valid []task
 	for _, pkg := range pkgs {
-		if len(*runPkg) > 0 && !strings.HasSuffix(pkg.ID, *runPkg) {
+		if len(*runPkg) > 0 && !strings.HasSuffix(pkg.ID, "/"+*runPkg) {
 			continue
 		}
 


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem

when using the --pkg flag running tests thru t locally, currently it takes any suffix match.
ex. if i set --pkg=auth, it will run tests not only for auth but also for admin_auth
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
Add a "/" before the suffix check to ensure only full pkg name works
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->