### PR TITLE
fix(Security): add dist-upgrade to get security updates in base docker image

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 RUN export DEBIAN_FRONTEND=noninteractive && \
   apt-get update -qq && \
   apt-get install -yq --no-install-recommends apt-utils && \
-  apt-get dist-upgrade -yq && \
+  apt-get upgrade -yq && \
   apt-get install -yq --no-install-recommends \
     ca-certificates \
     curl \

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -7,8 +7,11 @@
 FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
+RUN export DEBIAN_FRONTEND=noninteractive && \
+  apt-get update -qq && \
+  apt-get install -yq --no-install-recommends apt-utils && \
+  apt-get dist-upgrade -yq && \
+  apt-get install -yq --no-install-recommends \
     ca-certificates \
     curl \
     htop \


### PR DESCRIPTION
## Problem

The dgraph/dgraph images have high and critical severity security vulnerabilities inherited from base images.  

## Solution

The solution in this scenario forces a dist-upgrade to upgrade packages on the image.  

There will still be medium and low severity packages, which will require building custom packages, repository to fetch alternative packages, and likely extensive testing to make sure the base image is not tested. This fix does not do that, and instead upgrades existing available packages from Ubuntu upstream that have been fixed.