### PR TITLE
feat(cloud): add shared-instance flag in limit superflag in alpha

### DIFF
--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -208,6 +208,10 @@ they form a Raft group and provide synchronous replication.
 				"worker in a failed state. Use -1 to retry infinitely.").
 		Flag("txn-abort-after", "Abort any pending transactions older than this duration."+
 			" The liveness of a transaction is determined by its last mutation.").
+		Flag("shared-instance", "When set to true, it disables ACLs for non-galaxy users. "+
+			"It expects the access JWT to be contructed outside dgraph for those users as even "+
+			"login is denied to them. Additionally, this disables access to environment variables"+
+			"for minio, aws, etc.").
 		String())
 
 	flag.String("ludicrous", worker.LudicrousDefaults, z.NewSuperFlagHelp(worker.LudicrousDefaults).
@@ -639,7 +643,6 @@ func run() {
 		pstoreBlockCacheSize, pstoreIndexCacheSize)
 	bopts := badger.DefaultOptions("").FromSuperFlag(worker.BadgerDefaults + cacheOpts).
 		FromSuperFlag(Alpha.Conf.GetString("badger"))
-
 	security := z.NewSuperFlag(Alpha.Conf.GetString("security")).MergeAndCheckDefault(
 		worker.SecurityDefaults)
 	conf := audit.GetAuditConf(Alpha.Conf.GetString("audit"))
@@ -732,6 +735,7 @@ func run() {
 	x.Config.LimitNormalizeNode = int(x.Config.Limit.GetInt64("normalize-node"))
 	x.Config.QueryTimeout = x.Config.Limit.GetDuration("query-timeout")
 	x.Config.MaxRetries = x.Config.Limit.GetInt64("max-retries")
+	x.Config.SharedInstance = x.Config.Limit.GetBool("shared-instance")
 
 	x.Config.GraphQL = z.NewSuperFlag(Alpha.Conf.GetString("graphql")).MergeAndCheckDefault(
 		worker.GraphQLDefaults)

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -199,7 +199,7 @@ func validateToken(jwtStr string) (*userData, error) {
 		return nil, errors.Errorf("userid in claims is not a string:%v", userId)
 	}
 
-	/*  
+	/*
 	 * Since, JSON numbers follow JavaScript's double-precision floating-point
 	 * format . . .
 	 * -- references: https://restfulapi.net/json-data-types/

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -51,6 +51,10 @@ type predsAndvars struct {
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
 
+	if !shouldAllowAcls(request.GetNamespace()) {
+		return nil, errors.New("operation is not allowed in cloud mode")
+	}
+
 	if err := x.HealthCheck(); err != nil {
 		return nil, err
 	}
@@ -628,18 +632,11 @@ type authPredResult struct {
 }
 
 func authorizePreds(ctx context.Context, userData *userData, preds []string,
-	aclOp *acl.Operation) (*authPredResult, error) {
-
-	ns, err := x.ExtractNamespace(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "While authorizing preds")
-	}
-	if !worker.AclCachePtr.Loaded() {
-		RefreshACLs(ctx)
-	}
+	aclOp *acl.Operation) *authPredResult {
 
 	userId := userData.userId
 	groupIds := userData.groupIds
+	ns := userData.namespace
 	blockedPreds := make(map[string]struct{})
 	for _, pred := range preds {
 		nsPred := x.NamespaceAttr(ns, pred)
@@ -659,7 +656,7 @@ func authorizePreds(ctx context.Context, userData *userData, preds []string,
 	if worker.HasAccessToAllPreds(ns, groupIds, aclOp) {
 		// Setting allowed to nil allows access to all predicates. Note that the access to ACL
 		// predicates will still be blocked.
-		return &authPredResult{allowed: nil, blocked: blockedPreds}, nil
+		return &authPredResult{allowed: nil, blocked: blockedPreds}
 	}
 	// User can have multiple permission for same predicate, add predicate
 	allowedPreds := make([]string, 0, len(worker.AclCachePtr.GetUserPredPerms(userId)))
@@ -669,7 +666,7 @@ func authorizePreds(ctx context.Context, userData *userData, preds []string,
 			allowedPreds = append(allowedPreds, predicate)
 		}
 	}
-	return &authPredResult{allowed: allowedPreds, blocked: blockedPreds}, nil
+	return &authPredResult{allowed: allowedPreds, blocked: blockedPreds}
 }
 
 // authorizeAlter parses the Schema in the operation and authorizes the operation
@@ -724,10 +721,7 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 				"only guardians are allowed to drop all data, but the current user is %s", userId)
 		}
 
-		result, err := authorizePreds(ctx, userData, preds, acl.Modify)
-		if err != nil {
-			return nil
-		}
+		result := authorizePreds(ctx, userData, preds, acl.Modify)
 		if len(result.blocked) > 0 {
 			var msg strings.Builder
 			for key := range result.blocked {
@@ -836,12 +830,17 @@ func authorizeMutation(ctx context.Context, gmu *gql.Mutation) error {
 			case isAclPredMutation(gmu.Del):
 				return errors.Errorf("ACL predicates can't be deleted")
 			}
+			if !shouldAllowAcls(userData.namespace) {
+				for _, pred := range preds {
+					if x.IsAclPredicate(pred) {
+						return status.Errorf(codes.PermissionDenied,
+							"unauthorized to mutate acl predicates: %s\n", pred)
+					}
+				}
+			}
 			return nil
 		}
-		result, err := authorizePreds(ctx, userData, preds, acl.Write)
-		if err != nil {
-			return err
-		}
+		result := authorizePreds(ctx, userData, preds, acl.Write)
 		if len(result.blocked) > 0 {
 			var msg strings.Builder
 			for key := range result.blocked {
@@ -949,6 +948,11 @@ func logAccess(log *accessEntry) {
 	}
 }
 
+// With shared instance enabled, we don't allow ACL operations from any of the non-galaxy namespace.
+func shouldAllowAcls(ns uint64) bool {
+	return !x.Config.SharedInstance || ns == x.GalaxyNamespace
+}
+
 // authorizeQuery authorizes the query using the aclCachePtr. It will silently drop all
 // unauthorized predicates from query.
 // At this stage, namespace is not attached in the predicates.
@@ -960,6 +964,7 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 
 	var userId string
 	var groupIds []string
+	var namespace uint64
 	predsAndvars := parsePredsFromQuery(parsedReq.Query)
 	preds := predsAndvars.preds
 	varsToPredMap := predsAndvars.vars
@@ -979,14 +984,24 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 
 		userId = userData.userId
 		groupIds = userData.groupIds
+		namespace = userData.namespace
 
 		if x.IsGuardian(groupIds) {
-			// Members of guardian groups are allowed to query anything.
-			return nil, nil, nil
+			if shouldAllowAcls(userData.namespace) {
+				// Members of guardian groups are allowed to query anything.
+				return nil, nil, nil
+			}
+			blocked := make(map[string]struct{})
+			for _, pred := range preds {
+				if x.IsAclPredicate(pred) {
+					blocked[pred] = struct{}{}
+				}
+			}
+			return blocked, nil, nil
 		}
 
-		result, err := authorizePreds(ctx, userData, preds, acl.Read)
-		return result.blocked, result.allowed, err
+		result := authorizePreds(ctx, userData, preds, acl.Read)
+		return result.blocked, result.allowed, nil
 	}
 
 	blockedPreds, allowedPreds, err := doAuthorizeQuery()
@@ -1007,7 +1022,7 @@ func authorizeQuery(ctx context.Context, parsedReq *gql.Result, graphql bool) er
 	if len(blockedPreds) != 0 {
 		// For GraphQL requests, we allow filtered access to the ACL predicates.
 		// Filter for user_id and group_id is applied for the currently logged in user.
-		if graphql {
+		if graphql && shouldAllowAcls(namespace) {
 			for _, gq := range parsedReq.Query {
 				addUserFilterToQuery(gq, userId, groupIds)
 			}
@@ -1068,11 +1083,20 @@ func authorizeSchemaQuery(ctx context.Context, er *query.ExecutionResult) error 
 
 		groupIds := userData.groupIds
 		if x.IsGuardian(groupIds) {
-			// Members of guardian groups are allowed to query anything.
-			return nil, nil
+			if shouldAllowAcls(userData.namespace) {
+				// Members of guardian groups are allowed to query anything.
+				return nil, nil
+			}
+			blocked := make(map[string]struct{})
+			for _, pred := range preds {
+				if x.IsAclPredicate(pred) {
+					blocked[pred] = struct{}{}
+				}
+			}
+			return blocked, nil
 		}
-		result, err := authorizePreds(ctx, userData, preds, acl.Read)
-		return result.blocked, err
+		result := authorizePreds(ctx, userData, preds, acl.Read)
+		return result.blocked, nil
 	}
 
 	// find the predicates which are blocked for the schema query
@@ -1115,8 +1139,7 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	}
 	ns, err := x.ExtractJWTNamespace(ctx)
 	if err != nil {
-		return status.Error(codes.Unauthenticated,
-			"AuthGuardianOfTheGalaxy: extracting jwt token, error: "+err.Error())
+		return errors.Wrap(err, "Authorize guardian of the galaxy, extracting jwt token, error:")
 	}
 	if ns != 0 {
 		return status.Error(

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -634,6 +634,10 @@ type authPredResult struct {
 func authorizePreds(ctx context.Context, userData *userData, preds []string,
 	aclOp *acl.Operation) *authPredResult {
 
+	if !worker.AclCachePtr.Loaded() {
+		RefreshACLs(ctx)
+	}
+
 	userId := userData.userId
 	groupIds := userData.groupIds
 	ns := userData.namespace

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"math"
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -26,6 +27,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 )
@@ -92,27 +94,19 @@ func resolveExport(ctx context.Context, m schema.Mutation) (*resolve.Resolved, b
 		Anonymous:    input.Anonymous,
 	}
 
-	files, err := worker.ExportOverNetwork(context.Background(), req)
+	taskId, err := worker.Tasks.Enqueue(req)
 	if err != nil {
 		return resolve.EmptyResult(m, err), false
 	}
 
-	data := response("Success", "Export completed.")
-	data["exportedFiles"] = toInterfaceSlice(files)
+	msg := fmt.Sprintf("Export queued with ID %#x", taskId)
+	data := response("Success", msg)
+	data["taskId"] = fmt.Sprintf("%#x", taskId)
 	return resolve.DataResult(
 		m,
 		map[string]interface{}{m.Name(): data},
 		nil,
 	), true
-}
-
-// toInterfaceSlice converts []string to []interface{}
-func toInterfaceSlice(in []string) []interface{} {
-	out := make([]interface{}, 0, len(in))
-	for _, s := range in {
-		out = append(out, s)
-	}
-	return out
 }
 
 func getExportInput(m schema.Mutation) (*exportInput, error) {

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func prepare(t *testing.T) {
+	dc := testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
+	require.NoError(t, dc.Alter(context.Background(), &api.Operation{DropAll: true}))
+}
+
+func readFile(t *testing.T, path string) []byte {
+	data, err := ioutil.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+func getHttpToken(t *testing.T, user, password string, ns uint64) *testutil.HttpToken {
+	jwt := testutil.GetAccessJwt(t, testutil.JwtParams{
+		User:   user,
+		Groups: []string{"guardians"},
+		Ns:     ns,
+		Exp:    time.Hour,
+		Secret: readFile(t, "../../ee/acl/hmac-secret"),
+	})
+
+	return &testutil.HttpToken{
+		UserId:    user,
+		Password:  password,
+		AccessJwt: jwt,
+	}
+}
+
+func graphqlHelper(t *testing.T, query string, headers http.Header,
+	expectedResult string) {
+	params := &common.GraphQLParams{
+		Query:   query,
+		Headers: headers,
+	}
+	queryResult := params.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, queryResult)
+	testutil.CompareJSON(t, expectedResult, string(queryResult.Data))
+}
+
+func TestDisallowNonGalaxy(t *testing.T) {
+	prepare(t)
+
+	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+	require.Greater(t, int(ns), 0)
+
+	nsToken := getHttpToken(t, "groot", "password", ns)
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", nsToken.AccessJwt)
+
+	// User from namespace ns should be able to query/mutate.
+	schema := `
+	type Author {
+		id: ID!
+		name: String
+	}`
+	common.SafelyUpdateGQLSchema(t, common.Alpha1HTTP, schema, header)
+
+	graphqlHelper(t, `
+	mutation {
+		addAuthor(input:{name: "Alice"}) {
+			author{
+				name
+			}
+		}
+	}`, header,
+		`{
+			"addAuthor": {
+				"author":[{
+					"name":"Alice"
+				}]
+			}
+		}`)
+
+	query := `
+	query {
+		queryAuthor {
+			name
+		}
+	}`
+	graphqlHelper(t, query, header,
+		`{
+			"queryAuthor": [
+				{
+					"name":"Alice"
+				}
+			]
+		}`)
+
+	// Login to namespace 1 via groot and create new user alice. Non-galaxy namespace user should
+	// not be able to do so in cloud mode.
+	_, err = testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint:  testutil.AdminUrl(),
+		UserID:    "groot",
+		Passwd:    "password",
+		Namespace: ns,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "operation is not allowed in cloud mode")
+
+	// Ns guardian should not be able to create user.
+	resp := testutil.CreateUser(t, nsToken, "alice", "newpassword")
+	require.Greater(t, len(resp.Errors), 0)
+	require.Contains(t, resp.Errors.Error(), "unauthorized to mutate acl predicates")
+
+	// Galaxy guardian should be able to create user.
+	resp = testutil.CreateUser(t, galaxyToken, "alice", "newpassword")
+	require.Equal(t, 0, len(resp.Errors))
+}
+
+func TestEnvironmentAccess(t *testing.T) {
+	prepare(t)
+
+	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+	require.Greater(t, int(ns), 0)
+
+	nsToken := getHttpToken(t, "groot", "password", ns)
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", nsToken.AccessJwt)
+
+	// Create a minio bucket.
+	bucketname := "dgraph-export"
+	mc, err := testutil.NewMinioClient()
+	require.NoError(t, err)
+	require.NoError(t, mc.MakeBucket(bucketname, ""))
+	minioDest := "minio://minio:9001/dgraph-export?secure=false"
+
+	// Export without the minio creds should fail for non-galaxy.
+	resp := testutil.Export(t, nsToken, minioDest, "", "")
+	require.Greater(t, len(resp.Errors), 0)
+	require.Contains(t, resp.Errors.Error(), "task failed")
+
+	// Export without the minio creds should work for non-galaxy.
+	resp = testutil.Export(t, nsToken, minioDest, "accesskey", "secretkey")
+	require.Zero(t, len(resp.Errors))
+
+	// Galaxy guardian should provide the crednetials as well.
+	resp = testutil.Export(t, galaxyToken, minioDest, "accesskey", "secretkey")
+	require.Zero(t, len(resp.Errors))
+
+}
+
+func TestMain(m *testing.M) {
+	fmt.Printf("Using adminEndpoint : %s for cloud test.\n", testutil.AdminUrl())
+	os.Exit(m.Run())
+}

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -1,0 +1,53 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/zero1
+    ports:
+      - 5080
+      - 6080
+    labels:
+      cluster: test
+      service: zero
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph zero --my=zero1:5080 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+
+  alpha1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/alpha1
+    env_file:
+        - ./minio.env
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ../../ee/acl/hmac-secret
+        target: /dgraph-acl/hmac-secret
+        read_only: true
+    ports:
+      - 8080
+      - 9080
+    labels:
+      cluster: test
+      service: alpha
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
+      --limit "shared-instance=true"
+
+  minio:
+    image: minio/minio:latest
+    env_file:
+      - ./minio.env
+    working_dir: /data/minio
+    ports:
+      - 9001
+    labels:
+      cluster: test
+    command: minio server /data/minio --address :9001

--- a/systest/cloud/minio.env
+++ b/systest/cloud/minio.env
@@ -1,0 +1,2 @@
+MINIO_ACCESS_KEY=accesskey
+MINIO_SECRET_KEY=secretkey

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -310,46 +310,45 @@ func HttpLogin(params *LoginParams) (*HttpToken, error) {
 		return nil, errors.New(fmt.Sprintf("got non 200 response from the server with %s ",
 			string(respBody)))
 	}
-	var outputJson map[string]interface{}
-	if err := json.Unmarshal(respBody, &outputJson); err != nil {
-		var errOutputJson map[string]interface{}
-		if err := json.Unmarshal(respBody, &errOutputJson); err == nil {
-			if _, ok := errOutputJson["errors"]; ok {
-				return nil, errors.Errorf("response error: %v", string(respBody))
+
+	var gqlResp GraphQLResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		return nil, err
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return nil, errors.Errorf(gqlResp.Errors.Error())
+	}
+
+	if gqlResp.Data == nil {
+		return nil, errors.Wrapf(err, "data entry found in the output")
+	}
+
+	type Response struct {
+		Login struct {
+			Response struct {
+				AccessJWT  string
+				RefreshJwt string
 			}
 		}
-		return nil, errors.Wrapf(err, "unable to unmarshal the output to get JWTs")
+	}
+	var r Response
+	if err := json.Unmarshal(gqlResp.Data, &r); err != nil {
+		return nil, err
 	}
 
-	data, found := outputJson["data"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	l, found := data["login"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	response, found := l["response"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	newAccessJwt, found := response["accessJWT"].(string)
-	if !found || newAccessJwt == "" {
+	if r.Login.Response.AccessJWT == "" {
 		return nil, errors.Errorf("no access JWT found in the output")
 	}
-	newRefreshJwt, found := response["refreshJWT"].(string)
-	if !found || newRefreshJwt == "" {
+	if r.Login.Response.RefreshJwt == "" {
 		return nil, errors.Errorf("no refresh JWT found in the output")
 	}
 
 	return &HttpToken{
 		UserId:       params.UserID,
 		Password:     params.Passwd,
-		AccessJwt:    newAccessJwt,
-		RefreshToken: newRefreshJwt,
+		AccessJwt:    r.Login.Response.AccessJWT,
+		RefreshToken: r.Login.Response.RefreshJwt,
 	}, nil
 }
 

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/require"
 )
 
@@ -57,6 +58,30 @@ func GalaxyIndexKey(attr, term string) []byte {
 func GalaxyCountKey(attr string, count uint32, reverse bool) []byte {
 	attr = x.GalaxyAttr(attr)
 	return x.CountKey(attr, count, reverse)
+}
+
+type JwtParams struct {
+	User   string
+	Groups []string
+	Ns     uint64
+	Exp    time.Duration
+	Secret []byte
+}
+
+// GetAccessJwt constructs an access jwt with the given user id, groupIds, namespace
+// and expiration TTL.
+func GetAccessJwt(t *testing.T, params JwtParams) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"userid":    params.User,
+		"groups":    params.Groups,
+		"namespace": params.Ns,
+		// set the jwt exp according to the ttl
+		"exp": time.Now().Add(params.Exp).Unix(),
+	})
+
+	jwtString, err := token.SignedString(params.Secret)
+	require.NoError(t, err)
+	return jwtString
 }
 
 func WaitForTask(t *testing.T, taskId string, useHttps bool) {

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -40,19 +40,19 @@ const (
 	//       breaks.
 	AuditDefaults  = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
 	BadgerDefaults = `compression=snappy; numgoroutines=8;`
-	RaftDefaults   = `learner=false; snapshot-after-entries=10000; ` +
-		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
-	SecurityDefaults  = `token=; whitelist=;`
-	LudicrousDefaults = `enabled=false; concurrency=2000;`
-	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
+	CacheDefaults  = `size-mb=1024; percentage=0,65,35;`
+	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
-	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
-		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m; ` +
-		` max-retries=-1;max-pending-queries=10000`
-	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
-	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
+	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
-	CacheDefaults = `size-mb=1024; percentage=0,65,35;`
+	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
+		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;` +
+		`max-pending-queries=10000;  max-retries=-1; shared-instance=false;`
+	LudicrousDefaults = `enabled=false; concurrency=2000;`
+	RaftDefaults      = `learner=false; snapshot-after-entries=10000; ` +
+		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
+	SecurityDefaults   = `token=; whitelist=;`
+	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -40,19 +40,19 @@ const (
 	//       breaks.
 	AuditDefaults  = `compress=false; days=10; size=100; dir=; output=; encrypt-file=;`
 	BadgerDefaults = `compression=snappy; numgoroutines=8;`
-	CacheDefaults  = `size-mb=1024; percentage=0,65,35;`
-	CDCDefaults    = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
+	RaftDefaults   = `learner=false; snapshot-after-entries=10000; ` +
+		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
+	SecurityDefaults  = `token=; whitelist=;`
+	LudicrousDefaults = `enabled=false; concurrency=2000;`
+	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
 		`client_key=; sasl-mechanism=PLAIN;`
-	GraphQLDefaults = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
-		`lambda-url=;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m;` +
 		`max-pending-queries=10000;  max-retries=-1; shared-instance=false;`
-	LudicrousDefaults = `enabled=false; concurrency=2000;`
-	RaftDefaults      = `learner=false; snapshot-after-entries=10000; ` +
-		`snapshot-after-duration=30m; pending-proposals=256; idx=; group=;`
-	SecurityDefaults   = `token=; whitelist=;`
 	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
+	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
+		`lambda-url=;`
+	CacheDefaults = `size-mb=1024; percentage=0,65,35;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/x/config.go
+++ b/x/config.go
@@ -38,6 +38,8 @@ type Options struct {
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
 	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
 	// query-timeout duration - Maximum time after which a query execution will fail.
+	// max-retries int64 - maximum number of retries made by dgraph to commit a transaction to disk.
+	// shared-instance bool - if set to true, ACLs will be disabled for non-galaxy users.
 	Limit                *z.SuperFlag
 	LimitMutationsNquad  int
 	LimitQueryEdge       uint64
@@ -45,6 +47,7 @@ type Options struct {
 	LimitNormalizeNode   int
 	QueryTimeout         time.Duration
 	MaxRetries           int64
+	SharedInstance       bool
 
 	// GraphQL options:
 	//


### PR DESCRIPTION

This PR adds a shared-instance flag to --limit superflag. When set to true (false by default), it will:

- Restrict access to any of the ACL operations like Login, add/remove/update user from non-galaxy namespaces.
- Prevent the leaking of environment variables for minio and aws.

(cherry picked from commit 5f3cece75da375077c45ab64228cb7053cf03d02) (cherry picked from commit eeb7bea1a7cb49636d38c14994cf3cf10bf857d2)

<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

