### PR TITLE
refactor(metrics) record function is not needed as both calls are always made sequentially

### DIFF
--- a/x/metrics.go
+++ b/x/metrics.go
@@ -579,27 +579,15 @@ func RegisterExporters(conf *viper.Viper, service string) {
 func MonitorCacheHealth(db *badger.DB, closer *z.Closer) {
 	defer closer.Done()
 
-	record := func(ct string) {
-		switch ct {
-		case "pstore-block":
-			metrics := db.BlockCacheMetrics()
-			ostats.Record(context.Background(), PBlockHitRatio.M(metrics.Ratio()))
-		case "pstore-index":
-			metrics := db.IndexCacheMetrics()
-			ostats.Record(context.Background(), PIndexHitRatio.M(metrics.Ratio()))
-		default:
-			panic("invalid cache type")
-		}
-	}
-
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
+	backgroundContext := context.Background()
 
 	for {
 		select {
 		case <-ticker.C:
-			record("pstore-block")
-			record("pstore-index")
+			ostats.Record(backgroundContext, PBlockHitRatio.M(db.BlockCacheMetrics().Ratio()))
+			ostats.Record(backgroundContext, PIndexHitRatio.M(db.IndexCacheMetrics().Ratio()))
 		case <-closer.HasBeenClosed():
 			return
 		}


### PR DESCRIPTION
 ## Problem
MonitorCacheHealth uses an internal function to record metrics. 2 calls are done always sequentially to this method. It always handles a case where the wrong type is used but that would never happen.
 
## Solution
Get rid of that function and inline both calls sequentially