### PR TITLE
fix(test): adds docker sec checks

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -1,0 +1,30 @@
+name: ci-aqua-security-trivy-tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "*/30 * * * *"
+jobs:
+  build:
+    name: trivy-tests
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Build Docker image
+        run: |
+          make image-local
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'dgraph/dgraph:local'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
docker layers are not tested for sec

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
enabling aqua trivy checks

this is how we build our docker image, and this step references a dockerfile as detailed here https://github.com/dgraph-io/dgraph/blob/skrdgraph/docker_sec_checks/Makefile#L76 ... which points to https://github.com/dgraph-io/dgraph/blob/skrdgraph/docker_sec_checks/contrib/Dockerfile

the GH-action in this PR checks for security CVEs using `trivy` and dumps the output into https://github.com/dgraph-io/dgraph/security/code-scanning (where we can analyze the severity, and make fixes)

This GH Action captures the exact CVEs.