### PR TITLE
fix(probe): do not contend for lock in lazy load (#8037) (#8041)

### DIFF
--- a/graphql/admin/admin.go
+++ b/graphql/admin/admin.go
@@ -1026,12 +1026,9 @@ func (as *adminServer) resetSchema(ns uint64, gqlSchema schema.Schema) {
 
 func (as *adminServer) lazyLoadSchema(namespace uint64) error {
 	// if the schema is already in memory, no need to fetch it from disk
-	as.mux.RLock()
 	if currentSchema, ok := as.gqlSchemas.GetCurrent(namespace); ok && currentSchema.Loaded {
-		as.mux.RUnlock()
 		return nil
 	}
-	as.mux.RUnlock()
 
 	// otherwise, fetch the schema from disk
 	sch, err := getCurrentGraphQLSchema(namespace)


### PR DESCRIPTION
Earlier the admin server mutex lock was used to protect the graphql schema map. But now we store that in schema store that internally handles the concurrency. Hence, we don't need to take the admin server's read lock to access schema.

/probe/graphql is used as health check and is called very frequently. This rlock on adminserver mutex makes the /probe/graphql requests block while lazy loading when restore operation gets triggered at the startup. That leads to so many go routines being spun up.

(cherry picked from commit 5ad40d8479163697049612f28ba40429652b765a)