### PR TITLE
Add test that after snapshot is applied, GraphQL schema is updated

### DIFF
--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -271,3 +271,24 @@ func DockerInspect(containerID string) (types.ContainerJSON, error) {
 	x.Check(err)
 	return cli.ContainerInspect(context.Background(), containerID)
 }
+
+// checkHealthContainer check health of container and determine wheather container is ready to accept request or not
+func CheckHealthContainer(socketAddrHttp string) error {
+	var err error
+	var resp *http.Response
+	for i := 0; i < 30; i++ {
+		resp, err = http.Get("http://" + socketAddrHttp + "/health")
+		var body []byte
+		if resp != nil && resp.Body != nil {
+			body, _ = ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+		}
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return nil
+		}
+		fmt.Printf("Health for container failed: %v. Response: %q. Retrying...\n", err, body)
+		time.Sleep(time.Second)
+
+	}
+	return err
+}

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -272,21 +272,25 @@ func DockerInspect(containerID string) (types.ContainerJSON, error) {
 	return cli.ContainerInspect(context.Background(), containerID)
 }
 
-// checkHealthContainer check health of container and determine wheather container is ready to accept request or not
+// checkHealthContainer checks health of container and determines wheather container is ready to accept request
 func CheckHealthContainer(socketAddrHttp string) error {
 	var err error
 	var resp *http.Response
+	url := "http://" + socketAddrHttp + "/health"
 	for i := 0; i < 30; i++ {
-		resp, err = http.Get("http://" + socketAddrHttp + "/health")
+		resp, err = http.Get(url)
 		var body []byte
 		if resp != nil && resp.Body != nil {
-			body, _ = ioutil.ReadAll(resp.Body)
+			body, err = ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
 			resp.Body.Close()
 		}
 		if err == nil && resp.StatusCode == http.StatusOK {
 			return nil
 		}
-		fmt.Printf("Health for container failed: %v. Response: %q. Retrying...\n", err, body)
+		fmt.Printf("health check for container failed: %v. Response: %q. Retrying...\n", err, body)
 		time.Sleep(time.Second)
 
 	}

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -279,6 +279,9 @@ func CheckHealthContainer(socketAddrHttp string) error {
 	url := "http://" + socketAddrHttp + "/health"
 	for i := 0; i < 30; i++ {
 		resp, err = http.Get(url)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return nil
+		}
 		var body []byte
 		if resp != nil && resp.Body != nil {
 			body, err = ioutil.ReadAll(resp.Body)
@@ -286,9 +289,6 @@ func CheckHealthContainer(socketAddrHttp string) error {
 				return err
 			}
 			resp.Body.Close()
-		}
-		if err == nil && resp.StatusCode == http.StatusOK {
-			return nil
 		}
 		fmt.Printf("health check for container failed: %v. Response: %q. Retrying...\n", err, body)
 		time.Sleep(time.Second)

--- a/testutil/schema.go
+++ b/testutil/schema.go
@@ -17,8 +17,11 @@
 package testutil
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -132,4 +135,45 @@ func VerifySchema(t *testing.T, dg *dgo.Dgraph, opts SchemaOptions) {
 	require.NoError(t, err)
 
 	CompareJSON(t, GetFullSchemaJSON(opts), string(resp.GetJson()))
+}
+
+func UpdateGQLSchema(t *testing.T, sockAddrHttp, schema string) {
+	query := `mutation updateGQLSchema($sch: String!) {
+		updateGQLSchema(input: { set: { schema: $sch }}) {
+			gqlSchema {
+				schema
+			}
+		}
+	}`
+	adminUrl := "http://" + sockAddrHttp + "/admin"
+
+	params := GraphQLParams{
+		Query: query,
+		Variables: map[string]interface{}{
+			"sch": schema,
+		},
+	}
+	b, err := json.Marshal(params)
+	require.NoError(t, err)
+	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var data interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
+	// return JsonGet(data, "data", "updateGQLSchema", "gqlSchema", "schema").(string)
+}
+
+func GetGQLSchema(t *testing.T, sockAddrHttp string) string {
+	query := `{getGQLSchema {schema}}`
+	params := GraphQLParams{Query: query}
+	b, err := json.Marshal(params)
+	adminUrl := "http://" + sockAddrHttp + "/admin"
+	require.NoError(t, err)
+	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	var data interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
+	fmt.Println("data is ", data)
+	return JsonGet(data, "data", "getGQLSchema", "schema").(string)
 }

--- a/testutil/schema.go
+++ b/testutil/schema.go
@@ -158,9 +158,6 @@ func UpdateGQLSchema(t *testing.T, sockAddrHttp, schema string) {
 	resp, err := http.Post(adminUrl, "application/json", bytes.NewBuffer(b))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	var data interface{}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
-	// return JsonGet(data, "data", "updateGQLSchema", "gqlSchema", "schema").(string)
 }
 
 func GetGQLSchema(t *testing.T, sockAddrHttp string) string {
@@ -174,6 +171,5 @@ func GetGQLSchema(t *testing.T, sockAddrHttp string) string {
 	defer resp.Body.Close()
 	var data interface{}
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&data))
-	fmt.Println("data is ", data)
 	return JsonGet(data, "data", "getGQLSchema", "schema").(string)
 }

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -103,6 +103,7 @@ func TestSnapshot(t *testing.T) {
 		require.NoError(t, err)
 	}
 	const testSchema = "type Person { name: String }"
+	// uploading new schema while alpha2 is not running so we can test whether the stopped alpha gets new schema in snapshot
 	testutil.UpdateGQLSchema(t, testutil.SockAddrHttp, testSchema)
 	_ = waitForSnapshot(t, snapshotTs)
 
@@ -120,7 +121,7 @@ func TestSnapshot(t *testing.T) {
 	}
 	verifySnapshot(t, dg2, 400)
 	resp := testutil.GetGQLSchema(t, testutil.ContainerAddr("alpha2", 8080))
-	//comparing uploaded graphql schema and schema acquired from stopped container
+	// comparing uploaded graphql schema and schema acquired from stopped container
 	require.Equal(t, testSchema, resp)
 }
 

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -83,7 +83,10 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	// Wait for the container to start.
-	time.Sleep(time.Second * 2)
+	err = testutil.CheckHealthContainer(testutil.ContainerAddr("alpha2", 8080))
+	if err != nil {
+		fmt.Print("error while getting alpha container health")
+	}
 	dg2, err := testutil.DgraphClient(testutil.ContainerAddr("alpha2", 9080))
 	if err != nil {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
@@ -107,6 +110,10 @@ func TestSnapshot(t *testing.T) {
 	t.Logf("Starting alpha2.\n")
 	err = testutil.DockerRun("alpha2", testutil.Start)
 	require.NoError(t, err)
+	err = testutil.CheckHealthContainer(testutil.ContainerAddr("alpha2", 8080))
+	if err != nil {
+		fmt.Print("error while getting alpha container health")
+	}
 
 	dg2, err = testutil.DgraphClient(testutil.ContainerAddr("alpha2", 9080))
 	if err != nil {

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/dgraph-io/dgraph/testutil"
 )
 
+const testSchema = "type Person { name: String }"
+
 func TestSnapshot(t *testing.T) {
 	snapshotTs := uint64(0)
 
@@ -99,6 +101,7 @@ func TestSnapshot(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
+	testutil.UpdateGQLSchema(t, testutil.SockAddrHttp, testSchema)
 	_ = waitForSnapshot(t, snapshotTs)
 
 	t.Logf("Starting alpha2.\n")
@@ -110,6 +113,8 @@ func TestSnapshot(t *testing.T) {
 		t.Fatalf("Error while getting a dgraph client: %v", err)
 	}
 	verifySnapshot(t, dg2, 400)
+	resp := testutil.GetGQLSchema(t, testutil.ContainerAddr("alpha2", 8080))
+	require.Equal(t, testSchema, resp)
 }
 
 func verifySnapshot(t *testing.T, dg *dgo.Dgraph, num int) {

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -34,8 +34,6 @@ import (
 	"github.com/dgraph-io/dgraph/testutil"
 )
 
-const testSchema = "type Person { name: String }"
-
 func TestSnapshot(t *testing.T) {
 	snapshotTs := uint64(0)
 
@@ -85,7 +83,7 @@ func TestSnapshot(t *testing.T) {
 	// Wait for the container to start.
 	err = testutil.CheckHealthContainer(testutil.ContainerAddr("alpha2", 8080))
 	if err != nil {
-		fmt.Print("error while getting alpha container health")
+		t.Fatalf("error while getting alpha container health: %v", err)
 	}
 	dg2, err := testutil.DgraphClient(testutil.ContainerAddr("alpha2", 9080))
 	if err != nil {
@@ -104,6 +102,7 @@ func TestSnapshot(t *testing.T) {
 		})
 		require.NoError(t, err)
 	}
+	const testSchema = "type Person { name: String }"
 	testutil.UpdateGQLSchema(t, testutil.SockAddrHttp, testSchema)
 	_ = waitForSnapshot(t, snapshotTs)
 
@@ -112,7 +111,7 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	err = testutil.CheckHealthContainer(testutil.ContainerAddr("alpha2", 8080))
 	if err != nil {
-		fmt.Print("error while getting alpha container health")
+		t.Fatalf("error while getting alpha container health: %v", err)
 	}
 
 	dg2, err = testutil.DgraphClient(testutil.ContainerAddr("alpha2", 9080))

--- a/worker/snapshot_test.go
+++ b/worker/snapshot_test.go
@@ -121,6 +121,7 @@ func TestSnapshot(t *testing.T) {
 	}
 	verifySnapshot(t, dg2, 400)
 	resp := testutil.GetGQLSchema(t, testutil.ContainerAddr("alpha2", 8080))
+	//comparing uploaded graphql schema and schema acquired from stopped container
 	require.Equal(t, testSchema, resp)
 }
 


### PR DESCRIPTION
Tests automated for following scenarios:
- After  snapshot stream is received from other running alpha , check  whether graphql schema is loaded into memory .

Sequence of steps during automation:

- Stop one alpha container 
- Add data into cluster + apply new graphql schema 
- Start alpha container
- Check whether the newly started alpha got graphql schema in snapshot.
