### PR TITLE
use env var for Mac for supporting dev workflow

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -176,7 +176,7 @@ func initService(basename string, idx, grpcPort int) service {
 	if opts.LocalBin {
 		svc.Volumes = append(svc.Volumes, volume{
 			Type:     "bind",
-			Source:   "$GOPATH/bin",
+			Source:   "${DGRAPH_BIN_PATH:-$GOPATH/bin}",
 			Target:   "/gobin",
 			ReadOnly: true,
 		})

--- a/contrib/config/datadog/docker-compose.yml
+++ b/contrib/config/datadog/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - 9180:9180
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha -o 100 --my=alpha1:7180 --zero=zero1:5080 --logtostderr -v=2
@@ -27,7 +27,7 @@ services:
     - 6080:6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero -o 0 --raft "idx=1;" --my=zero1:5080 --replicas=3 --logtostderr -v=2 --bindall

--- a/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
+++ b/dgraph/cmd/alpha/mutations_mode/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080,zero2:5080,zero3:5080
@@ -30,7 +30,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080,zero2:5080,zero3:5080
@@ -47,7 +47,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080,zero2:5080,zero3:5080
@@ -64,7 +64,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr
@@ -81,7 +81,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2:5080 --replicas=1 --logtostderr
@@ -98,7 +98,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=3;" --my=zero3:5080 --replicas=1 --logtostderr

--- a/dgraph/docker-compose.yml
+++ b/dgraph/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero1:5080 --replicas 3 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
@@ -29,7 +29,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph   ${COVERAGE_OUTPUT} zero --my=zero2:5080 --replicas 3 --raft="idx=2" --logtostderr -v=2 --peer=zero1:5080
@@ -47,7 +47,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero3:5080 --replicas 3 --raft="idx=3" --logtostderr -v=2 --peer=zero1:5080
@@ -57,7 +57,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -85,7 +85,7 @@ services:
       - alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -113,7 +113,7 @@ services:
       - alpha2
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -141,7 +141,7 @@ services:
       - alpha3
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -169,7 +169,7 @@ services:
       - alpha4
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -197,7 +197,7 @@ services:
       - alpha5
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
+++ b/graphql/e2e/admin_auth/poorman_auth_with_acl/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero1:5080 --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/graphql/e2e/auth/debug_off/docker-compose.yml
+++ b/graphql/e2e/auth/debug_off/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/auth/docker-compose.yml
+++ b/graphql/e2e/auth/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/auth_closed_by_default/docker-compose.yml
+++ b/graphql/e2e/auth_closed_by_default/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/custom_logic/docker-compose.yml
+++ b/graphql/e2e/custom_logic/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080
@@ -28,7 +28,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr

--- a/graphql/e2e/directives/docker-compose.yml
+++ b/graphql/e2e/directives/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/multi_tenancy/docker-compose.yml
+++ b/graphql/e2e/multi_tenancy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -35,7 +35,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -58,7 +58,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -79,7 +79,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr

--- a/graphql/e2e/normal/docker-compose.yml
+++ b/graphql/e2e/normal/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --my=zero1:5080
@@ -21,7 +21,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     ports:

--- a/graphql/e2e/schema/docker-compose.yml
+++ b/graphql/e2e/schema/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080
@@ -38,7 +38,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080
@@ -60,7 +60,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080
@@ -76,7 +76,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --replicas=1 --logtostderr

--- a/graphql/e2e/subscription/docker-compose.yml
+++ b/graphql/e2e/subscription/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080
@@ -30,7 +30,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080
@@ -48,7 +48,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080
@@ -64,7 +64,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr

--- a/graphql/testdata/custom_bench/profiling/docker-compose.yml
+++ b/graphql/testdata/custom_bench/profiling/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     - 9180:9180
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -42,7 +42,7 @@ services:
     - 6180:6180
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero -o 100 --raft="idx=1;" --my=zero1:5180 --logtostderr -v=2

--- a/ocagent/docker-compose.yml
+++ b/ocagent/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     - 9180:9180
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha -o 100 --my=alpha1:7180 --zero=zero1:5180 --logtostderr -v=2
@@ -27,7 +27,7 @@ services:
     - 6180:6180
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero -o 100 --raft="idx=1" --my=zero1:5180 --replicas=3 --logtostderr -v=2 --bindall

--- a/systest/1million/alpha.yml
+++ b/systest/1million/alpha.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/1million/docker-compose.yml
+++ b/systest/1million/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: volume

--- a/systest/21million/bulk/alpha.yml
+++ b/systest/21million/bulk/alpha.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/21million/bulk/docker-compose.yml
+++ b/systest/21million/bulk/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: volume

--- a/systest/21million/live/docker-compose.yml
+++ b/systest/21million/live/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
@@ -28,7 +28,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr

--- a/systest/acl/restore/docker-compose.yml
+++ b/systest/acl/restore/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -38,7 +38,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft='idx=1' --my=zero1:5080 --logtostderr

--- a/systest/audit/docker-compose.yml
+++ b/systest/audit/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -27,7 +27,7 @@ services:
       - "6080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/audit_encrypted/docker-compose.yml
+++ b/systest/audit_encrypted/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -31,7 +31,7 @@ services:
       - "6080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/backup/advanced-scenarios/127-Namespace/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/127-Namespace/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -37,7 +37,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -55,7 +55,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -77,7 +77,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/

--- a/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/acl-nonAcl/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -38,7 +38,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -57,7 +57,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -73,7 +73,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -93,7 +93,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -115,7 +115,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -134,7 +134,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -150,7 +150,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/

--- a/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
+++ b/systest/backup/advanced-scenarios/deleted-namespace/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -36,7 +36,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/
@@ -54,7 +54,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -76,7 +76,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - data-volume:/data/backups/

--- a/systest/backup/encryption/docker-compose.yml
+++ b/systest/backup/encryption/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -38,7 +38,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -64,7 +64,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -88,7 +88,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/backup/filesystem/docker-compose.yml
+++ b/systest/backup/filesystem/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -36,7 +36,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -60,7 +60,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -84,7 +84,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/backup/minio-large/docker-compose.yml
+++ b/systest/backup/minio-large/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -36,7 +36,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -58,7 +58,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -85,7 +85,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/backup/minio/docker-compose.yml
+++ b/systest/backup/minio/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -36,7 +36,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -58,7 +58,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -78,7 +78,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/backup/multi-tenancy/docker-compose.yml
+++ b/systest/backup/multi-tenancy/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -37,7 +37,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -62,7 +62,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -87,7 +87,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/backup/nfs-backup/docker-compose.yml
+++ b/systest/backup/nfs-backup/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command:
@@ -42,7 +42,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha2_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -61,7 +61,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha3_backup_clust_ha:7080  --zero=zero1_backup_clust_ha:5080,zero2_backup_clust_ha:5080,zero3_backup_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -80,7 +80,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
@@ -98,7 +98,7 @@ services:
       service: zero
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero2_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
@@ -116,7 +116,7 @@ services:
       service: zero
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=3;" --my=zero3_backup_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero1_backup_clust_ha:5080
@@ -138,7 +138,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command:
@@ -162,7 +162,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha5_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -181,7 +181,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT}  alpha   --my=alpha6_restore_clust_ha:7080  --zero=zero4_restore_clust_ha:5080,zero5_restore_clust_ha:5080,zero6_restore_clust_ha:5080 --logtostderr -v=2  --security "whitelist=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16;"
@@ -200,7 +200,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero4_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall
@@ -218,7 +218,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=2;" --my=zero5_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
@@ -236,7 +236,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=3;" --my=zero6_restore_clust_ha:5080 --replicas=3 --logtostderr -v=2 --bindall  --peer=zero4_restore_clust_ha:5080
@@ -257,7 +257,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero7_backup_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
@@ -277,7 +277,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command:
@@ -303,7 +303,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero8_restore_clust_non_ha:5080 --replicas=1 --logtostderr -v=2 --bindall
@@ -323,7 +323,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command:

--- a/systest/bgindex/docker-compose.yml
+++ b/systest/bgindex/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -33,7 +33,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/systest/bulk_live/bulk/alpha.yml
+++ b/systest/bulk_live/bulk/alpha.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/bulk_live/bulk/alpha_acl.yml
+++ b/systest/bulk_live/bulk/alpha_acl.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/bulk_live/bulk/docker-compose.yml
+++ b/systest/bulk_live/bulk/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2

--- a/systest/bulk_live/live/docker-compose.yml
+++ b/systest/bulk_live/live/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
@@ -39,7 +39,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph zero --raft='idx=1' --my=zero1:5080 --logtostderr -v=2

--- a/systest/cdc/docker-compose.yml
+++ b/systest/cdc/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -29,7 +29,7 @@ services:
       - "6080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/systest/cloud/docker-compose.yml
+++ b/systest/cloud/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph zero --my=zero1:5080 --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10
@@ -23,7 +23,7 @@ services:
         - ./../../dgraph/minio.env
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/export/docker-compose.yml
+++ b/systest/export/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: volume
@@ -36,7 +36,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: volume
@@ -58,7 +58,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: volume
@@ -85,7 +85,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --replicas=3 --logtostderr

--- a/systest/group-delete/docker-compose.yml
+++ b/systest/group-delete/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
@@ -28,7 +28,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha2:7080 --zero=zero1:5080 --logtostderr
@@ -44,7 +44,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha3:7080 --zero=zero1:5080 --logtostderr
@@ -60,7 +60,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --replicas=1 --logtostderr

--- a/systest/ldbc/alpha.yml
+++ b/systest/ldbc/alpha.yml
@@ -10,7 +10,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/ldbc/docker-compose.yml
+++ b/systest/ldbc/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft="idx=1" --my=zero1:5080 --logtostderr

--- a/systest/license/docker-compose.yml
+++ b/systest/license/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr
@@ -28,7 +28,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/systest/loader-benchmark/docker-compose.yml
+++ b/systest/loader-benchmark/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       cluster: test
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero -o 100 --my=zero1:5180 --logtostderr --bindall
@@ -24,7 +24,7 @@ services:
     working_dir: /data/dg1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: volume

--- a/systest/loader/docker-compose.yml
+++ b/systest/loader/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -32,7 +32,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/multi-tenancy/docker-compose.yml
+++ b/systest/multi-tenancy/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       service: zero
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --my=zero1:5080  --raft="idx=1" --logtostderr -v=2 --bindall --expose_trace --profile_mode block --block_rate 10 --limit refill-interval=20s --limit uid-lease=50
@@ -20,7 +20,7 @@ services:
     working_dir: /data/alpha1
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/systest/online-restore/docker-compose.yml
+++ b/systest/online-restore/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -45,7 +45,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -80,7 +80,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -115,7 +115,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -150,7 +150,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -185,7 +185,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -218,7 +218,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/systest/plugin/docker-compose.yml
+++ b/systest/plugin/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -33,7 +33,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2

--- a/testutil/testaudit/docker-compose.yml
+++ b/testutil/testaudit/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "9080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -31,7 +31,7 @@ services:
       - "6080"
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/tlstest/acl/docker-compose.yml
+++ b/tlstest/acl/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     - 9080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -35,7 +35,7 @@ services:
     - 6080
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/tlstest/certrequest/docker-compose.yml
+++ b/tlstest/certrequest/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -32,7 +32,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/tlstest/certrequireandverify/docker-compose.yml
+++ b/tlstest/certrequireandverify/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -32,7 +32,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/tlstest/certverifyifgiven/docker-compose.yml
+++ b/tlstest/certverifyifgiven/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind
@@ -32,7 +32,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft "idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/tlstest/mtls_internal/ha_6_node/docker-compose.yml
+++ b/tlstest/mtls_internal/ha_6_node/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -30,7 +30,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -50,7 +50,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -70,7 +70,7 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -89,7 +89,7 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -108,7 +108,7 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/tlstest/mtls_internal/multi_group/docker-compose.yml
+++ b/tlstest/mtls_internal/multi_group/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -30,7 +30,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -50,7 +50,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -70,7 +70,7 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/tlstest/mtls_internal/single_node/docker-compose.yml
+++ b/tlstest/mtls_internal/single_node/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - 9080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind
@@ -30,7 +30,7 @@ services:
       - 6080
     volumes:
       - type: bind
-        source: $GOPATH/bin
+        source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
         target: /gobin
         read_only: true
       - type: bind

--- a/tlstest/zero_https/all_routes_tls/docker-compose.yml
+++ b/tlstest/zero_https/all_routes_tls/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
@@ -27,7 +27,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     - type: bind

--- a/tlstest/zero_https/no_tls/docker-compose.yml
+++ b/tlstest/zero_https/no_tls/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} alpha --my=alpha1:7080 --zero=zero1:5080 --logtostderr -v=2 
@@ -27,7 +27,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph ${COVERAGE_OUTPUT} zero --raft="idx=1;" --my=zero1:5080 --logtostderr -v=2 --bindall

--- a/worker/docker-compose.yml
+++ b/worker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha1:7080
@@ -28,7 +28,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha2:7080
@@ -44,7 +44,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha3:7080
@@ -60,7 +60,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha4:7080
@@ -76,7 +76,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha5:7080
@@ -92,7 +92,7 @@ services:
     - "9080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} alpha --trace "jaeger=http://jaeger:14268;" --my=alpha6:7080
@@ -118,7 +118,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --trace "jaeger=http://jaeger:14268;" --raft='idx=1'
@@ -135,7 +135,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --trace "jaeger=http://jaeger:14268;" --raft='idx=2'
@@ -152,7 +152,7 @@ services:
     - "6080"
     volumes:
     - type: bind
-      source: $GOPATH/bin
+      source: ${DGRAPH_BIN_PATH:-$GOPATH/bin}
       target: /gobin
       read_only: true
     command: /gobin/dgraph  ${COVERAGE_OUTPUT} zero --trace "jaeger=http://jaeger:14268;" --raft='idx=3'


### PR DESCRIPTION
Because MAC runs a linux VM for running docker container, we can't follow the normal development workflow on Mac. we need to make two changes in the workflow:
 1. Additionally run GOOS=linux make install whenever running make install
 2. export the following variable in your rc file
       export DGRAPH_BIN_PATH=$GOPATH/bin/linux_$GOARCH