### PR TITLE
fix(Query): Do an error check before bubbling up nil error

### DIFF
--- a/query/query.go
+++ b/query/query.go
@@ -2843,10 +2843,6 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 				continue
 			}
 
-			fmt.Println("##################################################")
-			fmt.Printf("Executing: %d\n", idx)
-			fmt.Println("##################################################")
-
 			switch {
 			case sg.Params.Alias == "shortest":
 				// We allow only one shortest path block per query.

--- a/query/query.go
+++ b/query/query.go
@@ -2363,7 +2363,7 @@ func ProcessGraph(ctx context.Context, sg, parent *SubGraph, rch chan error) {
 		}
 	}
 
-	if sg.DestUIDs == nil || len(sg.DestUIDs.Uids) == 0 {
+	if (sg.DestUIDs == nil || len(sg.DestUIDs.Uids) == 0) && childErr == nil {
 		// Looks like we're done here. Be careful with nil srcUIDs!
 		if span != nil {
 			span.Annotatef(nil, "Zero uids for %q", sg.Attr)
@@ -2842,6 +2842,10 @@ func (req *Request) ProcessQuery(ctx context.Context) (err error) {
 				errChan <- nil
 				continue
 			}
+
+			fmt.Println("##################################################")
+			fmt.Printf("Executing: %d\n", idx)
+			fmt.Println("##################################################")
 
 			switch {
 			case sg.Params.Alias == "shortest":

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1439,6 +1439,24 @@ func TestQueryVarEmptyRootOrderError(t *testing.T) {
 	require.Contains(t, err.Error(), "Cannot sort by unknown attribute id")
 }
 
+func TestQueryVarEmptyRootOrderChildQueryError(t *testing.T) {
+	query := `
+		{
+			var(func: eq(name, "DNEinDB")) {
+				friend(orderdesc: id) {
+					f as count(uid)
+				}
+			}
+			q(func: uid(f)){
+				name
+			}
+		}
+	`
+	_, err := processQuery(context.Background(), t, query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Cannot sort by unknown attribute id")
+}
+
 func TestQueryVarValOrderDesc(t *testing.T) {
 	query := `
 		{

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1427,7 +1427,7 @@ func TestQueryVarValOrderError(t *testing.T) {
 func TestQueryVarEmptyRootOrderError(t *testing.T) {
 	query := `
 		{
-			q(func: eq(name, "Alicey")) {
+			q(func: eq(name, "DNEinDB")) {
 				friend(orderdesc: id) {
 					name
 				}

--- a/query/query0_test.go
+++ b/query/query0_test.go
@@ -1424,6 +1424,21 @@ func TestQueryVarValOrderError(t *testing.T) {
 	require.Contains(t, err.Error(), "Cannot sort by unknown attribute n")
 }
 
+func TestQueryVarEmptyRootOrderError(t *testing.T) {
+	query := `
+		{
+			q(func: eq(name, "Alicey")) {
+				friend(orderdesc: id) {
+					name
+				}
+			}
+		}
+	`
+	_, err := processQuery(context.Background(), t, query)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Cannot sort by unknown attribute id")
+}
+
 func TestQueryVarValOrderDesc(t *testing.T) {
 	query := `
 		{


### PR DESCRIPTION
## Problem
Without the check, the code erraneously bubbles up nil error even when there's been an error in one of the child subgraph. This later causes a panic because the downstream code expects no error.

Reproduce this:

DQL Query:
```
{
    var(func: eq(name, "Alicey")){
        friend(orderdesc: id) {
            f as count(uid)
        }
    }
    q(func: uid(f)){
        name
    } 
}
```

Fixes: https://github.com/dgraph-io/projects-internal/issues/89

## Solution
Add an error check.