### PR TITLE
fix(test) fix cron cycles

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
 jobs:
   build:
     name: trivy-tests

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "30 * * * *"
 jobs:
   dgraph-load-tests:
     runs-on: self-hosted

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
 jobs:
   dgraph-tests:
     runs-on: self-hosted

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "0 * * * *"
 jobs:
   golang-lint:
     name: lint


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->
we have switched to self-hosted runners, and we are spending $'s for our runners. Our tests are now stable, and we ideal need 1-runner during the night for scheduled runs. And if we do get PRs etc. on our `main` branch - it would still be able to run those tests. We should not need 2 runners during the 12hr off-work window.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->
Adjust the schedule in such a way that `unit test run` is followed by `load test run` sequentially. This will keep the resource busy for ~20mins. And we will need only 1 runner for the night.