### PR TITLE
chore(worker): unify mapper receiver names

### DIFF
--- a/worker/acl_cache.go
+++ b/worker/acl_cache.go
@@ -22,7 +22,7 @@ import (
 	"github.com/dgraph-io/dgraph/x"
 )
 
-// aclCache is the cache mapping group names to the corresponding group acls
+// AclCache is the cache mapping group names to the corresponding group acls
 type AclCache struct {
 	sync.RWMutex
 	loaded        bool

--- a/worker/aggregator.go
+++ b/worker/aggregator.go
@@ -26,14 +26,14 @@ func couldApplyAggregatorOn(agrtr string, typ types.TypeID) bool {
 	}
 	switch agrtr {
 	case "min", "max":
-		return (typ == types.IntID ||
+		return typ == types.IntID ||
 			typ == types.FloatID ||
 			typ == types.DateTimeID ||
 			typ == types.StringID ||
-			typ == types.DefaultID)
+			typ == types.DefaultID
 	case "sum", "avg":
-		return (typ == types.IntID ||
-			typ == types.FloatID)
+		return typ == types.IntID ||
+			typ == types.FloatID
 	default:
 		return false
 	}

--- a/worker/backup.go
+++ b/worker/backup.go
@@ -36,7 +36,7 @@ type predicateSet map[string]struct{}
 // to the readTs of the current backup).
 // Groups are the IDs of the groups involved.
 type Manifest struct {
-	//Type is the type of backup, either full or incremental.
+	// Type is the type of backup, either full or incremental.
 	Type string `json:"type"`
 	// SinceTsDeprecated is kept for backward compatibility. Use readTs instead of sinceTs.
 	SinceTsDeprecated uint64 `json:"since"`

--- a/worker/backup_ee.go
+++ b/worker/backup_ee.go
@@ -220,12 +220,12 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 
 	var dropOperations []*pb.DropOperation
 	for range groups {
-		if backupRes := <-resCh; backupRes.err != nil {
+		backupRes := <-resCh
+		if backupRes.err != nil {
 			glog.Errorf("Error received during backup: %v", backupRes.err)
 			return backupRes.err
-		} else {
-			dropOperations = append(dropOperations, backupRes.res.GetDropOperations()...)
 		}
+		dropOperations = append(dropOperations, backupRes.res.GetDropOperations()...)
 	}
 
 	dir := fmt.Sprintf(backupPathFmt, req.UnixTs)
@@ -246,7 +246,7 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 		m.BackupId = latestManifest.BackupId
 		m.BackupNum = latestManifest.BackupNum + 1
 	}
-	m.Encrypted = (x.WorkerConfig.EncryptionKey != nil)
+	m.Encrypted = x.WorkerConfig.EncryptionKey != nil
 
 	bp := NewBackupProcessor(nil, req)
 	defer bp.Close()

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -276,10 +276,9 @@ func (h *s3Handler) FileExists(path string) bool {
 		return true
 	}
 	errResponse := minio.ToErrorResponse(err)
-	if errResponse.Code == "NoSuchKey" {
-		return false
+	if errResponse.Code != "NoSuchKey" {
+		glog.Errorf("Failed to verify object existence: %v", err)
 	}
-	glog.Errorf("Failed to verify object existence: %v", err)
 	return false
 }
 

--- a/worker/backup_handler.go
+++ b/worker/backup_handler.go
@@ -272,16 +272,15 @@ func (h *s3Handler) DirExists(path string) bool  { return true }
 func (h *s3Handler) FileExists(path string) bool {
 	objectPath := h.getObjectPath(path)
 	_, err := h.mc.StatObject(h.bucketName, objectPath, minio.StatObjectOptions{})
-	if err != nil {
-		errResponse := minio.ToErrorResponse(err)
-		if errResponse.Code == "NoSuchKey" {
-			return false
-		} else {
-			glog.Errorf("Failed to verify object existence: %v", err)
-			return false
-		}
+	if err == nil {
+		return true
 	}
-	return true
+	errResponse := minio.ToErrorResponse(err)
+	if errResponse.Code == "NoSuchKey" {
+		return false
+	}
+	glog.Errorf("Failed to verify object existence: %v", err)
+	return false
 }
 
 func (h *s3Handler) JoinPath(path string) string {

--- a/worker/backup_manifest.go
+++ b/worker/backup_manifest.go
@@ -283,8 +283,6 @@ func GetManifest(h UriHandler, uri *url.URL) (*MasterManifest, error) {
 }
 
 func CreateManifest(h UriHandler, uri *url.URL, manifest *MasterManifest) error {
-	var err error
-
 	w, err := h.CreateFile(tmpManifest)
 	if err != nil {
 		return errors.Wrap(err, "createManifest failed to create tmp path: ")

--- a/worker/backup_oss.go
+++ b/worker/backup_oss.go
@@ -39,8 +39,6 @@ func ProcessBackupRequest(ctx context.Context, req *pb.BackupRequest) error {
 	return x.ErrNotSupported
 }
 
-func ProcessListBackups(ctx context.Context, location string, creds *x.MinioCredentials) (
-	[]*Manifest, error) {
-
+func ProcessListBackups(ctx context.Context, location string, creds *x.MinioCredentials) ([]*Manifest, error) {
 	return nil, x.ErrNotSupported
 }

--- a/worker/compare.go
+++ b/worker/compare.go
@@ -16,12 +16,6 @@
 
 package worker
 
-import (
-	"errors"
-
-	"github.com/dgraph-io/dgraph/x"
-)
-
 func evalCompare(cmp string, lv, rv int64) bool {
 	switch cmp {
 	case "le":
@@ -35,6 +29,6 @@ func evalCompare(cmp string, lv, rv int64) bool {
 	case "eq":
 		return lv == rv
 	}
-	x.Panic(errors.New("EvalCompare: unreachable"))
+	panic("EvalCompare: unreachable")
 	return false
 }

--- a/worker/draft.go
+++ b/worker/draft.go
@@ -750,7 +750,7 @@ func (n *node) processApplyCh() {
 				// Don't break here. We still need to call the Done below.
 
 			} else {
-				// if this applyCommited fails, how do we ensure
+				// if this applyCommitted fails, how do we ensure
 				start := time.Now()
 				perr = n.applyCommitted(&proposal, key)
 				if key != 0 {

--- a/worker/groups.go
+++ b/worker/groups.go
@@ -368,7 +368,7 @@ func (g *groupi) applyState(myId uint64, state *pb.MembershipState) {
 					// Don't try to remove a member if it's already marked as removed in
 					// the membership state and is not a current peer of the node.
 					_, isPeer := g.Node.Peer(member.GetId())
-					// isPeer should only be true if the rmeoved node is not the same as this node.
+					// isPeer should only be true if the removed node is not the same as this node.
 					isPeer = isPeer && member.GetId() != g.Node.RaftContext.Id
 
 					for _, oldMember := range oldState.GetRemoved() {
@@ -841,7 +841,7 @@ func (g *groupi) sendMembershipUpdates() {
 
 // receiveMembershipUpdates receives membership updates from ANY Zero server. This is the main
 // connection which tells Alpha about the state of the cluster, including the latest Zero leader.
-// All the other connections to Zero, are only made only to the leader.
+// All the other connections to Zero, are made only to the leader.
 func (g *groupi) receiveMembershipUpdates() {
 	defer func() {
 		glog.Infoln("Closing receiveMembershipUpdates")

--- a/worker/match.go
+++ b/worker/match.go
@@ -29,7 +29,7 @@ import (
 // single-character edits (i.e. insertions, deletions or substitutions)
 // required to change one word into the other.
 //
-// This implemention is optimized to use O(min(m,n)) space and is based on the
+// This implementation is optimized to use O(min(m,n)) space and is based on the
 // optimized C version found here:
 // http://en.wikibooks.org/wiki/Algorithm_implementation/Strings/Levenshtein_distance#C
 func levenshteinDistance(s, t string) int {
@@ -62,7 +62,8 @@ func levenshteinDistance(s, t string) int {
 func min(a, b, c int) int {
 	if a < b && a < c {
 		return a
-	} else if b < c {
+	}
+	if b < c {
 		return b
 	}
 	return c

--- a/worker/sort.go
+++ b/worker/sort.go
@@ -46,7 +46,7 @@ type sortresult struct {
 	// slice stores the remaining offset for individual uid lists that must be applied after all
 	// multi sort is done.
 	// TODO (pawan) - Offset has type int32 whereas paginate function returns an int. We should
-	// use a common type so that we can avoid casts between the two.
+	//                use a common type so that we can avoid casts between the two.
 	multiSortOffsets []int32
 	vals             [][]types.Val
 	err              error
@@ -231,7 +231,7 @@ func sortWithIndex(ctx context.Context, ts *pb.SortMessage) *sortresult {
 
 	var prefix []byte
 	if len(order.Langs) > 0 {
-		// Only one languge is allowed.
+		// Only one language is allowed.
 		lang := order.Langs[0]
 		tokenizer = tok.GetTokenizerForLang(tokenizer, lang)
 		langTokenizer, ok := tokenizer.(tok.ExactTokenizer)


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem
 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

`mapper` methods have different receiver names: `m` and `mw`.

## Solution
 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->

Unify receiver names for `mapper`.

Simplify some code btw.