### PR TITLE
fix(test): fix docker layers & test deps for local image

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -29,6 +29,8 @@ jobs:
           go mod tidy
           make regenerate
           git diff --exit-code -- .
+      - name: Make Docker Image
+        run: make image-local
       - name: Make Linux Build
         run: |
           #!/bin/bash

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -7,16 +7,16 @@
 FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    htop \
-    iputils-ping \
-    jq \
-    less \
-    sysstat && \
-  rm -rf /var/lib/apt/lists/*
+RUN apt-get update
+RUN apt-get -y --no-install-recommends ca-certificates
+RUN apt-get -y --no-install-recommends curl
+RUN apt-get -y --no-install-recommends htop
+RUN apt-get -y --no-install-recommends iputils-ping
+RUN apt-get -y --no-install-recommends jq
+RUN apt-get -y --no-install-recommends less
+RUN apt-get -y --no-install-recommends sysstat
+
+# rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 
 ADD linux /usr/local/bin
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,13 +8,13 @@ FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
 RUN apt-get update
-RUN apt-get -y --no-install-recommends ca-certificates
-RUN apt-get -y --no-install-recommends curl
-RUN apt-get -y --no-install-recommends htop
-RUN apt-get -y --no-install-recommends iputils-ping
-RUN apt-get -y --no-install-recommends jq
-RUN apt-get -y --no-install-recommends less
-RUN apt-get -y --no-install-recommends sysstat
+RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends curl
+RUN apt-get install -y --no-install-recommends htop
+RUN apt-get install -y --no-install-recommends iputils-ping
+RUN apt-get install -y --no-install-recommends jq
+RUN apt-get install -y --no-install-recommends less
+RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -4,7 +4,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -21,7 +21,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=disallow;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -38,7 +38,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -55,7 +55,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test
@@ -70,7 +70,7 @@ services:
     command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   zero2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero2
     depends_on:
     - zero1
@@ -87,7 +87,7 @@ services:
     command: /gobin/dgraph zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
   zero3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero3
     depends_on:
     - zero2

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   zero2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero2
     depends_on:
       - zero1
@@ -35,7 +35,7 @@ services:
     command: /gobin/dgraph zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
 
   zero3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero3
     depends_on:
       - zero2
@@ -53,7 +53,7 @@ services:
     command: /gobin/dgraph zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind
@@ -79,7 +79,7 @@ services:
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     depends_on:
       - alpha1
@@ -107,7 +107,7 @@ services:
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     depends_on:
       - alpha2
@@ -135,7 +135,7 @@ services:
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha4:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha4
     depends_on:
       - alpha3
@@ -163,7 +163,7 @@ services:
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha5:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha5
     depends_on:
       - alpha4
@@ -191,7 +191,7 @@ services:
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha6:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha6
     depends_on:
       - alpha5

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -24,7 +24,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     depends_on:
     - alpha1
@@ -47,7 +47,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     depends_on:
     - alpha2
@@ -70,7 +70,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
       - type: bind

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     ulimits:
       nofile:
@@ -23,7 +23,7 @@ services:
       --logtostderr -v=2 --raft "idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     ulimits:
       nofile:
@@ -45,7 +45,7 @@ services:
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     ulimits:
       nofile:
@@ -67,7 +67,7 @@ services:
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     depends_on:
     - alpha1
@@ -37,7 +37,7 @@ services:
       --logtostderr -v=2 --raft="idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     depends_on:
     - alpha2
@@ -55,7 +55,7 @@ services:
       --logtostderr -v=2 --raft="idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: alpha1
     working_dir: /data/alpha1
     ulimits:
@@ -28,7 +28,7 @@ services:
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: zero1
     working_dir: /data/zero1
     ulimits:

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: alpha1
     working_dir: /data/alpha1
     labels:
@@ -17,7 +17,7 @@ services:
     command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
       --trace "jaeger=http://ocagent:14268;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: zero1
     working_dir: /data/zero1
     labels:

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test

--- a/systest/1million/docker-compose.yml
+++ b/systest/1million/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/21million/bulk/alpha.yml
+++ b/systest/21million/bulk/alpha.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test

--- a/systest/21million/bulk/docker-compose.yml
+++ b/systest/21million/bulk/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/21million/live/docker-compose.yml
+++ b/systest/21million/live/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       -v=2 
       --security "whitelist=0.0.0.0/0;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/21million/ludicrous/docker-compose.yml
+++ b/systest/21million/ludicrous/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -20,7 +20,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --ludicrous "enabled=true;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -29,7 +29,7 @@ services:
         limits:
           memory: 32G
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     ports:
       - "8080"
@@ -18,7 +18,7 @@ services:
       --logtostderr --audit "output=/audit_dir;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -27,7 +27,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -53,7 +53,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -79,7 +79,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -27,7 +27,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -51,7 +51,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -75,7 +75,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     env_file:
       - ../../backup.env
@@ -25,7 +25,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     env_file:
       - ../../backup.env
@@ -47,7 +47,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     env_file:
       - ../../backup.env
@@ -76,7 +76,7 @@ services:
     - "9001"
     command: minio server /data/minio --address :9001
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     env_file:
       - ../../backup.env
@@ -25,7 +25,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     env_file:
       - ../../backup.env
@@ -47,7 +47,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     env_file:
       - ../../backup.env
@@ -69,7 +69,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -28,7 +28,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -53,7 +53,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -78,7 +78,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -24,7 +24,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/secret/hmac;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/bulk_live/bulk/alpha.yml
+++ b/systest/bulk_live/bulk/alpha.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test

--- a/systest/bulk_live/bulk/alpha_acl.yml
+++ b/systest/bulk_live/bulk/alpha_acl.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test

--- a/systest/bulk_live/bulk/docker-compose.yml
+++ b/systest/bulk_live/bulk/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       read_only: false
     command: minio server /data/minio --address :9001
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/bulk_live/live/docker-compose.yml
+++ b/systest/bulk_live/live/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -33,7 +33,7 @@ services:
       read_only: false
     command: minio server /data/minio --address :9001
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -20,7 +20,7 @@ services:
       --cdc "file=/cdc;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -25,7 +25,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -47,7 +47,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -76,7 +76,7 @@ services:
     - "9001"
     command: minio server /data/minio --address :9001
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       -v=2 --raft "group=1"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -35,7 +35,7 @@ services:
       -v=2 --raft "group=2"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -51,7 +51,7 @@ services:
       -v=2 --raft "group=3"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: bank-dg0.1
     working_dir: /data/dg0.1
     ports:
@@ -19,7 +19,7 @@ services:
     command: /gobin/dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   dg1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     container_name: bank-dg1
     working_dir: /data/dg1
     volumes:

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/ludicrous/docker-compose.yml
+++ b/systest/ludicrous/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -43,7 +43,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -63,7 +63,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -34,7 +34,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     depends_on:
     - alpha1
@@ -69,7 +69,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     depends_on:
     - alpha2
@@ -104,7 +104,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   alpha4:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha4
     depends_on:
     - alpha3
@@ -139,7 +139,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha4.crt; client-key=/dgraph-tls/client.alpha4.key;"
   alpha5:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha5
     depends_on:
     - alpha4
@@ -174,7 +174,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha5.crt; client-key=/dgraph-tls/client.alpha5.key;"
   alpha6:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha6
     depends_on:
     - alpha5
@@ -209,7 +209,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha6.crt; client-key=/dgraph-tls/client.alpha6.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -24,7 +24,7 @@ services:
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -26,7 +26,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key; client-auth-type=VERIFYIFGIVEN;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUEST; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUIREANDVERIFY; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -23,7 +23,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=VERIFYIFGIVEN; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -21,7 +21,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -41,7 +41,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -61,7 +61,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test
@@ -80,7 +80,7 @@ services:
     command: /gobin/dgraph zero --raft "idx=1;" --replicas 3 --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   zero2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero2
     labels:
       cluster: test

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     command: /gobin/dgraph zero --raft "idx=2;" --replicas 3 --my=zero2:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero2.crt; client-key=/dgraph-tls/client.zero2.key;"
   zero3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero3
     labels:
       cluster: test

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -41,7 +41,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -61,7 +61,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -21,7 +21,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -18,7 +18,7 @@ services:
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -18,7 +18,7 @@ services:
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -3,7 +3,7 @@
 version: "3.5"
 services:
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     labels:
       cluster: test
@@ -19,7 +19,7 @@ services:
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha2
     labels:
       cluster: test
@@ -35,7 +35,7 @@ services:
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha3
     labels:
       cluster: test
@@ -51,7 +51,7 @@ services:
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha4
     labels:
       cluster: test
@@ -67,7 +67,7 @@ services:
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha5
     labels:
       cluster: test
@@ -83,7 +83,7 @@ services:
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha6
     labels:
       cluster: test
@@ -109,7 +109,7 @@ services:
     command: --badger.ephemeral=false --badger.directory-key /working/jaeger --badger.directory-value
       /working/jaeger
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     labels:
       cluster: test
@@ -124,7 +124,7 @@ services:
     command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
       --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
   zero2:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero2
     depends_on:
     - zero1
@@ -141,7 +141,7 @@ services:
     command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
       --my=zero2:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
   zero3:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero3
     depends_on:
     - zero2


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
Current problem is as follows: 
- we are referencing stale docker images for our tests
- the image we are using comes from our repository, which was built 1+yr ago
- this means our test environment is running tests on a stale docker environment
- we should move away from this model for obvious reasons because:
  - we are testing `environment`
  - we also testing our `build` in that `environment` (they are coupled*) - and we should treat them this way!

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
- I am building the fresh local docker image
- I am changing the reference spec for this and we are moving out of `dgraph/dgraph:latest` -> `:local`
- I am also changing the Docker RUN cmd to layer it correctly to speed up the build steps
