### PR TITLE
fix(test) add cleanup at start

### DIFF
--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -9,12 +9,17 @@ on:
   schedule:
     - cron: "*/30 * * * *"
 jobs:
+  #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
+  cleanup:
+    runs-on: self-hosted
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Cleaning up the $GITHUB_WORKSPACE as root from a Docker image
+        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
   dgraph-load-tests:
     runs-on: self-hosted
     steps:
-      #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
-      - name: Cleaning Up $GITHUB_WORKSPACE
-        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -12,6 +12,9 @@ jobs:
   dgraph-load-tests:
     runs-on: self-hosted
     steps:
+      #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
+      - name: Cleaning Up $GITHUB_WORKSPACE
+        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3
@@ -63,6 +66,3 @@ jobs:
           ./t --suite=load
           # clean up docker containers after test execution
           ./t -r
-      - name: Cleaning Up $GITHUB_WORKSPACE
-        # Volume auto mounted by gh actions pointing to the current working-directory
-        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -12,6 +12,9 @@ jobs:
   dgraph-tests:
     runs-on: self-hosted
     steps:
+      #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
+      - name: Cleaning Up $GITHUB_WORKSPACE
+        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -20,8 +20,6 @@ jobs:
   dgraph-tests:
     runs-on: self-hosted
     steps:
-      - name: Cleaning Up $GITHUB_WORKSPACE
-        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -9,10 +9,17 @@ on:
   schedule:
     - cron: "*/30 * * * *"
 jobs:
+  #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
+  cleanup:
+    runs-on: self-hosted
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Cleaning up the $GITHUB_WORKSPACE as root from a Docker image
+        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
   dgraph-tests:
     runs-on: self-hosted
     steps:
-      #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
       - name: Cleaning Up $GITHUB_WORKSPACE
         run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
so the current issue is the cleanup step does not work because crufts left by `load-test` are in sudo user group. The action runner cannot clean those because of user perm issues. This was the original PR https://github.com/dgraph-io/dgraph/pull/8301 which I closed, but in hindsight had the right fix. The fix details are referenced in the solution section.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
this is an elegant way to clean it, because the underlying container runs in sudo-ers group.