### PR TITLE
fix(GraphQL): Nested Auth Rules not working properly (#7915)

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -513,6 +513,44 @@ func TestAuthOnInterfaces(t *testing.T) {
 	}
 }
 
+func TestNestedAndAuthRulesWithMissingJWT(t *testing.T) {
+	addParams := &common.GraphQLParams{
+		Query: `
+		mutation($user1: String!, $user2: String!){
+			addGroup(input: [{users: {username: $user1}, createdBy: {username: $user2}}, {users: {username: $user2}, createdBy: {username: $user1}}]){
+			  numUids
+			}
+		  }
+		`,
+		Variables: map[string]interface{}{"user1": "user1", "user2": "user2"},
+	}
+	gqlResponse := addParams.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+	require.JSONEq(t, `{"addGroup": {"numUids": 2}}`, string(gqlResponse.Data))
+
+	queryParams := &common.GraphQLParams{
+		Query: `
+		query{
+			queryGroup{
+			  users{
+				username
+			  }
+			}
+		  }
+		`,
+		Headers: common.GetJWT(t, "user1", nil, metaInfo),
+	}
+
+	expectedJSON := `{"queryGroup": [{"users": [{"username": "user1"}]}]}`
+
+	gqlResponse = queryParams.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+	require.JSONEq(t, expectedJSON, string(gqlResponse.Data))
+
+	deleteFilter := map[string]interface{}{"has": "users"}
+	common.DeleteGqlType(t, "Group", deleteFilter, 2, nil)
+}
+
 func TestAuthRulesWithNullValuesInJWT(t *testing.T) {
 	testCases := []TestCase{
 		{

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -644,13 +644,10 @@
       queryGroup(func: uid(GroupRoot)) {
         Group.id : uid
       }
-      GroupRoot as var(func: uid(Group_1)) @filter((uid(Group_Auth2) OR uid(Group_Auth3)))
+      GroupRoot as var(func: uid(Group_1)) @filter(uid(Group_Auth2))
       Group_1 as var(func: type(Group))
       Group_Auth2 as var(func: uid(Group_1)) @cascade {
         Group.users : Group.users @filter(eq(User.username, "user1"))
-      }
-      Group_Auth3 as var(func: uid(Group_1)) @cascade {
-        Group.createdBy : Group.createdBy @filter(eq(User.username, "user1"))
       }
     }
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -978,6 +978,11 @@ func (authRw *authRewriter) rewriteRuleNode(
 
 	switch {
 	case len(rn.And) > 0:
+		// if there is atleast one RBAC rule which is false, then this
+		// whole And block needs to be ignored.
+		if rn.EvaluateStatic(authRw.authVariables) == schema.Negative {
+			return nil, nil
+		}
 		qrys, filts := nodeList(typ, rn.And)
 		if len(filts) == 0 {
 			return qrys, nil


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
Nested Auth Rules causing issues with "And" in queries

https://discuss.dgraph.io/t/auth-directives-dont-apply-to-nested-objects-when-using-interfaces/14157

 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->