### PR TITLE
chore(test): improve health check for NFS backup tests

### DIFF
--- a/systest/backup/nfs-backup/backup_test.go
+++ b/systest/backup/nfs-backup/backup_test.go
@@ -28,7 +28,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -51,11 +50,8 @@ var (
 
 func TestBackupHAClust(t *testing.T) {
 	//TODO: Polling for health-checks with a 1sec wait for 100 times
-	for i := 1; i <= 100; i++ {
-		if err := testutil.CheckHealthContainer(testutil.ContainerAddr("alpha1", 8080)); err == nil {
-			break
-		}
-		time.Sleep(1 * time.Second)
+	if err := testutil.CheckHealthContainer(testutil.ContainerAddr("alpha1", 8080)); err != nil {
+		require.NoError(t, err, "alpha1 did not pass health check")
 	}
 
 	backupRestoreTest(t, testutil.SockAddr, testutil.SockAddrAlpha4Http,

--- a/systest/backup/nfs-backup/backup_test.go
+++ b/systest/backup/nfs-backup/backup_test.go
@@ -50,12 +50,12 @@ var (
 )
 
 func TestBackupHAClust(t *testing.T) {
-	// check health of alpha1
-	for i := 1; i <= 50; i++ {
+	//TODO: Polling for health-checks with a 1sec wait for 100 times
+	for i := 1; i <= 100; i++ {
 		if err := testutil.CheckHealthContainer(testutil.ContainerAddr("alpha1", 8080)); err == nil {
 			break
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(1 * time.Second)
 	}
 
 	backupRestoreTest(t, testutil.SockAddr, testutil.SockAddrAlpha4Http,

--- a/systest/backup/nfs-backup/backup_test.go
+++ b/systest/backup/nfs-backup/backup_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -49,6 +50,13 @@ var (
 )
 
 func TestBackupHAClust(t *testing.T) {
+	// check health of alpha1
+	for i := 1; i <= 50; i++ {
+		if err := testutil.CheckHealthContainer(testutil.ContainerAddr("alpha1", 8080)); err == nil {
+			break
+		}
+		time.Sleep(2 * time.Second)
+	}
 
 	backupRestoreTest(t, testutil.SockAddr, testutil.SockAddrAlpha4Http,
 		testutil.SockAddrZeroHttp, backupDstHA, testutil.SockAddrHttp)

--- a/testutil/docker.go
+++ b/testutil/docker.go
@@ -293,7 +293,7 @@ func CheckHealthContainer(socketAddrHttp string) error {
 	var err error
 	var resp *http.Response
 	url := "http://" + socketAddrHttp + "/health"
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 100; i++ {
 		resp, err = http.Get(url)
 		if err == nil && resp.StatusCode == http.StatusOK {
 			return nil


### PR DESCRIPTION
NFS backup tests fail frequently in CI. The test installs the NFS client before starting the alpha service because of this the Alpha container takes more time to reach a healthy state and may not pass the health check. To solve this, we check the health of Alpha within the tests itself (essentially giving Alpha 100 seconds to reach a healthy state). Example failed run is available here https://github.com/dgraph-io/dgraph/actions/runs/4744244095/jobs/8424889366