### PR TITLE
fix(parser): Check order of inputs before evaluating nested eq func

### DIFF
--- a/dql/parser.go
+++ b/dql/parser.go
@@ -1721,8 +1721,15 @@ L:
 							itemInFunc.Errorf("len function only allowed inside inequality" +
 								" function")
 					}
-					function.Attr = nestedFunc.NeedsVar[0].Name
-					function.IsLenVar = true
+					if len(function.Attr) == 0 {
+						// eq(len(a), 1)
+						function.Attr = nestedFunc.NeedsVar[0].Name
+						function.IsLenVar = true
+					} else {
+						// eq(1, len(a))
+						return nil, itemInFunc.Errorf("incorrect order of value and len" +
+							" try eq(len(), val)")
+					}
 					function.NeedsVar = append(function.NeedsVar, nestedFunc.NeedsVar...)
 				case countFunc:
 					function.Attr = nestedFunc.Attr

--- a/dql/parser.go
+++ b/dql/parser.go
@@ -1727,8 +1727,7 @@ L:
 						function.IsLenVar = true
 					} else {
 						// eq(1, len(a))
-						return nil, itemInFunc.Errorf("incorrect order of value and len" +
-							" try eq(len(), val)")
+						return nil, itemInFunc.Errorf("incorrect order of value and nested function")
 					}
 					function.NeedsVar = append(function.NeedsVar, nestedFunc.NeedsVar...)
 				case countFunc:

--- a/dql/parser.go
+++ b/dql/parser.go
@@ -1727,7 +1727,7 @@ L:
 						function.IsLenVar = true
 					} else {
 						// eq(1, len(a))
-						return nil, itemInFunc.Errorf("incorrect order of value and nested function")
+						return nil, itemInFunc.Errorf("incorrect order, the first argument should be len function")
 					}
 					function.NeedsVar = append(function.NeedsVar, nestedFunc.NeedsVar...)
 				case countFunc:

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -5358,6 +5358,7 @@ func TestFilterWithEqAndLenInWrongOrderArgs(t *testing.T) {
 		Str: query,
 	})
 	require.Error(t, err)
+	require.Contains(t, err.Error(), "incorrect order of value and nested function")
 }
 
 func TestFilterWithVar(t *testing.T) {

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -5358,7 +5358,7 @@ func TestFilterWithEqAndLenInWrongOrderArgs(t *testing.T) {
 		Str: query,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "incorrect order of value and nested function")
+	require.Contains(t, err.Error(), "incorrect order, the first argument should be len function")
 }
 
 func TestFilterWithVar(t *testing.T) {

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -5343,6 +5343,23 @@ func TestFilterWithDollarError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestFilterWithEqAndLenInWrongOrderArgs(t *testing.T) {
+	query := `
+	{
+		var(func: has(school), first: 3) {
+			f as uid
+		}
+
+		me(func: uid(f)) @filter(eq(3, len(f))) {
+			count(uid)
+		}
+	}`
+	_, err := Parse(Request{
+		Str: query,
+	})
+	require.Error(t, err)
+}
+
 func TestFilterWithVar(t *testing.T) {
 	query := `query data($a: string = "dgraph")
 	{


### PR DESCRIPTION
This PR adds a check while evaluating order of arguments passed to eq function. This prevents `eq(val, len())`, and suggests the reverse order as a valid query.

Fixes: https://github.com/dgraph-io/dgraph/issues/8637