### PR TITLE
fix(ci/cd): pin linux deps

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -11,12 +11,12 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
 RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends sysstat
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
 RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
-RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,12 +10,12 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
+RUN apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
 RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
-RUN apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-# RUN apt-get install -y --no-install-recommends ca-certificates="20211016~20.04.1"
+RUN apt-get install -y --no-install-recommends ca-certificates="20211016ubuntu20.04.1"
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-RUN apt-get install -y --no-install-recommends ca-certificates="20211016ubuntu20.04.1"
+RUN apt-get install -y --no-install-recommends ca-certificates="20211016ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y --no-install-recommends curl
 RUN apt-get install -y --no-install-recommends htop
-RUN apt-get install -y --no-install-recommends iputils-ping
-RUN apt-get install -y --no-install-recommends jq
-RUN apt-get install -y --no-install-recommends less
+RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
+RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
+RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
 RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
 RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
-RUN apt-get install -y --no-install-recommends sysstat="12.2.0-2ubuntu0.1"
+# RUN apt-get install -y --no-install-recommends sysstat="12.2.0-2ubuntu0.1"
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -21,9 +21,9 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates
 RUN apt-get install -y --no-install-recommends curl
 RUN apt-get install -y --no-install-recommends htop
-RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
-RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
-RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
+RUN apt-get install -y --no-install-recommends iputils-ping
+RUN apt-get install -y --no-install-recommends jq
+RUN apt-get install -y --no-install-recommends less
 RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -7,26 +7,21 @@
 FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
+# need to remove the cache of sources lists
+# apt-get Error Code 100
+# https://www.marnel.net/2015/08/apt-get-error-code-100/
+RUN rm -rf /var/lib/apt/lists/*
+
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-# RUN apt-get install -y --no-install-recommends ca-certificates
-# RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
-# RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
-# RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
-# RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
-# RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
-# RUN apt-get install -y --no-install-recommends sysstat
-
-RUN apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y --no-install-recommends curl
-RUN apt-get install -y --no-install-recommends htop
-RUN apt-get install -y --no-install-recommends iputils-ping
-RUN apt-get install -y --no-install-recommends jq
-RUN apt-get install -y --no-install-recommends less
-RUN apt-get install -y --no-install-recommends sysstat
-
-# rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
+RUN apt-get install -y --no-install-recommends ca-certificates="20211016ubuntu0.20.04.1"
+RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
+RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
+RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
+RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
+RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
+RUN apt-get install -y --no-install-recommends sysstat="12.2.0-2ubuntu0.2"
 
 ADD linux /usr/local/bin
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,13 +10,21 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
+# RUN apt-get install -y --no-install-recommends ca-certificates
+# RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
+# RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
+# RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
+# RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
+# RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
+# RUN apt-get install -y --no-install-recommends sysstat
+
 RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends curl
+RUN apt-get install -y --no-install-recommends htop
+RUN apt-get install -y --no-install-recommends iputils-ping
+RUN apt-get install -y --no-install-recommends jq
+RUN apt-get install -y --no-install-recommends less
 RUN apt-get install -y --no-install-recommends sysstat
-RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
-RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
-RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
-RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
-RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -7,6 +7,7 @@
 FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
+# only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
 RUN apt-get install -y --no-install-recommends ca-certificates=20211016~20.04.1

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,13 +10,13 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-RUN apt-get install -y --no-install-recommends ca-certificates="20211016ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
 RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
 RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
-# RUN apt-get install -y --no-install-recommends sysstat="12.2.0-2ubuntu0.1"
+RUN apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get install -y --no-install-recommends sysstat
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,7 +10,7 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-RUN apt-get install -y --no-install-recommends ca-certificates="20211016~20.04.1"
+# RUN apt-get install -y --no-install-recommends ca-certificates="20211016~20.04.1"
 RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
 RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
 RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,13 +8,14 @@ FROM ubuntu:20.04
 LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y --no-install-recommends curl
-RUN apt-get install -y --no-install-recommends htop
-RUN apt-get install -y --no-install-recommends iputils-ping
-RUN apt-get install -y --no-install-recommends jq
-RUN apt-get install -y --no-install-recommends less
-RUN apt-get install -y --no-install-recommends sysstat
+# pin package versions always & bring in CVE fixes as needed
+RUN apt-get install -y --no-install-recommends ca-certificates=20211016~20.04.1
+RUN apt-get install -y --no-install-recommends curl=7.68.0-1ubuntu2.14
+RUN apt-get install -y --no-install-recommends htop=2.2.0-2build1
+RUN apt-get install -y --no-install-recommends iputils-ping=3:20190709-3
+RUN apt-get install -y --no-install-recommends jq=1.6-1ubuntu0.20.04.1
+RUN apt-get install -y --no-install-recommends less=551-1ubuntu0.1
+RUN apt-get install -y --no-install-recommends sysstat=12.2.0-2ubuntu0.1
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -10,13 +10,13 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 # only update, don't run upgrade
 RUN apt-get update
 # pin package versions always & bring in CVE fixes as needed
-RUN apt-get install -y --no-install-recommends ca-certificates=20211016~20.04.1
-RUN apt-get install -y --no-install-recommends curl=7.68.0-1ubuntu2.14
-RUN apt-get install -y --no-install-recommends htop=2.2.0-2build1
-RUN apt-get install -y --no-install-recommends iputils-ping=3:20190709-3
-RUN apt-get install -y --no-install-recommends jq=1.6-1ubuntu0.20.04.1
-RUN apt-get install -y --no-install-recommends less=551-1ubuntu0.1
-RUN apt-get install -y --no-install-recommends sysstat=12.2.0-2ubuntu0.1
+RUN apt-get install -y --no-install-recommends ca-certificates="20211016~20.04.1"
+RUN apt-get install -y --no-install-recommends curl="7.68.0-1ubuntu2.14"
+RUN apt-get install -y --no-install-recommends htop="2.2.0-2build1"
+RUN apt-get install -y --no-install-recommends iputils-ping="3:20190709-3"
+RUN apt-get install -y --no-install-recommends jq="1.6-1ubuntu0.20.04.1"
+RUN apt-get install -y --no-install-recommends less="551-1ubuntu0.1"
+RUN apt-get install -y --no-install-recommends sysstat="12.2.0-2ubuntu0.1"
 
 # rm -rf /var/lib/apt/lists/* # TODO: clean this up only if necessary
 


### PR DESCRIPTION
## Problem
The current problem with our Dgraph Docker environment is that the base linux packages are NOT pinned. We build the Docker container in our CI setup every time, and are pulling the `latest` tags. It's a good practice to make these dependencies static. This will avoid potential issues that can arise from environment changes.

## Solution
use `apt-cache policy <package name>` to identify the candidate version & old installed version. 
pin the packages correctly, and maintain them when CVE fixes are needed in the future.