### PR TITLE
`chore`: Integration test for acl to nonacl backup/restore and vice versa

### DIFF
--- a/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
@@ -27,7 +27,8 @@ func TestNonAclToAclBackupRestore(t *testing.T) {
 	BackupRestore(t, "", jwtTokenAlpha3, headerAlpha3, "alpha4", "alpha3")
 }
 
-func BackupRestore(t *testing.T, jwtTokenBackupAlpha string, jwtTokenRestoreAlpha string, header http.Header, backupAlpha string, restoreAlpha string) { //nolint:lll
+func BackupRestore(t *testing.T, jwtTokenBackupAlpha string, jwtTokenRestoreAlpha string,
+	header http.Header, backupAlpha string, restoreAlpha string) {
 
 	utilsCommon.AddItemSchema(t, header, backupAlpha)
 	e2eCommon.AssertGetGQLSchema(t, testutil.ContainerAddr(backupAlpha, 8080), header)

--- a/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/backup_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	e2eCommon "github.com/dgraph-io/dgraph/graphql/e2e/common"
+	utilsCommon "github.com/dgraph-io/dgraph/systest/backup/common"
+	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
+)
+
+const (
+	restoreLocation = "/data/backups/"
+	backupDst       = "/data/backups/"
+)
+
+func TestAclToNonAclBackupRestore(t *testing.T) {
+	t.Logf("acl(backup cluster) to non-Acl(restore cluster) Test")
+	jwtTokenAlpha1, headerAlpha1 := utilsCommon.GetJwtTokenAndHeader(t, "alpha1", 0)
+	BackupRestore(t, jwtTokenAlpha1, "", headerAlpha1, "alpha1", "alpha2")
+}
+
+func TestNonAclToAclBackupRestore(t *testing.T) {
+	t.Logf("non-acl(backup cluster) to acl(restore cluster) Test")
+	jwtTokenAlpha3, headerAlpha3 := utilsCommon.GetJwtTokenAndHeader(t, "alpha3", 0)
+	BackupRestore(t, "", jwtTokenAlpha3, headerAlpha3, "alpha4", "alpha3")
+}
+
+func BackupRestore(t *testing.T, jwtTokenBackupAlpha string, jwtTokenRestoreAlpha string, header http.Header, backupAlpha string, restoreAlpha string) { //nolint:lll
+
+	utilsCommon.AddItemSchema(t, header, backupAlpha)
+	e2eCommon.AssertGetGQLSchema(t, testutil.ContainerAddr(backupAlpha, 8080), header)
+	utilsCommon.AddItem(t, 1, 10, jwtTokenBackupAlpha, backupAlpha)
+	utilsCommon.CheckItemExists(t, 5, jwtTokenBackupAlpha, backupAlpha)
+	utilsCommon.TakeBackup(t, jwtTokenBackupAlpha, backupDst, backupAlpha)
+	utilsCommon.RunRestore(t, jwtTokenRestoreAlpha, restoreLocation, restoreAlpha)
+	dg := testutil.DgClientWithLogin(t, "groot", "password", x.GalaxyNamespace)
+	testutil.WaitForRestore(t, dg, testutil.ContainerAddr(restoreAlpha, 8080))
+	utilsCommon.CheckItemExists(t, 5, jwtTokenRestoreAlpha, restoreAlpha)
+}

--- a/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
@@ -1,0 +1,159 @@
+# Auto-generated with: [./compose -a 3 -z 1 -r 1 -w --port_offset=0 --expose_ports=false --alpha_volume=./data/backups:/data/backups/ --zero_volume=./data/backups:/data/backups/ --mem= --names=false -O ../systest/backup/multi-tenancy/docker-compose.yml --acl]
+#
+version: "3.5"
+services:
+#For acl to non-acl
+  # acl setup
+  alpha1:
+    image: dgraph/dgraph:local
+    working_dir: /data/alpha1
+    depends_on:
+      - zero1
+    labels:
+      cluster: test
+    ports:
+    - 8080
+    - 9080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - type: bind
+      source: ../../../acl/restore/acl-secret
+      target: /secret/hmac
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080
+      --logtostderr -v=2 --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --acl "secret-file=/secret/hmac;"
+  
+  zero1:
+    image: dgraph/dgraph:local
+    working_dir: /data/zero1
+    labels:
+      cluster: test
+    ports:
+    - 5080
+    - 6080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall
+
+  # non-acl setup
+  alpha2:
+    image: dgraph/dgraph:local
+    working_dir: /data/alpha2
+    depends_on:
+      - zero2
+    labels:
+      cluster: test
+    ports:
+    - 8080
+    - 9080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero2:5080 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+  
+  zero2:
+    image: dgraph/dgraph:local
+    working_dir: /data/zero2
+    labels:
+      cluster: test
+    ports:
+    - 5080
+    - 6080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero2:5080 --logtostderr -v=2 --bindall
+
+#For non-acl to acl
+  # acl setup
+  alpha3:
+    image: dgraph/dgraph:local
+    working_dir: /data/alpha3
+    depends_on:
+      - zero3
+    labels:
+      cluster: test
+    ports:
+    - 8080
+    - 9080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - type: bind
+      source: ../../../acl/restore/acl-secret
+      target: /secret/hmac
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero3:5080
+      --logtostderr -v=2 --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+      --acl "secret-file=/secret/hmac;"
+  
+  zero3:
+    image: dgraph/dgraph:local
+    working_dir: /data/zero3
+    labels:
+      cluster: test
+    ports:
+    - 5080
+    - 6080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero3:5080 --logtostderr -v=2 --bindall
+
+  # non-acl setup
+  alpha4:
+    image: dgraph/dgraph:local
+    working_dir: /data/alpha4
+    depends_on:
+      - zero4
+    labels:
+      cluster: test
+    ports:
+    - 8080
+    - 9080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha4:7080 --zero=zero4:5080 --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
+  
+  zero4:
+    image: dgraph/dgraph:local
+    working_dir: /data/zero4
+    labels:
+      cluster: test
+    ports:
+    - 5080
+    - 6080
+    volumes:
+    - type: bind
+      source: $GOPATH/bin
+      target: /gobin
+      read_only: true
+    - data-volume:/data/backups/
+    command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4:5080 --logtostderr -v=2 --bindall
+volumes:
+  data-volume:


### PR DESCRIPTION
This PR contains an Integration test for acl to nonacl backup/restore and vice versa

This test follows the following flow:

- Take a backup from acl enabled cluster and restore on non-acl cluster.
- Take a backup from non-acl cluster and restore on acl cluster.