### PR TITLE
chore(cd): make latest tag release configurable

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -1,5 +1,10 @@
 name: cd-dgraph
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      latest:
+        type: boolean
+        description: Release latest tag on Dockerhub
 jobs:
   dgraph-build-amd64:
     runs-on: ubuntu-20.04
@@ -67,10 +72,11 @@ jobs:
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
           docker tag dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/dgraph:latest-amd64
+          inputs.
       - name: Make Dgraph Standalone Docker Image with Version
         run: |
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
-          docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/standalone:latest-amd64
+          [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 dgraph/standalone:latest-amd64 || true
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -150,7 +156,7 @@ jobs:
       - name: Make Dgraph Standalone Docker Image with Version
         run: |
           make docker-image-standalone DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-          docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/standalone:latest-arm64
+          [[ "${{ inputs.latest }}" = true ]] && docker tag dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 dgraph/standalone:latest-arm64 || true
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
@@ -190,10 +196,10 @@ jobs:
           # standalone
           docker manifest create dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }} --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           docker manifest push dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}
-          docker manifest create dgraph/standalone:latest --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-          docker manifest push dgraph/standalone:latest
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest create dgraph/standalone:latest --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/standalone:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest push dgraph/standalone:latest || true
           # dgraph
           docker manifest create dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }} --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
           docker manifest push dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}
-          docker manifest create dgraph/dgraph:latest --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64
-          docker manifest push dgraph/dgraph:latest
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest create dgraph/dgraph:latest --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-amd64 --amend dgraph/dgraph:${{ env.DGRAPH_RELEASE_VERSION }}-arm64 || true
+          [[ "${{ inputs.latest }}" = true ]] && docker manifest push dgraph/dgraph:latest || true


### PR DESCRIPTION
Previously our CD workflow would push out a docker image with the latest tag by default.  This is now configurable upon invoking CD workflow.