### PR TITLE
fix(JoinCluster): Avoid retrying JoinCluster indefinitely (#7961)

### DIFF
--- a/conn/node.go
+++ b/conn/node.go
@@ -573,7 +573,7 @@ var errInternalRetry = errors.New("Retry proposal again")
 func (n *Node) proposeConfChange(ctx context.Context, conf raftpb.ConfChange) error {
 	if ctx.Err() != nil {
 		// If ctx has already errored out, return without proposing.
-		return errors.Wrapf(ctx.Err(), "while proposeConfChange")
+		return errors.Wrap(ctx.Err(), "while proposeConfChange")
 	}
 	// Don't use ctx here, so we can give a proper shot to the proposal. We
 	// don't want to error out due to ctx after having proposed.

--- a/conn/node.go
+++ b/conn/node.go
@@ -571,7 +571,14 @@ func (n *Node) DeletePeer(pid uint64) {
 var errInternalRetry = errors.New("Retry proposal again")
 
 func (n *Node) proposeConfChange(ctx context.Context, conf raftpb.ConfChange) error {
-	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	if ctx.Err() != nil {
+		// If ctx has already errored out, return without proposing.
+		return errors.Wrapf(ctx.Err(), "while proposeConfChange")
+	}
+	// Don't use ctx here, so we can give a proper shot to the proposal. We
+	// don't want to error out due to ctx after having proposed.
+	// Relevant PR: https://github.com/dgraph-io/dgraph/pull/2467
+	cctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
 	ch := make(chan error, 1)
@@ -588,8 +595,6 @@ func (n *Node) proposeConfChange(ctx context.Context, conf raftpb.ConfChange) er
 	select {
 	case err := <-ch:
 		return err
-	case <-ctx.Done():
-		return ctx.Err()
 	case <-cctx.Done():
 		return errInternalRetry
 	}
@@ -781,7 +786,7 @@ func (n *Node) joinCluster(ctx context.Context, rc *pb.RaftContext) (*api.Payloa
 	}
 	n.Connect(rc.Id, rc.Addr)
 
-	err := n.addToCluster(context.Background(), rc)
+	err := n.addToCluster(ctx, rc)
 	glog.Infof("[%#x] Done joining cluster with err: %v", rc.Id, err)
 	return &api.Payload{}, err
 }


### PR DESCRIPTION
If a Zero follower receives a JoinCluster request, it won't process the proposal because it can't forward the request to leader. Raft doesn't send an error back in this case. In the current code, it would retry indefinitely. With this change, we now use the request context to give up at some point.

<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->