### PR TITLE
add CIFuzz github action

### DIFF
--- a/.github/workflows/ci-cifuzz.yml
+++ b/.github/workflows/ci-cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'dgraph'
+        dry-run: false
+        language: go
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'dgraph'
+        fuzz-seconds: 300
+        dry-run: false
+        language: go
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

## Problem
 Fuzzers are integrated into OSS-Fuzz but does not run as part of the CI to prevent issues and regressions being merged.

## Solution
 Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR. This is a service offered by OSS-Fuzz where Dgraph already runs. In the current PR the fuzzers gets build on a pull request and will run for 300 seconds.