### PR TITLE
feat(metrics): add badger metrics (#8034)

### DIFF
--- a/dgraph/cmd/alpha/metrics_test.go
+++ b/dgraph/cmd/alpha/metrics_test.go
@@ -184,7 +184,8 @@ func TestMetrics(t *testing.T) {
 		// Badger Metrics
 		"badger_disk_reads_total", "badger_disk_writes_total", "badger_gets_total",
 		"badger_memtable_gets_total", "badger_puts_total", "badger_read_bytes",
-		"badger_written_bytes",
+		"badger_written_bytes", "badger_blocked_puts_total",
+		"badger_compactions_current", "badger_pending_writes_total",
 		// The following metrics get exposed after 1 minute from Badger, so
 		// they're not available in time for this test
 		// "badger_lsm_size_bytes", "badger_vlog_size_bytes",

--- a/x/metrics.go
+++ b/x/metrics.go
@@ -496,6 +496,11 @@ func NewBadgerCollector() prometheus.Collector {
 			"Total number of puts",
 			nil, nil,
 		),
+		"badger_v3_blocked_puts_total": prometheus.NewDesc(
+			"badger_blocked_puts_total",
+			"Total number of blocked puts",
+			nil, nil,
+		),
 		"badger_v3_memtable_gets_total": prometheus.NewDesc(
 			"badger_memtable_gets_total",
 			"Total number of memtable gets",
@@ -510,6 +515,16 @@ func NewBadgerCollector() prometheus.Collector {
 			"badger_vlog_size_bytes",
 			"Size of the value log in bytes",
 			[]string{"dir"}, nil,
+		),
+		"badger_v3_pending_writes_total": prometheus.NewDesc(
+			"badger_pending_writes_total",
+			"Total number of pending writes",
+			[]string{"dir"}, nil,
+		),
+		"badger_v3_compactions_current": prometheus.NewDesc(
+			"badger_compactions_current",
+			"Number of tables being actively compacted",
+			nil, nil,
 		),
 	})
 }


### PR DESCRIPTION
These metrics have been part of Badger for a while. This PR exports them in orometheus format at the /metrics endpoint.

 * badger_blocked_puts_total
 * badger_pending_writes_total
 * badger_compactions_current

fixes #8481 