### PR TITLE
contrib: stop exposing only Alpha ports in docker image

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -29,9 +29,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ADD linux /usr/local/bin
 
-EXPOSE 8080
-EXPOSE 9080
-
 RUN mkdir /dgraph
 WORKDIR /dgraph
 


### PR DESCRIPTION
We used to only expose alpha ports in the docker image. This would unnecessarily expose alpha ports even when the container is running zero. That is not good from security point of view.