### PR TITLE
chore: remove unused build tag

### DIFF
--- a/tok/stopwords_test.go
+++ b/tok/stopwords_test.go
@@ -1,5 +1,3 @@
-//go:build iunit_test
-
 /*
  * Copyright 2023 Dgraph Labs, Inc. and Contributors
  *


### PR DESCRIPTION
This was added in https://github.com/dgraph-io/dgraph/pull/8665 but seems to have been an oversight.