### PR TITLE
fix(rollups): cherry-pick-7609

### DIFF
--- a/posting/list.go
+++ b/posting/list.go
@@ -567,7 +567,7 @@ func (l *List) setMutation(startTs uint64, data []byte) {
 // The function will loop until either the posting List is fully iterated, or you return a false
 // in the provided function, which will indicate to the function to break out of the iteration.
 //
-//		pl.Iterate(..., func(p *pb.posting) error {
+//	pl.Iterate(..., func(p *pb.posting) error {
 //	   // Use posting p
 //	   return nil // to continue iteration.
 //	   return errStopIteration // to break iteration.
@@ -865,7 +865,6 @@ func (l *List) ToBackupPostingList(bl *pb.BackupPostingList, alloc *z.Allocator,
 	// out is only nil when the list's minTs is greater than readTs but readTs
 	// is math.MaxUint64 so that's not possible. Assert that's true.
 	x.AssertTrue(out != nil)
-
 	defer out.free()
 
 	ol := out.plist
@@ -951,7 +950,6 @@ func (out *rollupOutput) free() {
 	for _, part := range out.parts {
 		codec.FreePack(part.Pack)
 	}
-
 }
 
 /*
@@ -1596,14 +1594,9 @@ func (out *rollupOutput) splits() []uint64 {
 	for startUid := range out.parts {
 		splits = append(splits, startUid)
 	}
-	//<<<<<<< HEAD
+
 	sortSplits(splits)
 	return splits
-	// =======
-	//
-	//	out.updateSplits()
-	//
-	// >>>>>>> d9ffc2cfe (Fix(rollups): Fix splits in roll-up (#7609))
 }
 
 // isPlistEmpty returns true if the given plist is empty. Plists with splits are

--- a/posting/list.go
+++ b/posting/list.go
@@ -1553,14 +1553,8 @@ func binSplit(lowUid uint64, plist *pb.PostingList) ([]uint64, []*pb.PostingList
 	return []uint64{lowUid, midUid}, []*pb.PostingList{lowPl, highPl}
 }
 
-// <<<<<<< HEAD
 // removeEmptySplits updates the split list by removing empty posting lists' startUids.
 func (out *rollupOutput) removeEmptySplits() {
-	// =======
-	// finalize updates the split list by removing empty posting lists' startUids. In case there is
-	// only part, then that part is set to main plist.
-	//func (out *rollupOutput) finalize() {
-	//>>>>>>> d9ffc2cfe (Fix(rollups): Fix splits in roll-up (#7609))
 	for startUid, plist := range out.parts {
 		// Do not remove the first split for now, as every multi-part list should always
 		// have a split starting with UID 1.

--- a/posting/list.go
+++ b/posting/list.go
@@ -1588,7 +1588,6 @@ func (out *rollupOutput) splits() []uint64 {
 	for startUid := range out.parts {
 		splits = append(splits, startUid)
 	}
-
 	sortSplits(splits)
 	return splits
 }

--- a/posting/list.go
+++ b/posting/list.go
@@ -567,7 +567,7 @@ func (l *List) setMutation(startTs uint64, data []byte) {
 // The function will loop until either the posting List is fully iterated, or you return a false
 // in the provided function, which will indicate to the function to break out of the iteration.
 //
-//	pl.Iterate(..., func(p *pb.posting) error {
+//		pl.Iterate(..., func(p *pb.posting) error {
 //	   // Use posting p
 //	   return nil // to continue iteration.
 //	   return errStopIteration // to break iteration.

--- a/posting/list.go
+++ b/posting/list.go
@@ -951,70 +951,7 @@ func (out *rollupOutput) free() {
 	for _, part := range out.parts {
 		codec.FreePack(part.Pack)
 	}
-	/*
-	   	<<<<<<< HEAD
 
-	   =======
-
-	   		return false, nil
-	   	}
-
-	   func (ro *rollupOutput) runSplits() error {
-	   top:
-
-	   		for startUid, pl := range ro.parts {
-	   			should, err := ShouldSplit(pl)
-	   			if err != nil {
-	   				return err
-	   			}
-	   			if should {
-	   				if err := ro.split(startUid); err != nil {
-	   					return err
-	   				}
-	   				// Had to split something. Let's run again.
-	   				goto top
-	   			}
-	   		}
-	   		return nil
-	   	}
-
-	   	func (ro *rollupOutput) split(startUid uint64) error {
-	   		pl := ro.parts[startUid]
-
-	   		r := roaring64.New()
-	   		if err := codec.FromPostingList(r, pl); err != nil {
-	   			return errors.Wrapf(err, "split codec.FromPostingList")
-	   		}
-
-	   		num := r.GetCardinality()
-	   		uid, err := r.Select(num / 2)
-	   		if err != nil {
-	   			return errors.Wrapf(err, "split Select rank: %d", num/2)
-	   		}
-
-	   		newpl := &pb.PostingList{}
-	   		ro.parts[uid] = newpl
-
-	   		// Remove everything from startUid to uid.
-	   		nr := r.Clone()
-	   		nr.RemoveRange(0, uid) // Keep all uids >= uid.
-	   		newpl.Bitmap = codec.ToBytes(nr)
-
-	   		// Take everything from the first posting where posting.Uid >= uid.
-	   		idx := sort.Search(len(pl.Postings), func(i int) bool {
-	   			return pl.Postings[i].Uid >= uid
-	   		})
-	   		newpl.Postings = pl.Postings[idx:]
-
-	   		// Update pl as well. Keeps the lower UIDs.
-	   		codec.RemoveRange(r, uid, math.MaxUint64)
-	   		pl.Bitmap = codec.ToBytes(r)
-	   		pl.Postings = pl.Postings[:idx]
-
-	   		return nil
-
-	   >>>>>>> d9ffc2cfe (Fix(rollups): Fix splits in roll-up (#7609))
-	*/
 }
 
 /*

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -973,6 +973,53 @@ func createAndDeleteMultiPartList(t *testing.T, size int) (*List, int) {
 	return ol, commits
 }
 
+func TestLargePlistSplit(t *testing.T) {
+	key := x.DataKey(uuid.New().String(), 1331)
+	ol, err := getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	b := make([]byte, 30<<20)
+	rand.Read(b)
+	for i := 1; i <= 2; i++ {
+		edge := &pb.DirectedEdge{
+			ValueId: uint64(i),
+			Facets:  []*api.Facet{{Key: strconv.Itoa(i)}},
+			Value:   b,
+		}
+		txn := Txn{StartTs: uint64(i)}
+		addMutationHelper(t, ol, edge, Set, &txn)
+		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+	}
+	_, err = ol.Rollup(nil)
+	require.NoError(t, err)
+
+	ol, err = getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	b = make([]byte, 10<<20)
+	rand.Read(b)
+	for i := 0; i < 63; i++ {
+		edge := &pb.DirectedEdge{
+			Entity:  uint64(1 << uint32(i)),
+			ValueId: uint64(i),
+			Facets:  []*api.Facet{{Key: strconv.Itoa(i)}},
+			Value:   b,
+		}
+		txn := Txn{StartTs: uint64(i)}
+		addMutationHelper(t, ol, edge, Set, &txn)
+		require.NoError(t, ol.commitMutation(uint64(i), uint64(i)+1))
+	}
+
+	kvs, err := ol.Rollup(nil)
+	require.NoError(t, err)
+	require.NoError(t, writePostingListToDisk(kvs))
+	ol, err = getNew(key, ps, math.MaxUint64)
+	require.NoError(t, err)
+	//require.Nil(t, ol.plist.Bitmap)
+	require.Equal(t, 0, len(ol.plist.Postings))
+	t.Logf("Num splits: %d\n", len(ol.plist.Splits))
+	require.True(t, len(ol.plist.Splits) > 0)
+	verifySplits(t, ol.plist.Splits)
+}
+
 func TestDeleteStarMultiPartList(t *testing.T) {
 	numEdges := 10000
 


### PR DESCRIPTION
[Cherry-pick-7609](https://github.com/dgraph-io/dgraph/pull/7609)

The old PR fixed an issue that arose after posting/list.go was significantly refactored when roaring bitmaps were incorporated.  The previous team first implemented roaring and then wrote the sroar library to compress the posting lists.  In 21.03 we are not using roaring nor sroar so this code should not be merged.  However a new test was written that we can bring in.