### PR TITLE
chore: remove unused functions in x and replace panic with x.Panic

### DIFF
--- a/chunker/json_parser.go
+++ b/chunker/json_parser.go
@@ -404,7 +404,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 	// move all facets from global map to smaller mr.rawFacets map
 	mr.rawFacets = make(map[string]interface{})
 	for k, v := range m {
-		if strings.Contains(k, x.FacetDelimeter) {
+		if strings.Contains(k, x.FacetDelimiter) {
 			mr.rawFacets[k] = v
 			delete(m, k)
 		}
@@ -514,7 +514,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 			Namespace: namespace,
 		}
 
-		prefix := pred + x.FacetDelimeter
+		prefix := pred + x.FacetDelimiter
 		if _, ok := v.([]interface{}); !ok {
 			fts, err := parseScalarFacets(mr.rawFacets, prefix)
 			if err != nil {
@@ -654,7 +654,7 @@ func (buf *NQuadBuffer) mapToNquads(m map[string]interface{}, op int, parentPred
 		}
 	}
 
-	fts, err := parseScalarFacets(mr.rawFacets, parentPred+x.FacetDelimeter)
+	fts, err := parseScalarFacets(mr.rawFacets, parentPred+x.FacetDelimiter)
 	mr.fcts = fts
 
 	return mr, err

--- a/codec/benchmark/benchmark.go
+++ b/codec/benchmark/benchmark.go
@@ -25,7 +25,6 @@ package main
 import (
 	"compress/gzip"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -60,9 +59,7 @@ const (
 
 func read(filename string) []int {
 	f, err := os.Open(filename)
-	if err != nil {
-		x.Panic(err)
-	}
+	x.Panic(err)
 	defer func() {
 		if err := f.Close(); err != nil {
 			glog.Warningf("error while closing fd: %v", err)
@@ -70,9 +67,7 @@ func read(filename string) []int {
 	}()
 
 	fgzip, err := gzip.NewReader(f)
-	if err != nil {
-		x.Panic(err)
-	}
+	x.Panic(err)
 	defer fgzip.Close()
 
 	buf := make([]byte, 4)
@@ -183,7 +178,7 @@ func fmtBenchmark(name string, speed int) {
 func main() {
 	data := read("clustered1M.bin.gz")
 	if !sort.IsSorted(sort.IntSlice(data)) {
-		x.Panic(errors.New("test data must be sorted"))
+		panic("test data must be sorted")
 	}
 
 	chunks64 := chunkify64(data)

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1081,7 +1081,7 @@ func TestListTypeSchemaChange(t *testing.T) {
 	res, err = runGraphqlQuery(q)
 	require.NoError(t, err)
 	testutil.CompareJSON(t, testutil.GetFullSchemaHTTPResponse(testutil.
-		SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}), res)
+	SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}), res)
 }
 
 func TestDeleteAllSP2(t *testing.T) {
@@ -1653,13 +1653,12 @@ func TestGeoValidWkbData(t *testing.T) {
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
 	s := `{"type": "Point", "coordinates": [1.0, 2.0]}`
 	var gt geom.T
-	if err := geojson.Unmarshal([]byte(s), &gt); err != nil {
-		panic(err)
-	}
+	err = geojson.Unmarshal([]byte(s), &gt)
+	x.Panic(err)
+
 	data, err := wkb.Marshal(gt, binary.LittleEndian)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
+
 	n := &api.NQuad{
 		Subject:   "_:test",
 		Predicate: "loc",

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1080,8 +1080,9 @@ func TestListTypeSchemaChange(t *testing.T) {
 	q = `schema{}`
 	res, err = runGraphqlQuery(q)
 	require.NoError(t, err)
-	testutil.CompareJSON(t, testutil.GetFullSchemaHTTPResponse(testutil.
-	SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}), res)
+	testutil.CompareJSON(t,
+		testutil.GetFullSchemaHTTPResponse(testutil.SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}),
+		res)
 }
 
 func TestDeleteAllSP2(t *testing.T) {
@@ -1653,8 +1654,7 @@ func TestGeoValidWkbData(t *testing.T) {
 	require.NoError(t, dg.Alter(ctx, &api.Operation{Schema: `loc: geo .`}))
 	s := `{"type": "Point", "coordinates": [1.0, 2.0]}`
 	var gt geom.T
-	err = geojson.Unmarshal([]byte(s), &gt)
-	x.Panic(err)
+	x.Panic(geojson.Unmarshal([]byte(s), &gt))
 
 	data, err := wkb.Marshal(gt, binary.LittleEndian)
 	x.Panic(err)

--- a/dgraph/cmd/alpha/run_test.go
+++ b/dgraph/cmd/alpha/run_test.go
@@ -1080,9 +1080,8 @@ func TestListTypeSchemaChange(t *testing.T) {
 	q = `schema{}`
 	res, err = runGraphqlQuery(q)
 	require.NoError(t, err)
-	testutil.CompareJSON(t,
-		testutil.GetFullSchemaHTTPResponse(testutil.SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}),
-		res)
+	testutil.CompareJSON(t, testutil.GetFullSchemaHTTPResponse(
+		testutil.SchemaOptions{UserPreds: `{"predicate":"occupations","type":"string"}`}), res)
 }
 
 func TestDeleteAllSP2(t *testing.T) {

--- a/dgraph/cmd/bulk/run.go
+++ b/dgraph/cmd/bulk/run.go
@@ -101,8 +101,7 @@ func init() {
 	flag.StringP("zero", "z", "localhost:5080", "gRPC address for Dgraph zero")
 	flag.String("xidmap", "", "Directory to store xid to uid mapping")
 	// TODO: Potentially move http server to main.
-	flag.String("http", "localhost:8080",
-		"Address to serve http (pprof).")
+	flag.String("http", "localhost:8080", "Address to serve http (pprof).")
 	flag.Bool("ignore_errors", false, "ignore line parsing errors in rdf files")
 	flag.Int("map_shards", 1,
 		"Number of map output shards. Must be greater than or equal to the number of reduce "+

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -390,10 +390,7 @@ func (l *loader) upsertUids(nqs []*api.NQuad) {
 		Query:     query.String(),
 		Mutations: []*api.Mutation{{Set: mutations}},
 	})
-
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	type dResult struct {
 		Uid string
@@ -401,28 +398,22 @@ func (l *loader) upsertUids(nqs []*api.NQuad) {
 
 	var result map[string][]dResult
 	err = json.Unmarshal(resp.GetJson(), &result)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	for xid, idx := range ids {
 		// xid already exist in dgraph
 		if val, ok := result[idx]; ok && len(val) > 0 {
 			uid, err := strconv.ParseUint(val[0].Uid, 0, 64)
-			if err != nil {
-				panic(err)
-			}
+			x.Panic(err)
 
 			l.alloc.SetUid(xid, uid)
 			continue
 		}
 
-		// new uid created in draph
+		// new uid created in dgraph
 		if val, ok := resp.GetUids()[generateUidFunc(idx)]; ok {
 			uid, err := strconv.ParseUint(val, 0, 64)
-			if err != nil {
-				panic(err)
-			}
+			x.Panic(err)
 
 			l.alloc.SetUid(xid, uid)
 			continue

--- a/dgraph/cmd/live/run.go
+++ b/dgraph/cmd/live/run.go
@@ -397,8 +397,7 @@ func (l *loader) upsertUids(nqs []*api.NQuad) {
 	}
 
 	var result map[string][]dResult
-	err = json.Unmarshal(resp.GetJson(), &result)
-	x.Panic(err)
+	x.Panic(json.Unmarshal(resp.GetJson(), &result))
 
 	for xid, idx := range ids {
 		// xid already exist in dgraph

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -289,8 +289,7 @@ http://zsh.sourceforge.net/Doc/Release/Completion-System.html
 func convertJSON(old string) io.Reader {
 	dec := json.NewDecoder(strings.NewReader(old))
 	config := make(map[string]interface{})
-	err := dec.Decode(&config)
-	x.Panic(err)
+	x.Panic(dec.Decode(&config))
 
 	// super holds superflags to later be condensed into 'good'
 	super, good := make(map[string]map[string]interface{}), make(map[string]string)
@@ -313,8 +312,7 @@ func convertJSON(old string) io.Reader {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetIndent("", "    ")
-	err = enc.Encode(&good)
-	x.Panic(err)
+	x.Panic(enc.Encode(&good))
 
 	return buf
 }

--- a/dgraph/cmd/root.go
+++ b/dgraph/cmd/root.go
@@ -289,9 +289,9 @@ http://zsh.sourceforge.net/Doc/Release/Completion-System.html
 func convertJSON(old string) io.Reader {
 	dec := json.NewDecoder(strings.NewReader(old))
 	config := make(map[string]interface{})
-	if err := dec.Decode(&config); err != nil {
-		panic(err)
-	}
+	err := dec.Decode(&config)
+	x.Panic(err)
+
 	// super holds superflags to later be condensed into 'good'
 	super, good := make(map[string]map[string]interface{}), make(map[string]string)
 	for k, v := range config {
@@ -313,9 +313,9 @@ func convertJSON(old string) io.Reader {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetIndent("", "    ")
-	if err := enc.Encode(&good); err != nil {
-		panic(err)
-	}
+	err = enc.Encode(&good)
+	x.Panic(err)
+
 	return buf
 }
 

--- a/graphql/bench/auth_test.go
+++ b/graphql/bench/auth_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (
@@ -45,9 +46,7 @@ func getJWT(b require.TestingT, metaInfo *testutil.AuthMeta) http.Header {
 
 func getAuthMeta(schema string) *testutil.AuthMeta {
 	authMeta, err := authorization.Parse(schema)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	return &testutil.AuthMeta{
 		PublicKey: authMeta.VerificationKey,

--- a/graphql/e2e/auth/auth_test.go
+++ b/graphql/e2e/auth/auth_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (
@@ -1942,14 +1943,10 @@ func TestMain(m *testing.M) {
 	jwtAlgo := []string{jwt.SigningMethodHS256.Name, jwt.SigningMethodRS256.Name}
 	for _, algo := range jwtAlgo {
 		authSchema, err := testutil.AppendAuthInfo(schema, algo, "./sample_public_key.pem", false)
-		if err != nil {
-			panic(err)
-		}
+		x.Panic(err)
 
 		authMeta, err := authorization.Parse(string(authSchema))
-		if err != nil {
-			panic(err)
-		}
+		x.Panic(err)
 
 		metaInfo = &testutil.AuthMeta{
 			PublicKey:      authMeta.VerificationKey,

--- a/graphql/e2e/auth/debug_off/debugoff_test.go
+++ b/graphql/e2e/auth/debug_off/debugoff_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dgraph-io/dgraph/graphql/authorization"
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 var (
@@ -127,9 +128,7 @@ func TestAddMutationWithXid(t *testing.T) {
 func TestMain(m *testing.M) {
 	schemaFile := "../schema.graphql"
 	schema, err := os.ReadFile(schemaFile)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	jsonFile := "../test_data.json"
 	data, err := os.ReadFile(jsonFile)
@@ -140,14 +139,10 @@ func TestMain(m *testing.M) {
 	jwtAlgo := []string{jwt.SigningMethodHS256.Name, jwt.SigningMethodRS256.Name}
 	for _, algo := range jwtAlgo {
 		authSchema, err := testutil.AppendAuthInfo(schema, algo, "../sample_public_key.pem", false)
-		if err != nil {
-			panic(err)
-		}
+		x.Panic(err)
 
 		authMeta, err := authorization.Parse(string(authSchema))
-		if err != nil {
-			panic(err)
-		}
+		x.Panic(err)
 
 		metaInfo = &testutil.AuthMeta{
 			PublicKey:      authMeta.VerificationKey,

--- a/graphql/e2e/auth_closed_by_default/auth_closed_by_default_test.go
+++ b/graphql/e2e/auth_closed_by_default/auth_closed_by_default_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dgraph-io/dgraph/graphql/e2e/common"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 type TestCase struct {
@@ -201,9 +202,7 @@ func TestMain(m *testing.M) {
 	algo := jwt.SigningMethodHS256.Name
 	schema, data := common.BootstrapAuthData()
 	authSchema, err := testutil.AppendAuthInfo(schema, algo, "../auth/sample_public_key.pem", true)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 	common.BootstrapServer(authSchema, data)
 	os.Exit(m.Run())
 }

--- a/graphql/e2e/common/admin.go
+++ b/graphql/e2e/common/admin.go
@@ -38,6 +38,7 @@ import (
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgraph/testutil"
+	"github.com/dgraph-io/dgraph/x"
 )
 
 const (
@@ -186,9 +187,7 @@ func admin(t *testing.T) {
 
 	schemaFile := "schema.graphql"
 	schema, err := os.ReadFile(schemaFile)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	jsonFile := "test_data.json"
 	data, err := os.ReadFile(jsonFile)

--- a/graphql/e2e/common/common.go
+++ b/graphql/e2e/common/common.go
@@ -1445,9 +1445,7 @@ func GetJWTForInterfaceAuth(t *testing.T, user, role string, ans bool, metaInfo 
 func BootstrapAuthData() ([]byte, []byte) {
 	schemaFile := "../auth/schema.graphql"
 	schema, err := os.ReadFile(schemaFile)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	jsonFile := "../auth/test_data.json"
 	data, err := os.ReadFile(jsonFile)

--- a/graphql/e2e/normal/normal_test.go
+++ b/graphql/e2e/normal/normal_test.go
@@ -46,9 +46,7 @@ func TestSchema_Normal(t *testing.T) {
 func TestMain(m *testing.M) {
 	schemaFile := "schema.graphql"
 	schema, err := os.ReadFile(schemaFile)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	jsonFile := "test_data.json"
 	data, err := os.ReadFile(jsonFile)

--- a/graphql/resolve/resolver_error_test.go
+++ b/graphql/resolve/resolver_error_test.go
@@ -123,9 +123,7 @@ func (ex *executor) Execute(ctx context.Context, req *dgoapi.Request,
 	}
 
 	res, err := json.Marshal(ex.result)
-	if err != nil {
-		panic(err)
-	}
+	x.Panic(err)
 
 	return &dgoapi.Response{
 		Json: res,

--- a/query/outputnode.go
+++ b/query/outputnode.go
@@ -1329,7 +1329,7 @@ func facetName(fieldName string, f *api.Facet) string {
 	if f.Alias != "" {
 		return f.Alias
 	}
-	return fieldName + x.FacetDelimeter + f.Key
+	return fieldName + x.FacetDelimiter + f.Key
 }
 
 // This method gets the values and children for a subprotos.

--- a/query/outputnode_test.go
+++ b/query/outputnode_test.go
@@ -203,9 +203,7 @@ func buildTestTree(b *testing.B, enc *encoder, level, maxlevel int, fj fastJsonN
 		var ch fastJsonNode
 		if level == maxlevel-1 {
 			val, err := valToBytes(testVal)
-			if err != nil {
-				panic(err)
-			}
+			x.Panic(err)
 
 			ch, err = enc.makeScalarNode(enc.idForAttr(testAttr), val, false)
 			require.NoError(b, err)

--- a/systest/bgindex/count_test.go
+++ b/systest/bgindex/count_test.go
@@ -77,9 +77,7 @@ func TestCountIndex(t *testing.T) {
 			edgeCount[uid] = rand.Intn(1000)
 			for j := 0; j < edgeCount[uid]; j++ {
 				_, err := bb.WriteString(fmt.Sprintf("<%v> <value> \"%v\" .\n", uid, j))
-				if err != nil {
-					panic(err)
-				}
+				x.Panic(err)
 			}
 			if err := testutil.RetryMutation(dg, &api.Mutation{
 				CommitNow: true,

--- a/types/facets/facet_types.go
+++ b/types/facets/facet_types.go
@@ -17,10 +17,7 @@
 package facets
 
 import (
-	"errors"
-
 	"github.com/dgraph-io/dgo/v210/protos/api"
-	"github.com/dgraph-io/dgraph/x"
 )
 
 const (
@@ -52,7 +49,7 @@ func ValTypeForTypeID(typId TypeID) api.Facet_ValType {
 		return api.Facet_DATETIME
 	case StringID:
 		return api.Facet_STRING
+	default:
+		panic("unhandled case in ValTypeForTypeID")
 	}
-	x.Panic(errors.New("unhandled case in ValTypeForTypeID"))
-	return api.Facet_ValType(0)
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -834,7 +834,7 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 		if err != nil {
 			glog.Errorf("Error while applying txn status to disk (%d -> %d): %v",
 				start, commit, err)
-			panic(err)
+			x.Panic(err)
 		}
 	}
 

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -834,7 +834,7 @@ func (n *node) commitOrAbort(pkey uint64, delta *pb.OracleDelta) error {
 		if err != nil {
 			glog.Errorf("Error while applying txn status to disk (%d -> %d): %v",
 				start, commit, err)
-			x.Panic(err)
+			panic(err)
 		}
 	}
 

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -180,7 +180,7 @@ func (t *tasks) enqueue(req interface{}) (uint64, error) {
 	case *pb.ExportRequest:
 		kind = TaskKindExport
 	default:
-		x.Panic(fmt.Errorf("invalid TaskKind: %d", kind))
+		panic(fmt.Sprintf("invalid TaskKind: %d", kind))
 	}
 
 	t.logMu.Lock()

--- a/worker/queue.go
+++ b/worker/queue.go
@@ -180,8 +180,7 @@ func (t *tasks) enqueue(req interface{}) (uint64, error) {
 	case *pb.ExportRequest:
 		kind = TaskKindExport
 	default:
-		err := fmt.Errorf("invalid TaskKind: %d", kind)
-		panic(err)
+		x.Panic(fmt.Errorf("invalid TaskKind: %d", kind))
 	}
 
 	t.logMu.Lock()

--- a/x/config.go
+++ b/x/config.go
@@ -35,7 +35,7 @@ type Options struct {
 	//
 	// query-edge uint64 - maximum number of edges that can be returned in a query
 	// normalize-node int - maximum number of nodes that can be returned in a query that uses the
-	//                      normalize directive
+	//                      normalized directive
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
 	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
 	// query-timeout duration - Maximum time after which a query execution will fail.
@@ -88,7 +88,7 @@ type WorkerOptions struct {
 	//
 	// ratio float64 - the ratio of queries to trace (must be between 0 and 1)
 	// jaeger string - URL of Jaeger to send OpenCensus traces
-	// datadog string - URL of Datadog to to send OpenCensus traces
+	// datadog string - URL of Datadog to send OpenCensus traces
 	Trace *z.SuperFlag
 	// MyAddr stores the address and port for this alpha.
 	MyAddr string

--- a/x/config.go
+++ b/x/config.go
@@ -35,7 +35,7 @@ type Options struct {
 	//
 	// query-edge uint64 - maximum number of edges that can be returned in a query
 	// normalize-node int - maximum number of nodes that can be returned in a query that uses the
-	//                      normalized directive
+	//                      normalize directive
 	// mutations-nquad int - maximum number of nquads that can be inserted in a mutation request
 	// BlockDropAll bool - if set to true, the drop all operation will be rejected by the server.
 	// query-timeout duration - Maximum time after which a query execution will fail.

--- a/x/file.go
+++ b/x/file.go
@@ -169,11 +169,7 @@ func WriteGroupIdFile(pdir string, group_id uint32) error {
 	if _, err := f.WriteString("\n"); err != nil {
 		return err
 	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	return f.Close()
 }
 
 // ReadGroupIdFile reads the file at the given path and attempts to retrieve the

--- a/x/init.go
+++ b/x/init.go
@@ -134,7 +134,7 @@ var versionRe *regexp.Regexp = regexp.MustCompile(`-g[[:xdigit:]]{7,}`)
 //  1. v2.0.0-rc1-127-gd20a768b3 => dev version
 //  2. v2.0.0 => prod version
 func DevVersion() (matched bool) {
-	return (versionRe.MatchString(dgraphVersion))
+	return versionRe.MatchString(dgraphVersion)
 }
 
 // ExecutableChecksum returns a byte slice containing the SHA256 checksum of the executable.

--- a/x/keys.go
+++ b/x/keys.go
@@ -369,19 +369,6 @@ func (p ParsedKey) SkipPredicate() []byte {
 }
 
 // TODO(Naman): Remove these functions as they are unused.
-// SkipSchema returns the first key after all the schema keys.
-func (p ParsedKey) SkipSchema() []byte {
-	var buf [1]byte
-	buf[0] = ByteSchema + 1
-	return buf[:]
-}
-
-// SkipType returns the first key after all the type keys.
-func (p ParsedKey) SkipType() []byte {
-	var buf [1]byte
-	buf[0] = ByteType + 1
-	return buf[:]
-}
 
 // DataPrefix returns the prefix for data keys.
 func (p ParsedKey) DataPrefix() []byte {

--- a/x/log.go
+++ b/x/log.go
@@ -23,8 +23,7 @@ import (
 )
 
 // ToGlog is a logger that forwards the output to glog.
-type ToGlog struct {
-}
+type ToGlog struct{}
 
 func (rl *ToGlog) Debug(v ...interface{})                   { glog.V(3).Info(v...) }
 func (rl *ToGlog) Debugf(format string, v ...interface{})   { glog.V(3).Infof(format, v...) }

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -177,9 +177,7 @@ func PanicHandler(out string) {
 // WrapPanics is a wrapper on panics. We use it to send sentry events about panics
 func WrapPanics() {
 	exitStatus, err := panicwrap.BasicWrap(PanicHandler)
-	if err != nil {
-		panic(err)
-	}
+	Panic(err)
 
 	// Note: panicwrap.Wrap documentation states that exitStatus == -1
 	// should be used to determine whether the process is the child.

--- a/x/sentry_integration.go
+++ b/x/sentry_integration.go
@@ -177,7 +177,9 @@ func PanicHandler(out string) {
 // WrapPanics is a wrapper on panics. We use it to send sentry events about panics
 func WrapPanics() {
 	exitStatus, err := panicwrap.BasicWrap(PanicHandler)
-	Panic(err)
+	if err != nil {
+		panic(err)
+	}
 
 	// Note: panicwrap.Wrap documentation states that exitStatus == -1
 	// should be used to determine whether the process is the child.

--- a/x/server.go
+++ b/x/server.go
@@ -46,10 +46,7 @@ func startServers(m cmux.CMux, tlsConf *tls.Config) {
 		// health endpoint will always be available over http.
 		// This is necessary for orchestration. It needs to be worked for
 		// monitoring tools which operate without authentication.
-		if strings.HasPrefix(path, "/health") {
-			return true
-		}
-		return false
+		return strings.HasPrefix(path, "/health")
 	})
 	go startListen(httpRule)
 

--- a/x/x.go
+++ b/x/x.go
@@ -119,8 +119,8 @@ const (
 	// AppliedUntil - TxnMarks.DoneUntil() before old transactions start getting aborted.
 	ForceAbortDifference = 5000
 
-	// FacetDelimeter is the symbol used to distinguish predicate names from facets.
-	FacetDelimeter = "|"
+	// FacetDelimiter is the symbol used to distinguish predicate names from facets.
+	FacetDelimiter = "|"
 
 	// GrootId is the ID of the admin user for ACLs.
 	GrootId = "groot"
@@ -151,7 +151,7 @@ var (
 	Nilbyte []byte
 	// GuardiansUid is a map from namespace to the Uid of guardians group node.
 	GuardiansUid = &sync.Map{}
-	// GrootUser Uid is a map from namespace to the Uid of groot user node.
+	// GrootUid is a map from namespace to the Uid of groot user node.
 	GrootUid = &sync.Map{}
 )
 
@@ -212,10 +212,8 @@ type queryRes struct {
 
 // IsGqlErrorList tells whether the given err is a list of GraphQL errors.
 func IsGqlErrorList(err error) bool {
-	if _, ok := err.(GqlErrorList); ok {
-		return true
-	}
-	return false
+	_, ok := err.(GqlErrorList)
+	return ok
 }
 
 func (gqlErr *GqlError) Error() string {
@@ -586,7 +584,7 @@ func HasWhitelistedIP(ctx context.Context) (net.Addr, error) {
 	return peerInfo.Addr, nil
 }
 
-// Write response body, transparently compressing if necessary.
+// WriteResponse writes response body, transparently compressing if necessary.
 func WriteResponse(w http.ResponseWriter, r *http.Request, b []byte) (int, error) {
 	var out io.Writer = w
 


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

1. Some functions in package `x` are unused
2. package `x` provides `Panic` to simplify error checking and handling (for panics)

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 3. Make it easier for the reviewer by describing complex sections with comments.
 -->

1. Remove unused functions
2. use `x.Panic` to replace 3-line codes like below:

```go
if err != nil {
    panic(err)
}
```