### PR TITLE
Fix(lsbackup): Fix profiler in lsBackup (#7729)

### DIFF
--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -1,4 +1,3 @@
-//go:build !oss
 // +build !oss
 
 /*

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -41,9 +41,6 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Restore is the sub-command used to restore a backup.
-var Restore x.SubCommand
-
 // LsBackup is the sub-command used to list the backups in a folder.
 var LsBackup x.SubCommand
 
@@ -162,7 +159,7 @@ func initBackupLs() {
 		Short: "List info on backups in a given location",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			defer x.StartProfile(Restore.Conf).Stop()
+			defer x.StartProfile(LsBackup.Conf).Stop()
 			if err := runLsbackupCmd(); err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -40,6 +41,10 @@ import (
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
 )
+
+// Restore is the sub-command used to restore a backup.
+
+var Restore x.SubCommand
 
 // LsBackup is the sub-command used to list the backups in a folder.
 var LsBackup x.SubCommand

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -42,7 +42,6 @@ import (
 )
 
 // Restore is the sub-command used to restore a backup.
-
 var Restore x.SubCommand
 
 // LsBackup is the sub-command used to list the backups in a folder.


### PR DESCRIPTION
cherry pick from #7729

## Problem
wrong config set for profiler (set to Restore instead of Backup)<!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
set profiler to Backup.conf
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->