### PR TITLE
Fix zero's health endpoint to return a json response

### DIFF
--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -267,17 +267,15 @@ func (st *state) pingResponse(w http.ResponseWriter, r *http.Request) {
 			}       
 			w.Header().Set("Content-Type", "application/json; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
-			_, err = w.Write(resp.Json)
-			if err != nil {
-				x.SetStatus(w, x.Error, err.Error())
+			if _, err := w.Write(resp.Json); err != nil {
+				glog.Warningf("Could not send error msg=%+v code=%+v due to http error %+v", err.Error(), x.Error, err)
 				return
 			}       
 		default:
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("OK"))
-			if err != nil {
-				x.SetStatus(w, x.Error, err.Error())
+			if _, err := w.Write([]byte("OK")); err != nil {
+				glog.Warningf("Could not send error msg=%+v code=%+v due to http error %+v", err.Error(), x.Error, err)
 				return
 			}       
 	}

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -257,26 +257,19 @@ func (st *state) pingResponse(w http.ResponseWriter, r *http.Request) {
 	var err error
 	x.AddCorsHeaders(w)
 
-	var ok = false
-	for _, s := range r.Header["Content-Type"] {
-		if s == "application/json" {
-			ok = true
-			break
-		}
+	switch r.Header.Get("Accept") {
+		case "application/json":
+			var resp *api.Response
+			if resp, err = (st.zero).zeroHealth(r.Context()); err != nil {
+				x.SetStatus(w, x.Error, err.Error())
+				return
+			}       
+			w.Header().Set("Content-Type", "application/json; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(resp.Json)
+		default:
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
 	}
-	if ok {
-		var resp *api.Response
-		if resp, err = (st.zero).zeroHealth(r.Context()); err != nil {
-			x.SetStatus(w, x.Error, err.Error())
-			return
-		}       
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(resp.Json)
-
-		return
-	}
-
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK"))
 }

--- a/dgraph/cmd/zero/http.go
+++ b/dgraph/cmd/zero/http.go
@@ -25,13 +25,13 @@ import (
 	"time"
 	"encoding/json"
 
+	"github.com/pkg/errors"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/golang/glog"
 
 	"github.com/dgraph-io/dgraph/protos/pb"
 	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/dgraph-io/dgraph/x"
-	"github.com/dgraph-io/dgraph/worker"
 )
 
 // intFromQueryParam checks for name as a query param, converts it to uint64 and returns it.
@@ -243,13 +243,15 @@ func (s *Server) zeroHealth(ctx context.Context) (*api.Response, error) {
 		Instance:    "zero",
 		Address:     x.WorkerConfig.MyAddr,
 		Status:      "healthy",
-		Group:       strconv.Itoa(int(worker.GroupId())),
 		Version:     x.Version(),
 		Uptime:      int64(time.Since(x.WorkerConfig.StartTime) / time.Second),
 		LastEcho:    time.Now().Unix(),
 	}}
 
-	jsonOut, _ := json.Marshal(healthAll)
+	jsonOut, err := json.Marshal(healthAll)
+	if err != nil {
+		return nil, errors.Errorf("Unable to Marshal. Err %v", err)
+	}
 	return &api.Response{Json: jsonOut}, nil
 }
 


### PR DESCRIPTION
Zero's /health endpoint returns just "OK" where the same Alpha's endpoint returns a JSON. Now, zero's '/health' endpoint also returns a JSON response if the "Accept" HTTP header in the request it set to "application/json". It continues to return "OK" by default.

```
$ curl -H "Accept: application/json" http://localhost:61983/health
{"instance":"zero","address":"zero3:5080","status":"healthy","version":"v23.0.0-beta1-28-g05b90a580","uptime":9223372036,"lastEcho":1679305435}
```

Earlier:
```
$ curl http://localhost:61983/health
OK
```
