### PR TITLE
chore(docs): fix local-test cluster makefile

### DIFF
--- a/contrib/local-test/Makefile
+++ b/contrib/local-test/Makefile
@@ -1,4 +1,4 @@
-DGRAPH_VERSION = local
+DGRAPH_VERSION ?= local
 
 current_dir = $(shell pwd)
 


### PR DESCRIPTION
## Remark

**This is a makefile only for local testing purposes.  It spins up a toy cluster for testing.  This is not the makefile used in our pipelines.**

## Problem

Currently the makefile sets `DGRAPH_VERSION` to local no matter what is set in the environment.  This is undesirable if one wants to use a specific version of Dgraph to spin up.  E.g.,

```
docker pull dgraph/dgraph:v22.0.2
DGRAPH_VERSION=v22.0.2 make up
```

should spin up a cluster using the desired version of Dgraph.  This change fixes that behavior.  Note that this does not break existing behavior.  E.g., if I want to build my image from source locally,

```
make docker-image # builds dgraph and creates dgraph/dgraph:local image
cd contrib/local-test
make up
```
has the expected behavior of spinning up a cluster with the version of Dgraph I just built locally.