### PR TITLE
Fix(GraphQL): Make mutation rewriting tests more robust (#7768)

### DIFF
--- a/graphql/resolve/auth_add_test.yaml
+++ b/graphql/resolve/auth_add_test.yaml
@@ -169,7 +169,7 @@
     }
   queryjson: |
     {
-      "Project_1": [ { "uid": "0x123" } ]
+      "Project_1": [ { "uid": "0x123", "dgraph.type": ["Project"] } ]
     }
   uids: |
     {
@@ -464,8 +464,8 @@
     }
   queryjson: |
     {
-      "Project_1": [ { "uid": "0x123" } ],
-      "Ticket_2": [ { "uid": "0x789" } ]
+      "Project_1": [ { "uid": "0x123", "dgraph.type": ["Project"] } ],
+      "Ticket_2": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {
@@ -627,7 +627,7 @@
     }
   queryjson: |
     {
-      "Ticket_1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -783,13 +783,17 @@ func checkAddUpdateCase(
 	resolver := NewDgraphResolver(rewriter(), ex)
 
 	// -- Act --
-	resolved, _ := resolver.Resolve(ctx, mut)
+	resolved, success := resolver.Resolve(ctx, mut)
 
 	// -- Assert --
 	// most cases are built into the authExecutor
 	if tcase.Error != nil {
+		require.False(t, success, "Mutation should have failed as it throws an error")
 		require.NotNil(t, resolved.Err)
 		require.Equal(t, tcase.Error.Error(), resolved.Err.Error())
+	} else {
+		require.True(t, success, "Mutation should have not failed as it did not"+
+			" throw an error")
 	}
 }
 

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -685,16 +685,16 @@ func deleteQueryRewriting(t *testing.T, sch string, authMeta *testutil.AuthMeta,
 
 // In an add mutation
 //
-// mutation {
-// 	addAnswer(input: [
-// 	  {
-// 		text: "...",
-// 		datePublished: "2020-03-26",
-// 		author: { username: "u1" },
-// 		inAnswerTo: { id: "0x7e" }
-// 	  }
-// 	]) {
-// 	  answer { ... }
+//	mutation {
+//		addAnswer(input: [
+//		  {
+//			text: "...",
+//			datePublished: "2020-03-26",
+//			author: { username: "u1" },
+//			inAnswerTo: { id: "0x7e" }
+//		  }
+//		]) {
+//		  answer { ... }
 //
 // There's no initial auth verification.  We add the nodes and then check the auth rules.
 // So the only auth to check is through authorizeNewNodes() function.
@@ -792,8 +792,7 @@ func checkAddUpdateCase(
 		require.NotNil(t, resolved.Err)
 		require.Equal(t, tcase.Error.Error(), resolved.Err.Error())
 	} else {
-		require.True(t, success, "Mutation should have not failed as it did not"+
-			" throw an error")
+		require.True(t, success, "Mutation should have not failed as it did not throw an error")
 	}
 }
 

--- a/graphql/resolve/auth_update_test.yaml
+++ b/graphql/resolve/auth_update_test.yaml
@@ -184,7 +184,7 @@
     }
   queryjson: |
     {
-      "Ticket_1": [ { "uid": "0x789" } ]
+      "Ticket_1": [ { "uid": "0x789", "dgraph.type": ["Ticket"] } ]
     }
   dgquerysec: |-
     query {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -446,7 +446,7 @@ func (mr *dgraphResolver) rewriteAndExecute(
 	dgQuery, err = mr.mutationRewriter.FromMutationResult(ctx, mutation, mutResp.GetUids(), result)
 	queryErrs = schema.AppendGQLErrs(queryErrs, schema.GQLWrapf(err,
 		"couldn't rewrite query for mutation %s", mutation.Name()))
-	if dgQuery == nil && err != nil {
+	if err != nil {
 		return emptyResult(queryErrs), resolverFailed
 	}
 

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -792,7 +792,11 @@ func (arw *AddRewriter) FromMutationResult(
 	}
 	authRw.hasAuthRules = hasAuthRules(mutation.QueryField(), authRw)
 
-	return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), errs
+	if errs != nil {
+		return nil, errs
+	}
+	// No errors are thrown while rewriting queries by Ids.
+	return rewriteAsQueryByIds(mutation.QueryField(), uids, authRw), nil
 }
 
 // FromMutationResult rewrites the query part of a GraphQL update mutation into a Dgraph query.


### PR DESCRIPTION
* Make mutation rewriting tests more robust
* Fix lint
* Cherry pick: https://github.com/dgraph-io/dgraph/pull/7768
