### PR TITLE
fix(restore): consider the banned namespaces while bumping (#7839)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -620,6 +620,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 	dropAll := false
 	dropAttr := make(map[string]struct{})
 	dropNs := make(map[uint64]struct{})
+	var maxBannedNs uint64
 
 	// manifests are ordered as: latest..full
 	for i, manifest := range manifests {
@@ -711,6 +712,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 				if err := pstore.BanNamespace(ns); err != nil {
 					return nil, errors.Wrapf(err, "Map phase failed to ban namespace: %d", ns)
 				}
+				maxBannedNs = x.Max(maxBannedNs, ns)
 			}
 		}
 	} // done with all the manifests.
@@ -727,5 +729,7 @@ func RunMapper(req *pb.RestoreRequest, mapDir string) (*mapResult, error) {
 		maxUid: mapper.maxUid,
 		maxNs:  mapper.maxNs,
 	}
+	// update the maxNsId considering banned namespaces.
+	mapRes.maxNs = x.Max(mapRes.maxNs, maxBannedNs)
 	return mapRes, nil
 }


### PR DESCRIPTION
We were not considering the banned namespaces while bumping the lease. So, if we restore a backup with namespace 0,1,2 not-banned and 3,4 banned. We will bump only up to 2. This would error out when creating a namespace