### PR TITLE
chore(ci): avoid mounting dgraph binary for tests

### DIFF
--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -41,15 +41,7 @@ jobs:
           make regenerate
           git diff --exit-code -- .
       - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
-        run: |
-          #!/bin/bash
-          # go settings
-          export GOOS=linux
-          export GOARCH=amd64
-          # make dgraph binary
-          make dgraph
+        run: make docker-image
       - name: Clean Up Environment
         run: |
           #!/bin/bash
@@ -62,14 +54,8 @@ jobs:
       - name: Run Load Tests
         run: |
           #!/bin/bash
-          # clean cache
-          go clean -testcache
           # go env settings
           export GOPATH=~/go
-          # move the binary
-          cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
           # run the load tests
           ./t --suite=load
           # clean up docker containers after test execution

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -57,6 +57,7 @@ jobs:
           # go env settings
           export GOPATH=~/go
           # run the load tests
+          cd t
           ./t --suite=load
           # clean up docker containers after test execution
           ./t -r

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -57,6 +57,7 @@ jobs:
           # go env settings
           export GOPATH=~/go
           # run the tests
+          cd t
           ./t --coverage=true
           # clean up docker containers after test execution
           ./t -r

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -41,13 +41,7 @@ jobs:
           make regenerate
           git diff --exit-code -- .
       - name: Make Docker Image
-        run: make image-local
-      - name: Make Linux Build
-        run: |
-          #!/bin/bash
-          # go settings
-          # make dgraph binary
-          make dgraph
+        run: make docker-image
       - name: Clean Up Environment
         run: |
           #!/bin/bash
@@ -60,14 +54,8 @@ jobs:
       - name: Run Unit Tests
         run: |
           #!/bin/bash
-          # clean cache
-          go clean -testcache
           # go env settings
           export GOPATH=~/go
-          # move the binary
-          cp dgraph/dgraph ~/go/bin 
-          # build the test binary
-          cd t; go build .
           # run the tests
           ./t --coverage=true
           # clean up docker containers after test execution

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -203,7 +203,7 @@ func initService(basename string, idx, grpcPort int) service {
 
 	svc.Command = "dgraph"
 	if opts.LocalBin {
-		svc.Command = "/gobin/dgraph"
+		svc.Command = "dgraph"
 	}
 	if opts.UserOwnership {
 		user, err := user.Current()

--- a/contrib/config/datadog/docker-compose.yml
+++ b/contrib/config/datadog/docker-compose.yml
@@ -9,12 +9,7 @@ services:
     ports:
     - 8180:8180
     - 9180:9180
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   zero1:
     image: dgraph/dgraph:latest
@@ -25,12 +20,7 @@ services:
     ports:
     - 5080:5080
     - 6080:6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
+    command: dgraph zero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   datadog:
     image: datadog/agent:latest

--- a/contrib/embargo/embargo.yml
+++ b/contrib/embargo/embargo.yml
@@ -17,7 +17,7 @@ containers:
     expose:
       - 5080
       - 6080
-    command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
+    command: dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
 
   zero2:
     image: dgraph/dgraph:latest
@@ -29,7 +29,7 @@ containers:
     expose:
       - 5082
       - 6082
-    command: /gobin/dgraph zero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
+    command: dgraph zero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
 
   zero3:
     image: dgraph/dgraph:latest
@@ -41,7 +41,7 @@ containers:
     expose:
       - 5083
       - 6083
-    command: /gobin/dgraph zero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
+    command: dgraph zero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
 
   dg1:
     image: dgraph/dgraph:latest
@@ -53,7 +53,7 @@ containers:
     expose:
       - 8180
       - 9180
-    command: /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
+    command: dgraph alpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
 
   dg2:
@@ -67,7 +67,7 @@ containers:
       - 8182
       - 9182
     start_delay: 8
-    command: /gobin/dgraph alpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
+    command: dgraph alpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
 
   dg3:
@@ -81,7 +81,7 @@ containers:
       - 8183
       - 9183
     start_delay: 16
-    command: /gobin/dgraph alpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
+    command: dgraph alpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
 
 network:

--- a/contrib/embargo/embargo.yml
+++ b/contrib/embargo/embargo.yml
@@ -18,10 +18,6 @@ containers:
       - 5080
       - 6080
     command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
-    volumes:
-      # Note: Any environment variables must use the ${} syntax.
-      # ${GOPATH} works, $GOPATH does not.
-      "${GOPATH}/bin": "/gobin"
 
   zero2:
     image: dgraph/dgraph:latest
@@ -34,8 +30,6 @@ containers:
       - 5082
       - 6082
     command: /gobin/dgraph zero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
-    volumes:
-      "${GOPATH}/bin": "/gobin"
 
   zero3:
     image: dgraph/dgraph:latest
@@ -48,8 +42,6 @@ containers:
       - 5083
       - 6083
     command: /gobin/dgraph zero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
-    volumes:
-      "${GOPATH}/bin": "/gobin"
 
   dg1:
     image: dgraph/dgraph:latest
@@ -63,8 +55,6 @@ containers:
       - 9180
     command: /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
-    volumes:
-      "${GOPATH}/bin": "/gobin"
 
   dg2:
     image: dgraph/dgraph:latest
@@ -79,8 +69,6 @@ containers:
     start_delay: 8
     command: /gobin/dgraph alpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
-    volumes:
-      "${GOPATH}/bin": "/gobin"
 
   dg3:
     image: dgraph/dgraph:latest
@@ -95,8 +83,6 @@ containers:
     start_delay: 16
     command: /gobin/dgraph alpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
-    volumes:
-      "${GOPATH}/bin": "/gobin"
 
 network:
   driver: "udn"

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -117,7 +117,7 @@ var (
 		"Interval of Dgraph's tablet rebalancing.")
 	nemesisInterval = pflag.String("nemesis-interval", "10",
 		"Roughly how long to wait (in seconds) between nemesis operations.")
-	localBinary = pflag.StringP("local-binary", "b", "/gobin/dgraph",
+	localBinary = pflag.StringP("local-binary", "b", "dgraph",
 		"Path to Dgraph binary within the Jepsen control node.")
 	nodes     = pflag.String("nodes", "n1,n2,n3,n4,n5", "Nodes to run on.")
 	replicas  = pflag.Int("replicas", 3, "How many replicas of data should dgraph store?")

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -11,12 +11,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=disallow;"
@@ -28,12 +23,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -45,12 +35,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -62,12 +47,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -79,12 +59,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -96,11 +71,6 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
 volumes: {}

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -9,12 +9,7 @@ services:
     labels:
       cluster: test
       service: zero
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   zero2:
     image: dgraph/dgraph:local
@@ -27,12 +22,7 @@ services:
     labels:
       cluster: test
       service: zero
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
+    command: dgraph zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
 
   zero3:
     image: dgraph/dgraph:local
@@ -45,21 +35,12 @@ services:
     labels:
       cluster: test
       service: zero
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
+    command: dgraph zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
@@ -74,7 +55,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -85,10 +66,6 @@ services:
       - alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
@@ -102,7 +79,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -113,10 +90,6 @@ services:
       - alpha2
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
@@ -130,7 +103,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -141,10 +114,6 @@ services:
       - alpha3
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
@@ -158,7 +127,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -169,10 +138,6 @@ services:
       - alpha4
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
@@ -186,7 +151,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -197,10 +162,6 @@ services:
       - alpha5
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
@@ -214,7 +175,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -9,27 +9,17 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -9,21 +9,12 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../../../../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
@@ -34,7 +25,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" 
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -9,27 +9,17 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -9,28 +9,18 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "debug=true;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -9,28 +9,18 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
+    command: dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --graphql "debug=true;" 
       --trace "ratio=1.0;"

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -26,12 +21,7 @@ services:
     ports:
     - 5080
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   mock:
     build:

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -9,28 +9,18 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace
+    command: dgraph alpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -35,14 +31,10 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -58,14 +50,10 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -77,11 +65,6 @@ services:
     ports:
     - 5080
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -9,28 +9,18 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
     working_dir: /data/alpha1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     ports:
       - 8080
       - 9080
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace
+    command: dgraph alpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -14,12 +14,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -36,12 +31,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -58,12 +48,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -74,11 +59,6 @@ services:
     ports:
     - 5080
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -28,12 +23,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -46,12 +36,7 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -62,11 +47,6 @@ services:
     ports:
     - 580
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -17,14 +17,10 @@ services:
     - 9180:9180
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./p
       target: /data/alpha1/p
       read_only: false
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+    command: dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -40,12 +36,7 @@ services:
     ports:
     - 5180:5180
     - 6180:6180
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
+    command: dgraph zero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
       --bindall
 volumes: {}
 

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -9,12 +9,7 @@ services:
     ports:
     - 8180:8180
     - 9180:9180
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
+    command: dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
       --trace "jaeger=http://ocagent:14268;"
   zero1:
     image: dgraph/dgraph:local
@@ -25,12 +20,7 @@ services:
     ports:
     - 5180:5180
     - 6180:6180
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
+    command: dgraph zero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://ocagent:14268;"
   ocagent:
     image: omnition/opencensus-agent:0.1.6

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -10,13 +10,9 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ./out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/1million/docker-compose.yml
+++ b/systest/1million/docker-compose.yml
@@ -9,15 +9,11 @@ services:
     - "5080"
     - "6080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph zero --raft="idx=1" --my=zero1:5080 --logtostderr
+    command: dgraph zero --raft="idx=1" --my=zero1:5080 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/21million/bulk/alpha.yml
+++ b/systest/21million/bulk/alpha.yml
@@ -10,13 +10,9 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ./out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/21million/bulk/docker-compose.yml
+++ b/systest/21million/bulk/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph zero --raft="idx=1" --my=zero1:5080 --logtostderr
+    command: dgraph zero --raft="idx=1" --my=zero1:5080 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/21million/live/docker-compose.yml
+++ b/systest/21million/live/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=0.0.0.0/0;"
   zero1:
@@ -26,10 +21,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr
       -v=2 --bindall

--- a/systest/21million/ludicrous/docker-compose.yml
+++ b/systest/21million/ludicrous/docker-compose.yml
@@ -10,11 +10,6 @@ services:
     ports:
     - 8080
     - 9080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -27,9 +22,4 @@ services:
     ports:
     - 5080
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/systest/21million/ludicrous/docker-compose.yml
+++ b/systest/21million/ludicrous/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --ludicrous "enabled=true;"
@@ -32,4 +32,4 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1; group=1" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
     deploy:
@@ -41,7 +41,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr
+    command: dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr
       -v=2 --bindall
     deploy:
       resources:

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - type: bind
         source: ./audit_dir/aa
         target: /audit_dir
-    command: /gobin/dgraph alpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
       --logtostderr --audit "output=/audit_dir;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -33,6 +33,6 @@ services:
       - type: bind
         source: ./audit_dir/za
         target: /audit_dir
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --audit "output=/audit_dir;"
 volumes: {}

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -49,7 +49,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -75,7 +75,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -95,7 +95,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:latest

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -12,10 +12,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./data/backups
       target: /data/backups/
       read_only: false
@@ -23,7 +19,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -36,10 +32,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./data/backups
       target: /data/backups/
       read_only: false
@@ -47,7 +39,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -60,10 +52,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./data/backups
       target: /data/backups/
       read_only: false
@@ -71,7 +59,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -84,10 +72,6 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./data/backups
       target: /data/backups/
       read_only: false
@@ -95,6 +79,6 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -14,14 +14,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -36,14 +32,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -58,14 +50,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   minio:
@@ -85,13 +73,9 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -14,14 +14,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -36,14 +32,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -58,14 +50,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -78,14 +66,10 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:RELEASE.2020-11-13T20-10-18Z

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -12,10 +12,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
@@ -23,7 +19,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=1; group=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -37,10 +33,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
@@ -48,7 +40,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=2; group=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -62,10 +54,6 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
@@ -73,7 +61,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=3; group=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -87,13 +75,9 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/secret/hmac;"
@@ -31,10 +27,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/bulk_live/bulk/alpha.yml
+++ b/systest/bulk_live/bulk/alpha.yml
@@ -17,5 +17,5 @@ services:
         source: ./data/out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 -p=/posting
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 -p=/posting
       --security "whitelist=0.0.0.0/0;"

--- a/systest/bulk_live/bulk/alpha_acl.yml
+++ b/systest/bulk_live/bulk/alpha_acl.yml
@@ -10,10 +10,6 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ./data/out/0/p
         target: /posting
         read_only: false
@@ -21,5 +17,5 @@ services:
         source: ../../../ee/acl/hmac-secret
         target: /dgraph-acl/hmac-secret
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 -p=/posting
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 -p=/posting
       --security "whitelist=0.0.0.0/0;" --acl "secret-file=/dgraph-acl/hmac-secret; "

--- a/systest/bulk_live/bulk/docker-compose.yml
+++ b/systest/bulk_live/bulk/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2
+    command: dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2
       --bindall
     deploy:
       resources:

--- a/systest/bulk_live/live/docker-compose.yml
+++ b/systest/bulk_live/live/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft='idx=1; group=1;' 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
     deploy:
@@ -45,7 +45,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2
+    command: dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2
       --bindall
     deploy:
       resources:

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ./cdc_logs
         target: /cdc
     command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
@@ -27,10 +23,5 @@ services:
     ports:
       - "5080"
       - "6080"
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     command: dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - type: bind
         source: ./cdc_logs
         target: /cdc
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --cdc "file=/cdc;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -32,5 +32,5 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -13,15 +13,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -35,15 +31,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -57,15 +49,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   minio:
@@ -83,12 +71,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=3 --logtostderr
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=3 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=1"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -26,12 +21,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=2"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -42,12 +32,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=3"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -58,11 +43,6 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -26,10 +21,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -11,11 +11,6 @@ services:
       - 6180:6180
     labels:
       cluster: test
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
     command: dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   dg1:
@@ -23,10 +18,6 @@ services:
     container_name: bank-dg1
     working_dir: /data/dg1
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: volume
         source: data
         target: /data/dg1

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
+    command: dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   dg1:
     image: dgraph/dgraph:local
@@ -36,7 +36,7 @@ services:
     labels:
       cluster: test
     command: >
-      /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5180 -o 100 --logtostderr
+      dgraph alpha --my=dg1:7180 --zero=zero1:5180 -o 100 --logtostderr
                           --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
 
 volumes:

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
@@ -32,13 +28,9 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/ludicrous/docker-compose.yml
+++ b/systest/ludicrous/docker-compose.yml
@@ -11,15 +11,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -31,15 +27,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -51,15 +43,11 @@ services:
     - "8080"
     - "9080"
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: volume
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -70,12 +58,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1" --my=zero1:5080 --replicas=1 --logtostderr
+    command: dgraph zero --raft="idx=1" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
@@ -64,7 +64,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
@@ -99,7 +99,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
@@ -134,7 +134,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha4
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha4:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha4:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=4;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha4.crt; client-key=/dgraph-tls/client.alpha4.key;"
@@ -169,7 +169,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha5
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha5:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha5:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=5;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha5.crt; client-key=/dgraph-tls/client.alpha5.key;"
@@ -204,7 +204,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha6
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha6:7080 --zero=zero1:5080
+    command: dgraph alpha --my=alpha6:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=6;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha6.crt; client-key=/dgraph-tls/client.alpha6.key;"
@@ -225,7 +225,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes:
   backup: {}

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -10,10 +10,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./keys
       target: /data/keys
       read_only: true
@@ -44,10 +40,6 @@ services:
     - 8080
     - 9080
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: bind
       source: ./backup
       target: /data/backup2
@@ -80,10 +72,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./keys
       target: /data/keys
       read_only: true
@@ -114,10 +102,6 @@ services:
     - 8080
     - 9080
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: bind
       source: ./keys
       target: /data/keys
@@ -150,10 +134,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./keys
       target: /data/keys
       read_only: true
@@ -185,10 +165,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ./keys
       target: /data/keys
       read_only: true
@@ -217,10 +193,6 @@ services:
     - 5080
     - 6080
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: bind
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -12,10 +12,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../testutil/custom_plugins
       target: /plugins
       read_only: true
@@ -31,11 +27,6 @@ services:
     ports:
     - 5080
     - 6080
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
       --bindall
 volumes: {}

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../testutil/custom_plugins
       target: /plugins
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --custom_tokenizers=/plugins/0.so,/plugins/1.so,/plugins/2.so,/plugins/3.so
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -36,6 +36,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
       --bindall
 volumes: {}

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -10,10 +10,6 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
@@ -34,10 +30,6 @@ services:
     - 5080
     - 6080
     volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
     - type: bind
       source: ../mtls_internal/tls/zero1
       target: /dgraph-tls

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --acl "secret-file=/dgraph-acl/hmac-secret;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key; client-auth-type=VERIFYIFGIVEN;"
@@ -42,6 +42,6 @@ services:
       source: ../mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUEST; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -30,10 +26,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUIREANDVERIFY; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -30,10 +26,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -12,14 +12,10 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=VERIFYIFGIVEN; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -30,10 +26,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -37,7 +37,7 @@ services:
         source: ../tls/alpha2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -57,7 +57,7 @@ services:
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -77,7 +77,7 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --replicas 3 --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --replicas 3 --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   zero2:
     image: dgraph/dgraph:local
@@ -96,7 +96,7 @@ services:
         source: ../tls/zero2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=2;" --replicas 3 --my=zero2:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
+    command: dgraph zero --raft "idx=2;" --replicas 3 --my=zero2:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero2.crt; client-key=/dgraph-tls/client.zero2.key;"
   zero3:
     image: dgraph/dgraph:local
@@ -115,6 +115,6 @@ services:
         source: ../tls/zero3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=3;" --replicas 3 --my=zero3:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
+    command: dgraph zero --raft "idx=3;" --replicas 3 --my=zero3:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero3.crt; client-key=/dgraph-tls/client.zero3.key;"
 volumes: {}

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
@@ -29,10 +25,6 @@ services:
       - 8080
       - 9080
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../tls/alpha2
         target: /dgraph-tls
@@ -50,10 +42,6 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
@@ -70,10 +58,6 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
@@ -89,10 +73,6 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/zero2
         target: /dgraph-tls
         read_only: true
@@ -107,10 +87,6 @@ services:
       - 5080
       - 6080
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../tls/zero3
         target: /dgraph-tls

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -37,7 +37,7 @@ services:
         source: ../tls/alpha2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -57,7 +57,7 @@ services:
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -77,6 +77,6 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
@@ -29,10 +25,6 @@ services:
       - 8080
       - 9080
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../tls/alpha2
         target: /dgraph-tls
@@ -50,10 +42,6 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
@@ -69,10 +57,6 @@ services:
       - 5080
       - 6080
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../tls/zero1
         target: /dgraph-tls

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -10,10 +10,6 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-      - type: bind
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
@@ -29,10 +25,6 @@ services:
       - 5080
       - 6080
     volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
       - type: bind
         source: ../tls/zero1
         target: /dgraph-tls

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
@@ -37,6 +37,6 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:local
@@ -27,13 +22,9 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    - type: bind
       source: ../../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
 volumes: {}

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:local
@@ -25,10 +20,5 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -10,12 +10,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -26,12 +21,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -42,12 +32,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
@@ -58,12 +43,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
@@ -74,12 +54,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
@@ -90,12 +65,7 @@ services:
     ports:
     - "8080"
     - "9080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
+    command: dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   jaeger:
@@ -116,12 +86,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
+    command: dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
       --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -133,12 +98,7 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
+    command: dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
       --my=zero2:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -150,11 +110,6 @@ services:
     ports:
     - "5080"
     - "6080"
-    volumes:
-    - type: bind
-      source: $GOPATH/bin
-      target: /gobin
-      read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
+    command: dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
       --my=zero3:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
 volumes: {}


### PR DESCRIPTION
## Problem

Currently our test suite make a local docker image to run tests against.  However each cluster creates a bind mount in which we need to place a dgraph binary.  This is unnatural and not how clients are expected to use our Docker image.

## Solution

This change reflects how clients actually use our Docker images.