### PR TITLE
chore(lint:gosec): Fix or bypass gosec lint failures

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
   enable:
     #- errcheck
     #- ineffassign
-    #- gas
+    - gas
     #- gofmt
     #- golint
     #- gosimple

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ image:
 	@rm -r linux
 
 image-local:
-	@GOOS=linux $(MAKE) dgraph
+	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:local .

--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -110,13 +110,15 @@ func handleBasicFacetsType(key string, facetVal interface{}) (*api.Facet, error)
 // parseMapFacets parses facets which are of map type. Facets for scalar list predicates are
 // specified in map format. For example below predicate nickname and kind facet associated with it.
 // Here nickname "bob" doesn't have any facet associated with it.
-// {
+//
+//	{
 //		"nickname": ["alice", "bob", "josh"],
 //		"nickname|kind": {
 //			"0": "friends",
 //			"2": "official"
-// 		}
-// }
+//		}
+//	}
+//
 // Parsed response would a slice of maps[int]*api.Facet, one map for each facet.
 // Map key would be the index of scalar value for respective facets.
 func parseMapFacets(m map[string]interface{}, prefix string) ([]map[int]*api.Facet, error) {
@@ -385,6 +387,7 @@ var nextIdx uint64
 var randomID uint32
 
 func init() {
+	//nolint:gosec // random node id generator does not require cryptographic precision
 	randomID = rand.Uint32()
 }
 

--- a/conn/node.go
+++ b/conn/node.go
@@ -137,8 +137,9 @@ func NewNode(rc *pb.RaftContext, store *raftwal.DiskStorage, tlsConfig *tls.Conf
 		},
 		// processConfChange etc are not throttled so some extra delta, so that we don't
 		// block tick when applyCh is full
-		Applied:         y.WaterMark{Name: "Applied watermark"},
-		RaftContext:     rc,
+		Applied:     y.WaterMark{Name: "Applied watermark"},
+		RaftContext: rc,
+		//nolint:gosec // random node id generator does not require cryptographic precision
 		Rand:            rand.New(&lockedSource{src: rand.NewSource(time.Now().UnixNano())}),
 		confChanges:     make(map[uint64]chan error),
 		messages:        make(chan sendmsg, 100),
@@ -205,6 +206,7 @@ func (n *Node) DoneConfChange(id uint64, err error) {
 	ch <- err
 }
 
+//nolint:gosec // random node id generator does not require cryptographic precision
 func (n *Node) storeConfChange(che chan error) uint64 {
 	n.Lock()
 	defer n.Unlock()

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -25,6 +25,8 @@ import (
 	"math"
 	"net"
 	"net/http"
+
+	//nolint:gosec // profiling on alpha server accepted and documented
 	_ "net/http/pprof" // http profiler
 	"net/url"
 	"os"

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -344,7 +344,7 @@ func run() {
 			fmt.Fprintln(os.Stderr, "Error serializing bulk meta file")
 			os.Exit(1)
 		}
-		if err = ioutil.WriteFile(bulkMetaPath, bulkMetaData, 0644); err != nil {
+		if err = ioutil.WriteFile(bulkMetaPath, bulkMetaData, 0600); err != nil {
 			fmt.Fprintln(os.Stderr, "Error writing to bulk meta file")
 			os.Exit(1)
 		}

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -23,6 +23,8 @@ import (
 	"log"
 	"math"
 	"net/http"
+
+	//nolint:gosec // profiling on bulk-loader tool considered noncritical
 	_ "net/http/pprof" // http profiler
 	"os"
 	"path/filepath"

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -26,7 +26,9 @@ import (
 	"log"
 	"math"
 	"net/http"
-	_ "net/http/pprof"
+
+	//nolint:gosec // profiling on debug tool considered noncritical
+	_ "net/http/pprof" // http profiler
 	"os"
 	"sort"
 	"strconv"

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -118,6 +118,7 @@ func handleError(err error, isRetry bool) {
 	case s.Code() == codes.Internal, s.Code() == codes.Unavailable:
 		// Let us not crash live loader due to this. Instead, we should infinitely retry to
 		// reconnect and retry the request.
+		//nolint:gosec // random generator in closed set does not require cryptographic precision
 		dur := time.Duration(1+rand.Intn(60)) * time.Second
 		fmt.Printf("Connection has been possibly interrupted. Got error: %v."+
 			" Will retry after %s.\n", err, dur.Round(time.Second))
@@ -129,6 +130,7 @@ func handleError(err error, isRetry bool) {
 			fmt.Printf("Transaction aborted. Will retry in background.\n")
 		}
 	case strings.Contains(s.Message(), "Server overloaded."):
+		//nolint:gosec // random generator in closed set does not require cryptographic precision
 		dur := time.Duration(1+rand.Intn(10)) * time.Minute
 		fmt.Printf("Server is overloaded. Will retry after %s.\n", dur.Round(time.Minute))
 		time.Sleep(dur)

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -28,6 +28,8 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
+
+	//nolint:gosec // profiling on live-loader tool considered noncritical
 	_ "net/http/pprof" // http profiler
 	"os"
 	"sort"

--- a/dgraph/cmd/zero/assign.go
+++ b/dgraph/cmd/zero/assign.go
@@ -204,6 +204,7 @@ func (s *Server) AssignIds(ctx context.Context, num *pb.Num) (*pb.AssignedIds, e
 
 		if !s.rateLimiter.Allow(ns, int64(num.Val)) {
 			// Return error after random delay.
+			//nolint:gosec // random generator in closed set does not require cryptographic precision
 			delay := rand.Intn(int(opts.limiterConfig.RefillAfter))
 			time.Sleep(time.Duration(delay) * time.Second)
 			return errors.Errorf("Cannot lease UID because UID lease for the namespace %#x is "+

--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -167,6 +167,7 @@ func (o *Oracle) newSubscriber() (<-chan pb.OracleDelta, int) {
 	defer o.Unlock()
 	var id int
 	for {
+		//nolint:gosec // random generator for node id does not require cryptographic precision
 		id = rand.Int()
 		if _, has := o.subscribers[id]; !has {
 			break

--- a/worker/sink_handler.go
+++ b/worker/sink_handler.go
@@ -87,7 +87,9 @@ func newKafkaSink(config *z.SuperFlag) (Sink, error) {
 	saramaConf.Producer.Return.Errors = true
 
 	if config.GetPath("ca-cert") != "" {
-		tlsCfg := &tls.Config{}
+		tlsCfg := &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 		var pool *x509.CertPool
 		var err error
 		if pool, err = x509.SystemCertPool(); err != nil {

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -245,7 +245,7 @@ func (l *LogWriter) open() error {
 		l.writer = bufio.NewWriterSize(l.file, bufferSize)
 
 		if l.EncryptionKey != nil {
-			rand.Read(l.baseIv[:])
+			rand.Read(l.baseIv[:]) //nolint:gosec // cryptographic precision not required for randomly selecting from slice
 			bytes, err := encrypt(l.EncryptionKey, l.baseIv, []byte(VerificationText))
 			if err != nil {
 				return err

--- a/x/names-generator.go
+++ b/x/names-generator.go
@@ -1280,12 +1280,14 @@ var (
 // integer between 0 and 10 will be added to the end of the name, e.g `focused_turing3`
 func GetRandomName(retry int) string {
 begin:
+	//nolint:gosec // cryptographic precision not required for randomly selecting from set
 	name := fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))])
 	if name == "boring_wozniak" /* Steve Wozniak is not boring */ {
 		goto begin
 	}
 
 	if retry > 0 {
+		//nolint:gosec // cryptographic precision not required for randomly selecting from fixed range
 		name = fmt.Sprintf("%s%d", name, rand.Intn(10))
 	}
 	return name

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -126,7 +126,7 @@ func WriteCidFile(cid string) {
 	if cid == "" {
 		return
 	}
-	if err := ioutil.WriteFile(cidPath, []byte(cid), 0644); err != nil {
+	if err := ioutil.WriteFile(cidPath, []byte(cid), 0600); err != nil {
 		glog.Warningf("unable to write CID to file %v %v", cidPath, err)
 		return
 	}

--- a/x/sentry_integration_test.go
+++ b/x/sentry_integration_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-2018 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package x
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCidFileWriteDelete(t *testing.T) {
+	InitSentry(false)
+	ConfigureSentryScope("test")
+
+	errString := "This is a test exception"
+	WriteCidFile(errString)
+	require.Equal(t, errString, readAndRemoveCidFile())
+	require.NoFileExists(t, cidPath)
+}

--- a/x/server.go
+++ b/x/server.go
@@ -63,9 +63,10 @@ func startServers(m cmux.CMux, tlsConf *tls.Config) {
 
 func startListen(l net.Listener) {
 	srv := &http.Server{
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 600 * time.Second,
-		IdleTimeout:  2 * time.Minute,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      600 * time.Second,
+		IdleTimeout:       2 * time.Minute,
+		ReadHeaderTimeout: 60 * time.Second,
 	}
 
 	err := srv.Serve(l)

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -168,6 +168,7 @@ func SlashTLSConfig(endpoint string) (*tls.Config, error) {
 	return &tls.Config{
 		RootCAs:    pool,
 		ServerName: hostWithoutPort,
+		MinVersion: tls.VersionTLS12,
 	}, nil
 }
 
@@ -184,7 +185,9 @@ func LoadClientTLSConfig(v *viper.Viper) (*tls.Config, error) {
 	// server requires a client certificate.
 	caCert := tlsFlag.GetPath("ca-cert")
 	if caCert != "" {
-		tlsCfg := tls.Config{}
+		tlsCfg := tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 
 		// 1. set up the root CA
 		pool, err := generateCertPool(caCert, tlsFlag.GetBool("use-system-ca"))
@@ -312,7 +315,9 @@ func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err e
 // configuration provided.
 func GenerateClientTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err error) {
 	if config.CertRequired {
-		tlsCfg := tls.Config{}
+		tlsCfg := tls.Config{
+			MinVersion: tls.VersionTLS12,
+		}
 		// 1. set up the root CA
 		pool, err := generateCertPool(config.RootCACert, config.UseSystemCACerts)
 		if err != nil {

--- a/x/x.go
+++ b/x/x.go
@@ -954,7 +954,7 @@ func SpanTimer(span *trace.Span, name string) func() {
 	if span == nil {
 		return func() {}
 	}
-	uniq := int64(rand.Int31())
+	uniq := int64(rand.Int31()) //nolint:gosec // unique id for tracing does not require cryptographic precision
 	attrs := []trace.Attribute{
 		trace.Int64Attribute("funcId", uniq),
 		trace.StringAttribute("funcName", name),

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -342,6 +342,7 @@ func (m *XidMap) BumpTo(uid uint64) {
 
 // AllocateUid gives a single uid without creating an xid to uid mapping.
 func (m *XidMap) AllocateUid() uint64 {
+	//nolint:gosec // random index in slice does not require cryptographic precision
 	sh := m.shards[rand.Intn(len(m.shards))]
 	sh.Lock()
 	defer sh.Unlock()


### PR DESCRIPTION
This PR includes all fixes/directives that allow the gosec (gas) linter to pass.

Most of the commits are straightforward. However one in particular might need some more attention, see https://dgraph.atlassian.net/browse/D2209-168 for details.

One other commit (https://github.com/dgraph-io/dgraph/pull/8273/commits/a664c35365ace2669040f52f04337c84b3826753)  is actually a pretty important change that mitigates a DoS vulnerability.