### PR TITLE
chore(ci): fix breaking tests

### DIFF
--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -1,4 +1,4 @@
-name: ci-dgraph-load-tests-amd64
+name: ci-dgraph-load-tests
 on:
   push:
     branches:

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -1,4 +1,4 @@
-name: ci-dgraph-load-tests
+name: ci-dgraph-load-tests-amd64
 on:
   push:
     branches:
@@ -16,13 +16,18 @@ on:
 jobs:
   dgraph-load-tests:
     if: github.event.pull_request.draft == false
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64]
     steps:
       - uses: actions/checkout@v3
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.GOVERSION }}
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -1,4 +1,4 @@
-name: ci-dgraph-tests
+name: ci-dgraph-tests-amd64
 on:
   push:
     branches:
@@ -16,13 +16,18 @@ on:
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false
-    runs-on: self-hosted
+    runs-on: [self-hosted, x64]
     steps:
       - uses: actions/checkout@v3
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ env.GOVERSION }}
       - name: Set up Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -1,4 +1,4 @@
-name: ci-dgraph-tests-amd64
+name: ci-dgraph-tests
 on:
   push:
     branches:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action@latest
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -33,7 +33,7 @@ jobs:
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -33,9 +33,9 @@ jobs:
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@latest
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: latest
           only-new-issues: true
           args: --timeout=10m

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -19,15 +19,23 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Get Go Version
+        run: |
+          #!/bin/bash
+          GOVERSION=$({ [ -f .go-version ] && cat .go-version; })
+          echo "GOVERSION=$GOVERSION" >> $GITHUB_ENV
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GOVERSION }}
       - name: golang-lint
         env:
           # prevent OOM
           GOGC: 10
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.36
+          version: v1.48
           only-new-issues: true
           args: --timeout=10m
-          skip-go-installation: true


### PR DESCRIPTION
## Problem

Since we added arm64 runners, they are being picked up by our workflows.  Tests are failing after about 1 minute with exec format error (due to documented Badger/Ristretto issue).  

For more info on runner labels [see here.](https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow#using-default-labels-to-route-jobs)

## Solution

We modify workflows to only pickup amd runners.  We also pin the Go version.