### PR TITLE
feat(testing): simplify package testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOPATH         ?= $(shell go env GOPATH)
 ###############
 
 .PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image
-all: $(SUBDIRS)
+all: dgraph
 
 dgraph:
 	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
@@ -44,19 +44,15 @@ version:
 	@echo Go version: $(shell go version)
 
 install:
-	@(set -e;for i in $(SUBDIRS); do \
-		echo Installing $$i ...; \
-		GOOS=linux GOARCH=amd64 $(MAKE) -C $$i install; \
-	done)
+	@echo Installing dgraph...; \
+		GOOS=linux GOARCH=amd64 $(MAKE) -C dgraph install;
 
 install_oss oss_install:
 	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
 
 uninstall:
-	@(set -e;for i in $(SUBDIRS); do \
-		echo Uninstalling $$i ...; \
-		$(MAKE) -C $$i uninstall; \
-	done)
+	@echo Uninstalling dgraph...; \
+		$(MAKE) -C dgraph uninstall;
 
 test: image-local
 	@cp dgraph/dgraph ${GOPATH}/bin

--- a/t/Makefile
+++ b/t/Makefile
@@ -18,7 +18,7 @@
 GOOS          ?= $(shell go env GOOS)
 GOPATH        ?= $(shell go env GOPATH)
 
-.PHONY: test
+.PHONY: all test
 
 all: test
 
@@ -27,7 +27,14 @@ test:
 	@go build .
 #	clean go testcache
 	go clean -testcache
-#	run the tests
-	@./t --skip systest/backup,systest/online-restore,systest/loader,tlstest
+#	run the tests specified in pkg; otherwise run standard suite
+	@if [ -n "$(PKG)" ]; then \
+		./t --pkg=$(PKG); \
+	else \
+		./t --skip systest/backup,systest/online-restore,systest/loader,tlstest; \
+	fi
 #	clean up docker containers after test execution
 	./t -r
+#	Exit message
+	@echo "Testing complete, goodbye!"
+		

--- a/t/Makefile
+++ b/t/Makefile
@@ -35,6 +35,4 @@ test:
 	fi
 #	clean up docker containers after test execution
 	./t -r
-#	Exit message
-	@echo "Testing complete, goodbye!"
 		


### PR DESCRIPTION
## Problem

Previously calling `make test` ran a set of tests specified in t/Makefile.  This had to be modified every time we want to run a specific package test.

## Solution

We can now run `make test PKG=<package>` to run a specific package test.  E.g., to run the posting package test, run `make test PKG=posting`.  If the package is not specified, a standard suite of tests is run as before.

This PR also fixes the `make install` command (the SUBDIRS variable was removed in a previous PR but still referenced in the `make install` command).  

## Remark

The command `make test` is only used when testing locally.  This change will not affect CI/CD jobs.

## TODO

What should be the standard suite of tests to run when testing locally?  Some tests require high resources and often (or sporadically) fail when run locally.  We should figure out which tests can be run consistently locally and set `make test` to run these by default.