### PR TITLE
Artifact fix to directly get dgraph binary from tar

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -39,14 +39,14 @@ jobs:
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
       - name: Generate SHA for Linux Build
-        run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-linux-amd64.sha256
+        run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-amd64.sha256
       - name: Tar Archive for Linux Build
         run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph
       - name: Upload Dgraph Binary Build Artifacts
         uses: actions/upload-artifact@v3
         with:
           path: |
-            dgraph/dgraph-linux-amd64.sha256
+            dgraph/dgraph-checksum-linux-amd64.sha256
             dgraph/dgraph-linux-amd64.tar.gz
       - name: Make Dgraph Docker Image
         run: |

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -39,15 +39,15 @@ jobs:
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
       - name: Generate SHA for Linux Build
-        run: sha256sum dgraph/dgraph | cut -c-64 > dgraph/dgraph-linux-amd64.sha256
+        run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-linux-amd64.sha256 && mv dgraph-linux-amd64.sha256 ..
       - name: Tar Archive for Linux Build
-        run: tar -zcvf dgraph/dgraph-linux-amd64.tar.gz dgraph/dgraph
+        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph && mv dgraph-linux-amd64.tar.gz ..
       - name: Upload Dgraph Binary Build Artifacts
         uses: actions/upload-artifact@v3
         with:
           path: |
-            dgraph/dgraph-linux-amd64.sha256
-            dgraph/dgraph-linux-amd64.tar.gz
+            dgraph-linux-amd64.sha256
+            dgraph-linux-amd64.tar.gz
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -39,15 +39,15 @@ jobs:
       - name: Make Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
       - name: Generate SHA for Linux Build
-        run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-linux-amd64.sha256 && mv dgraph-linux-amd64.sha256 ..
+        run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-linux-amd64.sha256
       - name: Tar Archive for Linux Build
-        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph && mv dgraph-linux-amd64.tar.gz ..
+        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph
       - name: Upload Dgraph Binary Build Artifacts
         uses: actions/upload-artifact@v3
         with:
           path: |
-            dgraph-linux-amd64.sha256
-            dgraph-linux-amd64.tar.gz
+            dgraph/dgraph-linux-amd64.sha256
+            dgraph/dgraph-linux-amd64.tar.gz
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
fix(release): Current dgraph tar from Artifact has a folder (dgraph) with binary inside. We want the tar to directly return the binary when opened
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
Fix cd-dgraph.yml to point tar directly to dgraph binary
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->