### PR TITLE
fix(GraphQL): optimize eq filter queries (#7895)

### DIFF
--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -671,6 +671,17 @@ func rewriteAsQuery(field schema.Field, authRw *authRewriter) []*gql.GraphQuery 
 		return append(dgQuery, selectionAuth...)
 	}
 
+	dgQuery = rootQueryOptimization(dgQuery)
+	return dgQuery
+}
+
+func rootQueryOptimization(dgQuery []*gql.GraphQuery) []*gql.GraphQuery {
+	if dgQuery[0].Filter != nil && dgQuery[0].Filter.Func != nil &&
+		dgQuery[0].Filter.Func.Name == "eq" && dgQuery[0].Func.Name == "type" {
+		rootFunc := dgQuery[0].Func
+		dgQuery[0].Func = dgQuery[0].Filter.Func
+		dgQuery[0].Filter.Func = rootFunc
+	}
 	return dgQuery
 }
 

--- a/graphql/resolve/query_test.yaml
+++ b/graphql/resolve/query_test.yaml
@@ -41,7 +41,7 @@
     }
   dgquery: |-
     query {
-      queryState(func: type(State)) @filter(eq(State.code, "abc", "def", "ghi")) {
+      queryState(func: eq(State.code, "abc", "def", "ghi")) @filter(type(State)) {
         State.code : State.code
         State.name : State.name
         dgraph.uid : uid
@@ -59,7 +59,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.reputation, "10.3", "12.6", "13.6")) {
+      queryAuthor(func: eq(Author.reputation, "10.3", "12.6", "13.6")) @filter(type(Author)) {
         Author.name : Author.name
         Author.dob : Author.dob
         dgraph.uid : uid
@@ -77,7 +77,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.dob, "2001-01-01", "2002-02-01")) {
+      queryAuthor(func: eq(Author.dob, "2001-01-01", "2002-02-01")) @filter(type(Author)) {
         Author.name : Author.name
         Author.reputation : Author.reputation
         dgraph.uid : uid
@@ -94,7 +94,7 @@
     }
   dgquery: |-
     query {
-      queryPost(func: type(Post)) @filter(eq(Post.numLikes, 10, 15, 100)) {
+      queryPost(func: eq(Post.numLikes, 10, 15, 100)) @filter(type(Post)) {
         Post.title : Post.title
         dgraph.uid : uid
       }
@@ -110,7 +110,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.prevStatus, "ACTIVE", "DEACTIVATED")) {
+      queryVerification(func: eq(Verification.prevStatus, "ACTIVE", "DEACTIVATED")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.prevStatus : Verification.prevStatus
         dgraph.uid : uid
@@ -128,7 +128,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.status, "ACTIVE", "DEACTIVATED")) {
+      queryVerification(func: eq(Verification.status, "ACTIVE", "DEACTIVATED")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.status : Verification.status
         dgraph.uid : uid
@@ -145,7 +145,7 @@
     }
   dgquery: |-
     query {
-      queryVerification(func: type(Verification)) @filter(eq(Verification.status, "ACTIVE")) {
+      queryVerification(func: eq(Verification.status, "ACTIVE")) @filter(type(Verification)) {
         Verification.name : Verification.name
         Verification.status : Verification.status
         dgraph.uid : uid
@@ -847,8 +847,8 @@
       }
     }
 
--
-  name: "Filter gets rewritten as @filter"
+
+- name: "eq Filter gets rewritten as root func"
   gqlquery: |
     query {
       queryAuthor(filter: { name: { eq: "A. N. Author" } }) {
@@ -857,7 +857,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -873,7 +873,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1127,7 +1127,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), first: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), first: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1143,7 +1143,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), first: 10, offset: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1159,7 +1159,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderasc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderasc: Author.reputation) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1175,7 +1175,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1192,7 +1192,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation, orderasc: Author.dob) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation, orderasc: Author.dob) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1208,7 +1208,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author), orderdesc: Author.reputation, first: 10, offset: 10) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author"), orderdesc: Author.reputation, first: 10, offset: 10) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -1448,7 +1448,7 @@
     }
   dgquery: |-
     query {
-      queryAuthor(func: type(Author)) @filter(eq(Author.name, "A. N. Author")) {
+      queryAuthor(func: eq(Author.name, "A. N. Author")) @filter(type(Author)) {
         Author.name : Author.name
         dgraph.uid : uid
       }
@@ -3407,7 +3407,7 @@
     }
   dgquery: |-
     query {
-      queryLinkX(func: type(LinkX)) @filter(eq(LinkX.f9, "Alice")) {
+      queryLinkX(func: eq(LinkX.f9, "Alice")) @filter(type(LinkX)) {
         LinkX.f1 : ~link @filter((eq(LinkY.f6, "Eve") AND type(LinkY))) {
           LinkY.f6 : LinkY.f6
           dgraph.uid : uid


### PR DESCRIPTION
Fixes GQLSAAS-1236.
This PR optimizes `eq` filter GraphQL queries.
For ex:
The below DQL query:
```
query {
  queryPerson(filter: {nick: {eq: "Dgraph"}}){
    id
    name
    nick
  }
}
```
will now be written into:
```
query {
  queryPerson(func: eq(Person.nick, "Dgraph")) @filter(type(Person)) {
    Person.id : uid
    Person.name : Person.name
    Person.nick : Person.nick
  }
}
```
which was earlier written into:-
```
query {
  queryPerson(func: type(Person)) @filter(eq(Person.nick, "Dgraph")){
    Person.id : uid
    Person.name : Person.name
    Person.nick : Person.nick
  }
}
```

<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->