### PR TITLE
fix(ci) increase frequency

### DIFF
--- a/.github/workflows/ci-dgraph-code-coverage.yml
+++ b/.github/workflows/ci-dgraph-code-coverage.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0 * * *" # 1-run per day
+    - cron: "0 */2 * * *" # every 2hrs
 jobs:
   dgraph-code-coverage:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-load-tests.yml
+++ b/.github/workflows/ci-dgraph-load-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,12 * * *" # 2-runs per day
+    - cron: "0 */2 * * *" # every 2hrs
 jobs:
   dgraph-load-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests-arm64.yml
+++ b/.github/workflows/ci-dgraph-tests-arm64.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,12 * * *" # 2-runs per day
+    - cron: "0 */2 * * *" # every 2hrs
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-dgraph-tests.yml
+++ b/.github/workflows/ci-dgraph-tests.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 0,12 * * *" # 2-runs per day
+    - cron: "0 */2 * * *" # every 2hrs
 jobs:
   dgraph-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/ci-golang-lint.yml
+++ b/.github/workflows/ci-golang-lint.yml
@@ -14,7 +14,7 @@ on:
       - main
       - 'release/**'
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 */2 * * *" # every 2hrs
 jobs:
   golang-lint:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
## Problem
Need more test runs because we are closing in on our next release

## Solution
Increase frequency for critical CI runs to happen every 2hrs
This will increase our CI spends, but it's better we keep this running for a few days to detect any failures.

**note** 
- we are doing this because we noticed some flaky failures in our tests on `main` (*`scheduled runs`*)
- the last change was on jan-6  https://github.com/dgraph-io/dgraph/pull/8592, where we reduced the frequency because of a stable baseline