### PR TITLE
fix(backup): create directory before writing backup

### DIFF
--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -147,6 +147,11 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 	if err != nil {
 		return err
 	}
+	if !handler.DirExists("./") {
+		if err := handler.CreateDir("./"); err != nil {
+			return errors.Wrap(err, "while creating backup directory")
+		}
+	}
 	latestManifest, err := GetLatestManifest(handler, uri)
 	if err != nil {
 		return err

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -62,11 +62,6 @@ const (
 )
 
 func createBackupFile(h UriHandler, uri *url.URL, req *pb.BackupRequest) (io.WriteCloser, error) {
-	if !h.DirExists("./") {
-		if err := h.CreateDir("./"); err != nil {
-			return nil, errors.Wrap(err, "while creating backup file")
-		}
-	}
 	fileName := backupName(req.ReadTs, req.GroupId)
 	dir := fmt.Sprintf(backupPathFmt, req.UnixTs)
 	if err := h.CreateDir(dir); err != nil {

--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -213,13 +213,6 @@ func GetManifest(h UriHandler, uri *url.URL) (*MasterManifest, error) {
 }
 
 func createManifest(h UriHandler, uri *url.URL, manifest *MasterManifest) error {
-	var err error
-	if !h.DirExists("./") {
-		if err := h.CreateDir("./"); err != nil {
-			return errors.Wrap(err, "createManifest failed to create path: ")
-		}
-	}
-
 	w, err := h.CreateFile(tmpManifest)
 	if err != nil {
 		return errors.Wrap(err, "createManifest failed to create tmp path: ")


### PR DESCRIPTION
We used to create the directory while creating a backup if one didn't exist. Slash branch doesn't create one but I think we should continue with the behaviour of creating a directory as was there in main branch.