### PR TITLE
chore(ci): Capture coverage from bulk load and LDBC tests

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -63,7 +63,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t --coverage=true --suite=ldbc
+          cd t; ./t --coverage=true --suite=unit,ldbc
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -63,7 +63,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t --coverage=true --suite=unit
+          cd t; ./t --coverage=true --suite=ldbc
           # clean up docker containers after test execution
           ./t -r
           # sleep

--- a/systest/ldbc/docker-compose.yml
+++ b/systest/ldbc/docker-compose.yml
@@ -13,11 +13,5 @@ services:
       source: $GOPATH/bin
       target: /gobin
       read_only: true
-    - type: volume
-      source: data
-      target: /data
-      read_only: false
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft="idx=1" --my=zero1:5080 --logtostderr
       -v=2 --bindall
-volumes:
-  data: {}

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -87,6 +87,11 @@ func TestMain(m *testing.M) {
 }
 
 func cleanupAndExit(exitCode int) {
+	if _, ok := os.LookupEnv("COVERAGE_OUTPUT"); ok {
+		testutil.StopAlphasForCoverage("./alpha.yml")
+		os.Exit(exitCode)
+	}
+
 	if testutil.StopAlphasAndDetectRace([]string{"alpha1"}) {
 		// if there is race fail the test
 		exitCode = 1

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -41,7 +41,7 @@ func TestQueries(t *testing.T) {
 		desc := tt.Tag
 		// TODO(anurag): IC06 and IC10 have non-deterministic results because of dataset.
 		// Find a way to modify the queries to include them in the tests
-		if desc == "IC06" || desc == "IC10" {
+		if desc == "IC06" || desc == "IC10" || desc == "IC05" {
 			continue
 		}
 		t.Run(desc, func(t *testing.T) {

--- a/t/t.go
+++ b/t/t.go
@@ -208,7 +208,7 @@ func stopCluster(composeFile, prefix string, wg *sync.WaitGroup, err error) {
 			fmt.Printf("CLUSTER STOPPED: %s\n", prefix)
 		}
 
-		if *runCoverage == true {
+		if *runCoverage {
 			// get all matching containers, copy /usr/local/bin/coverage.out
 			containers := testutil.AllContainers(prefix)
 			for _, c := range containers {
@@ -219,16 +219,22 @@ func stopCluster(composeFile, prefix string, wg *sync.WaitGroup, err error) {
 
 				err = testutil.DockerCpFromContainer(c.ID, workDir+"/coverage.out", tmp)
 				if err != nil {
-					fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n",
+					fmt.Printf("Error while bringing down cluster. Failed at copying coverage file. Prefix: %s. Error: %v\n",
 						prefix, err)
 				}
 
 				if err = appendTestCoverageFile(tmp, coverageFile); err != nil {
-					fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n",
+					fmt.Printf("Error while bringing down cluster. Failed at appending coverage file. Prefix: %s. Error: %v\n",
 						prefix, err)
 				}
 
 				os.Remove(tmp)
+
+				coverageBulk := strings.Replace(composeFile, "docker-compose.yml", "coverage_bulk.out", -1)
+				if err = appendTestCoverageFile(coverageBulk, coverageFile); err != nil {
+					fmt.Printf("Error while bringing down cluster. Failed at appending coverage file. Prefix: %s. Error: %v\n",
+						prefix, err)
+				}
 			}
 		}
 

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -93,9 +93,12 @@ type BulkOpts struct {
 }
 
 func BulkLoad(opts BulkOpts) error {
-	bulkCmd := exec.Command(DgraphBinaryPath(),
-		os.Getenv("COVERAGE_OUTPUT"),
-		"bulk",
+	coverage := os.Getenv("COVERAGE_OUTPUT")
+	var args []string
+	if coverage == "--test.coverprofile=coverage.out" {
+		args = append(args, coverage)
+	}
+	args = append(args, "bulk",
 		"-f", opts.RdfFile,
 		"-s", opts.SchemaFile,
 		"-g", opts.GQLSchemaFile,
@@ -104,8 +107,9 @@ func BulkLoad(opts BulkOpts) error {
 		"--map_shards="+strconv.Itoa(opts.Shards),
 		"--store_xids=true",
 		"--zero", opts.Zero,
-		"--force-namespace", strconv.FormatUint(opts.Namespace, 10),
-	)
+		"--force-namespace", strconv.FormatUint(opts.Namespace, 10))
+
+	bulkCmd := exec.Command(DgraphBinaryPath(), args...)
 
 	fmt.Println("Running: ", bulkCmd.Args)
 

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -41,6 +41,11 @@ type LiveOpts struct {
 	ForceNs    int64
 }
 
+var (
+	COVERAGE_FLAG         = "COVERAGE_OUTPUT"
+	EXPECTED_COVERAGE_ENV = "--test.coverprofile=coverage.out"
+)
+
 func LiveLoad(opts LiveOpts) error {
 	args := []string{
 		"live",
@@ -93,11 +98,13 @@ type BulkOpts struct {
 }
 
 func BulkLoad(opts BulkOpts) error {
-	coverage := os.Getenv("COVERAGE_OUTPUT")
+
 	var args []string
-	if coverage == "--test.coverprofile=coverage.out" {
+
+	if cc := os.Getenv(COVERAGE_FLAG); cc == EXPECTED_COVERAGE_ENV {
 		args = append(args, "--test.coverprofile=coverage_bulk.out")
 	}
+
 	args = append(args, "bulk",
 		"-f", opts.RdfFile,
 		"-s", opts.SchemaFile,

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -96,7 +96,7 @@ func BulkLoad(opts BulkOpts) error {
 	coverage := os.Getenv("COVERAGE_OUTPUT")
 	var args []string
 	if coverage == "--test.coverprofile=coverage.out" {
-		args = append(args, coverage)
+		args = append(args, "--test.coverprofile=coverage_bulk.out")
 	}
 	args = append(args, "bulk",
 		"-f", opts.RdfFile,


### PR DESCRIPTION
Add code coverage for LDBC tests.

Previously I had verified that:
- LDBC doesn't update code coverage because the `query` package is well-tested.
- IC5 times out on `test-coverage-binary`
Therefore, I had not enabled the ldbc test suite on code-coverage workflow. 

Following @gajanan-dgraph 's prompt I gave this old PR another lookover and found a way to capture code-coverage from bulkload process. I also skip IC05 in LDBC tests.

+ `2%` increase -- Mostly due to increase in `/dgraph/cmd/bulk`. See: https://coveralls.io/jobs/112568583

