### PR TITLE
fix(ApolloFederation): '_entity' query now returns correct result for nonexistent entities

### DIFF
--- a/graphql/resolve/query_apollo_federation.go
+++ b/graphql/resolve/query_apollo_federation.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package resolve
 
 import (
@@ -149,9 +165,8 @@ func (resolver *entitiesQueryResolver) complete(result *Resolved) {
 	// have been requested by the client.
 	// If there are any non-unique keys, then the entity should
 	// accordingly be placed multiple times in the result.
-	// If there are any entites which have not been found/returned
-	// by Dgraph, it's essential to add the original representation
-	// in their place.
+	// And if there are any entites which have not been found by
+	// Dgraph, then 'null' should be placed in the resulting list.
 	// Should this not be implemented properly, the Apollo Router
 	// (or equivalent) will end up merging the results incorrectly.
 

--- a/graphql/resolve/query_apollo_federation.go
+++ b/graphql/resolve/query_apollo_federation.go
@@ -1,0 +1,307 @@
+package resolve
+
+import (
+	"context"
+	"encoding/json"
+
+	dgoapi "github.com/dgraph-io/dgo/v210/protos/api"
+	"github.com/dgraph-io/dgraph/dql"
+	"github.com/dgraph-io/dgraph/graphql/schema"
+)
+
+//// Introduction ////
+
+// Separation of concerns. Best-case scenario: This file contains all code
+// related to query resolution in the context of Apollo Federation.
+
+// TODO Add support for multiple `@key` directives on a type (see `schema.Query.RepresentationsArg()`)
+// TODO Add support for different `__typename` arguments in one `_entities` query (see `schema.Query.RepresentationsArg()`)
+// TODO Possibly move `schema.Query.RepresentationsArg()` here? But it's used in `outputnode_graphql.go` as well.
+
+// Unfortunately, I can't just add a new field to the selection set in a
+// `QueryRewriter`. Depending on where you put it, it'll either trigger errors,
+// or just be stripped / ignored in the JSON serialization step during Dgraph
+// query execution.
+// In order to properly fulfill the `_entities` query contract, we need this
+// ability though.
+// Options:
+// A) Adapt code in `wrappers.go` and rewrite the GQL query itself in
+//    `entitiesQueryResolver.rewrite`.
+//    Drawback: We'd make the wrappers even more mutable - is that desirable?
+// B) Wrap `QueryRewriter` and `DgraphExecutor` individually, rewrite query to a
+//    DQL query (as before) and use the executor make sure it gets run in DQL
+//    mode (so that we can actually use the added fields).
+//    Drawback: Might lead to more code duplication, or not work at all, if the
+//    DQL result is too different from what we need.
+//    Benefit: Better encapsulation / self-contained.
+//    Benefit: More in line with the rest of the code.
+//    Benefit: Possibly more efficient because we skip the intermediary rewrite
+// 	  step.
+// Decision Log:
+// * I guess it all comes down to whether option B) will work or not. I'll use
+//   option A as fallback.
+// * First of all, it works :) But the results are too different, and I didn't
+//   find a straightforward way of converting them to GraphQL. What about a
+//   compromise?
+
+//// QueryResolver Implementation ////
+
+type entitiesQueryResolver struct {
+	nested QueryResolver
+}
+
+// NewEntitiesQueryResolver creates a new query resolver for Apollo Federation
+// `_entities` queries. The query resolution strategy is slightly different when
+// compared to normal queries.
+func NewEntitiesQueryResolver(rewriter QueryRewriter, executor DgraphExecutor) QueryResolver {
+	return &entitiesQueryResolver{
+		NewQueryResolver(
+			&entitiesQueryRewriter{rewriter},
+			&entitiesQueryExecutor{executor},
+		),
+	}
+}
+
+func (resolver *entitiesQueryResolver) Resolve(context context.Context, query schema.Query) *Resolved {
+	// In the future we might (correctly) support different `__typename`
+	// arguments in a single `_entities` query. In this case, we would need to
+	// split the query into multiple queries and merge the results.
+
+	// query, err := resolver.rewrite(query)
+	// if err != nil {
+	// 	panic("not implemented yet")
+	// }
+
+	result := resolver.nested.Resolve(context, query)
+
+	// TODO WIP Should also be timed and traced, i.e. run inside the resolver
+	// On the other side, how to proceed if we're going to support multiple
+	// `@key` directives later on?
+	resolver.complete(result)
+
+	return result
+}
+
+// This function was originally called `entitiesQueryCompletion` and was moved
+// here from `resolver.go`.
+// Transforms the result of the `_entities` query. It changes the order of the
+// result to the order of keyField in the `_representations` argument.
+func (resolver *entitiesQueryResolver) complete(result *Resolved) {
+	// return if Data is not present
+	if len(result.Data) == 0 {
+		return
+	}
+	query, ok := result.Field.(schema.Query)
+	if !ok {
+		// this function shouldn't be called for anything other than a query
+		return
+	}
+
+	// Fetch the 'representations' argument from the '_entities' query
+	representationsArg, err := query.RepresentationsArg()
+	if err != nil {
+		result.Err = schema.AppendGQLErrs(result.Err, err)
+		return
+	}
+
+	var data map[string][]interface{}
+	err = schema.Unmarshal(result.Data, &data)
+	if err != nil {
+		result.Err = schema.AppendGQLErrs(result.Err, err)
+		return
+	}
+
+	// Arrange entities (returned by Dgraph) in a map: <key> to <entity>
+
+	entitiesMap := make(map[interface{}]interface{}, len(data["_entities"]))
+
+	for _, entity := range data["_entities"] {
+		entity, ok := entity.(map[string]interface{})
+		if !ok {
+			// TODO WIP Should this ever happen?
+			continue
+		}
+
+		// TODO WIP WIP WIP How to convert DQL results to GraphQL results?
+
+		key := entity["dgraph.entityKey"]
+		entitiesMap[key] = entity
+	}
+
+	// Build a new array with all entities matching the order defined
+	// by the 'representations' argument.
+	// It's essential to return the exact number of elements that
+	// have been requested by the client.
+	// If there are any non-unique keys, then the entity should
+	// accordingly be placed multiple times in the result.
+	// If there are any entites which have not been found/returned
+	// by Dgraph, it's essential to add the original representation
+	// in their place.
+	// Should this not be implemented properly, the Apollo Router
+	// (or equivalent) will end up merging the results incorrectly.
+
+	orderedEntities := make([]interface{}, len(representationsArg.KeyVals))
+
+	for i, key := range representationsArg.KeyVals {
+		// TODO WIP Do we need to convert any keys?
+		orderedEntities[i] = entitiesMap[key]
+
+		// TODO WIP Remove
+		// if !ok {
+		// 	result[i] = representationsArg.
+		// 		KeyValToRepresentation[key.(string)]
+		// }
+	}
+
+	// replace the result obtained from the dgraph and marshal back.
+	data["_entities"] = orderedEntities
+	result.Data, err = json.Marshal(data)
+	if err != nil {
+		result.Err = schema.AppendGQLErrs(result.Err, err)
+	}
+}
+
+//// QueryRewriter Implementation ////
+
+type entitiesQueryRewriter struct {
+	nested QueryRewriter
+}
+
+func (rewriter *entitiesQueryRewriter) Rewrite(context context.Context, query schema.Query) ([]*dql.GraphQuery, error) {
+	if query.QueryType() != schema.EntitiesQuery {
+		panic("Should never happen: entitiesQueryRewriter.Rewrite has been invoked for a query other than schema.EntitiesQuery.")
+	}
+
+	authRw, err := prepareAuthRewriter(context, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return rewriter.rewriteImpl(query, authRw)
+
+	// representationsArg, err := query.RepresentationsArg()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// return rewriter.nested.Rewrite(context, query)
+}
+
+// This function was originally called `entitiesQuery` and was moved here from
+// `query_rewriter.go`.
+// Rewrites the Apollo `_entities` Query which is sent from the federation
+// router to a DQL query. This query is sent to the Dgraph service to resolve
+// types `extended` and defined by this service (in Federation v1 lingo).
+func (rewriter *entitiesQueryRewriter) rewriteImpl(query schema.Query, authRw *authRewriter) ([]*dql.GraphQuery, error) {
+	// Input Argument to the Query is a List of "__typename" and "keyField" pair.
+	// For this type Extension:-
+	// 	extend type Product @key(fields: "upc") {
+	// 		upc: String @external
+	// 		reviews: [Review]
+	// 	}
+	// Input to the Query will be
+	// "_representations": [
+	// 		{
+	// 		  "__typename": "Product",
+	// 	 	 "upc": "B00005N5PF"
+	// 		},
+	// 		...
+	//   ]
+
+	parsedRepr, err := query.RepresentationsArg()
+	if err != nil {
+		return nil, err
+	}
+
+	typeDefn := parsedRepr.TypeDefn
+	rbac := authRw.evaluateStaticRules(typeDefn)
+
+	dgQuery := &dql.GraphQuery{
+		Attr: query.Name(),
+	}
+
+	if rbac == schema.Negative {
+		dgQuery.Attr = dgQuery.Attr + "()"
+		return []*dql.GraphQuery{dgQuery}, nil
+	}
+
+	// Construct Filter at Root Func.
+	// if keyFieldsIsID = true and keyFieldValueList = {"0x1", "0x2"}
+	// then query will be formed as:-
+	// 	_entities(func: uid("0x1", "0x2") {
+	//		...
+	//	}
+	// if keyFieldsIsID = false then query will be like:-
+	// 	_entities(func: eq(keyFieldName,"0x1", "0x2") {
+	//		...
+	//	}
+
+	// If the key field is of ID type and is not an external field
+	// then we query it using the `uid` otherwise we treat it as string
+	// and query using `eq` function.
+	if parsedRepr.KeyField.IsID() && !parsedRepr.KeyField.IsExternal() {
+		addUIDFunc(dgQuery, convertIDs(parsedRepr.KeyVals))
+	} else {
+		addEqFunc(dgQuery, typeDefn.DgraphPredicate(parsedRepr.KeyField.Name()), parsedRepr.KeyVals)
+	}
+
+	// AddTypeFilter in as the Filter to the Root the Query.
+	// Query will be like :-
+	// 	_entities(func: ...) @filter(type(typeName)) {
+	//		...
+	// 	}
+	addTypeFilter(dgQuery, typeDefn)
+
+	selectionAuth := addSelectionSetFrom(dgQuery, query, authRw)
+	addUID(dgQuery)
+
+	// Add the key field back to the selection set - this will be used
+	// by `entitiesQueryCompletion` in 'resolver.go' to rearrange/map
+	// the entities according to the `representations` arg.
+	// Make sure to add any custom fields like this one after the
+	// original selection set, or else it breaks (see
+	// 'query/outputnode_graphql.go').
+	dgQuery.Children = append(dgQuery.Children, &dql.GraphQuery{
+		Attr:  parsedRepr.KeyField.DgraphPredicate(),
+		Alias: "dgraph.entityKey",
+	})
+
+	dgQueries := authRw.addAuthQueries(typeDefn, []*dql.GraphQuery{dgQuery}, rbac)
+	return append(dgQueries, selectionAuth...), nil
+}
+
+//// DgraphExecutor Wrapper ////
+
+type entitiesQueryExecutor struct {
+	nested DgraphExecutor
+}
+
+// Wraps the Executor. Doesn't pass through the `field´ variable, making Dgraph
+// run in DQL mode, so that we can add aditional fields to the query without
+// actually changing the GQL query.
+func (executor *entitiesQueryExecutor) Execute(ctx context.Context, req *dgoapi.Request, field schema.Field) (*dgoapi.Response, error) {
+	return executor.nested.Execute(ctx, req, nil)
+}
+
+func (executor *entitiesQueryExecutor) CommitOrAbort(ctx context.Context, tc *dgoapi.TxnContext) (*dgoapi.TxnContext, error) {
+	panic("Should never happen: entitiesQueryExecutor.CommitOrAbort has been invoked.")
+}
+
+//// Other stuff ////
+
+// TODO Remove. This was considered as a fallback plan - see option "A" in the
+// first few lines of this file.
+// func (resolver *entitiesQueryResolver) rewrite(query schema.Query) (schema.Query, error) {
+// 	entityRepresentations, err := query.RepresentationsArg()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	// Algorithm:
+// 	// * Fetch return type from entityRepresentations and set on query
+// 	// * Use entityRepresentations to map the argument to the corresponding API args
+// 	// * Add the entityRepresentations key arg to the selection set in order to allow mapping later
+// 	// We'd need to add a few abilities to wrappers.go:
+// 	// Change the return type
+// 	// Change the arguments
+// 	// Add new fields to the selection set
+// 	return query, nil
+// }

--- a/graphql/resolve/query_rewriter.go
+++ b/graphql/resolve/query_rewriter.go
@@ -109,11 +109,7 @@ func getAuthSelector(queryType schema.QueryType) func(t schema.Type) *schema.Rul
 	return queryAuthSelector
 }
 
-// Rewrite rewrites a GraphQL query into a Dgraph GraphQuery.
-func (qr *queryRewriter) Rewrite(
-	ctx context.Context,
-	gqlQuery schema.Query) ([]*dql.GraphQuery, error) {
-
+func prepareAuthRewriter(ctx context.Context, gqlQuery schema.Query) (*authRewriter, error) {
 	customClaims, err := gqlQuery.GetAuthMeta().ExtractCustomClaims(ctx)
 	if err != nil {
 		return nil, err
@@ -127,6 +123,19 @@ func (qr *queryRewriter) Rewrite(
 	}
 	authRw.hasAuthRules = hasAuthRules(gqlQuery, authRw)
 	authRw.hasCascade = hasCascadeDirective(gqlQuery)
+
+	return authRw, nil
+}
+
+// Rewrite rewrites a GraphQL query into a Dgraph GraphQuery.
+func (qr *queryRewriter) Rewrite(
+	ctx context.Context,
+	gqlQuery schema.Query) ([]*dql.GraphQuery, error) {
+
+	authRw, err := prepareAuthRewriter(ctx, gqlQuery)
+	if err != nil {
+		return nil, err
+	}
 
 	switch gqlQuery.QueryType() {
 	case schema.GetQuery:
@@ -154,87 +163,9 @@ func (qr *queryRewriter) Rewrite(
 		return passwordQuery(gqlQuery, authRw)
 	case schema.AggregateQuery:
 		return aggregateQuery(gqlQuery, authRw), nil
-	case schema.EntitiesQuery:
-		return entitiesQuery(gqlQuery, authRw)
 	default:
 		return nil, errors.Errorf("unimplemented query type %s", gqlQuery.QueryType())
 	}
-}
-
-// entitiesQuery rewrites the Apollo `_entities` Query which is sent from the Apollo gateway to a DQL query.
-// This query is sent to the Dgraph service to resolve types `extended` and defined by this service.
-func entitiesQuery(field schema.Query, authRw *authRewriter) ([]*dql.GraphQuery, error) {
-
-	// Input Argument to the Query is a List of "__typename" and "keyField" pair.
-	// For this type Extension:-
-	// 	extend type Product @key(fields: "upc") {
-	// 		upc: String @external
-	// 		reviews: [Review]
-	// 	}
-	// Input to the Query will be
-	// "_representations": [
-	// 		{
-	// 		  "__typename": "Product",
-	// 	 	 "upc": "B00005N5PF"
-	// 		},
-	// 		...
-	//   ]
-
-	parsedRepr, err := field.RepresentationsArg()
-	if err != nil {
-		return nil, err
-	}
-
-	typeDefn := parsedRepr.TypeDefn
-	rbac := authRw.evaluateStaticRules(typeDefn)
-
-	dgQuery := &dql.GraphQuery{
-		Attr: field.Name(),
-	}
-
-	if rbac == schema.Negative {
-		dgQuery.Attr = dgQuery.Attr + "()"
-		return []*dql.GraphQuery{dgQuery}, nil
-	}
-
-	// Construct Filter at Root Func.
-	// if keyFieldsIsID = true and keyFieldValueList = {"0x1", "0x2"}
-	// then query will be formed as:-
-	// 	_entities(func: uid("0x1", "0x2") {
-	//		...
-	//	}
-	// if keyFieldsIsID = false then query will be like:-
-	// 	_entities(func: eq(keyFieldName,"0x1", "0x2") {
-	//		...
-	//	}
-
-	// If the key field is of ID type and is not an external field
-	// then we query it using the `uid` otherwise we treat it as string
-	// and query using `eq` function.
-	// We also don't need to add Order to the query as the results are
-	// automatically returned in the ascending order of the uids.
-	if parsedRepr.KeyField.IsID() && !parsedRepr.KeyField.IsExternal() {
-		addUIDFunc(dgQuery, convertIDs(parsedRepr.KeyVals))
-	} else {
-		addEqFunc(dgQuery, typeDefn.DgraphPredicate(parsedRepr.KeyField.Name()), parsedRepr.KeyVals)
-		// Add the  ascending Order of the keyField in the query.
-		// The result will be converted into the exact in the resultCompletion step.
-		dgQuery.Order = append(dgQuery.Order,
-			&pb.Order{Attr: typeDefn.DgraphPredicate(parsedRepr.KeyField.Name())})
-	}
-	// AddTypeFilter in as the Filter to the Root the Query.
-	// Query will be like :-
-	// 	_entities(func: ...) @filter(type(typeName)) {
-	//		...
-	// 	}
-	addTypeFilter(dgQuery, typeDefn)
-
-	selectionAuth := addSelectionSetFrom(dgQuery, field, authRw)
-	addUID(dgQuery)
-
-	dgQueries := authRw.addAuthQueries(typeDefn, []*dql.GraphQuery{dgQuery}, rbac)
-	return append(dgQueries, selectionAuth...), nil
-
 }
 
 func aggregateQuery(query schema.Query, authRw *authRewriter) []*dql.GraphQuery {


### PR DESCRIPTION
## Problem

The previous implementation of the '_entity' query resolver didn't properly follow the [Apollo Federation Subgraph Specification](https://www.apollographql.com/docs/federation/subgraph-spec/) (neither v2, nor v1, for that matter).

In particular, after receiving the intermediate results from the executor, it would:
1. Sort the entity representations, i.e. the query arguments, by their keys in ascending order and discard any duplicates, so as to match the order in which the results are presumably returned by the executor. (However not properly handling hex ids, it seems. See #8120.)
3. Check if we have the same number of results as unique entity representations and abort if not, assuming that the query would lead to an error at the Apollo gateway anyway. This assumption is false.
4. Match the results to their entity representations and generate a properly ordered result list, with duplicates if so requested.

There are few issues with that, but the primary problem that I encountered was with handling entities that don't exist in Dgraph.

As an example, imagine two subgraphs, one being ultimately responsible for storing products, the other one, implemented via Dgraph, storing an additional string field on these products. It's quite possible, and explicitly allowed by the spec, that there could be a product that Dgraph doesn't know about. In this case, Dgraph should be returning a list with null in place of the missing elements.

Since the previous implementation didn't do that and instead would just return a shorter list, the results would be merged wrongly by the Apollo gateway, offset by the missing elements – e.g. the additional field for product A would get merged onto product B. That's quite catastrophic for my application.

This PR also fixes #8120.

## Solution

For context, let me give you a quick overview of how I arrived at the current solution:

First I tried to fix the function by skipping the key sorting step and instead building the result list by creating a hash map of the results by their keys and then iterating over the entity representations argument and mapping them to their respective entities. This seemed to fix all issues.

However, it quickly fell apart when tested with the Apollo gateway, because it doesn't work when the key itself is not included in the selection set, and that's precisely what the gateway does. For example, when requesting a product with id=3, it wouldn't include the id in the selection set again.

The solution then is, of course, rather simple: Just add the entity key itself to the selection set. However, implementing it wasn't as straightforward – that's why there are so many changes.

I also tried cleaning up the code as I was touching it, according to the project contribution guidelines. For example, I started moving all the code relating to Federation queries to a new file.

## Remarks

I implemented these changes about 1-2 months ago, and have been using them so far successfully. Before proceeding with the PR and spending more time on it, I wanted to check with you guys if this is the right direction and if it has any chance of getting merged soon (rebasing took some time today).

There are of course still some tasks left, namely adding regression tests, addressing "TODO WIP" comments and doing some final cleanup.

And lastly, this is my first time working with Golang, so please be lenient :) Feedback would definitely be appreciated!