### PR TITLE
fix(ci): unskip directives and normal in graphql/e2e for arm

### DIFF
--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -62,7 +62,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          cd t; ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/normal,graphql/e2e/directives,graphql/e2e/custom_logic"
+          cd t; ./t --skip="systest/export,systest/backup/minio,systest/backup/minio-large,graphql/e2e/custom_logic"
           # clean up docker containers after test execution
           ./t -r
           # sleep


### PR DESCRIPTION
## Problem

We were skipping these tests due to lambda containers not being compatible with arm.

## Solution

We pushed a new multi-architecture lambda image and use this when running arm tests.