### PR TITLE
fix(ci): add cleanup step

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -9,7 +9,16 @@ on:
   schedule:
     - cron: "*/30 * * * *"
 jobs:
+  cleanup:
+    runs-on: self-hosted
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Cleaning up the $GITHUB_WORKSPACE as root from a Docker image
+        # Volume auto mounted by gh actions pointing to the current working-directory
+        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
   dgraph-tests:
+    needs: cleanup
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Problem

Dgraph CI tests were failing overnight during the Github actions/checkout setup.  This looks like a small, common issue.  See [here](https://github.com/actions/checkout/issues/211) and [here](https://github.com/Gamify-IT/issues/issues/60).  

## Solution
 
Add a cleanup job before running the actual tests.