### PR TITLE
feat(cloud): add shared-instance flag in limit superflag in alpha #8513

### DIFF
--- a/codec/codec.go
+++ b/codec/codec.go
@@ -406,7 +406,8 @@ func Decode(pack *pb.UidPack, seek uint64) []uint64 {
 
 // DecodeToBuffer is the same as Decode but it returns a z.Buffer which is
 // calloc'ed and can be SHOULD be freed up by calling buffer.Release().
-func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) {
+func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) *z.Buffer {
+
 	var last uint64
 	tmp := make([]byte, 16)
 	dec := Decoder{Pack: pack}
@@ -417,6 +418,7 @@ func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) {
 			last = u
 		}
 	}
+	return buf
 }
 
 func match32MSB(num1, num2 uint64) bool {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -406,8 +406,7 @@ func Decode(pack *pb.UidPack, seek uint64) []uint64 {
 
 // DecodeToBuffer is the same as Decode but it returns a z.Buffer which is
 // calloc'ed and can be SHOULD be freed up by calling buffer.Release().
-func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) *z.Buffer {
-
+func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) {
 	var last uint64
 	tmp := make([]byte, 16)
 	dec := Decoder{Pack: pack}
@@ -418,7 +417,6 @@ func DecodeToBuffer(buf *z.Buffer, pack *pb.UidPack) *z.Buffer {
 			last = u
 		}
 	}
-	return buf
 }
 
 func match32MSB(num1, num2 uint64) bool {

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -76,7 +76,6 @@ func TestBufferUidPack(t *testing.T) {
 	// Some edge case tests.
 	pack := Encode([]uint64{}, 128)
 	FreePack(pack)
-
 	buf := z.NewBuffer(10<<10, "TestBufferUidPack")
 	defer buf.Release()
 	DecodeToBuffer(buf, &pb.UidPack{})

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -76,6 +76,7 @@ func TestBufferUidPack(t *testing.T) {
 	// Some edge case tests.
 	pack := Encode([]uint64{}, 128)
 	FreePack(pack)
+
 	buf := z.NewBuffer(10<<10, "TestBufferUidPack")
 	defer buf.Release()
 	DecodeToBuffer(buf, &pb.UidPack{})

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -205,6 +205,10 @@ they form a Raft group and provide synchronous replication.
 				"worker in a failed state. Use -1 to retry infinitely.").
 		Flag("txn-abort-after", "Abort any pending transactions older than this duration."+
 			" The liveness of a transaction is determined by its last mutation.").
+		Flag("shared-instance", "When set to true, it disables ACLs for non-galaxy users. "+
+			"It expects the access JWT to be contructed outside dgraph for those users as even "+
+			"login is denied to them. Additionally, this disables access to environment variables"+
+			"for minio, aws, etc.").
 		String())
 
 	flag.String("graphql", worker.GraphQLDefaults, z.NewSuperFlagHelp(worker.GraphQLDefaults).
@@ -628,7 +632,6 @@ func run() {
 		pstoreBlockCacheSize, pstoreIndexCacheSize)
 	bopts := badger.DefaultOptions("").FromSuperFlag(worker.BadgerDefaults + cacheOpts).
 		FromSuperFlag(Alpha.Conf.GetString("badger"))
-
 	security := z.NewSuperFlag(Alpha.Conf.GetString("security")).MergeAndCheckDefault(
 		worker.SecurityDefaults)
 	conf := audit.GetAuditConf(Alpha.Conf.GetString("audit"))
@@ -717,6 +720,7 @@ func run() {
 	x.Config.LimitNormalizeNode = int(x.Config.Limit.GetInt64("normalize-node"))
 	x.Config.QueryTimeout = x.Config.Limit.GetDuration("query-timeout")
 	x.Config.MaxRetries = x.Config.Limit.GetInt64("max-retries")
+	x.Config.SharedInstance = x.Config.Limit.GetBool("shared-instance")
 
 	x.Config.GraphQL = z.NewSuperFlag(Alpha.Conf.GetString("graphql")).MergeAndCheckDefault(
 		worker.GraphQLDefaults)

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 Dgraph Labs, Inc. and Contributors
+ * Copyright 2017-2023 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -207,8 +207,8 @@ they form a Raft group and provide synchronous replication.
 			" The liveness of a transaction is determined by its last mutation.").
 		Flag("shared-instance", "When set to true, it disables ACLs for non-galaxy users. "+
 			"It expects the access JWT to be contructed outside dgraph for those users as even "+
-			"login is denied to them. Additionally, this disables access to environment variables"+
-			"for minio, aws, etc.").
+			"login is denied to them. This can be done via online tools or jwt libraries. Additionally, "+
+			"this disables access to environment variables for minio, aws, etc.").
 		String())
 
 	flag.String("graphql", worker.GraphQLDefaults, z.NewSuperFlagHelp(worker.GraphQLDefaults).

--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -26,15 +26,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	"go.opencensus.io/trace"
-
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"go.opencensus.io/trace"
 )
 
 // Increment is the sub-command invoked when calling "dgraph increment".

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -21,11 +21,11 @@ import (
 	"math"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/testutil"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 )
 
 func TestRemoveNode(t *testing.T) {

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -632,6 +632,10 @@ type authPredResult struct {
 func authorizePreds(ctx context.Context, userData *userData, preds []string,
 	aclOp *acl.Operation) *authPredResult {
 
+	if !worker.AclCachePtr.Loaded() {
+		RefreshACLs(ctx)
+	}
+
 	userId := userData.userId
 	groupIds := userData.groupIds
 	ns := userData.namespace

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -49,6 +49,10 @@ type predsAndvars struct {
 func (s *Server) Login(ctx context.Context,
 	request *api.LoginRequest) (*api.Response, error) {
 
+	if !shouldAllowAcls(request.GetNamespace()) {
+		return nil, errors.New("operation is not allowed in cloud mode")
+	}
+
 	if err := x.HealthCheck(); err != nil {
 		return nil, err
 	}
@@ -626,18 +630,11 @@ type authPredResult struct {
 }
 
 func authorizePreds(ctx context.Context, userData *userData, preds []string,
-	aclOp *acl.Operation) (*authPredResult, error) {
-
-	ns, err := x.ExtractNamespace(ctx)
-	if err != nil {
-		return nil, errors.Wrapf(err, "While authorizing preds")
-	}
-	if !worker.AclCachePtr.Loaded() {
-		RefreshACLs(ctx)
-	}
+	aclOp *acl.Operation) *authPredResult {
 
 	userId := userData.userId
 	groupIds := userData.groupIds
+	ns := userData.namespace
 	blockedPreds := make(map[string]struct{})
 	for _, pred := range preds {
 		nsPred := x.NamespaceAttr(ns, pred)
@@ -657,7 +654,7 @@ func authorizePreds(ctx context.Context, userData *userData, preds []string,
 	if worker.HasAccessToAllPreds(ns, groupIds, aclOp) {
 		// Setting allowed to nil allows access to all predicates. Note that the access to ACL
 		// predicates will still be blocked.
-		return &authPredResult{allowed: nil, blocked: blockedPreds}, nil
+		return &authPredResult{allowed: nil, blocked: blockedPreds}
 	}
 	// User can have multiple permission for same predicate, add predicate
 	allowedPreds := make([]string, 0, len(worker.AclCachePtr.GetUserPredPerms(userId)))
@@ -667,7 +664,7 @@ func authorizePreds(ctx context.Context, userData *userData, preds []string,
 			allowedPreds = append(allowedPreds, predicate)
 		}
 	}
-	return &authPredResult{allowed: allowedPreds, blocked: blockedPreds}, nil
+	return &authPredResult{allowed: allowedPreds, blocked: blockedPreds}
 }
 
 // authorizeAlter parses the Schema in the operation and authorizes the operation
@@ -722,10 +719,7 @@ func authorizeAlter(ctx context.Context, op *api.Operation) error {
 				"only guardians are allowed to drop all data, but the current user is %s", userId)
 		}
 
-		result, err := authorizePreds(ctx, userData, preds, acl.Modify)
-		if err != nil {
-			return nil
-		}
+		result := authorizePreds(ctx, userData, preds, acl.Modify)
 		if len(result.blocked) > 0 {
 			var msg strings.Builder
 			for key := range result.blocked {
@@ -834,12 +828,17 @@ func authorizeMutation(ctx context.Context, gmu *dql.Mutation) error {
 			case isAclPredMutation(gmu.Del):
 				return errors.Errorf("ACL predicates can't be deleted")
 			}
+			if !shouldAllowAcls(userData.namespace) {
+				for _, pred := range preds {
+					if x.IsAclPredicate(pred) {
+						return status.Errorf(codes.PermissionDenied,
+							"unauthorized to mutate acl predicates: %s\n", pred)
+					}
+				}
+			}
 			return nil
 		}
-		result, err := authorizePreds(ctx, userData, preds, acl.Write)
-		if err != nil {
-			return err
-		}
+		result := authorizePreds(ctx, userData, preds, acl.Write)
 		if len(result.blocked) > 0 {
 			var msg strings.Builder
 			for key := range result.blocked {
@@ -947,6 +946,11 @@ func logAccess(log *accessEntry) {
 	}
 }
 
+// With shared instance enabled, we don't allow ACL operations from any of the non-galaxy namespace.
+func shouldAllowAcls(ns uint64) bool {
+	return !x.Config.SharedInstance || ns == x.GalaxyNamespace
+}
+
 // authorizeQuery authorizes the query using the aclCachePtr. It will silently drop all
 // unauthorized predicates from query.
 // At this stage, namespace is not attached in the predicates.
@@ -958,6 +962,7 @@ func authorizeQuery(ctx context.Context, parsedReq *dql.Result, graphql bool) er
 
 	var userId string
 	var groupIds []string
+	var namespace uint64
 	predsAndvars := parsePredsFromQuery(parsedReq.Query)
 	preds := predsAndvars.preds
 	varsToPredMap := predsAndvars.vars
@@ -977,14 +982,24 @@ func authorizeQuery(ctx context.Context, parsedReq *dql.Result, graphql bool) er
 
 		userId = userData.userId
 		groupIds = userData.groupIds
+		namespace = userData.namespace
 
 		if x.IsGuardian(groupIds) {
-			// Members of guardian groups are allowed to query anything.
-			return nil, nil, nil
+			if shouldAllowAcls(userData.namespace) {
+				// Members of guardian groups are allowed to query anything.
+				return nil, nil, nil
+			}
+			blocked := make(map[string]struct{})
+			for _, pred := range preds {
+				if x.IsAclPredicate(pred) {
+					blocked[pred] = struct{}{}
+				}
+			}
+			return blocked, nil, nil
 		}
 
-		result, err := authorizePreds(ctx, userData, preds, acl.Read)
-		return result.blocked, result.allowed, err
+		result := authorizePreds(ctx, userData, preds, acl.Read)
+		return result.blocked, result.allowed, nil
 	}
 
 	blockedPreds, allowedPreds, err := doAuthorizeQuery()
@@ -1005,7 +1020,7 @@ func authorizeQuery(ctx context.Context, parsedReq *dql.Result, graphql bool) er
 	if len(blockedPreds) != 0 {
 		// For GraphQL requests, we allow filtered access to the ACL predicates.
 		// Filter for user_id and group_id is applied for the currently logged in user.
-		if graphql {
+		if graphql && shouldAllowAcls(namespace) {
 			for _, gq := range parsedReq.Query {
 				addUserFilterToQuery(gq, userId, groupIds)
 			}
@@ -1066,11 +1081,20 @@ func authorizeSchemaQuery(ctx context.Context, er *query.ExecutionResult) error 
 
 		groupIds := userData.groupIds
 		if x.IsGuardian(groupIds) {
-			// Members of guardian groups are allowed to query anything.
-			return nil, nil
+			if shouldAllowAcls(userData.namespace) {
+				// Members of guardian groups are allowed to query anything.
+				return nil, nil
+			}
+			blocked := make(map[string]struct{})
+			for _, pred := range preds {
+				if x.IsAclPredicate(pred) {
+					blocked[pred] = struct{}{}
+				}
+			}
+			return blocked, nil
 		}
-		result, err := authorizePreds(ctx, userData, preds, acl.Read)
-		return result.blocked, err
+		result := authorizePreds(ctx, userData, preds, acl.Read)
+		return result.blocked, nil
 	}
 
 	// find the predicates which are blocked for the schema query
@@ -1113,8 +1137,7 @@ func AuthGuardianOfTheGalaxy(ctx context.Context) error {
 	}
 	ns, err := x.ExtractJWTNamespace(ctx)
 	if err != nil {
-		return status.Error(codes.Unauthenticated,
-			"AuthGuardianOfTheGalaxy: extracting jwt token, error: "+err.Error())
+		return errors.Wrap(err, "Authorize guardian of the galaxy, extracting jwt token, error:")
 	}
 	if ns != 0 {
 		return status.Error(

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/glog"
+	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -23,12 +23,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/posting"
@@ -36,6 +30,12 @@ import (
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Restore is the sub-command used to restore a backup.
@@ -467,10 +467,8 @@ func runExportBackup() error {
 		if err := worker.RunReducer(w, mapDir); err != nil {
 			return errors.Wrap(err, "Failed to reduce the map")
 		}
-		if files, err := exportStorage.FinishWriting(writers); err != nil {
+		if _, err := exportStorage.FinishWriting(writers); err != nil {
 			return errors.Wrap(err, "Failed to finish write")
-		} else {
-			glog.Infof("done exporting files: %v\n", files)
 		}
 	}
 	return nil

--- a/ee/vault/vault.go
+++ b/ee/vault/vault.go
@@ -20,10 +20,10 @@
 package vault
 
 import (
+	"github.com/dgraph-io/dgraph/ee"
+
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
-
-	"github.com/dgraph-io/dgraph/ee"
 )
 
 func GetKeys(config *viper.Viper) (*ee.Keys, error) {

--- a/ee/vault_ee.go
+++ b/ee/vault_ee.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/dgraph-io/ristretto/z"
 
 	"github.com/golang/glog"

--- a/ee/vault_ee.go
+++ b/ee/vault_ee.go
@@ -19,12 +19,12 @@ import (
 	"io/ioutil"
 	"reflect"
 
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
+
 	"github.com/golang/glog"
 	"github.com/hashicorp/vault/api"
 	"github.com/spf13/viper"
-
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 )
 
 func vaultGetKeys(config *viper.Viper) (aclKey, encKey x.Sensitive) {

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -22,14 +22,14 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 const notSet = math.MaxInt64

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -19,6 +19,7 @@ package admin
 import (
 	"context"
 	"encoding/json"
+	"github.com/dgraph-io/dgraph/worker"
 
 	"github.com/golang/glog"
 

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -19,9 +19,6 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"github.com/dgraph-io/dgraph/worker"
-
-	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -29,6 +26,7 @@ import (
 	"github.com/dgraph-io/dgraph/query"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
 )
 
 type getSchemaResolver struct {

--- a/systest/acl/restore/acl_restore_test.go
+++ b/systest/acl/restore/acl_restore_test.go
@@ -36,7 +36,8 @@ func disableDraining(t *testing.T) {
 	b, err := json.Marshal(params)
 	require.NoError(t, err)
 
-	token := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: 0})
+	token, err := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: 0})
+	require.NoError(t, err, "login failed")
 
 	client := &http.Client{}
 	req, err := http.NewRequest("POST", testutil.AdminUrl(), bytes.NewBuffer(b))
@@ -70,7 +71,9 @@ func sendRestoreRequest(t *testing.T, location, backupId string, backupNum int) 
 		},
 	}
 
-	token := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: 0})
+	token, err := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: 0})
+	require.NoError(t, err, "login failed")
+
 	resp := testutil.MakeGQLRequestWithAccessJwt(t, params, token.AccessJwt)
 	resp.RequireNoGraphQLErrors(t)
 
@@ -97,8 +100,9 @@ func TestAclCacheRestore(t *testing.T) {
 	sendRestoreRequest(t, "/backups", "vibrant_euclid5", 1)
 	testutil.WaitForRestore(t, dg)
 
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "alice1", Passwd: "password", Namespace: 0})
+	require.NoError(t, err, "login failed")
 	params := &common.GraphQLParams{
 		Query: `query{
 					queryPerson{

--- a/systest/backup/multi-tenancy/backup_test.go
+++ b/systest/backup/multi-tenancy/backup_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210"

--- a/systest/backup/multi-tenancy/backup_test.go
+++ b/systest/backup/multi-tenancy/backup_test.go
@@ -53,7 +53,8 @@ func TestBackupMultiTenancy(t *testing.T) {
 	testutil.DropAll(t, dg)
 
 	galaxyCreds := &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace}
-	galaxyToken := testutil.Login(t, galaxyCreds)
+	galaxyToken, err := testutil.Login(t, galaxyCreds)
+	require.NoError(t, err, "login failed")
 
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
+)
+
+func prepare(t *testing.T) {
+	dc := testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
+	require.NoError(t, dc.Alter(context.Background(), &api.Operation{DropAll: true}))
+}
+
+func readFile(t *testing.T, path string) []byte {
+	data, err := ioutil.ReadFile(path)
+	require.NoError(t, err)
+	return data
+}
+
+func getHttpToken(t *testing.T, user, password string, ns uint64) *testutil.HttpToken {
+	jwt := testutil.GetAccessJwt(t, testutil.JwtParams{
+		User:   user,
+		Groups: []string{"guardians"},
+		Ns:     ns,
+		Exp:    time.Hour,
+		Secret: readFile(t, "../../ee/acl/hmac-secret"),
+	})
+
+	return &testutil.HttpToken{
+		UserId:    user,
+		Password:  password,
+		AccessJwt: jwt,
+	}
+}
+
+func graphqlHelper(t *testing.T, query string, headers http.Header,
+	expectedResult string) {
+	params := &common.GraphQLParams{
+		Query:   query,
+		Headers: headers,
+	}
+	queryResult := params.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, queryResult)
+	testutil.CompareJSON(t, expectedResult, string(queryResult.Data))
+}
+
+func TestDisallowNonGalaxy(t *testing.T) {
+	prepare(t)
+
+	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+	require.Greater(t, int(ns), 0)
+
+	nsToken := getHttpToken(t, "groot", "password", ns)
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", nsToken.AccessJwt)
+
+	// User from namespace ns should be able to query/mutate.
+	schema := `
+	type Author {
+		id: ID!
+		name: String
+	}`
+	common.SafelyUpdateGQLSchema(t, common.Alpha1HTTP, schema, header)
+
+	graphqlHelper(t, `
+	mutation {
+		addAuthor(input:{name: "Alice"}) {
+			author{
+				name
+			}
+		}
+	}`, header,
+		`{
+			"addAuthor": {
+				"author":[{
+					"name":"Alice"
+				}]
+			}
+		}`)
+
+	query := `
+	query {
+		queryAuthor {
+			name
+		}
+	}`
+	graphqlHelper(t, query, header,
+		`{
+			"queryAuthor": [
+				{
+					"name":"Alice"
+				}
+			]
+		}`)
+
+	// Login to namespace 1 via groot and create new user alice. Non-galaxy namespace user should
+	// not be able to do so in cloud mode.
+	_, err = testutil.HttpLogin(&testutil.LoginParams{
+		Endpoint:  testutil.AdminUrl(),
+		UserID:    "groot",
+		Passwd:    "password",
+		Namespace: ns,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "operation is not allowed in cloud mode")
+
+	// Ns guardian should not be able to create user.
+	resp := testutil.CreateUser(t, nsToken, "alice", "newpassword")
+	require.Greater(t, len(resp.Errors), 0)
+	require.Contains(t, resp.Errors.Error(), "unauthorized to mutate acl predicates")
+
+	// Galaxy guardian should be able to create user.
+	resp = testutil.CreateUser(t, galaxyToken, "alice", "newpassword")
+	require.Equal(t, 0, len(resp.Errors))
+}
+
+func TestEnvironmentAccess(t *testing.T) {
+	prepare(t)
+
+	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
+	// Create a new namespace
+	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
+	require.NoError(t, err)
+	require.Greater(t, int(ns), 0)
+
+	nsToken := getHttpToken(t, "groot", "password", ns)
+	header := http.Header{}
+	header.Set("X-Dgraph-AccessToken", nsToken.AccessJwt)
+
+	// Create a minio bucket.
+	bucketname := "dgraph-export"
+	mc, err := testutil.NewMinioClient()
+	require.NoError(t, err)
+	require.NoError(t, mc.MakeBucket(bucketname, ""))
+	minioDest := "minio://minio:9001/dgraph-export?secure=false"
+
+	// Export without the minio creds should fail for non-galaxy.
+	resp := testutil.Export(t, nsToken, minioDest, "", "")
+	require.Greater(t, len(resp.Errors), 0)
+	require.Contains(t, resp.Errors.Error(), "task failed")
+
+	// Export without the minio creds should work for non-galaxy.
+	resp = testutil.Export(t, nsToken, minioDest, "accesskey", "secretkey")
+	require.Zero(t, len(resp.Errors))
+
+	// Galaxy guardian should provide the crednetials as well.
+	resp = testutil.Export(t, galaxyToken, minioDest, "accesskey", "secretkey")
+	require.Zero(t, len(resp.Errors))
+
+}
+
+func TestMain(m *testing.M) {
+	fmt.Printf("Using adminEndpoint : %s for cloud test.\n", testutil.AdminUrl())
+	os.Exit(m.Run())
+}

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func prepare(t *testing.T) {
+func setup(t *testing.T) {
 	dc := testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
 	require.NoError(t, dc.Alter(context.Background(), &api.Operation{DropAll: true}))
 }
@@ -72,7 +72,7 @@ func graphqlHelper(t *testing.T, query string, headers http.Header,
 }
 
 func TestDisallowNonGalaxy(t *testing.T) {
-	prepare(t)
+	setup(t)
 
 	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
 	// Create a new namespace
@@ -145,7 +145,7 @@ func TestDisallowNonGalaxy(t *testing.T) {
 }
 
 func TestEnvironmentAccess(t *testing.T) {
-	prepare(t)
+	setup(t)
 
 	galaxyToken := getHttpToken(t, "groot", "password", x.GalaxyNamespace)
 	// Create a new namespace

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Dgraph Labs, Inc. and Contributors
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/systest/cloud/cloud_test.go
+++ b/systest/cloud/cloud_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -1,0 +1,53 @@
+version: "3.5"
+services:
+  zero1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/zero1
+    ports:
+      - 5080
+      - 6080
+    labels:
+      cluster: test
+      service: zero
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+    command: /gobin/dgraph zero --my=zero1:5080 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
+
+  alpha1:
+    image: dgraph/dgraph:latest
+    working_dir: /data/alpha1
+    env_file:
+        - ./minio.env
+    volumes:
+      - type: bind
+        source: $GOPATH/bin
+        target: /gobin
+        read_only: true
+      - type: bind
+        source: ../../ee/acl/hmac-secret
+        target: /dgraph-acl/hmac-secret
+        read_only: true
+    ports:
+      - 8080
+      - 9080
+    labels:
+      cluster: test
+      service: alpha
+    command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080 --expose_trace --profile_mode block --block_rate 10 --logtostderr -v=2 
+      --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --acl "secret-file=/dgraph-acl/hmac-secret; access-ttl=20s;"
+      --limit "shared-instance=true"
+
+  minio:
+    image: minio/minio:latest
+    env_file:
+      - ./minio.env
+    working_dir: /data/minio
+    ports:
+      - 9001
+    labels:
+      cluster: test
+    command: minio server /data/minio --address :9001

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
   zero1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/zero1
     ports:
       - 5080
@@ -17,10 +17,10 @@ services:
     command: /gobin/dgraph zero --my=zero1:5080 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
 
   alpha1:
-    image: dgraph/dgraph:latest
+    image: dgraph/dgraph:local
     working_dir: /data/alpha1
     env_file:
-        - ./minio.env
+        - ./../../dgraph/minio.env
     volumes:
       - type: bind
         source: $GOPATH/bin
@@ -44,7 +44,7 @@ services:
   minio:
     image: minio/minio:latest
     env_file:
-      - ./minio.env
+      - ./../../dgraph/minio.env
     working_dir: /data/minio
     ports:
       - 9001

--- a/systest/cloud/minio.env
+++ b/systest/cloud/minio.env
@@ -1,0 +1,2 @@
+MINIO_ACCESS_KEY=accesskey
+MINIO_SECRET_KEY=secretkey

--- a/systest/cloud/minio.env
+++ b/systest/cloud/minio.env
@@ -1,2 +1,0 @@
-MINIO_ACCESS_KEY=accesskey
-MINIO_SECRET_KEY=secretkey

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -48,9 +48,10 @@ var timeout = 5 * time.Second
 // this file can me made common to the other acl tests as well. Needs some refactoring as well.
 func TestAclBasic(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
 
+	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
@@ -80,7 +81,8 @@ func TestAclBasic(t *testing.T) {
 	testutil.CompareJSON(t, `{"me": []}`, string(resp))
 
 	// Login to namespace 1 via groot and create new user alice.
-	token := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
+	token, err := testutil.Login(t, &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
+	require.NoError(t, err, "login failed")
 	testutil.CreateUser(t, token, "alice", "newpassword")
 
 	// Alice should not be able to see data added by groot in namespace 1
@@ -100,8 +102,9 @@ func TestAclBasic(t *testing.T) {
 }
 
 func createGroupAndSetPermissions(t *testing.T, namespace uint64, group, user, predicate string) {
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: namespace})
+	require.NoError(t, err, "login failed")
 	testutil.CreateGroup(t, token, group)
 	testutil.AddToGroup(t, token, user, group)
 	testutil.AddRulesToGroup(t, token, group,
@@ -110,9 +113,9 @@ func createGroupAndSetPermissions(t *testing.T, namespace uint64, group, user, p
 
 func TestTwoPermissionSetsInNameSpacesWithAcl(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
-
+	require.NoError(t, err, "login failed")
 	query := `
 		{
 			me(func: has(name)) {
@@ -130,8 +133,9 @@ func TestTwoPermissionSetsInNameSpacesWithAcl(t *testing.T) {
 	testutil.AddData(t, dc)
 
 	// Create user alice
-	token1 := testutil.Login(t,
+	token1, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns1})
+	require.NoError(t, err, "login failed")
 	testutil.CreateUser(t, token1, "alice", "newpassword")
 
 	// Create a new group, add alice to that group and give read access of <name> to dev group.
@@ -150,8 +154,9 @@ func TestTwoPermissionSetsInNameSpacesWithAcl(t *testing.T) {
 	testutil.AddData(t, dc)
 
 	// Create user bob
-	token2 := testutil.Login(t,
+	token2, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns2})
+	require.NoError(t, err, "login failed")
 	testutil.CreateUser(t, token2, "bob", "newpassword")
 
 	// Create a new group, add bob to that group and give read access of <nickname> to dev group.
@@ -167,8 +172,9 @@ func TestTwoPermissionSetsInNameSpacesWithAcl(t *testing.T) {
 	testutil.CompareJSON(t, `{"me": [{"name":"guy2"}, {"name":"guy1"}]}`, string(resp))
 
 	// Change permissions in namespace-2
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns2})
+	require.NoError(t, err, "login failed")
 	testutil.AddRulesToGroup(t, token, "dev",
 		[]testutil.Rule{{Predicate: "name", Permission: acl.Read.Code}}, false)
 
@@ -185,16 +191,16 @@ func TestTwoPermissionSetsInNameSpacesWithAcl(t *testing.T) {
 
 func TestCreateNamespace(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
-
+	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
 
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
-
+	require.NoError(t, err, "login failed")
 	// Create a new namespace using guardian of other namespace.
 	_, err = testutil.CreateNamespaceWithRetry(t, token)
 	require.Error(t, err)
@@ -204,9 +210,9 @@ func TestCreateNamespace(t *testing.T) {
 func TestResetPassword(t *testing.T) {
 	prepare(t)
 
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
-
+	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
@@ -216,23 +222,24 @@ func TestResetPassword(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try and Fail with old password for groot
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
 
+	require.Error(t, err, "expected error because incorrect login")
 	require.Nil(t, token, "nil token because incorrect login")
 
 	// Try and success with new password for groot
-	token = testutil.Login(t,
+	token, err = testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "newpassword", Namespace: ns})
-
+	require.NoError(t, err, "login failed")
 	require.Equal(t, token.Password, "newpassword", "new password matches the reset password")
 }
 
 func TestDeleteNamespace(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
-
+	require.NoError(t, err, "login failed")
 	dg := make(map[uint64]*dgo.Dgraph)
 	dg[x.GalaxyNamespace] = testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
 	// Create a new namespace
@@ -320,8 +327,8 @@ func TestLiveLoadMulti(t *testing.T) {
 	prepare(t)
 	dc0 := testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
 	galaxyCreds := &testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace}
-	galaxyToken := testutil.Login(t, galaxyCreds)
-
+	galaxyToken, err := testutil.Login(t, galaxyCreds)
+	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
@@ -493,16 +500,16 @@ func postPersistentQuery(t *testing.T, query, sha, accessJwt string) *common.Gra
 
 func TestPersistentQuery(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
-
+	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
 
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
-
+	require.NoError(t, err, "login failed")
 	sch := `type Product {
 			productID: ID!
 			name: String @search(by: [term])
@@ -536,18 +543,22 @@ func TestPersistentQuery(t *testing.T) {
 
 func TestTokenExpired(t *testing.T) {
 	prepare(t)
-	galaxyToken := testutil.Login(t,
+	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
+	require.NoError(t, err, "login failed")
 
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)
 	require.NoError(t, err)
-	token := testutil.Login(t,
+	token, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: ns})
+	require.NoError(t, err, "login failed")
 
 	// Relogin using refresh JWT.
-	token = testutil.Login(t,
+	token, err = testutil.Login(t,
 		&testutil.LoginParams{RefreshJwt: token.RefreshToken})
+	require.NoError(t, err, "login failed")
+
 	_, err = testutil.CreateNamespaceWithRetry(t, token)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Only guardian of galaxy is allowed to do this operation")

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Dgraph Labs, Inc. and Contributors
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ func TestAclBasic(t *testing.T) {
 	galaxyToken, err := testutil.Login(t,
 		&testutil.LoginParams{UserID: "groot", Passwd: "password", Namespace: x.GalaxyNamespace})
 
+	require.NotNil(t, galaxyToken, "galaxy token is nil")
 	require.NoError(t, err, "login failed")
 	// Create a new namespace
 	ns, err := testutil.CreateNamespaceWithRetry(t, galaxyToken)

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -310,46 +310,45 @@ func HttpLogin(params *LoginParams) (*HttpToken, error) {
 		return nil, errors.New(fmt.Sprintf("got non 200 response from the server with %s ",
 			string(respBody)))
 	}
-	var outputJson map[string]interface{}
-	if err := json.Unmarshal(respBody, &outputJson); err != nil {
-		var errOutputJson map[string]interface{}
-		if err := json.Unmarshal(respBody, &errOutputJson); err == nil {
-			if _, ok := errOutputJson["errors"]; ok {
-				return nil, errors.Errorf("response error: %v", string(respBody))
+
+	var gqlResp GraphQLResponse
+	if err := json.Unmarshal(respBody, &gqlResp); err != nil {
+		return nil, err
+	}
+
+	if len(gqlResp.Errors) > 0 {
+		return nil, errors.Errorf(gqlResp.Errors.Error())
+	}
+
+	if gqlResp.Data == nil {
+		return nil, errors.Wrapf(err, "data entry found in the output")
+	}
+
+	type Response struct {
+		Login struct {
+			Response struct {
+				AccessJWT  string
+				RefreshJwt string
 			}
 		}
-		return nil, errors.Wrapf(err, "unable to unmarshal the output to get JWTs")
+	}
+	var r Response
+	if err := json.Unmarshal(gqlResp.Data, &r); err != nil {
+		return nil, err
 	}
 
-	data, found := outputJson["data"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	l, found := data["login"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	response, found := l["response"].(map[string]interface{})
-	if !found {
-		return nil, errors.Wrapf(err, "data entry found in the output")
-	}
-
-	newAccessJwt, found := response["accessJWT"].(string)
-	if !found || newAccessJwt == "" {
+	if r.Login.Response.AccessJWT == "" {
 		return nil, errors.Errorf("no access JWT found in the output")
 	}
-	newRefreshJwt, found := response["refreshJWT"].(string)
-	if !found || newRefreshJwt == "" {
+	if r.Login.Response.RefreshJwt == "" {
 		return nil, errors.Errorf("no refresh JWT found in the output")
 	}
 
 	return &HttpToken{
 		UserId:       params.UserID,
 		Password:     params.Passwd,
-		AccessJwt:    newAccessJwt,
-		RefreshToken: newRefreshJwt,
+		AccessJwt:    r.Login.Response.AccessJWT,
+		RefreshToken: r.Login.Response.RefreshJwt,
 	}, nil
 }
 

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -56,7 +56,7 @@ func MakeRequest(t *testing.T, token *HttpToken, params GraphQLParams) *GraphQLR
 	return MakeGQLRequestWithAccessJwt(t, &params, token.AccessJwt)
 }
 
-func Login(t *testing.T, loginParams *LoginParams) *HttpToken {
+func Login(t *testing.T, loginParams *LoginParams) (*HttpToken, error) {
 	if loginParams.Endpoint == "" {
 		loginParams.Endpoint = AdminUrl()
 	}
@@ -66,8 +66,7 @@ func Login(t *testing.T, loginParams *LoginParams) *HttpToken {
 		token, err = HttpLogin(loginParams)
 		return err
 	})
-	require.NoError(t, err, "login failed")
-	return token
+	return token, err
 }
 
 func ResetPassword(t *testing.T, token *HttpToken, userID, newPass string, nsID uint64) (string, error) {

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/require"
 )
 
 func GalaxySchemaKey(attr string) []byte {
@@ -58,6 +59,30 @@ func GalaxyIndexKey(attr, term string) []byte {
 func GalaxyCountKey(attr string, count uint32, reverse bool) []byte {
 	attr = x.GalaxyAttr(attr)
 	return x.CountKey(attr, count, reverse)
+}
+
+type JwtParams struct {
+	User   string
+	Groups []string
+	Ns     uint64
+	Exp    time.Duration
+	Secret []byte
+}
+
+// GetAccessJwt constructs an access jwt with the given user id, groupIds, namespace
+// and expiration TTL.
+func GetAccessJwt(t *testing.T, params JwtParams) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"userid":    params.User,
+		"groups":    params.Groups,
+		"namespace": params.Ns,
+		// set the jwt exp according to the ttl
+		"exp": time.Now().Add(params.Exp).Unix(),
+	})
+
+	jwtString, err := token.SignedString(params.Secret)
+	require.NoError(t, err)
+	return jwtString
 }
 
 func WaitForTask(t *testing.T, taskId string, useHttps bool) {

--- a/worker/acl_cache.go
+++ b/worker/acl_cache.go
@@ -16,10 +16,10 @@ package worker
 import (
 	"sync"
 
-	"github.com/pkg/errors"
-
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/pkg/errors"
 )
 
 // aclCache is the cache mapping group names to the corresponding group acls

--- a/worker/acl_cache_test.go
+++ b/worker/acl_cache_test.go
@@ -16,10 +16,10 @@ package worker
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAclCache(t *testing.T) {

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"math"
 
-	"github.com/pkg/errors"
-
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/pkg/errors"
 )
 
 // predicateSet is a map whose keys are predicates. It is meant to be used as a set.

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -25,12 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/snappy"
-	"github.com/pkg/errors"
-	ostats "go.opencensus.io/stats"
-
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
@@ -39,6 +33,12 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/pkg/errors"
+	ostats "go.opencensus.io/stats"
 )
 
 // Backup handles a request coming from another node.

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -23,13 +23,13 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
+
 	"github.com/golang/glog"
 	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/credentials"
 	"github.com/pkg/errors"
-
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -20,10 +20,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/pkg/errors"
 )
 
 func verifyManifests(manifests []*Manifest) error {

--- a/worker/backup_oss.go
+++ b/worker/backup_oss.go
@@ -22,10 +22,10 @@ package worker
 import (
 	"context"
 
-	"github.com/golang/glog"
-
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/glog"
 )
 
 // Backup implements the Worker interface.

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -23,15 +23,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft/raftpb"
-
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft/raftpb"
 )
 
 const (

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -28,16 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft"
-	"go.etcd.io/etcd/raft/raftpb"
-	ostats "go.opencensus.io/stats"
-	"go.opencensus.io/tag"
-	otrace "go.opencensus.io/trace"
-	"golang.org/x/net/trace"
-
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/conn"
@@ -48,6 +38,16 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+	ostats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	otrace "go.opencensus.io/trace"
+	"golang.org/x/net/trace"
 )
 
 type operation struct {

--- a/worker/draft_test.go
+++ b/worker/draft_test.go
@@ -21,13 +21,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"go.etcd.io/etcd/raft/raftpb"
-
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/raftpb"
 )
 
 func getEntryForMutation(index, startTs uint64) raftpb.Entry {

--- a/worker/export.go
+++ b/worker/export.go
@@ -32,10 +32,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/minio/minio-go/v6"
-	"github.com/pkg/errors"
-
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -46,6 +42,10 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/golang/glog"
+	"github.com/minio/minio-go/v6"
+	"github.com/pkg/errors"
 )
 
 // DefaultExportFormat stores the name of the default format for exports.

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -32,9 +32,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/require"
-
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/dql"
@@ -46,6 +43,9 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -22,14 +22,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/metadata"
-
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/metadata"
 )
 
 const (

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -25,10 +25,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
-
 	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/conn"
@@ -38,6 +34,10 @@ import (
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 type groupi struct {

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -25,12 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgraph/conn"
@@ -39,6 +33,12 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 )
 
 const (

--- a/worker/online_restore_oss.go
+++ b/worker/online_restore_oss.go
@@ -23,10 +23,9 @@ import (
 	"context"
 	"sync"
 
-	"github.com/golang/glog"
-
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/golang/glog"
 )
 
 func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync.WaitGroup) error {

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -30,12 +30,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/golang/snappy"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
-
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/codec"
@@ -45,6 +39,12 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/golang/snappy"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 type backupReader struct {

--- a/worker/restore_reduce.go
+++ b/worker/restore_reduce.go
@@ -25,14 +25,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/golang/snappy"
-
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
+
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/golang/snappy"
 )
 
 const (

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -52,7 +52,7 @@ const (
 	ZeroLimitsDefaults = `uid-lease=0; refill-interval=30s; disable-admin-http=false;`
 	GraphQLDefaults    = `introspection=true; debug=false; extensions=true; poll-interval=1s; ` +
 		`lambda-url=;`
-	CacheDefaults = `size-mb=1024; percentage=0,65,35;`
+	LudicrousDefaults = `enabled=false; concurrency=2000;`
 )
 
 // ServerState holds the state of the Dgraph server.

--- a/x/config.go
+++ b/x/config.go
@@ -39,6 +39,8 @@ type Options struct {
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
 	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
 	// query-timeout duration - Maximum time after which a query execution will fail.
+	// max-retries int64 - maximum number of retries made by dgraph to commit a transaction to disk.
+	// shared-instance bool - if set to true, ACLs will be disabled for non-galaxy users.
 	Limit                *z.SuperFlag
 	LimitMutationsNquad  int
 	LimitQueryEdge       uint64
@@ -46,6 +48,7 @@ type Options struct {
 	LimitNormalizeNode   int
 	QueryTimeout         time.Duration
 	MaxRetries           int64
+	SharedInstance       bool
 
 	// GraphQL options:
 	//


### PR DESCRIPTION
This PR adds a shared-instance flag to --limit superflag. When set to true (false by default), it will:

- Restrict access to any of the ACL operations like Login, add/remove/update user from non-galaxy namespaces.
- Prevent the leaking of environment variables for minio and aws.

(cherry picked from commit 5f3cece75da375077c45ab64228cb7053cf03d02) (cherry picked from commit eeb7bea1a7cb49636d38c14994cf3cf10bf857d2)