### PR TITLE
fix(ci) fixing the file permission issue for CI runner

### DIFF
--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -9,14 +9,6 @@ on:
   schedule:
     - cron: "*/30 * * * *"
 jobs:
-  #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
-  cleanup:
-    runs-on: self-hosted
-    container:
-      image: ubuntu:latest
-    steps:
-      - name: Cleaning up the $GITHUB_WORKSPACE as root from a Docker image
-        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
   dgraph-load-tests:
     runs-on: self-hosted
     steps:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -9,14 +9,6 @@ on:
   schedule:
     - cron: "*/30 * * * *"
 jobs:
-  #TODO: WE NEED TO REMOVE THIS CLEANUP, and handle it more elegantly, it makes us incompatible with gh-hosted-runners
-  cleanup:
-    runs-on: self-hosted
-    container:
-      image: ubuntu:latest
-    steps:
-      - name: Cleaning up the $GITHUB_WORKSPACE as root from a Docker image
-        run: find /__w/${{ github.event.repository.name }}/${{ github.event.repository.name }}/. -name . -o -prune -exec rm -rf -- {} + || true
   dgraph-tests:
     runs-on: self-hosted
     steps:

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -26,7 +26,8 @@ curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/ru
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
+sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work # fixes the test cruft issue
 sudo ./svc.sh install
-sudo ./svc.sh start root
+sudo ./svc.sh start
 # Reboot Machine
 sudo reboot

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -27,6 +27,6 @@ echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
 sudo ./svc.sh install
-sudo ./svc.sh start
+sudo ./svc.sh start root
 # Reboot Machine
 sudo reboot

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -26,7 +26,7 @@ curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/ru
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
-sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work # fixes the test cruft issue
+sudo chown -R $USER:$USER /home/ubuntu/actions-runner/_work # fixes the test cruft cleanup issue
 sudo ./svc.sh install
 sudo ./svc.sh start
 # Reboot Machine


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
The previous fixes were introducing a cleanup step in our CI, which is not ideal & it is not consistent either - because any files created from within the container cannot be cleaned up by other steps because of root user issues. Docker runs as root. 

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
The correct fix is to have the runner run as root, which is the ideal way of dealing with this. There are security concerns here, but I have looked further to ensure we are not impacted. This change is made in this PR. The earlier PRs https://github.com/dgraph-io/dgraph/pull/8307 https://github.com/dgraph-io/dgraph/pull/8301 & issues https://github.com/actions/checkout/issues/211 https://github.com/Gamify-IT/issues/issues/60 talk about the fixes. 