### PR TITLE
fix(cd): fix docker latest tag's dgraph version

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -40,12 +40,12 @@ jobs:
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
       - name: Make Dgraph Docker Image
         run: |
-          make docker-image DGRAPH_VERSION=latest
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
+          docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }} dgraph/dgraph:latest
       - name: Make Dgraph Standalone Docker Image with Version
         run: |
-          make docker-image-standalone DGRAPH_VERSION=latest
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
+          docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }} dgraph/standalone:latest
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME_TEST }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN_TEST }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD_TOKEN }}
       - name: Push Images to DockerHub
         run: |
           docker push dgraph/standalone:latest


### PR DESCRIPTION
## Problem
the latest docker container we build yields `latest` for `dgraph version`

## Solution
I am changing this pattern where we build the versioned container & re-tag it with latest. This way the dgraph binary has the correct version and doesn't show latest.