### PR TITLE
Add tests for ResetPassword

### DIFF
--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -200,6 +200,33 @@ func TestCreateNamespace(t *testing.T) {
 	require.Contains(t, err.Error(), "Only guardian of galaxy is allowed to do this operation")
 }
 
+func TestResetPassword(t *testing.T) {
+	prepare(t)
+
+	galaxyToken := testutil.Login(t,
+		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
+
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+
+	// Reset Password
+	_, err = testutil.ResetPassword(t, galaxyToken, "groot", "newpassword", ns)
+	require.NoError(t, err)
+
+	// Try and Fail with old password for groot
+	token := testutil.Login(t,
+		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
+
+	require.Nil(t, token, "nil token because incorrect login")
+
+	// Try and success with new password for groot
+	token = testutil.Login(t,
+		&testutil.LoginParams{UserID: "groot", Passwd: "newpassword", Namespace: ns})
+
+	require.Equal(t, token.Password, "newpassword", "new password matches the reset password")
+}
+
 func TestDeleteNamespace(t *testing.T) {
 	prepare(t)
 	galaxyToken := testutil.Login(t,

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -110,7 +110,7 @@ func CreateNamespaceWithRetry(t *testing.T, token *HttpToken) (uint64, error) {
 					 addNamespace
 					  {
 					    namespaceId
-						message
+					    message
 					  }
 					}`
 


### PR DESCRIPTION

## Description
As per coverall report of [integration tests](https://coveralls.io/builds/54838866/source?filename=edgraph%2Fmulti_tenancy_ee.go#L91), we didn't have a test for `ResetPassword` flow. This PR adds a test.

This PR also removes `time.Sleep(defaultTimeToSleep)` at some places to make the acl tests run faster.
