### PR TITLE
chore(deps): update badger dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.2103.6-0.20230206174300-f35dd0f0c98c
+	github.com/dgraph-io/badger/v3 v3.2103.6-0.20230209075919-3045f88d615c
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger/v3 v3.2103.6-0.20230206174300-f35dd0f0c98c h1:r/szX2ayiqpRXyvfwUDBKAAtkDAY9pgMka8fLb5i1gw=
 github.com/dgraph-io/badger/v3 v3.2103.6-0.20230206174300-f35dd0f0c98c/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
+github.com/dgraph-io/badger/v3 v3.2103.6-0.20230209075919-3045f88d615c h1:CxDBAdDBThd0cOT9xboEzbKQ0s5b3RxQnXSL0/O8BqQ=
+github.com/dgraph-io/badger/v3 v3.2103.6-0.20230209075919-3045f88d615c/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987 h1:5aN6H88a2q3HkO8vSZxDlgjEpJf4Fz8rfy+/Wzx2uAc=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=


### PR DESCRIPTION
Previous PR #8654 was a SHA not located on the new Badger release branch.  We use the latest SHA on `release/v4.0`.