### PR TITLE
fix(debug): Check length of wal entry before parsing

### DIFF
--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -36,8 +36,13 @@ func printEntry(es raftpb.Entry, pending map[uint64]bool, isZero bool) {
 	defer func() {
 		fmt.Printf("%s\n", buf.Bytes())
 	}()
+
+	var key uint64
+	if len(es.Data) >= 8 {
+		key = binary.BigEndian.Uint64(es.Data[:8])
+	}
 	fmt.Fprintf(&buf, "%d . %d . %v . %-6s . %8d .", es.Term, es.Index, es.Type,
-		humanize.Bytes(uint64(es.Size())), binary.BigEndian.Uint64(es.Data[:8]))
+		humanize.Bytes(uint64(es.Size())), key)
 	if es.Type == raftpb.EntryConfChange {
 		return
 	}


### PR DESCRIPTION
Check for the length of wal entry's data before parsing it for key