### PR TITLE
fix(GraphQL): Nested Auth Rules not working properly. (#7915) (#8084)

### DIFF
--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -513,6 +513,44 @@ func TestAuthOnInterfaces(t *testing.T) {
 	}
 }
 
+func TestNestedAndAuthRulesWithMissingJWT(t *testing.T) {
+	addParams := &common.GraphQLParams{
+		Query: `
+		mutation($user1: String!, $user2: String!){
+			addGroup(input: [{users: {username: $user1}, createdBy: {username: $user2}}, {users: {username: $user2}, createdBy: {username: $user1}}]){
+			  numUids
+			}
+		  }
+		`,
+		Variables: map[string]interface{}{"user1": "user1", "user2": "user2"},
+	}
+	gqlResponse := addParams.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+	require.JSONEq(t, `{"addGroup": {"numUids": 2}}`, string(gqlResponse.Data))
+
+	queryParams := &common.GraphQLParams{
+		Query: `
+		query{
+			queryGroup{
+			  users{
+				username
+			  }
+			}
+		  }
+		`,
+		Headers: common.GetJWT(t, "user1", nil, metaInfo),
+	}
+
+	expectedJSON := `{"queryGroup": [{"users": [{"username": "user1"}]}]}`
+
+	gqlResponse = queryParams.ExecuteAsPost(t, common.GraphqlURL)
+	common.RequireNoGQLErrors(t, gqlResponse)
+	require.JSONEq(t, expectedJSON, string(gqlResponse.Data))
+
+	deleteFilter := map[string]interface{}{"has": "users"}
+	common.DeleteGqlType(t, "Group", deleteFilter, 2, nil)
+}
+
 func TestAuthRulesWithNullValuesInJWT(t *testing.T) {
 	testCases := []TestCase{
 		{

--- a/graphql/resolve/auth_query_test.yaml
+++ b/graphql/resolve/auth_query_test.yaml
@@ -644,13 +644,10 @@
       queryGroup(func: uid(GroupRoot)) {
         Group.id : uid
       }
-      GroupRoot as var(func: uid(Group_1)) @filter((uid(Group_Auth2) OR uid(Group_Auth3)))
+      GroupRoot as var(func: uid(Group_1)) @filter(uid(Group_Auth2))
       Group_1 as var(func: type(Group))
       Group_Auth2 as var(func: uid(Group_1)) @cascade {
         Group.users : Group.users @filter(eq(User.username, "user1"))
-      }
-      Group_Auth3 as var(func: uid(Group_1)) @cascade {
-        Group.createdBy : Group.createdBy @filter(eq(User.username, "user1"))
       }
     }
 

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -978,6 +978,11 @@ func (authRw *authRewriter) rewriteRuleNode(
 
 	switch {
 	case len(rn.And) > 0:
+		// if there is atleast one RBAC rule which is false, then this
+		// whole And block needs to be ignored.
+		if rn.EvaluateStatic(authRw.authVariables) == schema.Negative {
+			return nil, nil
+		}
 		qrys, filts := nodeList(typ, rn.And)
 		if len(filts) == 0 {
 			return qrys, nil


### PR DESCRIPTION
Improves nested auth rule implementation in graphql.

(cherry picked from commit e7a19317a16214761e0db1f838ba48a0a382f0df)

Co-authored-by: minhaj-shakeel <minhaj@dgraph.io>
(cherry picked from commit 26845c431df5cc8cb3a1f0242b52a09aa4058840)
