### PR TITLE
add upgrade tests in query package for all version combinations

### DIFF
--- a/.github/workflows/ci-dgraph-upgrade-tests.yml
+++ b/.github/workflows/ci-dgraph-upgrade-tests.yml
@@ -45,7 +45,7 @@ jobs:
           # move the binary
           cp dgraph/dgraph ~/go/bin/dgraph
           # run the tests
-          go test -v -failfast -tags=upgrade,integration2 ./...
+          go test -v -timeout=60m -failfast -tags=upgrade,integration2 ./...
           # clean up docker containers after test execution
           go clean -testcache
           # sleep

--- a/dgraphtest/cluster.go
+++ b/dgraphtest/cluster.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pkg/errors"
 
@@ -407,6 +406,13 @@ func (gc *GrpcClient) DropAll() error {
 	return gc.Alter(ctx, &api.Operation{DropAll: true})
 }
 
+// DropPredicate drops the predicate from the data in the db
+func (gc *GrpcClient) DropPredicate(pred string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	return gc.Alter(ctx, &api.Operation{DropAttr: pred})
+}
+
 // Mutate performs a given mutation in a txn
 func (gc *GrpcClient) Mutate(rdfs string) (*api.Response, error) {
 	txn := gc.NewTxn()
@@ -450,9 +456,9 @@ func isParent(ancestor, descendant string) (bool, error) {
 		return false, nil
 	}
 
-	repo, err := git.PlainOpen(repoDir)
+	repo, err := openDgraphRepo()
 	if err != nil {
-		return false, errors.Wrap(err, "error opening git repo")
+		return false, err
 	}
 
 	ancestorHash, err := repo.ResolveRevision(plumbing.Revision(ancestor))

--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -22,6 +22,20 @@ import (
 	"time"
 )
 
+var UpgradeCombos = [][]string{
+	// {"v20.11.3", "v23.0.0-rc1"},
+	// {"v21.03.0", "v23.0.0-rc1"},
+	{"v21.03.0-92-g0c9f60156", "v23.0.0-rc1"},
+	{"v21.03.0-98-g19f71a78a-slash", "v23.0.0-rc1"},
+	{"v21.03.0-99-g4a03c144a-slash", "v23.0.0-rc1"},
+	{"v21.03.1", "v23.0.0-rc1"},
+	{"v21.03.2", "v23.0.0-rc1"},
+	{"v21.12.0", "v23.0.0-rc1"},
+	{"v22.0.0", "v23.0.0-rc1"},
+	{"v22.0.1", "v23.0.0-rc1"},
+	{"v22.0.2", "v23.0.0-rc1"},
+}
+
 type ClusterConfig struct {
 	prefix     string
 	numAlphas  int

--- a/dgraphtest/local_cluster.go
+++ b/dgraphtest/local_cluster.go
@@ -459,7 +459,7 @@ func (c *LocalCluster) Upgrade(version string, strategy UpgradeStrategy) error {
 			return err
 		}
 		if err := hc.LoginIntoNamespace(DefaultUser, DefaultPassword, 0); err != nil {
-			return err
+			return errors.Wrapf(err, "error during login before upgrade")
 		}
 		if err := hc.Backup(true, DefaultBackupDir); err != nil {
 			return errors.Wrap(err, "error taking backup during upgrade")

--- a/worker/restore_map.go
+++ b/worker/restore_map.go
@@ -240,7 +240,7 @@ func (m *mapper) writeToDisk(buf *z.Buffer) error {
 		glog.Infof("Created new backup map file: %s of size: %s\n",
 			fi.Name(), humanize.IBytes(uint64(fi.Size())))
 	}
-	return f.Close()
+	return nil
 }
 
 func (m *mapper) sendForWriting() error {


### PR DESCRIPTION
This PR allows us to run upgrade tests for various combinations of before and after dgraph versions in the query package.