### PR TITLE
fix(chore): add the word "dev" to the version to avoid breaking the local test

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -148,12 +148,12 @@ func GetGQLSchema(namespace uint64) (uid, graphQLSchema string, err error) {
 	resp, err := (&Server{}).Query(ctx,
 		&api.Request{
 			Query: `
-			query {
-			  ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
-				uid
-				dgraph.graphql.schema
-			  }
-			}`})
+			 query {
+			   ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
+				 uid
+				 dgraph.graphql.schema
+			   }
+			 }`})
 	if err != nil {
 		return "", "", err
 	}
@@ -719,7 +719,7 @@ func buildUpsertQuery(qc *queryContext) string {
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
 			upsertQuery += qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
-			 `
+			  `
 		}
 	}
 	upsertQuery += `}`
@@ -887,8 +887,8 @@ func updateValInMutations(gmu *gql.Mutation, qc *queryContext) error {
 }
 
 // updateUIDInMutations does following transformations:
-//   * uid(v) -> 0x123     -- If v is defined in query block
-//   * uid(v) -> _:uid(v)  -- Otherwise
+//   - uid(v) -> 0x123     -- If v is defined in query block
+//   - uid(v) -> _:uid(v)  -- Otherwise
 func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) error {
 	// usedMutationVars keeps track of variables that are used in mutations.
 	getNewVals := func(s string) []string {
@@ -1035,13 +1035,19 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 		}
 	}
 
+	var Version = x.Version()
+
+	if Version == "" {
+		Version = "dev"
+	}
+
 	// Append self.
 	healthAll = append(healthAll, pb.HealthInfo{
 		Instance:    "alpha",
 		Address:     x.WorkerConfig.MyAddr,
 		Status:      "healthy",
 		Group:       strconv.Itoa(int(worker.GroupId())),
-		Version:     x.Version(),
+		Version:     Version,
 		Uptime:      int64(time.Since(x.WorkerConfig.StartTime) / time.Second),
 		LastEcho:    time.Now().Unix(),
 		Ongoing:     worker.GetOngoingTasks(),
@@ -1616,9 +1622,9 @@ func (s *Server) CheckVersion(ctx context.Context, c *api.Check) (v *api.Version
 	return v, nil
 }
 
-//-------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 // HELPER FUNCTIONS
-//-------------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------------
 func isMutationAllowed(ctx context.Context) bool {
 	if worker.Config.MutationsMode != worker.DisallowMutations {
 		return true

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -150,10 +150,10 @@ func GetGQLSchema(namespace uint64) (uid, graphQLSchema string, err error) {
 			Query: `
 			query {
 				ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
-				  uid
-				  dgraph.graphql.schema
-				}
-			  }`})
+					uid
+					dgraph.graphql.schema
+				  }
+				}`})
 	if err != nil {
 		return "", "", err
 	}
@@ -719,7 +719,7 @@ func buildUpsertQuery(qc *queryContext) string {
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
 			upsertQuery += qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
-			`
+			 `
 		}
 	}
 	upsertQuery += `}`

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -148,12 +148,12 @@ func GetGQLSchema(namespace uint64) (uid, graphQLSchema string, err error) {
 	resp, err := (&Server{}).Query(ctx,
 		&api.Request{
 			Query: `
-			 query {
-			   ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
-				 uid
-				 dgraph.graphql.schema
-			   }
-			 }`})
+			query {
+				ExistingGQLSchema(func: has(dgraph.graphql.schema)) {
+				  uid
+				  dgraph.graphql.schema
+				}
+			  }`})
 	if err != nil {
 		return "", "", err
 	}
@@ -719,7 +719,7 @@ func buildUpsertQuery(qc *queryContext) string {
 			//      * be empty if the condition is true
 			//      * have 1 UID (the 0 UID) if the condition is false
 			upsertQuery += qc.condVars[i] + ` as var(func: uid(0)) ` + cond + `
-			  `
+			`
 		}
 	}
 	upsertQuery += `}`
@@ -887,8 +887,8 @@ func updateValInMutations(gmu *gql.Mutation, qc *queryContext) error {
 }
 
 // updateUIDInMutations does following transformations:
-//   - uid(v) -> 0x123     -- If v is defined in query block
-//   - uid(v) -> _:uid(v)  -- Otherwise
+//   * uid(v) -> 0x123     -- If v is defined in query block
+//   * uid(v) -> _:uid(v)  -- Otherwise
 func updateUIDInMutations(gmu *gql.Mutation, qc *queryContext) error {
 	// usedMutationVars keeps track of variables that are used in mutations.
 	getNewVals := func(s string) []string {
@@ -1622,9 +1622,9 @@ func (s *Server) CheckVersion(ctx context.Context, c *api.Check) (v *api.Version
 	return v, nil
 }
 
-// -------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
 // HELPER FUNCTIONS
-// -------------------------------------------------------------------------------------------------
+//-------------------------------------------------------------------------------------------------
 func isMutationAllowed(ctx context.Context) bool {
 	if worker.Config.MutationsMode != worker.DisallowMutations {
 		return true

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1035,19 +1035,13 @@ func (s *Server) Health(ctx context.Context, all bool) (*api.Response, error) {
 		}
 	}
 
-	var Version = x.Version()
-
-	if Version == "" {
-		Version = "dev"
-	}
-
 	// Append self.
 	healthAll = append(healthAll, pb.HealthInfo{
 		Instance:    "alpha",
 		Address:     x.WorkerConfig.MyAddr,
 		Status:      "healthy",
 		Group:       strconv.Itoa(int(worker.GroupId())),
-		Version:     Version,
+		Version:     x.Version(),
 		Uptime:      int64(time.Since(x.WorkerConfig.StartTime) / time.Second),
 		LastEcho:    time.Now().Unix(),
 		Ongoing:     worker.GetOngoingTasks(),

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -96,7 +96,7 @@ func (t *Telemetry) Post() error {
 	}
 
 	var requestURL string
-	if len(t.Version) > 0 {
+	if t.Version != "dev" {
 		requestURL = url + "/pings"
 	} else {
 		requestURL = url + "/dev"

--- a/x/init.go
+++ b/x/init.go
@@ -65,6 +65,10 @@ func Init() {
 	// TODO: why is this here?
 	// Config.QueryEdgeLimit = 1e6
 
+	if dgraphVersion == "" {
+		dgraphVersion = "dev"
+	}
+
 	// Next, run all the init functions that have been added.
 	for _, f := range initFunc {
 		f()

--- a/x/init.go
+++ b/x/init.go
@@ -46,6 +46,13 @@ func SetTestRun() {
 	isTest = true
 }
 
+// check if any version is set by ldflags. If not so, it should be set as "dev"
+func checkDev() {
+	if dgraphVersion == "" {
+		dgraphVersion = "dev"
+	}
+}
+
 // IsTestRun indicates whether a test is being executed. Useful to handle special
 // conditions during tests that differ from normal execution.
 func IsTestRun() bool {
@@ -65,9 +72,7 @@ func Init() {
 	// TODO: why is this here?
 	// Config.QueryEdgeLimit = 1e6
 
-	if dgraphVersion == "" {
-		dgraphVersion = "dev"
-	}
+	checkDev()
 
 	// Next, run all the init functions that have been added.
 	for _, f := range initFunc {
@@ -116,6 +121,7 @@ func PrintVersion() {
 
 // Version returns a string containing the dgraphVersion.
 func Version() string {
+	checkDev()
 	return dgraphVersion
 }
 


### PR DESCRIPTION
## Problem

When you debug locally, without going through the build process. Dgraph doesn't set a default version. It returns empty. And that breaks Ratel and possibly some test that depends on the version information.

## Solution
 
 Check for missing version and put "dev" in place if it returns null.