### PR TITLE
feat(testing): automate local testing workflow

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -23,47 +23,5 @@ jobs:
           node-version: 16
       - name: Install protobuf-compiler
         run: sudo apt-get install -y protobuf-compiler
-      - name: Check protobuf
-        run: |
-          cd ./protos
-          go mod tidy
-          make regenerate
-          git diff --exit-code -- .
-      - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
-        run: |
-          #!/bin/bash
-          # go settings
-          export GOOS=linux
-          export GOARCH=amd64
-          # make dgraph binary
-          make dgraph
-      - name: Clean Up Environment
-        run: |
-          #!/bin/bash
-          # clean cache
-          go clean -testcache
-          # build the test binary
-          cd t; go build .
-          # clean up docker containers before test execution
-          ./t -r
-      - name: Run Unit Tests
-        run: |
-          #!/bin/bash
-          # clean cache
-          go clean -testcache
-          # go env settings
-          export GOPATH=~/go
-          # move the binary
-          cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
-          # run the tests
-          ./t --coverage=true --skip systest/backup,systest/online-restore,systest/loader,tlstest
-          # clean up docker containers after test execution
-          ./t -r
-      - name: Install Goveralls
-        run: go install github.com/mattn/goveralls@latest
-      - name: Send Coverage Results
-        run: cd t && goveralls -repotoken ${{ secrets.COVERALLSIO_TOKEN }} -coverprofile=coverage.out
+      - name: Run Dgraph tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,12 @@ BUILD_VERSION  ?= $(shell git describe --always --tags)
 
 MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
-SUBDIRS = dgraph
-
 ###############
 
-.PHONY: $(SUBDIRS) all oss version install install_oss oss_install uninstall test help image
+.PHONY: dgraoh all oss version install install_oss oss_install uninstall test help image
 all: $(SUBDIRS)
 
-$(SUBDIRS):
+dgraoh:
 	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
 
 oss:
@@ -59,8 +57,9 @@ uninstall:
 	done)
 
 test: image-local dgraph
-	@echo Running ./test.sh
-	./test.sh
+	@cp dgraph/dgraph ${GOPATH}/bin
+	@rm dgraph/dgraph
+	@$(MAKE) -C t test
 
 image:
 	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
@@ -86,4 +85,5 @@ help:
 	@echo "  make uninstall - Uninstall known targets"
 	@echo "  make version   - Show current build info"
 	@echo "  make help      - This help"
+	@echo "  make test      - Make local image and run t.go"
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ SUBDIRS = dgraph
 all: $(SUBDIRS)
 
 $(SUBDIRS):
-	$(MAKE) -w -C $@ all
+	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
 
 oss:
-	$(MAKE) BUILD_TAGS=oss
+	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss
 
 version:
 	@echo Dgraph ${BUILD_VERSION}
@@ -46,11 +46,11 @@ version:
 install:
 	@(set -e;for i in $(SUBDIRS); do \
 		echo Installing $$i ...; \
-		$(MAKE) -C $$i install; \
+		GOOS=linux GOARCH=amd64 $(MAKE) -C $$i install; \
 	done)
 
 install_oss oss_install:
-	$(MAKE) BUILD_TAGS=oss install
+	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
 
 uninstall:
 	@(set -e;for i in $(SUBDIRS); do \
@@ -58,18 +58,18 @@ uninstall:
 		$(MAKE) -C $$i uninstall; \
 	done)
 
-test:
+test: image-local dgraph
 	@echo Running ./test.sh
 	./test.sh
 
 image:
-	@GOOS=linux $(MAKE) dgraph
+	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:$(subst /,-,${BUILD_BRANCH}) .
 	@rm -r linux
 
-image-local:
+image-local local-image:
 	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,9 @@ BUILD_DATE     ?= $(shell git log -1 --format=%ci)
 BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILD_VERSION  ?= $(shell git describe --always --tags)
 
-MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
+MODIFIED        = $(shell git diff-index --quiet HEAD || echo "-mod")
+
+GOPATH         ?= $(shell go env GOPATH)
 
 ###############
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ MODIFIED = $(shell git diff-index --quiet HEAD || echo "-mod")
 
 ###############
 
-.PHONY: dgraoh all oss version install install_oss oss_install uninstall test help image
+.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image
 all: $(SUBDIRS)
 
-dgraoh:
+dgraph:
 	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
 
 oss:
@@ -56,7 +56,7 @@ uninstall:
 		$(MAKE) -C $$i uninstall; \
 	done)
 
-test: image-local dgraph
+test: image-local
 	@cp dgraph/dgraph ${GOPATH}/bin
 	@rm dgraph/dgraph
 	@$(MAKE) -C t test
@@ -71,7 +71,7 @@ image:
 image-local local-image:
 	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux
-	@mv ./dgraph/dgraph ./linux/dgraph
+	@cp ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:local .
 	@rm -r linux
 

--- a/t/Makefile
+++ b/t/Makefile
@@ -28,6 +28,6 @@ test:
 #	clean go testcache
 	go clean -testcache
 #	run the tests
-	@./t --pkg=posting
+	@./t --skip systest/backup,systest/online-restore,systest/loader,tlstest
 #	clean up docker containers after test execution
 	./t -r

--- a/t/Makefile
+++ b/t/Makefile
@@ -1,0 +1,45 @@
+#
+# Copyright 2018 Dgraph Labs, Inc. and Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# linux || darwin
+GOOS          ?= $(shell go env GOOS)
+GOPATH        ?= $(shell go env GOPATH)
+
+.PHONY: test
+
+all: test
+
+rosetta:
+#	Install Rosetta if on MacOS
+	@if [ "$(GOOS)" = 'darwin' ]; then \
+		/usr/bin/pgrep -q oahd; \
+		if [ $$? -eq 0 ]; then \
+			echo "Rosetta already installed"; \
+		else \
+			echo "Rosetta is not installed, installing..."; \
+			/usr/sbin/softwareupdate --install-rosetta; \
+		fi \
+	fi
+
+test: rosetta node protobuf
+# 	build the t.go binary
+	@go build .
+#	clean go testcache
+	go clean -testcache
+#	run the tests
+	@./t --skip systest,tlstest
+#	clean up docker containers after test execution
+	./t -r

--- a/t/Makefile
+++ b/t/Makefile
@@ -28,6 +28,6 @@ test:
 #	clean go testcache
 	go clean -testcache
 #	run the tests
-	@./t --skip systest,tlstest
+	@./t --pkg=posting
 #	clean up docker containers after test execution
 	./t -r

--- a/t/Makefile
+++ b/t/Makefile
@@ -22,19 +22,7 @@ GOPATH        ?= $(shell go env GOPATH)
 
 all: test
 
-rosetta:
-#	Install Rosetta if on MacOS
-	@if [ "$(GOOS)" = 'darwin' ]; then \
-		/usr/bin/pgrep -q oahd; \
-		if [ $$? -eq 0 ]; then \
-			echo "Rosetta already installed"; \
-		else \
-			echo "Rosetta is not installed, installing..."; \
-			/usr/sbin/softwareupdate --install-rosetta; \
-		fi \
-	fi
-
-test: rosetta node protobuf
+test: 
 # 	build the t.go binary
 	@go build .
 #	clean go testcache


### PR DESCRIPTION
## Problem

Currently in order to run tests locally we are mirroring the workflow [here](https://github.com/dgraph-io/dgraph/blob/main/.github/workflows/ci-dgraph-tests.yml#L32-L65).  On a local machine this requires running (from root dgraph directory):

```
make image-local
GOOS=linux GOARCH=amd64 make dgraph
cp dgraph/dgraph $GOPATH/bin
cd t; go build t
./t -r
go clean -testcache
./t --coverage=true --skip systest/backup,systest/online-restore,systest/loader,tlstest
./t -r
```

This is tedious to do repeatedly.

## Solution

I modified the root Makefile and added a Makefile in the t directory to automate this workflow.  If you want to change which tests you run, simply modify t/Makefile appropriately.  This workflow was written with an Apple M1 in mind but it should also work on Linux.  To use this workflow now, all you need to do is run `make test`.