### PR TITLE
chore(vlog): Fix outdated doc comments on RunVlogGC

### DIFF
--- a/x/x.go
+++ b/x/x.go
@@ -1135,12 +1135,11 @@ func IsGuardian(groups []string) bool {
 	return false
 }
 
-// RunVlogGC runs value log gc on store. It runs GC unconditionally after every 10 minutes.
-// Additionally it also runs GC if vLogSize has grown more than 1 GB in last minute.
+// RunVlogGC runs value log gc on store. It runs GC unconditionally after every 1 minute.
 func RunVlogGC(store *badger.DB, closer *z.Closer) {
 	defer closer.Done()
 
-	// Runs every 1m, checks size of vlog and runs GC conditionally.
+	// Runs every 1m
 	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 


### PR DESCRIPTION
## Problem
This [commit](https://github.com/dgraph-io/dgraph/commit/786ff4af79802b146e8d67ba8ed4c009dd0a7f16) changes the behavior of `x/x.go/RunVlogGC` to run **unconditionally every minute**. But the author forgot to update the comments on the function to reflect that change. 

The doc comments still says it `"runs GC unconditionally after every 10 minutes. Additionally it also runs GC if vLogSize has grown more than 1 GB in last minute"`, so it can be confusing for readers.

## Solution
 Fix the comments to reflect the latest behavior, which is that it runs **uncoditionally every minute**