### PR TITLE
fix(mutation): validate mutation before applying it

### DIFF
--- a/dgraph/cmd/alpha/upsert_test.go
+++ b/dgraph/cmd/alpha/upsert_test.go
@@ -2911,3 +2911,55 @@ upsert {
 	_, _, err = queryWithTs(queryInp{body: q2, typ: "application/dql"})
 	require.NoError(t, err)
 }
+
+func TestLargeStringIndex(t *testing.T) {
+	require.NoError(t, dropAll())
+
+	// Exact Index
+	require.NoError(t, alterSchemaWithRetry(`name_exact: string @index(exact) .`))
+	bigval := strings.Repeat("biggest value", 7000)
+	mu := fmt.Sprintf(`{ set { <0x01> <name_exact> "%v" . } }`, bigval)
+	require.Contains(t, runMutation(mu).Error(), "value in the mutation is too large for the index")
+
+	// Term Index
+	require.NoError(t, alterSchemaWithRetry(`name_term: string @index(term) .`))
+	bigval = strings.Repeat("biggestvalue", 7000)
+	mu = fmt.Sprintf(`{ set { <0x01> <name_term> "%v" . } }`, bigval)
+	require.Contains(t, runMutation(mu).Error(), "value in the mutation is too large for the index")
+	// while the value is large, term index is fine
+	bigval = strings.Repeat("biggestvalue", 3000)
+	mu = fmt.Sprintf(`{ set { <0x01> <name_term> "%v %v" . } }`, bigval, bigval)
+	require.NoError(t, runMutation(mu))
+
+	// FullText Index
+	require.NoError(t, alterSchemaWithRetry(`name_fulltext: string @index(fulltext) .`))
+	bigval = strings.Repeat("biggestvalue", 7000)
+	mu = fmt.Sprintf(`{ set { <0x01> <name_fulltext> "%v" . } }`, bigval)
+	require.Contains(t, runMutation(mu).Error(), "value in the mutation is too large for the index")
+	// while the value is large, fulltext index is fine
+	bigval = strings.Repeat("biggestvalue", 3000)
+	mu = fmt.Sprintf(`{ set { <0x01> <name_fulltext> "%v %v" . } }`, bigval, bigval)
+	require.NoError(t, runMutation(mu))
+
+	// Trigram Index
+	require.NoError(t, alterSchemaWithRetry(`name_trigram: string @index(trigram) .`))
+	bigval = strings.Repeat("biggestvalue", 7000)
+	mu = fmt.Sprintf(`{ set { <0x01> <name_trigram> "%v" . } }`, bigval)
+	require.NoError(t, runMutation(mu))
+
+	// Large Predicate
+	bigpred := strings.Repeat("large-predicate", 2000)
+	require.NoError(t, alterSchemaWithRetry(fmt.Sprintf(`%v: string @index(exact) .`, bigpred)))
+	bigval = strings.Repeat("biggestvalue", 3000)
+	mu = fmt.Sprintf(`{ set { <0x01> <%v> "%v" . } }`, bigpred, bigval)
+	require.Contains(t, runMutation(mu).Error(), "value in the mutation is too large for the index")
+
+	// name_term has index term. Now, if we create an exact index, that will fail.
+	// This is because one of the value has small terms but the whole value is bigger
+	// than the limit. In such a case, indexing will fail and the schema should not change.
+	require.NoError(t, alterSchemaWithRetry(`name_term: string @index(exact) .`))
+	dqlSchema, err := runGraphqlQuery(`schema{}`)
+	require.NoError(t, err)
+	require.Contains(t, dqlSchema,
+		`{"predicate":"name_term","type":"string","index":true,"tokenizer":["term"]}`)
+}

--- a/worker/graphql_schema.go
+++ b/worker/graphql_schema.go
@@ -258,6 +258,7 @@ func (w *grpcWorker) UpdateGraphQLSchema(ctx context.Context,
 // WaitForIndexing does a busy wait for indexing to finish or the context to error out,
 // if the input flag shouldWait is true. Otherwise, it just returns nil straight away.
 // If the context errors, it returns that error.
+// TODO(aman): we should return an error if the indexing fails
 func WaitForIndexing(ctx context.Context, shouldWait bool) error {
 	for shouldWait {
 		if ctx.Err() != nil {


### PR DESCRIPTION
This change ensures that the value in the mutation is not too big. The challenge here is that the keys in badger have a limitation on their size (< 2<<16). We need to ensure that no key, either primary or secondary index key is bigger than that.

Fixes https://github.com/dgraph-io/projects/issues/73