### PR TITLE
fix(ci): adjust cron schedules

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "0 0 * * *" # we need only 1-run per day
 jobs:
   dgraph-code-coverage:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0 * * *" # we need only 1-run per day
+    - cron: "0 0 * * *" # 1-run per day
 jobs:
   dgraph-code-coverage:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "30 * * * *"
+    - cron: "0 0 * * *" # 1-run per day
 jobs:
   dgraph-ldbc-tests:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "0 0,12 * * *" # 2-runs per day
 jobs:
   dgraph-load-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "0 0,12 * * *" # 2-runs per day
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -12,7 +12,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "0 0,6,12,18 * * *"
+    - cron: "0 0,12 * * *" # 2-runs per day
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
## Problem
Our scheduled runs happen too often. We now have a stable baseline - and we can limit these runs. We are also adjusting triggering evented runs when a PR is opened, and when a PR is merged*. Reducing the scheduled run makes more sense now.

## Solution
changing these runs to happen twice daily