### PR TITLE
fix(slash): update badger dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Shopify/sarama v1.27.2
 	github.com/blevesearch/bleve v1.0.13
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
-	github.com/dgraph-io/badger/v3 v3.0.0-20210924144023-7677fcb1e0c2
+	github.com/dgraph-io/badger/v3 v3.0.0-20211108050342-6ed45ae41e5a
 	github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987
 	github.com/dgraph-io/gqlgen v0.13.2
 	github.com/dgraph-io/gqlparser/v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/dgraph-io/badger v1.6.0 h1:DshxFxZWXUcO0xX476VJC07Xsr6ZCBVRHKZ93Oh7Ev
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger/v3 v3.0.0-20210924144023-7677fcb1e0c2 h1:xVtqMIdhJV6Tu2LrymuqRVgzFMTen+cCfs4A3AunmMc=
 github.com/dgraph-io/badger/v3 v3.0.0-20210924144023-7677fcb1e0c2/go.mod h1:RHo4/GmYcKKh5Lxu63wLEMHJ70Pac2JqZRYGhlyAo2M=
+github.com/dgraph-io/badger/v3 v3.0.0-20211108050342-6ed45ae41e5a h1:O3ZghoxBczESRVgHy/UU0sy0fgSFW0QfBSYtfnTuw+Y=
+github.com/dgraph-io/badger/v3 v3.0.0-20211108050342-6ed45ae41e5a/go.mod h1:RHo4/GmYcKKh5Lxu63wLEMHJ70Pac2JqZRYGhlyAo2M=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987 h1:5aN6H88a2q3HkO8vSZxDlgjEpJf4Fz8rfy+/Wzx2uAc=
 github.com/dgraph-io/dgo/v210 v210.0.0-20210407152819-261d1c2a6987/go.mod h1:dCzdThGGTPYOAuNtrM6BiXj/86voHn7ZzkPL6noXR3s=
 github.com/dgraph-io/gqlgen v0.13.2 h1:TNhndk+eHKj5qE7BenKKSYdSIdOGhLqxR1rCiMso9KM=

--- a/graphql/e2e/custom_logic/cmd/Dockerfile
+++ b/graphql/e2e/custom_logic/cmd/Dockerfile
@@ -5,9 +5,12 @@ COPY . .
 
 RUN apk update && apk add git && apk add nodejs && apk add npm
 
-RUN go install gopkg.in/yaml.v2@latest
+# As of Go 1.16 modules are on by default
+RUN go env -w GO111MODULE=auto
 
-RUN go install github.com/graph-gophers/graphql-go@latest
+RUN go get gopkg.in/yaml.v2
+
+RUN go get github.com/graph-gophers/graphql-go
 
 RUN npm install
 

--- a/graphql/e2e/custom_logic/cmd/Dockerfile
+++ b/graphql/e2e/custom_logic/cmd/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM golang:1.14.2-alpine3.11
+FROM golang:1.19-alpine3.17
 
 COPY . .
 

--- a/graphql/e2e/custom_logic/cmd/Dockerfile
+++ b/graphql/e2e/custom_logic/cmd/Dockerfile
@@ -5,7 +5,8 @@ COPY . .
 
 RUN apk update && apk add git && apk add nodejs && apk add npm
 
-# As of Go 1.16 modules are on by default
+# As of Go 1.16 modules are always on by default
+# See https://go.dev/blog/go116-module-changes
 RUN go env -w GO111MODULE=auto
 
 RUN go get gopkg.in/yaml.v2

--- a/graphql/e2e/custom_logic/cmd/Dockerfile
+++ b/graphql/e2e/custom_logic/cmd/Dockerfile
@@ -5,9 +5,9 @@ COPY . .
 
 RUN apk update && apk add git && apk add nodejs && apk add npm
 
-RUN go get gopkg.in/yaml.v2
+RUN go install gopkg.in/yaml.v2@latest
 
-RUN go get github.com/graph-gophers/graphql-go
+RUN go install github.com/graph-gophers/graphql-go@latest
 
 RUN npm install
 


### PR DESCRIPTION
Update Badger from `7677fcb` to `6ed45ae` (on main-deprecated branch).  This fixes https://github.com/dgraph-io/badger/pull/1752 and https://github.com/dgraph-io/badger/pull/1756.

First CI failed [here](https://github.com/dgraph-io/dgraph/actions/runs/4208376321/jobs/7304322951).  This issue was resolved by bumping up the Go version used in the container.