### PR TITLE
fix(ci): add draft check in the workflow yaml

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
   schedule:

--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     name: trivy-tests
+    if: ! github.event.pull_request.draft
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   build:
     name: trivy-tests
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
   schedule:

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   dgraph-load-tests:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -10,6 +10,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   dgraph-load-tests:
+    if: ! github.event.pull_request.draft
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
   schedule:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -10,6 +10,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   dgraph-tests:
+    if: ! github.event.pull_request.draft
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   dgraph-tests:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
     branches:
       - main
   schedule:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -15,7 +15,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   golang-lint:
-    if: ! github.event.pull_request.draft
+    if: github.event.pull_request.draft == false
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -10,6 +10,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   golang-lint:
+    if: ! github.event.pull_request.draft
     name: lint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
Currently the tests runs on draft PR as well which is waste of resources.
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution

Add a `if: ! github.event.pull_request.draft` check to prevent GH runs on draft PRs. Reference: https://stackoverflow.com/questions/68349031/only-run-actions-on-non-draft-pull-request
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->