### PR TITLE
chore(debug): add summary to show LSM tree and namespace size (#7891)

### DIFF
--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/ristretto/z"
+	"github.com/dustin/go-humanize"
 
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee"
@@ -70,6 +71,7 @@ type flagOptions struct {
 	sizeHistogram bool
 	noKeys        bool
 	key           x.Sensitive
+	onlySummary   bool
 
 	// Options related to the WAL.
 	wdir           string
@@ -104,6 +106,10 @@ func init() {
 	flag.StringVarP(&opt.pdir, "postings", "p", "", "Directory where posting lists are stored.")
 	flag.BoolVar(&opt.sizeHistogram, "histogram", false,
 		"Show a histogram of the key and value sizes.")
+	flag.BoolVar(&opt.onlySummary, "only-summary", false,
+		"If true, only show the summary of the p directory.")
+
+	// Flags related to WAL.
 	flag.StringVarP(&opt.wdir, "wal", "w", "", "Directory where Raft write-ahead logs are stored.")
 	flag.Uint64VarP(&opt.wtruncateUntil, "truncate", "t", 0,
 		"Remove data from Raft entries until but not including this index.")
@@ -876,6 +882,51 @@ func printZeroProposal(buf *bytes.Buffer, zpr *pb.ZeroProposal) {
 	}
 }
 
+func printSummary(db *badger.DB) {
+	nsFromKey := func(key []byte) uint64 {
+		pk, err := x.Parse(key)
+		if err != nil {
+			// Some of the keys are badger's internal and couldn't be parsed.
+			// Hence, the error is expected in that case.
+			fmt.Printf("Unable to parse key: %#x\n", key)
+			return x.GalaxyNamespace
+		}
+		return x.ParseNamespace(pk.Attr)
+	}
+	banned := db.BannedNamespaces()
+	bannedNs := make(map[uint64]struct{})
+	for _, ns := range banned {
+		bannedNs[ns] = struct{}{}
+	}
+
+	tables := db.Tables()
+	levelSizes := make([]uint64, len(db.Levels()))
+	nsSize := make(map[uint64]uint64)
+	for _, tab := range tables {
+		levelSizes[tab.Level] += uint64(tab.OnDiskSize)
+		if nsFromKey(tab.Left) == nsFromKey(tab.Right) {
+			nsSize[nsFromKey(tab.Left)] += uint64(tab.OnDiskSize)
+		}
+	}
+
+	fmt.Println("[SUMMARY]")
+	totalSize := uint64(0)
+	for i, sz := range levelSizes {
+		fmt.Printf("Level %d size: %12s\n", i, humanize.IBytes(sz))
+		totalSize += sz
+	}
+	fmt.Printf("Total SST size: %12s\n", humanize.IBytes(totalSize))
+	fmt.Println()
+	for ns, sz := range nsSize {
+		fmt.Printf("Namespace %#x size: %12s", ns, humanize.IBytes(sz))
+		if _, ok := bannedNs[ns]; !ok {
+			fmt.Printf(" (banned)")
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+}
+
 func run() {
 	go func() {
 		for i := 8080; i < 9080; i++ {
@@ -921,6 +972,11 @@ func run() {
 	// Not using posting list cache
 	posting.Init(db, 0)
 	defer db.Close()
+
+	printSummary(db)
+	if opt.onlySummary {
+		return
+	}
 
 	// Commenting the following out because on large Badger DBs, this can take a LONG time.
 	// min, max := getMinMax(db, opt.readTs)

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -919,7 +919,7 @@ func printSummary(db *badger.DB) {
 	fmt.Println()
 	for ns, sz := range nsSize {
 		fmt.Printf("Namespace %#x size: %12s", ns, humanize.IBytes(sz))
-		if _, ok := bannedNs[ns]; !ok {
+		if _, ok := bannedNs[ns]; ok {
 			fmt.Printf(" (banned)")
 		}
 		fmt.Println()


### PR DESCRIPTION
Add --only-summary flag in dgraph debug to show LSM tree and namespace sizes.

(cherry picked from commit cc871539d0ab5c1ff5a767555adb606736ac9d09)


The flag restricts the output to only the summary:

```
╰─➤  dgraph debug --postings ./p --only-summary

Opening DB: ./p
Listening for /debug HTTP requests at port: 8080
badger 2022/12/23 01:01:08 INFO: All 1 tables opened in 0s
badger 2022/12/23 01:01:08 INFO: Discard stats nextEmptySlot: 0
badger 2022/12/23 01:01:08 INFO: Set nextTxnTs to 11
[SUMMARY]
Level 0 size:      1.3 KiB
Level 1 size:          0 B
Level 2 size:          0 B
Level 3 size:          0 B
Level 4 size:          0 B
Level 5 size:          0 B
Level 6 size:          0 B
Total SST size:      1.3 KiB

Namespace 0x0 size:      1.3 KiB (banned)

badger 2022/12/23 01:01:08 INFO: Lifetime L0 stalled for: 0s
badger 2022/12/23 01:01:08 INFO: 
Level 0 [ ]: NumTables: 01. Size: 1.3 KiB of 0 B. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 64 MiB
Level 1 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 2 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 3 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 4 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 5 [ ]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level 6 [B]: NumTables: 00. Size: 0 B of 10 MiB. Score: 0.00->0.00 StaleData: 0 B Target FileSize: 2.0 MiB
Level Done

```
