### PR TITLE
fix(cd): Update dgraph binary builds' filenames

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Generate SHA for Dgraph Linux Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-amd64.sha256
       - name: Tar Archive for Dgraph Linux Build
-        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph
+        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph-linux-amd64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -134,7 +134,7 @@ jobs:
       - name: Generate SHA for Dgraph Linux Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-arm64.sha256
       - name: Tar Archive for Dgraph Linux Build
-        run: cd dgraph && tar -zcvf dgraph-linux-arm64.tar.gz dgraph
+        run: cd dgraph && tar -zcvf dgraph-linux-arm64.tar.gz dgraph-linux-arm64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Generate SHA for Dgraph Linux amd64 Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-amd64.sha256
       - name: Tar Archive for Dgraph Linux amd64 Build
-        run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph-linux-amd64
+        run: cd dgraph && mv dgraph dgraph-linux-amd64 && tar -zcvf dgraph-linux-amd64.tar.gz dgraph-linux-amd64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -134,7 +134,7 @@ jobs:
       - name: Generate SHA for Dgraph Linux arm64 Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-arm64.sha256
       - name: Tar Archive for Dgraph Linux arm64 Build
-        run: cd dgraph && tar -zcvf dgraph-linux-arm64.tar.gz dgraph-linux-arm64
+        run: cd dgraph && mv dgraph dgraph-linux-arm64 && tar -zcvf dgraph-linux-arm64.tar.gz dgraph-linux-arm64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -51,9 +51,9 @@ jobs:
           echo "DGRAPH_RELEASE_VERSION=$DGRAPH_RELEASE_VERSION" >> $GITHUB_ENV
       - name: Make Dgraph Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
-      - name: Generate SHA for Dgraph Linux Build
+      - name: Generate SHA for Dgraph Linux amd64 Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-amd64.sha256
-      - name: Tar Archive for Dgraph Linux Build
+      - name: Tar Archive for Dgraph Linux amd64 Build
         run: cd dgraph && tar -zcvf dgraph-linux-amd64.tar.gz dgraph-linux-amd64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3
@@ -131,9 +131,9 @@ jobs:
           echo "DGRAPH_RELEASE_VERSION=$DGRAPH_RELEASE_VERSION" >> $GITHUB_ENV
       - name: Make Dgraph Linux Build
         run: make dgraph DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}
-      - name: Generate SHA for Dgraph Linux Build
+      - name: Generate SHA for Dgraph Linux arm64 Build
         run: cd dgraph && sha256sum dgraph | cut -c-64 > dgraph-checksum-linux-arm64.sha256
-      - name: Tar Archive for Dgraph Linux Build
+      - name: Tar Archive for Dgraph Linux arm64 Build
         run: cd dgraph && tar -zcvf dgraph-linux-arm64.tar.gz dgraph-linux-arm64
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Problem
cd-dgraph.yml builds dgraph binaries of the same name for both **ARM** and **amd** architectures. This causes confusion when downloading artifacts as the filename and file extensions are the same when opening in MacOS Finder. 

## Solution
Specify the right name for the kind of architecture we are building the architecture for.