### PR TITLE
Change intersect heuristic from 500 to 100

### DIFF
--- a/algo/benchmarks
+++ b/algo/benchmarks
@@ -1,170 +1,231 @@
-len: 10, compressed: 43, bytes/int: 4.300000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=10:overlap=0.01:-4         	50000000	        38.1 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=10:overlap=0.01:-4         	 2000000	       669 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=10:overlap=0.01:-4             	 2000000	       692 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=10:overlap=0.01:-4             	 2000000	       927 ns/op
+len: 1, compressed: 28, bytes/int: 28.000000
+goos: linux
+goarch: amd64
+pkg: github.com/dgraph-io/dgraph/algo
+cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=1:overlap=0.01:-8         	227971491	         5.268 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1:overlap=0.01:dr=100-8         	16380975	        72.46 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1:overlap=0.01:dr=500-8         	16398220	        89.15 ns/op
 
-len: 100, compressed: 208, bytes/int: 2.080000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=10:overlap=0.01:-4                         	20000000	        88.7 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10:size=10:overlap=0.01:-4        	 1000000	      1474 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10:size=10:overlap=0.01:-4            	 1000000	      1396 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10:size=10:overlap=0.01:-4            	 1000000	      1584 ns/op
+len: 10, compressed: 38, bytes/int: 3.800000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=1:overlap=0.01:-8                        	95598873	        13.21 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=1:overlap=0.01:dr=100-8        	 2245366	       534.9 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=1:overlap=0.01:dr=500-8        	 3133020	       389.5 ns/op
 
-len: 500, compressed: 875, bytes/int: 1.750000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=10:overlap=0.01:-4                         	 5000000	       320 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=50:size=10:overlap=0.01:-4        	  500000	      2763 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=50:size=10:overlap=0.01:-4            	  500000	      2664 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=50:size=10:overlap=0.01:-4            	  500000	      2709 ns/op
+len: 50, compressed: 88, bytes/int: 1.760000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=1:overlap=0.01:-8                        	64267141	        17.13 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=1:overlap=0.01:dr=100-8        	 1219317	       995.2 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=1:overlap=0.01:dr=500-8        	 1643157	       728.6 ns/op
 
-len: 1000, compressed: 1279, bytes/int: 1.279000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=10:overlap=0.01:-4                        	10000000	       207 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=100:size=10:overlap=0.01:-4       	  500000	      3173 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=100:size=10:overlap=0.01:-4           	  500000	      3012 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=100:size=10:overlap=0.01:-4           	  500000	      2841 ns/op
+len: 100, compressed: 147, bytes/int: 1.470000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=1:overlap=0.01:-8                       	41411936	        27.96 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=1:overlap=0.01:dr=100-8       	  773560	      1513 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=1:overlap=0.01:dr=500-8       	 1000000	      1160 ns/op
 
-len: 5000, compressed: 3115, bytes/int: 0.623000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=10:overlap=0.01:-4                        	 3000000	       491 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=500:size=10:overlap=0.01:-4       	 1000000	      2449 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=500:size=10:overlap=0.01:-4           	  300000	      4256 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=500:size=10:overlap=0.01:-4           	 1000000	      1729 ns/op
+len: 200, compressed: 274, bytes/int: 1.370000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=200:size=1:overlap=0.01:-8                       	35925672	        31.91 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=1:overlap=0.01:dr=100-8       	  459018	      2595 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=1:overlap=0.01:dr=500-8       	  572120	      2034 ns/op
 
-len: 10000, compressed: 3276, bytes/int: 0.327600
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=10:overlap=0.01:-4                       	 3000000	       538 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1000:size=10:overlap=0.01:-4      	  500000	      3378 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1000:size=10:overlap=0.01:-4          	  200000	      8346 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1000:size=10:overlap=0.01:-4          	 1000000	      2036 ns/op
+len: 400, compressed: 535, bytes/int: 1.337500
+BenchmarkListIntersectRatio/:IntersectWith:ratio=400:size=1:overlap=0.01:-8                       	51303427	        23.72 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=1:overlap=0.01:dr=100-8       	  304654	      4045 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=1:overlap=0.01:dr=500-8       	  304582	      3992 ns/op
 
-len: 100000, compressed: 35820, bytes/int: 0.358200
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10000:size=10:overlap=0.01:-4                      	 2000000	       645 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10000:size=10:overlap=0.01:-4     	  200000	      7103 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10000:size=10:overlap=0.01:-4         	   20000	     66790 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10000:size=10:overlap=0.01:-4         	 1000000	      2322 ns/op
+len: 500, compressed: 660, bytes/int: 1.320000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=1:overlap=0.01:-8                       	19757342	        57.60 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=1:overlap=0.01:dr=100-8       	  320407	      3826 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=1:overlap=0.01:dr=500-8       	  303950	      3857 ns/op
 
-len: 1000000, compressed: 210344, bytes/int: 0.210344
-BenchmarkListIntersectRatio/:IntersectWith:ratio=100000:size=10:overlap=0.01:-4                     	 2000000	       766 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=100000:size=10:overlap=0.01:-4    	   30000	     46978 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=100000:size=10:overlap=0.01:-4        	    2000	    623066 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=100000:size=10:overlap=0.01:-4        	 1000000	      2434 ns/op
+len: 1000, compressed: 1307, bytes/int: 1.307000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=1:overlap=0.01:-8                      	18622878	        60.91 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=1:overlap=0.01:dr=100-8      	  322821	      3796 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=1:overlap=0.01:dr=500-8      	  304449	      3806 ns/op
 
-len: 100, compressed: 224, bytes/int: 2.240000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=100:overlap=0.01:-4                         	 5000000	       265 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=100:overlap=0.01:-4        	 1000000	      1642 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=100:overlap=0.01:-4            	 1000000	      1562 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=100:overlap=0.01:-4            	  300000	      4465 ns/op
+len: 10000, compressed: 12950, bytes/int: 1.295000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10000:size=1:overlap=0.01:-8                     	16688434	        69.04 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=1:overlap=0.01:dr=100-8     	  261336	      4493 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=1:overlap=0.01:dr=500-8     	  266654	      4415 ns/op
 
-len: 1000, compressed: 1919, bytes/int: 1.919000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=100:overlap=0.01:-4                        	 2000000	       918 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10:size=100:overlap=0.01:-4       	  500000	      3502 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10:size=100:overlap=0.01:-4           	  500000	      3354 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10:size=100:overlap=0.01:-4           	  300000	      5892 ns/op
+len: 100000, compressed: 129308, bytes/int: 1.293080
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100000:size=1:overlap=0.01:-8                    	15534115	        86.48 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100000:size=1:overlap=0.01:dr=100-8    	  303458	      3965 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100000:size=1:overlap=0.01:dr=500-8    	  295129	      4984 ns/op
 
-len: 5000, compressed: 6507, bytes/int: 1.301400
-BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=100:overlap=0.01:-4                        	  500000	      3564 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=50:size=100:overlap=0.01:-4       	  200000	      7430 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=50:size=100:overlap=0.01:-4           	  200000	      6695 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=50:size=100:overlap=0.01:-4           	  200000	      7031 ns/op
+len: 1000000, compressed: 1292911, bytes/int: 1.292911
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1000000:size=1:overlap=0.01:-8                   	10487848	       113.3 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000000:size=1:overlap=0.01:dr=100-8   	  306295	      4124 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000000:size=1:overlap=0.01:dr=500-8   	  329948	      4110 ns/op
 
-len: 10000, compressed: 9789, bytes/int: 0.978900
-BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=100:overlap=0.01:-4                       	  500000	      2794 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=100:size=100:overlap=0.01:-4      	  200000	     10967 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=100:size=100:overlap=0.01:-4          	  200000	     10408 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=100:size=100:overlap=0.01:-4          	  200000	      8466 ns/op
+len: 10, compressed: 38, bytes/int: 3.800000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=10:overlap=0.01:-8                        	30331664	        39.59 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=10:overlap=0.01:dr=100-8        	 2105776	       497.1 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=10:overlap=0.01:dr=500-8        	 2898819	       432.0 ns/op
 
-len: 50000, compressed: 27064, bytes/int: 0.541280
-BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=100:overlap=0.01:-4                       	  300000	      5327 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=500:size=100:overlap=0.01:-4      	  100000	     20892 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=500:size=100:overlap=0.01:-4          	   30000	     42359 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=500:size=100:overlap=0.01:-4          	  100000	     13843 ns/op
+len: 100, compressed: 149, bytes/int: 1.490000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=10:overlap=0.01:-8                       	13708935	        92.13 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=10:overlap=0.01:dr=100-8       	 1000000	      1070 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=10:overlap=0.01:dr=500-8       	  951660	      1274 ns/op
 
-len: 100000, compressed: 36011, bytes/int: 0.360110
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=100:overlap=0.01:-4                      	  300000	      5785 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1000:size=100:overlap=0.01:-4     	   50000	     24653 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1000:size=100:overlap=0.01:-4         	   20000	     78757 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1000:size=100:overlap=0.01:-4         	  100000	     16175 ns/op
+len: 500, compressed: 663, bytes/int: 1.326000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=10:overlap=0.01:-8                       	 3942757	       317.4 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=10:overlap=0.01:dr=100-8       	  375542	      4166 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=10:overlap=0.01:dr=500-8       	  328249	      3944 ns/op
 
-len: 1000000, compressed: 336000, bytes/int: 0.336000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10000:size=100:overlap=0.01:-4                     	  200000	      8323 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10000:size=100:overlap=0.01:-4    	   20000	     67559 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10000:size=100:overlap=0.01:-4        	    2000	    777599 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10000:size=100:overlap=0.01:-4        	  100000	     21898 ns/op
+len: 1000, compressed: 1310, bytes/int: 1.310000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=10:overlap=0.01:-8                      	 8173806	       165.2 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=10:overlap=0.01:dr=100-8      	  121165	     13178 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=10:overlap=0.01:dr=500-8      	  284304	      4651 ns/op
 
-len: 1000, compressed: 2727, bytes/int: 2.727000
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=1000:overlap=0.01:-4                        	  500000	      2593 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=1000:overlap=0.01:-4       	  300000	      5650 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=1000:overlap=0.01:-4           	  300000	      5489 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=1000:overlap=0.01:-4           	   50000	     39633 ns/op
+len: 2000, compressed: 2607, bytes/int: 1.303500
+BenchmarkListIntersectRatio/:IntersectWith:ratio=200:size=10:overlap=0.01:-8                      	 5559526	       236.9 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=10:overlap=0.01:dr=100-8      	  106833	     14299 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=10:overlap=0.01:dr=500-8      	  147388	      8512 ns/op
 
-len: 10000, compressed: 16971, bytes/int: 1.697100
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=1000:overlap=0.01:-4                       	  100000	     14934 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10:size=1000:overlap=0.01:-4      	  100000	     19053 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10:size=1000:overlap=0.01:-4          	  100000	     17840 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10:size=1000:overlap=0.01:-4          	   30000	     55813 ns/op
+len: 4000, compressed: 5202, bytes/int: 1.300500
+BenchmarkListIntersectRatio/:IntersectWith:ratio=400:size=10:overlap=0.01:-8                      	 4426512	       304.6 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=10:overlap=0.01:dr=100-8      	   91539	     17241 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=10:overlap=0.01:dr=500-8      	  117110	     10956 ns/op
 
-len: 50000, compressed: 56091, bytes/int: 1.121820
-BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=1000:overlap=0.01:-4                       	   50000	     39451 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=50:size=1000:overlap=0.01:-4      	   20000	     62504 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=50:size=1000:overlap=0.01:-4          	   30000	     58590 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=50:size=1000:overlap=0.01:-4          	   20000	     96190 ns/op
+len: 5000, compressed: 6500, bytes/int: 1.300000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=10:overlap=0.01:-8                      	 3303600	       424.6 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=10:overlap=0.01:dr=100-8      	  103581	     15357 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=10:overlap=0.01:dr=500-8      	   92168	     14457 ns/op
 
-len: 100000, compressed: 93473, bytes/int: 0.934730
-BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=1000:overlap=0.01:-4                      	   30000	     47043 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=100:size=1000:overlap=0.01:-4     	   20000	     99033 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=100:size=1000:overlap=0.01:-4         	   10000	    100871 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=100:size=1000:overlap=0.01:-4         	   10000	    131206 ns/op
+len: 10000, compressed: 12984, bytes/int: 1.298400
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=10:overlap=0.01:-8                     	 3007788	       451.0 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=10:overlap=0.01:dr=100-8     	   92419	     14388 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=10:overlap=0.01:dr=500-8     	   89382	     14771 ns/op
 
-len: 500000, compressed: 254331, bytes/int: 0.508662
-BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=1000:overlap=0.01:-4                      	   10000	    129480 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=500:size=1000:overlap=0.01:-4     	   10000	    228660 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=500:size=1000:overlap=0.01:-4         	    3000	    418707 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=500:size=1000:overlap=0.01:-4         	   10000	    203561 ns/op
+len: 100000, compressed: 129654, bytes/int: 1.296540
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10000:size=10:overlap=0.01:-8                    	 2223891	       702.1 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=10:overlap=0.01:dr=100-8    	  101398	     12853 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=10:overlap=0.01:dr=500-8    	  108798	     13616 ns/op
 
-len: 1000000, compressed: 402898, bytes/int: 0.402898
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=1000:overlap=0.01:-4                     	   10000	    145888 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1000:size=1000:overlap=0.01:-4    	    5000	    244345 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1000:size=1000:overlap=0.01:-4        	    2000	    807267 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1000:size=1000:overlap=0.01:-4        	    5000	    234922 ns/op
+len: 1000000, compressed: 1296385, bytes/int: 1.296385
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100000:size=10:overlap=0.01:-8                   	 1693270	       777.8 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100000:size=10:overlap=0.01:dr=100-8   	  110076	     14049 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100000:size=10:overlap=0.01:dr=500-8   	  110184	     12731 ns/op
 
-len: 10000, compressed: 23144, bytes/int: 2.314400
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=10000:overlap=0.01:-4                       	   20000	     95952 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=10000:overlap=0.01:-4      	   10000	    103362 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=10000:overlap=0.01:-4          	   10000	    102460 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=10000:overlap=0.01:-4          	    5000	    386213 ns/op
+len: 100, compressed: 156, bytes/int: 1.560000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=100:overlap=0.01:-8                       	 3311553	       401.8 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=100:overlap=0.01:dr=100-8       	  758761	      1450 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=100:overlap=0.01:dr=500-8       	  777399	      1643 ns/op
 
-len: 100000, compressed: 150981, bytes/int: 1.509810
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=10000:overlap=0.01:-4                      	   10000	    183513 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10:size=10000:overlap=0.01:-4     	   10000	    231087 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10:size=10000:overlap=0.01:-4         	   10000	    225320 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10:size=10000:overlap=0.01:-4         	    2000	    615168 ns/op
+len: 1000, compressed: 1312, bytes/int: 1.312000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=100:overlap=0.01:-8                      	 1000000	      1073 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=100:overlap=0.01:dr=100-8      	  194467	      6043 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=100:overlap=0.01:dr=500-8      	  203936	      6286 ns/op
 
-len: 500000, compressed: 520695, bytes/int: 1.041390
-BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=10000:overlap=0.01:-4                      	    3000	    423944 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=50:size=10000:overlap=0.01:-4     	    2000	    622041 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=50:size=10000:overlap=0.01:-4         	    3000	    591211 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=50:size=10000:overlap=0.01:-4         	    2000	   1081434 ns/op
+len: 5000, compressed: 6502, bytes/int: 1.300400
+BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=100:overlap=0.01:-8                      	  426436	      2537 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=100:overlap=0.01:dr=100-8      	   68948	     18316 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=100:overlap=0.01:dr=500-8      	   67620	     21112 ns/op
 
-len: 1000000, compressed: 859680, bytes/int: 0.859680
-BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=10000:overlap=0.01:-4                     	    2000	    640508 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=100:size=10000:overlap=0.01:-4    	    2000	   1006359 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=100:size=10000:overlap=0.01:-4        	    2000	   1001509 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=100:size=10000:overlap=0.01:-4        	    1000	   1473389 ns/op
+len: 10000, compressed: 12989, bytes/int: 1.298900
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=100:overlap=0.01:-8                     	  674436	      1924 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=100:overlap=0.01:dr=100-8     	   10000	    114607 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=100:overlap=0.01:dr=500-8     	   34849	     35216 ns/op
 
-len: 100000, compressed: 223045, bytes/int: 2.230450
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=100000:overlap=0.01:-4                      	    2000	    982775 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=100000:overlap=0.01:-4     	    2000	   1040402 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=100000:overlap=0.01:-4         	    2000	   1029087 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=100000:overlap=0.01:-4         	     500	   3859866 ns/op
+len: 20000, compressed: 25957, bytes/int: 1.297850
+BenchmarkListIntersectRatio/:IntersectWith:ratio=200:size=100:overlap=0.01:-8                     	  544753	      2333 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=100:overlap=0.01:dr=100-8     	    9794	    144606 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=100:overlap=0.01:dr=500-8     	   22435	     56628 ns/op
 
-len: 1000000, compressed: 1472656, bytes/int: 1.472656
-BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=100000:overlap=0.01:-4                     	    1000	   1938682 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=10:size=100000:overlap=0.01:-4    	    1000	   2344582 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=10:size=100000:overlap=0.01:-4        	    1000	   2249649 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=10:size=100000:overlap=0.01:-4        	     200	   6201335 ns/op
+len: 40000, compressed: 51892, bytes/int: 1.297300
+BenchmarkListIntersectRatio/:IntersectWith:ratio=400:size=100:overlap=0.01:-8                     	  403574	      2856 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=100:overlap=0.01:dr=100-8     	   10000	    130685 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=100:overlap=0.01:dr=500-8     	   18820	     61552 ns/op
 
-len: 1000000, compressed: 2585277, bytes/int: 2.585277
-BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=1000000:overlap=0.01:-4                     	     100	  10075901 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLinJump:ratio=1:size=1000000:overlap=0.01:-4    	     100	  10527806 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithLin:ratio=1:size=1000000:overlap=0.01:-4        	     100	  10431302 ns/op
-BenchmarkListIntersectRatio/compressed:IntersectWithBin:ratio=1:size=1000000:overlap=0.01:-4        	      30	  38617011 ns/op
+len: 50000, compressed: 64859, bytes/int: 1.297180
+BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=100:overlap=0.01:-8                     	  333748	      3991 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=100:overlap=0.01:dr=100-8     	   10000	    141499 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=100:overlap=0.01:dr=500-8     	    8036	    130473 ns/op
+
+len: 100000, compressed: 129699, bytes/int: 1.296990
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=100:overlap=0.01:-8                    	  270432	      4617 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=100:overlap=0.01:dr=100-8    	    9918	    126638 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=100:overlap=0.01:dr=500-8    	    8860	    130475 ns/op
+
+len: 1000000, compressed: 1296844, bytes/int: 1.296844
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10000:size=100:overlap=0.01:-8                   	  240906	      5276 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=100:overlap=0.01:dr=100-8   	   10000	    101623 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10000:size=100:overlap=0.01:dr=500-8   	   12771	     90919 ns/op
+
+len: 1000, compressed: 1390, bytes/int: 1.390000
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=1000:overlap=0.01:-8                      	  381703	      2832 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1000:overlap=0.01:dr=100-8      	  131016	     10040 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1000:overlap=0.01:dr=500-8      	  105943	     10283 ns/op
+
+len: 10000, compressed: 13024, bytes/int: 1.302400
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=1000:overlap=0.01:-8                     	  139119	      7561 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=1000:overlap=0.01:dr=100-8     	   29917	     40842 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=1000:overlap=0.01:dr=500-8     	   29698	     43319 ns/op
+
+len: 50000, compressed: 65026, bytes/int: 1.300520
+BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=1000:overlap=0.01:-8                     	   35125	     34158 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=1000:overlap=0.01:dr=100-8     	    6567	    167150 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=1000:overlap=0.01:dr=500-8     	    6922	    163890 ns/op
+
+len: 100000, compressed: 130031, bytes/int: 1.300310
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=1000:overlap=0.01:-8                    	   48426	     24353 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=1000:overlap=0.01:dr=100-8    	    1009	   1322114 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=1000:overlap=0.01:dr=500-8    	    3474	    305384 ns/op
+
+len: 200000, compressed: 260046, bytes/int: 1.300230
+BenchmarkListIntersectRatio/:IntersectWith:ratio=200:size=1000:overlap=0.01:-8                    	   24470	     48146 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=1000:overlap=0.01:dr=100-8    	     808	   1560287 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=200:size=1000:overlap=0.01:dr=500-8    	    2005	    537326 ns/op
+
+len: 400000, compressed: 520074, bytes/int: 1.300185
+BenchmarkListIntersectRatio/:IntersectWith:ratio=400:size=1000:overlap=0.01:-8                    	   15487	     78377 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=1000:overlap=0.01:dr=100-8    	     808	   1638175 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=400:size=1000:overlap=0.01:dr=500-8    	    1208	    965490 ns/op
+
+len: 500000, compressed: 650090, bytes/int: 1.300180
+BenchmarkListIntersectRatio/:IntersectWith:ratio=500:size=1000:overlap=0.01:-8                    	   14812	     89868 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=1000:overlap=0.01:dr=100-8    	     798	   1486348 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=500:size=1000:overlap=0.01:dr=500-8    	     769	   1515945 ns/op
+
+len: 1000000, compressed: 1300154, bytes/int: 1.300154
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1000:size=1000:overlap=0.01:-8                   	   11560	    107251 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=1000:overlap=0.01:dr=100-8   	     826	   1452994 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1000:size=1000:overlap=0.01:dr=500-8   	     814	   1421231 ns/op
+
+len: 10000, compressed: 13818, bytes/int: 1.381800
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=10000:overlap=0.01:-8                     	   14757	     81576 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=10000:overlap=0.01:dr=100-8     	    6802	    150041 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=10000:overlap=0.01:dr=500-8     	    7584	    152012 ns/op
+
+len: 100000, compressed: 130090, bytes/int: 1.300900
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=10000:overlap=0.01:-8                    	    6154	    194280 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=10000:overlap=0.01:dr=100-8    	    2211	    538074 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=10000:overlap=0.01:dr=500-8    	    2174	    544745 ns/op
+
+len: 500000, compressed: 650378, bytes/int: 1.300756
+BenchmarkListIntersectRatio/:IntersectWith:ratio=50:size=10000:overlap=0.01:-8                    	    2665	    460360 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=10000:overlap=0.01:dr=100-8    	     517	   2078575 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=50:size=10000:overlap=0.01:dr=500-8    	     558	   2175557 ns/op
+
+len: 1000000, compressed: 1300737, bytes/int: 1.300737
+BenchmarkListIntersectRatio/:IntersectWith:ratio=100:size=10000:overlap=0.01:-8                   	    2118	    575899 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=10000:overlap=0.01:dr=100-8   	      79	  14206747 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=100:size=10000:overlap=0.01:dr=500-8   	     328	   3626739 ns/op
+
+len: 100000, compressed: 138159, bytes/int: 1.381590
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=100000:overlap=0.01:-8                    	    1063	   1124508 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=100000:overlap=0.01:dr=100-8    	     648	   1825853 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=100000:overlap=0.01:dr=500-8    	     648	   1878826 ns/op
+
+len: 1000000, compressed: 1303882, bytes/int: 1.303882
+BenchmarkListIntersectRatio/:IntersectWith:ratio=10:size=100000:overlap=0.01:-8                   	     548	   2274707 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=100000:overlap=0.01:dr=100-8   	     210	   5712391 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=10:size=100000:overlap=0.01:dr=500-8   	     208	   5759574 ns/op
+
+len: 1000000, compressed: 1382077, bytes/int: 1.382077
+BenchmarkListIntersectRatio/:IntersectWith:ratio=1:size=1000000:overlap=0.01:-8                   	      94	  11945857 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1000000:overlap=0.01:dr=100-8   	      63	  19101189 ns/op
+BenchmarkListIntersectRatio/compressed:IntersectWith:ratio=1:size=1000000:overlap=0.01:dr=500-8   	      64	  18839520 ns/op
 
 PASS
-ok  	github.com/dgraph-io/dgraph/algo	206.835s
+ok  	github.com/dgraph-io/dgraph/algo	204.439s

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -60,7 +60,7 @@ func IntersectCompressedWith(pack *pb.UidPack, afterUID uint64, v, o *pb.List) {
 
 	// Select appropriate function based on heuristics.
 	ratio := float64(m) / float64(n)
-	if ratio < 500 {
+	if ratio < 100 {
 		IntersectCompressedWithLinJump(&dec, v.Uids, &dst)
 	} else {
 		IntersectCompressedWithBin(&dec, v.Uids, &dst)

--- a/algo/uidlist.go
+++ b/algo/uidlist.go
@@ -26,6 +26,10 @@ import (
 
 const jump = 32 // Jump size in InsersectWithJump.
 
+var (
+	D = 100.0
+)
+
 // ApplyFilter applies a filter to our UIDList.
 func ApplyFilter(u *pb.List, f func(uint64, int) bool) {
 	out := u.Uids[:0]
@@ -60,7 +64,7 @@ func IntersectCompressedWith(pack *pb.UidPack, afterUID uint64, v, o *pb.List) {
 
 	// Select appropriate function based on heuristics.
 	ratio := float64(m) / float64(n)
-	if ratio < 100 {
+	if ratio < D {
 		IntersectCompressedWithLinJump(&dec, v.Uids, &dst)
 	} else {
 		IntersectCompressedWithBin(&dec, v.Uids, &dst)

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -369,7 +369,7 @@ func BenchmarkListIntersectRandom(b *testing.B) {
 
 func BenchmarkListIntersectRatio(b *testing.B) {
 	randomTests := func(sz int, overlap float64) {
-		rs := []int{1, 10, 50, 100, 200, 400, 500, 1000, 10000}
+		rs := []int{1, 10, 50, 100, 200, 400, 500, 1000, 10000, 100000, 1000000}
 		for _, r := range rs {
 			sz1 := sz
 			sz2 := sz * r
@@ -396,24 +396,24 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 
 			fmt.Printf("len: %d, compressed: %d, bytes/int: %f\n",
 				len(v1), compressedUids.Size(), float64(compressedUids.Size())/float64(len(v1)))
-			b.Run(fmt.Sprintf("compressed:IntersectWithLinJump:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
+			b.Run(fmt.Sprintf(":IntersectWith:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
 				func(b *testing.B) {
 					for k := 0; k < b.N; k++ {
-						dec := codec.Decoder{Pack: compressedUids}
-						dec.Seek(0, codec.SeekStart)
-						dst := v.Uids[:0]
-
-						IntersectCompressedWithLinJump(&dec, u.Uids, &dst)
+						IntersectWith(u, v, dst1)
 					}
 				})
-			b.Run(fmt.Sprintf("compressed:IntersectWithBin:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
+			b.Run(fmt.Sprintf("compressed:IntersectWith:ratio=%d:size=%d:overlap=%.2f:dr=%d", r, sz, overlap, 100),
 				func(b *testing.B) {
 					for k := 0; k < b.N; k++ {
-						dec := codec.Decoder{Pack: compressedUids}
-						dec.Seek(0, codec.SeekStart)
-						dst := v.Uids[:0]
-
-						IntersectCompressedWithBin(&dec, u.Uids, &dst)
+						D = 100.0
+						IntersectCompressedWith(compressedUids, 0, u, dst2)
+					}
+				})
+			b.Run(fmt.Sprintf("compressed:IntersectWith:ratio=%d:size=%d:overlap=%.2f:dr=%d", r, sz, overlap, 500),
+				func(b *testing.B) {
+					for k := 0; k < b.N; k++ {
+						D = 500.0
+						IntersectCompressedWith(compressedUids, 0, u, dst2)
 					}
 				})
 			fmt.Println()
@@ -435,12 +435,13 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 		}
 	}
 
-	randomTests(10, 0.1)
-	randomTests(100, 0.1)
-	randomTests(1000, 0.1)
-	randomTests(10000, 0.1)
-	randomTests(100000, 0.1)
-	randomTests(1000000, 0.1)
+	randomTests(1, 0.01)
+	randomTests(10, 0.01)
+	randomTests(100, 0.01)
+	randomTests(1000, 0.01)
+	randomTests(10000, 0.01)
+	randomTests(100000, 0.01)
+	randomTests(1000000, 0.01)
 }
 
 func skipDuplicate(in []uint64, idx int) int {

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -369,7 +369,7 @@ func BenchmarkListIntersectRandom(b *testing.B) {
 
 func BenchmarkListIntersectRatio(b *testing.B) {
 	randomTests := func(sz int, overlap float64) {
-		rs := []int{1, 10, 50, 100, 500, 1000, 10000, 100000, 1000000}
+		rs := []int{1, 10, 50, 100, 200, 400, 500, 1000, 10000}
 		for _, r := range rs {
 			sz1 := sz
 			sz2 := sz * r
@@ -396,16 +396,24 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 
 			fmt.Printf("len: %d, compressed: %d, bytes/int: %f\n",
 				len(v1), compressedUids.Size(), float64(compressedUids.Size())/float64(len(v1)))
-			b.Run(fmt.Sprintf(":IntersectWith:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
+			b.Run(fmt.Sprintf("compressed:IntersectWithLinJump:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
 				func(b *testing.B) {
 					for k := 0; k < b.N; k++ {
-						IntersectWith(u, v, dst1)
+						dec := codec.Decoder{Pack: compressedUids}
+						dec.Seek(0, codec.SeekStart)
+						dst := v.Uids[:0]
+
+						IntersectCompressedWithLinJump(&dec, u.Uids, &dst)
 					}
 				})
-			b.Run(fmt.Sprintf("compressed:IntersectWith:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
+			b.Run(fmt.Sprintf("compressed:IntersectWithBin:ratio=%d:size=%d:overlap=%.2f:", r, sz, overlap),
 				func(b *testing.B) {
 					for k := 0; k < b.N; k++ {
-						IntersectCompressedWith(compressedUids, 0, u, dst2)
+						dec := codec.Decoder{Pack: compressedUids}
+						dec.Seek(0, codec.SeekStart)
+						dst := v.Uids[:0]
+
+						IntersectCompressedWithBin(&dec, u.Uids, &dst)
 					}
 				})
 			fmt.Println()
@@ -427,12 +435,12 @@ func BenchmarkListIntersectRatio(b *testing.B) {
 		}
 	}
 
-	randomTests(10, 0.01)
-	randomTests(100, 0.01)
-	randomTests(1000, 0.01)
-	randomTests(10000, 0.01)
-	randomTests(100000, 0.01)
-	randomTests(1000000, 0.01)
+	randomTests(10, 0.1)
+	randomTests(100, 0.1)
+	randomTests(1000, 0.1)
+	randomTests(10000, 0.1)
+	randomTests(100000, 0.1)
+	randomTests(1000000, 0.1)
 }
 
 func skipDuplicate(in []uint64, idx int) int {


### PR DESCRIPTION
Currently for intersecting two different arrays, we either use linear or binary jump. This is decided on the basis of the ratio of the two arrays being intersected. Currently, the ratio is set to be 500. We have had certain customer issues where queries too long. After debugging, the issue seems to be the ratio. Changing the ratio back to 100 fixes the customer issues. Query time went from 9 sec to 0.3sec.