### PR TITLE
fix(zero): fix update membership to make bulk tablet proposal instead of multiple small (#8090)

### DIFF
--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -380,6 +380,8 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 			})
 		}
 	}
+
+	var tablets []*pb.Tablet
 	for key, dstTablet := range dst.Tablets {
 		group, has := s.state.Groups[dstTablet.GroupId]
 		if !has {
@@ -395,11 +397,12 @@ func (s *Server) createProposals(dst *pb.Group) ([]*pb.ZeroProposal, error) {
 		d := float64(dstTablet.OnDiskBytes)
 		if dstTablet.Remove || (s == 0 && d > 0) || (s > 0 && math.Abs(d/s-1) > 0.1) {
 			dstTablet.Force = false
-			proposal := &pb.ZeroProposal{
-				Tablet: dstTablet,
-			}
-			res = append(res, proposal)
+			tablets = append(tablets, dstTablet)
 		}
+	}
+
+	if len(tablets) > 0 {
+		res = append(res, &pb.ZeroProposal{Tablets: tablets})
 	}
 	return res, nil
 }


### PR DESCRIPTION
Converting the smaller tablet proposals into a single bulk call makes the execution faster. Else, this update becomes of the order of O(n^2), where n is the number of tablet updates.

(cherry picked from commit 695c6d763b9e75edb0e47dd1f32a0af98222511a)

