### PR TITLE
chore(tests): Unit test for edgraph/validateToken ()

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -195,6 +195,18 @@ func validateToken(jwtStr string) (*userData, error) {
 		return nil, errors.Errorf("userid in claims is not a string:%v", userId)
 	}
 
+	/*  
+	 * Since, JSON numbers follow JavaScript's double-precision floating-point
+	 * format . . .
+	 * -- references: https://restfulapi.net/json-data-types/
+	 * --             https://www.tutorialspoint.com/json/json_data_types.htm
+	 * . . . and fraction in IEEE 754 double precision binary floating-point
+	 * format has 52 bits, . . .
+	 * -- references: https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+	 * . . . the namespace field of the struct userData below can
+	 * only accomodate a maximum value of (1 << 52) despite it being declared as
+	 * uint64. Numbers bigger than this are likely to fail the test.
+	 */
 	namespace, ok := claims["namespace"].(float64)
 	if !ok {
 		return nil, errors.Errorf("namespace in claims is not valid:%v", namespace)

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -149,7 +149,10 @@ func TestGetAccessJwt(t *testing.T) {
 		 * One of the factor [signature] would differ is based on the expiry time.
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
-		compareTokenParts (tokstr, jwtstr, 1, 2 ,0) // compare 1st and 2nd part, ignore the 3rd.
+		match := compareTokenParts (tokstr, jwtstr, 1, 2 ,0) // compare 1st and 2nd part, ignore the 3rd.
+		if match == false {
+			t.Errorf ("Actual output is not equal to the expected output")
+		}
 	}
 }
 
@@ -169,6 +172,9 @@ func TestGetRefreshJwt(t *testing.T) {
 		 * One of the factor [signature] would differ is based on the expiry time.
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
-		compareTokenParts (tokstr, jwtstr, 1, 2 ,0) // compare 1st and 2nd part, ignore the 3rd.
+		match := compareTokenParts (tokstr, jwtstr, 1, 2 ,0) // compare 1st and 2nd part, ignore the 3rd.
+		if match == false {
+			t.Errorf ("Actual output is not equal to the expected output")
+		}
 	}
 }

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -1,48 +1,26 @@
 package edgraph
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/worker"
+
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
-var (
-	userDataList = []userData{
-		{1234567890, "user1", []string{"701", "702"}},
-		{2345678901, "user2", []string{"703", "701"}},
-		{3456789012, "user3", []string{"702", "703"}},
-	}
-)
-
-func generateJWT(namespace uint64, userId string, groupIds []string, exp int64) (string, error) {
-	var token *jwt.Token
-
-	e1 := exp
-	if e1 == 0 {
-		e1 = time.Now().Add(time.Minute * 30).Unix()
-	}
-
-	claims := jwt.MapClaims{
-		"namespace": namespace,
-		"userid":    userId,
-		"exp":       e1,
-	}
+func generateJWT(namespace uint64, userId string, groupIds []string, expiry int64) string {
+	claims := jwt.MapClaims{"namespace": namespace, "userid": userId, "exp": expiry}
 	if groupIds != nil {
 			claims["groups"] = groupIds
 	}
-	token = jwt.NewWithClaims(jwt.SigningMethodHS256, &claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims)
 
-	tokenString, err := token.SignedString([]byte(worker.Config.HmacSecret))
-	if err != nil {
-		_ = fmt.Errorf("Something Went Wrong: %s", err.Error())
-		return "", err
-	}
-	return tokenString, nil
+	tokenString, _ := token.SignedString([]byte(worker.Config.HmacSecret))
+
+	return tokenString
 }
 
 func sliceCompare(x, y []string) bool {
@@ -50,8 +28,8 @@ func sliceCompare(x, y []string) bool {
 		return false
 	}
 
-	for i, s := range x {
-		if s != y[i] {
+	for i := range x {
+		if x[i] != y[i] {
 			return false
 		}
 	}
@@ -59,43 +37,35 @@ func sliceCompare(x, y []string) bool {
 	return true
 }
 
-func compareTokenParts(tok1 string, tok2 string, part ...int) bool {
-	var (
-		match bool = true
-	)
-
+func compareTokenParts(tok1 string, tok2 string, part []bool) bool {
 	t1 := strings.Split(tok1, ".")
 	t2 := strings.Split(tok2, ".")
 
-	for _, p := range part {
-		if p <= 0 {
+	for i := range part {
+		if !part[i] {
 			continue
 		}
 
-		if t1[p-1] != t2[p-1] {
-			match = false
-			break
+		if t1[i] != t2[i] {
+			return false
 		}
 	}
 
-	return match
+	return true
 }
 
 func TestValidateToken(t *testing.T) {
-	var (
-		err         error
-		tokenString string
-	)
+	expiry := time.Now().Add(time.Minute * 30).Unix()
+	userDataList := []userData{
+		{1234567890, "user1", []string{"701", "702"}},
+		{2345678901, "user2", []string{"703", "701"}},
+		{3456789012, "user3", []string{"702", "703"}},
+	}
 
 	for _, userdata := range userDataList {
-		if tokenString, err = generateJWT(userdata.namespace, userdata.userId, userdata.groupIds, 0); err != nil {
-			t.Errorf("JWT token string generation error: %s", err)
-		}
+		tokenString := generateJWT(userdata.namespace, userdata.userId, userdata.groupIds, expiry)
 
-		ud, err := validateToken(tokenString)
-		if err != nil {
-			t.Errorf("validateToken() error: %s", err)
-		}
+		ud, _ := validateToken(tokenString)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, userdata.groupIds) {
 			t.Errorf("Actual output %+v is not equal to the expected output %+v", userdata, ud)
 		}
@@ -103,11 +73,6 @@ func TestValidateToken(t *testing.T) {
 }
 
 func TestGetAccessJwt(t *testing.T) {
-	var (
-		tokstr string
-		jwtstr string
-		exp    int64 = time.Now().Add(worker.Config.AccessJwtTtl).Unix()
-	)
 
 	grpLst := []acl.Group{
 		{
@@ -130,41 +95,53 @@ func TestGetAccessJwt(t *testing.T) {
 		},
 	}
 
+	expiry := time.Now().Add(worker.Config.AccessJwtTtl).Unix()
+	userDataList := []userData{
+		{1234567890, "user1", []string{"701", "702"}},
+		{2345678901, "user2", []string{"703", "701"}},
+		{3456789012, "user3", []string{"702", "703"}},
+	}
+
 	for _, userdata := range userDataList {
 		g := acl.GetGroupIDs(grpLst)
-		tokstr, _ = generateJWT(userdata.namespace, userdata.userId, g, exp)
-		jwtstr, _ = getAccessJwt(userdata.userId, grpLst, userdata.namespace)
+		tokstr := generateJWT(userdata.namespace, userdata.userId, g, expiry)
+		jwtstr, _ := getAccessJwt(userdata.userId, grpLst, userdata.namespace)
 
 		/*
 		 * JWT token format = [header].[payload].[signature].
 		 * One of the factor [signature] would differ is based on the expiry time.
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
-		match := compareTokenParts(tokstr, jwtstr, 1, 2, 0) // compare 1st and 2nd part, ignore the 3rd.
-		if match == false {
+
+		// compare 1st and 2nd part, ignore the 3rd.
+		testTokParts := []bool{true, true, false}
+		if !compareTokenParts(tokstr, jwtstr, testTokParts) {
 			t.Errorf("Actual output is not equal to the expected output")
 		}
 	}
 }
 
 func TestGetRefreshJwt(t *testing.T) {
-	var (
-		tokstr string
-		jwtstr string
-		exp    int64 = time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
-	)
+	expiry := time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
+	userDataList := []userData{
+		{1234567890, "user1", []string{"701", "702"}},
+		{2345678901, "user2", []string{"703", "701"}},
+		{3456789012, "user3", []string{"702", "703"}},
+	}
 
 	for _, userdata := range userDataList {
-		tokstr, _ = generateJWT(userdata.namespace, userdata.userId, nil, exp)
-		jwtstr, _ = getRefreshJwt(userdata.userId, userdata.namespace)
+		tokstr := generateJWT(userdata.namespace, userdata.userId, nil, expiry)
+		jwtstr, _ := getRefreshJwt(userdata.userId, userdata.namespace)
 
 		/*
 		 * JWT token format = [header].[payload].[signature]
 		 * One of the factor [signature] would differ is based on the expiry time.
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
-		match := compareTokenParts(tokstr, jwtstr, 1, 2, 0) // compare 1st and 2nd part, ignore the 3rd.
-		if match == false {
+
+		// compare 1st and 2nd part, ignore the 3rd.
+		testTokParts := []bool{true, true, false}
+		if !compareTokenParts(tokstr, jwtstr, testTokParts) {
 			t.Errorf("Actual output is not equal to the expected output")
 		}
 	}

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -87,9 +87,9 @@ func TestGetAccessJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		tokstr := generateJWT(userdata.namespace, userdata.userId, g, expiry)
-        ud1, _ := validateToken (tokstr)
+		ud1, _ := validateToken (tokstr)
 		jwtstr, _ := getAccessJwt(userdata.userId, grpLst, userdata.namespace)
-        ud2, _ := validateToken (jwtstr)
+		ud2, _ := validateToken (jwtstr)
 
 		if ud1.namespace != ud2.namespace || ud1.userId != ud2.userId || !sliceCompare(ud1.groupIds, ud2.groupIds) {
 			t.Errorf("Generated jwt output %+v is not equal to the access jwt output %+v", ud1, ud2)
@@ -107,9 +107,9 @@ func TestGetRefreshJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		tokstr := generateJWT(userdata.namespace, userdata.userId, nil, expiry)
-        ud1, _ := validateToken (tokstr)
+		ud1, _ := validateToken (tokstr)
 		jwtstr, _ := getRefreshJwt(userdata.userId, userdata.namespace)
-        ud2, _ := validateToken (jwtstr)
+		ud2, _ := validateToken (jwtstr)
 
 		if ud1.namespace != ud2.namespace || ud1.userId != ud2.userId || !sliceCompare(ud1.groupIds, ud2.groupIds) {
 			t.Errorf("Generated jwt output %+v is not equal to the refresh jwt output %+v", ud1, ud2)

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -1,3 +1,16 @@
+//go:build !oss
+//+build !oss
+
+/*
+ * Copyright 2022 Dgraph Labs, Inc. All rights reserved.
+ *
+ * Licensed under the Dgraph Community License (the "License"); you
+ * may not use this file except in compliance with the License. You
+ * may obtain a copy of the License at
+ *
+ *     https://github.com/dgraph-io/dgraph/blob/master/licenses/DCL.txt
+ */
+
 package edgraph
 
 import (
@@ -7,6 +20,7 @@ import (
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/worker"
 
+	"github.com/stretchr/testify/require"
 	jwt "github.com/dgrijalva/jwt-go"
 )
 
@@ -46,8 +60,8 @@ func TestValidateToken(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		tokenString := generateJWT(userdata.namespace, userdata.userId, userdata.groupIds, expiry)
-
-		ud, _ := validateToken(tokenString)
+		ud, err := validateToken(tokenString)
+		require.Nil(t, err)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, userdata.groupIds) {
 			t.Errorf("Actual output %+v is not equal to the expected output %+v", userdata, ud)
 		}
@@ -86,10 +100,11 @@ func TestGetAccessJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		jwtstr, _ := getAccessJwt(userdata.userId, grpLst, userdata.namespace)
-		ud, _ := validateToken (jwtstr)
-
+		ud, err := validateToken (jwtstr)
+		require.Nil(t, err)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, g) {
-			t.Errorf("Actual output {%v %v %v} is not equal to the output %v generated from getAccessJwt() token", userdata.namespace, userdata.userId, grpLst, ud)
+			t.Errorf("Actual output {%v %v %v} is not equal to the output %v generated from"+
+					 " getAccessJwt() token", userdata.namespace, userdata.userId, grpLst, ud)
 		}
 	}
 }
@@ -103,10 +118,11 @@ func TestGetRefreshJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		jwtstr, _ := getRefreshJwt(userdata.userId, userdata.namespace)
-		ud, _ := validateToken (jwtstr)
-
+		ud, err := validateToken (jwtstr)
+		require.Nil(t, err)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId {
-			t.Errorf("Actual output {%v %v} is not equal to the output {%v %v} generated from getRefreshJwt() token", userdata.namespace, userdata.userId, ud.namespace, ud.userId)
+			t.Errorf("Actual output {%v %v} is not equal to the output {%v %v} generated from"+
+					 "getRefreshJwt() token", userdata.namespace, userdata.userId, ud.namespace, ud.userId)
 		}
 	}
 }

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -78,7 +78,6 @@ func TestGetAccessJwt(t *testing.T) {
 	}
 
 	g := acl.GetGroupIDs(grpLst)
-	expiry := time.Now().Add(worker.Config.AccessJwtTtl).Unix()
 	userDataList := []userData{
 		{1234567890, "user1", []string{"701", "702"}},
 		{2345678901, "user2", []string{"703", "701"}},
@@ -86,19 +85,16 @@ func TestGetAccessJwt(t *testing.T) {
 	}
 
 	for _, userdata := range userDataList {
-		tokstr := generateJWT(userdata.namespace, userdata.userId, g, expiry)
-		ud1, _ := validateToken (tokstr)
 		jwtstr, _ := getAccessJwt(userdata.userId, grpLst, userdata.namespace)
-		ud2, _ := validateToken (jwtstr)
+		ud, _ := validateToken (jwtstr)
 
-		if ud1.namespace != ud2.namespace || ud1.userId != ud2.userId || !sliceCompare(ud1.groupIds, ud2.groupIds) {
-			t.Errorf("Generated jwt output %+v is not equal to the access jwt output %+v", ud1, ud2)
+		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, g) {
+			t.Errorf("Actual output {%v %v %v} is not equal to the output %v generated from getAccessJwt() token", userdata.namespace, userdata.userId, grpLst, ud)
 		}
 	}
 }
 
 func TestGetRefreshJwt(t *testing.T) {
-	expiry := time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
 	userDataList := []userData{
 		{1234567890, "user1", []string{"701", "702"}},
 		{2345678901, "user2", []string{"703", "701"}},
@@ -106,13 +102,11 @@ func TestGetRefreshJwt(t *testing.T) {
 	}
 
 	for _, userdata := range userDataList {
-		tokstr := generateJWT(userdata.namespace, userdata.userId, nil, expiry)
-		ud1, _ := validateToken (tokstr)
 		jwtstr, _ := getRefreshJwt(userdata.userId, userdata.namespace)
-		ud2, _ := validateToken (jwtstr)
+		ud, _ := validateToken (jwtstr)
 
-		if ud1.namespace != ud2.namespace || ud1.userId != ud2.userId || !sliceCompare(ud1.groupIds, ud2.groupIds) {
-			t.Errorf("Generated jwt output %+v is not equal to the refresh jwt output %+v", ud1, ud2)
+		if ud.namespace != userdata.namespace || ud.userId != userdata.userId {
+			t.Errorf("Actual output {%v %v} is not equal to the output {%v %v} generated from getRefreshJwt() token", userdata.namespace, userdata.userId, ud.namespace, ud.userId)
 		}
 	}
 }

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -1,27 +1,27 @@
 package edgraph
 
 import (
-        "fmt"
-        "testing"
-        "time"
-        "strings"
-	"github.com/dgraph-io/dgraph/worker"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/dgraph-io/dgraph/ee/acl"
-        jwt "github.com/dgrijalva/jwt-go"
+	"github.com/dgraph-io/dgraph/worker"
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 var (
-        secretkey string = "secretkey"
+	secretkey string = "secretkey"
 
-        userDataList = []userData {
-                        userData{1234567890, "user1", []string {"701", "702"}},
-                        userData{2345678901, "user2", []string {"703", "701"}},
-                        userData{3456789012, "user3", []string {"702", "703"}},
-
-        }
+	userDataList = []userData{
+		userData{1234567890, "user1", []string{"701", "702"}},
+		userData{2345678901, "user2", []string{"703", "701"}},
+		userData{3456789012, "user3", []string{"702", "703"}},
+	}
 )
 
-func generateJWT (namespace uint64, userId string, groupIds []string, exp int64) (string, error) {
+func generateJWT(namespace uint64, userId string, groupIds []string, exp int64) (string, error) {
 	var e1 int64
 	var token *jwt.Token
 
@@ -32,108 +32,108 @@ func generateJWT (namespace uint64, userId string, groupIds []string, exp int64)
 	}
 
 	if groupIds != nil {
-		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims {
-				"namespace": namespace,
-				"userid": userId,
-				"groups": groupIds,
-				"exp":    e1,
-			})
+		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims{
+			"namespace": namespace,
+			"userid":    userId,
+			"groups":    groupIds,
+			"exp":       e1,
+		})
 	} else {
-		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims {
-				"namespace": namespace,
-				"userid": userId,
-				"exp":    e1,
-			})
+		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims{
+			"namespace": namespace,
+			"userid":    userId,
+			"exp":       e1,
+		})
 	}
 
-        tokenString, err := token.SignedString([]byte (worker.Config.HmacSecret))
-        if err != nil {
-                fmt.Errorf("Something Went Wrong: %s", err.Error())
-                return "", err
-        }
-        return tokenString, nil
+	tokenString, err := token.SignedString([]byte(worker.Config.HmacSecret))
+	if err != nil {
+		_ = fmt.Errorf("Something Went Wrong: %s", err.Error())
+		return "", err
+	}
+	return tokenString, nil
 }
 
-func sliceCompare (x, y []string) bool {
-        if len(x) != len(y) {
-                return false
-        }
+func sliceCompare(x, y []string) bool {
+	if len(x) != len(y) {
+		return false
+	}
 
-        for i, s := range x {
-                if s != y[i] {
-                        return false
-                }
-        }
+	for i, s := range x {
+		if s != y[i] {
+			return false
+		}
+	}
 
-        return true
+	return true
 }
 
-func TestValidateToken (t *testing.T) {
-        var (
-                err error
-                tokenString string
-        )
-
-        for _, userdata := range userDataList {
-                if tokenString, err = generateJWT (userdata.namespace, userdata.userId, userdata.groupIds, 0); err != nil {
-                        t.Errorf ("JWT token string generation error: %s", err)
-                        return
-                }
-
-                ud, err := validateToken (tokenString)
-                if err != nil {
-                        t.Errorf ("validateToken() error: %s", err)
-                        return
-                }
-                if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare (ud.groupIds, userdata.groupIds) {
-                        t.Errorf ("Actual output %+v is not equal to the expected output %+v", userdata, ud)
-                }
-        }
-}
-
-func TestGetAccessJwt (t *testing.T) {
+func TestValidateToken(t *testing.T) {
 	var (
-		err error
-		tokstr string
-		jwtstr string
-		exp int64 = time.Now().Add(worker.Config.AccessJwtTtl).Unix()
+		err         error
+		tokenString string
 	)
 
-	grpLst := []acl.Group {
-					acl.Group {
-						"100",
-						"1001",
-						[]acl.User{},
-						[]acl.Acl{},
-					},
-					acl.Group {
-						"101",
-						"1011",
-						[]acl.User{},
-						[]acl.Acl{},
-					},
-					acl.Group {
-						"102",
-						"1021",
-						[]acl.User{},
-						[]acl.Acl{},
-					},
+	for _, userdata := range userDataList {
+		if tokenString, err = generateJWT(userdata.namespace, userdata.userId, userdata.groupIds, 0); err != nil {
+			t.Errorf("JWT token string generation error: %s", err)
+			return
+		}
+
+		ud, err := validateToken(tokenString)
+		if err != nil {
+			t.Errorf("validateToken() error: %s", err)
+			return
+		}
+		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, userdata.groupIds) {
+			t.Errorf("Actual output %+v is not equal to the expected output %+v", userdata, ud)
+		}
+	}
+}
+
+func TestGetAccessJwt(t *testing.T) {
+	var (
+		err    error
+		tokstr string
+		jwtstr string
+		exp    int64 = time.Now().Add(worker.Config.AccessJwtTtl).Unix()
+	)
+
+	grpLst := []acl.Group{
+		{
+			Uid:     "100",
+			GroupID: "1001",
+			Users:   []acl.User{},
+			Rules:   []acl.Acl{},
+		},
+		{
+			Uid:     "101",
+			GroupID: "1011",
+			Users:   []acl.User{},
+			Rules:   []acl.Acl{},
+		},
+		{
+			Uid:     "102",
+			GroupID: "1021",
+			Users:   []acl.User{},
+			Rules:   []acl.Acl{},
+		},
 	}
 
 	for _, userdata := range userDataList {
-		g := acl.GetGroupIDs (grpLst)
-		if tokstr, err = generateJWT (userdata.namespace, userdata.userId, g, exp); err != nil {
-			t.Errorf ("JWT token string generation error: %s", err)
+		g := acl.GetGroupIDs(grpLst)
+		if tokstr, err = generateJWT(userdata.namespace, userdata.userId, g, exp); err != nil {
+			t.Errorf("JWT token string generation error: %s", err)
 			return
 		}
-		t1 := strings.Split (tokstr, ".")
+		t1 := strings.Split(tokstr, ".")
 
-		jwtstr, err = getAccessJwt (userdata.userId, grpLst, userdata.namespace)
+		jwtstr, err = getAccessJwt(userdata.userId, grpLst, userdata.namespace)
 		if err != nil {
-			t.Errorf ("getAccessJwt () error: %s", err)
+			t.Errorf("getAccessJwt () error: %s", err)
 			return
 		}
-		t2 := strings.Split (jwtstr, ".")
+		t2 := strings.Split(jwtstr, ".")
 
 		/*
 		 * JWT token format = [header].[payload].[signature].
@@ -141,32 +141,32 @@ func TestGetAccessJwt (t *testing.T) {
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
 		if t1[0] != t2[0] || t1[1] != t2[1] {
-			t.Errorf ("Actual output is not equal to the expected output")
+			t.Errorf("Actual output is not equal to the expected output")
 		}
 	}
 }
 
-func TestGetRefreshJwt (t *testing.T) {
+func TestGetRefreshJwt(t *testing.T) {
 	var (
-		err error
+		err    error
 		tokstr string
 		jwtstr string
-		exp int64 = time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
+		exp    int64 = time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
 	)
 
 	for _, userdata := range userDataList {
-		if tokstr, err = generateJWT (userdata.namespace, userdata.userId, nil, exp); err != nil {
-                        t.Errorf ("JWT token string generation error: %s", err)
-                        return
-                }
-		t1 := strings.Split (tokstr, ".")
+		if tokstr, err = generateJWT(userdata.namespace, userdata.userId, nil, exp); err != nil {
+			t.Errorf("JWT token string generation error: %s", err)
+			return
+		}
+		t1 := strings.Split(tokstr, ".")
 
-                jwtstr, err = getRefreshJwt (userdata.userId, userdata.namespace)
+		jwtstr, err = getRefreshJwt(userdata.userId, userdata.namespace)
 		if err != nil {
-			t.Errorf ("getAccessJwt () error: %s", err)
-                        return
-                }
-		t2 := strings.Split (jwtstr, ".")
+			t.Errorf("getAccessJwt () error: %s", err)
+			return
+		}
+		t2 := strings.Split(jwtstr, ".")
 
 		/*
 		 * JWT token format = [header].[payload].[signature].
@@ -174,7 +174,7 @@ func TestGetRefreshJwt (t *testing.T) {
 		 * This will differ for tokstr and jwtstr and hence ignoring it.
 		 */
 		if t1[0] != t2[0] || t1[1] != t2[1] {
-                        t.Errorf ("Actual output is not equal to the expected output")
-                }
-        }
+			t.Errorf("Actual output is not equal to the expected output")
+		}
+	}
 }

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -27,20 +27,15 @@ func generateJWT(namespace uint64, userId string, groupIds []string, exp int64) 
 		e1 = time.Now().Add(time.Minute * 30).Unix()
 	}
 
-	claims := &jwt.MapClaims{
+	claims := jwt.MapClaims{
 		"namespace": namespace,
 		"userid":    userId,
 		"exp":       e1,
 	}
 	if groupIds != nil {
-		claims = &jwt.MapClaims{
-			"namespace": namespace,
-			"userid":    userId,
-			"groups":    groupIds,
-			"exp":       e1,
-		}
+			claims["groups"] = groupIds
 	}
-	token = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token = jwt.NewWithClaims(jwt.SigningMethodHS256, &claims)
 
 	tokenString, err := token.SignedString([]byte(worker.Config.HmacSecret))
 	if err != nil {

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -1,0 +1,180 @@
+package edgraph
+
+import (
+        "fmt"
+        "testing"
+        "time"
+        "strings"
+	"github.com/dgraph-io/dgraph/worker"
+	"github.com/dgraph-io/dgraph/ee/acl"
+        jwt "github.com/dgrijalva/jwt-go"
+)
+
+var (
+        secretkey string = "secretkey"
+
+        userDataList = []userData {
+                        userData{1234567890, "user1", []string {"701", "702"}},
+                        userData{2345678901, "user2", []string {"703", "701"}},
+                        userData{3456789012, "user3", []string {"702", "703"}},
+
+        }
+)
+
+func generateJWT (namespace uint64, userId string, groupIds []string, exp int64) (string, error) {
+	var e1 int64
+	var token *jwt.Token
+
+	if exp == 0 {
+		e1 = time.Now().Add(time.Minute * 30).Unix()
+	} else {
+		e1 = exp
+	}
+
+	if groupIds != nil {
+		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims {
+				"namespace": namespace,
+				"userid": userId,
+				"groups": groupIds,
+				"exp":    e1,
+			})
+	} else {
+		token = jwt.NewWithClaims(jwt.SigningMethodHS256, &jwt.MapClaims {
+				"namespace": namespace,
+				"userid": userId,
+				"exp":    e1,
+			})
+	}
+
+        tokenString, err := token.SignedString([]byte (worker.Config.HmacSecret))
+        if err != nil {
+                fmt.Errorf("Something Went Wrong: %s", err.Error())
+                return "", err
+        }
+        return tokenString, nil
+}
+
+func sliceCompare (x, y []string) bool {
+        if len(x) != len(y) {
+                return false
+        }
+
+        for i, s := range x {
+                if s != y[i] {
+                        return false
+                }
+        }
+
+        return true
+}
+
+func TestValidateToken (t *testing.T) {
+        var (
+                err error
+                tokenString string
+        )
+
+        for _, userdata := range userDataList {
+                if tokenString, err = generateJWT (userdata.namespace, userdata.userId, userdata.groupIds, 0); err != nil {
+                        t.Errorf ("JWT token string generation error: %s", err)
+                        return
+                }
+
+                ud, err := validateToken (tokenString)
+                if err != nil {
+                        t.Errorf ("validateToken() error: %s", err)
+                        return
+                }
+                if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare (ud.groupIds, userdata.groupIds) {
+                        t.Errorf ("Actual output %+v is not equal to the expected output %+v", userdata, ud)
+                }
+        }
+}
+
+func TestGetAccessJwt (t *testing.T) {
+	var (
+		err error
+		tokstr string
+		jwtstr string
+		exp int64 = time.Now().Add(worker.Config.AccessJwtTtl).Unix()
+	)
+
+	grpLst := []acl.Group {
+					acl.Group {
+						"100",
+						"1001",
+						[]acl.User{},
+						[]acl.Acl{},
+					},
+					acl.Group {
+						"101",
+						"1011",
+						[]acl.User{},
+						[]acl.Acl{},
+					},
+					acl.Group {
+						"102",
+						"1021",
+						[]acl.User{},
+						[]acl.Acl{},
+					},
+	}
+
+	for _, userdata := range userDataList {
+		g := acl.GetGroupIDs (grpLst)
+		if tokstr, err = generateJWT (userdata.namespace, userdata.userId, g, exp); err != nil {
+			t.Errorf ("JWT token string generation error: %s", err)
+			return
+		}
+		t1 := strings.Split (tokstr, ".")
+
+		jwtstr, err = getAccessJwt (userdata.userId, grpLst, userdata.namespace)
+		if err != nil {
+			t.Errorf ("getAccessJwt () error: %s", err)
+			return
+		}
+		t2 := strings.Split (jwtstr, ".")
+
+		/*
+		 * JWT token format = [header].[payload].[signature].
+		 * One of the factor [signature] would differ is based on the expiry time.
+		 * This will differ for tokstr and jwtstr and hence ignoring it.
+		 */
+		if t1[0] != t2[0] || t1[1] != t2[1] {
+			t.Errorf ("Actual output is not equal to the expected output")
+		}
+	}
+}
+
+func TestGetRefreshJwt (t *testing.T) {
+	var (
+		err error
+		tokstr string
+		jwtstr string
+		exp int64 = time.Now().Add(worker.Config.RefreshJwtTtl).Unix()
+	)
+
+	for _, userdata := range userDataList {
+		if tokstr, err = generateJWT (userdata.namespace, userdata.userId, nil, exp); err != nil {
+                        t.Errorf ("JWT token string generation error: %s", err)
+                        return
+                }
+		t1 := strings.Split (tokstr, ".")
+
+                jwtstr, err = getRefreshJwt (userdata.userId, userdata.namespace)
+		if err != nil {
+			t.Errorf ("getAccessJwt () error: %s", err)
+                        return
+                }
+		t2 := strings.Split (jwtstr, ".")
+
+		/*
+		 * JWT token format = [header].[payload].[signature].
+		 * One of the factor [signature] would differ is based on the expiry time.
+		 * This will differ for tokstr and jwtstr and hence ignoring it.
+		 */
+		if t1[0] != t2[0] || t1[1] != t2[1] {
+                        t.Errorf ("Actual output is not equal to the expected output")
+                }
+        }
+}


### PR DESCRIPTION
## Problem
Missing unit tests for validateToken (), getAcessJwt (), getRefreshJwt () of edgraph package

## Solution
TestValidateToken (), TestGetAccessJwt () and TestRefreshJwt () generates a signed JSON Web token using the static data defined in the test file, using the helper function generateJWT (). The generated token includes the token expiry time which is passed as an argument to the helper function.
TestValidateToken () calls validateToken and extracts data from the signed token which is then compared to validate with the original data.

TestGetAccessJwt() and TestRefreshJwt () are direct wrappers over jwt.NewWithClaims () but with their predefined expiry duration.