### PR TITLE
feat(upgrade): introduce basic upgrade test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /build
 /installs
+/t/bin
+/linux
 /coverage.out
 /dgraph-bulk-loader
 /osx-docker-gopath

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,14 @@ test: docker-image
 	@mv dgraph/dgraph ${GOPATH}/bin/dgraph
 	@$(MAKE) -C t test
 
+test-upgrade: docker-image
+	@echo "Loading LDBC data using dgraph.old..."
+	@cp t/bin/dgraph.old ${GOPATH}/bin/dgraph
+	@$(MAKE) -C t test args="--suite=ldbc --ldbcLoadOnly=true"
+	@echo "Querying LDBC data using dgraph.new..."
+	@cp t/bin/dgraph.new ${GOPATH}/bin/dgraph
+	@$(MAKE) -C t test args="--suite=ldbc --ldbcQueryOnly=true --download=false"
+
 image-local local-image:
 	@GOOS=linux GOARCH=amd64 $(MAKE) dgraph
 	@mkdir -p linux

--- a/t/t.go
+++ b/t/t.go
@@ -96,7 +96,9 @@ var (
 	skip = pflag.String("skip", "",
 		"comma separated list of packages that needs to be skipped. "+
 			"Package Check uses string.Contains(). Please check the flag carefully")
-	runCoverage = pflag.Bool("coverage", false, "Set true to calculate test coverage")
+	runCoverage   = pflag.Bool("coverage", false, "Set true to calculate test coverage")
+	ldbcLoadOnly  = pflag.Bool("ldbcLoadOnly", false, "Set true to run only bulkloader of ldbc suite")
+	ldbcQueryOnly = pflag.Bool("ldbcQueryOnly", false, "Set true to run only queries of ldbc suite")
 )
 
 func commandWithContext(ctx context.Context, args ...string) *exec.Cmd {
@@ -110,6 +112,16 @@ func commandWithContext(ctx context.Context, args ...string) *exec.Cmd {
 	if runtime.GOARCH == "arm64" {
 		cmd.Env = append(cmd.Env, "MINIO_IMAGE_ARCH=RELEASE.2020-11-13T20-10-18Z-arm64")
 		cmd.Env = append(cmd.Env, "NFS_SERVER_IMAGE_ARCH=11-arm")
+	}
+	if *ldbcLoadOnly {
+		cmd.Env = append(cmd.Env, "LDBC_BULK_LOAD_ONLY=true")
+	} else {
+		cmd.Env = append(cmd.Env, "LDBC_BULK_LOAD_ONLY=false")
+	}
+	if *ldbcQueryOnly {
+		cmd.Env = append(cmd.Env, "LDBC_QUERY_ONLY=true")
+	} else {
+		cmd.Env = append(cmd.Env, "LDBC_QUERY_ONLY=false")
 	}
 
 	return cmd


### PR DESCRIPTION
Use existing LDBC test suite to run a basic upgrade test.  E.g.

```
./t --suite=ldbc --ldbcLoadOnly=true
./t --suite=ldbc --ldbcQueryOnly=true --download=false
```

will essentially split LDBC test suite into two steps.  Firstly we run Bulkloader on LDBC data.  Secondly we run queries against this data.  

This allows us to test upgrade paths.  E.g. use bulkloader with Dgraph v21.03, then query data using Dgraph v22.00.  To do this we have added a new Makefile target `make test-upgrade`.  This target looks for the directory `t/bin` and expects to see two binaries, `dgraph.old` and `dgraph.new`.  The bulkloader will run using the old binary, and the queries will be run using the new binary.  This provides us one check of data incompatibility.

Note that this target does not compile any binaries.  We expect this target to be incorporated as part of a larger upgrade script, which will take responsibility for compiling the base dgraph binary and target dgraph binary.