### PR TITLE
fix(linter): address gosimple linter reports & errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,11 +19,11 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - errcheck
-    - ineffassign
-    - gas
+    #- errcheck
+    #- ineffassign
+    #- gas
     - gofmt
-    - golint
+    #- golint
     - gosimple
     - govet
     - lll

--- a/dgraph/cmd/bulk/loader.go
+++ b/dgraph/cmd/bulk/loader.go
@@ -404,7 +404,6 @@ func (ld *loader) processGqlSchema(loadType chunker.InputFormat) {
 		}
 		process(ld.opt.Namespace, schemas[ld.opt.Namespace])
 	}
-	return
 }
 
 func (ld *loader) reduceStage() {

--- a/dgraph/cmd/bulk/schema.go
+++ b/dgraph/cmd/bulk/schema.go
@@ -110,7 +110,6 @@ func (s *schemaStore) checkAndSetInitialSchema(namespace uint64) {
 		}
 	}
 	s.namespaces.Store(namespace, struct{}{})
-	return
 }
 
 func (s *schemaStore) validateType(de *pb.DirectedEdge, objectIsUID bool) {

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -365,6 +365,7 @@ func (enc *encoder) setCustom(fj fastJsonNode) {
 	fj.meta |= customBit
 }
 
+//nolint:unused // appendAttrs is used in outputnode_test.go as a helper function
 func (enc *encoder) appendAttrs(fj, child fastJsonNode) {
 	enc.addChildren(fj, child)
 }
@@ -907,7 +908,7 @@ func (enc *encoder) normalize(fj fastJsonNode) ([]fastJsonNode, error) {
 	var shead, curScalar fastJsonNode
 	chead = enc.children(fj)
 	for chead != nil {
-		if enc.children(chead) != nil && enc.getFacetsParent(chead) == false {
+		if enc.children(chead) != nil && !enc.getFacetsParent(chead) {
 			chead = chead.next
 			continue
 		}

--- a/query/query.go
+++ b/query/query.go
@@ -2187,9 +2187,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 					// we end up modifying the first list from the uidMatrix which ends up modifying the srcUids of the next level.
 					// So to avoid that we make a copy.
 					newDestUIDList := &pb.List{Uids: make([]uint64, 0, len(sg.DestUIDs.Uids))}
-					for _, uid := range sg.DestUIDs.GetUids() {
-						newDestUIDList.Uids = append(newDestUIDList.Uids, uid)
-					}
+					newDestUIDList.Uids = append(newDestUIDList.Uids, sg.DestUIDs.GetUids()...)
 					sg.uidMatrix = []*pb.List{newDestUIDList}
 				} else {
 					sg.uidMatrix = []*pb.List{sg.DestUIDs}

--- a/upgrade/upgrade.go
+++ b/upgrade/upgrade.go
@@ -214,10 +214,6 @@ func formatAsFlagParsingError(flag string, err error) error {
 	return fmt.Errorf("error parsing flag `%s`: %w", flag, err)
 }
 
-func formatAsFlagRequiredError(flag string) error {
-	return formatAsFlagParsingError(flag, fmt.Errorf("`%s` is required", flag))
-}
-
 // parseVersionFromString parses a version given as string to internal representation.
 // Some examples for input and output:
 //  1. input : v1.2.2


### PR DESCRIPTION
GoLinter failures: 
- related to https://github.com/dgraph-io/dgraph/pull/8620 & https://github.com/dgraph-io/dgraph/actions/runs/3971511349/jobs/6815792372
- Addressing this partially https://github.com/dgraph-io/dgraph/pull/8572#issuecomment-1401541634 
- fix `gosimple` & `unused` linter reports
- comment the rest to address later 