### PR TITLE
fix(restore): Set kv version to restoreTs for all keys (#7930)

### DIFF
--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -367,7 +367,9 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 					return err
 				}
 				for _, kv := range kvs {
-					if err := toBuffer(kv, kv.Version); err != nil {
+					version := kv.Version
+					kv.Version = m.restoreTs
+					if err := toBuffer(kv, version); err != nil {
 						return err
 					}
 				}
@@ -398,8 +400,10 @@ func (m *mapper) processReqCh(ctx context.Context) error {
 			kv.StreamId = 0
 			// Schema and type keys are not stored in an intermediate format so their
 			// value can be written as is.
+			version := kv.Version
+			kv.Version = m.restoreTs
 			kv.Key = restoreKey
-			if err := toBuffer(kv, kv.Version); err != nil {
+			if err := toBuffer(kv, version); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
The kv version should be set to restore timestamp for rolled-up keys and schema keys as well. It would be inconsistent to write data at different timestamp compared to the timestamp that we use for writing schema keys.