### PR TITLE
feat(cdc): Add superflag to enable TLS without CA or certs (#7946)

### DIFF
--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -45,7 +45,7 @@ const (
 	SecurityDefaults  = `token=; whitelist=;`
 	LudicrousDefaults = `enabled=false; concurrency=2000;`
 	CDCDefaults       = `file=; kafka=; sasl_user=; sasl_password=; ca_cert=; client_cert=; ` +
-		`client_key=; sasl-mechanism=PLAIN;`
+		`client_key=; sasl-mechanism=PLAIN; tls=false;`
 	LimitDefaults = `mutations=allow; query-edge=1000000; normalize-node=10000; ` +
 		`mutations-nquad=1000000; disallow-drop=false; query-timeout=0ms; txn-abort-after=5m; ` +
 		` max-retries=-1;max-pending-queries=10000`

--- a/worker/sink_handler.go
+++ b/worker/sink_handler.go
@@ -86,10 +86,18 @@ func newKafkaSink(config *z.SuperFlag) (Sink, error) {
 	saramaConf.Producer.Return.Successes = true
 	saramaConf.Producer.Return.Errors = true
 
-	if config.GetPath("ca-cert") != "" {
-		tlsCfg := &tls.Config{
-			MinVersion: tls.VersionTLS12,
+	if config.GetBool("tls") && config.GetPath("ca-cert") == "" {
+		tlsCfg := x.TLSBaseConfig()
+		var pool *x509.CertPool
+		var err error
+		if pool, err = x509.SystemCertPool(); err != nil {
+			return nil, err
 		}
+		tlsCfg.RootCAs = pool
+		saramaConf.Net.TLS.Enable = true
+		saramaConf.Net.TLS.Config = tlsCfg
+	} else if config.GetPath("ca-cert") != "" {
+		tlsCfg := x.TLSBaseConfig()
 		var pool *x509.CertPool
 		var err error
 		if pool, err = x509.SystemCertPool(); err != nil {

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -266,11 +266,34 @@ func setupClientAuth(authType string) (tls.ClientAuthType, error) {
 	return tls.NoClientCert, nil
 }
 
+// TLSBaseConfig returns a *tls.Config with the base set of security
+// requirements (minimum TLS v1.2 and set of cipher suites)
+func TLSBaseConfig() *tls.Config {
+	tlsCfg := new(tls.Config)
+	tlsCfg.MinVersion = tls.VersionTLS12
+	tlsCfg.CipherSuites = []uint16{
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	}
+	return tlsCfg
+}
+
 // GenerateServerTLSConfig creates and returns a new *tls.Config with the
 // configuration provided.
 func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err error) {
 	if config.CertRequired {
-		tlsCfg = new(tls.Config)
+		tlsCfg = TLSBaseConfig()
 		cert, err := tls.LoadX509KeyPair(config.Cert, config.Key)
 		if err != nil {
 			return nil, err
@@ -288,23 +311,6 @@ func GenerateServerTLSConfig(config *TLSHelperConfig) (tlsCfg *tls.Config, err e
 			return nil, err
 		}
 		tlsCfg.ClientAuth = auth
-
-		tlsCfg.MinVersion = tls.VersionTLS12
-		tlsCfg.CipherSuites = []uint16{
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-		}
 
 		return tlsCfg, nil
 	}


### PR DESCRIPTION
Does the following changes:
 * will attempt to connect to Kafka over TLS using the system certs.
 * add helper function x.TLSBaseConfig.
 * sets the min TLS version to v1.2 along with the minimum cipher suites.