### PR TITLE
fix(tests): wait for license to be applied before trying to login

### DIFF
--- a/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080
       --logtostderr -v=2 --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
-  
+
   zero1:
     image: dgraph/dgraph:local
     working_dir: /data/zero1
@@ -65,7 +65,7 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero2:5080
       --logtostderr -v=2 --raft "idx=1; group=1;" --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
       --acl "secret-file=/secret/hmac;"
-  
+
   zero2:
     image: dgraph/dgraph:local
     working_dir: /data/zero2
@@ -83,4 +83,3 @@ services:
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero2:5080 --logtostderr -v=2 --bindall
 volumes:
   data-volume:
-  


### PR DESCRIPTION
once the zero cluster is up, it applies a trial license. Until the license is not applied, health check for alpha returns that the cluster is an OSS cluster.

This PR ensures that the t driver code now waits for the license to be proposed and applied in the cluster. Then, it waits for the login to succeed before running the tests.