### PR TITLE
chore: CD cleanup

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -5,23 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Get Go Version
-        run: |
-          #!/bin/bash
-          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
-          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GOVERSION }}
-      - name: Install protobuf-compiler
-        run: sudo apt-get install -y protobuf-compiler
-      - name: Check protobuf
-        run: |
-          cd ./protos
-          go mod tidy
-          make regenerate
-          git diff --exit-code -- .
       - name: Set Dgraph Release Version
         run: |
           #!/bin/bash
@@ -34,18 +17,48 @@ jobs:
             exit 1
           fi
           DGRAPH_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
-          echo "making a new release for "$DGRAPH_RELEASE_VERSION
-          echo "DGRAPH_RELEASE_VERSION=$DGRAPH_RELEASE_VERSION" >> $GITHUB_ENV
+          echo "making a new release for "$DGRAPH_VERSION
+          echo "DGRAPH_VERSION=$DGRAPH_VERSION" >> $GITHUB_ENV
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
+      - name: Install dependencies
+        run: make linux-dependency
+      - name: go mod tidy check
+        run: |
+          #!/bin/bash
+          go mod tidy
+          if [[ "$(git status --porcelain)" ]]; then \
+             echo "need to run go mod tidy"
+             exit 1
+          fi
+      - name: protobuf check
+        run: |
+          #!/bin/bash
+          pushd protos
+          make regenerate
+          popd
+          if [[ "$(git status --porcelain)" ]]; then \
+            echo "Generated protos different in release."
+            echo "Or need to go mod tidy"
+            exit 1
+          fi
       - name: Make Linux Build
-        run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
+        run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_VERSION }}
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=latest
-          make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
-      - name: Make Dgraph Standalone Docker Image with Version
+          make docker-image DGRAPH_VERSION=${{ env.DGRAPH_VERSION }}
+      - name: Make Dgraph Standalone Docker Image
         run: |
           make docker-image-standalone DGRAPH_VERSION=latest
-          make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
+          make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_VERSION }}
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -54,6 +67,6 @@ jobs:
       - name: Push Images to DockerHub
         run: |
           docker push dgraph/standalone:latest
-          docker push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}
+          docker push dgraph/standalone:${{ env.DGRAPH_VERSION }}
           docker push dgraph/dgraph:latest
-          docker push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}
+          docker push dgraph/dgraph:${{ env.DGRAPH_VERSION }}

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -32,7 +32,6 @@ jobs:
           popd
           if [[ "$(git status --porcelain)" ]]; then \
             echo "Generated protos different in release."
-            echo "Or need to go mod tidy"
             exit 1
           fi
       - name: Set Dgraph Release Version
@@ -46,7 +45,7 @@ jobs:
             echo "this is NOT a release branch"
             exit 1
           fi
-          DGRAPH_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
+          DGRAPH_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
           echo "making a new release for "$DGRAPH_VERSION
           echo "DGRAPH_VERSION=$DGRAPH_VERSION" >> $GITHUB_ENV
       - name: Make Linux Build

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -50,6 +50,16 @@ jobs:
           echo "DGRAPH_VERSION=$DGRAPH_VERSION" >> $GITHUB_ENV
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_VERSION }}
+      - name: Get SHA
+        run: sha256sum dgraph/dgraph | cut -c-64 > dgraph/dgraph-linux-amd64.sha256
+      - name: Make Archive
+        run: tar -zcvf dgraph/dgraph-linux-amd64.tar.gz dgraph/dgraph
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dgraph
+          path: |
+            dgraph/dgraph.sha256
+            dgraph/dgraph.tar.gz
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=latest

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -58,8 +58,8 @@ jobs:
         with:
           name: dgraph
           path: |
-            dgraph/dgraph.sha256
-            dgraph/dgraph.tar.gz
+            dgraph/dgraph-linux-amd64.sha256
+            dgraph/dgraph-linux-amd64.tar.gz
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=latest

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -5,20 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set Dgraph Release Version
-        run: |
-          #!/bin/bash
-          GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          if [[ "$GIT_BRANCH_NAME" == "release/v"* ]]; 
-          then
-            echo "this is a release branch"
-          else
-            echo "this is NOT a release branch"
-            exit 1
-          fi
-          DGRAPH_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
-          echo "making a new release for "$DGRAPH_VERSION
-          echo "DGRAPH_VERSION=$DGRAPH_VERSION" >> $GITHUB_ENV
       - name: Get Go Version
         run: |
           #!/bin/bash
@@ -49,6 +35,20 @@ jobs:
             echo "Or need to go mod tidy"
             exit 1
           fi
+      - name: Set Dgraph Release Version
+        run: |
+          #!/bin/bash
+          GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$GIT_BRANCH_NAME" == "release/v"* ]]; 
+          then
+            echo "this is a release branch"
+          else
+            echo "this is NOT a release branch"
+            exit 1
+          fi
+          DGRAPH_RELEASE_VERSION=$(git rev-parse --abbrev-ref HEAD | sed  's/release\///')
+          echo "making a new release for "$DGRAPH_VERSION
+          echo "DGRAPH_VERSION=$DGRAPH_VERSION" >> $GITHUB_ENV
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_VERSION }}
       - name: Make Dgraph Docker Image

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,6 @@
 # limitations under the License.
 #
 
-BUILD          ?= $(shell git rev-parse --short HEAD)
-BUILD_CODENAME  = dgraph
-BUILD_DATE     ?= $(shell git log -1 --format=%ci)
-BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
-#BUILD_VERSION  ?= $(shell git describe --always --tags)
-
 GOPATH         ?= $(shell go env GOPATH)
 
 ######################
@@ -38,14 +32,6 @@ dgraph:
 
 oss:
 	GOOS=linux GOARCH=amd64 $(MAKE) BUILD_TAGS=oss
-
-version:
-	@echo Dgraph ${BUILD_VERSION}
-	@echo Build: ${BUILD}
-	@echo Codename: ${BUILD_CODENAME}
-	@echo Build date: ${BUILD_DATE}
-	@echo Branch: ${BUILD_BRANCH}
-	@echo Go version: $(shell go version)
 
 install:
 	@echo "Installing dgraph ..."; \
@@ -86,7 +72,7 @@ docker-image-standalone: dgraph docker-image
 	@cp ./dgraph/dgraph ./linux/dgraph
 	$(MAKE) -w -C contrib/standalone all DOCKER_TAG=$(DGRAPH_VERSION) DGRAPH_VERSION=$(DGRAPH_VERSION)
 
-# build and run dependencies for ubuntu linux
+# build and runtime dependencies for ubuntu linux
 linux-dependency:
 	sudo apt-get update
 	sudo apt-get -y upgrade
@@ -96,6 +82,9 @@ linux-dependency:
 	sudo apt-get -y install lsb-release
 	sudo apt-get -y install build-essential
 	sudo apt-get -y install protobuf-compiler
+
+version:
+	@$(MAKE) -C dgraph version
 
 help:
 	@echo

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -15,7 +15,6 @@
 #
 
 USER_ID         = $(shell id -u)
-BIN             = dgraph
 BUILD          ?= $(shell git rev-parse --short HEAD)
 BUILD_CODENAME ?= dgraph
 BUILD_DATE     ?= $(shell git log -1 --format=%ci)
@@ -65,23 +64,23 @@ endif
 HAS_JEMALLOC = $(shell test -f /usr/local/lib/libjemalloc.a && echo "jemalloc")
 JEMALLOC_URL = "https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2"
 
-.PHONY: all $(BIN)
-all: $(BIN)
+.PHONY: all dgraph
+all: dgraph
 
-$(BIN): clean jemalloc
-	@go build $(BUILD_FLAGS) -o $(BIN)
+dgraph: clean jemalloc
+	@go build $(BUILD_FLAGS) -o dgraph
 
 clean:
-	@rm -f $(BIN)
+	@rm -f dgraph
 
 uninstall:
 	@go clean -i -x
 
 install: jemalloc
 	@echo "Commit SHA256: `git rev-parse HEAD`"
-	@echo "Old SHA256:" `sha256sum $(GOPATH)/bin/$(BIN) 2>/dev/null | cut -c-64`
+	@echo "Old SHA256:" `sha256sum $(GOPATH)/bin/dgraph 2>/dev/null | cut -c-64`
 	@go install $(BUILD_FLAGS)
-	@echo "New SHA256:" `sha256sum $(GOPATH)/bin/$(BIN) 2>/dev/null | cut -c-64`
+	@echo "New SHA256:" `sha256sum $(GOPATH)/bin/dgraph 2>/dev/null | cut -c-64`
 
 jemalloc:
 	@if [ -z "$(HAS_JEMALLOC)" ] ; then \
@@ -99,4 +98,12 @@ jemalloc:
 			sudo make install ; \
 		fi \
 	fi
+
+version:
+	@echo Dgraph Version: ${BUILD_VERSION}
+	@echo Build: ${BUILD}
+	@echo Codename: ${BUILD_CODENAME}
+	@echo Build date: ${BUILD_DATE}
+	@echo Branch: ${BUILD_BRANCH}
+	@echo Go version: $(shell go version)
 


### PR DESCRIPTION
## Problem

We continue work on CD pipeline.

## Solution
- Artifacts are now saved and uploaded to Github (i.e. binary and sha)
- `make linux-dependency` include protobuf-compiler and other build/runtime dependencies
- Add `go mod tidy` check in CD steps
- Replace DGRAPH_RELEASE_VERSION with DGRAPH_VERSION
- Remove build parameters from root makefile, so they are now located only in dgraph/Makefile (they were duplicated in both Makefile and dgraph/Makefile)
- `make version` now uses build parameters located in dgraph/Makefile
- Replace $(BIN) with dgraph 

Feel free to make any other additions or subtractions...

## Remarks

We found interesting cross compilation issues in this process.  First, building a dgraph binary on an M1 Mac via 
```
GOOS=linux GOARCH=amd64 make dgraph
```
does NOT produce the same binary as on a linux/amd64 machine.  This can be seen in the following:

Artifact binary (made on linux/amd64 github runner):
```
> file dgraph
dgraph: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=62ab033f988e88edf53ec37e1d9363d34204890f, for GNU/Linux 3.2.0, not stripped
```
Compare with my locally made binary (M1 Mac):
```
> file dgraph/dgraph 
dgraph/dgraph: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=_SlrYO5M_ydJ_Wmfq2Qd/IxFWCCM1HR57u9G_UJxW/ojAnfYroSwaLqpInrpxt/w4QvLEaQMAzelTEmavC8, with debug_info, not stripped
```

If I download the artifact binary on my M1 machine and build a local Docker image,
 ```
docker build -f contrib/Dockerfile -t dgraph/dgraph:local .
```
(the Dockerfile file will pick up the binary), I will not be able to run the container:
```
> docker run dgraph/dgraph:local
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
```

Furthermore, if I spin up a clean ec2 instance and scp the two dgraph binaries into the instance (i.e. the artifact binary, and my locally compiled binary), I will see that jemalloc is enabled on the artifact binary but is not enabled on my locally made binary, _even though at build time the jemalloc tag was specified in both cases._

Why is all of this happening?  The answer probably has to do with jemalloc and the fact that it is a C dependency.  Go code can be easily cross compiled which we take for granted,  whereas C code must be compiled appropriately for each environment.  This does not matter so much in production since everyone uses linux, but this is something to keep in mind as we run tests on our local machines (darwin/amd64, darwin/arm64, etc.).  It is also important that the binaries we produce are compiled in the appropriate environment.





