### PR TITLE
WIP ci(runners): Add gh-runner Packer configuration files

### DIFF
--- a/contrib/gh-runner/README.md
+++ b/contrib/gh-runner/README.md
@@ -1,5 +1,25 @@
 # GH Actions Runner
 
+### Automatic Setup
+We use [Packer](https://www.packer.io) to create an AWS automated machine image (AMI) for our EC2 self-hosted runners. 
+This machine image contains all the dependencies (based on `installl-deps.sh`) that we need to run a Github actions job. It will also
+register itself as a runner, which is done by `init-runner.sh` which we put in `/var/lib/cloud/scripts/per-instance`
+so that it runs when an instance is first booted. 
+
+In summary, every instance that is created from this AMI is ready to run a Github actions job without any further configurations.
+
+How to build the AMI?
+
+1. [Install](https://developer.hashicorp.com/packer/tutorials/aws-get-started/get-started-install-cli) Packer on your machine
+2. [Authenticate](https://developer.hashicorp.com/packer/plugins/builders/amazon#authentication) to AWS
+3. Build the AMI
+```shell
+packer build . -var "<VARIABLE_NAME>=<VARIABLE_VALUE>"
+```
+4. Visit the [AWS AMI](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#Images:visibility=owned-by-me;sort=imageName) page to verify that Packer successfully built your AMI.
+
+
+### Manual Setup
 How to bake an AWS Virtual Machine for GH Actions?
 
 1. Get a Github Actions Runner Token from the UI

--- a/contrib/gh-runner/aws-ubuntu.pkr.hcl
+++ b/contrib/gh-runner/aws-ubuntu.pkr.hcl
@@ -9,7 +9,8 @@ packer {
 
 variable "instance_type" {
   type    = string
-  default = "m6a.4xlarge"
+  default = "t2.medium"
+  description = "Instance type to use for creating the image"
 }
 
 variable "region" {
@@ -23,7 +24,7 @@ variable "aws_profile" {
 }
 
 source "amazon-ebs" "ubuntu" {
-  ami_name      = "gh-runner-linux-aws"
+  ami_name      = "gh-runner-linux-aws-v4"
   profile       = var.aws_profile
   instance_type = var.instance_type
   region        = var.region

--- a/contrib/gh-runner/aws-ubuntu.pkr.hcl
+++ b/contrib/gh-runner/aws-ubuntu.pkr.hcl
@@ -1,0 +1,57 @@
+packer {
+  required_plugins {
+    amazon = {
+      version = ">= 0.0.2"
+      source  = "github.com/hashicorp/amazon"
+    }
+  }
+}
+
+variable "instance_type" {
+  type    = string
+  default = "m6a.4xlarge"
+}
+
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "default"
+}
+
+source "amazon-ebs" "ubuntu" {
+  ami_name      = "gh-runner-linux-aws"
+  profile       = var.aws_profile
+  instance_type = var.instance_type
+  region        = var.region
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["099720109477"]
+  }
+  ssh_username = "ubuntu"
+}
+
+build {
+  name = "gh-runner"
+  sources = [
+    "source.amazon-ebs.ubuntu"
+  ]
+  provisioner "shell" {
+    inline = ["sleep 10"]
+  }
+  provisioner "shell" {
+    script = "install-deps.sh"
+  }
+  provisioner "file" {
+    source      = "init-runner.sh"
+    destination = "/home/ubuntu/init-runner.sh"
+  }
+}

--- a/contrib/gh-runner/aws-ubuntu.pkr.hcl
+++ b/contrib/gh-runner/aws-ubuntu.pkr.hcl
@@ -8,8 +8,8 @@ packer {
 }
 
 variable "instance_type" {
-  type    = string
-  default = "t2.medium"
+  type        = string
+  default     = "t2.medium"
   description = "Instance type to use for creating the image"
 }
 
@@ -24,7 +24,7 @@ variable "aws_profile" {
 }
 
 source "amazon-ebs" "ubuntu" {
-  ami_name      = "gh-runner-linux-aws-v4"
+  ami_name      = "gh-runner-linux-aws"
   profile       = var.aws_profile
   instance_type = var.instance_type
   region        = var.region
@@ -53,6 +53,14 @@ build {
   }
   provisioner "file" {
     source      = "init-runner.sh"
-    destination = "/home/ubuntu/init-runner.sh"
+    destination = "/tmp/init-runner.sh"
+  }
+  provisioner "shell" {
+    inline = [
+      # A hack to make cloud-init run the script when a new instance is first booted
+      # Ref: https://cloudinit.readthedocs.io/en/latest/topics/modules.html?highlight=per%20instance#scripts-per-instance
+      "sudo mv /tmp/init-runner.sh /var/lib/cloud/scripts/per-instance/init-runner.sh",
+      "sudo chmod 744 /var/lib/cloud/scripts/per-instance/init-runner.sh"
+    ]
   }
 }

--- a/contrib/gh-runner/init-runner.sh
+++ b/contrib/gh-runner/init-runner.sh
@@ -9,7 +9,7 @@ mkdir actions-runner && cd actions-runner
 curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
-./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
+./config.sh --unattended --url https://github.com/dgraph/dgraph --token $TOKEN --name $EC2_INSTANCE_NAME
 # Start GH Actions
 ./svc.sh install
 ./svc.sh start

--- a/contrib/gh-runner/init-runner.sh
+++ b/contrib/gh-runner/init-runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Get GH Actions Runner registration token
 export AWS_REGION=us-east-1
-AWS_INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 EC2_INSTANCE_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AWS_INSTANCE_ID" "Name=key,Values=Name" --output text | cut -f5)
 TOKEN=$(aws ssm get-parameter --name $EC2_INSTANCE_NAME --with-decryption | jq -r '.Parameter.Value')
 # Install & Setup GH Actions Runner
@@ -9,7 +9,9 @@ mkdir actions-runner && cd actions-runner
 curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
-./config.sh --unattended --url https://github.com/dgraph/dgraph --token $TOKEN --name $EC2_INSTANCE_NAME
+RUNNER_ALLOW_RUNASROOT="1" ./config.sh --unattended --url https://github.com/dgraph/dgraph --token $TOKEN --name $EC2_INSTANCE_NAME
+# Delete token
+aws ssm delete-parameter --name $EC2_INSTANCE_NAME
 # Start GH Actions
 ./svc.sh install
 ./svc.sh start

--- a/contrib/gh-runner/init-runner.sh
+++ b/contrib/gh-runner/init-runner.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Get GH Actions Runner registration token
+export AWS_REGION=us-east-1
+AWS_INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+EC2_INSTANCE_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AWS_INSTANCE_ID" "Name=key,Values=Name" --output text | cut -f5)
+TOKEN=$(aws ssm get-parameter --name $EC2_INSTANCE_NAME --with-decryption | jq -r '.Parameter.Value')
+# Install & Setup GH Actions Runner
+mkdir actions-runner && cd actions-runner
+curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
+echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
+tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
+./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
+# Start GH Actions
+./svc.sh install
+./svc.sh start
+# Reboot Machine
+reboot

--- a/contrib/gh-runner/init-runner.sh
+++ b/contrib/gh-runner/init-runner.sh
@@ -4,16 +4,19 @@ export AWS_REGION=us-east-1
 AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 EC2_INSTANCE_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AWS_INSTANCE_ID" "Name=key,Values=Name" --output text | cut -f5)
 TOKEN=$(aws ssm get-parameter --name $EC2_INSTANCE_NAME --with-decryption | jq -r '.Parameter.Value')
+sudo -i -u ubuntu bash << EOF
 # Install & Setup GH Actions Runner
+cd /home/ubuntu
 mkdir actions-runner && cd actions-runner
 curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
-RUNNER_ALLOW_RUNASROOT="1" ./config.sh --unattended --url https://github.com/dgraph/dgraph --token $TOKEN --name $EC2_INSTANCE_NAME
+./config.sh --unattended --url https://github.com/dgraph/dgraph --token $TOKEN --name $EC2_INSTANCE_NAME
 # Delete token
 aws ssm delete-parameter --name $EC2_INSTANCE_NAME
 # Start GH Actions
-./svc.sh install
-./svc.sh start
+sudo ./svc.sh install
+sudo ./svc.sh start
 # Reboot Machine
-reboot
+sudo reboot
+EOF

--- a/contrib/gh-runner/install-deps.sh
+++ b/contrib/gh-runner/install-deps.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Machine Setup
+sudo apt-get update
+sudo apt-get -y upgrade
+sudo apt-get -y install \
+    ca-certificates \
+    curl \
+    unzip \
+    jq \
+    gnupg \
+    lsb-release \
+    build-essential #Libc Packages
+# Docker Setup
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+ echo \
+   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get -y update
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo apt-get -y install docker-compose
+#Add Docker to sudoers group
+sudo usermod -aG docker ${USER}
+newgrp docker &
+# CI Permission Issue
+sudo touch /etc/cron.d/ci_permissions_resetter
+sudo chown $USER:$USER /etc/cron.d/ci_permissions_resetter
+sudo echo "* * * * * root for i in {0..60}; do chown -R $USER:$USER /home/ubuntu/actions-runner/_work & sleep 1; done" >  /etc/cron.d/ci_permissions_resetter
+sudo chown root:root /etc/cron.d/ci_permissions_resetter
+# Increase file descriptor limit
+sudo sh -c 'echo "*         hard    nofile      2000000" >> /etc/security/limits.conf'
+sudo sh -c 'echo "*         soft    nofile      2000000" >> /etc/security/limits.conf'
+sudo sh -c 'echo "root      hard    nofile      2000000" >> /etc/security/limits.conf'
+sudo sh -c 'echo "root      soft    nofile      2000000" >> /etc/security/limits.conf'
+sudo sh -c 'echo "fs.nr_open = 2000000" >> /etc/sysctl.conf'
+# AWS CLI Setup
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+sudo ./aws/install


### PR DESCRIPTION
## Problem
Right now, setting up an ec2 instance to use as a self-hosted runner is still done manually.

## Solution
Use Packer to automate building the machine image, so that no additional configurations need to be done every single time.