### PR TITLE
Update base ubuntu image

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -4,7 +4,7 @@
 # This gets built as part of release.sh. Must be run from /tmp/build, with the linux binaries
 # already built and placed there.
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
 RUN apt-get update


### PR DESCRIPTION
## Problem
Our base image for building dgraph docker images is `ubuntu:20.04`. This causes issue when we want to run tests on github provided machines. 
## Solution
PR updates base image to `ubuntu:22.04`. 