### PR TITLE
chore(ci): let pkg flag take multiple arguments

### DIFF
--- a/t/t.go
+++ b/t/t.go
@@ -495,7 +495,7 @@ func getPackages() []task {
 
 	slowPkgs := []string{"systest", "ee/acl", "cmd/alpha", "worker", "e2e"}
 	skipPkgs := strings.Split(*skip, ",")
-	runPkgs := strings.Split(*runPkg, ",")
+	runPkgs  := strings.Split(*runPkg, ",")
 
 	moveSlowToFront := func(list []task) []task {
 		// These packages typically take over a minute to run.
@@ -535,12 +535,12 @@ func getPackages() []task {
 			found := false
 			for _, eachPkg := range runPkgs {
 				if strings.HasSuffix(pkg.ID, eachPkg) {
-					fmt.Printf("******* breaking for %s\n", pkg.ID)
 					found = true
 					break
 				}
 			}
 			if !found {
+				// pkg did not match any element of runPkg
 				continue
 			}
 		}

--- a/t/t.go
+++ b/t/t.go
@@ -495,6 +495,7 @@ func getPackages() []task {
 
 	slowPkgs := []string{"systest", "ee/acl", "cmd/alpha", "worker", "e2e"}
 	skipPkgs := strings.Split(*skip, ",")
+	runPkgs := strings.Split(*runPkg, ",")
 
 	moveSlowToFront := func(list []task) []task {
 		// These packages typically take over a minute to run.
@@ -530,8 +531,18 @@ func getPackages() []task {
 
 	var valid []task
 	for _, pkg := range pkgs {
-		if len(*runPkg) > 0 && !strings.HasSuffix(pkg.ID, "/"+*runPkg) {
-			continue
+		if len(*runPkg) > 0 {
+			found := false
+			for _, eachPkg := range runPkgs {
+				if strings.HasSuffix(pkg.ID, eachPkg) {
+					fmt.Printf("******* breaking for %s\n", pkg.ID)
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
 		}
 
 		if len(*runTest) > 0 {


### PR DESCRIPTION
## Problem
Previously running

```
./t --pkg="systest/backup/common,systest/backup/encryption"
```

would not run any packages, because the pkg flag is currently parsed as a single string and matched against the list of packages in the repository.  Internally, a pkg.ID looks like 
```
github.com/dgraph-io/dgraph/systest/backup/common
```

so we are matching against this string.

## Solution

We split the string argument provided to --pkg by comma.  Now the above command will run two packages as expected.