### PR TITLE
dgraphtest: add support for export

### DIFF
--- a/dgraphtest/config.go
+++ b/dgraphtest/config.go
@@ -22,10 +22,6 @@ import (
 	"time"
 )
 
-const (
-	localVersion = "local"
-)
-
 type ClusterConfig struct {
 	prefix     string
 	numAlphas  int
@@ -42,6 +38,7 @@ type ClusterConfig struct {
 func NewClusterConfig() ClusterConfig {
 	prefix := fmt.Sprintf("test-%d", rand.NewSource(time.Now().Unix()).Int63()%10000)
 	defaultBackupVol := fmt.Sprintf("%v_backup", prefix)
+	defaultExportVol := fmt.Sprintf("%v_export", prefix)
 	return ClusterConfig{
 		prefix:    prefix,
 		numAlphas: 1,
@@ -49,7 +46,7 @@ func NewClusterConfig() ClusterConfig {
 		replicas:  1,
 		verbosity: 2,
 		version:   localVersion,
-		volumes:   map[string]string{DefaultBackupDir: defaultBackupVol},
+		volumes:   map[string]string{DefaultBackupDir: defaultBackupVol, DefaultExportDir: defaultExportVol},
 	}
 }
 

--- a/dgraphtest/dgraph.go
+++ b/dgraphtest/dgraph.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
@@ -45,12 +46,21 @@ const (
 	alphaWorkingDir  = "/data/alpha"
 	zeroWorkingDir   = "/data/zero"
 	DefaultBackupDir = "/data/backups"
+	DefaultExportDir = "/data/exports"
 
 	aclSecretMountPath = "/dgraph-acl/hmac-secret"
 	encKeyMountPath    = "/dgraph-enc/enc-key"
 
 	DefaultUser     = "groot"
 	DefaultPassword = "password"
+
+	localVersion       = "local"
+	waitDurBeforeRetry = time.Second
+	requestTimeout     = 90 * time.Second
+)
+
+var (
+	errNotImplemented = errors.New("NOT IMPLEMENTED")
 )
 
 func fileExists(filename string) (bool, error) {
@@ -229,7 +239,7 @@ func (a *alpha) mounts(c *LocalCluster) ([]mount.Mount, error) {
 	for dir, vol := range c.conf.volumes {
 		mounts = append(mounts, mount.Mount{
 			Type:     mount.TypeVolume,
-			Source:   fmt.Sprintf(volNameFmt, c.conf.prefix, vol),
+			Source:   vol,
 			Target:   dir,
 			ReadOnly: false,
 		})

--- a/query/upgrade_test.go
+++ b/query/upgrade_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 	c, err := dgraphtest.NewLocalCluster(conf)
 	x.Panic(err)
 	defer c.Cleanup()
-	c.Start()
+	require.NoError(t, c.Start())
 
 	// setup the global Cluster var
 	dc = c

--- a/systest/incremental-restore/incremental_restore_test.go
+++ b/systest/incremental-restore/incremental_restore_test.go
@@ -35,7 +35,7 @@ func TestIncrementalRestore(t *testing.T) {
 	c, err := dgraphtest.NewLocalCluster(conf)
 	require.NoError(t, err)
 	defer c.Cleanup()
-	c.Start()
+	require.NoError(t, c.Start())
 
 	gc, cleanup, err := c.Client()
 	require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestIncrementalRestore(t *testing.T) {
 	require.NoError(t, hc.LoginIntoNamespace(dgraphtest.DefaultUser, dgraphtest.DefaultPassword, 0))
 
 	uids := []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}
-	c.AssignUids(gc, uint64(len(uids)))
+	c.AssignUids(gc.Dgraph, uint64(len(uids)))
 	require.NoError(t, gc.SetupSchema(`money: [int] @index(int) @count .`))
 
 	for i := 1; i <= len(uids); i++ {


### PR DESCRIPTION
This PR adds the Export and DropAll function in dgraphtest package. The Export function enables to run export mutation and export data out of dgraph. The DropAll function drops all the data in the db.