### PR TITLE
feat(restore): Introduce incremental restore (#7942)

### DIFF
--- a/posting/index.go
+++ b/posting/index.go
@@ -1240,15 +1240,26 @@ func DeleteData() error {
 	return pstore.DropPrefix([]byte{x.DefaultPrefix})
 }
 
-// DeletePredicate deletes all entries and indices for a given predicate.
-func DeletePredicate(ctx context.Context, attr string, ts uint64) error {
+// DeletePredicate deletes all entries and indices for a given predicate. The delete may be logical
+// based on DB options set.
+func DeletePredicate(ctx context.Context, attr string) error {
 	glog.Infof("Dropping predicate: [%s]", attr)
 	prefix := x.PredicatePrefix(attr)
 	if err := pstore.DropPrefix(prefix); err != nil {
 		return err
 	}
+	return schema.State().Delete(attr)
+}
 
-	return schema.State().Delete(attr, ts)
+// DeletePredicateBlocking deletes all entries and indices for a given predicate. It also blocks the
+// writes.
+func DeletePredicateBlocking(ctx context.Context, attr string) error {
+	glog.Infof("Dropping predicate: [%s]", attr)
+	prefix := x.PredicatePrefix(attr)
+	if err := pstore.DropPrefixBlocking(prefix); err != nil {
+		return err
+	}
+	return schema.State().Delete(attr)
 }
 
 // DeleteNamespace bans the namespace and deletes its predicates/types from the schema.

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -1458,7 +1458,7 @@ func TestMain(m *testing.M) {
 	dir, err := ioutil.TempDir("", "storetest_")
 	x.Check(err)
 
-	ps, err = badger.OpenManaged(badger.DefaultOptions(dir))
+	ps, err = badger.OpenManaged(badger.DefaultOptions(dir).WithAllowStopTheWorld(false))
 	x.Check(err)
 	// Not using posting list cache
 	Init(ps, 0)

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -146,7 +146,7 @@ func deleteStalePreds(ctx context.Context, kvs *pb.KVS, ts uint64) error {
 				// While retrieving the snapshot, we mark the node as unhealthy. So it is better to
 				// a blocking delete of predicate as we know that no new writes will arrive at
 				// this alpha.
-				err := posting.DeletePredicate(ctx, pred, ts)
+				err := posting.DeletePredicateBlocking(ctx, pred)
 				switch err {
 				case badger.ErrBlockedWrites:
 					time.Sleep(1 * time.Second)


### PR DESCRIPTION
This commit introduces incremental restore. It allows incremental backups to be restored on top of a set of already restored backups. In between two incremental restores, the cluster is in draining mode.

(cherry picked from commit dfa5daec1e7b825e990b111e98d3875734d6801d)

fixes #8533 

