### PR TITLE
Aditya: create new ci pipeline for arm tests and test with gh-runner-arm64

### DIFF
--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -1,0 +1,77 @@
+name: ci-dgraph-tests
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+  schedule:
+    - cron: "0 * * * *"
+jobs:
+  dgraph-tests:
+    if: github.event.pull_request.draft == false
+    runs-on: [self-hosted, ARM64]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install protobuf-compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Check protobuf
+        run: |
+          cd ./protos
+          go mod tidy
+          make regenerate
+          git diff --exit-code -- .
+      - name: Make Docker Image
+        run: make image-local
+      - name: Make Linux Build
+        run: |
+          #!/bin/bash
+          # go settings
+          export GOOS=linux
+          export GOARCH=arm64
+          # make dgraph binary
+          make dgraph
+      - name: Clean Up Environment
+        run: |
+          #!/bin/bash
+          # clean cache
+          go clean -testcache
+          # build the test binary
+          cd t; go build .
+          # clean up docker containers before test execution
+          ./t -r
+      - name: Run Unit Tests
+        run: |
+          #!/bin/bash
+          # clean cache
+          go clean -testcache
+          # go env settings
+          export GOPATH=~/go
+          # move the binary
+          cp dgraph/dgraph ~/go/bin 
+          # build the test binary
+          cd t; go build .
+          # Trial: Singular test PKG
+          ./t --pkg=worker
+          # clean up docker containers after test execution
+          ./t -r
+          # sleep
+          sleep 5
+      - name: Install Goveralls
+        run: go install github.com/mattn/goveralls@latest
+      - name: Send Coverage Results
+        run: cd t && goveralls -repotoken ${{ secrets.COVERALLSIO_TOKEN }} -coverprofile=coverage.out

--- a/contrib/gh-runner/README.md
+++ b/contrib/gh-runner/README.md
@@ -8,7 +8,7 @@ export TOKEN=<GITHUB ACTIONS RUNNER TOKEN>
 ```
 2. Download the setup script onto the machine
 ```
-wget https://raw.githubusercontent.com/dgraph-io/dgraph/main/contrib/gh-runner/gh-runner.sh
+wget https://raw.githubusercontent.com/adityasadalage/dgraph/main/contrib/gh-runner/gh-runner.sh
 ```
 3. Run the script to attach this machine to Github Actions Runner Pool
 ```

--- a/contrib/gh-runner/gh-runner.sh
+++ b/contrib/gh-runner/gh-runner.sh
@@ -43,7 +43,7 @@ else
     exit 1
 fi
 # Create the runner and start the configuration experience
-./config.sh --url https://github.com/dgraph-io/dgraph --token $TOKEN
+./config.sh --url https://github.com/adityasadalage/dgraph --token $TOKEN
 # CI Permission Issue
 sudo touch /etc/cron.d/ci_permissions_resetter
 sudo chown $USER:$USER /etc/cron.d/ci_permissions_resetter


### PR DESCRIPTION
##Problem##
Old ci-dgraph-tests.yml pipeline will not pass for arm based changes in the code

##Solution##
Create new ci pipeline to check unit tests for arm binary. To enable further development