### PR TITLE
fix(sec): upgrade networkx to 

### DIFF
--- a/contrib/config/marketplace/aws/tests/requirements.txt
+++ b/contrib/config/marketplace/aws/tests/requirements.txt
@@ -22,7 +22,7 @@ jsonschema==3.2.0
 MarkupSafe==1.1.1
 mock==2.0.0
 mypy-extensions==0.4.3
-networkx==2.4
+networkx==2.6
 pbr==5.4.5
 pyasn1==0.4.8
 pyrsistent==0.16.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in networkx 2.4
- [MPS-2022-15000](https://www.oscs1024.com/hd/MPS-2022-15000)


### What did I do？
Upgrade networkx from 2.4 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS