### PR TITLE
fix(makefile): fix dgraph version pinning inside container

### DIFF
--- a/dgraph/Makefile
+++ b/dgraph/Makefile
@@ -25,7 +25,7 @@ BUILD_VERSION  ?= $(shell git describe --always --tags)
 # check if DGRAPH_VERSION flag is set (used for release pipeline)
 ifneq ($(DGRAPH_VERSION),)
 # remove arch suffix from DGRAPH_VERSION for CD steps only
-BUILD_VERSION := $(shell echo ${DGRAPH_VERSION} | cut -d "-" -f 1)
+BUILD_VERSION := $(shell echo ${DGRAPH_VERSION} | sed -e 's/-amd64//' -e 's/-arm64//')
 endif
 
 GOOS          ?= $(shell go env GOOS)


### PR DESCRIPTION
## Problem
current docker dgraph does not have the right version
for ex. v23.0.0-beta-arm64 -> v23.0.0

what we want 
 v23.0.0-beta-arm64 -> v23.0.0-beta

## Solution
use sed & make necessary fixes in makefile