### PR TITLE
fix(ci): gh-runner.sh refactored to account for ARM architecture

### DIFF
--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -40,6 +40,7 @@ elif [ "$(uname -m)" = "x86_64" ]; then
     tar xzf ./actions-runner-linux-x64-2.298.2.tar.gz
 else
     echo "Unrecognized architecture"
+    exit 1
 fi
 # Create the runner and start the configuration experience
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -24,32 +24,23 @@ newgrp docker &
 mkdir actions-runner && cd actions-runner
 if [ "$(uname -m)" = "aarch64" ]; then
     echo "Detected arm64 architecture"
-
     # Download the latest runner package
     curl -o actions-runner-linux-arm64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz
-
     # Optional: Validate the hash
     echo "803e4aba36484ef4f126df184220946bc151ae1bbaf2b606b6e2f2280f5042e8  actions-runner-linux-arm64-2.298.2.tar.gz" | shasum -a 256 -c
-
     # Extract the installer
     tar xzf ./actions-runner-linux-arm64-2.298.2.tar.gz
-    
 elif [ "$(uname -m)" = "x86_64" ]; then
     echo "Detected amd64 architecture"
-
     # Download the latest runner package
     curl -o actions-runner-linux-x64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz
-
     # Optional: Validate the hash
     echo "0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117  actions-runner-linux-x64-2.298.2.tar.gz" | shasum -a 256 -c 
-
     # Extract the installer
     tar xzf ./actions-runner-linux-x64-2.298.2.tar.gz
-
 else
     echo "Unrecognized architecture"
 fi
-
 # Create the runner and start the configuration experience
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
 # CI Permission Issue

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -22,6 +22,13 @@ sudo usermod -aG docker ${USER}
 newgrp docker &
 # Install & Setup GH Actions Runner
 mkdir actions-runner && cd actions-runner
+if [ "$(uname -m)" = "aarch64" ]; then
+    echo "Detected arm64 architecture"
+elif [ "$(uname -m)" = "x86_64" ]; then
+    echo "Detected amd64 architecture"
+else
+    echo "Unrecognized architecture"
+fi
 curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
 echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
 tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -38,10 +38,10 @@ elif [ "$(uname -m)" = "x86_64" ]; then
     echo "Detected amd64 architecture"
 
     # Download the latest runner package
-    curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
+    curl -o actions-runner-linux-x64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-x64-2.298.2.tar.gz
 
     # Optional: Validate the hash
-    echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c 
+    echo "0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117  actions-runner-linux-x64-2.298.2.tar.gz" | shasum -a 256 -c 
 
     # Extract the installer
     tar xzf ./actions-runner-linux-x64-2.298.2.tar.gz

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -24,14 +24,33 @@ newgrp docker &
 mkdir actions-runner && cd actions-runner
 if [ "$(uname -m)" = "aarch64" ]; then
     echo "Detected arm64 architecture"
+
+    # Download the latest runner package
+    curl -o actions-runner-linux-arm64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-linux-arm64-2.298.2.tar.gz
+
+    # Optional: Validate the hash
+    echo "803e4aba36484ef4f126df184220946bc151ae1bbaf2b606b6e2f2280f5042e8  actions-runner-linux-arm64-2.298.2.tar.gz" | shasum -a 256 -c
+
+    # Extract the installer
+    tar xzf ./actions-runner-linux-arm64-2.298.2.tar.gz
+    
 elif [ "$(uname -m)" = "x86_64" ]; then
     echo "Detected amd64 architecture"
+
+    # Download the latest runner package
+    curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
+
+    # Optional: Validate the hash
+    echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c 
+
+    # Extract the installer
+    tar xzf ./actions-runner-linux-x64-2.298.2.tar.gz
+
 else
     echo "Unrecognized architecture"
 fi
-curl -o actions-runner-linux-x64-2.296.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.296.2/actions-runner-linux-x64-2.296.2.tar.gz
-echo "34a8f34956cdacd2156d4c658cce8dd54c5aef316a16bbbc95eb3ca4fd76429a  actions-runner-linux-x64-2.296.2.tar.gz" | shasum -a 256 -c
-tar xzf ./actions-runner-linux-x64-2.296.2.tar.gz
+
+# Create the runner and start the configuration experience
 ./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
 # CI Permission Issue
 sudo touch /etc/cron.d/ci_permissions_resetter


### PR DESCRIPTION
## Problem
gh-runner.sh in contrib folder does not account for different installs in arm architecture

## Solution
Adding if condition checks to install the right .tar files in the existing runner script