### PR TITLE
fix(version): bump up dgraph version in source

### DIFF
--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -215,9 +215,7 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 		}
 	}
 
-	// DgraphVersion hard coded in x.go
-	// todo: dgraph version probably should not be hard coded in source
-	// todo: we should use ldflag in init.go (currently not exported) to set this version
+	// TODO: we should use ldflag in init.go to set this version (currently DgraphVersion hard coded in x.go)
 	dir := fmt.Sprintf(backupPathFmt, req.UnixTs)
 	m := Manifest{
 		ReadTs:         req.ReadTs,

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -217,7 +217,7 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 
 	// DgraphVersion hard coded in x.go
 	// todo: dgraph version probably should not be hard coded in source
-	// todo: we should use ldflag in init.go (currently not exported)
+	// todo: we should use ldflag in init.go (currently not exported) to set this version
 	dir := fmt.Sprintf(backupPathFmt, req.UnixTs)
 	m := Manifest{
 		ReadTs:         req.ReadTs,

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -214,6 +215,9 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 		}
 	}
 
+	// DgraphVersion hard coded in x.go
+	// todo: dgraph version probably should not be hard coded in source
+	// todo: we should use ldflag in init.go (currently not exported)
 	dir := fmt.Sprintf(backupPathFmt, req.UnixTs)
 	m := Manifest{
 		ReadTs:         req.ReadTs,

--- a/x/x.go
+++ b/x/x.go
@@ -140,7 +140,7 @@ const (
 		"X-CSRF-Token, X-Auth-Token, X-Requested-With"
 	DgraphCostHeader = "Dgraph-TouchedUids"
 
-	// todo: we should use ldflag in init.go (currently not exported) to set this version
+	// TODO: we should use ldflag in init.go (currently not exported) to set this version
 	DgraphVersion = 2200
 )
 

--- a/x/x.go
+++ b/x/x.go
@@ -140,7 +140,8 @@ const (
 		"X-CSRF-Token, X-Auth-Token, X-Requested-With"
 	DgraphCostHeader = "Dgraph-TouchedUids"
 
-	DgraphVersion = 2103
+	// todo: we should use ldflag in init.go (currently not exported) to set this version
+	DgraphVersion = 2200
 )
 
 var (


### PR DESCRIPTION
## Problem
 
Dgraph version is hard coded in source.  Currently it is still at 2103.  This should be bumped up to the latest version.  Thanks to @MichelDiz for noticing this issue.

## Solution

Added todo's because we probably should not be hard coding this into source.  We already pass the version in via ldflags, we could potentially use this instead.