### PR TITLE
chore(ci): fix arm workflows + minor CI cleanup

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Build Docker image
         run: |
-          make image-local
+          make docker-image
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -40,38 +40,29 @@ jobs:
           go mod tidy
           make regenerate
           git diff --exit-code -- .
-      - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
+      - name: Make Linux Build and Docker Image
+        run: make docker-image # this internally builds dgraph binary
+      - name: Build Test Binary
         run: |
           #!/bin/bash
-          # go settings
-          export GOOS=linux
-          export GOARCH=amd64
-          # make dgraph binary
-          make dgraph
+          # build the test binary
+          cd t; go build .
       - name: Clean Up Environment
         run: |
           #!/bin/bash
           # clean cache
           go clean -testcache
-          # build the test binary
-          cd t; go build .
           # clean up docker containers before test execution
-          ./t -r
+          cd t; ./t -r
       - name: Run Load Tests
         run: |
           #!/bin/bash
-          # clean cache
-          go clean -testcache
           # go env settings
           export GOPATH=~/go
           # move the binary
-          cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
+          cp dgraph/dgraph ~/go/bin/dgraph
           # run the load tests
-          ./t --suite=load
+          cd t; ./t --suite=load
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -57,7 +57,7 @@ jobs:
           # go env settings
           export GOPATH=~/go
           # move the binary
-          cp dgraph/dgraph ~/go/bin 
+          cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
           cd t
           ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -42,15 +42,18 @@ jobs:
           git diff --exit-code -- .
       - name: Make Linux Build and Docker Image
         run: make docker-image # this internally builds dgraph binary
+      - name: Build Test Binary
+        run: |
+          #!/bin/bash
+          # build the test binary
+          cd t; go build .
       - name: Clean Up Environment
         run: |
           #!/bin/bash
           # clean cache
           go clean -testcache
-          # build the test binary
-          cd t; go build .
           # clean up docker containers before test execution
-          ./t -r
+          cd t; ./t -r
       - name: Run Unit Tests
         run: |
           #!/bin/bash
@@ -59,8 +62,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t
-          ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
+          cd t; ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -69,7 +69,7 @@ jobs:
           # build the test binary
           cd t; go build .
           # run the tests
-          ./t --skip="systest/export,systest/backup/minio,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
+          ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -59,6 +59,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin 
           # run the tests
+          cd t
           ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
           # clean up docker containers after test execution
           ./t -r

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -40,8 +40,8 @@ jobs:
           go mod tidy
           make regenerate
           git diff --exit-code -- .
-      - name: Make Docker Image
-        run: make docker-image
+      - name: Make Linux Build and Docker Image
+        run: make docker-image # this internally builds dgraph binary
       - name: Clean Up Environment
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -69,7 +69,7 @@ jobs:
           # build the test binary
           cd t; go build .
           # run the tests
-          ./t --skip systest, graphql
+          ./t --skip="systest/export,systest/backup/minio,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -41,13 +41,7 @@ jobs:
           make regenerate
           git diff --exit-code -- .
       - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
-        run: |
-          #!/bin/bash
-          # go settings
-          # make dgraph binary
-          make dgraph
+        run: make docker-image
       - name: Clean Up Environment
         run: |
           #!/bin/bash
@@ -60,14 +54,10 @@ jobs:
       - name: Run Unit Tests
         run: |
           #!/bin/bash
-          # clean cache
-          go clean -testcache
           # go env settings
           export GOPATH=~/go
           # move the binary
           cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
           # run the tests
           ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
           # clean up docker containers after test execution

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -69,7 +69,7 @@ jobs:
           # build the test binary
           cd t; go build .
           # run the tests
-          ./t --skip systest/export, graphql
+          ./t --skip systest, graphql
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -40,36 +40,29 @@ jobs:
           go mod tidy
           make regenerate
           git diff --exit-code -- .
-      - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
+      - name: Make Linux Build and Docker Image
+        run: make docker-image # this internally builds dgraph binary
+      - name: Build Test Binary
         run: |
           #!/bin/bash
-          # go settings
-          # make dgraph binary
-          make dgraph
+          # build the test binary
+          cd t; go build .
       - name: Clean Up Environment
         run: |
           #!/bin/bash
           # clean cache
           go clean -testcache
-          # build the test binary
-          cd t; go build .
           # clean up docker containers before test execution
-          ./t -r
+          cd t; ./t -r
       - name: Run Unit Tests
         run: |
           #!/bin/bash
-          # clean cache
-          go clean -testcache
           # go env settings
           export GOPATH=~/go
           # move the binary
-          cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
+          cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          ./t --coverage=true
+          cd t; ./t --coverage=true
           # clean up docker containers after test execution
           ./t -r
           # sleep


### PR DESCRIPTION
## Problem

Arm tests were failing because skip list was not being parsed correctly by t.go.  We also perform some cleanup on the CI workflows (there was some redundancy in CI scripts).

## Solution

We pass 
```
./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
```

as an argument to t.go.  Failures in these packages are related to minio and lambda which we will work on resolving.  We also do some cleanup on the workflow file.
