### PR TITLE
fix(cd): upload dgraph binary artifacts

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -38,6 +38,16 @@ jobs:
           echo "DGRAPH_RELEASE_VERSION=$DGRAPH_RELEASE_VERSION" >> $GITHUB_ENV
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
+      - name: Generate SHA for Linux Build
+        run: sha256sum dgraph/dgraph | cut -c-64 > dgraph/dgraph-linux-amd64.sha256
+      - name: Tar Archive for Linux Build
+        run: tar -zcvf dgraph/dgraph-linux-amd64.tar.gz dgraph/dgraph
+      - name: Upload Dgraph Binary Build Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          path: |
+            dgraph/dgraph-linux-amd64.sha256
+            dgraph/dgraph-linux-amd64.tar.gz
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}


### PR DESCRIPTION
## Problem
Eliminate manual binary & related SHA uploads

## Solution
Adding automation to generate these binaries.

Reference PR from @joshua-goldstein https://github.com/dgraph-io/dgraph/pull/8378