### PR TITLE
chore(logging): add jaeger tag handler for queries and mutations

### DIFF
--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -1313,7 +1313,7 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (resp *api.Response,
 		if !isQuery {
 			m = req.req.String()
 		}
-		if strings.Contains(m, "#") {
+		if strings.Contains(m, "#tag") {
 			q := isQuery
 			validateComment(span, m, q)
 		}
@@ -1328,6 +1328,9 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (resp *api.Response,
 				"Non guardian of galaxy user cannot bypass namespaces. "+s.Message())
 		}
 	}
+
+	// extras tags for tracing
+	span.AddAttributes(otrace.BoolAttribute("isGraphQL", isGraphQL))
 
 	qc := &queryContext{
 		req:      req.req,

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -548,7 +548,7 @@ func annotateNamespace(span *otrace.Span, ns uint64) {
 	span.AddAttributes(otrace.Int64Attribute("ns", int64(ns)))
 }
 func validateComment(span *otrace.Span, Query string, q bool) {
-	// grab with regex the comment from the query. That starts with # and ends with dot
+	// grab with regex the comment from the query.
 	re := regexp.MustCompile(`(?m)#tag:(\w+)`)
 	querytag := re.FindStringSubmatch(Query)
 	if len(querytag) > 1 {
@@ -1313,7 +1313,6 @@ func (s *Server) doQuery(ctx context.Context, req *Request) (resp *api.Response,
 		if !isQuery {
 			m = req.req.String()
 		}
-		print(strings.Contains(m, "#"))
 		if strings.Contains(m, "#") {
 			q := isQuery
 			validateComment(span, m, q)

--- a/edgraph/server.go
+++ b/edgraph/server.go
@@ -552,10 +552,10 @@ func validateComment(span *otrace.Span, Query string, q bool) {
 	re := regexp.MustCompile(`(?m)#tag:(\w+)`)
 	querytag := re.FindStringSubmatch(Query)
 	if len(querytag) > 1 {
-		switch {
-		case !q:
+		switch q {
+		case false:
 			span.AddAttributes(otrace.StringAttribute("mutation.tag", querytag[1]))
-		case q:
+		case true:
 			span.AddAttributes(otrace.StringAttribute("query.tag", querytag[1]))
 		}
 	}

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -274,7 +274,7 @@ type Speaker {
 }
 
 type JaegerTest {
-	name
+	_name
 	<#tag:test>
 }
 
@@ -352,6 +352,7 @@ tweet-d                        : string @index(trigram) .
 name2                          : string @index(term)  .
 age2                           : int @index(int) .
 <#tag:test>                    : string .
+_name                          : string @index(term)  .
 `
 
 func populateCluster() {
@@ -882,13 +883,13 @@ func populateCluster() {
 		# Data for testing Tags in comments.
 
 		<300> <#tag:test> "Bob" .
-		<301> <name> "#tag:test" .
-		<302> <name> "#tag" .
-		<303> <name> "#tag:" .
-		<304> <name> "#test" .
-		<305> <name> "#" .
-		<306> <name> "something#" .
-		<307> <name> "something#tag:MyTest" .
+		<301> <_name> "#tag:test" .
+		<302> <_name> "#tag" .
+		<303> <_name> "#tag:" .
+		<304> <_name> "#test" .
+		<305> <_name> "#" .
+		<306> <_name> "something#" .
+		<307> <_name> "something#tag:MyTest" .
 
 		<300> <dgraph.type> "JaegerTest" .
 		<301> <dgraph.type> "JaegerTest" .

--- a/query/common_test.go
+++ b/query/common_test.go
@@ -273,6 +273,11 @@ type Speaker {
 	language
 }
 
+type JaegerTest {
+	name
+	<#tag:test>
+}
+
 name                           : string @index(term, exact, trigram) @count @lang .
 name_lang                      : string @lang .
 lang_type                      : string @index(exact) .
@@ -346,6 +351,7 @@ tweet-c                        : string @index(fulltext) .
 tweet-d                        : string @index(trigram) .
 name2                          : string @index(term)  .
 age2                           : int @index(int) .
+<#tag:test>                    : string .
 `
 
 func populateCluster() {
@@ -872,6 +878,27 @@ func populateCluster() {
 
 		<40> <name2> "Alice" .
 		<41> <age2> "20" .
+
+		# Data for testing Tags in comments.
+
+		<300> <#tag:test> "Bob" .
+		<301> <name> "#tag:test" .
+		<302> <name> "#tag" .
+		<303> <name> "#tag:" .
+		<304> <name> "#test" .
+		<305> <name> "#" .
+		<306> <name> "something#" .
+		<307> <name> "something#tag:MyTest" .
+
+		<300> <dgraph.type> "JaegerTest" .
+		<301> <dgraph.type> "JaegerTest" .
+		<302> <dgraph.type> "JaegerTest" .
+		<303> <dgraph.type> "JaegerTest" .
+		<304> <dgraph.type> "JaegerTest" .
+		<305> <dgraph.type> "JaegerTest" .
+		<306> <dgraph.type> "JaegerTest" .
+		<307> <dgraph.type> "JaegerTest" .
+
 	`)
 	if err != nil {
 		panic(fmt.Sprintf("Could not able add triple to the cluster. Got error %v", err.Error()))

--- a/query/query4_test.go
+++ b/query/query4_test.go
@@ -1564,3 +1564,51 @@ func TestNumUids(t *testing.T) {
 	require.Equal(t, metrics.NumUids["name"], uint64(16))
 	require.Equal(t, metrics.NumUids["_total"], uint64(26))
 }
+
+func TestJaegerTag(t *testing.T) {
+	query := `
+		 {
+			 #tag:test
+			 me(func: uid(0x01)) {
+				 uid
+			 }
+		 }
+	 `
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"me":[ {"uid": "0x1"}]}}`,
+		js)
+}
+
+func TestJaegerTag1(t *testing.T) {
+	query := `
+		 {
+			 me(func: uid(0x01)) {
+				 uid
+				 #tag:test
+			 }
+		 }
+	 `
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"me":[ {"uid": "0x1"}]}}`,
+		js)
+}
+
+func TestJaegerTag2(t *testing.T) {
+	query := `
+		 {
+			 me(func: has(<#tag:test>)) {
+				 uid
+				 <#tag:test>
+			 }
+		 }
+	 `
+	js := processQueryNoErr(t, query)
+	require.JSONEq(t,
+		`{"data": {"me":[ {
+			"uid": "0x12c",
+			"#tag:test": "Bob"
+		  }]}}`,
+		js)
+}


### PR DESCRIPTION


## Problem

It's hard to find a specific query. So having a tag in the query body as a comment helps filter through the sea of logs.

 Fixes #8677
 
## Solution

Usage is very simple. Add a comment #tag: + your tag name. It works for queries and mutations.

```gql
{
 set {
  #tag:mutation2334
   _:New <test> "test" .
 }
}
```

```gql
#tag:TESTING4
#xxxxxxxxxx only the tag TESTING4 will be captured

schema{}
```

PS. In Upsert Block the tag works only in the query block, not the mutation.

How you can use in Jaeger

![Captura de Tela (16)](https://user-images.githubusercontent.com/6570955/222323594-65aa7578-5be5-408c-91bb-84a813a1e897.png)

For mutations you have to use 
```gql
mutation.tag=
```
