### PR TITLE
fix: add validation of null values with correct order of graphql rule…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
-	github.com/dgraph-io/gqlparser/v2 v2.2.0
-	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed
+	github.com/dgraph-io/gqlparser/v2 v2.2.1
+	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -128,10 +128,10 @@ github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCz
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
 github.com/dgraph-io/gqlgen v0.13.2/go.mod h1:iCOrOv9lngN7KAo+jMgvUPVDlYHdf7qDwsTkQby2Sis=
 github.com/dgraph-io/gqlparser/v2 v2.1.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/gqlparser/v2 v2.2.0 h1:fKSCW8OxoMogjDwUhO9OrFvrgIA0UZspTDbcm0QGk9M=
-github.com/dgraph-io/gqlparser/v2 v2.2.0/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
-github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed h1:pgGMBoTtFhR+xkyzINaToLYRurHn+6pxMYffIGmmEPc=
-github.com/dgraph-io/graphql-transport-ws v0.0.0-20210223074046-e5b8b80bb4ed/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
+github.com/dgraph-io/gqlparser/v2 v2.2.1 h1:15msK9XEHOSrRqQO48UU+2ZTf1R1U8+tfL9H5D5/eQQ=
+github.com/dgraph-io/gqlparser/v2 v2.2.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
+github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15 h1:X2NRsgAtVUAp2nmTPCq+x+wTcRRrj74CEpy7E0Unsl4=
+github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -47,7 +47,11 @@ func init() {
 	validator.AddRule("Check variable type is correct", variableTypeCheck)
 	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
 	validator.AddRule("Check range for Int type", intRangeCheck)
-	validator.AddRule("Input Coercion to List", listInputCoercion)
+	// Graphql accept both single object and array of objects as value when the schema is defined
+	// as an array. listInputCoercion changes the value to array if the single object is provided.
+	// Changing the value can mess up with the other data validation rules hence we are setting
+	// up the order to a high value so that it will be executed last.
+	validator.AddRuleWithOrder("Input Coercion to List", 100, listInputCoercion)
 	validator.AddRule("Check filter functions", filterCheck)
 
 }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -31,6 +31,11 @@ import (
 	"github.com/dgraph-io/gqlparser/v2/validator"
 )
 
+const (
+	baseRules         = 0
+	listCoercionRules = 1000
+)
+
 func init() {
 	schemaDocValidations = append(schemaDocValidations, typeNameValidation,
 		customQueryNameValidation, customMutationNameValidation)
@@ -44,15 +49,15 @@ func init() {
 	fieldValidations = append(fieldValidations, listValidityCheck, fieldArgumentCheck,
 		fieldNameCheck, isValidFieldForList, hasAuthDirective, fieldDirectiveCheck)
 
-	validator.AddRule("Check variable type is correct", variableTypeCheck)
-	validator.AddRule("Check arguments of cascade directive", directiveArgumentsCheck)
-	validator.AddRule("Check range for Int type", intRangeCheck)
+	validator.AddRuleWithOrder("Check variable type is correct", baseRules, variableTypeCheck)
+	validator.AddRuleWithOrder("Check arguments of cascade directive", baseRules, directiveArgumentsCheck)
+	validator.AddRuleWithOrder("Check range for Int type", baseRules, intRangeCheck)
 	// Graphql accept both single object and array of objects as value when the schema is defined
 	// as an array. listInputCoercion changes the value to array if the single object is provided.
 	// Changing the value can mess up with the other data validation rules hence we are setting
 	// up the order to a high value so that it will be executed last.
-	validator.AddRuleWithOrder("Input Coercion to List", int(^uint(0)>>1), listInputCoercion)
-	validator.AddRule("Check filter functions", filterCheck)
+	validator.AddRuleWithOrder("Input Coercion to List", listCoercionRules, listInputCoercion)
+	validator.AddRuleWithOrder("Check filter functions", baseRules, filterCheck)
 
 }
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -31,6 +31,9 @@ import (
 	"github.com/dgraph-io/gqlparser/v2/validator"
 )
 
+const MaxUint = ^uint(0)
+const MaxInt = int(MaxUint >> 1)
+
 func init() {
 	schemaDocValidations = append(schemaDocValidations, typeNameValidation,
 		customQueryNameValidation, customMutationNameValidation)
@@ -51,7 +54,7 @@ func init() {
 	// as an array. listInputCoercion changes the value to array if the single object is provided.
 	// Changing the value can mess up with the other data validation rules hence we are setting
 	// up the order to a high value so that it will be executed last.
-	validator.AddRuleWithOrder("Input Coercion to List", 100, listInputCoercion)
+	validator.AddRuleWithOrder("Input Coercion to List", MaxInt, listInputCoercion)
 	validator.AddRule("Check filter functions", filterCheck)
 
 }
@@ -466,7 +469,8 @@ func nameCheck(schema *ast.Schema, defn *ast.Definition) gqlerror.List {
 }
 
 // This could be removed once the following gqlparser bug is fixed:
-// 	https://github.com/dgraph-io/gqlparser/issues/128
+//
+//	https://github.com/dgraph-io/gqlparser/issues/128
 func directiveLocationCheck(schema *ast.Schema, defn *ast.Definition) gqlerror.List {
 	var errs []*gqlerror.Error
 	for _, dir := range defn.Directives {

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -56,8 +56,8 @@ func init() {
 	// as an array. listInputCoercion changes the value to array if the single object is provided.
 	// Changing the value can mess up with the other data validation rules hence we are setting
 	// up the order to a high value so that it will be executed last.
-	validator.AddRuleWithOrder("Input Coercion to List", listCoercionRules, listInputCoercion)
 	validator.AddRuleWithOrder("Check filter functions", baseRules, filterCheck)
+	validator.AddRuleWithOrder("Input Coercion to List", listCoercionRules, listInputCoercion)
 
 }
 

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -31,9 +31,6 @@ import (
 	"github.com/dgraph-io/gqlparser/v2/validator"
 )
 
-const MaxUint = ^uint(0)
-const MaxInt = int(MaxUint >> 1)
-
 func init() {
 	schemaDocValidations = append(schemaDocValidations, typeNameValidation,
 		customQueryNameValidation, customMutationNameValidation)
@@ -54,7 +51,7 @@ func init() {
 	// as an array. listInputCoercion changes the value to array if the single object is provided.
 	// Changing the value can mess up with the other data validation rules hence we are setting
 	// up the order to a high value so that it will be executed last.
-	validator.AddRuleWithOrder("Input Coercion to List", MaxInt, listInputCoercion)
+	validator.AddRuleWithOrder("Input Coercion to List", int(^uint(0)>>1), listInputCoercion)
 	validator.AddRule("Check filter functions", filterCheck)
 
 }

--- a/graphql/schema/rules.go
+++ b/graphql/schema/rules.go
@@ -52,11 +52,11 @@ func init() {
 	validator.AddRuleWithOrder("Check variable type is correct", baseRules, variableTypeCheck)
 	validator.AddRuleWithOrder("Check arguments of cascade directive", baseRules, directiveArgumentsCheck)
 	validator.AddRuleWithOrder("Check range for Int type", baseRules, intRangeCheck)
+	validator.AddRuleWithOrder("Check filter functions", baseRules, filterCheck)
 	// Graphql accept both single object and array of objects as value when the schema is defined
 	// as an array. listInputCoercion changes the value to array if the single object is provided.
 	// Changing the value can mess up with the other data validation rules hence we are setting
 	// up the order to a high value so that it will be executed last.
-	validator.AddRuleWithOrder("Check filter functions", baseRules, filterCheck)
 	validator.AddRuleWithOrder("Input Coercion to List", listCoercionRules, listInputCoercion)
 
 }


### PR DESCRIPTION
… validation (#8007)

* fix: add validation of null values with correct order of graphql rule validation

<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->