### PR TITLE
fix(build): Update linux build steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GOPATH         ?= $(shell go env GOPATH)
 ###############
 
 .PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image
-all: $(SUBDIRS)
+all: dgraph
 
 dgraph:
 	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
@@ -44,23 +44,18 @@ version:
 	@echo Go version: $(shell go version)
 
 install:
-	@(set -e;for i in $(SUBDIRS); do \
-		echo Installing $$i ...; \
-		GOOS=linux GOARCH=amd64 $(MAKE) -C $$i install; \
-	done)
+	@echo Installing dgraph ...; \
+		GOOS=linux GOARCH=amd64 $(MAKE) -C dgraph install; \
 
 install_oss oss_install:
 	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
 
 uninstall:
-	@(set -e;for i in $(SUBDIRS); do \
-		echo Uninstalling $$i ...; \
-		$(MAKE) -C $$i uninstall; \
-	done)
+	@echo Uninstalling dgraph ...; \
+		$(MAKE) -C dgraph uninstall; \
 
 test: image-local
-	@cp dgraph/dgraph ${GOPATH}/bin
-	@rm dgraph/dgraph
+	@mv dgraph/dgraph ${GOPATH}/bin
 	@$(MAKE) -C t test
 
 image:

--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,14 @@ version:
 	@echo Go version: $(shell go version)
 
 install:
-	@echo Installing dgraph ...; \
+	@echo "Installing dgraph ..."; \
 		GOOS=linux GOARCH=amd64 $(MAKE) -C dgraph install; \
 
 install_oss oss_install:
 	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
 
 uninstall:
-	@echo Uninstalling dgraph ...; \
+	@echo "Uninstalling dgraph ..."; \
 		$(MAKE) -C dgraph uninstall; \
 
 test: image-local

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you want to install from source, install Go 1.13+ or later and the following 
 
 ```bash
 sudo apt-get update
-sudo apt-get install gcc make
+sudo apt-get install build-essential
 ```
 
 ### macOS


### PR DESCRIPTION
## Problem

1.)  When following install instructions for Linux, one will encounter the following error due to missing libraries:

```
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: cannot find -lstdc++
collect2: error: ld returned 1 exit status
```

2.)  Makefile in root Dgraph directory included a deprecated SUBDIRS variables.  This was referenced when `make install` is called, giving an error.


## Solution

1.)  Instead of `apt-get install make gcc` instructions should be `apt-get install build-essential` which includes gcc, make, as well as the necessary libc packages.

2.)  Update Makefile to run `make install` correctly.