### PR TITLE
fix(groot): do not upsert groot for all namespaces on restart

### DIFF
--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -118,7 +118,9 @@ func init() {
 	flag.Bool("new_uids", false,
 		"Ignore UIDs in load files and assign new ones.")
 	flag.Uint64("force-namespace", math.MaxUint64,
-		"Namespace onto which to load the data. If not set, will preserve the namespace.")
+		"Namespace onto which to load the data. If not set, will preserve the namespace."+
+			" When using this flag to load data into specific namespace, make sure that the "+
+			"load data do not have ACL data.")
 
 	flag.String("badger", BulkBadgerDefaults, z.NewSuperFlagHelp(BulkBadgerDefaults).
 		Head("Badger options (Refer to badger documentation for all possible options)").

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -434,10 +434,7 @@ func InitializeAcl(closer *z.Closer) {
 		// The acl feature is not turned on.
 		return
 	}
-
-	for ns := range schema.State().Namespaces() {
-		upsertGuardianAndGroot(closer, ns)
-	}
+	upsertGuardianAndGroot(closer, x.GalaxyNamespace)
 }
 
 // Note: The handling of closer should be done by caller.

--- a/ee/acl/run.go
+++ b/ee/acl/run.go
@@ -32,6 +32,6 @@ func init() {
 		Use:         "acl",
 		Short:       "Enterprise feature. Not supported in oss version",
 		Annotations: map[string]string{"group": "security"},
-	},
-		Acl.Cmd.SetHelpTemplate(x.NonRootTemplate)
+	}
+	CmdAcl.Cmd.SetHelpTemplate(x.NonRootTemplate)
 }


### PR DESCRIPTION
Earlier, whenever the alpha starts(or restarts), we were upserting guardian and groot for all the namespaces. This is not actually needed. The change was made in the PR #7759 to fix a bulk loader edge case. This PR fixes that by generating the required RDFs in the bulk loader itself. Essentially, it inserts the ACL RDFs when force loading into non-Galaxy namespace.

(cherry picked from commit 6730f10b62da7c7dc3bf5985ef957f08d3c733b4)