### PR TITLE
chore(ci): run CI jobs on release branches

### DIFF
--- a/.github/workflows/ci-aqua-security-trivy-tests.yml
+++ b/.github/workflows/ci-aqua-security-trivy-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 * * * *"
 jobs:

--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 0 * * *" # 1-run per day
 jobs:

--- a/.github/workflows/ci-dgraph-ldbc-tests.yml
+++ b/.github/workflows/ci-dgraph-ldbc-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 0 * * *" # 1-run per day
 jobs:

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 0,12 * * *" # 2-runs per day
 jobs:

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 0,12 * * *" # 2-runs per day
 jobs:

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 0,12 * * *" # 2-runs per day
 jobs:

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
   pull_request:
     types:
       - opened
@@ -11,6 +12,7 @@ on:
       - ready_for_review
     branches:
       - main
+      - 'release/**'
   schedule:
     - cron: "0 * * * *"
 jobs:


### PR DESCRIPTION
Currently we only run CI on our main branch.  We would like to run CI when changes are being considered on the release branches.