### PR TITLE
chore: fix imports order across the repo

### DIFF
--- a/algo/packed_test.go
+++ b/algo/packed_test.go
@@ -20,9 +20,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/stretchr/testify/require"
 )
 
 func newUidPack(data []uint64) *pb.UidPack {

--- a/algo/uidlist_test.go
+++ b/algo/uidlist_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/stretchr/testify/require"
 )
 
 func newList(data []uint64) *pb.List {

--- a/chunker/chunk.go
+++ b/chunker/chunk.go
@@ -28,11 +28,11 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
 )
 
 // Chunker describes the interface to parse and process the input to the live and bulk loaders.

--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -26,15 +26,16 @@ import (
 	"sync/atomic"
 	"unicode"
 
+	"github.com/pkg/errors"
+	geom "github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/encoding/geojson"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	simdjson "github.com/dgraph-io/simdjson-go"
-	"github.com/pkg/errors"
-	geom "github.com/twpayne/go-geom"
-	"github.com/twpayne/go-geom/encoding/geojson"
 )
 
 func stripSpaces(str string) string {

--- a/chunker/json_parser_test.go
+++ b/chunker/json_parser_test.go
@@ -25,13 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/tok"
 	"github.com/golang/glog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
-	"github.com/stretchr/testify/require"
 )
 
 func makeNquad(sub, pred string, val *api.Value) *api.NQuad {

--- a/chunker/rdf_parser.go
+++ b/chunker/rdf_parser.go
@@ -22,13 +22,14 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/chunker/rdf_parser_test.go
+++ b/chunker/rdf_parser_test.go
@@ -19,11 +19,12 @@ package chunker
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 var testNQuads = []struct {

--- a/chunker/rdf_state.go
+++ b/chunker/rdf_state.go
@@ -364,7 +364,8 @@ func lexLabel(l *lex.Lexer) lex.StateFn {
 
 // lexFacets parses key-value pairs of Facets. sample is :
 // ( key1 = "value1", key2=13, key3=, key4 =2.4, key5=2006-01-02T15:04:05,
-//   key6=2006-01-02 )
+//
+//	key6=2006-01-02 )
 func lexFacets(l *lex.Lexer) lex.StateFn {
 	r := l.Next()
 	if r != leftRound {

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -23,10 +23,11 @@ import (
 	"sort"
 	"unsafe"
 
+	"github.com/dgryski/go-groupvarint"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/dgryski/go-groupvarint"
 )
 
 type seekPos int

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
+	humanize "github.com/dustin/go-humanize"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	humanize "github.com/dustin/go-humanize"
-	"github.com/stretchr/testify/require"
 )
 
 func getUids(size int) []uint64 {

--- a/conn/node_test.go
+++ b/conn/node_test.go
@@ -26,11 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/raftwal"
 )
 
 func (n *Node) run(wg *sync.WaitGroup) {

--- a/conn/pool.go
+++ b/conn/pool.go
@@ -23,16 +23,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.opencensus.io/plugin/ocgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.opencensus.io/plugin/ocgrpc"
-
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var (

--- a/conn/raft_server.go
+++ b/conn/raft_server.go
@@ -25,13 +25,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft/raftpb"
 	otrace "go.opencensus.io/trace"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type sendmsg struct {

--- a/contrib/integration/bank/main.go
+++ b/contrib/integration/bank/main.go
@@ -35,11 +35,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var (

--- a/contrib/integration/bigdata/main.go
+++ b/contrib/integration/bigdata/main.go
@@ -28,10 +28,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
-	"google.golang.org/grpc"
 )
 
 var addrs = flag.String("addrs", "", "comma separated dgraph addresses")

--- a/contrib/integration/mutates/main.go
+++ b/contrib/integration/mutates/main.go
@@ -23,10 +23,11 @@ import (
 	"fmt"
 	"log"
 
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
-	"google.golang.org/grpc"
 )
 
 var alpha = flag.String("alpha", "localhost:9080", "Dgraph alpha addr")

--- a/contrib/integration/swap/main.go
+++ b/contrib/integration/swap/main.go
@@ -28,11 +28,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/contrib/integration/testtxn/main_test.go
+++ b/contrib/integration/testtxn/main_test.go
@@ -29,12 +29,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type state struct {

--- a/contrib/jepsen/main.go
+++ b/contrib/jepsen/main.go
@@ -43,8 +43,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/dgraph/contrib/jepsen/browser"
 	"github.com/spf13/pflag"
+
+	"github.com/dgraph-io/dgraph/contrib/jepsen/browser"
 )
 
 type jepsenTest struct {

--- a/dgraph/cmd/alpha/admin.go
+++ b/dgraph/cmd/alpha/admin.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/dgraph-io/dgraph/graphql/admin"
-
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"

--- a/dgraph/cmd/alpha/admin_backup.go
+++ b/dgraph/cmd/alpha/admin_backup.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -21,10 +22,10 @@ package alpha
 import (
 	"net/http"
 
-	"github.com/dgraph-io/dgraph/graphql/schema"
-
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func init() {

--- a/dgraph/cmd/alpha/http.go
+++ b/dgraph/cmd/alpha/http.go
@@ -32,18 +32,18 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/dgraph/graphql/admin"
-
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/dql"
-	"github.com/dgraph-io/dgraph/edgraph"
-	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/dgraph/query"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/dql"
+	"github.com/dgraph-io/dgraph/edgraph"
+	"github.com/dgraph-io/dgraph/graphql/admin"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/query"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func allowed(method string) bool {

--- a/dgraph/cmd/alpha/login_ee.go
+++ b/dgraph/cmd/alpha/login_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -17,10 +18,11 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 func loginHandler(w http.ResponseWriter, r *http.Request) {

--- a/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
+++ b/dgraph/cmd/alpha/mutations_mode/mutations_mode_test.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
-
-	"google.golang.org/grpc"
 )
 
 // Tests in this file require a cluster running with the --limit "mutations=<mode>;" flag.

--- a/dgraph/cmd/alpha/run.go
+++ b/dgraph/cmd/alpha/run.go
@@ -25,8 +25,6 @@ import (
 	"math"
 	"net"
 	"net/http"
-
-	//nolint:gosec // profiling on alpha server accepted and documented
 	_ "net/http/pprof" // http profiler
 	"net/url"
 	"os"
@@ -37,20 +35,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/dgraph/ee"
-	"github.com/dgraph-io/dgraph/ee/audit"
-
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/edgraph"
-	"github.com/dgraph-io/dgraph/ee/enc"
-	"github.com/dgraph-io/dgraph/graphql/admin"
-	"github.com/dgraph-io/dgraph/posting"
-	"github.com/dgraph-io/dgraph/schema"
-	"github.com/dgraph-io/dgraph/tok"
-	"github.com/dgraph-io/dgraph/worker"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -64,7 +48,20 @@ import (
 	"google.golang.org/grpc/health"
 	hapi "google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/edgraph"
+	"github.com/dgraph-io/dgraph/ee"
+	"github.com/dgraph-io/dgraph/ee/audit"
+	"github.com/dgraph-io/dgraph/ee/enc"
+	"github.com/dgraph-io/dgraph/graphql/admin"
+	"github.com/dgraph-io/dgraph/posting"
+	"github.com/dgraph-io/dgraph/schema"
+	"github.com/dgraph-io/dgraph/tok"
+	"github.com/dgraph-io/dgraph/worker"
+	"github.com/dgraph-io/dgraph/x"
 	_ "github.com/dgraph-io/gqlparser/v2/validator/rules" // make gql validator init() all rules
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -31,14 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/dql"
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/query"
-	"github.com/dgraph-io/dgraph/schema"
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,6 +39,15 @@ import (
 	"github.com/twpayne/go-geom/encoding/wkb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/dql"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/query"
+	"github.com/dgraph-io/dgraph/schema"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type defaultContextKey int

--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -24,11 +24,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 type QueryResult struct {

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -33,11 +33,11 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/y"
-
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/filestore"
@@ -45,8 +45,6 @@ import (
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/dgraph/xidmap"
-
-	"google.golang.org/grpc"
 )
 
 type options struct {

--- a/dgraph/cmd/bulk/mapper.go
+++ b/dgraph/cmd/bulk/mapper.go
@@ -29,6 +29,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	farm "github.com/dgryski/go-farm"
+	"github.com/golang/snappy"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/dql"
@@ -39,8 +42,6 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	farm "github.com/dgryski/go-farm"
-	"github.com/golang/snappy"
 )
 
 type mapper struct {

--- a/dgraph/cmd/bulk/progress.go
+++ b/dgraph/cmd/bulk/progress.go
@@ -21,9 +21,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
+
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/dustin/go-humanize"
 )
 
 type phase int32

--- a/dgraph/cmd/bulk/reduce.go
+++ b/dgraph/cmd/bulk/reduce.go
@@ -34,6 +34,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/golang/snappy"
+
 	"github.com/dgraph-io/badger/v3"
 	bo "github.com/dgraph-io/badger/v3/options"
 	bpb "github.com/dgraph-io/badger/v3/pb"
@@ -43,8 +46,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/dustin/go-humanize"
-	"github.com/golang/snappy"
 )
 
 type reducer struct {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -23,8 +23,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-
-	//nolint:gosec // profiling on bulk-loader tool considered noncritical
 	_ "net/http/pprof" // http profiler
 	"os"
 	"path/filepath"
@@ -32,16 +30,16 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/filestore"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/worker"
-	"github.com/dgraph-io/ristretto/z"
-
 	"github.com/dgraph-io/dgraph/tok"
+	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/spf13/cobra"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // Bulk is the sub-command invoked when running "dgraph bulk".

--- a/dgraph/cmd/cert/info.go
+++ b/dgraph/cmd/cert/info.go
@@ -29,8 +29,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type certInfo struct {

--- a/dgraph/cmd/cert/run.go
+++ b/dgraph/cmd/cert/run.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // Cert is the sub-command invoked when running "dgraph cert".

--- a/dgraph/cmd/conv/conv.go
+++ b/dgraph/cmd/conv/conv.go
@@ -27,8 +27,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	geojson "github.com/paulmach/go.geojson"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // TODO: Reconsider if we need this binary.

--- a/dgraph/cmd/conv/run.go
+++ b/dgraph/cmd/conv/run.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // Conv is the sub-command invoked when running "dgraph conv".

--- a/dgraph/cmd/debug/run.go
+++ b/dgraph/cmd/debug/run.go
@@ -26,8 +26,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-
-	//nolint:gosec // profiling on debug tool considered noncritical
 	_ "net/http/pprof" // http profiler
 	"os"
 	"sort"
@@ -35,11 +33,11 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/dustin/go-humanize"
+	"github.com/spf13/cobra"
+
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/ristretto/z"
-	"github.com/dustin/go-humanize"
-
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/posting"
@@ -47,7 +45,7 @@ import (
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/spf13/cobra"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/dgraph/cmd/debug/wal.go
+++ b/dgraph/cmd/debug/wal.go
@@ -23,12 +23,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/raftwal"
-	"github.com/dgraph-io/dgraph/x"
 	humanize "github.com/dustin/go-humanize"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/raftwal"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func printEntry(es raftpb.Entry, pending map[uint64]bool, isZero bool) {

--- a/dgraph/cmd/debuginfo/run.go
+++ b/dgraph/cmd/debuginfo/run.go
@@ -22,9 +22,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type debugInfoCmdOpts struct {

--- a/dgraph/cmd/decrypt/decrypt.go
+++ b/dgraph/cmd/decrypt/decrypt.go
@@ -22,11 +22,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/spf13/cobra"
 )
 
 type options struct {

--- a/dgraph/cmd/increment/increment.go
+++ b/dgraph/cmd/increment/increment.go
@@ -26,15 +26,15 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.opencensus.io/trace"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // Increment is the sub-command invoked when calling "dgraph increment".

--- a/dgraph/cmd/increment/increment_test.go
+++ b/dgraph/cmd/increment/increment_test.go
@@ -26,12 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 const N = 10

--- a/dgraph/cmd/live/batch.go
+++ b/dgraph/cmd/live/batch.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dgryski/go-farm"
+	"github.com/dustin/go-humanize/english"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,8 +42,6 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/dgraph/xidmap"
-	"github.com/dgryski/go-farm"
-	"github.com/dustin/go-humanize/english"
 )
 
 // batchMutationOptions sets the clients batch mode to Pending number of buffers each of Size.

--- a/dgraph/cmd/live/load-uids/load_test.go
+++ b/dgraph/cmd/live/load-uids/load_test.go
@@ -29,11 +29,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -28,8 +28,6 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
-
-	//nolint:gosec // profiling on live-loader tool considered noncritical
 	_ "net/http/pprof" // http profiler
 	"os"
 	"sort"
@@ -37,6 +35,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dgryski/go-farm"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -44,9 +47,6 @@ import (
 	bopt "github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/ristretto/z"
-	"github.com/dgryski/go-farm"
-
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/ee/enc"
@@ -55,11 +55,7 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/dgraph/xidmap"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 type options struct {

--- a/dgraph/cmd/migrate/run.go
+++ b/dgraph/cmd/migrate/run.go
@@ -23,10 +23,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (

--- a/dgraph/cmd/migrate/table_info.go
+++ b/dgraph/cmd/migrate/table_info.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type keyType int

--- a/dgraph/cmd/migrate/utils.go
+++ b/dgraph/cmd/migrate/utils.go
@@ -24,9 +24,10 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/go-sql-driver/mysql"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func getPool(host, port, user, password, db string) (*sql.DB,

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -28,6 +28,10 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	"github.com/dgraph-io/dgraph/dgraph/cmd/alpha"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/bulk"
 	"github.com/dgraph-io/dgraph/dgraph/cmd/cert"
@@ -42,10 +46,6 @@ import (
 	"github.com/dgraph-io/dgraph/dgraph/cmd/zero"
 	"github.com/dgraph-io/dgraph/upgrade"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -262,29 +262,29 @@ http://zsh.sourceforge.net/Doc/Release/Completion-System.html
 // respective subcommands. If JSON hierarchical config objects are not used, convertJSON doesn't
 // change anything and returns the config file string as it is. For example:
 //
-//  {
-//    "mutations": "strict",
-//    "badger": {
-//      "compression": "zstd:1",
-//      "goroutines": 5
-//    },
-//    "raft": {
-//      "idx": 2,
-//      "learner": true
-//    },
-//    "security": {
-//      "whitelist": "127.0.0.1,0.0.0.0"
-//    }
-//  }
+//	{
+//	  "mutations": "strict",
+//	  "badger": {
+//	    "compression": "zstd:1",
+//	    "goroutines": 5
+//	  },
+//	  "raft": {
+//	    "idx": 2,
+//	    "learner": true
+//	  },
+//	  "security": {
+//	    "whitelist": "127.0.0.1,0.0.0.0"
+//	  }
+//	}
 //
 // Is converted into:
 //
-//  {
-//    "mutations": "strict",
-//    "badger": "compression=zstd:1; goroutines=5;",
-//    "raft": "idx=2; learner=true;",
-//    "security": "whitelist=127.0.0.1,0.0.0.0;"
-//  }
+//	{
+//	  "mutations": "strict",
+//	  "badger": "compression=zstd:1; goroutines=5;",
+//	  "raft": "idx=2; learner=true;",
+//	  "security": "whitelist=127.0.0.1,0.0.0.0;"
+//	}
 //
 // Viper then uses the "converted" JSON to set the z.SuperFlag strings in subcommand option structs.
 func convertJSON(old string) io.Reader {
@@ -325,22 +325,22 @@ func convertJSON(old string) io.Reader {
 // subcommands. If YAML hierarchical notation is not used, convertYAML doesn't change anything and
 // returns the config file string as it is. For example:
 //
-//  mutations: strict
-//  badger:
-//    compression: zstd:1
-//    goroutines: 5
-//  raft:
-//    idx: 2
-//    learner: true
-//  security:
-//    whitelist: "127.0.0.1,0.0.0.0"
+//	mutations: strict
+//	badger:
+//	  compression: zstd:1
+//	  goroutines: 5
+//	raft:
+//	  idx: 2
+//	  learner: true
+//	security:
+//	  whitelist: "127.0.0.1,0.0.0.0"
 //
 // Is converted into:
 //
-//  mutations: strict
-//  badger: "compression=zstd:1; goroutines=5;"
-//  raft: "idx=2; learner=true;"
-//  security: "whitelist=127.0.0.1,0.0.0.0;"
+//	mutations: strict
+//	badger: "compression=zstd:1; goroutines=5;"
+//	raft: "idx=2; learner=true;"
+//	security: "whitelist=127.0.0.1,0.0.0.0;"
 //
 // Viper then uses the "converted" YAML to set the z.SuperFlag strings in subcommand option structs.
 func convertYAML(old string) io.Reader {

--- a/dgraph/cmd/version/version_test.go
+++ b/dgraph/cmd/version/version_test.go
@@ -6,8 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 // Test `dgraph version` with an empty config file.

--- a/dgraph/cmd/zero/assign.go
+++ b/dgraph/cmd/zero/assign.go
@@ -21,13 +21,13 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 var emptyAssignedIds pb.AssignedIds

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // intFromQueryParam checks for name as a query param, converts it to uint64 and returns it.

--- a/dgraph/cmd/zero/license.go
+++ b/dgraph/cmd/zero/license.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/dgraph/cmd/zero/license_ee.go
+++ b/dgraph/cmd/zero/license_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -19,14 +20,14 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/dgraph-io/dgraph/ee/audit"
-
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/dgraph/ee/audit"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // proposeTrialLicense proposes an enterprise license valid for 30 days.

--- a/dgraph/cmd/zero/oracle.go
+++ b/dgraph/cmd/zero/oracle.go
@@ -23,15 +23,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	otrace "go.opencensus.io/trace"
 
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	otrace "go.opencensus.io/trace"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 type syncMark struct {

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -27,11 +27,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/dgraph/conn"
-	"github.com/dgraph-io/dgraph/ee/audit"
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	farm "github.com/dgryski/go-farm"
 	"github.com/golang/glog"
 	"github.com/google/uuid"
@@ -41,6 +36,12 @@ import (
 	ostats "go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 	otrace "go.opencensus.io/trace"
+
+	"github.com/dgraph-io/dgraph/conn"
+	"github.com/dgraph-io/dgraph/ee/audit"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/dgraph/cmd/zero/run.go
+++ b/dgraph/cmd/zero/run.go
@@ -29,9 +29,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/dgraph/ee/audit"
-	"github.com/dgraph-io/dgraph/worker"
-
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
 	"go.opencensus.io/plugin/ocgrpc"
 	otrace "go.opencensus.io/trace"
 	"go.opencensus.io/zpages"
@@ -40,13 +39,13 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/dgraph/conn"
+	"github.com/dgraph-io/dgraph/ee/audit"
 	"github.com/dgraph-io/dgraph/ee/enc"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
+	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/spf13/cobra"
 )
 
 type options struct {

--- a/dgraph/cmd/zero/tablet.go
+++ b/dgraph/cmd/zero/tablet.go
@@ -22,12 +22,13 @@ import (
 	"sort"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (
@@ -58,7 +59,7 @@ This would trigger G1 to get latest state. Wait for it.
 
 */
 
-//  TODO: Have a event log for everything.
+// TODO: Have a event log for everything.
 func (s *Server) rebalanceTablets() {
 	ticker := time.NewTicker(opts.rebalanceInterval)
 	for range ticker.C {

--- a/dgraph/cmd/zero/zero.go
+++ b/dgraph/cmd/zero/zero.go
@@ -25,6 +25,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -33,9 +36,6 @@ import (
 	"github.com/dgraph-io/dgraph/telemetry"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/gogo/protobuf/proto"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -21,10 +21,11 @@ import (
 	"math"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestRemoveNode(t *testing.T) {

--- a/dgraph/main.go
+++ b/dgraph/main.go
@@ -21,10 +21,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/dgraph-io/dgraph/dgraph/cmd"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/dgraph/dgraph/cmd"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func main() {

--- a/dql/bench_test.go
+++ b/dql/bench_test.go
@@ -19,8 +19,9 @@ package dql
 import (
 	"testing"
 
-	"github.com/dgraph-io/dgraph/schema"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/schema"
 )
 
 var sc = `type.object.name.en: string @index .

--- a/dql/math.go
+++ b/dql/math.go
@@ -21,10 +21,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 type mathTreeStack struct{ a []*MathTree }

--- a/dql/mutation.go
+++ b/dql/mutation.go
@@ -19,11 +19,12 @@ package dql
 import (
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/dql/parser.go
+++ b/dql/parser.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -22,11 +22,12 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/lex"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func childAttrs(g *GraphQuery) []string {

--- a/edgraph/access.go
+++ b/edgraph/access.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*
@@ -21,12 +22,13 @@ package edgraph
 import (
 	"context"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/dql"
 	"github.com/dgraph-io/dgraph/query"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
 )
 
 // Login handles login requests from clients. This version rejects all requests

--- a/edgraph/access_ee.go
+++ b/edgraph/access_ee.go
@@ -21,25 +21,23 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dgraph-io/dgraph/query"
-
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	otrace "go.opencensus.io/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/dql"
 	"github.com/dgraph-io/dgraph/ee/acl"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/query"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/golang/glog"
-	otrace "go.opencensus.io/trace"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 type predsAndvars struct {
@@ -195,7 +193,7 @@ func validateToken(jwtStr string) (*userData, error) {
 		return nil, errors.Errorf("userid in claims is not a string:%v", userId)
 	}
 
-	/*  
+	/*
 	 * Since, JSON numbers follow JavaScript's double-precision floating-point
 	 * format . . .
 	 * -- references: https://restfulapi.net/json-data-types/

--- a/edgraph/access_ee_test.go
+++ b/edgraph/access_ee_test.go
@@ -1,5 +1,5 @@
 //go:build !oss
-//+build !oss
+// +build !oss
 
 /*
  * Copyright 2022 Dgraph Labs, Inc. All rights reserved.
@@ -17,17 +17,17 @@ import (
 	"testing"
 	"time"
 
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/worker"
-
-	"github.com/stretchr/testify/require"
-	jwt "github.com/dgrijalva/jwt-go"
 )
 
 func generateJWT(namespace uint64, userId string, groupIds []string, expiry int64) string {
 	claims := jwt.MapClaims{"namespace": namespace, "userid": userId, "exp": expiry}
 	if groupIds != nil {
-			claims["groups"] = groupIds
+		claims["groups"] = groupIds
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &claims)
 
@@ -100,11 +100,11 @@ func TestGetAccessJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		jwtstr, _ := getAccessJwt(userdata.userId, grpLst, userdata.namespace)
-		ud, err := validateToken (jwtstr)
+		ud, err := validateToken(jwtstr)
 		require.Nil(t, err)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId || !sliceCompare(ud.groupIds, g) {
 			t.Errorf("Actual output {%v %v %v} is not equal to the output %v generated from"+
-					 " getAccessJwt() token", userdata.namespace, userdata.userId, grpLst, ud)
+				" getAccessJwt() token", userdata.namespace, userdata.userId, grpLst, ud)
 		}
 	}
 }
@@ -118,11 +118,11 @@ func TestGetRefreshJwt(t *testing.T) {
 
 	for _, userdata := range userDataList {
 		jwtstr, _ := getRefreshJwt(userdata.userId, userdata.namespace)
-		ud, err := validateToken (jwtstr)
+		ud, err := validateToken(jwtstr)
 		require.Nil(t, err)
 		if ud.namespace != userdata.namespace || ud.userId != userdata.userId {
 			t.Errorf("Actual output {%v %v} is not equal to the output {%v %v} generated from"+
-					 "getRefreshJwt() token", userdata.namespace, userdata.userId, ud.namespace, ud.userId)
+				"getRefreshJwt() token", userdata.namespace, userdata.userId, ud.namespace, ud.userId)
 		}
 	}
 }

--- a/edgraph/config_mem.go
+++ b/edgraph/config_mem.go
@@ -1,3 +1,4 @@
+//go:build (linux || darwin) && cgo
 // +build linux darwin
 // +build cgo
 

--- a/edgraph/graphql.go
+++ b/edgraph/graphql.go
@@ -23,24 +23,25 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // ProcessPersistedQuery stores and retrieves persisted queries by following waterfall logic:
-// 1. If sha256Hash is not provided process queries without persisting
-// 2. If sha256Hash is provided try retrieving persisted queries
-//		2a. Persisted Query not found
-//		    i) If query is not provided then throw "PersistedQueryNotFound"
-//			ii) If query is provided then store query in dgraph only if sha256 of the query is correct
-//				otherwise throw "provided sha does not match query"
-//      2b. Persisted Query found
-//		    i)  If query is not provided then update gqlRes with the found query and proceed
-//			ii) If query is provided then match query retrieved, if identical do nothing else
-//				throw "query does not match persisted query"
+//  1. If sha256Hash is not provided process queries without persisting
+//  2. If sha256Hash is provided try retrieving persisted queries
+//     2a. Persisted Query not found
+//     i) If query is not provided then throw "PersistedQueryNotFound"
+//     ii) If query is provided then store query in dgraph only if sha256 of the query is correct
+//     otherwise throw "provided sha does not match query"
+//     2b. Persisted Query found
+//     i)  If query is not provided then update gqlRes with the found query and proceed
+//     ii) If query is provided then match query retrieved, if identical do nothing else
+//     throw "query does not match persisted query"
 func ProcessPersistedQuery(ctx context.Context, gqlReq *schema.Request) error {
 	query := gqlReq.Query
 	sha256Hash := gqlReq.Extensions.PersistedQuery.Sha256Hash

--- a/edgraph/multi_tenancy.go
+++ b/edgraph/multi_tenancy.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/edgraph/multi_tenancy_ee.go
+++ b/edgraph/multi_tenancy_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -18,14 +19,15 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/query"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 type ResetPasswordInput struct {

--- a/edgraph/server_test.go
+++ b/edgraph/server_test.go
@@ -18,16 +18,17 @@ package edgraph
 
 import (
 	"context"
-	"github.com/dgraph-io/dgraph/schema"
-	"google.golang.org/grpc/metadata"
 	"io/ioutil"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/chunker"
+	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 func makeNquad(sub, pred string, val *api.Value) *api.NQuad {

--- a/ee/acl/acl.go
+++ b/ee/acl/acl.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -19,12 +20,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func getUserAndGroup(conf *viper.Viper) (userId string, groupId string, err error) {

--- a/ee/acl/acl_curl_test.go
+++ b/ee/acl/acl_curl_test.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -17,10 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var adminEndpoint string

--- a/ee/acl/acl_test.go
+++ b/ee/acl/acl_test.go
@@ -24,13 +24,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/ee/acl/run.go
+++ b/ee/acl/run.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*
@@ -19,8 +20,9 @@
 package acl
 
 import (
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var CmdAcl x.SubCommand

--- a/ee/acl/run_ee.go
+++ b/ee/acl/run_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -16,10 +17,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (

--- a/ee/acl/utils.go
+++ b/ee/acl/utils.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -15,13 +16,14 @@ package acl
 import (
 	"encoding/json"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
 )
 
 // GetGroupIDs returns a slice containing the group ids of all the given groups.

--- a/ee/audit/audit.go
+++ b/ee/audit/audit.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/ee/audit/audit_ee.go
+++ b/ee/audit/audit_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -19,11 +20,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/ee/audit/interceptor.go
+++ b/ee/audit/interceptor.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/ee/audit/interceptor_ee.go
+++ b/ee/audit/interceptor_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -25,18 +26,17 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/gqlparser/v2/ast"
-	"github.com/dgraph-io/gqlparser/v2/parser"
 	"github.com/golang/glog"
-
-	"github.com/dgraph-io/dgraph/x"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
-	"google.golang.org/grpc"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/gqlparser/v2/ast"
+	"github.com/dgraph-io/gqlparser/v2/parser"
 )
 
 const (

--- a/ee/audit/run.go
+++ b/ee/audit/run.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*
@@ -19,8 +20,9 @@
 package audit
 
 import (
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var CmdAudit x.SubCommand

--- a/ee/audit/run_ee.go
+++ b/ee/audit/run_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -21,10 +22,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var CmdAudit x.SubCommand

--- a/ee/backup/run.go
+++ b/ee/backup/run.go
@@ -23,6 +23,12 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/posting"
@@ -30,12 +36,6 @@ import (
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 // Restore is the sub-command used to restore a backup.

--- a/ee/enc/util.go
+++ b/ee/enc/util.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/ee/enc/util_ee.go
+++ b/ee/enc/util_ee.go
@@ -18,9 +18,10 @@ import (
 	"crypto/cipher"
 	"io"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 // EeBuild indicates if this is a Enterprise build.

--- a/ee/flags.go
+++ b/ee/flags.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/spf13/pflag"
 )
 
 // Keys holds the configuration for ACL and encryption.

--- a/ee/keys_ee.go
+++ b/ee/keys_ee.go
@@ -17,8 +17,9 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // GetKeys returns the ACL and encryption keys as configured by the user

--- a/ee/vault/vault.go
+++ b/ee/vault/vault.go
@@ -20,10 +20,10 @@
 package vault
 
 import (
-	"github.com/dgraph-io/dgraph/ee"
-
 	"github.com/golang/glog"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgraph/ee"
 )
 
 func GetKeys(config *viper.Viper) (*ee.Keys, error) {

--- a/ee/vault_ee.go
+++ b/ee/vault_ee.go
@@ -19,12 +19,12 @@ import (
 	"io/ioutil"
 	"reflect"
 
-	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/hashicorp/vault/api"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func vaultGetKeys(config *viper.Viper) (aclKey, encKey x.Sensitive) {

--- a/filestore/remote_files.go
+++ b/filestore/remote_files.go
@@ -22,9 +22,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/minio/minio-go/v6"
+
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/minio/minio-go/v6"
 )
 
 type remoteFiles struct {

--- a/graphql/admin/backup.go
+++ b/graphql/admin/backup.go
@@ -21,11 +21,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
-	"github.com/golang/glog"
 )
 
 type backupInput struct {

--- a/graphql/admin/config.go
+++ b/graphql/admin/config.go
@@ -21,10 +21,11 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/worker"
-	"github.com/golang/glog"
 )
 
 type configInput struct {

--- a/graphql/admin/draining.go
+++ b/graphql/admin/draining.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 func resolveDraining(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {

--- a/graphql/admin/endpoints.go
+++ b/graphql/admin/endpoints.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/graphql/admin/endpoints_ee.go
+++ b/graphql/admin/endpoints_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*

--- a/graphql/admin/export.go
+++ b/graphql/admin/export.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"math"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const notSet = math.MaxInt64

--- a/graphql/admin/health.go
+++ b/graphql/admin/health.go
@@ -19,12 +19,13 @@ package admin
 import (
 	"context"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 func resolveHealth(ctx context.Context, q schema.Query) *resolve.Resolved {

--- a/graphql/admin/http.go
+++ b/graphql/admin/http.go
@@ -28,6 +28,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.opencensus.io/trace"
+
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/api"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
@@ -35,9 +39,6 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/subscription"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/graphql-transport-ws/graphqlws"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.opencensus.io/trace"
 )
 
 type Headerkey string

--- a/graphql/admin/list_backups.go
+++ b/graphql/admin/list_backups.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 type lsBackupInput struct {

--- a/graphql/admin/login.go
+++ b/graphql/admin/login.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/golang/glog"
+
 	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/golang/glog"
 )
 
 type loginInput struct {

--- a/graphql/admin/moveTablet.go
+++ b/graphql/admin/moveTablet.go
@@ -19,14 +19,13 @@ package admin
 import (
 	"context"
 
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/pkg/errors"
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type moveTabletInput struct {

--- a/graphql/admin/reset_password.go
+++ b/graphql/admin/reset_password.go
@@ -21,10 +21,11 @@ import (
 	"encoding/json"
 	"strconv"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/golang/glog"
 )
 
 func resolveResetPassword(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {

--- a/graphql/admin/restore.go
+++ b/graphql/admin/restore.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"sync"
 
-	"github.com/dgraph-io/dgraph/edgraph"
+	"github.com/pkg/errors"
 
+	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
-	"github.com/pkg/errors"
 )
 
 type restoreInput struct {

--- a/graphql/admin/schema.go
+++ b/graphql/admin/schema.go
@@ -19,14 +19,15 @@ package admin
 import (
 	"context"
 	"encoding/json"
-	"github.com/dgraph-io/dgraph/worker"
+
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/query"
+	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 type getSchemaResolver struct {

--- a/graphql/admin/shutdown.go
+++ b/graphql/admin/shutdown.go
@@ -19,10 +19,11 @@ package admin
 import (
 	"context"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 func resolveShutdown(ctx context.Context, m schema.Mutation) (*resolve.Resolved, bool) {

--- a/graphql/admin/state.go
+++ b/graphql/admin/state.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/pkg/errors"
 )
 
 type membershipState struct {

--- a/graphql/admin/task.go
+++ b/graphql/admin/task.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
-	"github.com/pkg/errors"
 )
 
 type taskInput struct {

--- a/graphql/authorization/auth.go
+++ b/graphql/authorization/auth.go
@@ -29,11 +29,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/metadata"
 	"gopkg.in/square/go-jose.v2"
+
+	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 )
 
 type ctxKey string

--- a/graphql/bench/auth_test.go
+++ b/graphql/bench/auth_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
+++ b/graphql/e2e/admin_auth/poorman_auth/admin_auth_test.go
@@ -22,11 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/admin_auth_test.go
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/admin_auth_test.go
@@ -22,11 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/graphql/e2e/auth/add_mutation_test.go
+++ b/graphql/e2e/auth/add_mutation_test.go
@@ -20,10 +20,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 )
 
 func (p *Project) delete(t *testing.T, user, role string) {

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -25,16 +25,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/authorization"
-
 	"github.com/dgrijalva/jwt-go/v4"
-
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/graphql/e2e/auth/debug_off/debugoff_test.go
+++ b/graphql/e2e/auth/debug_off/debugoff_test.go
@@ -7,14 +7,14 @@ import (
 	"testing"
 
 	"github.com/dgrijalva/jwt-go/v4"
-
-	"github.com/dgraph-io/dgraph/graphql/authorization"
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/authorization"
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 var (

--- a/graphql/e2e/auth/delete_mutation_test.go
+++ b/graphql/e2e/auth/delete_mutation_test.go
@@ -5,8 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 )
 
 func (c *Column) add(t *testing.T, user, role string) {

--- a/graphql/e2e/auth/update_mutation_test.go
+++ b/graphql/e2e/auth/update_mutation_test.go
@@ -20,8 +20,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 )
 
 func getAllProjects(t *testing.T, users, roles []string) []string {

--- a/graphql/e2e/auth_closed_by_default/auth_closed_by_default_test.go
+++ b/graphql/e2e/auth_closed_by_default/auth_closed_by_default_test.go
@@ -20,10 +20,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 type TestCase struct {

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -25,16 +25,16 @@ import (
 	"testing"
 
 	"github.com/gogo/protobuf/jsonpb"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -30,15 +30,15 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 var (
@@ -599,26 +599,27 @@ func assertUpdateGqlSchemaUsingAdminSchemaEndpt(t *testing.T, authority, schema 
 // To avoid issues, don't use space for indentation in expected input.
 //
 // The comparison requirements for JSON reported by /graphql are following:
-//  * The key order matters in object comparison, i.e.
-//        {"hello": "world", "foo": "bar"}
-//    is not same as:
-//        {"foo": "bar", "hello": "world"}
-//  * A key missing in an object is not same as that key present with value null, i.e.
-//        {"hello": "world"}
-//    is not same as:
-//        {"hello": "world", "foo": null}
-//  * Integers that are out of the [-(2^53)+1, (2^53)-1] precision range supported by JSON RFC,
-//    should still be encoded with full precision. i.e., the number 9007199254740993 ( = 2^53 + 1)
-//    should not get encoded as 9007199254740992 ( = 2^53). This happens in Go's standard JSON
-//    parser due to IEEE754 precision loss for floating point numbers.
+//   - The key order matters in object comparison, i.e.
+//     {"hello": "world", "foo": "bar"}
+//     is not same as:
+//     {"foo": "bar", "hello": "world"}
+//   - A key missing in an object is not same as that key present with value null, i.e.
+//     {"hello": "world"}
+//     is not same as:
+//     {"hello": "world", "foo": null}
+//   - Integers that are out of the [-(2^53)+1, (2^53)-1] precision range supported by JSON RFC,
+//     should still be encoded with full precision. i.e., the number 9007199254740993 ( = 2^53 + 1)
+//     should not get encoded as 9007199254740992 ( = 2^53). This happens in Go's standard JSON
+//     parser due to IEEE754 precision loss for floating point numbers.
 //
 // The above requirements are not satisfied by the standard require.JSONEq or testutil.CompareJSON
 // methods.
 // In order to satisfy all these requirements, this implementation just requires that the input
 // strings be equal after removing `\r`, `\n`, `\t` whitespace characters from the inputs.
 // TODO:
-//  Find a better way to do this such that order isn't mandated in list comparison.
-//  So that it is actually usable at places it is not used at present.
+//
+//	Find a better way to do this such that order isn't mandated in list comparison.
+//	So that it is actually usable at places it is not used at present.
 func JSONEqGraphQL(t *testing.T, expected, actual string) {
 	expected = strings.ReplaceAll(expected, "\r", "")
 	expected = strings.ReplaceAll(expected, "\n", "")

--- a/graphql/e2e/common/error.go
+++ b/graphql/e2e/common/error.go
@@ -27,20 +27,20 @@ import (
 	"strings"
 	"testing"
 
-	admin2 "github.com/dgraph-io/dgraph/graphql/admin"
-
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/graphql/resolve"
-	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/dgraph/graphql/test"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/peer"
 	"gopkg.in/yaml.v2"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
+	admin2 "github.com/dgraph-io/dgraph/graphql/admin"
+	"github.com/dgraph-io/dgraph/graphql/resolve"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/graphql/e2e/common/fragment.go
+++ b/graphql/e2e/common/fragment.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func fragmentInMutation(t *testing.T) {

--- a/graphql/e2e/common/mutation.go
+++ b/graphql/e2e/common/mutation.go
@@ -28,14 +28,15 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // TestAddMutation tests that add mutations work as expected.  There's a few angles

--- a/graphql/e2e/common/query.go
+++ b/graphql/e2e/common/query.go
@@ -29,20 +29,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/spf13/cast"
-
-	"github.com/google/go-cmp/cmp/cmpopts"
-
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/schema"
-
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
 )
 
 func queryCountryByRegExp(t *testing.T, regexp string, expectedCountries []*country) {

--- a/graphql/e2e/common/schema.go
+++ b/graphql/e2e/common/schema.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 const (

--- a/graphql/e2e/common/subscription.go
+++ b/graphql/e2e/common/subscription.go
@@ -23,8 +23,9 @@ import (
 	"math/rand"
 	"net/http"
 
-	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/gorilla/websocket"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
 )
 
 // Reference: https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md

--- a/graphql/e2e/custom_logic/custom_logic_test.go
+++ b/graphql/e2e/custom_logic/custom_logic_test.go
@@ -27,11 +27,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/graphql/e2e/directives/dgraph_directives_test.go
+++ b/graphql/e2e/directives/dgraph_directives_test.go
@@ -21,11 +21,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRunAll_WithDgraphDirectives(t *testing.T) {

--- a/graphql/e2e/multi_tenancy/multi_tenancy_test.go
+++ b/graphql/e2e/multi_tenancy/multi_tenancy_test.go
@@ -25,11 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -21,12 +21,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/e2e/common"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func TestRunAll_Normal(t *testing.T) {

--- a/graphql/e2e/schema/schema_test.go
+++ b/graphql/e2e/schema/schema_test.go
@@ -29,12 +29,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -163,9 +164,9 @@ func TestSchemaSubscribe(t *testing.T) {
 
 // TestConcurrentSchemaUpdates checks that if there are too many concurrent requests to update the
 // GraphQL schema, then the system works as expected by either:
-// 	1. failing the schema update because there is another one in progress, OR
-// 	2. if the schema update succeeds, then the last successful schema update is reflected by both
-//	Dgraph and GraphQL schema
+//  1. failing the schema update because there is another one in progress, OR
+//  2. if the schema update succeeds, then the last successful schema update is reflected by both
+//     Dgraph and GraphQL schema
 //
 // It also tests that only one node exists for GraphQL schema in Dgraph after all the
 // concurrent requests have executed.

--- a/graphql/e2e/subscription/subscription_test.go
+++ b/graphql/e2e/subscription/subscription_test.go
@@ -23,12 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (

--- a/graphql/resolve/auth_test.go
+++ b/graphql/resolve/auth_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 
 	"github.com/dgrijalva/jwt-go/v4"
-
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+	"gopkg.in/yaml.v2"
 
 	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/dql"
@@ -37,8 +38,6 @@ import (
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 	_ "github.com/dgraph-io/gqlparser/v2/validator/rules" // make gql validator init() all rules
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 type AuthQueryRewritingCase struct {

--- a/graphql/resolve/extensions_test.go
+++ b/graphql/resolve/extensions_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/graphql/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/test"
 )
 
 func TestQueriesPropagateExtensions(t *testing.T) {

--- a/graphql/resolve/middlewares.go
+++ b/graphql/resolve/middlewares.go
@@ -19,11 +19,12 @@ package resolve
 import (
 	"context"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // QueryMiddleware represents a middleware for queries
@@ -43,17 +44,23 @@ type QueryMiddlewares []QueryMiddleware
 type MutationMiddlewares []MutationMiddleware
 
 // Then chains the middlewares and returns the final QueryResolver.
-//     QueryMiddlewares{m1, m2, m3}.Then(r)
+//
+//	QueryMiddlewares{m1, m2, m3}.Then(r)
+//
 // is equivalent to:
-//     m1(m2(m3(r)))
+//
+//	m1(m2(m3(r)))
+//
 // When the request comes in, it will be passed to m1, then m2, then m3
 // and finally, the given resolverFunc
 // (assuming every middleware calls the following one).
 //
 // A chain can be safely reused by calling Then() several times.
-//     commonMiddlewares := QueryMiddlewares{authMiddleware, loggingMiddleware}
-//     healthResolver = commonMiddlewares.Then(resolveHealth)
-//     stateResolver = commonMiddlewares.Then(resolveState)
+//
+//	commonMiddlewares := QueryMiddlewares{authMiddleware, loggingMiddleware}
+//	healthResolver = commonMiddlewares.Then(resolveHealth)
+//	stateResolver = commonMiddlewares.Then(resolveState)
+//
 // Note that middlewares are called on every call to Then()
 // and thus several instances of the same middleware will be created
 // when a chain is reused in this way.
@@ -76,17 +83,23 @@ func (mws QueryMiddlewares) Then(resolver QueryResolver) QueryResolver {
 }
 
 // Then chains the middlewares and returns the final MutationResolver.
-//     MutationMiddlewares{m1, m2, m3}.Then(r)
+//
+//	MutationMiddlewares{m1, m2, m3}.Then(r)
+//
 // is equivalent to:
-//     m1(m2(m3(r)))
+//
+//	m1(m2(m3(r)))
+//
 // When the request comes in, it will be passed to m1, then m2, then m3
 // and finally, the given resolverFunc
 // (assuming every middleware calls the following one).
 //
 // A chain can be safely reused by calling Then() several times.
-//     commonMiddlewares := MutationMiddlewares{authMiddleware, loggingMiddleware}
-//     backupResolver = commonMiddlewares.Then(resolveBackup)
-//     configResolver = commonMiddlewares.Then(resolveConfig)
+//
+//	commonMiddlewares := MutationMiddlewares{authMiddleware, loggingMiddleware}
+//	backupResolver = commonMiddlewares.Then(resolveBackup)
+//	configResolver = commonMiddlewares.Then(resolveConfig)
+//
 // Note that middlewares are called on every call to Then()
 // and thus several instances of the same middleware will be created
 // when a chain is reused in this way.

--- a/graphql/resolve/middlewares_test.go
+++ b/graphql/resolve/middlewares_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
 )
 
 func TestQueryMiddlewares_Then_ExecutesMiddlewaresInOrder(t *testing.T) {

--- a/graphql/resolve/mutation.go
+++ b/graphql/resolve/mutation.go
@@ -24,14 +24,15 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	otrace "go.opencensus.io/trace"
+
 	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/dql"
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	otrace "go.opencensus.io/trace"
 )
 
 const touchedUidsKey = "_total"

--- a/graphql/resolve/mutation_rewriter.go
+++ b/graphql/resolve/mutation_rewriter.go
@@ -25,12 +25,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/dql"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
 )
 
 const (

--- a/graphql/resolve/mutation_test.go
+++ b/graphql/resolve/mutation_test.go
@@ -24,15 +24,15 @@ import (
 	"strings"
 	"testing"
 
-	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
+	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 // Tests showing that GraphQL mutations -> Dgraph mutations

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -24,11 +24,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/dql"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 type queryRewriter struct{}

--- a/graphql/resolve/query_test.go
+++ b/graphql/resolve/query_test.go
@@ -24,13 +24,14 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/graphql/test"
 	"github.com/dgraph-io/dgraph/testutil"
 	_ "github.com/dgraph-io/gqlparser/v2/validator/rules" // make gql validator init() all rules
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 // Tests showing that the query rewriter produces the expected Dgraph queries

--- a/graphql/resolve/resolver.go
+++ b/graphql/resolve/resolver.go
@@ -25,17 +25,16 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	otrace "go.opencensus.io/trace"
+
 	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/edgraph"
 	"github.com/dgraph-io/dgraph/graphql/api"
 	"github.com/dgraph-io/dgraph/graphql/dgraph"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	otrace "go.opencensus.io/trace"
-
-	"github.com/golang/glog"
-
 	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type resolveCtxKey string

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -23,14 +23,15 @@ import (
 	"sync"
 	"testing"
 
-	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/graphql/schema"
-	"github.com/dgraph-io/dgraph/graphql/test"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // Tests that result completion and GraphQL error propagation are working properly.

--- a/graphql/resolve/resolver_test.go
+++ b/graphql/resolve/resolver_test.go
@@ -19,12 +19,12 @@ package resolve
 import (
 	"testing"
 
-	"github.com/dgraph-io/dgraph/graphql/schema"
-
-	"github.com/dgraph-io/dgraph/graphql/test"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/graphql/test"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestErrorOnIncorrectValueType(t *testing.T) {

--- a/graphql/run.go
+++ b/graphql/run.go
@@ -19,7 +19,6 @@
 // GraphQL spec:
 // https://graphql.github.io/graphql-spec/June2018
 //
-//
 // GraphQL servers should serve both GET and POST
 // https://graphql.org/learn/serving-over-http/
 //
@@ -27,35 +26,37 @@
 // http://myapi/graphql?query={me{name}}
 //
 // POST should have a json content body like
-// 	{
-// 	  "query": "...",
-// 	  "operationName": "...",
-// 	  "variables": { "myVariable": "someValue", ... }
-// 	}
+//
+//	{
+//	  "query": "...",
+//	  "operationName": "...",
+//	  "variables": { "myVariable": "someValue", ... }
+//	}
 //
 // GraphQL servers should return 200 (even on errors),
 // and result body should be json:
-// 	{
-// 	  "data": { "query_name" : { ... } },
-// 	  "errors": [ { "message" : ..., ...} ... ]
-// 	}
+//
+//	{
+//	  "data": { "query_name" : { ... } },
+//	  "errors": [ { "message" : ..., ...} ... ]
+//	}
 //
 // Key points about the response
 // (https://graphql.github.io/graphql-spec/June2018/#sec-Response)
 //
-// - If an error was encountered before execution begins,
-//   the data entry should not be present in the result.
+//   - If an error was encountered before execution begins,
+//     the data entry should not be present in the result.
 //
-// - If an error was encountered during the execution that
-//   prevented a valid response, the data entry in the response should be null.
+//   - If an error was encountered during the execution that
+//     prevented a valid response, the data entry in the response should be null.
 //
 // - If there's errors and data, both are returned
 //
-// - If no errors were encountered during the requested operation,
-//   the errors entry should not be present in the result.
+//   - If no errors were encountered during the requested operation,
+//     the errors entry should not be present in the result.
 //
-// - There's rules around how errors work when there's ! fields in the schema
-//   https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability
+//   - There's rules around how errors work when there's ! fields in the schema
+//     https://graphql.github.io/graphql-spec/June2018/#sec-Errors-and-Non-Nullability
 //
 // - The "message" in an error is required, the rest is up to the implementation
 //

--- a/graphql/schema/completion.go
+++ b/graphql/schema/completion.go
@@ -70,16 +70,18 @@ func Unmarshal(data []byte, v interface{}) error {
 // CompleteObject builds a json GraphQL result object for the current query level.
 // It returns a bracketed json object like { f1:..., f2:..., ... }.
 // At present, it is only used for building custom results by:
-//  * Admin Server
-//  * @custom(http: {...}) query/mutation
-//  * @custom(dql: ...) queries
+//   - Admin Server
+//   - @custom(http: {...}) query/mutation
+//   - @custom(dql: ...) queries
 //
 // fields are all the fields from this bracketed level in the GraphQL  query, e.g:
-//  {
-//    name
-//    dob
-//    friends {...}
-//  }
+//
+//	{
+//	  name
+//	  dob
+//	  friends {...}
+//	}
+//
 // If it's the top level of a query then it'll be the top level query name.
 //
 // typ is the expected type matching those fields, e.g. above that'd be something
@@ -331,13 +333,15 @@ func mismatched(path []interface{}, field Field) ([]byte, x.GqlErrorList) {
 // defined in the GraphQL spec. If this is not possible, then it returns an error. The crux of
 // coercion rules defined in the spec is to not lose information during coercion.
 // Note that, admin server specifically uses these:
-//  * json.Number
-//  * schema.Unmarshal() everywhere else
+//   - json.Number
+//   - schema.Unmarshal() everywhere else
+//
 // And, @custom(http: {...}) query/mutation would always use schema.Unmarshal().
 // Now, schema.Unmarshal() can only give one of the following types for scalars:
-//  * bool
-//  * string
-//  * json.Number (because it uses custom JSON decoder which preserves number precision)
+//   - bool
+//   - string
+//   - json.Number (because it uses custom JSON decoder which preserves number precision)
+//
 // So, we need to consider only these cases at present.
 func coerceScalar(val interface{}, field Field, path []interface{}) (interface{},
 	x.GqlErrorList) {

--- a/graphql/schema/custom_http.go
+++ b/graphql/schema/custom_http.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/dgraph-io/dgraph/graphql/authorization"
-
 	"github.com/dgraph-io/dgraph/x"
 )
 

--- a/graphql/schema/errors.go
+++ b/graphql/schema/errors.go
@@ -19,9 +19,8 @@ package schema
 import (
 	"fmt"
 
-	"github.com/dgraph-io/gqlparser/v2/ast"
-
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 )
 

--- a/graphql/schema/errors_test.go
+++ b/graphql/schema/errors_test.go
@@ -21,11 +21,11 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/gqlparser/v2/gqlerror"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 )
 
 func TestGQLWrapf_Error(t *testing.T) {

--- a/graphql/schema/introspection.go
+++ b/graphql/schema/introspection.go
@@ -470,7 +470,7 @@ func (ec *executionContext) marshalType(sel ast.SelectionSet, v *introspection.T
 }
 
 // Returns all the types associated with the schema, including the ones that are part
-//of introspection system (i.e., the type name begins with __ )
+// of introspection system (i.e., the type name begins with __ )
 func getAllTypes(s *ast.Schema) []introspection.Type {
 	types := make([]introspection.Type, 0, len(s.Types))
 	for _, typ := range s.Types {

--- a/graphql/schema/remote.go
+++ b/graphql/schema/remote.go
@@ -25,8 +25,9 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/gqlparser/v2/ast"
 )
 
 func validateUrl(rawURL string) error {

--- a/graphql/schema/request.go
+++ b/graphql/schema/request.go
@@ -108,41 +108,42 @@ func (s *schema) Operation(req *Request) (Operation, error) {
 // field's selection set, and does it recursively for all the fields in this field's selection
 // set. This eventually expands all the fragment references anywhere in the hierarchy.
 // To understand how expansion works, let's consider following graphql schema (Reference: Starwars):
-// 			interface Employee { ... }
-// 			interface Character { ... }
-// 			type Human implements Character & Employee { ... }
-// 			type Droid implements Character { ... }
-// 1. field returns an Interface: Consider executing following query:
-//			query {
-//				queryCharacter {
-//					...commonCharacterFrag
-//					...humanFrag
-//					...droidFrag
-//				}
-//			}
-//			fragment commonCharacterFrag on Character { ... }
-//			fragment humanFrag on Human { ... }
-//			fragment droidFrag on Droid { ... }
-//    As queryCharacter returns Characters, so any fragment reference used inside queryCharacter and
-//    defined on Character interface should be expanded. Also, any fragments defined on the types
-//    which implement Character interface should also be expanded. That means, any fragments on
-//    Character, Human and Droid will be expanded in the result of queryCharacter.
-// 2. field returns an Object: Consider executing following query:
-// 			query {
-//				queryHuman {
-//					...employeeFrag
-//					...characterFrag
-//					...humanFrag
-//				}
-//			}
-//			fragment employeeFrag on Employee { ... }
-//			fragment characterFrag on Character { ... }
-//			fragment humanFrag on Human { ... }
-//    As queryHuman returns Humans, so any fragment reference used inside queryHuman and
-//    defined on Human type should be expanded. Also, any fragments defined on the interfaces
-//    which are implemented by Human type should also be expanded. That means, any fragments on
-//    Human, Character and Employee will be expanded in the result of queryHuman.
-// 3. field returns a Union: process is similar to the case when field returns an interface.
+//
+//		interface Employee { ... }
+//		interface Character { ... }
+//		type Human implements Character & Employee { ... }
+//		type Droid implements Character { ... }
+//	 1. field returns an Interface: Consider executing following query:
+//	    query {
+//	    queryCharacter {
+//	    ...commonCharacterFrag
+//	    ...humanFrag
+//	    ...droidFrag
+//	    }
+//	    }
+//	    fragment commonCharacterFrag on Character { ... }
+//	    fragment humanFrag on Human { ... }
+//	    fragment droidFrag on Droid { ... }
+//	    As queryCharacter returns Characters, so any fragment reference used inside queryCharacter and
+//	    defined on Character interface should be expanded. Also, any fragments defined on the types
+//	    which implement Character interface should also be expanded. That means, any fragments on
+//	    Character, Human and Droid will be expanded in the result of queryCharacter.
+//	 2. field returns an Object: Consider executing following query:
+//	    query {
+//	    queryHuman {
+//	    ...employeeFrag
+//	    ...characterFrag
+//	    ...humanFrag
+//	    }
+//	    }
+//	    fragment employeeFrag on Employee { ... }
+//	    fragment characterFrag on Character { ... }
+//	    fragment humanFrag on Human { ... }
+//	    As queryHuman returns Humans, so any fragment reference used inside queryHuman and
+//	    defined on Human type should be expanded. Also, any fragments defined on the interfaces
+//	    which are implemented by Human type should also be expanded. That means, any fragments on
+//	    Human, Character and Employee will be expanded in the result of queryHuman.
+//	 3. field returns a Union: process is similar to the case when field returns an interface.
 func recursivelyExpandFragmentSelections(field *ast.Field, op *operation) {
 	// This happens in case of introspection queries, as they don't have any types in graphql schema
 	// but explicit resolvers defined. So, when the parser parses the raw request, it is not able to

--- a/graphql/schema/response.go
+++ b/graphql/schema/response.go
@@ -249,7 +249,7 @@ func (t *Trace) Merge(other *Trace) {
 	}
 }
 
-//ExecutionTrace records all the resolvers
+// ExecutionTrace records all the resolvers
 type ExecutionTrace struct {
 	Resolvers []*ResolverTrace `json:"resolvers"`
 }

--- a/graphql/schema/response_test.go
+++ b/graphql/schema/response_test.go
@@ -20,10 +20,11 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 )
 
 func TestDataAndErrors(t *testing.T) {

--- a/graphql/schema/schemagen.go
+++ b/graphql/schema/schemagen.go
@@ -23,13 +23,14 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 	"github.com/dgraph-io/gqlparser/v2/parser"
 	"github.com/dgraph-io/gqlparser/v2/validator"
-	"github.com/pkg/errors"
 )
 
 // A Handler can produce valid GraphQL and Dgraph schemas given an input of

--- a/graphql/schema/schemagen_test.go
+++ b/graphql/schema/schemagen_test.go
@@ -22,16 +22,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 
 	dschema "github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/gqlparser/v2/gqlerror"
 	_ "github.com/dgraph-io/gqlparser/v2/validator/rules"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 type Tests map[string][]TestCase

--- a/graphql/schema/wrappers.go
+++ b/graphql/schema/wrappers.go
@@ -26,12 +26,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/graphql/authorization"
-	"github.com/dgraph-io/gqlparser/v2/parser"
+	"github.com/pkg/errors"
 
+	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/gqlparser/v2/ast"
-	"github.com/pkg/errors"
+	"github.com/dgraph-io/gqlparser/v2/parser"
 )
 
 // Wrap the github.com/dgraph-io/gqlparser/ast defintions so that the bulk of the GraphQL
@@ -454,14 +454,15 @@ func (o *operation) CacheControl() string {
 // typDef inherited from. If there is no such interface, then it returns an empty string.
 //
 // Given the following schema
-// interface A {
-//   name: String
-// }
 //
-// type B implements A {
-//	 name: String
-//   age: Int
-// }
+//	interface A {
+//	  name: String
+//	}
+//
+//	type B implements A {
+//		 name: String
+//	  age: Int
+//	}
 //
 // calling parentInterface on the fieldName name with type definition for B, would return A.
 func parentInterface(sch *ast.Schema, typDef *ast.Definition, fieldName string) *ast.Definition {
@@ -674,24 +675,24 @@ func typeMappings(s *ast.Schema) map[string][]*ast.Definition {
 }
 
 // customAndLambdaMappings does following things:
-// * If there is @custom on any field, it removes the directive from the list of directives on
-//	 that field. Instead, it puts it in a map of typeName->fieldName->custom directive definition.
-//	 This mapping is returned as the first return value, which is later used to determine if some
-//	 field has custom directive or not, and accordingly construct the HTTP request for the field.
-// * If there is @lambda on any field, it removes the directive from the list of directives on
-//	 that field. Instead, it puts it in a map of typeName->fieldName->bool. This mapping is returned
-//	 as the second return value, which is later used to determine if some field has lambda directive
-//	 or not. An appropriate @custom directive is also constructed for the field with @lambda and
-//	 put into the first mapping. Both of these mappings together are used to construct the HTTP
-//	 request for @lambda field. Internally, @lambda is just @custom(http: {
-//	   url: "<graphql_lambda_url: a-fixed-pre-defined-url>",
-//	   method: POST,
-//	   body: "<all-the-args-for-a-query-or-mutation>/<all-the-scalar-fields-from-parent-type-for-a
-//	   -@lambda-on-field>"
-//	   mode: BATCH (set only if @lambda was on a non query/mutation field)
-//	 })
-//	 So, by constructing an appropriate custom directive for @lambda fields,
-//	 we just reuse logic from @custom.
+//   - If there is @custom on any field, it removes the directive from the list of directives on
+//     that field. Instead, it puts it in a map of typeName->fieldName->custom directive definition.
+//     This mapping is returned as the first return value, which is later used to determine if some
+//     field has custom directive or not, and accordingly construct the HTTP request for the field.
+//   - If there is @lambda on any field, it removes the directive from the list of directives on
+//     that field. Instead, it puts it in a map of typeName->fieldName->bool. This mapping is returned
+//     as the second return value, which is later used to determine if some field has lambda directive
+//     or not. An appropriate @custom directive is also constructed for the field with @lambda and
+//     put into the first mapping. Both of these mappings together are used to construct the HTTP
+//     request for @lambda field. Internally, @lambda is just @custom(http: {
+//     url: "<graphql_lambda_url: a-fixed-pre-defined-url>",
+//     method: POST,
+//     body: "<all-the-args-for-a-query-or-mutation>/<all-the-scalar-fields-from-parent-type-for-a
+//     -@lambda-on-field>"
+//     mode: BATCH (set only if @lambda was on a non query/mutation field)
+//     })
+//     So, by constructing an appropriate custom directive for @lambda fields,
+//     we just reuse logic from @custom.
 func customAndLambdaMappings(s *ast.Schema, ns uint64) (map[string]map[string]*ast.Directive,
 	map[string]map[string]bool) {
 	customDirectives := make(map[string]map[string]*ast.Directive)
@@ -874,6 +875,7 @@ func externalAndNonKeyField(fld *ast.FieldDefinition, defn *ast.Definition, prov
 
 // buildCustomDirectiveForLambda returns custom directive for the given field to be used for @lambda
 // The constructed @custom looks like this:
+//
 //	@custom(http: {
 //	   url: "<graphql_lambda_url: a-fixed-pre-defined-url>",
 //	   method: POST,
@@ -2670,33 +2672,33 @@ func (t *astType) ImplementingTypes() []Type {
 //
 // For our reference types for adding/linking objects, we'd like to have something like
 //
-// input PostRef {
-// 	id: ID!
-// }
+//	input PostRef {
+//		id: ID!
+//	}
 //
-// input PostNew {
-// 	title: String!
-// 	text: String
-// 	author: AuthorRef!
-// }
+//	input PostNew {
+//		title: String!
+//		text: String
+//		author: AuthorRef!
+//	}
 //
 // and then have something like this
 //
 // input PostNewOrReference = PostRef | PostNew
 //
-// input AuthorNew {
-//   ...
-//   posts: [PostNewOrReference]
-// }
+//	input AuthorNew {
+//	  ...
+//	  posts: [PostNewOrReference]
+//	}
 //
 // but GraphQL doesn't allow union types in input, so best we can do is
 //
-// input PostRef {
-// 	id: ID
-// 	title: String
-// 	text: String
-// 	author: AuthorRef
-// }
+//	input PostRef {
+//		id: ID
+//		title: String
+//		text: String
+//		author: AuthorRef
+//	}
 //
 // and then check ourselves that either there's an ID, or there's all the bits to
 // satisfy a valid post.
@@ -2983,24 +2985,27 @@ func substituteVarInSliceInBody(slice []interface{}, variables map[string]interf
 // Given a JSON representation for a body with variables defined, this function substitutes
 // the variables and returns the final JSON.
 // for e.g.
-// {
-//		"author" : "$id",
-//		"name" : "Jerry",
-//		"age" : 23,
-//		"post": {
-//			"id": "$postID"
-//		}
-// }
+//
+//	{
+//			"author" : "$id",
+//			"name" : "Jerry",
+//			"age" : 23,
+//			"post": {
+//				"id": "$postID"
+//			}
+//	}
+//
 // with variables {"id": "0x3",	postID: "0x9"}
 // should return
-// {
-//		"author" : "0x3",
-//		"name" : "Jerry",
-//		"age" : 23,
-//		"post": {
-//			"id": "0x9"
-//		}
-// }
+//
+//	{
+//			"author" : "0x3",
+//			"name" : "Jerry",
+//			"age" : 23,
+//			"post": {
+//				"id": "0x9"
+//			}
+//	}
 func SubstituteVarsInBody(jsonTemplate interface{}, variables map[string]interface{}) interface{} {
 	if jsonTemplate == nil {
 		return nil
@@ -3040,19 +3045,22 @@ func (t *astType) FieldOriginatedFrom(fieldName string) string {
 
 // buildGraphqlRequestFields will build graphql request body from ast.
 // for eg:
-// Hello{
-// 	name {
-// 		age
-// 	}
-// 	friend
-// }
+//
+//	Hello{
+//		name {
+//			age
+//		}
+//		friend
+//	}
+//
 // will return
-// {
-// 	name {
-// 		age
-// 	}
-// 	friend
-// }
+//
+//	{
+//		name {
+//			age
+//		}
+//		friend
+//	}
 func buildGraphqlRequestFields(writer *bytes.Buffer, field *ast.Field) {
 	// Add beginning curly braces
 	if len(field.SelectionSet) == 0 {

--- a/graphql/schema/wrappers_test.go
+++ b/graphql/schema/wrappers_test.go
@@ -22,13 +22,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/gqlparser/v2/ast"
 )
 
 func TestDgraphMapping_WithoutDirectives(t *testing.T) {

--- a/graphql/subscription/poller.go
+++ b/graphql/subscription/poller.go
@@ -26,12 +26,12 @@ import (
 	"time"
 
 	"github.com/dgrijalva/jwt-go/v4"
+	"github.com/dgryski/go-farm"
+	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/graphql/resolve"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgryski/go-farm"
-	"github.com/golang/glog"
 )
 
 // Poller is used to poll user subscription query.

--- a/graphql/test/test.go
+++ b/graphql/test/test.go
@@ -21,13 +21,13 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/graphql/schema"
+	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/gqlparser/v2/ast"
 	"github.com/dgraph-io/gqlparser/v2/parser"
 	"github.com/dgraph-io/gqlparser/v2/validator"
-	"github.com/stretchr/testify/require"
 )
 
 // Various helpers used in GQL testing

--- a/graphql/testdata/datagen/cmd/root.go
+++ b/graphql/testdata/datagen/cmd/root.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/graphql/testdata/datagen/main.go
+++ b/graphql/testdata/datagen/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/lex/lexer.go
+++ b/lex/lexer.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"unicode/utf8"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // EOF indicates the end of the an input.

--- a/posting/index_test.go
+++ b/posting/index_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/badger/v3"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/types"

--- a/posting/list.go
+++ b/posting/list.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 
 	"github.com/dgryski/go-farm"
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
 	bpb "github.com/dgraph-io/badger/v3/pb"
@@ -37,7 +38,6 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/protobuf/proto"
 )
 
 var (

--- a/posting/list_test.go
+++ b/posting/list_test.go
@@ -26,17 +26,17 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3"
-	bpb "github.com/dgraph-io/badger/v3/pb"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/badger/v3"
+	bpb "github.com/dgraph-io/badger/v3/pb"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/codec"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func setMaxListSize(newMaxListSize int) {

--- a/posting/lists.go
+++ b/posting/lists.go
@@ -26,11 +26,10 @@ import (
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/ristretto"
-	"github.com/dgraph-io/ristretto/z"
-
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/posting/mvcc.go
+++ b/posting/mvcc.go
@@ -25,15 +25,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 type pooledKeys struct {

--- a/posting/mvcc_test.go
+++ b/posting/mvcc_test.go
@@ -20,9 +20,10 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 func TestRollupTimestamp(t *testing.T) {

--- a/posting/oracle.go
+++ b/posting/oracle.go
@@ -23,10 +23,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	ostats "go.opencensus.io/stats"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var o *oracle

--- a/posting/size_test.go
+++ b/posting/size_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math"
+	_ "net/http/pprof"
 	"os"
 	"os/exec"
 	"runtime"
@@ -30,15 +31,13 @@ import (
 	"strings"
 	"testing"
 
-	_ "net/http/pprof"
+	"github.com/dustin/go-humanize"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dustin/go-humanize"
-	"github.com/pkg/errors"
-
-	"github.com/stretchr/testify/require"
 )
 
 var manual = flag.Bool("manual", false, "Set when manually running some tests.")

--- a/posting/writer.go
+++ b/posting/writer.go
@@ -20,9 +20,10 @@ import (
 	"math"
 	"sync"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/pb"
-	"github.com/golang/glog"
 )
 
 // TxnWriter is in charge or writing transactions to badger.

--- a/posting/writer_test.go
+++ b/posting/writer_test.go
@@ -24,10 +24,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/options"
 	bpb "github.com/dgraph-io/badger/v3/pb"
-	"github.com/stretchr/testify/require"
 )
 
 var val = make([]byte, 128)

--- a/protos/protos_test.go
+++ b/protos/protos_test.go
@@ -19,8 +19,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestProtosRegenerate(t *testing.T) {

--- a/query/aggregator.go
+++ b/query/aggregator.go
@@ -21,10 +21,11 @@ import (
 	"math"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 type aggregator struct {

--- a/query/fastjson_test.go
+++ b/query/fastjson_test.go
@@ -5,11 +5,12 @@ import (
 	"math"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/types"
-	"github.com/stretchr/testify/require"
 )
 
 func subgraphWithSingleResultAndSingleValue(val *pb.TaskValue) *SubGraph {

--- a/query/groupby.go
+++ b/query/groupby.go
@@ -21,10 +21,11 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
-	"github.com/pkg/errors"
 )
 
 type groupPair struct {

--- a/query/math.go
+++ b/query/math.go
@@ -17,9 +17,10 @@
 package query
 
 import (
-	"github.com/dgraph-io/dgraph/types"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/types"
 )
 
 type mathTree struct {

--- a/query/math_test.go
+++ b/query/math_test.go
@@ -20,8 +20,9 @@ import (
 	"math"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/types"
 )
 
 func TestProcessBinary(t *testing.T) {

--- a/query/mutation.go
+++ b/query/mutation.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -29,8 +31,6 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // ApplyMutations performs the required edge expansions and forwards the results to the

--- a/query/mutation_test.go
+++ b/query/mutation_test.go
@@ -21,9 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestReserverPredicateForMutation(t *testing.T) {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -30,8 +30,6 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	gqlSchema "github.com/dgraph-io/dgraph/graphql/schema"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
@@ -39,6 +37,7 @@ import (
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/algo"
+	gqlSchema "github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/task"
 	"github.com/dgraph-io/dgraph/types"
@@ -287,21 +286,21 @@ const (
 
 // fastJsonNode represents node of a tree, which is formed to convert a subgraph into json response
 // for a query. A fastJsonNode has following meta data:
-// 1. Attr => predicate associated with this node.
-// 2. ScalarVal => Any value associated with node, if it is a leaf node.
-// 3. List => Stores boolean value, true if this node is part of list.
-// 4. FacetsParent => Stores boolean value, true if this node is a facetsParent. facetsParent is
-//    node which is parent for facets values for a scalar list predicate. Eg: node "city|country"
-//    will have FacetsParent value as true.
-//    {
-//		"city": ["Bengaluru", "San Francisco"],
-//		"city|country": {
-//			"0": "india",
-//			"1": "US"
-//		}
-//	  }
-// 5. Children(Attrs) => List of all children.
-// 6. Visited => Stores boolen values, true if node has been visited for fixing children's order.
+//  1. Attr => predicate associated with this node.
+//  2. ScalarVal => Any value associated with node, if it is a leaf node.
+//  3. List => Stores boolean value, true if this node is part of list.
+//  4. FacetsParent => Stores boolean value, true if this node is a facetsParent. facetsParent is
+//     node which is parent for facets values for a scalar list predicate. Eg: node "city|country"
+//     will have FacetsParent value as true.
+//     {
+//     "city": ["Bengaluru", "San Francisco"],
+//     "city|country": {
+//     "0": "india",
+//     "1": "US"
+//     }
+//     }
+//  5. Children(Attrs) => List of all children.
+//  6. Visited => Stores boolen values, true if node has been visited for fixing children's order.
 //
 // All of the data for fastJsonNode tree is stored in encoder to optimise memory usage. fastJsonNode
 // struct is pointer to node object. node object stores below information.

--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -25,11 +25,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEncodeMemory(t *testing.T) {

--- a/query/outputrdf.go
+++ b/query/outputrdf.go
@@ -21,11 +21,12 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 // rdfBuilder is used to generate RDF from subgraph.

--- a/query/query1_test.go
+++ b/query/query1_test.go
@@ -25,10 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 func TestSchemaBlock2(t *testing.T) {

--- a/query/query3_test.go
+++ b/query/query3_test.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestRecurseError(t *testing.T) {

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -22,10 +22,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestBigMathValue(t *testing.T) {

--- a/query/recurse.go
+++ b/query/recurse.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 func (start *SubGraph) expandRecurse(ctx context.Context, maxDepth uint64) error {

--- a/query/shortest.go
+++ b/query/shortest.go
@@ -22,12 +22,13 @@ import (
 	"math"
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 type pathInfo struct {
@@ -437,7 +438,6 @@ func runKShortestPaths(ctx context.Context, sg *SubGraph) ([]*SubGraph, error) {
 }
 
 // Djikstras algorithm pseudocode for reference.
-//
 //
 // 1  function Dijkstra(Graph, source):
 // 2      dist[source] ← 0                                    // Initialization

--- a/raftwal/log.go
+++ b/raftwal/log.go
@@ -28,14 +28,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft/raftpb"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft/raftpb"
 )
 
 // WAL is divided up into entryFiles. Each entry file stores maxNumEntries in

--- a/raftwal/meta.go
+++ b/raftwal/meta.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
+
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 type MetaInfo int

--- a/raftwal/storage.go
+++ b/raftwal/storage.go
@@ -20,12 +20,13 @@ import (
 	"math"
 	"sync"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 	"golang.org/x/net/trace"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // versionKey is hardcoded into the special key used to fetch the maximum version from the DB.

--- a/raftwal/storage_test.go
+++ b/raftwal/storage_test.go
@@ -41,11 +41,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
 	pb "go.etcd.io/etcd/raft/raftpb"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestStorageTerm(t *testing.T) {

--- a/raftwal/wal.go
+++ b/raftwal/wal.go
@@ -20,13 +20,14 @@ import (
 	"bytes"
 	"sort"
 
-	"github.com/dgraph-io/badger/v3/y"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"go.etcd.io/etcd/raft"
 	"go.etcd.io/etcd/raft/raftpb"
+
+	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var errNotFound = errors.New("Unable to find raft entry")

--- a/schema/parse.go
+++ b/schema/parse.go
@@ -21,14 +21,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/lex"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // ParseBytes parses the byte array which holds the schema. We will reset

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -23,17 +23,17 @@ import (
 	"math"
 	"sync"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"golang.org/x/net/trace"
+
 	"github.com/dgraph-io/badger/v3"
 	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
-	"golang.org/x/net/trace"
 )
 
 var (

--- a/systest/1million/1million_test.go
+++ b/systest/1million/1million_test.go
@@ -25,9 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 var tc = []struct {

--- a/systest/21million/bulk/run_test.go
+++ b/systest/21million/bulk/run_test.go
@@ -19,11 +19,10 @@ package bulk
 import (
 	"os"
 	"path/filepath"
+	"testing"
 
 	"github.com/dgraph-io/dgraph/systest/21million/common"
 	"github.com/dgraph-io/dgraph/testutil"
-
-	"testing"
 )
 
 func TestQueries(t *testing.T) {

--- a/systest/21million/live/run_test.go
+++ b/systest/21million/live/run_test.go
@@ -19,12 +19,10 @@ package bulk
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/dgraph-io/dgraph/testutil"
+	"testing"
 
 	"github.com/dgraph-io/dgraph/systest/21million/common"
-
-	"testing"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestQueries(t *testing.T) {

--- a/systest/acl/restore/acl_restore_test.go
+++ b/systest/acl/restore/acl_restore_test.go
@@ -10,12 +10,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 // disableDraining disables draining mode before each test for increased reliability.

--- a/systest/audit/audit_test.go
+++ b/systest/audit/audit_test.go
@@ -25,8 +25,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestZeroAudit(t *testing.T) {

--- a/systest/backup/common/utils.go
+++ b/systest/backup/common/utils.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3/options"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"
 )

--- a/systest/backup/encryption/backup_test.go
+++ b/systest/backup/encryption/backup_test.go
@@ -28,16 +28,17 @@ import (
 	"testing"
 	"time"
 
+	minio "github.com/minio/minio-go/v6"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/ee"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	minio "github.com/minio/minio-go/v6"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 )
 
 var (

--- a/systest/backup/filesystem/backup_test.go
+++ b/systest/backup/filesystem/backup_test.go
@@ -28,14 +28,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/dgraph-io/dgraph/systest/backup/common"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"

--- a/systest/backup/minio-large/backup_test.go
+++ b/systest/backup/minio-large/backup_test.go
@@ -26,15 +26,14 @@ import (
 	"testing"
 	"time"
 
+	minio "github.com/minio/minio-go/v6"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	minio "github.com/minio/minio-go/v6"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"

--- a/systest/backup/minio/backup_test.go
+++ b/systest/backup/minio/backup_test.go
@@ -28,15 +28,14 @@ import (
 	"testing"
 	"time"
 
+	minio "github.com/minio/minio-go/v6"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	minio "github.com/minio/minio-go/v6"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"

--- a/systest/backup/multi-tenancy/backup_test.go
+++ b/systest/backup/multi-tenancy/backup_test.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/systest/backup/common"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -31,13 +31,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestCountIndex(t *testing.T) {

--- a/systest/bgindex/parallel_test.go
+++ b/systest/bgindex/parallel_test.go
@@ -27,13 +27,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (

--- a/systest/bgindex/reverse_test.go
+++ b/systest/bgindex/reverse_test.go
@@ -30,12 +30,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestReverseIndex(t *testing.T) {

--- a/systest/bgindex/string_test.go
+++ b/systest/bgindex/string_test.go
@@ -30,13 +30,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func TestStringIndex(t *testing.T) {

--- a/systest/bulk_live/common/bulk_live_cases.go
+++ b/systest/bulk_live/common/bulk_live_cases.go
@@ -31,12 +31,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/stretchr/testify/require"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 // TODO: This test was used just to make sure some really basic examples work.

--- a/systest/bulk_live/common/bulk_live_fixture.go
+++ b/systest/bulk_live/common/bulk_live_fixture.go
@@ -25,11 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
-
 	"github.com/minio/minio-go/v6"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 var rootDir = "./data"

--- a/systest/cdc/cdc_test.go
+++ b/systest/cdc/cdc_test.go
@@ -26,9 +26,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestCDC(t *testing.T) {

--- a/systest/export/export_test.go
+++ b/systest/export/export_test.go
@@ -26,12 +26,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
 	minio "github.com/minio/minio-go/v6"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 )
 

--- a/systest/group-delete/group_delete_test.go
+++ b/systest/group-delete/group_delete_test.go
@@ -31,11 +31,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func NodesSetup(t *testing.T, c *dgo.Dgraph) {

--- a/systest/ldbc/ldbc_test.go
+++ b/systest/ldbc/ldbc_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 type TestCases struct {

--- a/systest/license/license_test.go
+++ b/systest/license/license_test.go
@@ -23,8 +23,9 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 var expiredKey = []byte(`-----BEGIN PGP MESSAGE-----

--- a/systest/live_pw_test.go
+++ b/systest/live_pw_test.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLivePassword(t *testing.T) {

--- a/systest/loader/loader_test.go
+++ b/systest/loader/loader_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210/protos/api"

--- a/systest/multi-tenancy/basic_test.go
+++ b/systest/multi-tenancy/basic_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/ee/acl"
@@ -33,7 +35,6 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 func prepare(t *testing.T) {

--- a/systest/mutations_test.go
+++ b/systest/mutations_test.go
@@ -30,10 +30,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 // TestSystem uses the externally run Dgraph cluster for testing. Most other

--- a/systest/online-restore/online_restore_test.go
+++ b/systest/online-restore/online_restore_test.go
@@ -28,14 +28,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"

--- a/systest/posting-list-benchmark/main.go
+++ b/systest/posting-list-benchmark/main.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/cobra"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/spf13/cobra"
 )
 
 type flagOptions struct {

--- a/systest/queries_test.go
+++ b/systest/queries_test.go
@@ -25,10 +25,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestQuery(t *testing.T) {

--- a/t/t.go
+++ b/t/t.go
@@ -37,14 +37,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/spf13/pflag"
 	"golang.org/x/tools/go/packages"
+
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -24,11 +24,12 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/worker"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // Telemetry holds information about the state of the zero and alpha server.

--- a/testutil/backup.go
+++ b/testutil/backup.go
@@ -26,6 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgraph/ee"
@@ -33,10 +37,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/require"
 )
 
 // KeyFile is set to the path of the file containing the key. Used for testing purposes only.

--- a/testutil/bulk.go
+++ b/testutil/bulk.go
@@ -25,8 +25,9 @@ import (
 	"os/exec"
 	"strconv"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type LiveOpts struct {

--- a/testutil/client.go
+++ b/testutil/client.go
@@ -32,15 +32,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/dql"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/dql"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 // socket addr = IP address and port number

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -29,11 +29,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/testutil/graphql.go
+++ b/testutil/graphql.go
@@ -27,14 +27,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
-
 	"github.com/dgrijalva/jwt-go/v4"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/stretchr/testify/require"
 )
 
 const ExportRequest = `mutation {

--- a/testutil/multi_tenancy.go
+++ b/testutil/multi_tenancy.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 type Rule struct {

--- a/testutil/schema.go
+++ b/testutil/schema.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210"
 )
 
 const (
@@ -87,10 +88,11 @@ func GetInternalTypes(excludeAclTypes bool) string {
 // GetFullSchemaJSON returns a string representation of the JSON object returned by the full
 // schema{} query. It uses the user provided predicates and types along with the initial internal
 // schema to generate the string. Example response looks like:
-// 	{
-// 		"schema": [ ... ],
-// 		"types": [ ... ]
-// 	}
+//
+//	{
+//		"schema": [ ... ],
+//		"types": [ ... ]
+//	}
 func GetFullSchemaJSON(opts SchemaOptions) string {
 	expectedPreds := GetInternalPreds(opts.ExcludeAclSchema)
 	if len(opts.UserPreds) > 0 {
@@ -112,12 +114,13 @@ func GetFullSchemaJSON(opts SchemaOptions) string {
 // GetFullSchemaHTTPResponse returns a string representation of the HTTP response returned by the
 // full schema{} query. It uses the user provided predicates and types along with the initial
 // internal schema to generate the string. Example response looks like:
-// 	{
-// 		"data": {
-// 			"schema": [ ... ],
-// 			"types": [ ... ]
-// 		}
-// 	}
+//
+//	{
+//		"data": {
+//			"schema": [ ... ],
+//			"types": [ ... ]
+//		}
+//	}
 func GetFullSchemaHTTPResponse(opts SchemaOptions) string {
 	return `{"data":` + GetFullSchemaJSON(opts) + `}`
 }

--- a/testutil/utils.go
+++ b/testutil/utils.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
 )
 
 func GalaxySchemaKey(attr string) []byte {

--- a/testutil/zero.go
+++ b/testutil/zero.go
@@ -24,10 +24,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dgraph-io/dgo/v210"
-	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 type Member struct {

--- a/tlstest/acl/acl_over_tls_test.go
+++ b/tlstest/acl/acl_over_tls_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/spf13/viper"
 )
 
 func TestLoginOverTLS(t *testing.T) {

--- a/tlstest/certrequest/certrequest_test.go
+++ b/tlstest/certrequest/certrequest_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestAccessOverPlaintext(t *testing.T) {

--- a/tlstest/certrequireandverify/certrequireandverify_test.go
+++ b/tlstest/certrequireandverify/certrequireandverify_test.go
@@ -11,10 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestAccessWithoutClientCert(t *testing.T) {

--- a/tlstest/certverifyifgiven/certverifyifgiven_test.go
+++ b/tlstest/certverifyifgiven/certverifyifgiven_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 func TestAccessWithoutClientCert(t *testing.T) {

--- a/tlstest/mtls_internal/ha_6_node/ha_test.go
+++ b/tlstest/mtls_internal/ha_6_node/ha_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func runTests(t *testing.T, client *dgo.Dgraph) {

--- a/tlstest/mtls_internal/multi_group/multi_group_test.go
+++ b/tlstest/mtls_internal/multi_group/multi_group_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func runTests(t *testing.T, client *dgo.Dgraph) {

--- a/tlstest/mtls_internal/single_node/single_node_test.go
+++ b/tlstest/mtls_internal/single_node/single_node_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 func runTests(t *testing.T, client *dgo.Dgraph) {

--- a/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
+++ b/tlstest/zero_https/all_routes_tls/all_routes_tls_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 type testCase struct {

--- a/tlstest/zero_https/no_tls/no_tls_test.go
+++ b/tlstest/zero_https/no_tls/no_tls_test.go
@@ -7,8 +7,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/testutil"
 )
 
 type testCase struct {

--- a/tok/bleve.go
+++ b/tok/bleve.go
@@ -17,14 +17,14 @@
 package tok
 
 import (
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/blevesearch/bleve/analysis"
 	"github.com/blevesearch/bleve/analysis/analyzer/custom"
 	"github.com/blevesearch/bleve/analysis/token/lowercase"
 	"github.com/blevesearch/bleve/analysis/token/unicodenorm"
 	"github.com/blevesearch/bleve/analysis/tokenizer/unicode"
 	"github.com/blevesearch/bleve/registry"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const unicodenormName = "unicodenorm_nfkc"

--- a/tok/tok.go
+++ b/tok/tok.go
@@ -23,13 +23,13 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/text/collate"
 
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 // Tokenizer identifiers are unique and can't be reused.

--- a/tools.go
+++ b/tools.go
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+//go:build tools
 // +build tools
 
 package tools

--- a/types/facets/utils.go
+++ b/types/facets/utils.go
@@ -22,11 +22,12 @@ import (
 	"strconv"
 	"unicode"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
-	"github.com/pkg/errors"
 )
 
 // SortAndValidate sorts And validates the facets.

--- a/types/geofilter.go
+++ b/types/geofilter.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 
 	"github.com/golang/geo/s2"
+	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
+	"github.com/twpayne/go-geom/xy"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	"github.com/twpayne/go-geom/xy"
 )
 
 // QueryType indicates the type of geo query.

--- a/types/password.go
+++ b/types/password.go
@@ -17,9 +17,8 @@
 package types
 
 import (
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
 )
 
 const (

--- a/types/s2.go
+++ b/types/s2.go
@@ -19,11 +19,12 @@ package types
 import (
 	"encoding/json"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/geo/s2"
 	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
 	"github.com/twpayne/go-geom/encoding/geojson"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func edgesCrossPoints(l *s2.Loop, pts []s2.Point) bool {

--- a/types/s2index.go
+++ b/types/s2index.go
@@ -20,10 +20,10 @@ import (
 	"log"
 
 	"github.com/golang/geo/s2"
+	"github.com/pkg/errors"
 	geom "github.com/twpayne/go-geom"
 
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 func parentCoverTokens(parents s2.CellUnion, cover s2.CellUnion) []string {

--- a/types/scalar_types.go
+++ b/types/scalar_types.go
@@ -19,8 +19,9 @@ package types
 import (
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
 	geom "github.com/twpayne/go-geom"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
 const nanoSecondsInSec = 1000000000

--- a/types/sort.go
+++ b/types/sort.go
@@ -20,11 +20,12 @@ import (
 	"sort"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/pkg/errors"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type sortBase struct {

--- a/types/sort_test.go
+++ b/types/sort_test.go
@@ -19,8 +19,9 @@ package types
 import (
 	"testing"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
 )
 
 func toString(t *testing.T, values [][]Val, vID TypeID) []string {

--- a/upgrade/change_v21.03.0.go
+++ b/upgrade/change_v21.03.0.go
@@ -22,6 +22,9 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -29,8 +32,6 @@ import (
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/upgrade/doc.go
+++ b/upgrade/doc.go
@@ -24,16 +24,16 @@
 // you really need to modify any existing files.
 //
 // When adding upgrade capability for a new dgraph release version, follow these steps:
-// 	1. Create a file named `change_<release_version>.go`. For example: change_v20.07.0.go
-// 	2. For any change that needs to be introduced in that version, create a function of the form
-//	`func() error` that applies that change, in the newly created file.
-// 	3. Add that function to change_list.go inside the changes for the change set introduced in
-//	that version. Also add a short name and some meaningful description with it.
+//  1. Create a file named `change_<release_version>.go`. For example: change_v20.07.0.go
+//  2. For any change that needs to be introduced in that version, create a function of the form
+//     `func() error` that applies that change, in the newly created file.
+//  3. Add that function to change_list.go inside the changes for the change set introduced in
+//     that version. Also add a short name and some meaningful description with it.
 //
 // Points to keep in mind:
-// 	1. Upgrade is expected only for breaking changes which go in as part of the breaking releases.
-// 	2. Look at the upgrade algorithm in upgrade.go to understand how & when a change is applied.
-// 	3. There are many re-usable functions in utils.go for the upgrade process, look at them too.
-// 	4. Thoroughly test your upgrade to make sure that it works correctly while upgrading from
-//	previous versions to the new release version, as an upgrade is very critical process.
+//  1. Upgrade is expected only for breaking changes which go in as part of the breaking releases.
+//  2. Look at the upgrade algorithm in upgrade.go to understand how & when a change is applied.
+//  3. There are many re-usable functions in utils.go for the upgrade process, look at them too.
+//  4. Thoroughly test your upgrade to make sure that it works correctly while upgrading from
+//     previous versions to the new release version, as an upgrade is very critical process.
 package upgrade

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -24,8 +24,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/spf13/cobra"
+
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (
@@ -131,7 +132,7 @@ type changeSet struct {
 
 // changeList represents a list of changeSet, i.e., a list of all the changes that were ever
 // introduced since the beginning of Dgraph.
-//The changeSets in this list are supposed to be in sorted order based on when they were introduced.
+// The changeSets in this list are supposed to be in sorted order based on when they were introduced.
 type changeList []*changeSet
 
 type commandInput struct {
@@ -219,14 +220,14 @@ func formatAsFlagRequiredError(flag string) error {
 
 // parseVersionFromString parses a version given as string to internal representation.
 // Some examples for input and output:
-// 	1. input : v1.2.2
-// 	   output: &version{major: 1, minor: 2, patch: 2}, nil
-// 	2. input : v20.03.0-beta.20200320
-// 	   output: &version{major: 20, minor: 3, patch: 0}, nil
-// 	3. input : 1.2.2
-// 	   output: nil, error
-// 	4. input : v1.2.2s
-// 	   output: nil, error
+//  1. input : v1.2.2
+//     output: &version{major: 1, minor: 2, patch: 2}, nil
+//  2. input : v20.03.0-beta.20200320
+//     output: &version{major: 20, minor: 3, patch: 0}, nil
+//  3. input : 1.2.2
+//     output: nil, error
+//  4. input : v1.2.2s
+//     output: nil, error
 func parseVersionFromString(v string) (*version, error) {
 	v = strings.TrimSpace(v)
 	if v == "" || v[:1] != "v" {

--- a/upgrade/utils.go
+++ b/upgrade/utils.go
@@ -26,11 +26,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/graphql/schema"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
 )
 
 func hasAclCreds() bool {
@@ -250,24 +251,29 @@ func alterWithClient(dg *dgo.Dgraph, operation *api.Operation) error {
 // will contain the new name for that predicate. Also, if some predicates need to be
 // removed from the type, then they can be supplied in predsToRemove. For example:
 // initialType:
-// 	type Person {
-// 		name
-// 		age
-// 		unnecessaryEdge
-// 	}
+//
+//	type Person {
+//		name
+//		age
+//		unnecessaryEdge
+//	}
+//
 // also,
-// 	newTypeName = "Human"
-// 	newPredNames = {
-// 		"age": "ageOnEarth'
-// 	}
-// 	predsToRemove = {
-// 		"unnecessaryEdge": {}
-// 	}
+//
+//	newTypeName = "Human"
+//	newPredNames = {
+//		"age": "ageOnEarth'
+//	}
+//	predsToRemove = {
+//		"unnecessaryEdge": {}
+//	}
+//
 // then returned type string will be:
-// 	type Human {
-// 		name
-// 		ageOnEarth
-// 	}
+//
+//	type Human {
+//		name
+//		ageOnEarth
+//	}
 func getTypeSchemaString(newTypeName string, typeNode *schemaTypeNode,
 	newPredNames map[string]string, predsToRemove map[string]struct{}) string {
 	var builder strings.Builder

--- a/worker/acl_cache.go
+++ b/worker/acl_cache.go
@@ -16,10 +16,10 @@ package worker
 import (
 	"sync"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
 )
 
 // aclCache is the cache mapping group names to the corresponding group acls

--- a/worker/acl_cache_test.go
+++ b/worker/acl_cache_test.go
@@ -16,10 +16,10 @@ package worker
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgraph/ee/acl"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestAclCache(t *testing.T) {

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"math"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
 )
 
 // predicateSet is a map whose keys are predicates. It is meant to be used as a set.

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -25,6 +25,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/pkg/errors"
+	ostats "go.opencensus.io/stats"
+
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
@@ -33,12 +39,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/golang/snappy"
-	"github.com/pkg/errors"
-	ostats "go.opencensus.io/stats"
 )
 
 // Backup handles a request coming from another node.

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -23,13 +23,13 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
-
 	"github.com/golang/glog"
 	"github.com/minio/minio-go/v6"
 	"github.com/minio/minio-go/v6/pkg/credentials"
 	"github.com/pkg/errors"
+
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (

--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -20,10 +20,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/pkg/errors"
 )
 
 func verifyManifests(manifests []*Manifest) error {

--- a/worker/backup_oss.go
+++ b/worker/backup_oss.go
@@ -22,10 +22,10 @@ package worker
 import (
 	"context"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
 )
 
 // Backup implements the Worker interface.

--- a/worker/cdc.go
+++ b/worker/cdc.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/worker/cdc_ee.go
+++ b/worker/cdc_ee.go
@@ -23,15 +23,15 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft/raftpb"
+
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft/raftpb"
 )
 
 const (

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -28,6 +28,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.etcd.io/etcd/raft"
+	"go.etcd.io/etcd/raft/raftpb"
+	ostats "go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	otrace "go.opencensus.io/trace"
+	"golang.org/x/net/trace"
+
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/conn"
@@ -38,16 +48,6 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"go.etcd.io/etcd/raft"
-	"go.etcd.io/etcd/raft/raftpb"
-	ostats "go.opencensus.io/stats"
-	"go.opencensus.io/tag"
-	otrace "go.opencensus.io/trace"
-	"golang.org/x/net/trace"
 )
 
 type operation struct {

--- a/worker/draft_test.go
+++ b/worker/draft_test.go
@@ -21,13 +21,13 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/raft/raftpb"
+
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/stretchr/testify/require"
-	"go.etcd.io/etcd/raft/raftpb"
 )
 
 func getEntryForMutation(index, startTs uint64) raftpb.Entry {

--- a/worker/executor.go
+++ b/worker/executor.go
@@ -25,6 +25,9 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/dgryski/go-farm"
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
@@ -33,9 +36,6 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dgryski/go-farm"
-	"github.com/golang/glog"
 )
 
 type subMutation struct {

--- a/worker/export.go
+++ b/worker/export.go
@@ -32,6 +32,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/minio/minio-go/v6"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/badger/v3"
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
@@ -42,10 +46,6 @@ import (
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/golang/glog"
-	"github.com/minio/minio-go/v6"
-	"github.com/pkg/errors"
 )
 
 // DefaultExportFormat stores the name of the default format for exports.

--- a/worker/export_test.go
+++ b/worker/export_test.go
@@ -32,6 +32,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/chunker"
 	"github.com/dgraph-io/dgraph/dql"
@@ -43,9 +46,6 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/protobuf/proto"
-	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -22,14 +22,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/metadata"
+
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/metadata"
 )
 
 const (

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -25,6 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/conn"
@@ -34,10 +38,6 @@ import (
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 type groupi struct {

--- a/worker/match.go
+++ b/worker/match.go
@@ -82,8 +82,8 @@ func matchFuzzy(query, val string, max int) bool {
 // Returns the list of uids even if empty, or an error otherwise.
 func uidsForMatch(attr string, arg funcArgs) (*pb.List, error) {
 	opts := posting.ListOptions{
-		ReadTs: arg.q.ReadTs,
-		First:  int(arg.q.First),
+		ReadTs:   arg.q.ReadTs,
+		First:    int(arg.q.First),
 		AfterUid: arg.q.AfterUid,
 	}
 	uidsForNgram := func(ngram string) (*pb.List, error) {

--- a/worker/multi_tenancy.go
+++ b/worker/multi_tenancy.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*

--- a/worker/multi_tenancy_ee.go
+++ b/worker/multi_tenancy_ee.go
@@ -1,3 +1,4 @@
+//go:build !oss
 // +build !oss
 
 /*
@@ -16,12 +17,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/dgraph-io/dgraph/conn"
-	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/x"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/dgraph-io/dgraph/conn"
+	"github.com/dgraph-io/dgraph/protos/pb"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 func (w *grpcWorker) DeleteNamespace(ctx context.Context,

--- a/worker/mutation.go
+++ b/worker/mutation.go
@@ -24,16 +24,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/badger/v3/y"
-	"google.golang.org/grpc/metadata"
-
-	ostats "go.opencensus.io/stats"
-
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
+	ostats "go.opencensus.io/stats"
 	otrace "go.opencensus.io/trace"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/conn"

--- a/worker/online_restore.go
+++ b/worker/online_restore.go
@@ -25,6 +25,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/badger/v3/options"
 	"github.com/dgraph-io/dgraph/conn"
@@ -33,12 +39,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
-
-	"github.com/golang/glog"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
-	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 )
 
 const (

--- a/worker/online_restore_oss.go
+++ b/worker/online_restore_oss.go
@@ -1,3 +1,4 @@
+//go:build oss
 // +build oss
 
 /*
@@ -22,9 +23,10 @@ import (
 	"context"
 	"sync"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 func ProcessRestoreRequest(ctx context.Context, req *pb.RestoreRequest, wg *sync.WaitGroup) error {

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -23,17 +23,16 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
+	ostats "go.opencensus.io/stats"
+	tag "go.opencensus.io/tag"
+	otrace "go.opencensus.io/trace"
+
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	ostats "go.opencensus.io/stats"
-	tag "go.opencensus.io/tag"
-	otrace "go.opencensus.io/trace"
-
-	"github.com/pkg/errors"
 )
 
 const baseTimeout time.Duration = 4 * time.Second

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -26,13 +26,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 // TaskStatusOverNetwork fetches the status of a task over the network. Alphas only know about the

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -30,6 +30,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/golang/snappy"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
 	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/codec"
@@ -39,12 +45,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/golang/snappy"
-	"github.com/pkg/errors"
-	"golang.org/x/sync/errgroup"
 )
 
 type backupReader struct {

--- a/worker/restore_reduce.go
+++ b/worker/restore_reduce.go
@@ -25,14 +25,14 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/golang/snappy"
+
 	"github.com/dgraph-io/badger/v3/y"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-
-	"github.com/dustin/go-humanize"
-	"github.com/golang/glog"
-	"github.com/golang/snappy"
 )
 
 const (

--- a/worker/server_state.go
+++ b/worker/server_state.go
@@ -22,12 +22,13 @@ import (
 	"os"
 	"time"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/glog"
 )
 
 const (

--- a/worker/sink_handler.go
+++ b/worker/sink_handler.go
@@ -28,10 +28,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Shopify/sarama"
 	"github.com/pkg/errors"
 	"github.com/xdg/scram"
-
-	"github.com/Shopify/sarama"
 
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"

--- a/worker/snapshot.go
+++ b/worker/snapshot.go
@@ -21,7 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
@@ -33,6 +32,7 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -27,10 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSnapshot(t *testing.T) {

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/badger/v3"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
 	otrace "go.opencensus.io/trace"
 
+	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/algo"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"

--- a/worker/stringfilter.go
+++ b/worker/stringfilter.go
@@ -19,11 +19,12 @@ package worker
 import (
 	"strings"
 
+	"github.com/golang/glog"
+
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/tok"
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
 )
 
 type matchFunc func(types.Val, *stringFilter) bool

--- a/worker/task.go
+++ b/worker/task.go
@@ -24,6 +24,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/golang/protobuf/proto"
+	cindex "github.com/google/codesearch/index"
+	cregexp "github.com/google/codesearch/regexp"
+	"github.com/pkg/errors"
+	otrace "go.opencensus.io/trace"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/algo"
@@ -36,14 +44,6 @@ import (
 	"github.com/dgraph-io/dgraph/types"
 	"github.com/dgraph-io/dgraph/types/facets"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/golang/glog"
-	otrace "go.opencensus.io/trace"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/golang/protobuf/proto"
-	cindex "github.com/google/codesearch/index"
-	cregexp "github.com/google/codesearch/regexp"
-	"github.com/pkg/errors"
 )
 
 func invokeNetworkRequest(ctx context.Context, addr string,

--- a/worker/trigram.go
+++ b/worker/trigram.go
@@ -35,8 +35,8 @@ func uidsForRegex(attr string, arg funcArgs,
 	query *cindex.Query, intersect *pb.List) (*pb.List, error) {
 	var results *pb.List
 	opts := posting.ListOptions{
-		ReadTs: arg.q.ReadTs,
-		First:  int(arg.q.First),
+		ReadTs:   arg.q.ReadTs,
+		First:    int(arg.q.First),
 		AfterUid: arg.q.AfterUid,
 	}
 	if intersect.Size() > 0 {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -26,18 +26,18 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"go.opencensus.io/plugin/ocgrpc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
 	"github.com/dgraph-io/badger/v3"
 	badgerpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	"go.opencensus.io/plugin/ocgrpc"
-
-	"github.com/golang/glog"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
 )
 
 var (

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
-
 	"github.com/dgraph-io/dgraph/posting"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"

--- a/worker/zero_proxy.go
+++ b/worker/zero_proxy.go
@@ -3,11 +3,12 @@ package worker
 import (
 	"context"
 
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 func forwardAssignUidsToZero(ctx context.Context, in *pb.Num) (*pb.AssignedIds, error) {

--- a/x/config.go
+++ b/x/config.go
@@ -21,9 +21,10 @@ import (
 	"net"
 	"time"
 
+	"github.com/spf13/viper"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/spf13/viper"
 )
 
 // Options stores the options for this package.

--- a/x/debug.go
+++ b/x/debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 /*

--- a/x/disk_metrics_linux.go
+++ b/x/disk_metrics_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package x
@@ -9,10 +10,11 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func MonitorDiskMetrics(dirTag string, dir string, lc *z.Closer) {

--- a/x/disk_metrics_others.go
+++ b/x/disk_metrics_others.go
@@ -1,10 +1,12 @@
+//go:build !linux
 // +build !linux
 
 package x
 
 import (
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 func MonitorDiskMetrics(_ string, _ string, lc *z.Closer) {

--- a/x/flags.go
+++ b/x/flags.go
@@ -17,8 +17,9 @@
 package x
 
 import (
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/spf13/pflag"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/x/init.go
+++ b/x/init.go
@@ -25,8 +25,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/x/keys.go
+++ b/x/keys.go
@@ -189,7 +189,8 @@ func TypeKey(attr string) []byte {
 // next byte: data type prefix (set to ByteData)
 // next eight bytes: value of uid
 // next eight bytes (optional): if the key corresponds to a split list, the startUid of
-//   the split stored in this key and the first byte will be sets to ByteSplit.
+//
+//	the split stored in this key and the first byte will be sets to ByteSplit.
 func DataKey(attr string, uid uint64) []byte {
 	prefixLen := 1 + 2 + len(attr)
 	totalLen := prefixLen + 1 + 8
@@ -212,7 +213,8 @@ func DataKey(attr string, uid uint64) []byte {
 // next byte: data type prefix (set to ByteReverse)
 // next eight bytes: value of uid
 // next eight bytes (optional): if the key corresponds to a split list, the startUid of
-//   the split stored in this key.
+//
+//	the split stored in this key.
 func ReverseKey(attr string, uid uint64) []byte {
 	prefixLen := 1 + 2 + len(attr)
 	totalLen := prefixLen + 1 + 8
@@ -235,7 +237,8 @@ func ReverseKey(attr string, uid uint64) []byte {
 // next byte: data type prefix (set to ByteIndex)
 // next len(term) bytes: value of term
 // next eight bytes (optional): if the key corresponds to a split list, the startUid of
-//   the split stored in this key.
+//
+//	the split stored in this key.
 func IndexKey(attr, term string) []byte {
 	prefixLen := 1 + 2 + len(attr)
 	totalLen := prefixLen + 1 + len(term)
@@ -710,9 +713,9 @@ func IsGraphqlReservedPredicate(pred string) bool {
 // actually defined internally or not.
 //
 // As an example, consider below predicates:
-// 	1. dgraph.type (reserved = true,  pre_defined = true )
-// 	2. dgraph.blah (reserved = true,  pre_defined = false)
-// 	3. person.name (reserved = false, pre_defined = false)
+//  1. dgraph.type (reserved = true,  pre_defined = true )
+//  2. dgraph.blah (reserved = true,  pre_defined = false)
+//  3. person.name (reserved = false, pre_defined = false)
 func IsReservedPredicate(pred string) bool {
 	return isReservedName(ParseAttr(pred))
 }

--- a/x/log_writer.go
+++ b/x/log_writer.go
@@ -32,9 +32,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
-
 	"github.com/dgraph-io/badger/v3/y"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 const (

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -33,8 +33,6 @@ import (
 	"contrib.go.opencensus.io/exporter/jaeger"
 	oc_prom "contrib.go.opencensus.io/exporter/prometheus"
 	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
-	"github.com/dgraph-io/badger/v3"
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/dustin/go-humanize"
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -44,6 +42,9 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"go.opencensus.io/trace"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/x/nodebug.go
+++ b/x/nodebug.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 /*
@@ -19,9 +20,8 @@
 package x
 
 import (
-	bpb "github.com/dgraph-io/badger/v3/pb"
-
 	"github.com/dgraph-io/badger/v3"
+	bpb "github.com/dgraph-io/badger/v3/pb"
 	"github.com/dgraph-io/dgraph/protos/pb"
 )
 

--- a/x/server.go
+++ b/x/server.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/golang/glog"
 	"github.com/soheilhy/cmux"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 var (

--- a/x/tls_helper.go
+++ b/x/tls_helper.go
@@ -22,10 +22,11 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/dgraph-io/ristretto/z"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+
+	"github.com/dgraph-io/ristretto/z"
 )
 
 // TLSHelperConfig define params used to create a tls.Config

--- a/x/ulimit_unix.go
+++ b/x/ulimit_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/x/ulimit_windows.go
+++ b/x/ulimit_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/x/x.go
+++ b/x/x.go
@@ -39,8 +39,20 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/dustin/go-humanize"
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"github.com/spf13/viper"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/trace"
+	"golang.org/x/crypto/ssh/terminal"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
+	"google.golang.org/grpc/status"
 
 	"github.com/dgraph-io/badger/v3"
 	bo "github.com/dgraph-io/badger/v3/options"
@@ -49,19 +61,6 @@ import (
 	"github.com/dgraph-io/dgo/v210"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/dustin/go-humanize"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
-	"github.com/spf13/viper"
-	"go.opencensus.io/plugin/ocgrpc"
-	"go.opencensus.io/trace"
-	"golang.org/x/crypto/ssh/terminal"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/encoding/gzip"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 // Error constants representing different types of errors.

--- a/xidmap/xidmap.go
+++ b/xidmap/xidmap.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/dgryski/go-farm"
+	"github.com/golang/glog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 
@@ -35,8 +37,6 @@ import (
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/dgryski/go-farm"
-	"github.com/golang/glog"
 )
 
 var maxLeaseRegex = regexp.MustCompile(`currMax:([0-9]+)`)

--- a/xidmap/xidmap_test.go
+++ b/xidmap/xidmap_test.go
@@ -12,12 +12,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/dgraph-io/badger/v3"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/dgraph/x"
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 )
 
 // Opens a badger db and runs a a test on it.


### PR DESCRIPTION
This is the command I ran at the root of the repo:

```
tree -f -P "*.go" -i | xargs gosimports -d -w -v -local "github.com/dgraph-io"  -
```

This required installing gosimports like this:
```
go install github.com/rinchsan/gosimports/cmd/gosimports@latest
```