### PR TITLE
(WIP) feat(Testing): Track code coverage for integration tests

### DIFF
--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -63,7 +63,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t --coverage=true --skip=dgraph/cmd/alpha/mutations_mode 
+          cd t; ./t --coverage=true
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -42,7 +42,7 @@ jobs:
           make regenerate
           git diff --exit-code -- .
       - name: Make Linux Build and Docker Image
-        run: make docker-image # this internally builds dgraph binary
+        run: make test-docker-image
       - name: Build Test Binary
         run: |
           #!/bin/bash

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -63,7 +63,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t --coverage=true
+          cd t; ./t --coverage=true --skip=dgraph/cmd/alpha/mutations_mode 
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ docker-image-standalone: dgraph docker-image
 
 test-docker-image: dgraph-test
 	@mkdir -p linux
-	@cp ./dgraph/dgraph.test ./linux/dgraph
+	@cp ./dgraph/dgraph ./linux/dgraph
 	docker build -f contrib/Dockerfile -t dgraph/dgraph:$(DGRAPH_VERSION) .
 
 # build and run dependencies for ubuntu linux

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ dgraph:
 	$(MAKE) -w -C $@ all
 
 dgraph-test:
-	$(MAKE) -w -C dgraph test
+	$(MAKE) -w -C dgraph test-binary
 
 oss:
 	$(MAKE) BUILD_TAGS=oss

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,14 @@ GOPATH         ?= $(shell go env GOPATH)
 ######################
 DGRAPH_VERSION ?= local
 
-.PHONY: dgraph all oss version install install_oss oss_install uninstall test help image image-local local-image docker-image docker-image-standalone
+.PHONY: dgraph dgraph-test all oss version install install_oss oss_install uninstall test help image image-local local-image docker-image docker-image-standalone
 all: dgraph
 
 dgraph:
 	$(MAKE) -w -C $@ all
+
+dgraph-test:
+	$(MAKE) -w -C dgraph test
 
 oss:
 	$(MAKE) BUILD_TAGS=oss
@@ -78,6 +81,11 @@ docker-image-standalone: dgraph docker-image
 	@mkdir -p linux
 	@cp ./dgraph/dgraph ./linux/dgraph
 	$(MAKE) -w -C contrib/standalone all DOCKER_TAG=$(DGRAPH_VERSION) DGRAPH_VERSION=$(DGRAPH_VERSION)
+
+test-docker-image: dgraph-test
+	@mkdir -p linux
+	@cp ./dgraph/dgraph.test ./linux/dgraph
+	docker build -f contrib/Dockerfile -t dgraph/dgraph:$(DGRAPH_VERSION) .
 
 # build and run dependencies for ubuntu linux
 linux-dependency:

--- a/contrib/config/datadog/docker-compose.yml
+++ b/contrib/config/datadog/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   zero1:
     image: dgraph/dgraph:latest
@@ -30,7 +30,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   datadog:
     image: datadog/agent:latest

--- a/contrib/config/datadog/docker-compose.yml
+++ b/contrib/config/datadog/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   zero1:
     image: dgraph/dgraph:latest
@@ -30,7 +30,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://jaeger:14268; datadog=datadog:8126;"
   datadog:
     image: datadog/agent:latest

--- a/contrib/embargo/embargo.yml
+++ b/contrib/embargo/embargo.yml
@@ -17,7 +17,7 @@ containers:
     expose:
       - 5080
       - 6080
-    command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       # Note: Any environment variables must use the ${} syntax.
       # ${GOPATH} works, $GOPATH does not.
@@ -33,7 +33,7 @@ containers:
     expose:
       - 5082
       - 6082
-    command: /gobin/dgraph zero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -47,7 +47,7 @@ containers:
     expose:
       - 5083
       - 6083
-    command: /gobin/dgraph zero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -61,7 +61,7 @@ containers:
     expose:
       - 8180
       - 9180
-    command: /gobin/dgraph alpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"
@@ -77,7 +77,7 @@ containers:
       - 8182
       - 9182
     start_delay: 8
-    command: /gobin/dgraph alpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"
@@ -93,7 +93,7 @@ containers:
       - 8183
       - 9183
     start_delay: 16
-    command: /gobin/dgraph alpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"

--- a/contrib/embargo/embargo.yml
+++ b/contrib/embargo/embargo.yml
@@ -17,7 +17,7 @@ containers:
     expose:
       - 5080
       - 6080
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero1:5080 --replicas 3 --raft="idx=1;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       # Note: Any environment variables must use the ${} syntax.
       # ${GOPATH} works, $GOPATH does not.
@@ -33,7 +33,7 @@ containers:
     expose:
       - 5082
       - 6082
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero -o 2 --my=zero2:5082 --replicas 3 --peer=zero1:5080 --raft="idx=2;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -47,7 +47,7 @@ containers:
     expose:
       - 5083
       - 6083
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero -o 3 --my=zero3:5083 --replicas 3 --peer=zero1:5080 --raft="idx=3;" --bindall --expose_trace --logtostderr -v=3
     volumes:
       "${GOPATH}/bin": "/gobin"
 
@@ -61,7 +61,7 @@ containers:
     expose:
       - 8180
       - 9180
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=dg1:7180 --zero=zero1:5080,zero2:5082,zero3:5083 -o 100 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"
@@ -77,7 +77,7 @@ containers:
       - 8182
       - 9182
     start_delay: 8
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=dg2:7182 --zero=zero1:5080,zero2:5082,zero3:5083 -o 102 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"
@@ -93,7 +93,7 @@ containers:
       - 8183
       - 9183
     start_delay: 16
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=dg3:7183 --zero=zero1:5080,zero2:5082,zero3:5083 -o 103 --expose_trace --logtostderr -v=3
       --trace "ratio=1.0;"
     volumes:
       "${GOPATH}/bin": "/gobin"

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -79,7 +79,7 @@ $(BIN): clean jemalloc
 	@go build $(BUILD_FLAGS) -o $(BIN)
 
 test: clean jemalloc
-	@go test -c -covermode=atomic -coverpkg ./... $(BUILD_FLAGS) -o $(BIN).test
+	@go test -c -covermode=atomic -coverpkg ./... $(BUILD_FLAGS) -o $(BIN)
 
 clean:
 	@rm -f $(BIN)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -79,7 +79,7 @@ $(BIN): clean jemalloc
 	@go build $(BUILD_FLAGS) -o $(BIN)
 
 test-binary: clean jemalloc
-	@go test -c -covermode=atomic -coverpkg ./... $(BUILD_FLAGS) -o $(BIN)
+	@go test -c -covermode=atomic -coverpkg ../... $(BUILD_FLAGS) -o $(BIN)
 
 clean:
 	@rm -f $(BIN)

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -78,6 +78,9 @@ all: $(BIN)
 $(BIN): clean jemalloc
 	@go build $(BUILD_FLAGS) -o $(BIN)
 
+test: clean jemalloc
+	@go test -c -covermode=atomic -coverpkg ./... $(BUILD_FLAGS) -o $(BIN).test
+
 clean:
 	@rm -f $(BIN)
 

--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -78,7 +78,7 @@ all: $(BIN)
 $(BIN): clean jemalloc
 	@go build $(BUILD_FLAGS) -o $(BIN)
 
-test: clean jemalloc
+test-binary: clean jemalloc
 	@go test -c -covermode=atomic -coverpkg ./... $(BUILD_FLAGS) -o $(BIN)
 
 clean:

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=disallow;"
@@ -33,7 +33,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -50,7 +50,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -67,7 +67,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -84,7 +84,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -101,6 +101,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
 volumes: {}

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=disallow;"
@@ -33,7 +33,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -50,7 +50,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
       --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --limit "mutations=strict;"
@@ -67,7 +67,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -84,7 +84,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -101,6 +101,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr
       -v=2 --peer=zero1:5080
 volumes: {}

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   zero2:
     image: dgraph/dgraph:local
@@ -32,7 +32,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
 
   zero3:
     image: dgraph/dgraph:local
@@ -50,7 +50,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -102,7 +102,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -130,7 +130,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -158,7 +158,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -186,7 +186,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -214,7 +214,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   zero2:
     image: dgraph/dgraph:local
@@ -32,7 +32,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
 
   zero3:
     image: dgraph/dgraph:local
@@ -50,7 +50,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -102,7 +102,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -130,7 +130,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -158,7 +158,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -186,7 +186,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -214,7 +214,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 

--- a/dgraph/main_test.go
+++ b/dgraph/main_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"flag"
+	"testing"
+)
+var systemTest *bool
+func init() {
+  systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
+}
+
+func TestSystem(t *testing.T) {
+  if *systemTest {
+     main()
+  }
+}

--- a/dgraph/main_test.go
+++ b/dgraph/main_test.go
@@ -10,7 +10,8 @@ func init() {
 }
 
 func TestSystem(t *testing.T) {
-  if *systemTest {
-     main()
-  }
+  // if *systemTest {
+  //    main()
+  // }
+  main()
 }

--- a/dgraph/main_test.go
+++ b/dgraph/main_test.go
@@ -10,8 +10,7 @@ func init() {
 }
 
 func TestSystem(t *testing.T) {
-  // if *systemTest {
-  //    main()
-  // }
-  main()
+  if *systemTest {
+     main()
+  }
 }

--- a/dgraph/main_test.go
+++ b/dgraph/main_test.go
@@ -1,16 +1,9 @@
 package main
 
 import (
-	"flag"
 	"testing"
 )
-var systemTest *bool
-func init() {
-  systemTest = flag.Bool("systemTest", false, "Set to true when running system tests")
-}
 
 func TestSystem(t *testing.T) {
-  if *systemTest {
-     main()
-  }
+  main()
 }

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -9,12 +9,7 @@ services:
     labels:
       cluster: test
       service: zero1
-    volumes:
-      - type: bind
-        source: $GOPATH/bin
-        target: /gobin
-        read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph --systemTest --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,6 +25,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command:
+      dgraph --systemTest --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -9,7 +9,12 @@ services:
     labels:
       cluster: test
       service: zero1
-    command: dgraph --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -26,6 +31,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     labels:
       cluster: test
       service: zero1
-    command: dgraph --systemTest --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: dgraph --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -26,6 +26,6 @@ services:
       cluster: test
       service: alpha1
     command:
-      dgraph --systemTest --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
     image: dgraph/dgraph:local
@@ -34,7 +34,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16; token=itIsSecret;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3s;" 
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,6 +30,6 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,6 +30,6 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "debug=true;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "debug=true;"
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --graphql "debug=true;" 
       --trace "ratio=1.0;"

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --zero=zero1:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=3 --my=alpha1:7080 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --graphql "debug=true;" 
       --trace "ratio=1.0;"

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -31,7 +31,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   mock:
     build:

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -31,7 +31,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
   mock:
     build:

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -42,7 +42,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -65,7 +65,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -82,6 +82,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -42,7 +42,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -65,7 +65,7 @@ services:
       source: ../../../ee/acl/hmac-secret
       target: /dgraph-acl/hmac-secret
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=3000s;"
@@ -82,6 +82,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -14,7 +14,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
 
   alpha1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
     labels:
       cluster: test
       service: alpha1
-    command: /gobin/dgraph alpha --zero=zero1:5080 --expose_trace
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --zero=zero1:5080 --expose_trace
       --profile_mode block --block_rate 10 --logtostderr -v=2 --my=alpha1:7080
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --graphql "lambda-url=http://lambda:8686/graphql-worker;"

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -41,7 +41,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -63,7 +63,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -79,6 +79,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -41,7 +41,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -63,7 +63,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -79,6 +79,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -33,7 +33,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -51,7 +51,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -67,6 +67,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -33,7 +33,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -51,7 +51,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft="idx=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -67,6 +67,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       source: ./p
       target: /data/alpha1/p
       read_only: false
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -45,7 +45,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
       --bindall
 volumes: {}
 

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       source: ./p
       target: /data/alpha1/p
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha -o 100 --my=alpha1:7180 --lru_mb=1024 --zero=zero1:5180
       --logtostderr -v=2 --raft="idx=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -45,7 +45,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2
       --bindall
 volumes: {}
 

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
       --trace "jaeger=http://ocagent:14268;"
   zero1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://ocagent:14268;"
   ocagent:
     image: omnition/opencensus-agent:0.1.6

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
       --trace "jaeger=http://ocagent:14268;"
   zero1:
     image: dgraph/dgraph:local
@@ -30,7 +30,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall
       --trace "jaeger=http://ocagent:14268;"
   ocagent:
     image: omnition/opencensus-agent:0.1.6

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -17,6 +17,6 @@ services:
         source: ./out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -17,6 +17,6 @@ services:
         source: ./out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -17,6 +17,6 @@ services:
         source: ./out/0/p
         target: /posting
         read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/21million/live/docker-compose.yml
+++ b/systest/21million/live/docker-compose.yml
@@ -31,5 +31,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr
       -v=2 --bindall

--- a/systest/21million/live/docker-compose.yml
+++ b/systest/21million/live/docker-compose.yml
@@ -31,5 +31,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr
       -v=2 --bindall

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1; group=1" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
     deploy:
@@ -41,7 +41,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft='idx=1' --my=zero1:5080 --logtostderr
       -v=2 --bindall
     deploy:
       resources:

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ./acl-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1; group=1" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
     deploy:
@@ -41,7 +41,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft='idx=1' --my=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft='idx=1' --my=zero1:5080 --logtostderr
       -v=2 --bindall
     deploy:
       resources:

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - type: bind
         source: ./audit_dir/aa
         target: /audit_dir
-    command: /gobin/dgraph alpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
       --logtostderr --audit "output=/audit_dir;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -33,6 +33,6 @@ services:
       - type: bind
         source: ./audit_dir/za
         target: /audit_dir
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --audit "output=/audit_dir;"
 volumes: {}

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - type: bind
         source: ./audit_dir/aa
         target: /audit_dir
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --raft="idx=1;group=1" --my=alpha1:7080 --zero=zero1:5080
       --logtostderr --audit "output=/audit_dir;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -33,6 +33,6 @@ services:
       - type: bind
         source: ./audit_dir/za
         target: /audit_dir
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --audit "output=/audit_dir;"
 volumes: {}

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -49,7 +49,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -75,7 +75,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -95,7 +95,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:latest

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -49,7 +49,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -75,7 +75,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 --encryption="key-file=/dgraph-enc/enc-key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -95,7 +95,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:latest

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -47,7 +47,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -71,7 +71,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -95,6 +95,6 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -47,7 +47,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -71,7 +71,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -95,6 +95,6 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -65,7 +65,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   minio:
@@ -92,6 +92,6 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -65,7 +65,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   minio:
@@ -92,6 +92,6 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -65,7 +65,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -85,7 +85,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:RELEASE.2020-11-13T20-10-18Z

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -65,7 +65,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -85,7 +85,7 @@ services:
       source: ../../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   minio:
     image: minio/minio:RELEASE.2020-11-13T20-10-18Z

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=1; group=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -48,7 +48,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=2; group=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -73,7 +73,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=3; group=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -94,6 +94,6 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=1; group=1;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -48,7 +48,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=2; group=2;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -73,7 +73,7 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "idx=3; group=3;" 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
@@ -94,6 +94,6 @@ services:
       source: ./data/backups
       target: /data/backups/
       read_only: false
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/secret/hmac;"
@@ -36,5 +36,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/secret/hmac;"
@@ -36,5 +36,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../ee/acl/hmac-secret
       target: /secret/hmac
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --acl "secret-file=/secret/hmac;"
@@ -36,5 +36,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - type: bind
         source: ./cdc_logs
         target: /cdc
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --cdc "file=/cdc;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -32,5 +32,5 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - type: bind
         source: ./cdc_logs
         target: /cdc
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --cdc "file=/cdc;" -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -32,5 +32,5 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   minio:
@@ -88,7 +88,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=3 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --replicas=3 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -43,7 +43,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=1"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -31,7 +31,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=2"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -47,7 +47,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 --raft "group=3"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -63,6 +63,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes: {}

--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -31,5 +31,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -31,5 +31,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         source: $GOPATH/bin
         target: /gobin
         read_only: true
-    command: /gobin/dgraph zero -o 100 --my=zero1:5180 --logtostderr --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero -o 100 --my=zero1:5180 --logtostderr --bindall
 
   dg1:
     image: dgraph/dgraph:local

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
@@ -39,6 +39,6 @@ services:
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
@@ -39,6 +39,6 @@ services:
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/systest/ludicrous/docker-compose.yml
+++ b/systest/ludicrous/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -39,7 +39,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -59,7 +59,7 @@ services:
       source: data
       target: /data
       read_only: false
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
@@ -75,7 +75,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1" --my=zero1:5080 --replicas=1 --logtostderr
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1" --my=zero1:5080 --replicas=1 --logtostderr
       -v=2 --bindall
 volumes:
   data: {}

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
@@ -64,7 +64,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha2
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=2;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
@@ -99,7 +99,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha3
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=3;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
@@ -134,7 +134,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha4
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha4:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha4:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=4;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha4.crt; client-key=/dgraph-tls/client.alpha4.key;"
@@ -169,7 +169,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha5
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha5:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha5:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=5;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha5.crt; client-key=/dgraph-tls/client.alpha5.key;"
@@ -204,7 +204,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/alpha6
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha6:7080 --zero=zero1:5080
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha6:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=6;" --encryption "key-file=/data/keys/enc_key;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha6.crt; client-key=/dgraph-tls/client.alpha6.key;"
@@ -225,7 +225,7 @@ services:
       source: ../../tlstest/mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes:
   backup: {}

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../testutil/custom_plugins
       target: /plugins
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --custom_tokenizers=/plugins/0.so,/plugins/1.so,/plugins/2.so,/plugins/3.so
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -36,6 +36,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
       --bindall
 volumes: {}

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../../testutil/custom_plugins
       target: /plugins
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
       --custom_tokenizers=/plugins/0.so,/plugins/1.so,/plugins/2.so,/plugins/3.so
       -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -36,6 +36,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2
       --bindall
 volumes: {}

--- a/t/t.go
+++ b/t/t.go
@@ -216,6 +216,8 @@ func stopCluster(composeFile, prefix string, wg *sync.WaitGroup, err error) {
 				fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n",
 					prefix, err)
 			}
+			
+			os.Remove(tmp)
 		}
 
 		cmd = command("docker-compose", "--compatibility", "-f", composeFile, "-p", prefix, "rm", "-v", "--force")

--- a/t/t.go
+++ b/t/t.go
@@ -119,12 +119,21 @@ func startCluster(composeFile, prefix string) error {
 	cmd := command(
 		"docker-compose", "--compatibility", "-f", composeFile, "-p", prefix,
 		"up", "--force-recreate", "--build", "--remove-orphans", "--detach")
-	cmd.Stderr = nil
+
+	stderr, _ := cmd.StderrPipe()
 
 	fmt.Printf("Bringing up cluster %s for package: %s ...\n", prefix, composeFile)
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("While running command: %q Error: %v\n",
 			strings.Join(cmd.Args, " "), err)
+
+		fmt.Println("DEBUG")
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			fmt.Println(scanner.Text())
+		}
+		fmt.Println("DEBUG")
+
 		return err
 	}
 	fmt.Printf("CLUSTER UP: %s. Package: %s\n", prefix, composeFile)

--- a/t/t.go
+++ b/t/t.go
@@ -206,7 +206,7 @@ func stopCluster(composeFile, prefix string, wg *sync.WaitGroup, err error) {
 			containerInfo, err := testutil.DockerInspect(c.ID)
 			workDir := containerInfo.Config.WorkingDir
 
-			err = testutil.DockerCp(c.ID, workDir + "/coverage.out", tmp)
+			err = testutil.DockerCpFromContainer(c.ID, workDir + "/coverage.out", tmp)
 			if err != nil {
 				fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n",
 					prefix, err)

--- a/t/t.go
+++ b/t/t.go
@@ -119,20 +119,12 @@ func startCluster(composeFile, prefix string) error {
 	cmd := command(
 		"docker-compose", "--compatibility", "-f", composeFile, "-p", prefix,
 		"up", "--force-recreate", "--build", "--remove-orphans", "--detach")
-	
-	var errb bytes.Buffer
-    cmd.Stderr = &errb
+	cmd.Stderr = nil
 
 	fmt.Printf("Bringing up cluster %s for package: %s ...\n", prefix, composeFile)
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("While running command: %q Error: %v\n",
 			strings.Join(cmd.Args, " "), err)
-
-		fmt.Println("DEBUG")
-    	stderr := errb.String()
-		fmt.Println(stderr)
-		fmt.Println("DEBUG")
-
 		return err
 	}
 	fmt.Printf("CLUSTER UP: %s. Package: %s\n", prefix, composeFile)
@@ -228,12 +220,12 @@ func stopCluster(composeFile, prefix string, wg *sync.WaitGroup, err error) {
 			os.Remove(tmp)
 		}
 
-		cmd = command("docker-compose", "--compatibility", "-f", composeFile, "-p", prefix, "rm", "-v", "--force")
+		cmd = command("docker-compose", "--compatibility", "-f", composeFile, "-p", prefix, "down", "-v")
 		if err := cmd.Run(); err != nil {
-			fmt.Printf("4. Error while bringing down cluster. Prefix: %s. Error: %v\n",
+			fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n",
 				prefix, err)
 		} else {
-			fmt.Printf("CLUSTER REMOVED: %s\n", prefix)
+			fmt.Printf("CLUSTER AND NETWORK REMOVED: %s\n", prefix)
 		}
 
 		wg.Done()

--- a/t/t.go
+++ b/t/t.go
@@ -119,8 +119,9 @@ func startCluster(composeFile, prefix string) error {
 	cmd := command(
 		"docker-compose", "--compatibility", "-f", composeFile, "-p", prefix,
 		"up", "--force-recreate", "--build", "--remove-orphans", "--detach")
-
-	stderr, _ := cmd.StderrPipe()
+	
+	var errb bytes.Buffer
+    cmd.Stderr = &errb
 
 	fmt.Printf("Bringing up cluster %s for package: %s ...\n", prefix, composeFile)
 	if err := cmd.Run(); err != nil {
@@ -128,10 +129,8 @@ func startCluster(composeFile, prefix string) error {
 			strings.Join(cmd.Args, " "), err)
 
 		fmt.Println("DEBUG")
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			fmt.Println(scanner.Text())
-		}
+    	stderr := errb.String()
+		fmt.Println(stderr)
 		fmt.Println("DEBUG")
 
 		return err

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -227,9 +227,15 @@ func DockerRun(instance string, op int) error {
 	return nil
 }
 
-// DockerCp copies from/to a container. Paths inside a container have the format
+// MARKED FOR DEPRECATION: DockerCp copies from/to a container. Paths inside a container have the format
 // container_name:path.
-func DockerCp(containerID, srcPath, dstPath string) error {
+func DockerCp(srcPath, dstPath string) error {
+	argv := []string{"docker", "cp", srcPath, dstPath}
+	return Exec(argv...)
+}
+
+// DockerCpFromContainer copies from a container.
+func DockerCpFromContainer(containerID, srcPath, dstPath string) error {
 	cli, err := client.NewEnvClient()
 	x.Check(err)
 

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       source: ../mtls_internal/tls/alpha1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --acl "secret-file=/dgraph-acl/hmac-secret;"
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key; client-auth-type=VERIFYIFGIVEN;"
@@ -42,6 +42,6 @@ services:
       source: ../mtls_internal/tls/zero1
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUEST; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -35,5 +35,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=REQUIREANDVERIFY; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -35,5 +35,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       source: ../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
       --tls "ca-cert=/dgraph-tls/ca.crt; client-auth-type=VERIFYIFGIVEN; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
   zero1:
@@ -35,5 +35,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -37,7 +37,7 @@ services:
         source: ../tls/alpha2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -57,7 +57,7 @@ services:
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -77,7 +77,7 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --replicas 3 --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --replicas 3 --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
   zero2:
     image: dgraph/dgraph:local
@@ -96,7 +96,7 @@ services:
         source: ../tls/zero2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=2;" --replicas 3 --my=zero2:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=2;" --replicas 3 --my=zero2:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero2.crt; client-key=/dgraph-tls/client.zero2.key;"
   zero3:
     image: dgraph/dgraph:local
@@ -115,6 +115,6 @@ services:
         source: ../tls/zero3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=3;" --replicas 3 --my=zero3:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=3;" --replicas 3 --my=zero3:5080 --logtostderr --peer zero1:5080 -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero3.crt; client-key=/dgraph-tls/client.zero3.key;"
 volumes: {}

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   alpha2:
@@ -37,7 +37,7 @@ services:
         source: ../tls/alpha2
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha2.crt; client-key=/dgraph-tls/client.alpha2.key;"
   alpha3:
@@ -57,7 +57,7 @@ services:
         source: ../tls/alpha3
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha3.crt; client-key=/dgraph-tls/client.alpha3.key;"
   zero1:
@@ -77,6 +77,6 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -17,7 +17,7 @@ services:
         source: ../tls/alpha1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.alpha1.crt; client-key=/dgraph-tls/client.alpha1.key;"
   zero1:
@@ -37,6 +37,6 @@ services:
         source: ../tls/zero1
         target: /dgraph-tls
         read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key; internal-port=true; client-cert=/dgraph-tls/client.zero1.crt; client-key=/dgraph-tls/client.zero1.key;"
 volumes: {}

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:local
@@ -34,6 +34,6 @@ services:
       source: ../../tls
       target: /dgraph-tls
       read_only: true
-    command: /gobin/dgraph zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
       --tls "ca-cert=/dgraph-tls/ca.crt; server-cert=/dgraph-tls/node.crt; server-key=/dgraph-tls/node.key;"
 volumes: {}

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
+    command: /gobin/dgraph --test.coverprofile=coverage.out alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   zero1:
     image: dgraph/dgraph:local
@@ -30,5 +30,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+    command: /gobin/dgraph --test.coverprofile=coverage.out zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
 volumes: {}

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -31,7 +31,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -47,7 +47,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
@@ -63,7 +63,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
@@ -79,7 +79,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
@@ -95,7 +95,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.out alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   jaeger:
@@ -121,7 +121,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
       --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -138,7 +138,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
       --my=zero2:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -155,6 +155,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
+    command: /gobin/dgraph  --test.coverprofile=coverage.out zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
       --my=zero3:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
 volumes: {}

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=1; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha2:
@@ -31,7 +31,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=2; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha3:
@@ -47,7 +47,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=3; group=1;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha4:
@@ -63,7 +63,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=4; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha5:
@@ -79,7 +79,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=5; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   alpha6:
@@ -95,7 +95,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
+    command: /gobin/dgraph  --test.coverprofile=coverage.outalpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
       --zero=zero1:5080,zero2:5080,zero3:5080 --logtostderr -v=2 --raft "idx=6; group=2;
       snapshot-after-entries=100; snapshot-after-duration=1m" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
   jaeger:
@@ -121,7 +121,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
       --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall
   zero2:
     image: dgraph/dgraph:local
@@ -138,7 +138,7 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
       --my=zero2:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
   zero3:
     image: dgraph/dgraph:local
@@ -155,6 +155,6 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    command: /gobin/dgraph zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
+    command: /gobin/dgraph  --test.coverprofile=coverage.outzero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'
       --my=zero3:5080 --replicas=3 --logtostderr -v=2 --peer=zero1:5080
 volumes: {}


### PR DESCRIPTION
## Problem

Currently, Dgraph's code coverage only tracks the coverage for unit tests only, it cannot track coverage for integration tests. 

## Solution

Add additional instrumentation to allow the code coverage tool to track coverage in integration tests, in order to have an accurate number for code coverage.