### PR TITLE
fix(build): Update dockerfile to use cache busting and reduce image size

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,15 +13,19 @@ LABEL maintainer="Dgraph Labs <contact@dgraph.io>"
 RUN rm -rf /var/lib/apt/lists/*
 
 # only update, don't run upgrade
-RUN apt-get update
-# pin package versions always & bring in CVE fixes as needed
-RUN apt-get install -y --no-install-recommends ca-certificates
-RUN apt-get install -y --no-install-recommends curl
-RUN apt-get install -y --no-install-recommends htop
-RUN apt-get install -y --no-install-recommends iputils-ping
-RUN apt-get install -y --no-install-recommends jq
-RUN apt-get install -y --no-install-recommends less
-RUN apt-get install -y --no-install-recommends sysstat
+# use cache busting to avoid old versions
+# remove /var/lib/apt/lists/* to reduce image size. 
+# see: https://docs.docker.com/develop/develop-images/dockerfile_best-practices 
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    htop \
+    curl \
+    htop \
+    iputils-ping \
+    jq \
+    less \
+    sysstat \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD linux /usr/local/bin
 


### PR DESCRIPTION
This PR fixes issue in building docker-images during CI and releases. It uses cache busting to ensure `apt-get update` is always run. It also reduces the image size by removing `/var/lib/apt/lists`

See: `RUN` in https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

