### PR TITLE
fix(test): unskip linters, we will open them one by one

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,16 +19,16 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - errcheck
-    - ineffassign
-    - gas
-    - gofmt
-    - golint
+    #- errcheck
+    #- ineffassign
+    #- gas
+    #- gofmt
+    #- golint
     #- gosimple
-    - govet
+    #- govet
     - lll
-    - varcheck
-    - unused
+    #- varcheck
+    #- unused
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
Lint tests are failing

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
Phase1: we are skipping most known lint errors
Phase2: we will be unskipping them one by one

This addresses the Phase1

@joshua-goldstein @dshekhar95 this PR lint run results show only `lll` failures (which is what we want). When we merge https://github.com/dgraph-io/dgraph/pull/8191 - this will pass for `lll`.