### PR TITLE
test(systest): avoid host volume mount in minio test

### DIFF
--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -102,7 +102,7 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
@@ -130,8 +130,8 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha4:
@@ -158,8 +158,8 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha4:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha5:
@@ -186,8 +186,8 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha5:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   alpha6:
@@ -214,8 +214,8 @@ services:
     labels:
       cluster: test
       service: alpha
-    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
-      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;" 
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --encryption "key-file=/dgraph-enc/enc-key;" --my=alpha6:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
 
   minio:

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -9329,7 +9329,7 @@ func TestMain(m *testing.M) {
 }
 
 func cleanupAndExit(exitCode int) {
-	if testutil.StopAlphasAndDetectRace("./alpha.yml") {
+	if testutil.StopAlphasAndDetectRace([]string{"alpha1"}) {
 		// if there is race fail the test
 		exitCode = 1
 	}

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -55,7 +55,7 @@ func TestMain(m *testing.M) {
 }
 
 func cleanupAndExit(exitCode int) {
-	if testutil.StopAlphasAndDetectRace("./alpha.yml") {
+	if testutil.StopAlphasAndDetectRace([]string{"alpha1"}) {
 		// if there is race fail the test
 		exitCode = 1
 	}

--- a/systest/bulk_live/bulk/docker-compose.yml
+++ b/systest/bulk_live/bulk/docker-compose.yml
@@ -2,15 +2,12 @@
 #
 version: "3.5"
 services:
-  minio1:
+  minio:
     image: minio/minio:RELEASE.2020-11-13T20-10-18Z
     ports:
     - "9001"
-    volumes:
-    - type: bind
-      source: .
-      target: /data/minio
-      read_only: false
+    env_file:
+    - ../../backup.env
     command: minio server /data/minio --address :9001
   zero1:
     image: dgraph/dgraph:local

--- a/systest/bulk_live/common/bulk_live_fixture.go
+++ b/systest/bulk_live/common/bulk_live_fixture.go
@@ -26,12 +26,14 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/dgraph/testutil"
+
+	"github.com/minio/minio-go/v6"
+	"github.com/stretchr/testify/require"
 )
 
 var rootDir = "./data"
+var rootBucket = "data"
 
 type suite struct {
 	t    *testing.T
@@ -75,6 +77,19 @@ func newSuiteInternal(t *testing.T, opts suiteOpts) *suite {
 		schemaPath = minioPath(schemaPath)
 		dataPath = minioPath(dataPath)
 		gqlSchemaPath = minioPath(gqlSchemaPath)
+
+		mc, err := testutil.NewMinioClient()
+		require.NoError(t, err)
+		if ok, err := mc.BucketExists(rootBucket); !ok {
+			require.NoError(t, err)
+			require.NoError(t, mc.MakeBucket(rootBucket, ""))
+		}
+		_, err = mc.FPutObject(rootBucket, "rdfs.rdf", rdfFile, minio.PutObjectOptions{})
+		require.NoError(t, err)
+		_, err = mc.FPutObject(rootBucket, "schema.txt", schemaFile, minio.PutObjectOptions{})
+		require.NoError(t, err)
+		_, err = mc.FPutObject(rootBucket, "gql_schema.txt", gqlSchemaFile, minio.PutObjectOptions{})
+		require.NoError(t, err)
 	}
 
 	s.setup(t, schemaPath, dataPath, gqlSchemaPath)
@@ -82,7 +97,7 @@ func newSuiteInternal(t *testing.T, opts suiteOpts) *suite {
 }
 
 func minioPath(path string) string {
-	return "minio://" + testutil.ContainerAddr("minio1", 9001) + "/data/" + path + "?secure=false"
+	return "minio://" + testutil.ContainerAddr("minio", 9001) + "/data/" + path + "?secure=false"
 }
 
 func newLiveOnlySuite(t *testing.T, schema, rdfs, gqlSchema string) *suite {
@@ -119,7 +134,7 @@ func newSuiteFromFile(t *testing.T, schemaFile, rdfFile, gqlSchemaFile string) *
 func (s *suite) setup(t *testing.T, schemaFile, rdfFile, gqlSchemaFile string) {
 	var env []string
 	if s.opts.remote {
-		env = append(env, "MINIO_ACCESS_KEY=minioadmin", "MINIO_SECRET_KEY=minioadmin")
+		env = append(env, "MINIO_ACCESS_KEY=accesskey", "MINIO_SECRET_KEY=secretkey")
 	}
 
 	require.NoError(s.t, makeDirEmpty(filepath.Join(rootDir, "out", "0")))
@@ -151,7 +166,6 @@ func (s *suite) setup(t *testing.T, schemaFile, rdfFile, gqlSchemaFile string) {
 	})
 
 	require.NoError(t, err)
-	return
 }
 
 func makeDirEmpty(dir string) error {
@@ -165,7 +179,7 @@ func (s *suite) cleanup(t *testing.T) {
 	// NOTE: Shouldn't raise any errors here or fail a test, since this is
 	// called when we detect an error (don't want to mask the original problem).
 	if s.opts.bulkSuite {
-		isRace := testutil.StopAlphasAndDetectRace(s.opts.bulkOpts.alpha)
+		isRace := testutil.StopAlphasAndDetectRace([]string{"alpha1"})
 		_ = os.RemoveAll(rootDir)
 		if isRace {
 			t.Fatalf("Failing because race condition is detected. " +

--- a/systest/bulk_live/live/docker-compose.yml
+++ b/systest/bulk_live/live/docker-compose.yml
@@ -16,21 +16,18 @@ services:
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
-      -v=2 --raft='idx=1; group=1;' 
+      -v=2 --raft='idx=1; group=1;'
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
     deploy:
       resources:
         limits:
           memory: 32G
-  minio1:
+  minio:
     image: minio/minio:RELEASE.2020-11-13T20-10-18Z
     ports:
-    - "9001"
-    volumes:
-    - type: bind
-      source: .
-      target: /data/minio
-      read_only: false
+      - "9001"
+    env_file:
+      - ../../backup.env
     command: minio server /data/minio --address :9001
   zero1:
     image: dgraph/dgraph:local

--- a/systest/ldbc/alpha.yml
+++ b/systest/ldbc/alpha.yml
@@ -18,5 +18,5 @@ services:
         target: /posting
         read_only: false
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 -p=/posting --logtostderr
-      -v=2 
+      -v=2
       --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -87,7 +87,7 @@ func TestMain(m *testing.M) {
 }
 
 func cleanupAndExit(exitCode int) {
-	if testutil.StopAlphasAndDetectRace("./alpha.yml") {
+	if testutil.StopAlphasAndDetectRace([]string{"alpha1"}) {
 		// if there is race fail the test
 		exitCode = 1
 	}

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -153,8 +153,8 @@ func freePort(port int) int {
 }
 
 func StartAlphas(compose string) error {
-	cmd := exec.Command("docker-compose", "-f", compose, "-p", DockerPrefix,
-		"up", "-d", "--force-recreate")
+	cmd := exec.Command("docker-compose", "--compatibility", "-f", compose,
+		"-p", DockerPrefix, "up", "-d", "--force-recreate")
 
 	fmt.Println("Starting alphas with: ", cmd.String())
 
@@ -176,10 +176,11 @@ func StartAlphas(compose string) error {
 	return nil
 }
 
-func StopAlphasAndDetectRace(compose string) (raceDetected bool) {
+func StopAlphasAndDetectRace(alphas []string) (raceDetected bool) {
 	raceDetected = DetectRaceInAlphas(DockerPrefix)
-	cmd := exec.CommandContext(context.Background(), "docker-compose", "-f", compose,
-		"-p", DockerPrefix, "rm", "-f", "-s", "-v")
+	args := []string{"-p", DockerPrefix, "rm", "-f", "-s", "-v"}
+	args = append(args, alphas...)
+	cmd := exec.CommandContext(context.Background(), "docker-compose", args...)
 	if err := cmd.Run(); err != nil {
 		fmt.Printf("Error while bringing down cluster. Prefix: %s. Error: %v\n", DockerPrefix, err)
 	}

--- a/testutil/minio.go
+++ b/testutil/minio.go
@@ -20,12 +20,7 @@ import (
 	"github.com/minio/minio-go/v6"
 )
 
-var (
-	accessKey = "accesskey"
-	secretKey = "secretkey"
-)
-
 // NewMinioClient returns a minio client.
 func NewMinioClient() (*minio.Client, error) {
-	return minio.New(MinioInstance, accessKey, secretKey, false)
+	return minio.New(MinioInstance, "accesskey", "secretkey", false)
 }


### PR DESCRIPTION
instead of a host mount, we do everything inside the container now. This avoids creating any files on the host and the delete error on during cleanup on the CI do not happen.