### PR TITLE
chore(cd): add badger binary to dgraph docker image

### DIFF
--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -77,10 +77,10 @@ jobs:
             dgraph/dgraph-linux-amd64.tar.gz
       - name: Move Badger Binary into Linux Directory
         run: |
-          tar -xzf badger/badger-linux-amd64.tar.gz
-          [ -d "./linux" ] && mkdir linux
+          tar -xzf badger/badger-linux-amd64.tar.gz --directory badger
+          [ -d "linux" ] || mkdir linux
           # linux directory will be added to docker image in build step
-          cp badger/badger-linux-amd64 ./linux/badger
+          cp badger/badger-linux-amd64 linux/badger
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
@@ -165,10 +165,10 @@ jobs:
             dgraph/dgraph-linux-arm64.tar.gz
       - name: Move Badger Binary into Linux Directory
         run: |
-          tar -xzf badger/badger-linux-amd64.tar.gz
-          [ -d "./linux" ] && mkdir linux
+          tar -xzf badger/badger-linux-amd64.tar.gz --directory badger
+          [ -d "linux" ] || mkdir linux
           # linux directory will be added to docker image in build step
-          cp badger/badger-linux-amd64 ./linux/badger
+          cp badger/badger-linux-amd64 linux/badger
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -75,6 +75,12 @@ jobs:
             badger/badger-linux-amd64.tar.gz
             dgraph/dgraph-checksum-linux-amd64.sha256
             dgraph/dgraph-linux-amd64.tar.gz
+      - name: Move Badger Binary into Linux Directory
+        run: |
+          tar -xzf badger/badger-linux-amd64.tar.gz
+          [ -d "./linux" ] && mkdir linux
+          # linux directory will be added to docker image in build step
+          cp badger/badger-linux-amd64 ./linux/badger
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-amd64
@@ -157,6 +163,12 @@ jobs:
             badger/badger-linux-arm64.tar.gz
             dgraph/dgraph-checksum-linux-arm64.sha256
             dgraph/dgraph-linux-arm64.tar.gz
+      - name: Move Badger Binary into Linux Directory
+        run: |
+          tar -xzf badger/badger-linux-amd64.tar.gz
+          [ -d "./linux" ] && mkdir linux
+          # linux directory will be added to docker image in build step
+          cp badger/badger-linux-amd64 ./linux/badger
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64

--- a/.github/workflows/cd-dgraph.yml
+++ b/.github/workflows/cd-dgraph.yml
@@ -165,10 +165,10 @@ jobs:
             dgraph/dgraph-linux-arm64.tar.gz
       - name: Move Badger Binary into Linux Directory
         run: |
-          tar -xzf badger/badger-linux-amd64.tar.gz --directory badger
+          tar -xzf badger/badger-linux-arm64.tar.gz --directory badger
           [ -d "linux" ] || mkdir linux
           # linux directory will be added to docker image in build step
-          cp badger/badger-linux-amd64 linux/badger
+          cp badger/badger-linux-arm64 linux/badger
       - name: Make Dgraph Docker Image
         run: |
           make docker-image DGRAPH_VERSION=${{ env.DGRAPH_RELEASE_VERSION }}-arm64


### PR DESCRIPTION
In releases <=v21 we included the badger CLI tool in our dgraph docker images.  We make this a part of our cd pipeline again.