### PR TITLE
Chore(Other|contrib): Fix Ratel refs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ Copyright 2015-2018 Dgraph Labs, Inc.
 ```
 
 For release images, follow [Doing a release](#doing-a-release). It creates
-Docker images that contains `dgraph`, `dgraph-ratel`, and `badger` commands.
+Docker images that contains `dgraph` and `badger` commands.
 
 ### Testing
 

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -434,12 +434,11 @@ func getRatel() service {
 		portFlag = fmt.Sprintf(" -port=%d", opts.RatelPort)
 	}
 	svc := service{
-		Image:         opts.Image + ":" + opts.Tag,
+		Image:         opts.RatelImage + ":" + opts.Tag,
 		ContainerName: containerName("ratel"),
 		Ports: []string{
 			toPort(opts.RatelPort),
 		},
-		Command: "dgraph-ratel" + portFlag,
 	}
 	return svc
 }
@@ -570,6 +569,8 @@ func main() {
 		"use locally-compiled binary if true, otherwise use binary from docker container")
 	cmd.PersistentFlags().StringVar(&opts.Image, "image", "dgraph/dgraph",
 		"Docker image for alphas and zeros.")
+	cmd.PersistentFlags().StringVar(&opts.RatelImage, "ratelImage", "dgraph/ratel",
+		"Docker image for Ratel.")
 	cmd.PersistentFlags().StringVarP(&opts.Tag, "tag", "t", "latest",
 		"Docker tag for the --image image. Requires -l=false to use binary from docker container.")
 	cmd.PersistentFlags().BoolVarP(&opts.WhiteList, "whitelist", "w", true,

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -103,6 +103,7 @@ type options struct {
 	WhiteList      bool
 	Ratel          bool
 	RatelPort      int
+	RatelImage     string
 	MemLimit       string
 	ExposePorts    bool
 	Encryption     bool

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -103,7 +103,6 @@ type options struct {
 	WhiteList      bool
 	Ratel          bool
 	RatelPort      int
-	RatelImage     string
 	MemLimit       string
 	ExposePorts    bool
 	Encryption     bool
@@ -430,12 +429,17 @@ func getMinio(minioDataDir string) service {
 }
 
 func getRatel() service {
+	portFlag := ""
+	if opts.RatelPort != 8000 {
+		portFlag = fmt.Sprintf(" -port=%d", opts.RatelPort)
+	}
 	svc := service{
-		Image:         opts.RatelImage + ":" + opts.Tag,
+		Image:         opts.Image + ":" + opts.Tag,
 		ContainerName: containerName("ratel"),
 		Ports: []string{
 			toPort(opts.RatelPort),
 		},
+		Command: "dgraph-ratel" + portFlag,
 	}
 	return svc
 }
@@ -566,8 +570,6 @@ func main() {
 		"use locally-compiled binary if true, otherwise use binary from docker container")
 	cmd.PersistentFlags().StringVar(&opts.Image, "image", "dgraph/dgraph",
 		"Docker image for alphas and zeros.")
-	cmd.PersistentFlags().StringVar(&opts.RatelImage, "ratelImage", "dgraph/ratel",
-		"Docker image for Ratel.")
 	cmd.PersistentFlags().StringVarP(&opts.Tag, "tag", "t", "latest",
 		"Docker tag for the --image image. Requires -l=false to use binary from docker container.")
 	cmd.PersistentFlags().BoolVarP(&opts.WhiteList, "whitelist", "w", true,

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -430,10 +430,6 @@ func getMinio(minioDataDir string) service {
 }
 
 func getRatel() service {
-	portFlag := ""
-	if opts.RatelPort != 8000 {
-		portFlag = fmt.Sprintf(" -port=%d", opts.RatelPort)
-	}
 	svc := service{
 		Image:         opts.RatelImage + ":" + opts.Tag,
 		ContainerName: containerName("ratel"),

--- a/contrib/config/backups/azure/docker-compose.yml
+++ b/contrib/config/backups/azure/docker-compose.yml
@@ -22,10 +22,9 @@ services:
       --security "whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1;"
 
   ratel:
-    image: dgraph/dgraph:${DGRAPH_VERSION}
+    image: dgraph/ratel:${DGRAPH_VERSION}
     ports:
       - 8000:8000
-    command: dgraph-ratel
     container_name: ratel
 
   minio:

--- a/contrib/config/backups/client/docker-compose.yml
+++ b/contrib/config/backups/client/docker-compose.yml
@@ -33,7 +33,7 @@ services:
 
   ratel:
     ## DGRAPH_VERSION set by ./compose-setup.sh
-    image: dgraph/dgraph:$DGRAPH_VERSION
+    image: dgraph/ratel:$DGRAPH_VERSION
     volumes:
       - type: bind
         source: ./data
@@ -41,5 +41,4 @@ services:
         read_only: false
     ports:
       - 8000:8000
-    command: dgraph-ratel
     container_name: ratel

--- a/contrib/config/backups/gcp/docker-compose.yml
+++ b/contrib/config/backups/gcp/docker-compose.yml
@@ -22,10 +22,9 @@ services:
       --security "whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1;"
 
   ratel:
-    image: dgraph/dgraph:${DGRAPH_VERSION}
+    image: dgraph/ratel:${DGRAPH_VERSION}
     ports:
       - 8000:8000
-    command: dgraph-ratel
     container_name: ratel
 
   minio:

--- a/contrib/config/backups/nfs/docker-compose.yml
+++ b/contrib/config/backups/nfs/docker-compose.yml
@@ -25,10 +25,9 @@ services:
         volume:
           nocopy: true
   ratel:
-    image: dgraph/dgraph:${DGRAPH_VERSION}
+    image: dgraph/ratel:${DGRAPH_VERSION}
     ports:
       - 8000:8000
-    command: dgraph-ratel
     container_name: ratel
 
 volumes:

--- a/contrib/config/backups/s3/docker-compose.yml
+++ b/contrib/config/backups/s3/docker-compose.yml
@@ -22,8 +22,7 @@ services:
       --security "whitelist=10.0.0.0/8,172.0.0.0/8,192.168.0.0/16,127.0.0.1;"
 
   ratel:
-    image: dgraph/dgraph:${DGRAPH_VERSION}
+    image: dgraph/ratel:${DGRAPH_VERSION}
     ports:
       - 8000:8000
-    command: dgraph-ratel
     container_name: ratel

--- a/contrib/config/docker/docker-compose-ha.yml
+++ b/contrib/config/docker/docker-compose-ha.yml
@@ -149,12 +149,11 @@ services:
           - node.hostname == aws06
     command: dgraph alpha --my=alpha6:7085 --zero=zero1:5080,zero2:5081,zero3:5082 -o 5
   ratel:
-    image: dgraph/dgraph:latest
+    image: dgraph/ratel:latest
     hostname: "ratel"
     ports:
       - 8000:8000
     networks:
       - dgraph
-    command: dgraph-ratel
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose-multi.yml
+++ b/contrib/config/docker/docker-compose-multi.yml
@@ -73,12 +73,11 @@ services:
           - node.hostname == aws03
     command: dgraph alpha --my=alpha3:7082 --zero=zero:5080 -o 2
   ratel:
-    image: dgraph/dgraph:latest
+    image: dgraph/ratel:latest
     hostname: "ratel"
     ports:
       - 8000:8000
     networks:
       - dgraph
-    command: dgraph-ratel
 volumes:
   data-volume:

--- a/contrib/config/docker/docker-compose.yml
+++ b/contrib/config/docker/docker-compose.yml
@@ -26,7 +26,6 @@ services:
     restart: on-failure
     command: dgraph alpha --my=alpha:7080 --zero=zero:5080
   ratel:
-    image: dgraph/dgraph:latest
+    image: dgraph/ratel:latest
     ports:
       - 8000:8000
-    command: dgraph-ratel

--- a/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
+++ b/contrib/config/kubernetes/dgraph-ha/dgraph-ha.yaml
@@ -355,8 +355,6 @@ spec:
     spec:
       containers:
       - name: ratel
-        image: dgraph/dgraph:latest
+        image: dgraph/ratel:latest
         ports:
         - containerPort: 8000
-        command:
-          - dgraph-ratel

--- a/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
+++ b/contrib/config/kubernetes/dgraph-single/dgraph-single.yaml
@@ -44,13 +44,11 @@ spec:
     spec:
       containers:
       - name: ratel
-        image: dgraph/dgraph:latest
+        image: dgraph/ratel:latest
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8000
           name: http-ratel
-        command:
-          - dgraph-ratel
       - name: zero
         image: dgraph/dgraph:latest
         imagePullPolicy: IfNotPresent

--- a/contrib/standalone/Dockerfile
+++ b/contrib/standalone/Dockerfile
@@ -3,7 +3,7 @@ FROM dgraph/dgraph:${DGRAPH_VERSION}
 LABEL MAINTAINER="Dgraph Labs <contact@dgraph.io>"
 
 # Ratel port
-EXPOSE 8000
+# EXPOSE 8000 ## Ratel is not supported in the standalone image
 # REST API port
 EXPOSE 8080
 # gRPC API port

--- a/contrib/standalone/run.sh
+++ b/contrib/standalone/run.sh
@@ -13,4 +13,4 @@ export DGRAPH_ALPHA_WHITELIST=0.0.0.0/0
 export DGRAPH_ALPHA_SECURITY='whitelist=0.0.0.0/0'
 
 # TODO properly handle SIGTERM for all three processes.
-dgraph-ratel & dgraph zero & dgraph alpha
+dgraph zero & dgraph alpha


### PR DESCRIPTION
## Problem

Users are having trouble starting some YML created in our documentation. Where a dgraph/dgraph:$Version container starts, which no longer has the Ratel binary.

## Solution

I'm correctly arranging the tag images for Ratel.

Fix #8386



