### PR TITLE
fix(sort): Only filter out nodes with positive offsets. (#8077)

### DIFF
--- a/query/common_test.go
+++ b/query/common_test.go
@@ -494,11 +494,6 @@ func populateCluster() {
 		<10006> <age> "25" .
 		<10007> <age> "25" .
 
-		<40> <age2> "10" .
-		<41> <age2> "20" .
-
-		<40> <name2> "Alice" .
-
 		<1> <alive> "true" .
 		<23> <alive> "true" .
 		<25> <alive> "false" .
@@ -866,6 +861,9 @@ func populateCluster() {
 		<61> <tweet-d> "aaabxxx" .
 		<62> <tweet-d> "aaacdxx" .
 		<63> <tweet-d> "aaabcd" .
+
+		<40> <name2> "Alice" .
+		<41> <age2> "20" .
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -209,6 +209,12 @@ func addGeoMultiPolygonToCluster(uid uint64, polygons [][][][]float64) error {
 }
 
 const testSchema = `
+type Person2 {
+	name2
+	age2
+	friend2
+}
+
 type Person {
 	name
 	pet
@@ -332,6 +338,8 @@ tweet-a                        : string @index(trigram) .
 tweet-b                        : string @index(term) .
 tweet-c                        : string @index(fulltext) .
 tweet-d                        : string @index(trigram) .
+name2                          : string @index(term)  .
+age2                           : int @index(int) .
 `
 
 func populateCluster() {
@@ -487,8 +495,12 @@ func populateCluster() {
 		<10006> <age> "25" .
 		<10007> <age> "25" .
 
+		<40> <age2> "10" .
+		<41> <age2> "20" .
+
+		<40> <name2> "Alice" .
+
 		<1> <alive> "true" .
-		<8> <alive> "true" .
 		<23> <alive> "true" .
 		<25> <alive> "false" .
 		<31> <alive> "false" .
@@ -630,7 +642,7 @@ func populateCluster() {
 		<5> <dgraph.type> "Pet" .
 		<6> <dgraph.type> "Animal" .
 		<6> <dgraph.type> "Pet" .
-		<8> <dgraph.type> "Person" .
+
 		<23> <dgraph.type> "Person" .
 		<24> <dgraph.type> "Person" .
 		<25> <dgraph.type> "Person" .
@@ -640,6 +652,8 @@ func populateCluster() {
 		<34> <dgraph.type> "SchoolInfo" .
 		<35> <dgraph.type> "SchoolInfo" .
 		<36> <dgraph.type> "SchoolInfo" .
+		<40> <dgraph.type> "Person2" .
+		<41> <dgraph.type> "Person2" .
 		<11100> <dgraph.type> "Node" .
 
 		<2> <pet> <5> .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -488,6 +488,7 @@ func populateCluster() {
 		<10007> <age> "25" .
 
 		<1> <alive> "true" .
+		<8> <alive> "true" .
 		<23> <alive> "true" .
 		<25> <alive> "false" .
 		<31> <alive> "false" .
@@ -629,6 +630,7 @@ func populateCluster() {
 		<5> <dgraph.type> "Pet" .
 		<6> <dgraph.type> "Animal" .
 		<6> <dgraph.type> "Pet" .
+		<8> <dgraph.type> "Person" .
 		<23> <dgraph.type> "Person" .
 		<24> <dgraph.type> "Person" .
 		<25> <dgraph.type> "Person" .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -209,18 +209,17 @@ func addGeoMultiPolygonToCluster(uid uint64, polygons [][][][]float64) error {
 }
 
 const testSchema = `
-type Person2 {
-	name2
-	age2
-	friend2
-}
-
 type Person {
 	name
 	pet
 	friend
 	gender
 	alive
+}
+
+type Person2 {
+	name2
+	age2
 }
 
 type Animal {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -550,14 +550,14 @@ func TestCascadeWithSort(t *testing.T) {
 func TestNegativeOffset(t *testing.T) {
 	query := `
 	{
-		me(func: type(Person2), offset: -1, orderasc: name2) {
+		me(func: type(Person2), offset: -1, orderasc: age2) {
 			name2
 			age2
 		}
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name2":"Alice","age2":10},{"age2":20}]}} `, js)
+	require.JSONEq(t, `{"data":{"me":[{"age2":20},{"name2":"Alice"}]}}`, js)
 }
 
 func TestLevelBasedFacetVarAggSum(t *testing.T) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -543,7 +543,7 @@ func TestCascadeWithSort(t *testing.T) {
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea"},{"name":"Daryl Dixon"},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes"},{"alive":true}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name": "Daryl Dixon","alive": false},{"name": "Rick Grimes","alive": true}]}}`, js)
 }
 
 // Resolved in PR #8441
@@ -557,7 +557,7 @@ func TestNegativeOffset(t *testing.T) {
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"alive":true}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea"},{"name":"Daryl Dixon"},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes"},{"alive":true}]}}`, js)
 }
 
 func TestLevelBasedFacetVarAggSum(t *testing.T) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -550,14 +550,14 @@ func TestCascadeWithSort(t *testing.T) {
 func TestNegativeOffset(t *testing.T) {
 	query := `
 	{
-		me(func: type(Person), offset: -1, orderasc: name) {
-			name
-			alive
+		me(func: type(Person2), offset: -1, orderasc: name2) {
+			name2
+			age2
 		}
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false},{"name":"Daryl Dixon","alive":false},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes","alive":true},{"alive":true}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name2":"Alice","age2":10},{"age2":20}]}} `, js)
 }
 
 func TestLevelBasedFacetVarAggSum(t *testing.T) {

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -546,6 +546,20 @@ func TestCascadeWithSort(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"name": "Daryl Dixon","alive": false},{"name": "Rick Grimes","alive": true}]}}`, js)
 }
 
+// Resolved in PR #8441
+func TestNegativeOffset(t *testing.T) {
+	query := `
+	{
+		me(func: type(Person), offset: -1, orderasc: name) {
+			name
+			alive
+		}
+	}
+	`
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t, `{"data":{"me":[{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"alive":true}]}}`, js)
+}
+
 func TestLevelBasedFacetVarAggSum(t *testing.T) {
 	query := `
 		{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -543,7 +543,7 @@ func TestCascadeWithSort(t *testing.T) {
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name": "Daryl Dixon","alive": false},{"name": "Rick Grimes","alive": true}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea"},{"name":"Daryl Dixon"},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes"},{"alive":true}]}}`, js)
 }
 
 // Resolved in PR #8441

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -546,7 +546,7 @@ func TestCascadeWithSort(t *testing.T) {
 	require.JSONEq(t, `{"data":{"me":[{"name": "Daryl Dixon","alive": false},{"name": "Rick Grimes","alive": true}]}}`, js)
 }
 
-// Resolved in PR #8441
+// Regression test for issue described in https://github.com/dgraph-io/dgraph/pull/8441
 func TestNegativeOffset(t *testing.T) {
 	query := `
 	{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -557,7 +557,7 @@ func TestNegativeOffset(t *testing.T) {
 	}
 	`
 	js := processQueryNoErr(t, query)
-	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea"},{"name":"Daryl Dixon"},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes"},{"alive":true}]}}`, js)
+	require.JSONEq(t, `{"data":{"me":[{"name":"Andrea","alive":false},{"name":"Daryl Dixon","alive":false},{"name":"Glenn Rhee"},{"name":"King Lear"},{"name":"Leonard"},{"name":"Margaret"},{"name":"Rick Grimes","alive":true},{"alive":true}]}}`, js)
 }
 
 func TestLevelBasedFacetVarAggSum(t *testing.T) {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -329,7 +329,9 @@ BUCKETS:
 
 		// Apply the offset on null nodes, if the nodes with value were not enough.
 		if out[i].offset < len(nullNodes) {
-			nullNodes = nullNodes[out[i].offset:]
+			if out[i].offset >= 0 {
+				nullNodes = nullNodes[out[i].offset:]
+			}
 		} else {
 			nullNodes = nullNodes[:0]
 		}


### PR DESCRIPTION
Cherry pick from #8077.

Steps to reproduce:
```
make image-local
cd contrib/local-test && make up
make schema-dql
make load-data-dql-rdf
make query-dql
curl: (52) Empty reply from server
make: *** [query-dql] Error 52
<alpha will crash and restart>
```

with the following minimal schema / data / query (should be placed in contrib/local-test):

schema.dql:
```
type Person {
    name
    age
    friend
}

name: string @index(term)  .
age: int @index(int) .
friend: [uid] @count .
```

dql-data.rdf
```
{
  set {
    _:michael <name> "Michael" .
    _:michael <dgraph.type> "Person" .
    _:michael <age> "314" .
    _:michael <friend> _:alice .
    _:michael <friend> _:bob .
    _:michael <friend> _:charlie .

    _:alice <name> "Alice" .
    _:alice <dgraph.type> "Person" .
    _:alice <age> "1" .

    _:bob <name> "Bob" .
    _:bob <dgraph.type> "Person" .
    _:bob <age> "2" .

    _:charlie <name> "Charlie" .
    _:charlie <dgraph.type> "Person" .
  }
}
```

query.dql
```
{
  michael_friends_first(func: allofterms(name, "Michael")) {
    name
    age
    friend (orderasc: age, offset: -1) {
      name
      age
    }
  }
}
```

### Remarks

- The cherry-pick does resolve the above crash
- This issue exists in main
- Why do we allow negative offsets?  If they are not useful, we should return an error when a user attempt to query using a negative offset.