### PR TITLE
fix(ACL): Prevents permissions overrride and merges acl cache to persist permissions across different namespaces (#8418)

### DIFF
--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -1180,14 +1181,13 @@ func AuthorizeGuardians(ctx context.Context) error {
 }
 
 /*
-	addUserFilterToQuery applies makes sure that a user can access only its own
-	acl info by applying filter of userid and groupid to acl predicates. A query like
-	Conversion pattern:
-		* me(func: type(dgraph.type.Group)) ->
-				me(func: type(dgraph.type.Group)) @filter(eq("dgraph.xid", groupIds...))
-		* me(func: type(dgraph.type.User)) ->
-				me(func: type(dgraph.type.User)) @filter(eq("dgraph.xid", userId))
-
+addUserFilterToQuery applies makes sure that a user can access only its own
+acl info by applying filter of userid and groupid to acl predicates. A query like
+Conversion pattern:
+  - me(func: type(dgraph.type.Group)) ->
+    me(func: type(dgraph.type.Group)) @filter(eq("dgraph.xid", groupIds...))
+  - me(func: type(dgraph.type.User)) ->
+    me(func: type(dgraph.type.User)) @filter(eq("dgraph.xid", userId))
 */
 func addUserFilterToQuery(gq *gql.GraphQuery, userId string, groupIds []string) {
 	if gq.Func != nil && gq.Func.Name == "type" {
@@ -1274,17 +1274,17 @@ func groupFilter(groupIds []string) *gql.FilterTree {
 }
 
 /*
- addUserFilterToFilter makes sure that user can't misue filters to access other user's info.
- If the *filter* have type(dgraph.type.Group) or type(dgraph.type.User) functions,
- it generate a *newFilter* with function like eq(dgraph.xid, userId) or eq(dgraph.xid,groupId...)
- and return a filter of the form
+	 addUserFilterToFilter makes sure that user can't misue filters to access other user's info.
+	 If the *filter* have type(dgraph.type.Group) or type(dgraph.type.User) functions,
+	 it generate a *newFilter* with function like eq(dgraph.xid, userId) or eq(dgraph.xid,groupId...)
+	 and return a filter of the form
 
-		&gql.FilterTree{
-			Op: "AND",
-			Child: []gql.FilterTree{
-				{filter, newFilter}
+			&gql.FilterTree{
+				Op: "AND",
+				Child: []gql.FilterTree{
+					{filter, newFilter}
+				}
 			}
-		}
 */
 func addUserFilterToFilter(filter *gql.FilterTree, userId string,
 	groupIds []string) *gql.FilterTree {

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*

--- a/testutil/json.go
+++ b/testutil/json.go
@@ -41,7 +41,7 @@ func CompareJSONMaps(t *testing.T, wantMap, gotMap map[string]interface{}) bool 
 	return DiffJSONMaps(t, wantMap, gotMap, "", false)
 }
 
-//EqualJSON compares two JSON objects for equality.
+// EqualJSON compares two JSON objects for equality.
 func EqualJSON(t *testing.T, want, got string, savepath string, quiet bool) bool {
 	wantMap := UnmarshalJSON(t, want)
 	gotMap := UnmarshalJSON(t, got)

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -267,7 +267,7 @@ func AddToGroup(t *testing.T, token *HttpToken, userName, group string) {
 	require.True(t, foundGroup)
 }
 
-func AddRulesToGroup(t *testing.T, token *HttpToken, group string, rules []Rule) {
+func AddRulesToGroup(t *testing.T, token *HttpToken, group string, rules []Rule, newGroup bool) {
 	addRuleToGroup := `mutation updateGroup($name: String!, $rules: [RuleRef!]!) {
 		updateGroup(input: {
 			filter: {
@@ -310,7 +310,9 @@ func AddRulesToGroup(t *testing.T, token *HttpToken, group string, rules []Rule)
 			]
 		  }
 	  }`, group, rulesb)
-	CompareJSON(t, expectedOutput, string(resp.Data))
+	if newGroup {
+		CompareJSON(t, expectedOutput, string(resp.Data))
+	}
 }
 
 func DgClientWithLogin(t *testing.T, id, password string, ns uint64) *dgo.Dgraph {

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/require"
@@ -130,4 +131,26 @@ func JsonGet(j interface{}, components ...string) interface{} {
 		j = j.(map[string]interface{})[component]
 	}
 	return j
+}
+
+func PollTillPassOrTimeout(t *testing.T, dc *dgo.Dgraph, query, want string, timeout time.Duration) {
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	to := time.NewTimer(timeout)
+	defer to.Stop()
+	for {
+		select {
+		case <-to.C:
+			wantMap := UnmarshalJSON(t, want)
+			gotMap := UnmarshalJSON(t, string(QueryData(t, dc, query)))
+			DiffJSONMaps(t, wantMap, gotMap, "", false)
+			return // timeout
+		case <-ticker.C:
+			wantMap := UnmarshalJSON(t, want)
+			gotMap := UnmarshalJSON(t, string(QueryData(t, dc, query)))
+			if DiffJSONMaps(t, wantMap, gotMap, "", true) {
+				return
+			}
+		}
+	}
 }


### PR DESCRIPTION
In the current implementation, when you update ACL rules across
different namespaces, the previous rules are overwritten. This results
in incorrect results for other namespaces (the ones which were created
earlier).

To reproduce:
1. Create a `namespace-1` with acl rules configured
2. Create a `namespace-2` with a different set of acl rules configured
3. Login to `namespace-1` and do a query. It will not respect the rules
configured in step-1.


1. `TestTwoPermissionSetsInNameSpacesWithAcl`

(cherry picked from commit de758acec0e046b78703e8c6ff3593c99cf71029)