### PR TITLE
chore(ci): pin runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -2,7 +2,7 @@ name: cd-dgraph
 on: workflow_dispatch
 jobs:
   dgraph-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -15,7 +15,7 @@ on:
     - cron: "30 * * * *"
 jobs:
   dgraph-ldbc-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout Dgraph
         uses: actions/checkout@v3

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -18,7 +18,7 @@ jobs:
     # TODO: uncomment this after release work
     # if: github.event.pull_request.draft == false
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Get Go Version


### PR DESCRIPTION
## Problem

As per [Github](https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/) the `ubuntu-latest` label is transitioning to Ubuntu 22.04.  We would like to continue running on Ubuntu 20.04 for now.

## Solution

Pin runner to Ubuntu 20.04.