### PR TITLE
chore(ci): remove arch from ldflag

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -24,7 +24,8 @@ BUILD_BRANCH   ?= $(shell git rev-parse --abbrev-ref HEAD)
 ifeq ($(DGRAPH_VERSION),)
 BUILD_VERSION ?= local
 else
-BUILD_VERSION ?= $(DGRAPH_VERSION)
+# remove arch suffix from DGRAPH_VERSION for CD steps only
+BUILD_VERSION := $(shell echo ${DGRAPH_VERSION} | cut -d "-" -f 1)
 endif
 
 GOOS          ?= $(shell go env GOOS)


### PR DESCRIPTION
Dgraph version ldflag should not have arch (only version number). We update the Makefile to not add this in the ldflags build arguments.