### PR TITLE
fix(test): fix the corner case for raft entries test

### DIFF
--- a/raftwal/encryption_test.go
+++ b/raftwal/encryption_test.go
@@ -32,12 +32,12 @@ func TestEntryReadWrite(t *testing.T) {
 	key := []byte("badger16byteskey")
 	dir, err := ioutil.TempDir("", "raftwal")
 	require.NoError(t, err)
+	defer os.RemoveAll(dir)
 	ds, err := InitEncrypted(dir, key)
 	require.NoError(t, err)
-	defer os.RemoveAll(dir)
 
 	// generate some random data
-	data := make([]byte, rand.Intn(1000))
+	data := make([]byte, 1+rand.Intn(1000))
 	rand.Read(data)
 
 	require.NoError(t, ds.wal.AddEntries([]raftpb.Entry{{Index: 1, Term: 1, Data: data}}))


### PR DESCRIPTION
A failure here: https://github.com/dgraph-io/dgraph/actions/runs/3952517043/jobs/6767694064

This happens when the length of data byte slice is 0. I do not think that is a valid case.

```
=== RUN   TestEntryReadWrite
    encryption_test.go:48: 
        	Error Trace:	encryption_test.go:48
        	Error:      	Not equal: 
        	            	expected: []byte{}
        	            	actual  : []byte(nil)
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,3 +1,2 @@
        	            	-([]uint8) {
        	            	-}
        	            	+([]uint8) <nil>
        	            	 
        	Test:       	TestEntryReadWrite
--- FAIL: TestEntryReadWrite (0.02s)
FAIL
```