### PR TITLE
chore(test): skip a test when dgraph's version does not support the feature

### DIFF
--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -17,10 +17,13 @@
 package dgraphtest
 
 import (
+	"testing"
+
 	"github.com/dgraph-io/dgo/v210"
 )
 
 type Cluster interface {
 	AssignUids(num uint64) error
 	Client() (*dgo.Dgraph, error)
+	SkipTest(t *testing.T, commit string) error
 }

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -17,13 +17,11 @@
 package dgraphtest
 
 import (
-	"testing"
-
 	"github.com/dgraph-io/dgo/v210"
 )
 
 type Cluster interface {
 	AssignUids(num uint64) error
 	Client() (*dgo.Dgraph, error)
-	SkipTest(t *testing.T, commit string) error
+	GetVersion() string
 }

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -80,7 +80,7 @@ func checkoutGitRepo(repo *git.Repository, hash *plumbing.Hash) error {
 	if err != nil {
 		return errors.Wrap(err, "error while getting git repo work tree")
 	}
-	if err = worktree.Checkout(&git.CheckoutOptions{Hash: *hash}); err != nil {
+	if err := worktree.Checkout(&git.CheckoutOptions{Hash: *hash}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error while checking out git repo with hash [%v]", hash.String()))
 	}
 	return nil

--- a/dgraphtest/image.go
+++ b/dgraphtest/image.go
@@ -63,7 +63,7 @@ func (c *LocalCluster) setupBinary() error {
 
 	hash, err := repo.ResolveRevision(plumbing.Revision(c.conf.version))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "error while getting refrence hash")
 	}
 	if err := checkoutGitRepo(repo, hash); err != nil {
 		return err
@@ -80,7 +80,7 @@ func checkoutGitRepo(repo *git.Repository, hash *plumbing.Hash) error {
 	if err != nil {
 		return errors.Wrap(err, "error while getting git repo work tree")
 	}
-	if err = worktree.Checkout(&git.CheckoutOptions{Hash: plumbing.NewHash(hash.String())}); err != nil {
+	if err = worktree.Checkout(&git.CheckoutOptions{Hash: *hash}); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error while checking out git repo with hash [%v]", hash.String()))
 	}
 	return nil

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -470,7 +470,7 @@ func isParent(ancestor, descendant string) (bool, error) {
 func ShouldSkipTest(t *testing.T, testCommit, clusterVersion string) error {
 	isParentCommit, err := isParent(testCommit, clusterVersion)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	if isParentCommit {
 		t.Skipf("test is valid for commits greater than [%v]", testCommit)

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -462,18 +462,22 @@ func isParent(ancestor, descendant string) (bool, error) {
 	isParentCommit, err := descendantCommit.IsAncestor(ancestorCommit)
 	if err != nil {
 		return false, errors.Wrapf(err, "unable to compare commit [%v] to commit [%v]",
-			descendantCommit.Hash, ancestorCommit.Hash)
+			descendant, ancestor)
 	}
 	return isParentCommit, nil
 }
 
-func (c *LocalCluster) SkipTest(t *testing.T, commit string) error {
-	isParentCommit, err := isParent(commit, c.conf.version)
+func ShouldSkipTest(t *testing.T, testCommit, clusterVersion string) error {
+	isParentCommit, err := isParent(testCommit, clusterVersion)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
 	if isParentCommit {
-		t.Skipf("test is valid for %v > %v", commit, c.conf.version)
+		t.Skipf("test is valid for commits greater than [%v]", testCommit)
 	}
 	return nil
+}
+
+func (c *LocalCluster) GetVersion() string {
+	return c.conf.version
 }

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3515,7 +3515,7 @@ func TestMatchingWithPagination(t *testing.T) {
 }
 
 func TestInvalidRegex(t *testing.T) {
-	dc.SkipTest(t, "e0cc0450b88593b7496c0947aea016fc6457cb61")
+	dgraphtest.ShouldSkipTest(t, "e0cc0450b88593b7496c0947aea016fc6457cb61", dc.GetVersion())
 	testCases := []struct {
 		regex  string
 		errStr string

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3515,9 +3515,7 @@ func TestMatchingWithPagination(t *testing.T) {
 }
 
 func TestInvalidRegex(t *testing.T) {
-	if err := dc.SkipTest(t, "e0cc0450b88593b7496c0947aea016fc6457cb61"); err != nil {
-		panic(err)
-	}
+	dc.SkipTest(t, "e0cc0450b88593b7496c0947aea016fc6457cb61")
 	testCases := []struct {
 		regex  string
 		errStr string

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -3515,6 +3515,9 @@ func TestMatchingWithPagination(t *testing.T) {
 }
 
 func TestInvalidRegex(t *testing.T) {
+	if err := dc.SkipTest(t, "e0cc0450b88593b7496c0947aea016fc6457cb61"); err != nil {
+		panic(err)
+	}
 	testCases := []struct {
 		regex  string
 		errStr string

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestMain(m *testing.M) {
 	conf := dgraphtest.NewClusterConfig().WithNumAlphas(3).WithNumZeros(3).WithReplicas(3).
-		WithACL(20 * time.Second).WithEncryption().WithVersion("8b3712e")
+		WithACL(20 * time.Second).WithEncryption().WithVersion("0c9f60156")
 	c, err := dgraphtest.NewLocalCluster(conf)
 	x.Panic(err)
 	defer c.Cleanup()
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 	populateCluster()
 
 	// upgrade
-	x.Panic(c.Upgrade("68427a7", dgraphtest.BackupRestore))
+	x.Panic(c.Upgrade("v23.0.0-beta1"))
 
 	// setup the client again
 	dg, err = c.Client()


### PR DESCRIPTION
When we do upgrade testing, it is possible that some of the tests that were added later fails for an older version of Dgraph. We would like to skip those tests when dgraph's version does not support that feature.