### PR TITLE
fix(changelog): update release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project will adhere to [Semantic Versioning](https://semver.org) starting `v22.0.0`.
 
-## [v23.0.0-beta] - 2023-03-01
-[v23.0.0-beta]: https://github.com/dgraph-io/dgraph/compare/v23.0.0-beta...v22.0.2
+## [v23.0.0-beta1] - 2023-03-01
+[v23.0.0-beta1]: https://github.com/dgraph-io/dgraph/compare/v23.0.0-beta1...v22.0.2
 
 ### Added
 


### PR DESCRIPTION
## Problem
Follow Strict SerVer for Beta / RC & GA

## Solution
https://commons.apache.org/releases/versioning.html

Beta Release Numbers
Beta releases are denoted by adding "beta<beta version number>" after the release number. For example, if the current release version is 2.0.4, and a developer wished to preview the next major release, the release would be labeled 3.0-beta1.