### PR TITLE
fix(deps): update dependencies on badger + ristretto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,16 +30,14 @@ GOPATH         ?= $(shell go env GOPATH)
 ######################
 DGRAPH_VERSION ?= local
 
-.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image-local local-image docker-image docker-image-standalone
+.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image docker-image docker-image-standalone
 all: dgraph
 
 dgraph:
-	@echo "Compiling Dgraph binary..."
-	@$(MAKE) -w -C $@ all
-	@echo "Dgraph binary placed in dgraph directory."
+	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
 
 oss:
-	@$(MAKE) BUILD_TAGS=oss
+	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss
 
 version:
 	@echo Dgraph ${BUILD_VERSION}
@@ -50,22 +48,29 @@ version:
 	@echo Go version: $(shell go version)
 
 install:
-	@echo "Installing Dgraph ..."; \
-		$(MAKE) -C dgraph install; \
+	@echo "Installing dgraph ..."; \
+		GOOS=linux GOARCH=amd64 $(MAKE) -C dgraph install; \
 
 install_oss oss_install:
-	$(MAKE) BUILD_TAGS=oss install
+	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
 
 uninstall:
-	@echo "Uninstalling Dgraph ..."; \
+	@echo "Uninstalling dgraph ..."; \
 		$(MAKE) -C dgraph uninstall; \
 
 test: image-local
 	@mv dgraph/dgraph ${GOPATH}/bin
 	@$(MAKE) -C t test
 
+image:
+	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
+	@mkdir -p linux
+	@mv ./dgraph/dgraph ./linux/dgraph
+	@docker build -f contrib/Dockerfile -t dgraph/dgraph:$(subst /,-,${BUILD_BRANCH}) .
+	@rm -r linux
+
 image-local local-image:
-	@$(MAKE) dgraph
+	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:local .

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ DGRAPH_VERSION ?= local
 all: dgraph
 
 dgraph:
-	GOOS=linux GOARCH=amd64 $(MAKE) -w -C $@ all
+	$(MAKE) -w -C $@ all
 
 oss:
-	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss
+	$(MAKE) BUILD_TAGS=oss
 
 version:
 	@echo Dgraph ${BUILD_VERSION}
@@ -49,10 +49,10 @@ version:
 
 install:
 	@echo "Installing dgraph ..."; \
-		GOOS=linux GOARCH=amd64 $(MAKE) -C dgraph install; \
+		$(MAKE) -C dgraph install; \
 
 install_oss oss_install:
-	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss install
+	$(MAKE) BUILD_TAGS=oss install
 
 uninstall:
 	@echo "Uninstalling dgraph ..."; \
@@ -63,14 +63,14 @@ test: image-local
 	@$(MAKE) -C t test
 
 image:
-	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
+	@$(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:$(subst /,-,${BUILD_BRANCH}) .
 	@rm -r linux
 
 image-local local-image:
-	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
+	@$(MAKE) dgraph
 	@mkdir -p linux
 	@mv ./dgraph/dgraph ./linux/dgraph
 	@docker build -f contrib/Dockerfile -t dgraph/dgraph:local .

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,16 @@ GOPATH         ?= $(shell go env GOPATH)
 ######################
 DGRAPH_VERSION ?= local
 
-.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image docker-image docker-image-standalone
+.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image-local local-image docker-image docker-image-standalone
 all: dgraph
 
 dgraph:
-	$(MAKE) -w -C $@ all
+	@echo "Compiling Dgraph binary..."
+	@$(MAKE) -w -C $@ all
+	@echo "Dgraph binary placed in dgraph directory."
 
 oss:
-	$(MAKE) BUILD_TAGS=oss
+	@$(MAKE) BUILD_TAGS=oss
 
 version:
 	@echo Dgraph ${BUILD_VERSION}
@@ -48,26 +50,19 @@ version:
 	@echo Go version: $(shell go version)
 
 install:
-	@echo "Installing dgraph ..."; \
+	@echo "Installing Dgraph ..."; \
 		$(MAKE) -C dgraph install; \
 
 install_oss oss_install:
 	$(MAKE) BUILD_TAGS=oss install
 
 uninstall:
-	@echo "Uninstalling dgraph ..."; \
+	@echo "Uninstalling Dgraph ..."; \
 		$(MAKE) -C dgraph uninstall; \
 
 test: image-local
 	@mv dgraph/dgraph ${GOPATH}/bin
 	@$(MAKE) -C t test
-
-image:
-	@$(MAKE) dgraph
-	@mkdir -p linux
-	@mv ./dgraph/dgraph ./linux/dgraph
-	@docker build -f contrib/Dockerfile -t dgraph/dgraph:$(subst /,-,${BUILD_BRANCH}) .
-	@rm -r linux
 
 image-local local-image:
 	@$(MAKE) dgraph

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,12 @@ require (
 	github.com/apache/thrift v0.13.0 // indirect
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.2103.1
+	github.com/dgraph-io/badger/v3 v3.2103.4
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.1
 	github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15
-	github.com/dgraph-io/ristretto v0.1.0
+	github.com/dgraph-io/ristretto v0.1.1
 	github.com/dgraph-io/simdjson-go v0.3.0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
@@ -40,7 +40,6 @@ require (
 	github.com/google/uuid v1.0.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/graph-gophers/graphql-go v0.0.0-20200309224638-dae41bde9ef9
-	github.com/graph-gophers/graphql-transport-ws v0.0.0-20190611222414-40c048432299 // indirect
 	github.com/hashicorp/vault/api v1.0.4
 	github.com/minio/minio-go/v6 v6.0.55
 	github.com/mitchellh/panicwrap v1.0.0
@@ -63,7 +62,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
 	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
-	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10
+	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
 	golang.org/x/text v0.3.7
 	golang.org/x/tools v0.0.0-20210106214847-113979e3529a
 	google.golang.org/grpc v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Evo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
-github.com/dgraph-io/badger/v3 v3.2103.1 h1:zaX53IRg7ycxVlkd5pYdCeFp1FynD6qBGQoQql3R3Hk=
-github.com/dgraph-io/badger/v3 v3.2103.1/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
+github.com/dgraph-io/badger/v3 v3.2103.4 h1:WE1B07YNTTJTtG9xjBcSW2wn0RJLyiV99h959RKZqM4=
+github.com/dgraph-io/badger/v3 v3.2103.4/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987 h1:5aN6H88a2q3HkO8vSZxDlgjEpJf4Fz8rfy+/Wzx2uAc=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=
@@ -132,8 +132,8 @@ github.com/dgraph-io/gqlparser/v2 v2.2.1 h1:15msK9XEHOSrRqQO48UU+2ZTf1R1U8+tfL9H
 github.com/dgraph-io/gqlparser/v2 v2.2.1/go.mod h1:MYS4jppjyx8b9tuUtjV7jU1UFZK6P9fvO8TsIsQtRKU=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15 h1:X2NRsgAtVUAp2nmTPCq+x+wTcRRrj74CEpy7E0Unsl4=
 github.com/dgraph-io/graphql-transport-ws v0.0.0-20210511143556-2cef522f1f15/go.mod h1:7z3c/5w0sMYYZF5bHsrh8IH4fKwG5O5Y70cPH1ZLLRQ=
-github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
-github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
+github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
 github.com/dgraph-io/simdjson-go v0.3.0 h1:h71LO7vR4LHMPUhuoGN8bqGm1VNfGOlAG8BI6iDUKw0=
 github.com/dgraph-io/simdjson-go v0.3.0/go.mod h1:Otpysdjaxj9OGaJusn4pgQV7OFh2bELuHANq0I78uvY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -250,8 +250,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/codesearch v1.0.0 h1:z4h5JoHkUS+GqxqPDrldC3Y0Qq0vHAGgaDEW5pWU/ys=
 github.com/google/codesearch v1.0.0/go.mod h1:qCnXDFnak/trCmLaE50kgPte3AX9jSeruZexWEOivi0=
-github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oogeh6w=
-github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
+github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
+github.com/google/flatbuffers v1.12.1/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -285,8 +285,6 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/graph-gophers/graphql-go v0.0.0-20200309224638-dae41bde9ef9 h1:kLnsdud6Fl1/7ZX/5oD23cqYAzBfuZBhNkGr2NvuEsU=
 github.com/graph-gophers/graphql-go v0.0.0-20200309224638-dae41bde9ef9/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
-github.com/graph-gophers/graphql-transport-ws v0.0.0-20190611222414-40c048432299 h1:BdXUpuP9yOGKcwD/mhhZ+6EeAmrPrAQA3yeq4YEOHL4=
-github.com/graph-gophers/graphql-transport-ws v0.0.0-20190611222414-40c048432299/go.mod h1:mA6VjyefgI7zd37tC3zopb51mW39gSfnEoWvtnxsqKQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.4.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
@@ -774,8 +772,9 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
+golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
## Problem

Dgraph currently uses Ristretto v0.1.0 and Badger v3.2103.1.  We encounter certain issues on arm64 machines that were patched in Ristretto v0.1.1 and Badger v3.2103.3.  Badger v3.2103.4 also fixes a potential manifest corruption issue.  

## Solution

We bump up the dependencies.  

```
> go get github.com/dgraph-io/ristretto@v0.1.1
go: upgraded github.com/dgraph-io/ristretto v0.1.0 => v0.1.1
go: upgraded golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 => v0.0.0-20221010170243-090e33056c14
> go get github.com/dgraph-io/badger/v3@v3.2103.4
go: downloading github.com/dgraph-io/badger/v3 v3.2103.4
go: module github.com/golang/protobuf is deprecated: Use the "google.golang.org/protobuf" module instead.
go: upgraded github.com/dgraph-io/badger/v3 v3.2103.1 => v3.2103.4
> go mod tidy                                    
```

## Remark

[Changelog of Badger v3.2103.1 to v3.2103.2](https://github.com/dgraph-io/badger/compare/v3.2103.1...v3.2103.2)
[Changelog of Badger v3.2103.2 to v3.2103.3](https://github.com/dgraph-io/badger/compare/v3.2103.2...v3.2103.3)
[Changelog of Badger v3.2103.2 to v3.2103.4](https://github.com/dgraph-io/badger/compare/v3.2103.1...v3.2103.2)
[Changelog of Ristretto v0.1.0 to v0.1.1](https://github.com/dgraph-io/ristretto/compare/v0.1.0...v0.1.1)