### PR TITLE
fix(proposalKey): Proposal key initialisation with correct byte ordering

### DIFF
--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -93,8 +93,10 @@ func (n *node) initProposalKey(id uint64) error {
 		return err
 	}
 	proposalKey = n.Id<<48 | uint64(binary.BigEndian.Uint32(random4Bytes))<<16
-	// We want to avoid spillage to node id in case of overflow. So by setting 48th bit to
-	// 0 we ensure that we never overflow even if our random bytes are all 1s
+	// We want to avoid spillage to node id in case of overflow. For instance, if the
+	// random bytes end up being [xx,xx, 255, 255, 255, 255, 0 , 0] (xx, xx being the node id)
+	// we would spill to node id after 65535 calls to unique key.
+	// So by setting 48th bit to 0 we ensure that we never spill out to node ids.
 	proposalKey &= ^(uint64(1) << 47)
 	return nil
 }

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -88,6 +89,9 @@ func (n *node) AmLeader() bool {
 func (n *node) initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
 	random4Bytes := make([]byte, 4)
+	if _, err := rand.Read(random4Bytes); err != nil {
+		return err
+	}
 	proposalKey = n.Id<<48 | uint64(binary.BigEndian.Uint32(random4Bytes))<<16
 	return nil
 }

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -18,11 +18,11 @@ package zero
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"log"
 	"math"
-	"math/rand"
 	"sort"
 	"strings"
 	"sync"

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -96,10 +96,6 @@ func (n *node) initProposalKey(id uint64) error {
 	return nil
 }
 
-func (n *node) proposalKey() uint64 {
-	return proposalKey
-}
-
 func (n *node) uniqueKey() uint64 {
 	return atomic.AddUint64(&proposalKey, 1)
 }

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -18,7 +18,6 @@ package zero
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"log"
@@ -88,14 +87,8 @@ func (n *node) AmLeader() bool {
 // {2 bytes Node ID} {4 bytes for random} {2 bytes zero}
 func (n *node) initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
-	b := make([]byte, 8)
-
 	random4Bytes := make([]byte, 4)
-	if _, err := rand.Read(random4Bytes); err != nil {
-		return err
-	}
-	copy(b[4:8], random4Bytes)
-	proposalKey = n.Id<<48 | binary.BigEndian.Uint64(b)<<16
+	proposalKey = n.Id<<48 | uint64(binary.BigEndian.Uint32(random4Bytes))<<16
 	return nil
 }
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -93,6 +93,9 @@ func (n *node) initProposalKey(id uint64) error {
 		return err
 	}
 	proposalKey = n.Id<<48 | uint64(binary.BigEndian.Uint32(random4Bytes))<<16
+	// We want to avoid spillage to node id in case of overflow. So by setting 48th bit to
+	// 0 we ensure that we never overflow even if our random bytes are all 1s
+	proposalKey &= ^(uint64(1) << 47)
 	return nil
 }
 

--- a/dgraph/cmd/zero/raft.go
+++ b/dgraph/cmd/zero/raft.go
@@ -89,11 +89,18 @@ func (n *node) AmLeader() bool {
 func (n *node) initProposalKey(id uint64) error {
 	x.AssertTrue(id != 0)
 	b := make([]byte, 8)
-	if _, err := rand.Read(b); err != nil {
+
+	random4Bytes := make([]byte, 4)
+	if _, err := rand.Read(random4Bytes); err != nil {
 		return err
 	}
+	copy(b[4:8], random4Bytes)
 	proposalKey = n.Id<<48 | binary.BigEndian.Uint64(b)<<16
 	return nil
+}
+
+func (n *node) proposalKey() uint64 {
+	return proposalKey
 }
 
 func (n *node) uniqueKey() uint64 {

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -90,10 +90,6 @@ func TestIdBump(t *testing.T) {
 	require.Contains(t, err.Error(), "Nothing to be leased")
 }
 
-func extractNodeIdFrom(proposalKey uint64) uint64 {
-	return proposalKey >> 48
-}
-
 func TestProposalKey(t *testing.T) {
 	dir, err := ioutil.TempDir("", "test_pk")
 	require.NoError(t, err)
@@ -108,7 +104,8 @@ func TestProposalKey(t *testing.T) {
 	node.initProposalKey(node.Id)
 
 	pkey := proposalKey
-	require.Equal(t, id, extractNodeIdFrom(proposalKey), "id extracted from proposal key is not equal to initial value")
+	nodeIdFromKey := proposalKey >> 48
+	require.Equal(t, id, nodeIdFromKey, "id extracted from proposal key is not equal to initial value")
 
 	node.uniqueKey()
 	require.Equal(t, pkey+1, proposalKey, "proposal key should increment by 1 at each call of unique key")

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -18,14 +18,11 @@ package zero
 
 import (
 	"context"
-	"io/ioutil"
 	"math"
-	"os"
 	"testing"
 
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
-	"github.com/dgraph-io/dgraph/raftwal"
 	"github.com/dgraph-io/dgraph/testutil"
 	"github.com/dgraph-io/ristretto/z"
 
@@ -91,16 +88,9 @@ func TestIdBump(t *testing.T) {
 }
 
 func TestProposalKey(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test_pk")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	store := raftwal.Init(dir)
 
 	id := uint64(2)
-	rc := &pb.RaftContext{Id: id}
-	n := conn.NewNode(rc, store, nil)
-	node := &node{Node: n, ctx: context.Background(), closer: z.NewCloser(1)}
+	node := &node{Node: &conn.Node{Id: id}, ctx: context.Background(), closer: z.NewCloser(1)}
 	node.initProposalKey(node.Id)
 
 	pkey := proposalKey

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -107,16 +107,16 @@ func TestProposalKey(t *testing.T) {
 	node := &node{Node: n, ctx: context.Background(), closer: z.NewCloser(1)}
 	node.initProposalKey(node.Id)
 
-	pkey := node.proposalKey()
-	require.Equal(t, id, extractNodeIdFrom(pkey), "id extracted from proposal key is not equal to initial value")
+	pkey := proposalKey
+	require.Equal(t, id, extractNodeIdFrom(proposalKey), "id extracted from proposal key is not equal to initial value")
 
 	node.uniqueKey()
-	require.Equal(t, pkey+1, node.proposalKey(), "proposal key should increment by 1 at each call of unique key")
+	require.Equal(t, pkey+1, proposalKey, "proposal key should increment by 1 at each call of unique key")
 
 	uniqueKeys := make(map[uint64]struct{})
 	for i := 0; i < 10; i++ {
 		node.uniqueKey()
-		uniqueKeys[node.proposalKey()] = struct{}{}
+		uniqueKeys[proposalKey] = struct{}{}
 	}
 	require.Equal(t, len(uniqueKeys), 10, "each iteration should create unique key")
 }

--- a/dgraph/cmd/zero/zero_test.go
+++ b/dgraph/cmd/zero/zero_test.go
@@ -97,6 +97,9 @@ func TestProposalKey(t *testing.T) {
 	nodeIdFromKey := proposalKey >> 48
 	require.Equal(t, id, nodeIdFromKey, "id extracted from proposal key is not equal to initial value")
 
+	valueOf48thBit := int(pkey & (1 << 48))
+	require.Equal(t, 0, valueOf48thBit, "48th bit is not set to zero on initialisation")
+
 	node.uniqueKey()
 	require.Equal(t, pkey+1, proposalKey, "proposal key should increment by 1 at each call of unique key")
 

--- a/worker/proposal.go
+++ b/worker/proposal.go
@@ -24,15 +24,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pkg/errors"
-	ostats "go.opencensus.io/stats"
-	tag "go.opencensus.io/tag"
-	otrace "go.opencensus.io/trace"
-
 	"github.com/dgraph-io/dgraph/conn"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/schema"
 	"github.com/dgraph-io/dgraph/x"
+
+	"github.com/pkg/errors"
+	ostats "go.opencensus.io/stats"
+	tag "go.opencensus.io/tag"
+	otrace "go.opencensus.io/trace"
 )
 
 const baseTimeout time.Duration = 4 * time.Second


### PR DESCRIPTION
Proposal key initialisation has a bug where we want to reserve first 2 bytes for node id but do not do because  we read random bytes in all 8 bytes and do a logical OR. This PR adds a test case and fixes the logic of initialising the proposal key.